### PR TITLE
Hide pip warning messages

### DIFF
--- a/prototype/sky/backends/backend_utils.py
+++ b/prototype/sky/backends/backend_utils.py
@@ -336,10 +336,11 @@ def _build_sky_wheel() -> pathlib.Path:
             str(wheel_dir)
         ],
                        stdout=subprocess.DEVNULL,
-                       stderr=subprocess.DEVNULL,
+                       stderr=subprocess.PIPE,
                        check=True)
     except subprocess.CalledProcessError as e:
-        raise RuntimeError('Fail to build pip wheel for Sky.') from e
+        raise RuntimeError('Fail to build pip wheel for Sky. '
+                           f'Error message: {e.stderr.decode()}') from e
     try:
         latest_wheel = max(wheel_dir.glob('sky-*.whl'), key=os.path.getctime)
     except ValueError:


### PR DESCRIPTION
Older pip versions would generate various warning messages, and we want to hide them from users. One is known as https://stackoverflow.com/questions/67301493/what-does-this-deprecation-warning-mean-and-how-to-fix-it.

**Why not disable them with pip flags?**: Unfortunately, these flags generate warnings and errors when using new pip versions, because newer pip versions could drop these flags. Besides, pip could generate `WARNING: You are using pip version xxx; however, version yyy is available.` at any time. Another workaround could be using the `redirect_process_output` util, but I am not confident with pip warnings.

Close #218 