### PR TITLE
Fix copy mount check for spot

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2088,8 +2088,8 @@ def spot_launch(
     if task.workdir is not None:
         raise click.UsageError('Workdir is not allowed for managed spot jobs.')
     copy_mounts = task.get_local_to_remote_file_mounts()
-    copy_mounts_str = '\n\t'.join(': '.join(m) for m in copy_mounts)
     if copy_mounts:
+        copy_mounts_str = '\n\t'.join(': '.join(m) for m in copy_mounts)
         raise click.UsageError(
             'Local file mounts are not allowed for managed spot jobs, '
             f'but following are found: {copy_mounts_str}')


### PR DESCRIPTION
A quick fix for a bug introduced by #790. Previously, `sky spot launch -y -n spot-logs-test 'while true; do echo $(date); sleep 5; done'` will generate the following error.

```
    copy_mounts_str = '\n\t'.join(': '.join(m) for m in copy_mounts)
TypeError: 'NoneType' object is not iterable
```