### PR TITLE
Fix Storage Download to Local

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -67,6 +67,11 @@ class StorageBucketDeleteError(StorageError):
     pass
 
 
+class StorageBucketDownloadError(StorageError):
+    # Error raised if an attempt to download from an existing bucket fails.
+    pass
+
+
 class StorageUploadError(StorageError):
     # Error raised when bucket is successfully initialized, but upload fails,
     # either due to permissions, ctrl-c, or other reasons.


### PR DESCRIPTION
Now Sky Storage advanced python users can download a bucket to local.

## Tests

```
from sky.data import storage, StoreType
storage_obj = storage.Storage(name='imagenet-bucket')
storage_obj.add_store(StoreType.S3)
s3_store =storage_obj.stores[StoreType.S3]
s3_store.download_remote_dir('~/Downloads/hello')
```