### PR TITLE
Add test_cancel() to smoke.

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -315,7 +315,6 @@ def test_azure_start_stop():
 
 
 # ---------- Testing Autostopping ----------
-# @pytest.mark.slow
 def test_autostop():
     name = _get_cluster_name()
     test = Test(
@@ -333,6 +332,26 @@ def test_autostop():
         ],
         f'sky down -y {name}',
         timeout=20 * 60,
+    )
+    run_one_test(test)
+
+
+# ---------- Testing `sky cancel` ----------
+def test_cancel():
+    name = _get_cluster_name()
+    test = Test(
+        'cancel',
+        [
+            f'sky launch -c {name} examples/resnet_app.yaml -y -d',
+            'sleep 60',
+            f'sky exec {name} "nvidia-smi | grep python"',
+            f'sky logs {name} 2 --status',
+            f'sky cancel {name} 1',
+            'sleep 5',
+            f'sky exec {name} "nvidia-smi | grep \'No running process\'"',
+            f'sky logs {name} 3 --status',
+        ],
+        f'sky down -y {name}',
     )
     run_one_test(test)
 


### PR DESCRIPTION
To ensure #757 doesn't regress.

Tested:
- `bash tests/run_smoke_tests.sh test_cancel` passed