### PR TITLE
Fix the incomplete logs

### DIFF
--- a/prototype/sky/backends/backend_utils.py
+++ b/prototype/sky/backends/backend_utils.py
@@ -251,11 +251,12 @@ def redirect_process_output(proc, log_path, stream_logs, start_streaming_at=''):
 
     start_streaming_flag = False
     with open(log_path, 'a') as fout:
-        while True:
+        while len(sel.get_map()) > 0:
             for key, _ in sel.select():
                 line = key.fileobj.readline()
                 if not line:
-                    return stdout, stderr
+                    sel.unregister(key.fileobj)
+                    break
                 if start_streaming_at in line:
                     start_streaming_flag = True
                 if key.fileobj is out_io:
@@ -268,3 +269,4 @@ def redirect_process_output(proc, log_path, stream_logs, start_streaming_at=''):
                     fout.flush()
                 if stream_logs and start_streaming_flag:
                     print(line, end='')
+    return stdout, stderr

--- a/prototype/sky/backends/cloud_vm_ray_backend.py
+++ b/prototype/sky/backends/cloud_vm_ray_backend.py
@@ -58,11 +58,12 @@ _TASK_LAUNCH_CODE_GENERATOR = """\
 
             start_streaming_flag = False
             with open(log_path, 'a') as fout:
-                while True:
+                while len(sel.get_map()) > 0:
                     for key, _ in sel.select():
                         line = key.fileobj.readline()
                         if not line:
-                            return stdout, stderr
+                            sel.unregister(key.fileobj)
+                            break
                         if start_streaming_at in line:
                             start_streaming_flag = True
                         if key.fileobj is out_io:
@@ -75,6 +76,7 @@ _TASK_LAUNCH_CODE_GENERATOR = """\
                             fout.flush()
                         if stream_logs and start_streaming_flag:
                             print(line, end='')
+            return stdout, stderr
         
         futures = []
 


### PR DESCRIPTION
The previous implementation will cause incomplete stdout or stderr, since the `redirect_process_output` will return the stdout/stderr whenever it meets EOF, but the stderr sometimes may not finish when stdout reaches EOF.