### PR TITLE
Add retry for head ip fetching

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -76,7 +76,7 @@ _LAUNCHED_WORKER_PATTERN = re.compile(r'(\d+) ray[._]worker[._]default')
 # 10.133.0.5: ray.worker.default,
 _LAUNCHING_IP_PATTERN = re.compile(
     r'({}): ray[._]worker[._]default'.format(IP_ADDR_REGEX))
-WAIT_HEAD_NODE_IP_RETRY_COUNT = 3
+WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 
 # We use fixed IP address to avoid DNS lookup blocking the check, for machine
 # with no internet connection.
@@ -719,7 +719,7 @@ def wait_until_ray_cluster_ready(
     # launched especially for Azure.
     try:
         head_ip = query_head_ip_with_retries(
-            cluster_config_file, retry_count=WAIT_HEAD_NODE_IP_RETRY_COUNT)
+            cluster_config_file, max_attempts=WAIT_HEAD_NODE_IP_MAX_ATTEMPTS)
     except RuntimeError as e:
         logger.error(e)
         return False  # failed
@@ -1151,9 +1151,9 @@ def generate_cluster_name():
     return f'sky-{uuid.uuid4().hex[:4]}-{getpass.getuser()}'
 
 
-def query_head_ip_with_retries(cluster_yaml: str, retry_count: int = 1) -> str:
+def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:
     """Returns the ip of the head node from yaml file."""
-    for i in range(retry_count):
+    for i in range(max_attempts):
         try:
             out = run(f'ray get-head-ip {cluster_yaml}',
                       stdout=subprocess.PIPE).stdout.decode().strip()
@@ -1162,7 +1162,7 @@ def query_head_ip_with_retries(cluster_yaml: str, retry_count: int = 1) -> str:
             head_ip = head_ip[0]
             break
         except subprocess.CalledProcessError as e:
-            if i == retry_count - 1:
+            if i == max_attempts - 1:
                 raise RuntimeError('Failed to get head ip') from e
             # Retry if the cluster is not up yet.
             logger.debug('Retrying to get head ip.')
@@ -1174,7 +1174,7 @@ def query_head_ip_with_retries(cluster_yaml: str, retry_count: int = 1) -> str:
 def get_node_ips(cluster_yaml: str,
                  expected_num_nodes: int,
                  handle: Optional[backends.Backend.ResourceHandle] = None,
-                 head_ip_retry_count: int = 1) -> List[str]:
+                 head_ip_max_attempts: int = 1) -> List[str]:
     """Returns the IPs of all nodes in the cluster."""
     # Try optimize for the common case where we have 1 node.
     if (expected_num_nodes == 1 and handle is not None and
@@ -1187,7 +1187,7 @@ def get_node_ips(cluster_yaml: str,
     check_network_connection()
     try:
         head_ip = query_head_ip_with_retries(cluster_yaml,
-                                             retry_count=head_ip_retry_count)
+                                             max_attempts=head_ip_max_attempts)
     except RuntimeError as e:
         raise exceptions.FetchIPError(
             exceptions.FetchIPError.Reason.HEAD) from e
@@ -1214,11 +1214,11 @@ def get_node_ips(cluster_yaml: str,
 def get_head_ip(
     handle: backends.Backend.ResourceHandle,
     use_cached_head_ip: bool = True,
-    retry_count: int = 1,
+    max_attempts: int = 1,
 ) -> str:
     """Returns the ip of the head node."""
-    assert not use_cached_head_ip or retry_count == 1, (
-        'Cannot use cached_head_ip when retry_count is not 1')
+    assert not use_cached_head_ip or max_attempts == 1, (
+        'Cannot use cached_head_ip when max_attempts is not 1')
     if use_cached_head_ip:
         if handle.head_ip is None:
             # This happens for INIT clusters (e.g., exit 1 in setup).
@@ -1228,7 +1228,7 @@ def get_head_ip(
                 ' the cluster status is UP (`sky status`).')
         head_ip = handle.head_ip
     else:
-        head_ip = query_head_ip_with_retries(handle.cluster_yaml, retry_count)
+        head_ip = query_head_ip_with_retries(handle.cluster_yaml, max_attempts)
     return head_ip
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -77,7 +77,7 @@ _RSYNC_EXCLUDE_OPTION = '--exclude-from={}'
 _RETRY_UNTIL_UP_INIT_GAP_SECONDS = 60
 
 # The maximum retry count for fetching head IP address.
-_HEAD_IP_RETRY_COUNT = 3
+_HEAD_IP_MAX_ATTEMPTS = 3
 
 _TEARDOWN_FAILURE_MESSAGE = (
     f'{colorama.Fore.RED}Failed to terminate '
@@ -1426,7 +1426,7 @@ class CloudVmRayBackend(backends.Backend):
                 ip_list = backend_utils.get_node_ips(
                     cluster_config_file,
                     config_dict['launched_nodes'],
-                    head_ip_retry_count=_HEAD_IP_RETRY_COUNT)
+                    head_ip_max_attempts=_HEAD_IP_MAX_ATTEMPTS)
                 head_ip = ip_list[0]
 
             handle = self.ResourceHandle(
@@ -2542,9 +2542,9 @@ class CloudVmRayBackend(backends.Backend):
         **kwargs,
     ) -> Union[int, Tuple[int, str, str]]:
         """Runs 'cmd' on the cluster's head node."""
-        retry_count = 1 if use_cached_head_ip else _HEAD_IP_RETRY_COUNT
+        max_attempts = 1 if use_cached_head_ip else _HEAD_IP_MAX_ATTEMPTS
         head_ip = backend_utils.get_head_ip(handle, use_cached_head_ip,
-                                            retry_count)
+                                            max_attempts)
         ssh_user, ssh_private_key = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         if under_remote_workdir:


### PR DESCRIPTION
The two smoke tests for azure sometimes fail due to errors from `ray get-head-ip`. This PR adds retries for getting head ip when the cluster is just created.

Tested:
- [x] `test_azure_start_stop`
- [x] `test_cancel_azure`