### PR TITLE
Fix T4

### DIFF
--- a/prototype/tests/test_optimizer_dryruns.py
+++ b/prototype/tests/test_optimizer_dryruns.py
@@ -21,7 +21,6 @@ def test_resources_gcp():
     _test_resources(sky.Resources(clouds.GCP(), 'n1-standard-16'))
 
 
-@pytest.mark.skip(reason='TODO: need to fix service catalog')
 def test_partial_t4():
     _test_resources(sky.Resources(accelerators='T4'))
     _test_resources(sky.Resources(accelerators={'T4': 8}, use_spot=True))


### PR DESCRIPTION
AWS offers `g4dn.{1,2,4,8,16}xlarge` instances, all of which has 1x T4 GPU. Without user specifying memory and other constraints, pick the cheapest one for them.