### PR TITLE
[docker] Fix a bug in launching a task with a working directory

### DIFF
--- a/sky/backends/docker_utils.py
+++ b/sky/backends/docker_utils.py
@@ -167,7 +167,7 @@ def build_dockerimage(task, tag):
     if copy_path:
         copy_dir_name = os.path.basename(os.path.dirname(copy_path))
         dst = os.path.join(temp_dir, copy_dir_name)
-        shutil.copytree(os.path.expanduser(copy_path), dst)
+        shutil.copytree(os.path.expanduser(copy_path), dst, dirs_exist_ok=True)
     logger.info(f'Using tempdir {temp_dir} for docker build.')
 
     # Run docker image build


### PR DESCRIPTION
Fixes #303
In fact, `sky launch examples/minimal.yaml --docker --workdir .` didn't work.

The problem is solved by simply adding `dirs_exist_ok=True` to `shutil.copytree`.
The destination temporary directory is not empty because it contains Dockerfile and setup scripts created by `create_dockerfile` in the preceding lines.