### PR TITLE
Fixing Relative Directory for Workdir and File Mounts (`~/sky_workdir/...` not `~/sky_workdir/workdir/...`)

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1241,9 +1241,9 @@ class CloudVmRayBackend(backends.Backend):
 
         # (2) Run the commands to create symlinks on all the nodes.
         symlink_command = ' && '.join(symlink_commands)
+        if not symlink_command:
+            return
         for ip in ip_list:
-            if not symlink_command:
-                break
             backend_utils.run_command_on_ip_via_ssh(
                 ip,
                 symlink_command,


### PR DESCRIPTION
Fixes #442 

The original PR #431 addressed symlinks by rsyncing only the symbolic link IF the specified filemount/workdir is a symbolic link. These changes introduced a new bug, which alters with `workdir` and `filemounts` dirs are located relative to mount path.

This is due to `rsync ~/Downloads/temp server:/sky` vs `rsync ~/Downloads/temp/ server:/sky` having very different behaviors. 
Problem 1: Choosing `rsync ~/Downloads/temp server:/sky` results in `~/sky_workdir/workdir/...` which is bad.
Problem 2: Choosing `rsync ~/Downloads/temp/ server:/sky` affects symbolic links.   if ` ~/Downloads/temp/` is a symlink, `rsync ~/Downloads/temp/ server:/sky` uploads the symlink's target folder contents.

This PR achieves a compromise between these two problems. When the workdir/source path is a symlink, it will `rsync ~/Downloads/temp server:/sky` and upload nothing onto the server (except for symlink). Otherwise (not a symlink normal dir), it will ``rsync ~/Downloads/temp/ server:/sky`

## Tests
- [x] Passes `examples/using_file_mounts.yaml`
- [x] Passes `examples/resnet_app_storage.yaml` (Tests the relative placement of workdir and file mounts such as all the TF record files in `/tmp/imagenet/...` for training)
<img width="1240" alt="Screen Shot 2022-02-24 at 3 26 56 AM" src="https://user-images.githubusercontent.com/20640975/155515719-67aba9fe-3cf1-4a8e-b86c-a617a34461f3.png">


