### PR TITLE
Disable workdir sync for interactive nodes

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -230,6 +230,8 @@ def _create_and_ssh_into_node(
                                    stream_logs=True,
                                    cluster_name=cluster_name)
 
+    # Use ssh rather than 'ray attach' to suppress ray messages, speed up
+    # connection, and for allowing adding 'cd workdir' in the future.
     # Disable check, since the returncode could be non-zero if the user Ctrl-D.
     commands = backend.ssh_head_command(handle, port_forward=port_forward)
     if session_manager == 'screen':


### PR DESCRIPTION
This is to address #135.

After discussion with @Michaelvll, it seems that `--sync` has slightly confusing semantics, since it only runs on cluster init. Additionally, what if you want to sync down or sync up? What if you want to a sync a workdir that's not the current directory. While we could design a custom solution that satisfies these requirements, it is much simpler for a user to use `rsync`, so we `rsync` examples in help strings everywhere.

### Tests
- [x] No longer syncs workdir
- [x] `rsync` commands work