### PR TITLE
Fix sky spot failover bug

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2156,7 +2156,6 @@ class CloudVmRayBackend(backends.Backend):
                 query_cmd = (
                     f'aws ec2 describe-instances --region {region} --filters '
                     f'Name=tag:ray-cluster-name,Values={handle.cluster_name} '
-                    'Name=instance-state-name,Values=stopping,stopped '
                     f'--query Reservations[].Instances[].InstanceId '
                     '--output text')
                 terminate_cmd = (


### PR DESCRIPTION
This PR removes a filter in awc cli which may cause bugs preventing sky spot from failing over to other regions. Because aws cli failed to capture the instance id when the status is `terminated` rather than `stopping/stopped`. so that the status table is not cleaned up (basically normal sky down failed) and sky spot can't fail over to other regions.

After discussion with @Michaelvll , we think remove the filter should be okay because the cluster name should be identifiable.

```
ubuntu@ip-172-31-90-228:~$ sky down sky-beab-weichiang-7
Terminating 1 cluster: sky-beab-weichiang-7. Proceed? [Y/n]: 
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] Failed to terminate sky-beab-weichiang-7. If you want to ignore this error and remove the cluster from from Sky's status table, use `sky down --purge`.
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] **** STDOUT ****
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] 
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] **** STDERR ****
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] 
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] An error occurred (InvalidParameterCombination) when calling the TerminateInstances operation: No instances specified
E 05-03 04:53:12 cloud_vm_ray_backend.py:2238] 
Terminating cluster sky-beab-weichiang-7...failed. Please check the logs and try again.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--
```