### PR TITLE
Add jupyter notebook example

### DIFF
--- a/prototype/examples/jupyter_app.py
+++ b/prototype/examples/jupyter_app.py
@@ -1,5 +1,4 @@
 import sky
-from sky import clouds
 
 
 def make_application():
@@ -31,5 +30,4 @@ def make_application():
 
 
 dag = make_application()
-dag = sky.Optimizer.optimize(dag, minimize=sky.Optimizer.COST)
 sky.execute(dag)


### PR DESCRIPTION
An example for starting a jupyter notebook with the sky. As suggested in #31, I reverted the port forwarding changes from the Task class and let the users run the `ray attach --port-forward` CLI in another terminal window.

TODO: One problem with this example is user's notebook will not be sync down from the server. Users' code may be lost if not handled properly. Is there a way to keep the workspace synced with the remote in the current implementation?