### PR TITLE
Fix rsync_exclude for gcp credential file_mounts

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -260,6 +260,6 @@ class GCP(clouds.Cloud):
         # credential, which causes problem for ray up multiple nodes, tracked
         # in #494, #496, #483.
         # rsync_exclude only supports relative paths.
-        return {
-            '~/.config/gcloud': '~/.config/gcloud'
-        }, ['/virtenv/bin/python*']
+        # TODO(zhwu): rsync_exclude here is unsafe as it may exclude the folder
+        # from other file_mounts as well in ray yaml.
+        return {'~/.config/gcloud': '~/.config/gcloud'}, ['virtenv']


### PR DESCRIPTION
Closes #494. The `rsync_exclude` will treat the absolute path as the relative path, so the previous symlink problem observed in #483 still exists. I changed the `rsync_exclude` for the symlink in the credential to be a relative path. The solution is a bit hacky right now, but it may be good to fix it first and then refactor it later.

Tested:
- [x] `sky launch -c fm examples/using_file_mounts.yaml` (adding a private gcs link in the file_mounts)