### PR TITLE
A quick fix for `CLOUD_REGISTRY.from_str` for None input

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -24,7 +24,9 @@ class Zone(collections.namedtuple('Zone', ['name'])):
 class _CloudRegistry(dict):
     """Registry of clouds."""
 
-    def from_str(self, name: str) -> Optional['Cloud']:
+    def from_str(self, name: Optional[str]) -> Optional['Cloud']:
+        if name is None:
+            return None
         return self.get(name.lower())
 
     def register(self, cloud_cls: 'Cloud') -> None:


### PR DESCRIPTION
Previously, `sky cpunode` will cause the following issue:

```
  File "/Users/zhwu/OneDrive/AResource/PhD/Research/sky-computing/code/sky-experiments/sky/cli.py", line 1558, in cpunode
    cloud_provider = _get_cloud(cloud)
  File "/Users/zhwu/OneDrive/AResource/PhD/Research/sky-computing/code/sky-experiments/sky/cli.py", line 86, in _get_cloud
    cloud_obj = clouds.CLOUD_REGISTRY.from_str(cloud)
  File "/Users/zhwu/OneDrive/AResource/PhD/Research/sky-computing/code/sky-experiments/sky/clouds/cloud.py", line 28, in from_str
    return self.get(name.lower())
AttributeError: 'NoneType' object has no attribute 'lower'
```