### PR TITLE
Surface setup error

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1786,8 +1786,9 @@ class CloudVmRayBackend(backends.Backend):
                     except subprocess.CalledProcessError:
                         last_10_lines = None
 
-                    err_msg = (f'Failed to setup with return code {returncode}.'
-                               f'Check the details in log: {setup_log_path}.')
+                    err_msg = (
+                        f'Failed to setup with return code {returncode}. '
+                        f'Check the details in log: {setup_log_path}.')
                     if last_10_lines:
                         err_msg += (
                             f'\n\n{colorama.Fore.RED}'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1788,14 +1788,14 @@ class CloudVmRayBackend(backends.Backend):
 
                     err_msg = (
                         f'Failed to setup with return code {returncode}. '
-                        f'Check the details in log: {setup_log_path}.')
+                        f'Check the details in log: {setup_log_path}')
                     if last_10_lines:
                         err_msg += (
                             f'\n\n{colorama.Fore.RED}'
                             '****** START Last lines of setup output ******'
                             f'{colorama.Style.RESET_ALL}\n'
                             f'{last_10_lines}'
-                            f'\n{colorama.Fore.RED}'
+                            f'{colorama.Fore.RED}'
                             '******* END Last lines of setup output *******'
                             f'{colorama.Style.RESET_ALL}')
                     return err_msg

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1765,15 +1765,43 @@ class CloudVmRayBackend(backends.Backend):
                                 stream_logs=False)
                 # Need this `-i` option to make sure `source ~/.bashrc` work
                 cmd = f'/bin/bash -i /tmp/{setup_file} 2>&1'
+                setup_log_path = os.path.join(self.log_dir,
+                                              f'setup-{runner.ip}.log')
                 returncode = runner.run(
                     cmd,
-                    log_path=os.path.join(self.log_dir, 'setup.log'),
+                    log_path=setup_log_path,
                     process_stream=False,
                 )
-                subprocess_utils.handle_returncode(
-                    returncode=returncode,
-                    command=cmd,
-                    error_msg=f'Failed to setup with return code {returncode}')
+
+                def error_message() -> str:
+                    # Use the function to avoid tailing the file in success case
+                    try:
+                        last_10_lines = subprocess.run(
+                            [
+                                'tail', '-n10',
+                                os.path.expanduser(setup_log_path)
+                            ],
+                            stdout=subprocess.PIPE,
+                            check=True).stdout.decode('utf-8')
+                    except subprocess.CalledProcessError:
+                        last_10_lines = None
+
+                    err_msg = (f'Failed to setup with return code {returncode}.'
+                               f'Check the details in log: {setup_log_path}.')
+                    if last_10_lines:
+                        err_msg += (
+                            f'\n\n{colorama.Fore.RED}'
+                            '****** START Last lines of setup output ******'
+                            f'{colorama.Style.RESET_ALL}\n'
+                            f'{last_10_lines}'
+                            f'\n{colorama.Fore.RED}'
+                            '******* END Last lines of setup output *******'
+                            f'{colorama.Style.RESET_ALL}')
+                    return err_msg
+
+                subprocess_utils.handle_returncode(returncode=returncode,
+                                                   command=cmd,
+                                                   error_msg=error_message)
 
             num_nodes = handle.launched_nodes
             plural = 's' if num_nodes > 1 else ''

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -1,7 +1,7 @@
 """Utility functions for subprocesses."""
 from multiprocessing import pool
 import subprocess
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Union
 
 import colorama
 
@@ -52,7 +52,7 @@ def run_in_parallel(func: Callable, args: List[Any]) -> List[Any]:
 
 def handle_returncode(returncode: int,
                       command: str,
-                      error_msg: str,
+                      error_msg: Union[str, Callable[[], str]],
                       stderr: Optional[str] = None,
                       stream_logs: bool = True) -> None:
     """Handle the returncode of a command.
@@ -67,6 +67,9 @@ def handle_returncode(returncode: int,
     if returncode != 0:
         if stderr is not None:
             echo(stderr)
+
+        if callable(error_msg):
+            error_msg = error_msg()
         format_err_msg = (
             f'{colorama.Fore.RED}{error_msg}{colorama.Style.RESET_ALL}')
         with ux_utils.print_exception_no_traceback():


### PR DESCRIPTION
Closes #518.

It surfaces the setup error at the end of the error message, as proposed by @concretevitamin.

Tested yaml:
```
setup: |
  set -ex
  somenonexit command
  echo "running setup"
```

Previously,
```
sky.exceptions.CommandError: Command /bin/bash -i /tmp/sky_setup_jsyb5vgm 2>&1 failed with return code 127.
Failed to setup with return code 127.
```

Currently,
```
sky.exceptions.CommandError: Command /bin/bash -i /tmp/sky_setup_jsyb5vgm 2>&1 failed with return code 127.
Failed to setup with return code 127. Check the details in log: ~/sky_logs/sky-2022-08-07-00-19-04-685768/setup-34.227.105.10.log.

****** START Last lines of setup output ******
+ somenonexit command
+ '[' -x /usr/lib/command-not-found ']'
+ /usr/lib/command-not-found -- somenonexit
somenonexit: command not found

******* END Last lines of setup output *******
```

Tested:
- [x] `sky launch -c fail-setup ./run.yaml`
- [x] `sky launch -c fail-setup-2 --num-nodes 2 ./run.yaml`