### PR TITLE
Add W&B setup in FAQ

### DIFF
--- a/docs/source/reference/faq.rst
+++ b/docs/source/reference/faq.rst
@@ -59,7 +59,7 @@ To get around this, mount the files to a different path, then symlink to them.  
 How to make Sky clusters use my Weights & Biases credentials?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install the wandb library on your laptop and login to your account via `wandb login`.
+Install the wandb library on your laptop and login to your account via ``wandb login``.
 Then, add the following lines in your task yaml file:
 
 .. code-block:: yaml


### PR DESCRIPTION
During the Sehoon's onboarding, `sky launch` wasn't successful at the first attempt because the wandb library wasn't properly set up. Thanks to @infwinston, the problem was quickly resolved by adding one line in the yaml file.

As many users are expected to face the same error as Sehoon, I think we should add this case to FAQ.