### PR TITLE
[easy] Fix Task repr

### DIFF
--- a/prototype/sky/task.py
+++ b/prototype/sky/task.py
@@ -292,10 +292,13 @@ class Task(object):
     def __repr__(self):
         if self.name:
             return self.name
-        if len(self.run) > 20:
-            s = 'Task(run=\'{}...\')'.format(self.run[:20])
+        if isinstance(self.run, str):
+            if len(self.run) > 20:
+                s = 'Task(run=\'{}...\')'.format(self.run[:20])
+            else:
+                s = 'Task(run=\'{}\')'.format(self.run)
         else:
-            s = 'Task(run=\'{}\')'.format(self.run)
+            s = 'Task(run=<generated>)'
         if self.inputs is not None:
             s += '\n  inputs: {}'.format(self.inputs)
         if self.outputs is not None:


### PR DESCRIPTION
Printing tasks now crashes if `task.run` is a function, e.g. in `multi_hostname.py`. This fixes it.

TODO(later): add these things into CI testing.