### PR TITLE
Optimize backend_utils.get_node_ips(), esp. for Azure.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1321,7 +1321,8 @@ class CloudVmRayBackend(backends.Backend):
         fore = colorama.Fore
         style = colorama.Style
         ip_list = backend_utils.get_node_ips(handle.cluster_yaml,
-                                             handle.launched_nodes)
+                                             handle.launched_nodes,
+                                             handle=handle)
         full_workdir = os.path.abspath(os.path.expanduser(workdir))
 
         # These asserts have been validated at Task construction time.
@@ -1391,7 +1392,8 @@ class CloudVmRayBackend(backends.Backend):
         logger.info(f'{fore.CYAN}Processing file mounts.{style.RESET_ALL}')
 
         ip_list = backend_utils.get_node_ips(handle.cluster_yaml,
-                                             handle.launched_nodes)
+                                             handle.launched_nodes,
+                                             handle=handle)
         ssh_user, ssh_key = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
 
@@ -1566,7 +1568,8 @@ class CloudVmRayBackend(backends.Backend):
             setup_file = os.path.basename(setup_sh_path)
             # Sync the setup script up and run it.
             ip_list = backend_utils.get_node_ips(handle.cluster_yaml,
-                                                 handle.launched_nodes)
+                                                 handle.launched_nodes,
+                                                 handle=handle)
             ssh_user, ssh_key = backend_utils.ssh_credential_from_yaml(
                 handle.cluster_yaml)
 
@@ -1638,7 +1641,8 @@ class CloudVmRayBackend(backends.Backend):
                     f'{style.BRIGHT}{local_log_dir}{style.RESET_ALL}')
 
         ips = backend_utils.get_node_ips(handle.cluster_yaml,
-                                         handle.launched_nodes)
+                                         handle.launched_nodes,
+                                         handle=handle)
 
         def rsync_down(ip: str) -> None:
             from ray.autoscaler import sdk  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
Azure's APIs are extremely slow; as a result, `ray get-head-ip` and the like are very slow for Azure clusters.

The below is for a 1-node Azure cluster.

Before: takes 1min 14sec
```
  » sky exec b2 --workdir=. -- <cmd>
  I 03-22 15:45:54 cloud_vm_ray_backend.py:1296] In sync_workdir
  I 03-22 15:47:08 cloud_vm_ray_backend.py:1301] Done get_node_ips()
```
After: instant
```
 » sky exec b2 --workdir=. -- <cmd>
  I 03-22 15:54:59 cloud_vm_ray_backend.py:1296] In sync_workdir
  I 03-22 15:54:59 cloud_vm_ray_backend.py:1302] Done get_node_ips()
```

Tested:
- [x] smoke tests (all passed, except huggingface, tracked in #633)