### PR TITLE
Switched `cancel` to `logs` in relevant place in docs

### DIFF
--- a/docs/source/examples/launch-many-tasks-vm.rst
+++ b/docs/source/examples/launch-many-tasks-vm.rst
@@ -34,7 +34,7 @@ To cancel a job, we can follow a similar pattern:
    sky queue mycluster
 
    # Pick a JOB_ID to view
-   sky cancel mycluster JOB_ID
+   sky logs mycluster JOB_ID
 
    # Cancel all jobs
    sky cancel mycluster --all

--- a/docs/source/reference/job-queue.rst
+++ b/docs/source/reference/job-queue.rst
@@ -32,7 +32,7 @@ To cancel a job, we can follow a similar pattern:
    sky queue mycluster
 
    # Pick a JOB_ID to view
-   sky cancel mycluster JOB_ID
+   sky logs mycluster JOB_ID
 
    # Cancel all jobs
    sky cancel mycluster --all


### PR DESCRIPTION
I noticed that two places in the docs used:

```
# View the jobs in the queue
sky queue mycluster

# Pick a JOB_ID to view
sky cancel mycluster JOB_ID

# Cancel all jobs
sky cancel mycluster --all
```

It seemed like the second one refers to using `sky logs` instead based on the CLI so this PR fixes that.