### PR TITLE
README example: change `K80:4` to `V100:1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sky launch -c mycluster hello_sky.yaml
 ```yaml
 # hello_sky.yaml
 resources:
-  accelerators: K80:4
+  accelerators: V100:1  # 1x NVIDIA V100 GPU
 
 setup: |
   # Typical use: pip install -r requirements.txt


### PR DESCRIPTION
Reasons:
- `K80:4` is not available on AWS, arguably the most common cloud our target users use, so they will hit resource unavailable
- `V100:1` is available on all three clouds and is a popular GPU