### PR TITLE
Fix logs sync for n_node

### DIFF
--- a/prototype/sky/backends/cloud_vm_ray_backend.py
+++ b/prototype/sky/backends/cloud_vm_ray_backend.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import textwrap
 from typing import Any, Callable, Dict, List, Optional, Tuple
+from googleapiclient.discovery import Resource
 import yaml
 
 import colorama
@@ -510,12 +511,33 @@ class CloudVmRayBackend(backends.Backend):
                 f'(To view the task names: ray exec {handle} "ls {log_dir}/")')
 
         self._exec_code_on_head(handle, codegen)
+        # Get external IPs for the nodes
+        external_ips = self._get_node_ips(handle,
+                                          expected_num_nodes=1,
+                                          return_private_ips=False)
+        self._rsync_down_logs(handle, log_dir, external_ips)
+
+    def _rsync_down_logs(self,
+                         handle: ResourceHandle,
+                         log_dir: str,
+                         ips: List[str] = None):
         local_log_dir = os.path.join(f'{self.log_dir}', 'tasks')
+        Style = colorama.Style
         logger.info(
-            f'Syncing down the logs to {Style.BRIGHT}{local_log_dir}{Style.RESET_ALL}.'
+            f'Syncing down the logs to {Style.BRIGHT}{local_log_dir}{Style.RESET_ALL}'
         )
         os.makedirs(local_log_dir, exist_ok=True)
-        _run(f'ray rsync_down {handle} {log_dir}/* {local_log_dir}')
+        # Call the ray sdk to rsync the logs back to local.
+        for ip in ips:
+            sdk.rsync(
+                handle,
+                source=f'{log_dir}/*',
+                target=f'{local_log_dir}',
+                down=True,
+                ip_address=ip,
+                use_internal_ip=False,
+                should_bootstrap=False,
+            )
 
     def _exec_code_on_head(self,
                            handle: ResourceHandle,
@@ -641,25 +663,12 @@ class CloudVmRayBackend(backends.Backend):
                 f'(To view the task names: ray exec {handle} "ls {log_dir}/")')
 
         self._exec_code_on_head(handle, codegen)
-        local_log_dir = os.path.join(f'{self.log_dir}', 'tasks')
-        logger.info(
-            f'Syncing down the logs to {Style.BRIGHT}{local_log_dir}{Style.RESET_ALL}.'
-        )
-        os.makedirs(local_log_dir, exist_ok=True)
+
+        # Get external IPs for the nodes
         external_ips = self._get_node_ips(handle,
                                           task.num_nodes,
                                           return_private_ips=False)
-        # Call the ray sdk to rsync the logs back to local.
-        for ip in external_ips:
-            sdk.rsync(
-                handle,
-                source=f'{log_dir}/*',
-                target=f'{local_log_dir}',
-                down=True,
-                ip_address=ip,
-                use_internal_ip=False,
-                should_bootstrap=False,
-            )
+        self._rsync_down_logs(handle, log_dir, external_ips)
 
     def post_execute(self, handle: ResourceHandle, teardown: bool) -> None:
         colorama.init()


### PR DESCRIPTION
We will now sync the logs back to local from the ray workers one by one for `_execute_task_n_nodes` using `ray.autoscaler.sdk`, since ray cli does not support syncing files from workers. 