### PR TITLE
Fix Azure resource leak

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1707,7 +1707,7 @@ class CloudVmRayBackend(backends.Backend):
                     stream_logs=False,
                     require_outputs=True)
         elif (terminate and
-                prev_status == global_user_state.ClusterStatus.STOPPED):
+              prev_status == global_user_state.ClusterStatus.STOPPED):
             if isinstance(cloud, clouds.AWS):
                 # TODO(zhwu): Room for optimization. We can move these cloud
                 # specific handling to the cloud class.

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -56,7 +56,11 @@ class AzureNodeProvider(NodeProvider):
 
     def __init__(self, provider_config, cluster_name):
         NodeProvider.__init__(self, provider_config, cluster_name)
-        # TODO(suquark): This is a temporary patch for creating the non-existing resource group.
+        # TODO(suquark): This is a temporary patch for resource group.
+        # By default, Ray autoscaler assumes the resource group is still here even
+        # after the whole cluster is destroyed. However, now we deletes the resource
+        # group after tearing down the cluster. To comfort the autoscaler, we need
+        # to create/update it here, so the resource group always exists.
         from sky.skylet.providers.azure.config import _configure_resource_group
         _configure_resource_group({"provider": provider_config})
         subscription_id = provider_config["subscription_id"]


### PR DESCRIPTION
Unfortunately I cannot reproduce the bug with my laptop. But it looks like the valid fix. @infwinston Could you try this simple fix?

BTW, we are still leaking other resources for all clouds (because of design of Ray autoscaler), e.g., credentials and security configurations. Not sure if there are limits of these resources. Check https://portal.azure.com/#blade/HubsExtension/BrowseResourceGroups for details. The fundamental fix would be deleting the resource group, which turns out incompatible with Ray autoscaler (raise exceptions). Also deleting the resource group is the correct way of cleaning up azure resources.

Closes #426
Closes #508