### PR TITLE
Retry for azure head fetching timeout

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -931,7 +931,7 @@ def generate_cluster_name():
 
 def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:
     """Returns the ip of the head node from yaml file."""
-    backoff = Backoff(initial_backoff = 5, max_backoff_factor=5)
+    backoff = Backoff(initial_backoff=5, max_backoff_factor=5)
     for i in range(max_attempts):
         try:
             out = subprocess_utils.run(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1620,14 +1620,16 @@ class CloudVmRayBackend(backends.Backend):
             f'--address=127.0.0.1:8265 --job-id {job_id} --no-wait '
             f'-- "{executable} -u {script_path} > {remote_log_path} 2>&1"')
 
-        returncode, stdout, stderr = self.run_on_head(handle,
-                                      f'{cd} && {job_submit_cmd}',
-                                      stream_logs=False,
-                                      require_outputs = True,
-                                    )
-        subprocess_utils.handle_returncode(returncode, job_submit_cmd,
+        returncode, stdout, stderr = self.run_on_head(
+            handle,
+            f'{cd} && {job_submit_cmd}',
+            stream_logs=False,
+            require_outputs=True,
+        )
+        subprocess_utils.handle_returncode(returncode,
+                                           job_submit_cmd,
                                            f'Failed to submit job {job_id}.',
-                                           stderr = stdout + stderr)
+                                           stderr=stdout + stderr)
 
         logger.info('Job submitted with Job ID: '
                     f'{style.BRIGHT}{job_id}{style.RESET_ALL}')


### PR DESCRIPTION
This PR is an attempt to close #908, by retrying the ray up for the azure cluster when the head node failed to launch.

Tested:
- [ ] run smoke test 5 times for with/without this PR.
  with this PR: (Failed once for the stop/start test, and the reason seems the Azure does not start the stopped instance but launched another one, when `sky start` was called)