### PR TITLE
[CLI] Improve interactive node configurability

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -229,7 +229,7 @@ def _create_and_ssh_into_node(
     commands = backend.ssh_head_command(handle, port_forward=port_forward)
     if session_manager == 'screen':
         commands += ['screen', '-D', '-R']
-    if session_manager == 'tmux':
+    elif session_manager == 'tmux':
         commands += ['tmux', 'attach', '||', 'tmux', 'new']
     backend_utils.run(commands, shell=False, check=False)
     cluster_name = global_user_state.get_cluster_name_from_handle(handle)


### PR DESCRIPTION
This should really be `sky up ARGS` and then `sky gpunode`/`sky tpunode`/`sky cpunode` are just aliases with single node defaults. 