### PR TITLE
Change default scheduling demand of 0.5 cpu/task to 1.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -97,9 +97,15 @@ _TEST_IP = 'https://8.8.8.8'
 # '-worker'. Here we do not distinguish these cases and take the lower limit.
 _MAX_CLUSTER_NAME_LEN_FOR_GCP = 35
 
-# Allow each CPU thread take 2 tasks.
-# Note: This value cannot be too small, otherwise OOM issue may occur.
-DEFAULT_TASK_CPU_DEMAND = 0.5
+# CPU resource demand: for each task, how many CPUs does it need?
+# NOTE:
+#  - This affects *scheduling*. It does not enforce at OS level each task can
+#    only use this many CPUs.
+#  - In fact, currently each task gets an env var OMP_NUM_THREADS=1. So some
+#    programs may be forced to use or see 1 cpu only (see #243 #951). Thus it's
+#    best to keep this var at 1 to be consistent (also see #1045).
+#  - This value cannot be too small, otherwise OOM issue may occur.
+DEFAULT_TASK_CPU_DEMAND = 1
 
 SKY_RESERVED_CLUSTER_NAMES = [spot_lib.SPOT_CONTROLLER_NAME]
 


### PR DESCRIPTION
Fixes #1045 - see that issue for the motivation of the change (UX/confusion on user's front).

**This change will half the maximum number of concurrent tasks**, compared to master. This means 
- for p3.2x (V100 x1), from 16 jobs to 8 jobs.  Should be fine as we're not seeing 1 GPU being shared among 8 jobs.
- similar argument for say, `(n1-highmem-8, tpu-v3-8:1)`.

Tested: exec'ing before and after:
```
» sky queue c2
Fetching and parsing job queue...
I 08-10 17:16:34 core.py:264]
I 08-10 17:16:34 core.py:264] Sky Job Queue of Cluster c2
ID  NAME     SUBMITTED    STARTED         DURATION     RESOURCES     STATUS     LOG
20  -        11 secs ago  a few secs ago  < 1s         1x [CPU:1]    SUCCEEDED  ~/sky_logs/sky-2022-08-10-17-16-20-247074
19  -        44 mins ago  44 mins ago     < 1s         1x [CPU:0.5]  SUCCEEDED  ~/sky_logs/sky-2022-08-10-16-32-09-948710
```