### PR TITLE
Fix download_via_gsutil and rsync workdir commands

### DIFF
--- a/prototype/sky/cloud_stores.py
+++ b/prototype/sky/cloud_stores.py
@@ -41,8 +41,7 @@ class GcsCloudStorage(CloudStorage):
             'tar xzf gsutil.tar.gz)',
             'popd &>/dev/null',
         ]
-        download_via_gsutil = '/tmp/gsutil/gsutil -m rsync -r {} {}'.format(
-            source, destination)
+        download_via_gsutil = f'mkdir -p {destination} && /tmp/gsutil/gsutil -m rsync -r {source} {destination}'
 
         all_commands = get_gsutil
         all_commands.append(download_via_gsutil)

--- a/prototype/sky/execution.py
+++ b/prototype/sky/execution.py
@@ -206,7 +206,7 @@ def execute(dag: sky.Dag, dryrun: bool = False, teardown: bool = False):
     if task.workdir is not None:
         runner.add_step(
             'sync', 'Sync files',
-            f'ray rsync_up {cluster_config_file} {task.workdir} {SKY_REMOTE_WORKDIR}'
+            f'ray rsync_up {cluster_config_file} {task.workdir}/ {SKY_REMOTE_WORKDIR}'
         )
 
     if task.get_cloud_to_remote_file_mounts() is not None:


### PR DESCRIPTION
`rsync` needs a trailing slash to have the intended behavior the following commands are expecting. Also the target_dir needs to be created before we copy stuff to it with `gsutil`.