### PR TITLE
Fix job status transition

### DIFF
--- a/examples/huggingface_glue_imdb_app.yaml
+++ b/examples/huggingface_glue_imdb_app.yaml
@@ -9,8 +9,8 @@ resources:
 setup: |
   git clone https://github.com/huggingface/transformers/
   # checkout to the correct version
-  git checkout v4.21.0
   cd transformers
+  git checkout v4.21.0
   pip3 install .
   cd examples/pytorch/text-classification
   pip3 install -r requirements.txt

--- a/examples/huggingface_glue_imdb_app.yaml
+++ b/examples/huggingface_glue_imdb_app.yaml
@@ -8,6 +8,8 @@ resources:
 # The setup command.  Will be run under the working directory.
 setup: |
   git clone https://github.com/huggingface/transformers/
+  # checkout to the correct version
+  git checkout v4.21.0
   cd transformers
   pip3 install .
   cd examples/pytorch/text-classification

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -973,9 +973,10 @@ def get_node_ips(cluster_yaml: str,
         while retry_cnt < worker_ip_max_attempts:
             retry_cnt += 1
             try:
-                proc = subprocess_utils.run(f'ray get-worker-ips {cluster_yaml}',
-                                            stdout=subprocess.PIPE,
-                                            stderr=subprocess.PIPE)
+                proc = subprocess_utils.run(
+                    f'ray get-worker-ips {cluster_yaml}',
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE)
                 out = proc.stdout.decode()
             except subprocess.CalledProcessError as e:
                 raise exceptions.FetchIPError(
@@ -985,7 +986,7 @@ def get_node_ips(cluster_yaml: str,
         # Workaround: List of IPs are shown in Stderr
         cluster_name = os.path.basename(cluster_yaml).split('.')[0]
         if ((handle is not None and hasattr(handle, 'local_handle') and
-                handle.local_handle is not None) or
+             handle.local_handle is not None) or
                 onprem_utils.check_if_local_cloud(cluster_name)):
             out = proc.stderr.decode()
             worker_ips = re.findall(IP_ADDR_REGEX, out)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1096,10 +1096,10 @@ class RetryingVmProvisioner(object):
                 logger.info(
                     'Retrying sky runtime setup due to ssh connection issue.')
                 return True
-            
-            if ('ConnectionResetError: [Errno 54] Connection reset by peer' in stderr):
-                logger.info(
-                    'Retrying due to Connection reset by peer.')
+
+            if ('ConnectionResetError: [Errno 54] Connection reset by peer'
+                    in stderr):
+                logger.info('Retrying due to Connection reset by peer.')
                 return True
             return False
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -67,7 +67,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = 30
 # Used only if --retry-until-up is set.
 _RETRY_UNTIL_UP_INIT_GAP_SECONDS = 60
 
-# The maximum retry count for fetching head IP address.
+# The maximum retry count for fetching IP address.
 _HEAD_IP_MAX_ATTEMPTS = 5
 _WORKER_IP_MAX_ATTEMPTS = 5
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1096,6 +1096,11 @@ class RetryingVmProvisioner(object):
                 logger.info(
                     'Retrying sky runtime setup due to ssh connection issue.')
                 return True
+            
+            if ('ConnectionResetError: [Errno 54] Connection reset by peer' in stderr):
+                logger.info(
+                    'Retrying due to Connection reset by peer.')
+                return True
             return False
 
         retry_cnt = 0

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -69,6 +69,7 @@ _RETRY_UNTIL_UP_INIT_GAP_SECONDS = 60
 
 # The maximum retry count for fetching head IP address.
 _HEAD_IP_MAX_ATTEMPTS = 5
+_WORKER_IP_MAX_ATTEMPTS = 5
 
 _TEARDOWN_FAILURE_MESSAGE = (
     f'{colorama.Fore.RED}Failed to terminate '
@@ -1592,7 +1593,8 @@ class CloudVmRayBackend(backends.Backend):
                 ip_list = backend_utils.get_node_ips(
                     cluster_config_file,
                     config_dict['launched_nodes'],
-                    head_ip_max_attempts=_HEAD_IP_MAX_ATTEMPTS)
+                    head_ip_max_attempts=_HEAD_IP_MAX_ATTEMPTS,
+                    worker_ip_max_attempts=_WORKER_IP_MAX_ATTEMPTS)
                 head_ip = ip_list[0]
 
             handle = self.ResourceHandle(

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -315,12 +315,8 @@ def update_status(job_owner: str, submitted_gap_sec: int = 0) -> None:
     job_status = query_job_status(job_owner, running_job_ids)
     # Process the results
     for job, status in zip(running_jobs, job_status):
-        # Do not update the status if the ray job status is RUNNING,
-        # because it could be pending for resources instead. The
-        # RUNNING status will be set by our generated ray program.
-        if status != JobStatus.RUNNING:
-            logger.info(f'Updating job {job["job_id"]} status to {status}')
-            set_status(job['job_id'], status)
+        logger.info(f'Updating job {job["job_id"]} status to {status}')
+        set_status(job['job_id'], status)
 
 
 def is_cluster_idle() -> bool:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -333,7 +333,7 @@ def update_job_status(job_owner: str,
             # TODO(mraheja): remove pylint disabling when filelock version
             # updated
             # pylint: disable=abstract-class-instantiated
-            with filelock.FileLock(_JOB_STATUS_LOCK.format(job_id)):
+            with filelock.FileLock(_get_lock_path(job_id)):
                 original_status = get_status_no_lock(job_id)
                 status = original_status
                 if not original_status.is_terminal():
@@ -352,7 +352,7 @@ def update_job_status(job_owner: str,
             # TODO(mraheja): remove pylint disabling when filelock version
             # updated
             # pylint: disable=abstract-class-instantiated
-            with filelock.FileLock(_JOB_STATUS_LOCK.format(job_id)):
+            with filelock.FileLock(_get_lock_path(job_id)):
                 original_status = get_status_no_lock(job_id)
                 # Taking max of the status is necessary because:
                 # 1. It avoids race condition, where the original status has

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -52,11 +52,11 @@ class JobStatus(enum.Enum):
 _RAY_TO_JOB_STATUS_MAP = {
     # These are intentionally set to one status before, because:
     # 1. when the ray status indicates the job is PENDING the generated
-    # python program should be not started yet, i.e. the job should be INIT.
+    # python program should not be started yet, i.e. the job should be INIT.
     # 2. when the ray status indicates the job is RUNNING the resources
     # may not be allocated yet, i.e. the job should be PENDING.
-    # Note: We need to compare the status with the sky cached job status
-    # to determine if the job is actually running.
+    # Note: We need to compare the status with the job status in our
+    # database for job, to determine if the job is actually running.
     'PENDING': JobStatus.INIT,
     'RUNNING': JobStatus.PENDING,
     'succeeded': JobStatus.SUCCEEDED,

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -27,7 +27,7 @@ _JOB_STATUS_LOCK = '~/.sky/locks/.job_{}.lock'
 
 def _get_lock_path(job_id: int) -> str:
     lock_path = os.path.expanduser(_JOB_STATUS_LOCK.format(job_id))
-    os.path.mkdir(os.path.dirname(lock_path), exist_ok=True)
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
     return lock_path
 
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -137,8 +137,6 @@ def add_job(job_name: str, username: str, run_timestamp: str,
 
 
 def set_status(job_id: int, status: JobStatus) -> None:
-    assert status != JobStatus.RUNNING, (
-        'Please use set_job_started() to set job status to RUNNING')
     # TODO(mraheja): remove pylint disabling when filelock version updated
     # pylint: disable=abstract-class-instantiated
     with filelock.FileLock(_JOB_STATUS_LOCK.format(job_id)):

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -41,8 +41,15 @@ class JobStatus(enum.Enum):
 
 
 _RAY_TO_JOB_STATUS_MAP = {
-    'PENDING': JobStatus.PENDING,
-    'RUNNING': JobStatus.RUNNING,
+    # These are intentionally set to one status before, because:
+    # 1. when the ray status indicates the job is PENDING the generated
+    # python program should be not started yet, i.e. the job should be INIT.
+    # 2. when the ray status indicates the job is RUNNING the resources
+    # may not be allocated yet, i.e. the job should be PENDING. 
+    # Note: We need to compare the status with the sky cached job status
+    # to determine if the job is actually running.
+    'PENDING': JobStatus.INIT,
+    'RUNNING': JobStatus.PENDING,
     'succeeded': JobStatus.SUCCEEDED,
     'failed': JobStatus.FAILED,
     'stopped': JobStatus.CANCELLED,

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -45,7 +45,7 @@ _RAY_TO_JOB_STATUS_MAP = {
     # 1. when the ray status indicates the job is PENDING the generated
     # python program should be not started yet, i.e. the job should be INIT.
     # 2. when the ray status indicates the job is RUNNING the resources
-    # may not be allocated yet, i.e. the job should be PENDING. 
+    # may not be allocated yet, i.e. the job should be PENDING.
     # Note: We need to compare the status with the sky cached job status
     # to determine if the job is actually running.
     'PENDING': JobStatus.INIT,

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -377,7 +377,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
-    job_lib.update_job_status(job_owner, [job_id])
+    job_lib.update_job_status(job_owner, [job_id], need_output=False)
     status = job_lib.get_status(job_id)
 
     # Wait for the log to be written. This is needed due to the `ray submit`
@@ -400,7 +400,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
-        job_lib.update_job_status(job_owner, [job_id])
+        job_lib.update_job_status(job_owner, [job_id], need_output=False)
         status = job_lib.get_status(job_id)
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -388,7 +388,7 @@ def tail_logs(job_owner: str,
             job_lib.JobStatus.RUNNING,
     ]:
         retry_cnt += 1
-        if os.path.exists(log_path):
+        if os.path.exists(log_path) and status != job_lib.JobStatus.INIT:
             break
         if retry_cnt >= _SKY_LOG_WAITING_MAX_RETRY:
             print(
@@ -399,6 +399,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
+        job_lib.update_job_status(job_owner, [job_id])
         status = job_lib.get_status(job_id)
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -321,7 +321,9 @@ def _follow_job_logs(file,
 
     `sleep_sec` is the time to sleep after empty reads. """
     line = ''
-    status = job_lib.get_status(job_id)
+    # No need to lock the status here, as the while loop can handle
+    # the older status.
+    status = job_lib.get_status_no_lock(job_id)
     start_streaming = False
     wait_last_logs = True
     while True:
@@ -355,7 +357,7 @@ def _follow_job_logs(file,
                 return
 
             time.sleep(_SKY_LOG_TAILING_GAP_SECONDS)
-            status = job_lib.get_status(job_id)
+            status = job_lib.get_status_no_lock(job_id)
 
 
 def tail_logs(job_owner: str,
@@ -378,7 +380,9 @@ def tail_logs(job_owner: str,
     log_path = os.path.expanduser(log_path)
 
     job_lib.update_job_status(job_owner, [job_id], need_output=False)
-    status = job_lib.get_status(job_id)
+    # No need to lock the status here, as the while loop can handle the
+    # older status.
+    status = job_lib.get_status_no_lock(job_id)
 
     # Wait for the log to be written. This is needed due to the `ray submit`
     # will take some time to start the job and write the log.
@@ -401,7 +405,7 @@ def tail_logs(job_owner: str,
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
         job_lib.update_job_status(job_owner, [job_id], need_output=False)
-        status = job_lib.get_status(job_id)
+        status = job_lib.get_status_no_lock(job_id)
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:
         # Not using `ray job logs` because it will put progress bar in

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -379,7 +379,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
-    status = job_lib.update_job_status(job_owner, [job_id], silent=True)
+    status = job_lib.update_job_status(job_owner, [job_id], silent=True)[0]
 
     # Wait for the log to be written. This is needed due to the `ray submit`
     # will take some time to start the job and write the log.
@@ -401,7 +401,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
-        status = job_lib.update_job_status(job_owner, [job_id], silent=True)
+        status = job_lib.update_job_status(job_owner, [job_id], silent=True)[0]
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:
         # Not using `ray job logs` because it will put progress bar in

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -377,6 +377,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
+    job_lib.update_job_status(job_owner, [job_id])
     status = job_lib.get_status(job_id)
 
     # Wait for the log to be written. This is needed due to the `ray submit`

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -377,7 +377,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
-    status = job_lib.query_job_status(job_owner, [job_id])[0]
+    status = job_lib.get_status(job_id)
 
     # Wait for the log to be written. This is needed due to the `ray submit`
     # will take some time to start the job and write the log.
@@ -399,7 +399,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
-        status = job_lib.query_job_status(job_owner, [job_id])[0]
+        status = job_lib.get_status(job_id)
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:
         # Not using `ray job logs` because it will put progress bar in

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -379,10 +379,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
-    job_lib.update_job_status(job_owner, [job_id], need_output=False)
-    # No need to lock the status here, as the while loop can handle the
-    # older status.
-    status = job_lib.get_status_no_lock(job_id)
+    status = job_lib.update_job_status(job_owner, [job_id], silent=True)
 
     # Wait for the log to be written. This is needed due to the `ray submit`
     # will take some time to start the job and write the log.
@@ -404,8 +401,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
-        job_lib.update_job_status(job_owner, [job_id], need_output=False)
-        status = job_lib.get_status_no_lock(job_id)
+        status = job_lib.update_job_status(job_owner, [job_id], silent=True)
 
     if status in [job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING]:
         # Not using `ray job logs` because it will put progress bar in

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -149,6 +149,22 @@ def test_region():
     )
     run_one_test(test)
 
+def test_stale_job():
+    name = _get_cluster_name()
+    test = Test(
+        'stale-job',
+        [
+            f'sky launch -y -c {name} --cloud gcp "echo hi"',
+            f'sky exec {name} --cloud gcp -d "echo start; sleep 10000"',
+            f'sky stop {name} -y',
+            'sleep 40',
+            f'sky start {name} -y',
+            f'sky logs {name} 1 --status',
+            f's=$(sky queue {name}); printf "$s"; echo; echo; printf "$s" | grep FAILED',
+        ],
+        f'sky down -y {name}',
+    )
+    run_one_test(test)
 
 # ---------- Check Sky's environment variables; workdir. ----------
 def test_env_check():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -149,6 +149,7 @@ def test_region():
     )
     run_one_test(test)
 
+
 def test_stale_job():
     name = _get_cluster_name()
     test = Test(
@@ -165,6 +166,7 @@ def test_stale_job():
         f'sky down -y {name}',
     )
     run_one_test(test)
+
 
 # ---------- Check Sky's environment variables; workdir. ----------
 def test_env_check():
@@ -354,6 +356,7 @@ def test_gcp_start_stop():
             f'sky exec {name} examples/gcp_start_stop.yaml',
             f'sky logs {name} 2 --status',  # Ensure the job succeeded.
             f'sky stop -y {name}',
+            f'sleep 20',
             f'sky start -y {name}',
             f'sky exec {name} examples/gcp_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.


### PR DESCRIPTION
Thanks to the observation by @michaelzhiluo (https://github.com/skypilot-org/skypilot/pull/969#issuecomment-1203440396), we found that there is a bug in mismatching of `job_lib.query_job_status` and `job_lib.get_status`.
Previously, we map the ray job status to sky job status with
```
'PENDING': JobStatus.PENDING
'RUNNING': JobStatus.RUNNING
```
This will cause a problem for the job status transition. When a job has not been allocated with required resources, the job will be set to RUNNING in the skylet, due to the following line.
https://github.com/skypilot-org/skypilot/blob/2cb62c542cfc48761d710586bb926f661722ac94/sky/skylet/job_lib.py#L278

**This PR also fixes the race condition caused by periodic job status update by skylet and job status set in generated ray program.**

Tested:
- [x] `tests/run_smoke_tests.sh`