### PR TITLE
Fix hint messages bug

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -458,11 +458,11 @@ def _fill_in_launchable_resources(
             if len(launchable[resources]) == 0:
                 logger.info(f'No resource satisfying {resources.accelerators} '
                             f'on {clouds_list}.')
-            if len(all_fuzzy_candidates) > 0:
-                logger.info('Did you mean: '
-                            f'{colorama.Fore.CYAN}'
-                            f'{sorted(all_fuzzy_candidates)}'
-                            f'{colorama.Style.RESET_ALL}')
+                if len(all_fuzzy_candidates) > 0:
+                    logger.info('Did you mean: '
+                                f'{colorama.Fore.CYAN}'
+                                f'{sorted(all_fuzzy_candidates)}'
+                                f'{colorama.Style.RESET_ALL}')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_launchable_resources)


### PR DESCRIPTION
To fix a bug that message like `Did you mean: ['K80:16', 'K80:8']` should not be outputted if any launchable resource is found.

Before:
```
(sky) weichiang@blaze:~/repos/sky$ sky gpunode -c xxx --gpus K80:4
I 03-23 16:55:34 optimizer.py:462] Did you mean: ['K80:16', 'K80:8']
I 03-23 16:55:34 optimizer.py:363] Optimizer - plan minimizing cost (~$0.9):
I 03-23 16:55:34 optimizer.py:378] 
I 03-23 16:55:34 optimizer.py:378] TASK     BEST_RESOURCE
I 03-23 16:55:34 optimizer.py:378] gpunode  Azure(Standard_NC24_Promo, {'K80': 4})
I 03-23 16:55:34 optimizer.py:378] 
I 03-23 16:55:34 optimizer.py:311] Considered resources -> cost ($)
I 03-23 16:55:34 optimizer.py:312] {Azure(Standard_NC24_Promo, {'K80': 4}): 0.86,
I 03-23 16:55:34 optimizer.py:312]  GCP(n1-highmem-8, {'K80': 4.0}): 2.27}
I 03-23 16:55:34 optimizer.py:312] 
I 03-23 16:55:34 optimizer.py:327] Multiple Azure instances satisfy K80:4. The cheapest Azure(Standard_NC24_Promo, {'K80': 4}) is considered among:
I 03-23 16:55:34 optimizer.py:327] ['Standard_NC24_Promo', 'Standard_NC24r_Promo', 'Standard_NC24', 'Standard_NC24r'].
I 03-23 16:55:34 optimizer.py:327] 
I 03-23 16:55:34 optimizer.py:333] To list more details, run 'sky show-gpus K80'.
```

After
```
(sky) weichiang@blaze:~/repos/sky$ sky gpunode -c xxx --gpus K80:4
I 03-23 16:56:03 optimizer.py:363] Optimizer - plan minimizing cost (~$0.9):
I 03-23 16:56:03 optimizer.py:378] 
I 03-23 16:56:03 optimizer.py:378] TASK     BEST_RESOURCE
I 03-23 16:56:03 optimizer.py:378] gpunode  Azure(Standard_NC24_Promo, {'K80': 4})
I 03-23 16:56:03 optimizer.py:378] 
I 03-23 16:56:03 optimizer.py:311] Considered resources -> cost ($)
I 03-23 16:56:03 optimizer.py:312] {Azure(Standard_NC24_Promo, {'K80': 4}): 0.86,
I 03-23 16:56:03 optimizer.py:312]  GCP(n1-highmem-8, {'K80': 4.0}): 2.27}
I 03-23 16:56:03 optimizer.py:312] 
I 03-23 16:56:03 optimizer.py:327] Multiple Azure instances satisfy K80:4. The cheapest Azure(Standard_NC24_Promo, {'K80': 4}) is considered among:
I 03-23 16:56:03 optimizer.py:327] ['Standard_NC24_Promo', 'Standard_NC24r_Promo', 'Standard_NC24', 'Standard_NC24r'].
I 03-23 16:56:03 optimizer.py:327] 
I 03-23 16:56:03 optimizer.py:333] To list more details, run 'sky show-gpus K80'.
```