### PR TITLE
Fix subprocess daemon bug

### DIFF
--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -30,10 +30,8 @@ if __name__ == '__main__':
 
     if parent_process is not None:
         # Wait for either parent or target process to exit.
-        while True:
+        while process.is_running() and parent_process.is_running():
             time.sleep(1)
-            if not process.is_running() or not parent_process.is_running():
-                break
 
     try:
         children = process.children(recursive=True)


### PR DESCRIPTION
This PR handles the error triggered by `process = psutil.Process(args.proc_pid)` if the parent or target process not exist.
Thanks @romilbhardwaj @michaelzhiluo for reporting it.

- [x] sky cancel smoke tests passed

```
>>> import psutil                                                                                              
>>> psutil.Process(12345)                                
Traceback (most recent call last):                     
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/_common.py", line 441, in wrapper
    ret = self._cache[fun]
AttributeError: _cache

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/_pslinux.py", line 1661, in wrapper
    return fun(self, *args, **kwargs)
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/_common.py", line 444, in wrapper
    return fun(self)
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/_pslinux.py", line 1703, in _parse_stat_file
    with open_binary("%s/%s/stat" % (self._procfs_path, self.pid)) as f:
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/_common.py", line 711, in open_binary
    return open(fname, "rb", **kwargs)
FileNotFoundError: [Errno 2] No such file or directory: '/proc/12345/stat'
...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/__init__.py", line 332, in __init__
    self._init(pid)
  File "/data/weichiang/miniconda3/envs/sky/lib/python3.8/site-packages/psutil/__init__.py", line 373, in _init
    raise NoSuchProcess(pid, msg='process PID not found')
psutil.NoSuchProcess: process PID not found (pid=12345)

>>> try:
...     psutil.Process(12345)
... except psutil.NoSuchProcess:
...     print('no such process')
... 
no such process
>>> 
```