### PR TITLE
Cache head node ip address

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1161,12 +1161,15 @@ def get_node_ips(cluster_yaml: str,
     if cluster_name is not None:
         # get the latest handle
         handle = global_user_state.get_handle_from_cluster_name(cluster_name)
-        head_ip = handle.head_ip
-        if not _check_node_alive_fast(head_ip):
-            raise exceptions.FetchIPError(exceptions.FetchIPError.Reason.HEAD)
-        # Try optimize for the common case where we have 1 node.
-        if not return_private_ips and expected_num_nodes == 1:
-            return [head_ip]
+        if handle is not None:
+            head_ip = handle.head_ip
+            if not _check_node_alive_fast(head_ip):
+                raise exceptions.FetchIPError(exceptions.FetchIPError.Reason.HEAD)
+            # Try optimize for the common case where we have 1 node.
+            if not return_private_ips and expected_num_nodes == 1:
+                return [head_ip]
+        else:
+            head_ip = None
     else:
         head_ip = None
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1596,7 +1596,8 @@ class CloudVmRayBackend(backends.Backend):
         logger.info(f'{fore.CYAN}Processing file mounts.{style.RESET_ALL}')
         start = time.time()
         ip_list = backend_utils.get_node_ips(handle.cluster_yaml,
-                                             handle.launched_nodes)
+                                             handle.launched_nodes,
+                                             handle=handle)
         ssh_user, ssh_key = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         log_path = os.path.join(self.log_dir, 'file_mounts.log')

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -212,6 +212,20 @@ def set_cluster_status(cluster_name: str, status: ClusterStatus) -> None:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
+def set_cluster_head_ip(cluster_name: str, head_ip: str):
+    handle = get_handle_from_cluster_name(cluster_name)
+    handle.head_ip = head_ip
+    _DB.cursor.execute('UPDATE clusters SET handle=(?) WHERE name=(?)', (
+        pickle.dumps(handle),
+        cluster_name,
+    ))
+    count = _DB.cursor.rowcount
+    _DB.conn.commit()
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
+
+
 def set_cluster_autostop_value(cluster_name: str, idle_minutes: int) -> None:
     _DB.cursor.execute('UPDATE clusters SET autostop=(?) WHERE name=(?)', (
         idle_minutes,

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -46,6 +46,7 @@ install_requires = [
     'grpcio<=1.43.0',
     'psutil',
     'pulp',
+    'requests',
 ]
 
 extras_require = {

--- a/tests/test_get_node_ip_cache.py
+++ b/tests/test_get_node_ip_cache.py
@@ -22,5 +22,8 @@ def test_head_ip_cache_invalidated():
     )
     global_user_state.add_or_update_cluster(cluster_name, handle, ready=True)
     with pytest.raises(exceptions.FetchIPError):
-        backend_utils.get_node_ips('', 1, cluster_name=cluster_name)
+        backend_utils.get_node_ips('',
+                                   1,
+                                   cluster_name=cluster_name,
+                                   check_cached_ips=True)
     global_user_state.remove_cluster(cluster_name, terminate=True)

--- a/tests/test_get_node_ip_cache.py
+++ b/tests/test_get_node_ip_cache.py
@@ -1,0 +1,26 @@
+import pytest
+
+import sky
+from sky import backends
+from sky import exceptions
+from sky import global_user_state
+from sky.backends import backend_utils
+
+
+def test_head_ip_cache_invalidated():
+    # This unittest ensures 'get_node_ips' will error with the
+    # cached IP but actually the IP is
+    cluster_name = 'test-head-ip-cache-invalidated'
+    handle = backends.CloudVmRayBackend.ResourceHandle(
+        cluster_name=cluster_name,
+        cluster_yaml='/tmp/cluster1.yaml',
+        head_ip='169.254.0.0',
+        launched_nodes=1,
+        launched_resources=sky.Resources(sky.AWS(),
+                                         instance_type='p3.2xlarge',
+                                         region='us-east-1'),
+    )
+    global_user_state.add_or_update_cluster(cluster_name, handle, ready=True)
+    with pytest.raises(exceptions.FetchIPError):
+        backend_utils.get_node_ips('', 1, cluster_name=cluster_name)
+    global_user_state.remove_cluster(cluster_name, terminate=True)


### PR DESCRIPTION
The original code tried to reuse a cached head node ip address, but this does not actually work well when multiple processes are accessing the same node. Also the reusing could be dangerous because the head node may already down, so the ip address is actually invalid, and it is not checked in `get_node_ips`.

This PR stores the head node ip address in the database in the right place (so multiple processes can share it once the head node ip is updated), and it performs a quick check of the aliveness of the head node when getting cached IP.

## Tests

- [x] Milestone "100 jobs"
- [x] Smoke tests
- [x] Unit test