### PR TITLE
[Storage] Progress Bar on Sky Storage

### DIFF
--- a/prototype/sky/data/storage.py
+++ b/prototype/sky/data/storage.py
@@ -1,8 +1,6 @@
 """Storage and Store Classes for Sky Data."""
 import enum
 import os
-import glob
-from multiprocessing import pool
 from typing import Any, Dict, Optional, Tuple
 
 from sky.data import data_utils, data_transfer


### PR DESCRIPTION
Before, there was no progress bar for the first time user ran with Sky Storage since there was manual code to upload/download files. Now the code has been removed.

Everytime Sky Storage storage is run, the backend will now use `aws s3 sync` and `gsutil rsync` to sync the bucket and the local folder. These commands implicitly have progress bars.

Images:
AWS
<img width="599" alt="Screen Shot 2022-02-09 at 10 44 35 PM" src="https://user-images.githubusercontent.com/20640975/153352299-7ea81f23-f89c-4513-ad33-6b9f9a82e6e3.png">
GCP
<img width="353" alt="Screen Shot 2022-02-09 at 10 45 10 PM" src="https://user-images.githubusercontent.com/20640975/153352367-fb6d09ea-a6a9-4ef6-abc9-0634b50d8c7b.png">

## Tests

`python examples/storage_playground.py` runs all the way through, syncing all the folders and buckets correctly.