### PR TITLE
Fix -a option for sky down

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -937,7 +937,7 @@ def down(
                 fg='yellow')
         else:
             names.append(cluster_name)
-    if not names:
+    if not all and not names:
         return
     _terminate_or_stop_clusters(names, apply_to_all=all, terminate=True)
 


### PR DESCRIPTION
This is a quick fix for `-a` option for sky down. Otherwise, it will just skip termination.