### PR TITLE
[Onprem] Sky Queue Logging

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1120,7 +1120,7 @@ def queue(clusters: Tuple[str], skip_finished: bool, all_users: bool):
         _show_job_queue_on_cluster(cluster, handle, backend, code)
 
     for local_cluster in local_clusters:
-        if local_cluster not in clusters:
+        if local_cluster not in clusters and len(clusters) > 1:
             click.secho(
                 f'Local cluster {local_cluster} is uninitialized;'
                 ' skipped.',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1088,15 +1088,16 @@ def queue(clusters: Tuple[str], skip_finished: bool, all_users: bool):
     """Show the job queue for cluster(s)."""
     click.secho('Fetching and parsing job queue...', fg='yellow')
     all_jobs = not skip_finished
-
     username = getpass.getuser()
     if all_users:
         username = None
     code = job_lib.JobLibCodeGen.show_jobs(username, all_jobs)
 
+    show_local_clusters = False
     if clusters:
         clusters = _get_glob_clusters(clusters)
     else:
+        show_local_clusters = True
         cluster_infos = global_user_state.get_clusters()
         clusters = [c['name'] for c in cluster_infos]
 
@@ -1120,7 +1121,7 @@ def queue(clusters: Tuple[str], skip_finished: bool, all_users: bool):
         _show_job_queue_on_cluster(cluster, handle, backend, code)
 
     for local_cluster in local_clusters:
-        if local_cluster not in clusters and len(clusters) > 1:
+        if local_cluster not in clusters and show_local_clusters:
             click.secho(
                 f'Local cluster {local_cluster} is uninitialized;'
                 ' skipped.',


### PR DESCRIPTION
Fixes bug discovered by @concretevitamin.
## Before:
`sky queue on-prem-test`
```
Fetching and parsing job queue...

Job queue of cluster on-prem-test
ID  NAME     SUBMITTED    STARTED      DURATION  RESOURCES     STATUS     LOG                                        
1   sky-cmd  43 mins ago  43 mins ago  1s        1x [CPU:0.5]  SUCCEEDED  ~/sky_logs/sky-2022-08-02-22-31-40-033756  

Local cluster azure-onprem-test1 is uninitialized; skipped.
Local cluster on-prem-smoke-test is uninitialized; skipped.
Local cluster dev-production is uninitialized; skipped.
Local cluster azure-onprem is uninitialized; skipped.
```

## After:
`sky queue on-prem-test`
```
Fetching and parsing job queue...

Job queue of cluster on-prem-test
ID  NAME     SUBMITTED    STARTED      DURATION  RESOURCES     STATUS     LOG                                        
1   sky-cmd  43 mins ago  43 mins ago  1s        1x [CPU:0.5]  SUCCEEDED  ~/sky_logs/sky-2022-08-02-22-31-40-033756  
```