### PR TITLE
Fix azure subscription id

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -260,3 +260,4 @@ class Azure(clouds.Cloud):
                 'Failed to get subscription id from azure cli. '
                 'Make sure you have logged in and run this Azure '
                 'cli command: "az account set -s <subscription_id>".') from e
+        return azure_subscription_id


### PR DESCRIPTION
A quick fix for the subscription id problem introduced by #692. It was not fully tested as our azure subscription is down.