### PR TITLE
AWS Ray Setup - Alias Python=Python3 if Alias does not exist

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -74,8 +74,8 @@ rsync_exclude: [
 setup_commands:
   # This AMI's system Python is version 2+.
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
-  - type -a python | grep -q python3 && true || echo 'alias python=python3' >> ~/.bashrc;
-    type -a pip | grep -q pip3 && true || echo 'alias pip=pip3' >> ~/.bashrc;
+  - (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
+    (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;


### PR DESCRIPTION
## Description
Adds automatic aliasing to python3 for AWS AMI (since the default python is python2).

## Tests
- Run sky launch -c hello examples/using_file_mounts.yaml many times. Should only observe 1 alias python=python3 in ~/.bashrc and type -a python should show alias to python3.