### PR TITLE
Roll back to debian-based image for GCP

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -186,7 +186,7 @@ class GCP(clouds.Cloud):
             'tpu': None,
             'custom_resources': None,
             'use_spot': r.use_spot,
-            'image_name': 'common-cpu-ubuntu-2004',
+            'image_name': 'common-cpu',
         }
         accelerators = r.accelerators
         if accelerators is not None:
@@ -206,7 +206,7 @@ class GCP(clouds.Cloud):
                 resources_vars['gpu'] = 'nvidia-tesla-{}'.format(acc.lower())
                 resources_vars['gpu_count'] = acc_count
                 # CUDA driver version 470.103.01, CUDA Library 11.3
-                resources_vars['image_name'] = 'common-cu113-ubuntu-2004'
+                resources_vars['image_name'] = 'common-cu113'
 
         return resources_vars
 


### PR DESCRIPTION
GCP's ubuntu image seems problematic and caused issues like https://github.com/sky-proj/sky/issues/633, https://github.com/sky-proj/sky/issues/618.
This PR rolls back to previous image based on debian and uses updated cuda library image for GPU VMs.