### PR TITLE
UX: type check sky.exec()'s first argument, and hint.

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -75,9 +75,8 @@ def _type_check_dag(dag):
     if isinstance(dag, str):
         raise TypeError(_ENTRYPOINT_STRING_AS_DAG_MESSAGE)
     elif not isinstance(dag, sky.Dag):
-        raise TypeError(
-            'Expected a sky.Dag but received argument of type: '
-            f'{type(dag)}')
+        raise TypeError('Expected a sky.Dag but received argument of type: '
+                        f'{type(dag)}')
 
 
 class Stage(enum.Enum):

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -123,9 +123,9 @@ def _execute(
     # see their own program in the stacktrace. Our CLI impl would not trigger
     # these errors.
     if isinstance(dag, str):
-        raise ValueError(_EXEC_STRING_AS_DAG_HINT_MESSAGE)
+        raise TypeError(_EXEC_STRING_AS_DAG_HINT_MESSAGE)
     elif not isinstance(dag, sky.Dag):
-        raise ValueError(
+        raise TypeError(
             'sky.exec() expects a sky.Dag as first argument; got type: '
             f'{type(dag)}')
 


### PR DESCRIPTION
Fixes #982, encountered by Erick a while ago.


Before
```
> sky.exec('echo hi', cluster_name=name)
...
    assert len(dag) == 1, f’Sky assumes 1 task for now. {dag}'
AssertionError: Sky assumes 1 task for now. echo hi
```

Now hinting with a copy-pasteable snippet:
```
> sky.exec('echo hi', cluster_name=name)
Traceback (most recent call last):
...
    raise TypeError(_EXEC_STRING_AS_DAG_HINT_MESSAGE)
TypeError: Programmatic API sky.exec() expects a sky.Dag but received a string.

If you meant to run a command, make it a Task's run command and wrap as a Dag:

  def to_dag(command, gpu=None):
      with sky.Dag() as dag:
          sky.Task(run=command).set_resources(
              sky.Resources(accelerators=gpu))
      return dag

  sky.exec(to_dag(cmd), cluster_name=..., ...)

If the task needs accelerators:

  sky.exec(to_dag(cmd, gpu='V100'), cluster_name=..., ...)
  sky.exec(to_dag(cmd, gpu={'V100': 1}), cluster_name=..., ...)
  sky.exec(to_dag(cmd, gpu='V100:0.5'), cluster_name=..., ...)```
```
Note that this check/hint would only be triggered by using the programmatic API, not by the CLI.