### PR TITLE
Fix using_file_mounts

### DIFF
--- a/examples/using_file_mounts.yaml
+++ b/examples/using_file_mounts.yaml
@@ -106,4 +106,5 @@ run: |
   # ls -lH /data/fake_imagenet | head -n10
 
   # sky.egg-info/ should not exists on remote due to the .gitingore
+  cd ~/sky_workdir
   ! ls sky.egg-info/


### PR DESCRIPTION
This PR fixes a bug introduced in #448 to `examples/using_file_mounts.yaml`. We were supposed to test the existence of `sky.egg-info` under the `~/sky_workdir`, but the original one tested it under `/sky`.