### PR TITLE
Allowed forced teardown when called within locked code

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1736,17 +1736,19 @@ class CloudVmRayBackend(backends.Backend):
                  _force: bool = False) -> None:
         cluster_name = handle.cluster_name
         lock_path = os.path.expanduser(_LOCK_FILENAME.format(cluster_name))
+
+        if _force:
+            # Should only be forced when teardown is called within a
+            # locked section of the code (i.e teardown when not enough
+            # resources can be provisioned)
+            self._teardown(handle, terminate)
+            return
+
         try:
-            if _force:
-                # Should only be forced when teardown is called within a
-                # locked section of the code (i.e teardown when not enough
-                # resources can be provisioned)
+            # TODO(mraheja): remove pylint disabling when filelock
+            # version updated
+            with filelock.FileLock(lock_path, 10):  # pylint: disable=abstract-class-instantiated
                 self._teardown(handle, terminate)
-            else:
-                # TODO(mraheja): remove pylint disabling when filelock
-                # version updated
-                with filelock.FileLock(lock_path, 10):  # pylint: disable=abstract-class-instantiated
-                    self._teardown(handle, terminate)
                 if terminate:
                     os.remove(lock_path)
         except filelock.Timeout:


### PR DESCRIPTION
Solves #576 by allowing forced teardown (which completes teardown without acquiring the cluster file lock) during already locked sections of the code--which right now is only provisioning.

Tested by manually setting `_force` to `True` and observing `sky down` proceed while provisioning still in progress.