### PR TITLE
Fix file_mounts for ubuntu 20

### DIFF
--- a/examples/using_file_mounts.yaml
+++ b/examples/using_file_mounts.yaml
@@ -74,7 +74,9 @@ file_mounts:
   # Commenting out as this takes a while.
   # /data/fake_imagenet: gs://cloud-tpu-test-datasets/fake_imagenet
 
-setup: 'sudo apt-get install -y tree'
+setup: |
+  # Ubuntu 20.04 LTS uses snap instead of apt.
+  sudo snap install tree
 
 run: |
   set -ex


### PR DESCRIPTION
The ubuntu 20 changes the package manager to `snap`, and AMI's default apt source cannot find `tree` package. Our previous `sudo apt install tree` is not working now for aws.