### PR TITLE
Add `conda init` to AWS setup commands

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -77,7 +77,7 @@ setup_commands:
   - (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false
+    which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false;
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;


### PR DESCRIPTION
Closes #602.

Now users can activate their conda envs without `conda init` and restarting the shell.

Tested:
* `sky gpunode --cloud aws --gpus T4`
*  `sky launch examples/minimal.yaml --gpus T4`