### PR TITLE
Remove azureTokens.json from the credential list

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -10,7 +10,6 @@ from sky.clouds import service_catalog
 
 # Minimum set of files under ~/.azure that grant Azure access.
 _CREDENTIAL_FILES = [
-    'accessTokens.json',
     'azureProfile.json',
     'clouds.config',
     'config',


### PR DESCRIPTION
Thanks to @concretevitamin and @romilb for finding and identifying this problem. With my `azure-core` cli (version `2.30.0`), there will be no `azureTokens.json` generated in the credential folder.  We should remove the file from the folder to avoid ray file_mounts failure.

Tested:
- [x] `sky cpunode --cloud azure` and `sky cpunode -c remote-cpunode --cloud azure` on the remote instance.