### PR TITLE
Install aws by default

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -24,7 +24,7 @@ dependencies installed.
 
 .. note::
 
-    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`conda install grpcio` prior to installing SkyPilot.
+    For Macs, macOS >= 10.15 is required to install SkyPilot. Apple Silicon-based devices (e.g. Apple M1) must run :code:`conda install grpcio=1.43.0` prior to installing SkyPilot.
 
 .. note::
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -94,6 +94,10 @@ extras_require = {
 
 extras_require['all'] = sum(extras_require.values(), [])
 
+# Install aws requirements by default, as it is the most common cloud provider,
+# and the installation is quick.
+install_requires += extras_require['aws']
+
 long_description = ''
 readme_filepath = 'README.md'
 # When sky/backends/wheel_utils.py builds wheels, it will not contain the README.


### PR DESCRIPTION
Based on the offline discussion, we found it makes sense to install AWS CLI by default when installing skypilot:
1. The AWS most commonly used by our users.
2. It makes no sense to install a no-cloud version of skypilot with `pip install skypilot`
3. The installation of AWS CLI is pretty quick.

This also fixes the hint in the document for installing `grpc` for Apple Silicon.

I will cherry-pick this PR into the `releases/0.1.1`.