### PR TITLE
For CLI-like messages, use print() not logging.

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -29,7 +29,7 @@ Copy the following YAML into a ``hello_sky.yaml`` file:
   # hello_sky.yaml
 
   resources:
-    # Optional; if left out, pick from the available clouds.
+    # Optional; if left out, automatically pick the cheapest cloud.
     cloud: aws
     # 1x NVIDIA V100 GPU
     accelerators: V100:1

--- a/docs/source/reference/faq.rst
+++ b/docs/source/reference/faq.rst
@@ -56,10 +56,10 @@ To get around this, mount the files to a different path, then symlink to them.  
     ln -s /tmp/tmp.txt ~/code-repo/
 
 
-How to edit or update the pricing information used by SkyPilot? (Advanced Use Case)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(Advanced) How to edit or update the regions or pricing information used by SkyPilot?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-SkyPilot stores pricing information for different cloud resource types in CSV files known as service catalogs.
+SkyPilot stores regions and pricing information for different cloud resource types in CSV files known as "service catalogs".
 These catalogs are cached in the ``~/.sky/catalogs/<schema-version>/`` directory.
 Check out your schema version by running the following command:
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -99,8 +99,8 @@ describe all fields available.
       #
       # If symlinks are present, they are copied as symlinks, and their targets
       # must also be synced using file_mounts to ensure correctness.
-      /remote/path/file: /local/path/file
-      /remote/path/dir: /local/path/dir
+      /remote/dir/file: /local/dir/file
+      /remote/dir: /local/dir
 
       # Uses SkyPilot Storage to create a S3 bucket named sky-dataset, uploads the
       # contents of /local/path/datasets to the bucket, and marks the bucket

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -99,8 +99,8 @@ describe all fields available.
       #
       # If symlinks are present, they are copied as symlinks, and their targets
       # must also be synced using file_mounts to ensure correctness.
-      /remote/dir/file: /local/dir/file
-      /remote/dir: /local/dir
+      /remote/dir1/file: /local/dir1/file
+      /remote/dir2: /local/dir2
 
       # Uses SkyPilot Storage to create a S3 bucket named sky-dataset, uploads the
       # contents of /local/path/datasets to the bucket, and marks the bucket

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -78,7 +78,7 @@ describe all fields available.
       # requested and should work for either case. If passing in an incompatible
       # version, GCP will throw an error during provisioning.
       accelerator_args:
-        # Default runtime_version is "2.5.0" for TPU node and "tpu-vm-base" for TPU VM.
+        # Default is "2.5.0" for TPU node and "tpu-vm-base" for TPU VM.
         runtime_version: 2.5.0
         tpu_name: mytpu
         tpu_vm: False  # False to use TPU nodes (the default); True to use TPU VMs.
@@ -95,11 +95,12 @@ describe all fields available.
       # image_id: projects/deeplearning-platform-release/global/images/family/tf2-ent-2-1-cpu-ubuntu-2004
 
     file_mounts:
-      # Uses rsync to copy local files to all nodes of the cluster.
+      # Uses rsync to sync local files/directories to all nodes of the cluster.
       #
       # If symlinks are present, they are copied as symlinks, and their targets
       # must also be synced using file_mounts to ensure correctness.
-      /remote/path/datasets: /local/path/datasets
+      /remote/path/file: /local/path/file
+      /remote/path/dir: /local/path/dir
 
       # Uses SkyPilot Storage to create a S3 bucket named sky-dataset, uploads the
       # contents of /local/path/datasets to the bucket, and marks the bucket

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2701,7 +2701,7 @@ class CloudVmRayBackend(backends.Backend):
                 subprocess_utils.handle_returncode(
                     returncode, symlink_command,
                     'Failed to create symlinks. The target destination '
-                    'may already exist')
+                    f'may already exist. Log: {log_path}')
 
             subprocess_utils.run_in_parallel(_symlink_node, runners)
         end = time.time()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1146,7 +1146,7 @@ def queue(clusters: Tuple[str], skip_finished: bool, all_users: bool):
             click.echo(str(e))
             continue
         job_table = job_lib.format_job_queue(job_table)
-        click.echo(f'{job_table}')
+        click.echo(f'\nJob queue of cluster {cluster}\n{job_table}')
 
     local_clusters = onprem_utils.check_and_get_local_clusters()
     for local_cluster in local_clusters:

--- a/sky/core.py
+++ b/sky/core.py
@@ -261,7 +261,6 @@ def queue(cluster_name: str,
     handle = _check_cluster_available(cluster_name, 'getting the job queue')
     backend = backend_utils.get_backend_from_handle(handle)
 
-    print(f'\nJob queue of cluster {cluster_name}')
     returncode, jobs_json, stderr = backend.run_on_head(handle,
                                                         code,
                                                         require_outputs=True)

--- a/sky/core.py
+++ b/sky/core.py
@@ -57,7 +57,7 @@ def _start(cluster_name: str,
     cluster_status, handle = backend_utils.refresh_cluster_status_handle(
         cluster_name)
     if cluster_status == global_user_state.ClusterStatus.UP:
-        logger.info(f'Cluster {cluster_name!r} is already up.')
+        print(f'Cluster {cluster_name!r} is already up.')
         return
     assert cluster_status in (
         global_user_state.ClusterStatus.INIT,
@@ -261,7 +261,7 @@ def queue(cluster_name: str,
     handle = _check_cluster_available(cluster_name, 'getting the job queue')
     backend = backend_utils.get_backend_from_handle(handle)
 
-    logger.info(f'\nSky Job Queue of Cluster {cluster_name}')
+    print(f'\nJob queue of cluster {cluster_name}')
     returncode, jobs_json, stderr = backend.run_on_head(handle,
                                                         code,
                                                         require_outputs=True)
@@ -300,16 +300,15 @@ def cancel(cluster_name: str,
     backend = backend_utils.get_backend_from_handle(handle)
 
     if all:
-        logger.info(f'{colorama.Fore.YELLOW}'
-                    f'Cancelling all jobs on cluster {cluster_name!r}...'
-                    f'{colorama.Style.RESET_ALL}')
+        print(f'{colorama.Fore.YELLOW}'
+              f'Cancelling all jobs on cluster {cluster_name!r}...'
+              f'{colorama.Style.RESET_ALL}')
         job_ids = None
     else:
         jobs_str = ', '.join(map(str, job_ids))
-        logger.info(
-            f'{colorama.Fore.YELLOW}'
-            f'Cancelling jobs ({jobs_str}) on cluster {cluster_name!r}...'
-            f'{colorama.Style.RESET_ALL}')
+        print(f'{colorama.Fore.YELLOW}'
+              f'Cancelling jobs ({jobs_str}) on cluster {cluster_name!r}...'
+              f'{colorama.Style.RESET_ALL}')
 
     backend.cancel_jobs(handle, job_ids)
 
@@ -331,9 +330,9 @@ def tail_logs(cluster_name: str, job_id: Optional[str]):
     job_str = f'job {job_id}'
     if job_id is None:
         job_str = 'the last job'
-    logger.info(f'{colorama.Fore.YELLOW}'
-                f'Tailing logs of {job_str} on cluster {cluster_name!r}...'
-                f'{colorama.Style.RESET_ALL}')
+    print(f'{colorama.Fore.YELLOW}'
+          f'Tailing logs of {job_str} on cluster {cluster_name!r}...'
+          f'{colorama.Style.RESET_ALL}')
 
     backend.tail_logs(handle, job_id)
 
@@ -357,9 +356,9 @@ def download_logs(
     if job_ids is not None and len(job_ids) == 0:
         return []
 
-    logger.info(f'{colorama.Fore.YELLOW}'
-                'Syncing down logs to local...'
-                f'{colorama.Style.RESET_ALL}')
+    print(f'{colorama.Fore.YELLOW}'
+          'Syncing down logs to local...'
+          f'{colorama.Style.RESET_ALL}')
     local_log_dirs = backend.sync_down_logs(handle, job_ids, local_dir)
     return local_log_dirs
 
@@ -386,9 +385,9 @@ def job_status(
     if job_ids is not None and len(job_ids) == 0:
         return []
 
-    logger.info(f'{colorama.Fore.YELLOW}'
-                'Getting job status...'
-                f'{colorama.Style.RESET_ALL}')
+    print(f'{colorama.Fore.YELLOW}'
+          'Getting job status...'
+          f'{colorama.Style.RESET_ALL}')
 
     statuses = backend.get_job_status(handle, job_ids, stream_logs=stream_logs)
     return statuses
@@ -406,7 +405,7 @@ def _is_spot_controller_up(
     controller_status, handle = backend_utils.refresh_cluster_status_handle(
         spot.SPOT_CONTROLLER_NAME, force_refresh=True)
     if controller_status is None:
-        logger.info('No managed spot job has been run.')
+        print('No managed spot job has been run.')
     elif controller_status != global_user_state.ClusterStatus.UP:
         msg = (f'Spot controller {spot.SPOT_CONTROLLER_NAME} '
                f'is {controller_status.value}.')
@@ -414,7 +413,7 @@ def _is_spot_controller_up(
             msg += f'\n{stopped_message}'
         if controller_status == global_user_state.ClusterStatus.INIT:
             msg += '\nPlease wait for the controller to be ready.'
-        logger.info(msg)
+        print(msg)
         handle = None
     return controller_status, handle
 
@@ -450,9 +449,9 @@ def spot_status(refresh: bool) -> List[Dict[str, Any]]:
             global_user_state.ClusterStatus.STOPPED,
             global_user_state.ClusterStatus.INIT
     ]):
-        logger.info(f'{colorama.Fore.YELLOW}'
-                    'Restarting controller for latest status...'
-                    f'{colorama.Style.RESET_ALL}')
+        print(f'{colorama.Fore.YELLOW}'
+              'Restarting controller for latest status...'
+              f'{colorama.Style.RESET_ALL}')
 
         handle = _start(spot.SPOT_CONTROLLER_NAME,
                         idle_minutes_to_autostop=spot.
@@ -524,7 +523,7 @@ def spot_cancel(name: Optional[str] = None,
     except exceptions.CommandError as e:
         raise RuntimeError(e.error_msg) from e
 
-    logger.info(stdout)
+    print(stdout)
     if 'Multiple jobs found with name' in stdout:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
@@ -587,7 +586,7 @@ def storage_delete(name: Optional[str] = None):
     if handle is None:
         raise ValueError(f'Storage name {name!r} not found.')
     else:
-        logger.info(f'Deleting storage object {name!r}.')
+        print(f'Deleting storage object {name!r}.')
         store_object = data.Storage(name=handle.storage_name,
                                     source=handle.source,
                                     sync_on_reconstruction=False)


### PR DESCRIPTION
The programmatic API PR changed some prior logging messages from just print() to logger.info() in core.py. This PR reverts those changes for the old behavior, which is arguably a more CLI-like experience.

Before this PR (note the `core.py` prefixed messages):
```
» sky queue c2
Fetching and parsing job queue...
I 08-10 19:11:14 core.py:264]
I 08-10 19:11:14 core.py:264] Sky Job Queue of Cluster c2
ID  NAME     SUBMITTED    STARTED      DURATION     RESOURCES     STATUS     LOG
20  sky-cmd  1 hr ago     1 hr ago     < 1s         1x [CPU:1]    SUCCEEDED  ~/sky_logs/sky-2022-08-10-17-16-20-247074

» sky cancel c2 -a
I 08-10 19:11:29 core.py:303] Cancelling all jobs on cluster 'c2'...

» sky logs c2 20
I 08-10 19:11:50 core.py:334] Tailing logs of job 20 on cluster 'c2'...
I 08-11 02:11:51 log_lib.py:373] Start streaming logs for job 20.
...

» sky logs c2 20 --status
I 08-10 19:11:41 core.py:389] Getting job status...
Job 20: SUCCEEDED
```

Now:
```
» sky queue c2
Fetching and parsing job queue...

Job queue of cluster c2
ID  NAME     SUBMITTED    STARTED      DURATION     RESOURCES     STATUS     LOG
20  sky-cmd  1 hr ago     1 hr ago     < 1s         1x [CPU:1]    SUCCEEDED  ~/sky_logs/sky-2022-08-10-17-16-20-247074

» sky cancel c2 -a
Cancelling all jobs on cluster 'c2'...

» sky logs c2
Tailing logs of the last job on cluster 'c2'...
I 08-10 19:10:03 cloud_vm_ray_backend.py:2210] Job ID not provided. Streaming the logs of the latest job.
...

» sky logs c2 20 --status
Getting job status...
Job 20: SUCCEEDED
```