### PR TITLE
Fix Ray autoscaler's failure of gpu auto detection

### DIFF
--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -119,7 +119,7 @@ head_start_ray_commands:
     (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
   - (ps aux | grep "-m sky.skylet.skylet" | grep -q python3) || nohup python3 -m sky.skylet.skylet >> ~/.sky/skylet.log 2>&1 & # Start skylet daemon. (Should not place it in the head_setup_commands, otherwise it will run before sky is installed.)
   - SKY_NUM_GPUS=0 && which nvidia-smi > /dev/null && SKY_NUM_GPUS=$(nvidia-smi --query-gpu=index,name --format=csv,noheader | wc -l);
-    echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
+    grep "export SKY_NUM_GPUS" ~/.bashrc > /dev/null || echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
   - ray stop; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
 
 {%- if num_nodes > 1 %}
@@ -127,7 +127,7 @@ worker_start_ray_commands:
   - sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 65535" >> /etc/security/limits.conf; echo "* hard nofile 65535" >> /etc/security/limits.conf;';
     (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
   - SKY_NUM_GPUS=0 && which nvidia-smi > /dev/null && SKY_NUM_GPUS=$(nvidia-smi --query-gpu=index,name --format=csv,noheader | wc -l);
-    echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
+    grep "export SKY_NUM_GPUS" ~/.bashrc > /dev/null || echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
   - ray stop; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076 {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
 {%- else %}
 worker_start_ray_commands: []


### PR DESCRIPTION
This PR aims to fix https://github.com/sky-proj/sky/issues/836 which has been a recurring issue to me (happened three times).
This fix is done by checking the #gpu by nvidia-smi and set it manually in `ray start` rather than relying on Ray autoscaler auto-detection.
I tested this PR with running some spot VMs on GCP and they have been through several preemptions. so far the issue seems to be fixed.
But this is a hard-to-reproduce problem. I will try to launch 10 gpu VMs with and without this PR to see if there's difference.

Not sure if we should apply this change to other cloud templates.