### PR TITLE
Fix sqlite3 rename problem with older version

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -46,10 +46,11 @@ class _SQLiteConn(threading.local):
         self.cursor.execute("""\
             CREATE TABLE IF NOT EXISTS clusters (
             name TEXT PRIMARY KEY,
-            lauched_at INTEGER,
+            launched_at INTEGER,
             handle BLOB,
             last_use TEXT,
-            status TEXT)""")
+            status TEXT,
+            autostop INTEGER DEFAULT -1)""")
         # Table for Sky Config (e.g. enabled clouds)
         self.cursor.execute("""\
             CREATE TABLE IF NOT EXISTS config (
@@ -58,7 +59,7 @@ class _SQLiteConn(threading.local):
         self.cursor.execute("""\
             CREATE TABLE IF NOT EXISTS storage (
             name TEXT PRIMARY KEY,
-            lauched_at INTEGER,
+            launched_at INTEGER,
             handle BLOB,
             last_use TEXT,
             status TEXT)""")
@@ -68,10 +69,6 @@ class _SQLiteConn(threading.local):
         # Add autostop column to clusters table
         db_utils.add_column_to_table(self.cursor, self.conn, 'clusters',
                                      'autostop', 'INTEGER DEFAULT -1')
-        db_utils.rename_column(self.cursor, self.conn, 'clusters', 'lauched_at',
-                               'launched_at')
-        db_utils.rename_column(self.cursor, self.conn, 'storage', 'lauched_at',
-                               'launched_at')
 
         self.conn.commit()
 

--- a/sky/skylet/utils/db_utils.py
+++ b/sky/skylet/utils/db_utils.py
@@ -29,6 +29,8 @@ def rename_column(
     new_name: str,
 ):
     """Rename a column in a table."""
+    # NOTE: This only works for sqlite3 >= 3.25.0. Be careful to use this.
+
     for row in cursor.execute(f'PRAGMA table_info({table_name})'):
         if row[1] == old_name:
             cursor.execute(f'ALTER TABLE {table_name} '


### PR DESCRIPTION
When we are trying to set up sky on Fabio's laptop with python virtenv, and found the `sky check` complains about renaming the column in the state.db.

After debugging with @infwinston , we found that the problem is caused by an older version of sqlite3 (<3.25) which does not support the syntax for renaming columns.

We remove the usage of the rename function since all our users should already be on our relatively new version of sky (within 2 months). It should be safe to use the new column name without the renaming.