### PR TITLE
Fix storage tests failing with parallel runners

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -461,7 +461,10 @@ class TestStorageWithCredentials:
     @pytest.fixture
     def tmp_bucket_name(self):
         # Creates a temporary bucket name
-        yield f'sky-test-{time.time_ns()}'
+        # time.time() returns varying precision on different systems, so we
+        # replace the decimal point and use whatever precision we can get.
+        timestamp = str(time.time()).replace('.', '')
+        yield f'sky-test-{timestamp}'
 
     @pytest.fixture
     def tmp_local_storage_obj(self, tmp_bucket_name, tmp_mount):


### PR DESCRIPTION
The bucket name used in the storage smoke tests uses `int(time.time())` to create a unique name for buckets to be created:

https://github.com/sky-proj/sky/blob/881e6cc39f440975dfaff724da436744c6bf0f0a/tests/test_smoke.py#L464

This is flaky when tests are run in parallel because two parallel runners may use the same bucket id, creating a race condition. This PR changes the id to `f'sky-test-{time.time_ns()}'`, which has a significantly less chance of collision. 

A more complex solution is to use the id of the worker [(in ~slaveinput~ `workerinput`)](https://github.com/pytest-dev/pytest-xdist/issues/47#issuecomment-187891183) to accurately label buckets, but using nanoseconds keeps the tests simple yet functional.