### PR TITLE
Add agent forwarding for `sky [cpu|gpu|tpu]node` connections

### DIFF
--- a/prototype/sky/backends/cloud_vm_ray_backend.py
+++ b/prototype/sky/backends/cloud_vm_ray_backend.py
@@ -109,6 +109,8 @@ def _ssh_options_list(ssh_private_key: Optional[str],
         'ControlPersist': '30s',
         # ConnectTimeout.
         'ConnectTimeout': '{}s'.format(timeout),
+        # ForwardAgent (for git credentials).
+        'ForwardAgent': 'yes',
     }
     ssh_key_option = [
         '-i',


### PR DESCRIPTION
This fixes an issue raised by @concretevitamin.

Currently agent forwarding (for git credentials, etc.) only works when using `ssh` directly (e.g. `ssh my_cluster`). This can be confusing because `sky cpunode -c my_cluster` also provides an interactive session but agent forwarding is not present (and git operations won't work with your local SSH keys). This PR fixes that.

## Tests
- [x] Successfully cloned private repo with `sky cpunode -c my_cluster`
