### PR TITLE
Specify the version of pycryptodome to avoid errors.

### DIFF
--- a/prototype/requirements.txt
+++ b/prototype/requirements.txt
@@ -5,7 +5,7 @@ jinja2
 networkx
 oauth2client
 pandas
-pycryptodome
+pycryptodome==3.4.3
 pendulum
 PrettyTable
 pytest


### PR DESCRIPTION
Without specifying the version, there will be an error `ModuleNotFoundError: No module named 'Crypto'`. [Reference](https://github.com/openthread/openthread/issues/1137) as mentioned by @michaelzhiluo. 