### PR TITLE
[docker] Quick fix to remove already-dead docker containers from `sky status`

### DIFF
--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -349,6 +349,10 @@ class LocalDockerBackend(backends.Backend):
             logger.warning(
                 'LocalDockerBackend.teardown() will terminate '
                 'containers for now, despite receiving terminate=False.')
+
+        # If handle is not found in the self.containers, it implies it has
+        # already been removed externally in docker. No action is needed
+        # except for removing it from global_user_state.
         if handle in self.containers:
             container = self.containers[handle]
             container.remove(force=True)


### PR DESCRIPTION
This PR is a quick fix for #416

Currently, `sky status` does not reflect the status change in docker containers that are externally stopped/removed (e.g., by `docker rm`).
This PR enables users to manually remove those containers by `sky stop`.