### PR TITLE
Fix `check_local_gpus`

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -737,22 +737,24 @@ def check_local_gpus() -> bool:
     Checks if GPUs are available locally.
 
     Returns whether GPUs are available on the local machine by checking
-    if nvidia-smi is installed and returns normally.
+    if nvidia-smi is installed and returns zero return code.
 
-    Returns True if nvidia-smi is installed and returns normally,
+    Returns True if nvidia-smi is installed and returns zero return code,
     False if not.
     """
+    is_functional = False
     installation_check = subprocess.run(['which', 'nvidia-smi'],
                                         stdout=subprocess.DEVNULL,
                                         stderr=subprocess.DEVNULL,
                                         check=False)
-    if installation_check.returncode == 0:
+    is_installed = installation_check.returncode == 0
+    if is_installed == 0:
         execution_check = subprocess.run(['nvidia-smi'],
                                          stdout=subprocess.DEVNULL,
                                          stderr=subprocess.DEVNULL,
                                          check=False)
-    return (installation_check.returncode == 0 and
-            execution_check.returncode == 0)
+        is_functional = execution_check.returncode == 0
+    return is_functional
 
 
 def generate_cluster_name():


### PR DESCRIPTION
Fixes #410 

Now the function additionally checks if the `nvidia-smi` toolkit actually works by seeing its return code.
If the machine has a GPU, `nvidia-smi` will return successfully.
Otherwise, `nvidia-smi` returns:
```bash
NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running.
```
with the return code 9.