### PR TITLE
Fix race condition between job set_state and update_status

### DIFF
--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -29,13 +29,6 @@ class JobStatus(enum.Enum):
     FAILED = 'FAILED'
     CANCELLED = 'CANCELLED'
 
-    @property
-    def _order_list(self):
-        return [
-            self.INIT, self.PENDING, self.RUNNING, self.SUCCEEDED, self.FAILED,
-            self.CANCELLED
-        ]
-
     def is_terminal(self):
         return self in (JobStatus.SUCCEEDED, JobStatus.FAILED,
                         JobStatus.CANCELLED)


### PR DESCRIPTION
This PR is to avoid the following race condition:
1. skylet start job_lib.update_status and get the job status from `ray job status` as PENDING
2. The generated ray program called `set_job_started` and change the job status in jobs.db to be `RUNNING`.
3. skylet set the job status in jobs.db to be PENDING.