### PR TITLE
Fix sky cancel

### DIFF
--- a/examples/resnet_app.yaml
+++ b/examples/resnet_app.yaml
@@ -1,5 +1,4 @@
 name: resnet-app
-workdir: ~/Downloads/tpu
 
 resources:
   cloud: aws
@@ -20,6 +19,10 @@ outputs: {
 # }
 
 setup: |
+  git clone https://github.com/concretevitamin/tpu || true
+  cd tpu
+  git checkout 9459fee
+
   . $(conda info --base)/etc/profile.d/conda.sh
   pip install --upgrade pip
 
@@ -37,6 +40,7 @@ setup: |
   fi
 
 run: |
+  cd tpu
   . $(conda info --base)/etc/profile.d/conda.sh
   conda activate resnet
 

--- a/sky/skylet/subprocess_daemon.sh
+++ b/sky/skylet/subprocess_daemon.sh
@@ -5,24 +5,26 @@ parent_pid=$1
 proc_pid=$2
 remote=${3:-0}
 
-while kill -s 0 ${parent_pid}; do sleep 1 done 
+while kill -s 0 ${parent_pid}; do sleep 1; done
 
 if [ ${remote} -eq 0 ]; then
     # This is to avoid the PIPE outputing to the console after being killed in next line.
     pkill -PIPE -P ${proc_pid}
 fi
-if [[ $OSTYPE == 'darwin'* ]]; then
+if [ $OSTYPE == 'darwin'* ]; then
     # MacOS do not have the ps --forest option, it is enough to do pkill here. (pkill
     # only kills the first level descendant of the process, not recursively find all
     # of the descendants.)
     pkill -TERM -P ${proc_pid}
+    sleep 5
+    kill -9 ${proc_pid}
 else
     # Uses pgid instead of sid, since sid can be changed by other processes.
     pgid=`ps -o pgid= -p ${proc_pid}`
     # Recursively gracefully kill (SIGTERM) all child processes of proc_pid.
     # We should not run this command if pgid is empty, i.e. the process is already dead.
     [[ -z "${pgid}" ]] || (ps --forest -o pid -g $pgid | tail -n +2 | xargs kill -15)
+    # Wait 30s for the processes to exit gracefully.
+    sleep 30
+    [[ -z "${pgid}" ]] || (ps --forest -o pid -g $pgid | tail -n +2 | xargs kill -9)
 fi
-# Wait the processes to gracefully exit
-sleep 5
-kill -9 ${proc_pid}


### PR DESCRIPTION
Currently sky cancel fails to kill processes due to some syntax error. This PR fixes the bug.

smoke test `test_cancel` passed.