### PR TITLE
Fix Azure restarting existing instance with different cluster_name

### DIFF
--- a/prototype/config/azure-ray.yml.j2
+++ b/prototype/config/azure-ray.yml.j2
@@ -7,6 +7,10 @@ idle_timeout_minutes: 60
 provider:
     type: azure
     location: {{region}}
+    # Ref: https://github.com/ray-project/ray/blob/2367a2cb9033913b68b1230316496ae273c25b54/python/ray/autoscaler/_private/_azure/node_provider.py#L87
+    # For Azure, ray distinguishes different instances by the resource_group,
+    # instead of the cluster_name. This ensures that ray creates new instances
+    # for different cluster_name.
     resource_group: {{cluster_name}}
 
 auth:


### PR DESCRIPTION
According to the [source code](https://github.com/ray-project/ray/blob/02465a6792ff625ceea60dae4ef3cbcb895ee083/python/ray/autoscaler/_private/_azure/node_provider.py#L76), for Azure, `ray` distinguishes different instances by the `resource_group`, instead of the `cluster_name`. Making `resource_group=cluster_name` for different clusters solves the problem in the title (the first problem in #110).