### PR TITLE
Fix gsutil error

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1181,7 +1181,7 @@ class GcsStore(AbstractStore):
             with backend_utils.safe_console_status(
                     f'[bold cyan]Deleting [green]bucket {bucket_name}'):
                 if num_files >= _GCS_RM_MAX_OBJS:
-                    remove_obj_command = f'gsutil rm -m -a gs://{bucket_name}/*'
+                    remove_obj_command = f'gsutil -m rm -a gs://{bucket_name}/*'
                     subprocess.check_output(remove_obj_command.split(' '))
                 bucket.delete(force=True)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
As reported by @Michaelvll, `sky storage delete` would fail for GCS buckets with newer versions of gsutil (5.9). Turns out `gsutil` now requires the `-m` flag to be before `rm` for deleting bucket objects. This PR fixes `GcsStore._delete_gcs_bucket` to reflect the change.