### PR TITLE
Get rid of sky dependencies in templates

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -88,9 +88,8 @@ setup_commands:
     sudo pkill -9 dpkg;
     sudo dpkg --configure -a;
     sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf; # This is needed for `-o allow_other` option for `goofys`
-  # we should install "sky[aws]", however this does not work with wheel file path
-  - pip3 install awscli boto3;
-    pip3 uninstall sky -y &> /dev/null; pip3 install {{sky_remote_path}}/*.whl;
+  - pip3 uninstall sky -y &> /dev/null;
+    pip3 install "$(echo {{sky_remote_path}}/*.whl)[aws]";
     python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
 
 # Command to start ray on the head node. You don't need to change this.

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -96,8 +96,9 @@ setup_commands:
     sudo dpkg --configure -a;
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base false);
     sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf; # This is needed for `-o allow_other` option for `goofys`
-  # We have to install azure-cli because the Azure cluster does not pre-install it.
-  - pip3 uninstall sky -y &> /dev/null; pip3 install {{sky_remote_path}}/*.whl && pip3 install azure-cli==2.30.0 && python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
+  - pip3 uninstall sky -y &> /dev/null;
+    pip3 install "$(echo {{sky_remote_path}}/*.whl)[azure]";
+    python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -108,7 +108,9 @@ initialization_commands: []
 setup_commands:
   - pip3 install -U ray[default]=={{ray_version}} && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf; # This is needed for `-o allow_other` option for `goofys`;
-  - pip3 uninstall sky -y &> /dev/null; pip3 install {{sky_remote_path}}/*.whl && python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
+  - pip3 uninstall sky -y &> /dev/null;
+    pip3 install "$(echo {{sky_remote_path}}/*.whl)";
+    python3 -c "from sky.skylet.ray_patches import patch; patch()" # patch the buggy ray file
 
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:


### PR DESCRIPTION
This PR gets rid of cloud-specific dependencies in templates.

Tests passed with different nodes with different clouds.