### PR TITLE
Make `sky launch` prompting consistent with interactive nodes

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -716,8 +716,6 @@ def launch(
             cluster_str = '' if cluster is None else f' {cluster!r}'
             prompt = f'Launching a new cluster{cluster_str}. Proceed?'
             dag = sky.optimize(dag)
-            task = dag.tasks[0]
-            backend.register_info(dag=dag)
         elif maybe_status == global_user_state.ClusterStatus.STOPPED:
             prompt = f'Restarting the stopped cluster {cluster!r}. Proceed?'
         if prompt is not None:


### PR DESCRIPTION
Fixes #703.

### Tests
```
sky launch examples/minimal.yaml
sky launch examples/minimal.yaml -y
sky launch examples/minimal.yaml -c c1
sky launch examples/minimal.yaml -c c1
sky cpunode
```