### PR TITLE
Fix test_cli by adding patching

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,11 @@
-import pytest
 import tempfile
 import textwrap
 
-import click
 from click import testing as cli_testing
 
 import sky
-import sky.cli as cli
 from sky import clouds
+import sky.cli as cli
 
 
 def test_infer_gpunode_type():
@@ -45,6 +43,13 @@ def test_infer_tpunode_type():
 
 def test_accelerator_mismatch(monkeypatch):
     """Test the specified accelerator does not match the instance_type."""
+    # Monkey-patching is required because in the test environment, no cloud is
+    # enabled. The optimizer checks the environment to find enabled clouds, and
+    # only generates plans within these clouds. The tests assume that all three
+    # clouds are enabled, so we monkeypatch the `sky.global_user_state` module
+    # to return all three clouds. We also monkeypatch `sky.check.check` so that
+    # when the optimizer tries calling it to update enabled_clouds, it does not
+    # raise exceptions.
     enabled_clouds = list(clouds.CLOUD_REGISTRY.values())
     monkeypatch.setattr(
         'sky.global_user_state.get_enabled_clouds',

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -24,7 +24,7 @@ def _test_parse_accelerators(spec, expected_accelerators):
 # clouds are enabled, so we monkeypatch the `sky.global_user_state` module
 # to return all three clouds. We also monkeypatch `sky.check.check` so that
 # when the optimizer tries calling it to update enabled_clouds, it does not
-# raise SystemExit.
+# raise exceptions.
 def _make_resources(
     monkeypatch,
     *resources_args,


### PR DESCRIPTION
Closes #947 .

This PR monkeypatch the `sky.check` so that AWS is not considered disabled. This is weird though, as github test sometimes succeeded even with the previous bug.