### PR TITLE
Update error message for unknown YAML fields

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1830,15 +1830,17 @@ def validate_schema(obj, schema, err_msg_prefix=''):
     try:
         validator.SchemaValidator(schema).validate(obj)
     except jsonschema.ValidationError as e:
-        err_msg = err_msg_prefix + e.message
         if e.validator == 'additionalProperties':
+            err_msg = err_msg_prefix + 'The following fields are invalid:'
             known_fields = set(e.schema.get('properties', {}).keys())
             for field in e.instance:
                 if field not in known_fields:
                     most_similar_field = difflib.get_close_matches(
                         field, known_fields, 1)
                     if most_similar_field:
-                        err_msg += f'\nInstead of {field}, did you mean {most_similar_field[0]}?'
+                        err_msg += f'\nInstead of \'{field}\', did you mean \'{most_similar_field[0]}\'?'
+        else:
+            err_msg = err_msg_prefix + e.message
 
     if err_msg:
         raise ValueError(err_msg)


### PR DESCRIPTION
As discussed in #674, this updates the default error message when unknown fields are encountered in the YAML schema to be clearer, building on #926. Please feel free to raise any nits on how to improve the message.

Previously:
```
❯ sky launch -c mycluster hello_sky.yaml --docker
Task from YAML spec: hello_sky.yaml
ValueError: Invalid resources YAML: Additional properties are not allowed ('spot_recovery1' was unexpected)
Instead of spot_recovery1, did you mean spot_recovery?
```

Now:
```
❯ sky launch -c mycluster hello_sky.yaml --docker
Task from YAML spec: hello_sky.yaml
ValueError: Invalid resources YAML: The following fields are invalid:
Instead of 'spot_recovery1', did you mean 'spot_recovery'?
```

Tested:
- [Full configuration](https://sky-proj-sky.readthedocs-hosted.com/en/latest/reference/yaml-spec.html)
- Failing enum checks
- Failing type checks
- Unknown fields