### PR TITLE
Glob cluster name for sky down

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -949,8 +949,8 @@ def stop(
 ):
     """Stop cluster(s).
 
-    CLUSTER is the name of the cluster to stop.  If both CLUSTER and --all are
-    supplied, the latter takes precedence.
+    CLUSTER is the name (or glob pattern) of the cluster to stop.  If both
+    CLUSTER and --all are supplied, the latter takes precedence.
 
     Stopping a cluster does not lose data on the attached disks (billing for
     the instances will stop while the disks will still be charged).  Those
@@ -972,7 +972,7 @@ def stop(
 
     .. code-block:: bash
 
-        # Tear down all clusters with prefix 'cluster'
+        # Stop down all clusters with prefix 'cluster'
         sky stop "cluster*"
 
     .. code-block:: bash
@@ -1126,8 +1126,8 @@ def down(
 ):
     """Tear down cluster(s).
 
-    CLUSTER is the name of the cluster to tear down.  If both CLUSTER and --all
-    are supplied, the latter takes precedence.
+    CLUSTER is the name of the cluster (or glob pattern) to tear down.  If both
+    CLUSTER and --all are supplied, the latter takes precedence.
 
     Terminating a cluster will delete all associated resources (all billing
     stops), and any data on the attached disks will be lost.

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -164,8 +164,7 @@ def get_handle_from_cluster_name(
         return pickle.loads(handle)
 
 
-def get_glob_cluster_names(
-        cluster_name: str) -> Optional['backends.Backend.ResourceHandle']:
+def get_glob_cluster_names(cluster_name: str) -> List[str]:
     assert cluster_name is not None, 'cluster_name cannot be None'
     rows = _CURSOR.execute('SELECT name FROM clusters WHERE name GLOB (?)',
                            (cluster_name,))


### PR DESCRIPTION
Closes #590. This PR adds glob search for the cluster_name during `sky down`. The user now can do `sky down test*` to kill all the cluster with a prefix of `test`.

```
(sky-dev) ➜  sky-experiment-dev (glob-cluster-name) sky status                                                                          ✂ ✭ ✈ ✱
NAME                 LAUNCHED    RESOURCES                          COMMAND                                           STATUS  
fallback             2 days ago  1x AWS(m4.2xlarge)                 sky launch -c fallback ./examples/minimal.yaml    UP      
hold-cpu-3           2 days ago  3x AWS(m4.2xlarge)                 sky launch -c hold-cpu-3 ./examples/minimal.yaml  UP      
cpunode-test-west-1  2 hrs ago   1x AWS(m4.2xlarge)                 sky cpunode -c cpunode-test-west-1                UP      
jq                   9 mins ago  1x AWS(p2.xlarge, {'K80': 1})      sky launch -y -c jq ...                           UP      
huggingface          6 mins ago  1x GCP(n1-highmem-8, {'V100': 1})  sky launch -y -c huggingface ...                  UP      
test1                3 mins ago  1x AWS(m4.2xlarge)                 sky cpunode -c test1                              INIT    
test2                3 mins ago  1x AWS(m4.2xlarge)                 sky cpunode -c test2                              INIT    
test3                3 mins ago  1x AWS(m4.2xlarge)                 sky cpunode -c test3                              INIT    
(sky-dev) ➜  sky-experiment-dev (glob-cluster-name) sky down "test*"                                                                        ✭ ✱
Terminating 3 clusters: test3, test2, test1. Proceed? [Y/n]: 
Terminating cluster test3...done.
Terminating cluster test2...done.
Terminating cluster test1...done.
(sky-dev) ➜  sky-experiment-dev (glob-cluster-name)                                                                                         ✭ ✱
```