### PR TITLE
Remove capture_output to maintain py3.6 support

### DIFF
--- a/prototype/sky/backends/backend_utils.py
+++ b/prototype/sky/backends/backend_utils.py
@@ -763,7 +763,8 @@ def check_local_gpus() -> bool:
     Returns True if nvidia-smi is installed, false if not.
     """
     p = subprocess.run(['which', 'nvidia-smi'],
-                       capture_output=True,
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL,
                        check=False)
     return p.returncode == 0
 


### PR DESCRIPTION
 Closes #329 by redirecting output to devnull instead of using capture_output.