### PR TITLE
Fix Azure credential errors on AWS

### DIFF
--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -59,8 +59,9 @@ class AzureNodeProvider(NodeProvider):
         subscription_id = provider_config["subscription_id"]
         self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes", True)
         # AWS provides managed identity for Azure, but it is not setup properly by
-        # default. This interferes with azure-cli credentials and causes failures.
-        # We disable it to give way to azure-cli credentials.
+        # default. This interferes with azure-cli credentials and causes failures,
+        # when using sky to launch Azure on AWS ec2 instances. We disable it to give
+        # way to azure-cli credentials.
         credential = DefaultAzureCredential(exclude_shared_token_cache_credential=True,
                                             exclude_managed_identity_credential=True)
         self.compute_client = ComputeManagementClient(credential, subscription_id)


### PR DESCRIPTION
AWS provides managed identity for Azure, but it is not setup properly by default. This interferes with azure-cli credentials and causes failures. We disable it to give way to azure-cli credentials.

Closes #364