### PR TITLE
Fix network connection check in spot

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -74,7 +74,7 @@ WAIT_HEAD_NODE_IP_RETRY_COUNT = 3
 # We use fixed IP address to avoid DNS lookup blocking the check, for machine
 # with no internet connection.
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
-_TEST_IP = '1.1.1.1'
+_TEST_IP = '8.8.8.8'
 
 # GCP has a 63 char limit; however, Ray autoscaler adds many
 # characters. Through testing, 37 chars is the maximum length for the Sky


### PR DESCRIPTION
I got the below error again when using `eduroam` in RISElab (we previously met this in retreat at Hyatt). I changed the target ip from `1.1.1.1` to `8.8.8.8` and it then works for some reason.. Not sure this is the best fix. Alternatively we should try to use IPs related to the cloud providers.
```
(sky) weichiang@mbp sky % sky spot status                                                                                      
Fetching managed spot job statuses...                                                                                          
Traceback (most recent call last):                                                                                             
  File "/Users/weichiang/repos/sky/sky/backends/backend_utils.py", line 1212, in check_network_connection          
    conn.request('HEAD', '/')                                  
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1256, in request          
    self._send_request(method, url, body, headers, encode_chunked)                                                             
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1302, in _send_request      
    self.endheaders(body, encode_chunked=encode_chunked)   
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1251, in endheaders         
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1011, in _send_output
    self.send(msg)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 951, in send
    self.connect()
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1418, in connect
    super().connect()
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 922, in connect
    self.sock = self._create_connection(
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
socket.timeout: timed out
....
sky.exceptions.NetworkError: Could not refresh the cluster. Network seems down.
```

With `8.8.8.8`
```
(sky) weichiang@mbp sky % sky spot status
Fetching managed spot job statuses...
Managed spot jobs:
In progress jobs: 1 RUNNING

ID  NAME                          RESOURCES     SUBMITTED   TOT. DURATION  JOB DURATION  #RECOVERIES  STATUS   
1   test-gcp-spot-weichiang-646c  1x [CPU:0.5]  9 mins ago  9m 50s         7m 19s        0            RUNNING  
```


```
>>> _TEST_IP='1.1.1.1'
>>> conn = httplib.HTTPSConnection(_TEST_IP, timeout=3)
>>> conn.request('HEAD', '/')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1256, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1302, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1251, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1011, in _send_output
    self.send(msg)
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 951, in send
    self.connect()
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/http/client.py", line 1425, in connect
    self.sock = self._context.wrap_socket(self.sock,
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/Users/weichiang/opt/miniconda3/envs/sky/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
socket.timeout: _ssl.c:1114: The handshake operation timed out
>>> _TEST_IP='8.8.8.8'
>>> conn = httplib.HTTPSConnection(_TEST_IP, timeout=3)
>>> conn.request('HEAD', '/')
>>> 
```