### PR TITLE
UX: Fix empty 'The following fields are invalid:' outputs.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1715,7 +1715,10 @@ def validate_schema(obj, schema, err_msg_prefix=''):
                     most_similar_field = difflib.get_close_matches(
                         field, known_fields, 1)
                     if most_similar_field:
-                        err_msg += f'\nInstead of \'{field}\', did you mean \'{most_similar_field[0]}\'?'
+                        err_msg += (f'\nInstead of {field!r}, did you mean '
+                                    f'{most_similar_field[0]!r}?')
+                    else:
+                        err_msg += f'\nFound unsupported field {field!r}.'
         else:
             err_msg = err_msg_prefix + e.message
 


### PR DESCRIPTION
```
resources:
  zone: europe-west4-a
```
would print
```
» sky launch t.yaml                                                                          
Task from YAML spec: t.yaml
ValueError: Invalid resources YAML: The following fields are invalid:
```
because there's no similar fields to `zone`. This PR fixes that.
