### PR TITLE
Fix the lock logic for provision

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1127,8 +1127,8 @@ class CloudVmRayBackend(backends.Backend):
 
             head_ip = backend_utils.query_head_ip_with_retries(
                 cluster_config_file,
-                # Retry is useful for azure, as sometimes it will need some time for
-                # ray get-head-ip to be able to fetch the head ip.
+                # Retry is useful for azure, as sometimes it will need some time
+                # for ray get-head-ip to be able to fetch the head ip.
                 retry_count=backend_utils.WAIT_HEAD_NODE_IP_RETRY_COUNT)
             handle = self.ResourceHandle(
                 cluster_name=cluster_name,


### PR DESCRIPTION
I separate this PR from #559, since this is a bit irrelevant with that PR.

L1128-L1148 should be locked to avoid race conditions with `teardown`. 
1. `teardown` can delete the row before L1143 adds an entry, causing the cluster has a `UP` status in the DB but actually killed.
2. `teardown` can delete the cluster_yaml before the read of L1146, causing the file loading failure.
3. `teardown` can remove the ssh entry before L1147, causing an entry in ssh config but actually killed.

@mraheja Do you think it makes sense?