### PR TITLE
Fix Repeating IP in SSH Config

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -235,7 +235,12 @@ class SSHConfigHelper(object):
                                        f'host named {cluster_name}.')
                         host_name = ip
                         logger.warning(f'Using {ip} to identify host instead.')
-                    break
+
+                if line.strip() == f'Host {ip}':
+                    prev_line = config[i - 1] if i - 1 > 0 else ''
+                    if prev_line.strip().startswith(sky_autogen_comment):
+                        overwrite = True
+                        overwrite_begin_idx = i - 1
         else:
             config = ['\n']
             with open(config_path, 'w') as f:


### PR DESCRIPTION
## Description

The edge case is the following. If SSH Config already has `Host hello` (from user's prior experiments prior to installing/using Sky) and the user runs `sky launch -c hello examples/env_check.yaml`, Sky will add 
```
# Added by sky (use `sky stop/down hello` to remove)
Host 18.215.241.153
  HostName 18.215.241.153
  User ubuntu
  IdentityFile /Users/michaelluo/.ssh/sky-key
  IdentitiesOnly yes
  ForwardAgent yes
  StrictHostKeyChecking no
  Port 22
```
However, if `sky launch -c hello examples/env_check.yaml` is run multiple times, the above block is added multiple times to the config file. This is due to the fact that there is no check for this case.

## Tests

Step 1: Add this block to the Config file.
```
# Fake SSH Config
Host hallo
  HostName 59.152.136.89
  User ubuntu
  IdentityFile /Users/michaelluo/.ssh/sky-key
  IdentitiesOnly yes
  ForwardAgent yes
  StrictHostKeyChecking no
  Port 22
```
Step 2: Run `sky launch -c examples/env_check.yaml`

Step 3: Random Sky up and Sky downs


