### PR TITLE
Storage delete no local folder fix

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -409,6 +409,7 @@ class Storage(object):
                     f'Found source={source}')
             # Local path, check if it exists
             source = os.path.abspath(os.path.expanduser(source))
+            # Only check if local source exists if it is synced to the bucket
             if not os.path.exists(source) and sync_on_reconstruction:
                 raise exceptions.StorageSourceError('Local source path does not'
                                                     f' exist: {source}')


### PR DESCRIPTION
Fixes #855. The bug was in `_validate_source` where Sky Storage detects `source` doesn't exist and errors out. To fix this, Sky Storage will not check if `source` exists if `sync_on_reconstruction` is False.

## Tests

Task YAML
```
file_mounts:
  /checkpoints:
    name: michaels-new-bucket-1
    source: ~/Downloads/hallo
    store: gcs
    mode: COPY
```

`mv ~/Downloads/hallo ~/Downloads/hello`
`sky storage delete michaels-new-bucket-1`
