### PR TITLE
Fix interactive node resource check when no cloud is specified

### DIFF
--- a/prototype/sky/cli.py
+++ b/prototype/sky/cli.py
@@ -220,6 +220,15 @@ def _check_interactive_node_resources_match(
         launched_resources: Existing launched resources associated with cluster.
         user_requested_resources: If true, user requested resources explicitly.
     """
+    # In the case where the user specifies no cloud, we infer the cloud from
+    # the launched resources before performing the check.
+    # e.g. user launches sky gpunode --gpus V100 creates an AWS(p3.2xlarge)
+    # but when the resource check will fail because is_same_resources expects
+    # resources.cloud and handle.launched_resources to match.
+    if resources.cloud is None:
+        assert launched_resources.cloud is not None, launched_resources
+        resources.cloud = launched_resources.cloud
+
     # TODO: Check for same number of launched_nodes if multi-node support is
     # added for gpu/cpu/tpunode.
     inferred_node_type = _infer_interactive_node_type(launched_resources)

--- a/prototype/tests/test_cli.py
+++ b/prototype/tests/test_cli.py
@@ -124,3 +124,14 @@ def test_node_type_check():
                 launched_resources,
                 user_requested_resources=False)
         assert 'Resources cannot change for an existing cluster' in str(e.value)
+
+
+def test_infer_cloud_resource_check():
+    # sky gpunode --gpus V100
+    resources = sky.Resources(cloud=None, accelerators='V100')
+    launched_resources = sky.Resources(cloud=sky.AWS(),
+                                       instance_type='p3.2xlarge')
+    cli._check_interactive_node_resources_match('gpunode',
+                                                resources,
+                                                launched_resources,
+                                                user_requested_resources=True)


### PR DESCRIPTION
This should get merged after #216.

`resources.is_same_resources` will currently return `False` if a user re-uses a cluster where the default cloud is `None` and the launched resources are something like `AWS(p3.2xlarge)`, causing our resource check to fail for cases like the following:

```
sky gpunode -c t1 --gpus V100
sky gpunode -c t2 --gpus K80
```

To handle this, the cloud is inferred from the launched resources before running the resource check with user-specified resources.

### Tests 
- [x] Add unit tests to handle this once #216 is merged
- [x] command line tests from #216 description
- [x] smoke tests