### PR TITLE
Add conda installation test

### DIFF
--- a/.github/workflows/condatest.yml
+++ b/.github/workflows/condatest.yml
@@ -1,0 +1,39 @@
+name: condatest
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  condatest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Add conda to system path
+      run: |
+          # $CONDA is an environment variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+
+    - name: conda installation test
+      run: |
+        conda create -n condatest python=3.7
+        conda init
+        eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+        conda activate condatest
+
+        pip install ".[all]"
+        sky
+        sky check

--- a/.github/workflows/condatest.yml
+++ b/.github/workflows/condatest.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - conda-test
   pull_request:
     branches:
       - master
+      - conda-test
 jobs:
   condatest:
     runs-on: ubuntu-latest

--- a/.github/workflows/condatest.yml
+++ b/.github/workflows/condatest.yml
@@ -6,11 +6,9 @@ on:
   push:
     branches:
       - master
-      - conda-test
   pull_request:
     branches:
       - master
-      - conda-test
 jobs:
   condatest:
     runs-on: ubuntu-latest
@@ -36,6 +34,6 @@ jobs:
         eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
         conda activate condatest
 
-        pip install ".[aws]"
+        pip install ".[all]"
         sky
         sky check

--- a/.github/workflows/condatest.yml
+++ b/.github/workflows/condatest.yml
@@ -34,6 +34,6 @@ jobs:
         eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
         conda activate condatest
 
-        pip install ".[all]"
+        pip install ".[aws]"
         sky
         sky check


### PR DESCRIPTION
To avoid issues like https://github.com/sky-proj/sky/issues/879 in the future. We didn't catch it because we use Python 3.6 in our test, with that version the latest protobuf won't be installed.