### PR TITLE
Add setup commands to install pip3/conda when needed

### DIFF
--- a/prototype/sky/templates/azure-ray.yml.j2
+++ b/prototype/sky/templates/azure-ray.yml.j2
@@ -100,10 +100,10 @@ rsync_filter:
 setup_commands:
   # This AMI's system Python is version 2+.
   # _gang_schedule_ray_up() requires first two lines; do not modify.
-  - (which pip3 || (sudo apt-get update && sudo apt install -y python3-pip)) && pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful
+  - (which pip3 > /dev/null 2>&1 || (sudo apt-get update && sudo apt install -y python3-pip)) && pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful
   # We have to install azure-cli because the Azure cluster does not pre-install it.
   - pip3 uninstall sky -y &> /dev/null; pip3 install {{sky_remote_path}}/*.whl && pip3 install azure-cli==2.30.0 && python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
-  - which conda || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base false)
+  - which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base false)
 {%- if setup_sh_path is not none %}
   - cd ~/sky_workdir && bash /tmp/setup.sh  # FIXME: /tmp is volatile.
 {%- endif %}


### PR DESCRIPTION
Azure A100 VM requires the ubuntu hpc image where pip3/conda are not installed.
To fix this I add commands in the yaml template to install pip3/conda when needed.