### PR TITLE
Improve optimizer message

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -295,7 +295,14 @@ class Optimizer:
                 for k, v in dp_best_cost.items()
                 if k.name not in (_DUMMY_SOURCE_NAME, _DUMMY_SINK_NAME)
             }
-            metric = 'cost' if minimize_cost else 'time'
+            metric = 'cost ($)' if minimize_cost else 'time (hr)'
+            for k, v in dp_best_cost.items():
+                dp_best_cost[k] = {
+                    resources: round(cost, 2) if minimize_cost \
+                        else round(cost / 3600, 2)
+                    for resources, cost in v.items()
+                }
+
             if len(dp_best_cost) > 1:
                 logger.info(f'Details: task -> {{resources -> {metric}}}')
                 logger.info('%s\n', pprint.pformat(dp_best_cost))


### PR DESCRIPTION
A small PR to better print the optimizer message.

For example,

```bash
$ python examples/example_app.py 
I 03-15 01:22:50 resources.py:79] Missing tf_version in accelerator_args, using default (2.5.0)
I 03-15 01:22:50 optimizer.py:52]   AWS -> GCP egress cost: $53.91 for 600.0 GB
I 03-15 01:22:50 optimizer.py:52]   GCP -> AWS egress cost: $0.012 for 0.1 GB
I 03-15 01:22:50 optimizer.py:52]   GCP -> AWS egress cost: $0.012 for 0.1 GB
I 03-15 01:22:50 optimizer.py:355] Optimizer - plan minimizing cost (~$57.1):
I 03-15 01:22:50 optimizer.py:370] 
I 03-15 01:22:50 optimizer.py:370] TASK      BEST_RESOURCE
I 03-15 01:22:50 optimizer.py:370] train_op  AWS(p3.2xlarge, {'V100': 1})
I 03-15 01:22:50 optimizer.py:370] infer_op  AWS(inf1.2xlarge, {'Inferentia': 1})
I 03-15 01:22:50 optimizer.py:370] 
I 03-15 01:22:50 optimizer.py:300] Details: task -> {resources -> cost}
I 03-15 01:22:50 optimizer.py:301] {train_op: {GCP(n1-standard-8, {'tpu-v3-8': 1}, accelerator_args={'tf_version': '2.5.0'}): 97.61669841451885,
I 03-15 01:22:50 optimizer.py:301]             AWS(p3.8xlarge, {'V100': 4}): 113.27995151999997,
I 03-15 01:22:50 optimizer.py:301]             AWS(p3.2xlarge, {'V100': 1}): 55.859051519999994},
I 03-15 01:22:50 optimizer.py:301]  infer_op: {GCP(n1-standard-8, {'T4': 1}): 60.83801223794871,
I 03-15 01:22:50 optimizer.py:301]             GCP(n1-standard-4, {'T4': 1}): 59.542121622564096,
I 03-15 01:22:50 optimizer.py:301]             AWS(p3.2xlarge, {'V100': 1}): 67.16405152,
I 03-15 01:22:50 optimizer.py:301]             AWS(inf1.2xlarge, {'Inferentia': 1}): 57.11285360333333}}
I 03-15 01:22:50 optimizer.py:301]
```
changes to

```bash
$ python examples/example_app.py 
I 03-15 01:23:23 resources.py:79] Missing tf_version in accelerator_args, using default (2.5.0)
I 03-15 01:23:23 optimizer.py:52]   AWS -> GCP egress cost: $53.91 for 600.0 GB
I 03-15 01:23:23 optimizer.py:52]   GCP -> AWS egress cost: $0.012 for 0.1 GB
I 03-15 01:23:23 optimizer.py:52]   GCP -> AWS egress cost: $0.012 for 0.1 GB
I 03-15 01:23:23 optimizer.py:362] Optimizer - plan minimizing cost (~$57.1):
I 03-15 01:23:23 optimizer.py:377] 
I 03-15 01:23:23 optimizer.py:377] TASK      BEST_RESOURCE
I 03-15 01:23:23 optimizer.py:377] train_op  AWS(p3.2xlarge, {'V100': 1})
I 03-15 01:23:23 optimizer.py:377] infer_op  AWS(inf1.2xlarge, {'Inferentia': 1})
I 03-15 01:23:23 optimizer.py:377] 
I 03-15 01:23:23 optimizer.py:307] Details: task -> {resources -> cost ($)}
I 03-15 01:23:23 optimizer.py:308] {train_op: {AWS(p3.8xlarge, {'V100': 4}): 113.28,
I 03-15 01:23:23 optimizer.py:308]             GCP(n1-standard-8, {'tpu-v3-8': 1}, accelerator_args={'tf_version': '2.5.0'}): 97.62,
I 03-15 01:23:23 optimizer.py:308]             AWS(p3.2xlarge, {'V100': 1}): 55.86},
I 03-15 01:23:23 optimizer.py:308]  infer_op: {AWS(p3.2xlarge, {'V100': 1}): 67.16,
I 03-15 01:23:23 optimizer.py:308]             AWS(inf1.2xlarge, {'Inferentia': 1}): 57.11,
I 03-15 01:23:23 optimizer.py:308]             GCP(n1-standard-8, {'T4': 1}): 60.84,
I 03-15 01:23:23 optimizer.py:308]             GCP(n1-standard-4, {'T4': 1}): 59.54}}
I 03-15 01:23:23 optimizer.py:308]
```