### PR TITLE
Remove storage_demo.yaml from smoke tests

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -542,6 +542,9 @@ class TestStorageWithCredentials:
 # Our sky storage requires credentials to check the bucket existance when
 # loading a task from the yaml file, so we cannot make it a unit test.
 class TestYamlSpecs:
+    # TODO(zhwu): Add test for `to_yaml_config` for the Storage object.
+    #  We should not use `examples/storage_demo.yaml` here, since it requires
+    #  users to ensure bucket names to not exist and/or be unique.
     _TEST_YAML_PATHS = [
         'examples/minimal.yaml', 'examples/managed_spot.yaml',
         'examples/using_file_mounts.yaml', 'examples/resnet_app.yaml',


### PR DESCRIPTION
 `examples/storage_demo.yaml` should be included in `TestYamlSpecs` since that file is intended purely as an example for users. It requires users to ensure bucket names to not exist and/or be unique. 

Perhaps we exclude `storage_demo.yaml` from `TestYamlSpecs`? Storage functionality tests are covered in `TestStorageWithCredentials` and `test_storage.py`.