### PR TITLE
Fix sky launch failure on GCP

### DIFF
--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -194,7 +194,7 @@ class GCPNodeProvider(NodeProvider):
                     count -= len(reuse_node_ids)
             if count:
                 resource.create_instances(base_config, labels, count)
-        # SSH connection is unstable in the beginning of VM creation.
+        # SSH connection can be unstable in the beginning of VM creation.
         # Workaround with sleeping one minute.
         # More details at https://github.com/ray-project/ray/issues/16539
         time.sleep(60)


### PR DESCRIPTION
Closes https://github.com/sky-proj/sky/issues/618. 
There seems to be no better solution than waiting for VM to stablize from our end. In the future hopefully Ray would add support for error handling on SSH connections. Check more details here https://github.com/ray-project/ray/issues/16539.

Before:
10 out of 10 `sky cpunode --cloud gcp` failed.

After:
10 out of 10 `sky cpunode --cloud gcp` succeeded.

- [x] single-node testing
- [ ] multi-node testing