### PR TITLE
SSH into Worker Nodes from Local

### DIFF
--- a/docs/source/examples/iterative-dev-project.rst
+++ b/docs/source/examples/iterative-dev-project.rst
@@ -45,7 +45,7 @@ Alternatively, the user can directly :code:`ssh` into the cluster's nodes and ru
   $ ssh dev-worker1
   $ ssh dev-worker2
 
-Sky provides easy password-less SSH access by automatically creating an entry for each cluster's head node in :code:`~/.ssh/config` and worker nodes in :code:`~/.sky/generated/ssh`.
+Sky provides easy password-less SSH access by automatically creating entries for each cluster in :code:`~/.ssh/config`.
 Referring to clusters by names also allows for seamless integration with common tools
 such as :code:`scp`, :code:`rsync`, and `Visual Studio Code Remote
 <https://code.visualstudio.com/docs/remote/remote-overview>`_.

--- a/docs/source/examples/syncing-code-artifacts.rst
+++ b/docs/source/examples/syncing-code-artifacts.rst
@@ -111,14 +111,12 @@ Downloading files and artifacts
 After a task's execution, artifacts such as **logs and checkpoints** may be
 transferred from remote clusters to the local machine.
 
-To transfer files from the head node of a cluster, use :code:`rsync` (or :code:`scp`):
+To transfer files from cluster nodes, use :code:`rsync` (or :code:`scp`):
 
 .. code-block:: console
 
+  $ # Rsync from head
   $ rsync -Pavz dev:/path/to/checkpoints local/
 
-.. note::
-    For a multi-node cluster, Sky currently does not natively support
-    downloading artifacts from the worker machines.  As temporary workarounds,
-    query the worker IPs from the cloud console, and run :code:`rsync -Pavz -e
-    'ssh -i ~/.ssh/sky-key' <worker_ip>:/path /local_path`.
+  $ # Rsync from worker nodes (1-based indexing)
+  $ rsync -Pavz dev-worker1:/path/to/checkpoints local/

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -270,22 +270,22 @@ class SSHConfigHelper(object):
     def _add_multinode_config(
         cls,
         cluster_name: str,
-        ips: List[str],
+        worker_ips: List[str],
         auth_config: Dict[str, str],
     ):
         username = auth_config['ssh_user']
         key_path = os.path.expanduser(auth_config['ssh_private_key'])
         host_name = cluster_name
-        sky_autogen_comment = '# Added by sky (use `sky stop/down ' + \
-                            f'{cluster_name}` to remove)'
+        sky_autogen_comment = ('# Added by sky (use `sky stop/down '
+                               f'{cluster_name}` to remove)')
 
-        overwrites = [False] * len(ips)
-        overwrite_begin_idxs = [None] * len(ips)
-        codegens = [None] * len(ips)
+        overwrites = [False] * len(worker_ips)
+        overwrite_begin_idxs = [None] * len(worker_ips)
+        codegens = [None] * len(worker_ips)
         worker_names = []
         extra_path_name = cls.ssh_multinode_path.format(cluster_name)
 
-        for idx in range(len(ips)):
+        for idx in range(len(worker_ips)):
             worker_names.append(cluster_name + f'-worker{idx+1}')
 
         config_path = os.path.expanduser(cls.ssh_conf_path)
@@ -329,10 +329,10 @@ class SSHConfigHelper(object):
                 prev_line = config[i - 1] if i > 0 else ''
                 logger.warning(f'{cls.ssh_conf_path} contains '
                                f'host named {worker_names[idx]}.')
-                host_name = ips[idx]
+                host_name = worker_ips[idx]
                 logger.warning(f'Using {host_name} to identify host instead.')
                 codegens[idx] = cls._get_generated_config(
-                    sky_autogen_comment, host_name, ips[idx], username,
+                    sky_autogen_comment, host_name, worker_ips[idx], username,
                     key_path)
 
         # All workers go to ~/.sky/generated/ssh/{cluster_name}
@@ -345,17 +345,17 @@ class SSHConfigHelper(object):
                     overwrites[idx] = True
                     overwrite_begin_idxs[idx] = i - 1
                 codegens[idx] = cls._get_generated_config(
-                    sky_autogen_comment, host_name, ips[idx], username,
+                    sky_autogen_comment, host_name, worker_ips[idx], username,
                     key_path)
 
         # This checks if all codegens have been created.
-        for idx, ip in enumerate(ips):
+        for idx, ip in enumerate(worker_ips):
             if not codegens[idx]:
                 codegens[idx] = cls._get_generated_config(
                     sky_autogen_comment, worker_names[idx], ip, username,
                     key_path)
 
-        for idx in range(len(ips)):
+        for idx in range(len(worker_ips)):
             # Add (or overwrite) the new config.
             overwrite = overwrites[idx]
             overwrite_begin_idx = overwrite_begin_idxs[idx]
@@ -453,8 +453,8 @@ class SSHConfigHelper(object):
             os.remove(extra_config_path)
 
         # Delete include statement
-        sky_autogen_comment = '# Added by sky (use `sky stop/down ' + \
-                            f'{cluster_name}` to remove)'
+        sky_autogen_comment = ('# Added by sky (use `sky stop/down '
+                               f'{cluster_name}` to remove)')
         with open(config_path) as f:
             config = f.readlines()
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -99,18 +99,6 @@ def _get_task_demands_dict(task: Task) -> Optional[Tuple[Optional[str], int]]:
     return accelerator_dict
 
 
-def _add_cluster_to_ssh_config(cluster_name: str, cluster_ips: List[str],
-                               auth_config: Dict[str, str]) -> None:
-    backend_utils.SSHConfigHelper.add_cluster(cluster_name, cluster_ips,
-                                              auth_config)
-
-
-def _remove_cluster_from_ssh_config(cluster_name: str, cluster_ip: str,
-                                    auth_config: Dict[str, str]) -> None:
-    backend_utils.SSHConfigHelper.remove_cluster(cluster_name, cluster_ip,
-                                                 auth_config)
-
-
 def _path_size_megabytes(path: str) -> int:
     """Returns the size of 'path' (directory or file) in megabytes."""
     return int(
@@ -1265,7 +1253,8 @@ class CloudVmRayBackend(backends.Backend):
                                                     handle,
                                                     ready=True)
             auth_config = backend_utils.read_yaml(handle.cluster_yaml)['auth']
-            _add_cluster_to_ssh_config(cluster_name, ip_list, auth_config)
+            backend_utils.SSHConfigHelper.add_cluster(cluster_name, ip_list,
+                                                      auth_config)
             os.remove(lock_path)
             return handle
 
@@ -1978,8 +1967,9 @@ class CloudVmRayBackend(backends.Backend):
                 f'{stderr}{colorama.Style.RESET_ALL}')
 
         auth_config = backend_utils.read_yaml(handle.cluster_yaml)['auth']
-        _remove_cluster_from_ssh_config(cluster_name, handle.head_ip,
-                                        auth_config)
+        backend_utils.SSHConfigHelper.remove_cluster(cluster_name,
+                                                     handle.head_ip,
+                                                     auth_config)
         name = global_user_state.get_cluster_name_from_handle(handle)
         global_user_state.remove_cluster(name, terminate=terminate)
 


### PR DESCRIPTION
## Description
This PR allows for easy access to Worker nodes from your local machine.
```
# Launch hello cluster
sky launch -c hello examples/using_file_mounts.yaml

# SSH into head node
ssh hello

# SSH into worker node 1
ssh hello-worker1
```

## Features
- [x] SSH into worker with `ssh [cluster-name]-worker[worker-index]`
- [x] Worker SSH config details are generated in `~/.sky/generated/ssh/[cluster-name]`, linked in `~/.ssh/config`

## Tests
- Launched/Downed/Started/Stopped Single and Multinode clusters in Random Order
- Tested edge case when  `[cluster-name]-worker[worker-index]` is already in `~/.ssh/config`

```
# Added by sky (use `sky stop/down test` to remove)
Include /Users/michaelluo/.sky/generated/ssh/test

# Added by sky (use `sky stop/down bbq` to remove)
Include /Users/michaelluo/.sky/generated/ssh/bbq

Host bb
  HostName 59.152.136.89
  User ubuntu
  IdentityFile /Users/michaelluo/.ssh/sky-key
  IdentitiesOnly yes
  ForwardAgent yes
  StrictHostKeyChecking no
  Port 22

# Added by sky (use `sky stop/down bbq` to remove)
Host bbq
  HostName 100.24.1.14
  User ubuntu
  IdentityFile /Users/michaelluo/.ssh/sky-key
  IdentitiesOnly yes
  ForwardAgent yes
  StrictHostKeyChecking no
  Port 22

# Added by sky (use `sky stop/down test` to remove)
Host test
  HostName 23.20.111.54
  User ubuntu
  IdentityFile /Users/michaelluo/.ssh/sky-key
  IdentitiesOnly yes
  ForwardAgent yes
  StrictHostKeyChecking no
  Port 22

```

### Caveats
- Provision step requires `get_node_ips`.