### PR TITLE
Unique cluster name list for sky down

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1164,6 +1164,7 @@ def _terminate_or_stop_clusters(names: Tuple[str], apply_to_all: Optional[bool],
 
     to_down = []
     if len(names) > 0:
+        names = list(set(names))
         for name in names:
             handle = global_user_state.get_handle_from_cluster_name(name)
             if handle is not None:


### PR DESCRIPTION
This is a small PR to make the `sky down` cluster name list unique before tearing down or stopping. Otherwise, `sky down env env jq` will fail due to the second `env` cluster will not have the ray yaml file.