### PR TITLE
Fix optimizer messages

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -605,8 +605,8 @@ class Optimizer:
         print_hourly_cost = False
         if len(node_to_cost_map) == 1:
             node = list(node_to_cost_map.keys())[0]
-            if node.time_estimator_func is None and \
-                node.get_inputs() is None and node.get_outputs() is None:
+            if (node.time_estimator_func is None and
+                    node.get_inputs() is None and node.get_outputs() is None):
                 print_hourly_cost = True
 
         if print_hourly_cost:


### PR DESCRIPTION
This PR closes #700

The fixed optimizer will 
* skip the head message (`Optimizer - plan minimizing cost`) if the search space is trivial, and
* print hourly cost when the DAG consists of a task that does not have a time estimator and does not involve any data egress.

NOTE: `sky gpunode` still prints the header message because there are three candidates (each for three cloud vendors).
```
$ sky gpunode
I 04-04 19:09:08 optimizer.py:601] Optimizer - plan minimizing cost
I 04-04 19:09:08 optimizer.py:613] Estimated hourly cost: ~$0.2/hr
I 04-04 19:09:08 optimizer.py:628] 
I 04-04 19:09:08 optimizer.py:628] TASK     BEST_RESOURCE
I 04-04 19:09:08 optimizer.py:628] gpunode  Azure(Standard_NC6_Promo, {'K80': 1})
I 04-04 19:09:08 optimizer.py:628] 
I 04-04 19:09:08 optimizer.py:648] Considered resources -> cost ($)
I 04-04 19:09:08 optimizer.py:649] {GCP(n1-highmem-8, {'K80': 1}): 0.92,
I 04-04 19:09:08 optimizer.py:649]  AWS(p2.xlarge, {'K80': 1}): 0.9,
I 04-04 19:09:08 optimizer.py:649]  Azure(Standard_NC6_Promo, {'K80': 1}): 0.22}
I 04-04 19:09:08 optimizer.py:649] 
I 04-04 19:09:08 optimizer.py:665] Multiple Azure instances satisfy K80:1. The cheapest Azure(Standard_NC6_Promo, {'K80': 1}) is considered among:
I 04-04 19:09:08 optimizer.py:665] ['Standard_NC6_Promo', 'Standard_NC6'].
I 04-04 19:09:08 optimizer.py:665]
```

On the other hand, `sky gpunode --cloud aws` skips the message (`Optimizer - plan minimizing cost`) since the candidate instance type is unique.
```
$ sky gpunode --cloud aws
I 04-04 19:04:58 optimizer.py:613] Estimated hourly cost: ~$0.9/hr
I 04-04 19:04:58 optimizer.py:628] 
I 04-04 19:04:58 optimizer.py:628] TASK     BEST_RESOURCE
I 04-04 19:04:58 optimizer.py:628] gpunode  AWS(p2.xlarge, {'K80': 1})
I 04-04 19:04:58 optimizer.py:628]
```
