### PR TITLE
[Docker] Fix cluster name from handle method

### DIFF
--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -89,7 +89,7 @@ class LocalDockerBackend(backends.Backend):
             return str.__new__(cls, prefixed_str, **kw)
 
         def get_cluster_name(self):
-            return self
+            return self.lstrip(_DOCKER_HANDLE_PREFIX)
 
     # Define the Docker-in-Docker mount
     _dind_mount = {


### PR DESCRIPTION
Closes #897.

Tested:
- [x] `sky launch -c mytask minimal.yaml`