### PR TITLE
Fix the stream_logs option removing bug

### DIFF
--- a/prototype/sky/execution.py
+++ b/prototype/sky/execution.py
@@ -130,7 +130,7 @@ def _execute(dag: sky.Dag,
 
         if stages is None or Stage.EXEC in stages:
             try:
-                backend.execute(handle, task, stream_logs, detach_run)
+                backend.execute(handle, task, detach_run)
             finally:
                 # Enables post_execute() to be run after KeyboardInterrupt.
                 backend.post_execute(handle, teardown)


### PR DESCRIPTION
Sorry that my previous PR #176 introduced a bug after removing the stream_logs option from the `backend.execute`. This is a quick fix for that.