### PR TITLE
Add ssh config during start

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -75,9 +75,11 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
+  # Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Make sure python3 & pip3 are available on this image.
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
-  - pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
+  - mkdir -p ~/.ssh; touch ~/.ssh/config;
+    pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
   # We set auto_activate_base to be false for pre-installed conda.
   # Refer to the issue link here: https://github.com/skypilot-org/skypilot/pull/1007

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -82,9 +82,11 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
+  # Create ~/.ssh/config file in case the file does not exist in the image.
   # Make sure python3 & pip3 are available on this image.
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
-  - pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
+  - mkdir -p ~/.ssh; touch ~/.ssh/config;
+    pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
   - which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
   - (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -117,8 +117,10 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
+  # Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Make sure python3 & pip3 are available on this image.
-  - pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
+  - mkdir -p ~/.ssh; touch ~/.ssh/config;
+    pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
   # GCP TPU VM image does not install conda by default.


### PR DESCRIPTION
Thanks for the issue reported by @lhqing! For some custom images, the `~/.ssh/config` can be missing, causing the commands in the following lines fail. This PR fixes the problem by creating the `~/.ssh/config` file after the cluster is launched.

https://github.com/skypilot-org/skypilot/blob/122ce0e921c1c64fbe6ffd5bcc71eef91556f09e/sky/templates/aws-ray.yml.j2#L103

https://github.com/skypilot-org/skypilot/blob/122ce0e921c1c64fbe6ffd5bcc71eef91556f09e/sky/templates/gcp-ray.yml.j2#L140

https://github.com/skypilot-org/skypilot/blob/122ce0e921c1c64fbe6ffd5bcc71eef91556f09e/sky/templates/azure-ray.yml.j2#L108