### PR TITLE
[docker] Fix a bug in updating image lists

### DIFF
--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -134,7 +134,7 @@ class LocalDockerBackend(backends.Backend):
                 if k.startswith(_DOCKER_LABEL_PREFIX):
                     # Remove 'skymeta_' from key
                     metadata[k[len(_DOCKER_LABEL_PREFIX):]] = v
-            self.images = {c.name: [c.image, metadata]}
+            self.images[c.name] = [c.image, metadata]
             self.containers[c.name] = c
 
     def provision(self,


### PR DESCRIPTION
I think the container image lists are not being properly updated in `_update_state`. Please check it out.

Commands for reproducing the bug:
```bash
sky launch examples/minimal.yaml --docker -c aa -y
sky launch examples/minimal.yaml --docker -c bb -y
sky exec bb -- pwd
```

