### PR TITLE
Fix smoke multi-job test

### DIFF
--- a/prototype/examples/run_smoke_tests.sh
+++ b/prototype/examples/run_smoke_tests.sh
@@ -65,8 +65,9 @@ time sky launch -c jq "$DIR"/job_queue/cluster.yaml
 time sky exec -c jq "$DIR"/job_queue/job.yaml -d
 time sky exec -c jq "$DIR"/job_queue/job.yaml -d
 time sky exec -c jq "$DIR"/job_queue/job.yaml -d
-# TODO(suquark): wait all jobs to be terminated. use 'sleep' as a workaround now
-sleep 150
+sky logs -c jq 2
+# TODO(suquark): wait all jobs to complete. use 'sleep' as a workaround now
+sleep 30
 sky queue jq
 sky down jq &
 
@@ -77,8 +78,8 @@ time sky exec -c mjq -d "$DIR"/job_queue/job_multinode.yaml -d
 # The job id is automatically incremented from 1 (inclusive).
 sky cancel -c mjq 1
 sky logs -c mjq 2
-# TODO(suquark): wait all jobs to be terminated. use 'sleep' as a workaround now
-sleep 150
+# TODO(suquark): wait all jobs to complete. use 'sleep' as a workaround now
+sleep 30
 sky queue mjq
 sky down mjq &
 


### PR DESCRIPTION
The yaml file path in the smoke test is incorrect, so the smoke test was not actually working.