### PR TITLE
`force_managed` field for Storage

### DIFF
--- a/examples/storage/force_managed.yaml
+++ b/examples/storage/force_managed.yaml
@@ -1,0 +1,24 @@
+# Demo to show the use of force_managed argument in sky.Storage.
+#
+# force_managed field in a Storage allows Sky to "take ownership" of an existing
+# store object. This is useful when you have an existing bucket and want to be
+# able to manage it using sky (e.g., use sky storage delete) to delete the bucket.
+#
+# Usage:
+#   sky launch -c force force_managed.yaml
+#   sky storage ls
+#   sky storage delete my-external-bucket
+
+name: force_managed
+
+resources:
+  cloud: aws
+
+file_mounts:
+  /mymount2:
+    source: s3://my-external-bucket  # Make sure this bucket already exists.
+    force_managed: true
+    mode: MOUNT
+
+run: |
+  echo "my-external-bucket should now show up in your sky storage ls"

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1995,7 +1995,6 @@ def storage_delete(all: bool, name: str):  # pylint: disable=redefined-builtin
         storages = global_user_state.get_storage()
         for row in storages:
             store_object = data.Storage(name=row['name'],
-                                        source=row['handle'].source,
                                         sync_on_reconstruction=False)
             store_object.delete()
     elif name:
@@ -2006,7 +2005,6 @@ def storage_delete(all: bool, name: str):  # pylint: disable=redefined-builtin
             else:
                 click.echo(f'Deleting storage object {n}.')
                 store_object = data.Storage(name=handle.storage_name,
-                                            source=handle.source,
                                             sync_on_reconstruction=False)
                 store_object.delete()
     else:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -485,6 +485,11 @@ class Storage(object):
                     f'Supported paths: local, s3://, gs://. Got: {source}')
         return source, is_local_source
 
+    @staticmethod
+    def _generate_name(source):
+        """Generates a name for the given source"""
+        return urllib.parse.urlsplit(source).netloc
+
     def _validate_storage_spec(self) -> None:
         """
         Validates the storage spec and updates local fields if necessary.
@@ -495,9 +500,6 @@ class Storage(object):
         """
         source, is_local_source = Storage._validate_source(
             self.source, self.mode, self.sync_on_reconstruction)
-        if self.sync_on_reconstruction:
-            # Reconstructed storages need only source validation.
-            return
         if self.source is None:
             # If the mode is COPY, the source must be specified
             if self.mode == StorageMode.COPY:
@@ -534,7 +536,7 @@ class Storage(object):
                             'local.')
                 else:
                     # Set name to source bucket name and continue
-                    self.name = urllib.parse.urlsplit(source).netloc
+                    self.name = self._generate_name(self.source)
                     return
             else:
                 if is_local_source:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -164,8 +164,7 @@ class AbstractStore:
                     raise exceptions.StorageInitError(
                         f'Unable to assert ownership of bucket {self.name} - '
                         'insufficient permissions. Cannot use '
-                        'force_managed=True for this store.'
-                    )
+                        'force_managed=True for this store.')
 
         elif self.is_sky_managed is None:
             # If is_sky_managed is not specified, then this is a new storage

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -161,7 +161,11 @@ class AbstractStore:
             # mark it as is_sky_managed=True.
             if not self._check_permissions():
                 with ux_utils.print_exception_no_traceback():
-                    raise exceptions.StorageInitError(f'Unable to assert ownership of bucket {self.name} - insufficient permissions. Cannot use force_managed=True for this store.')
+                    raise exceptions.StorageInitError(
+                        f'Unable to assert ownership of bucket {self.name} - '
+                        'insufficient permissions. Cannot use '
+                        'force_managed=True for this store.'
+                    )
 
         elif self.is_sky_managed is None:
             # If is_sky_managed is not specified, then this is a new storage
@@ -185,7 +189,8 @@ class AbstractStore:
             True if the user has read/write/delete permissions on the bucket.
             False otherwise.
         Raises:
-            exceptions.StorageInitError: If the user does not have permissions to check the bucket ACL or fetching the user id fails.
+            exceptions.StorageInitError: If the user does not have permissions
+            to check the bucket ACL or fetching the user id fails.
         """
         raise NotImplementedError()
 
@@ -297,10 +302,7 @@ class Storage(object):
         - (required) Source
         """
 
-        def __init__(self,
-                     *,
-                     storage_name: str,
-                     source: str):
+        def __init__(self, *, storage_name: str, source: str):
             assert storage_name is not None or source is not None
             self.storage_name = storage_name
             self.source = source
@@ -431,9 +433,10 @@ class Storage(object):
         """Validates the source path.
 
         Args:
-          source: str or None; File path where the data is initially stored. Can be a
-            local path or a cloud URI (s3://, gs://, etc.). Local paths do not
-            need to be absolute. Can be None, in which case it is a valid source.
+          source: str or None; File path where the data is initially stored.
+            Can be a local path or a cloud URI (s3://, gs://, etc.). Local
+            paths do not need to be absolute. Can be None, in which case it is
+            a valid source.
           mode: StorageMode; StorageMode of the storage object
 
         Returns:
@@ -537,7 +540,7 @@ class Storage(object):
                             'local.')
                 else:
                     # Set name to source bucket name and continue
-                    self.name = self._generate_name(self.source)
+                    self.name = self._generate_name(source)
                     return
             else:
                 if is_local_source:
@@ -781,7 +784,8 @@ class S3Store(AbstractStore):
             True if the user has read/write/delete permissions on the bucket.
             False otherwise.
         Raises:
-            exceptions.StorageInitError: If the user does not have permissions to check the bucket ACL or fetching the user id fails.
+            exceptions.StorageInitError: If the user does not have permissions
+              to check the bucket ACL or fetching the user id fails.
         """
         # TODO(romilb): User may have sufficient permissions even though the
         #  user may not be the owner of the bucket. This is hard to check
@@ -792,16 +796,17 @@ class S3Store(AbstractStore):
             user_id = self.client.list_buckets()['Owner']['ID']
         except (aws.client_exception(), KeyError) as e:
             raise exceptions.StorageInitError(
-                f'Failed to get user id for checking permissions.') from e
+                'Failed to get user id for checking permissions.') from e
         # Get the bucket owner's canonical id
         try:
-            owner_id = self.client.get_bucket_acl(Bucket=self.name)['Owner']['ID']
+            owner_id = self.client.get_bucket_acl(
+                Bucket=self.name)['Owner']['ID']
         except aws.client_exception() as e:
             raise exceptions.StorageInitError(
                 f'Failed to get bucket ACL for bucket {self.name}.') from e
         except KeyError as e:
             raise exceptions.StorageInitError(
-                f'Owner or ID field not found in bucket ACL response.') from e
+                'Owner or ID field not found in bucket ACL response.') from e
         return user_id == owner_id
 
     def upload(self):

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -96,7 +96,10 @@ def get_storage_schema():
                 'case_insensitive_enum': [
                     mode.value for mode in storage.StorageMode
                 ]
-            }
+            },
+            'force_managed': {
+                'type': 'boolean',
+            },
         }
     }
 


### PR DESCRIPTION
This PR introduces a new argument to sky storage - `force_managed`. If `force_managed` is set to True and the storage object points to an existing user owned bucket (e.g, `source=s3://my-existing-bucket`), the storage object `my-existing-bucket` will get populated in `sky storage ls`. 

This is required for #959, #974.


# Before
If I create a bucket through aws cli
```
aws s3 mb s3://my-external-bucket
```

And then run this YAML: 
```
file_mounts:
  /mymount:
    source: s3://my-external-bucket 
    mode: MOUNT
```

My `sky storage ls ` would have been empty.

```
(base) romilb@romilbx1yoga:~$ sky storage ls
No existing storage.
```
# After

If I set `force_managed: true`:
```
file_mounts:
  /mymount:
    source: s3://my-external-bucket 
    force_managed: true
    mode: MOUNT
```

My `sky storage ls`:
```
(base) romilb@romilbx1yoga:~$ sky storage ls
NAME                   CREATED    STORE  COMMAND                                 STATUS
romil-external-bucket  1 min ago  S3     sky launch -c force force_managed.yaml  READY
```


## Tested
- [ ] `./run_smoke_tests.sh`
- [x] `pytest tests/test_smoke.py::TestStorageWithCredentials`

## TODO:
- [ ] Add support for force_managed for `gcs` (will be done in this PR)
- [ ] Update docs