### PR TITLE
Add `sky tpunode`

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -562,7 +562,7 @@ def cpunode(cluster: str, port_forward: Optional[List[int]], screen):
         name = _default_interactive_node_name('cpunode')
     _create_and_ssh_into_node(
         'cpunode',
-        sky.Resources(sky.GCP()),
+        sky.Resources(sky.AWS()),
         cluster_name=name,
         port_forward=port_forward,
         use_screen=screen,


### PR DESCRIPTION
TPU nodes in addition to GPU/CPU nodes! Verified that `sky tpunode` exhibits same functionality as cpunode/gpunode and that the TPU is actually attached to the created cluster using `capture_tpu_profile --tpu=$TPU_NAME  --monitoring_level=2`.