### PR TITLE
Fix `None` cluster name in interactive node hints

### DIFF
--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -224,7 +224,7 @@ class LocalDockerBackend(backends.Backend):
         runtime = 'nvidia' if self._use_gpu else None
         logger.info(f'Image {image_tag} found. Running container now. use_gpu '
                     f'is {self._use_gpu}')
-        cluster_name = global_user_state.get_cluster_name_from_handle(handle)
+        cluster_name = handle.get_cluster_name()
         # Encode metadata in docker labels:
         labels = {f'{_DOCKER_LABEL_PREFIX}{k}': v for k, v in metadata.items()}
         labels.update(_DOCKER_DEFAULT_LABELS)
@@ -364,6 +364,6 @@ class LocalDockerBackend(backends.Backend):
         if handle in self.containers:
             container = self.containers[handle]
             container.remove(force=True)
-        cluster_name = global_user_state.get_cluster_name_from_handle(handle)
+        cluster_name = handle.get_cluster_name()
         global_user_state.remove_cluster(cluster_name, terminate=True)
         return True

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -452,7 +452,7 @@ def _create_and_ssh_into_node(
                         commands,
                         port_forward=port_forward,
                         ssh_mode=backend_utils.SshMode.LOGIN)
-    cluster_name = global_user_state.get_cluster_name_from_handle(handle)
+    cluster_name = handle.cluster_name
 
     click.echo('To attach to it again:  ', nl=False)
     if cluster_name == _default_interactive_node_name(node_type):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -200,15 +200,6 @@ def get_glob_cluster_names(cluster_name: str) -> List[str]:
     return [row[0] for row in rows]
 
 
-def get_cluster_name_from_handle(
-        cluster_handle: 'backends.Backend.ResourceHandle') -> Optional[str]:
-    handle = pickle.dumps(cluster_handle)
-    rows = _DB.cursor.execute('SELECT name FROM clusters WHERE handle=(?)',
-                              (handle,))
-    for (name,) in rows:
-        return name
-
-
 def set_cluster_status(cluster_name: str, status: ClusterStatus) -> None:
     _DB.cursor.execute('UPDATE clusters SET status=(?) WHERE name=(?)', (
         status.value,


### PR DESCRIPTION
It wasn't clear to me why we were using `global_user_state` to get the cluster name when it's already there in the ResourceHandle. Fixes #820.

### Tests
- [x] sky cpunode -c test4, disconnect, then run again.
```
sky ❯ sky cpunode -c test4
Last login: Sat May 14 01:57:08 2022 from 136.152.143.100
ubuntu@ip-172-31-2-41:~$ logout
Shared connection to 44.203.215.27 closed.
To attach to it again:  sky cpunode -c test4
To stop the node:	sky stop test4
To tear down the node:	sky down test4
To upload a folder:	rsync -rP /local/path test4:/remote/path
To download a folder:	rsync -rP test4:/remote/path /local/path
```