### PR TITLE
Align underscore / dash for num-nodes cli option

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -679,7 +679,7 @@ def exec(
     Execution and scheduling behavior:
     \b
     - If ENTRYPOINT is a YAML, or if it is a command with a resource demand
-      flag specified (`--gpus` or `--num_nodes`): it is treated as a proper
+      flag specified (`--gpus` or `--num-nodes`): it is treated as a proper
       task that will undergo job queue scheduling, respecting its resource
       requirement. It can be executed on any node of th cluster with enough
       resources.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -302,12 +302,12 @@ def test_azure_start_stop_two_nodes():
     test = Test(
         'azure-start-stop-two-nodes',
         [
-            f'sky launch --num_nodes=2 -y -c {name} examples/azure_start_stop.yaml',
-            f'sky exec --num_nodes=2 {name} examples/azure_start_stop.yaml',
+            f'sky launch --num-nodes=2 -y -c {name} examples/azure_start_stop.yaml',
+            f'sky exec --num-nodes=2 {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
             f'sky stop -y {name}',
             f'sky start -y {name}',
-            f'sky exec --num_nodes=2 {name} examples/azure_start_stop.yaml',
+            f'sky exec --num-nodes=2 {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 2 --status',  # Ensure the job succeeded.
         ],
         f'sky down -y {name}',


### PR DESCRIPTION
A quick fix for the cli from `--num_nodes` to `--num-nodes` to match other cli's.