### PR TITLE
Fix format all

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -44,7 +44,7 @@ YAPF_FLAGS=(
 )
 
 YAPF_EXCLUDES=(
-    # '--exclude' 'python/build/*'
+    '--exclude' 'sky/skylet/providers'
 )
 
 # Format specified files


### PR DESCRIPTION
The `./format.sh --all` was broken. This PR fixes it.

`./format.sh --all` provides a way to format all files, regardless they are changed or not. This is useful when
1. The formatter config changes
2. Some files that was formatted incorrectly was pushed, and you want to re-format it.