### PR TITLE
Fix GCP Lock Bug

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -73,7 +73,7 @@ rsync_exclude: [
 # List of shell commands to run to set up nodes.
 setup_commands:
   # This AMI's system Python is version 2+.
-  # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
+  # This also kills the service that is holding the lock on dpkg.
   - (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -104,6 +104,14 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
+  # This kills both the service and process that is holding the lock for dpkg.
+  - sudo systemctl stop unattended-upgrades;
+    sudo kill -9 `sudo find /proc/*/fd -ls | grep /var/lib/dpkg/lock-frontend | grep -oP '/proc/\d+' | tail -n 1 | grep -oP '\d+'` || true;
+    sudo pkill -9 apt-get;
+    sudo pkill -9 dpkg;
+    sudo apt-get remove google-cloud-sdk;
+    sudo dpkg --configure -a;
+    sudo apt-get install google-cloud-sdk; 
   - pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app
   - pip3 uninstall sky -y &> /dev/null; pip3 install {{sky_remote_path}}/*.whl && python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
 


### PR DESCRIPTION
## Description

Solves #629. Launching a GCP instance and having `sudo apt/apt-get install XYZ` will error out due to lock being held by DPKG process.

Unlike in AWS or Azure, GCP does not have `lsof` or `fuser`, so a more brute force method is used to identify the process that is holding the lock: 
`sudo kill -9  'sudo find /proc/*/fd -ls | grep /var/lib/dpkg/lock-frontend | grep -oP '/proc/\d+' | tail -n 1 | grep -oP '\d+'' || true;`
This line above goes through the process folder and through a bunch of regex, finds the process ID that is holding the lock. 


Last but not least, restarting DPKG has errors on GCP, and the work around is uninstalling and reinstalling `google-cloud-sdk`.

## Test
The following YAML passes without erorrs:
```
name: apt-lock-bug
resources:
  cloud: gcp
  instance_type: n1-highmem-2
setup: |
  sudo apt install cargo
  sudo apt-get install libosmesa6-dev
```
