### PR TITLE
Fix github action for PR on releases branches

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - 'releases/**'
   pull_request:
     branches:
       - master
+      - 'releases/**'
 
 jobs:
   pylint:

--- a/.github/workflows/pytest-generic.yml
+++ b/.github/workflows/pytest-generic.yml
@@ -7,9 +7,11 @@ on:
   push:
     branches:
       - master
+      - 'releases/**'
   pull_request:
     branches:
       - master
+      - 'releases/**'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - master
+      - 'releases/**'
   pull_request:
     branches:
       - master
+      - 'releases/**'
 jobs:
   test:
     strategy:

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -6,9 +6,11 @@ on:
   push:
     branches:
       - master
+      - 'releases/**'
   pull_request:
     branches:
       - master
+      - 'releases/**'
 jobs:
   yapf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This makes sure the actions are triggered for the releases branches.

Reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters
