### PR TITLE
Fix gpu override option in launch and exec

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -27,6 +27,7 @@ NOTE: the order of command definitions in this file corresponds to how they are
 listed in "sky --help".  Take care to put logically connected commands close to
 each other.
 """
+import copy
 import functools
 import getpass
 import time
@@ -402,11 +403,10 @@ def launch(entrypoint: str, cluster: Optional[str], dryrun: bool,
         if workdir is not None:
             task.workdir = workdir
         if gpus is not None:
-            task.set_resources(
-                sky.Resources(cloud=task.cloud,
-                              accelerators=_parse_accelerator_options(gpus),
-                              accelerator_args=task.accelerator_args,
-                              use_spot=task.use_spot))
+            assert len(task.resources) == 1
+            copied = copy.deepcopy(list(task.resources)[0])
+            copied.accelerators = _parse_accelerator_options(gpus)
+            task.set_resources({copied})
         if name is not None:
             task.name = name
 
@@ -547,11 +547,10 @@ def exec(cluster: str, entrypoint: str, detach_run: bool,
         if workdir is not None:
             task.workdir = workdir
         if gpus is not None:
-            task.set_resources(
-                sky.Resources(cloud=task.cloud,
-                              accelerators=_parse_accelerator_options(gpus),
-                              accelerator_args=task.accelerator_args,
-                              use_spot=task.use_spot))
+            assert len(task.resources) == 1
+            copied = copy.deepcopy(list(task.resources)[0])
+            copied.accelerators = _parse_accelerator_options(gpus)
+            task.set_resources({copied})
         if name is not None:
             task.name = name
 


### PR DESCRIPTION
The `--gpus` option for launch and exec does not respect the `cloud`, `accelerator_args` and `use_spot` options in the task.yaml. In this fix, I only override `accelerators` for the resources. #249 