### PR TITLE
Prompt Before Storage Initialization for `sky launch`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -569,6 +569,16 @@ def launch(
     if backend_name is None:
         backend_name = backends.CloudVmRayBackend.NAME
 
+    entrypoint = ' '.join(entrypoint)
+    is_yaml = _check_yaml(entrypoint)
+    if is_yaml:
+        # Treat entrypoint as a yaml.
+        click.secho('Task from YAML spec: ', fg='yellow', nl=False)
+    else:
+        # Treat entrypoint as a bash command.
+        click.secho('Task from command: ', fg='yellow', nl=False)
+    click.secho(entrypoint, bold=True)
+
     if not yes:
         # Prompt if (1) --cluster is None, or (2) cluster doesn't exist, or (3)
         # it exists but is STOPPED.
@@ -581,17 +591,10 @@ def launch(
         if prompt is not None:
             click.confirm(prompt, default=True, abort=True, show_default=True)
 
-    entrypoint = ' '.join(entrypoint)
     with sky.Dag() as dag:
-        if _check_yaml(entrypoint):
-            # Treat entrypoint as a yaml.
-            click.secho('Task from YAML spec: ', fg='yellow', nl=False)
-            click.secho(entrypoint, bold=True)
+        if is_yaml:
             task = sky.Task.from_yaml(entrypoint)
         else:
-            # Treat entrypoint as a bash command.
-            click.secho('Task from command: ', fg='yellow', nl=False)
-            click.secho(entrypoint, bold=True)
             task = sky.Task(name='sky-cmd', run=entrypoint)
             task.set_resources({sky.Resources()})
         # Override.


### PR DESCRIPTION
Fixes #681. The bug is that when the YAML file contains Storage, `sky launch -c hello myyaml.yml` will uploading contents/connect to Storage bucket before the prompt `Launching a new cluster. Proceed? [Y/n]:`.

## Tests

```
resources:
  cloud: aws

num_nodes: 1  

workdir: .

file_mounts:
  /datasets-storage:
    name: mluo-2022
    source: .

setup: |
  echo "here"
  echo "export TEST_VAR=test" >> ~/.bashrc

run: |
  if [[ -z "${TEST_VAR}" ]]; then
    echo "TEST_VAR is not set"
    exit 1
  else
    echo "TEST_VAR is set to ${TEST_VAR}"
  fi

  if [[ -d ~/sky_workdir/sky ]]; then
    echo "~/sky_workdir/sky exists"
  else
    echo "~/sky_workdir/sky does not exist"
    exit 1
  fi

  echo NODE ID: $SKY_NODE_RANK
  echo NODE IPS: "$SKY_NODE_IPS"
  worker_addr=`echo "$SKY_NODE_IPS" | sed -n 2p`
  echo Worker IP: $worker_addr
```