### PR TITLE
Add 3 GPU VMs to Azure catalog fetcher

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -97,6 +97,7 @@ def get_gpu_name(family: str) -> str:
         'standardNCPromoFamily': 'K80',
         'StandardNCASv3_T4Family': 'T4',
         'standardNDSv2Family': 'V100-32GB',
+        'StandardNCADSA100v4Family': 'A100-80GB',
         'standardNDAMSv4_A100Family': 'A100-80GB',
         'StandardNDASv4_A100Family': 'A100',
         'standardNVFamily': 'M60',
@@ -104,6 +105,8 @@ def get_gpu_name(family: str) -> str:
         'standardNVSv3Family': 'M60',
         'standardNVPromoFamily': 'M60',
         'standardNVSv4Family': 'Radeon MI25',
+        'standardNDSFamily': 'P40',
+        'StandardNVADSA10v5Family': 'A10',
     }
     # NP-series offer Xilinx U250 FPGAs which are not GPUs,
     # so we do not include them here.


### PR DESCRIPTION
I found that the three GPU VMs are missing in the Azure service catalog. While we cannot currently use those VMs due to the quota limit, I think it's good to include them in the catalog.

*This PR fixes the catalog fetcher, but does not directly add the GPU VMs to the catalog. The VMs will be added in the next catalog update.

StandardNCADSA100v4Family (1x, 2x, 4x A100-80GB): https://docs.microsoft.com/en-us/azure/virtual-machines/nc-a100-v4-series
standardNDSFamily (P40): https://docs.microsoft.com/en-us/azure/virtual-machines/nd-series
StandardNVADSA10v5Family (A10): https://docs.microsoft.com/en-us/azure/virtual-machines/nva10v5-series