### PR TITLE
Add sky start --all feature

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1415,8 +1415,9 @@ def autostop(
     help=('Retry provisioning infinitely until the cluster is up, '
           'if we fail to start the cluster due to unavailability errors.'))
 @usage_lib.entrypoint
-def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: int,
-          retry_until_up: bool):
+# pylint: disable=redefined-builtin
+def start(clusters: Tuple[str], all: bool, yes: bool, 
+          idle_minutes_to_autostop: int, retry_until_up: bool):
     """Restart cluster(s).
 
     If a cluster is previously stopped (status is STOPPED) or failed in
@@ -1448,7 +1449,7 @@ def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: 
 
     if not clusters and not all:
         raise click.UsageError(
-            f'sky start requires either a cluster name (see `sky status`) '
+            'sky start requires either a cluster name (see `sky status`) '
             'or --all.')
 
     if all:
@@ -1459,7 +1460,8 @@ def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: 
 
         # Get all clusters
         clusters = [
-            cluster['name'] for cluster in global_user_state.get_clusters() 
+            cluster['name']
+            for cluster in global_user_state.get_clusters()
             if cluster['name'] not in backend_utils.SKY_RESERVED_CLUSTER_NAMES
         ]
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1453,9 +1453,9 @@ def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: 
 
     if all:
         if len(clusters) > 0:
-            raise click.UsageError(
+            click.echo(
                 'Both --all and cluster(s) specified for sky start. '
-                'Please only specify one of the above.')
+                'Letting --all take effect.')
 
         # Get all clusters
         clusters = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1440,19 +1440,28 @@ def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: 
       # Restart multiple clusters.
       sky start cluster1 cluster2
       \b
-      # Restart all clusterss.
+      # Restart all clusters.
       sky start -a
 
     """
     to_start = []
 
+    if not len(clusters) and not all:
+        raise click.UsageError(
+            f'sky start requires either a cluster name (see `sky status`) '
+            'or --all.')
+
     if all:
         if len(clusters) > 0:
-            click.echo(
+            raise click.UsageError(
                 'Both --all and cluster(s) specified for sky start. '
-                'Letting --all take effect.')
+                'Please only specify one of the above.')
+
         # Get all clusters
-        clusters = [cluster['name'] for cluster in global_user_state.get_clusters()]
+        clusters = [
+            cluster['name'] for cluster in global_user_state.get_clusters() 
+            if cluster['name'] not in backend_utils.SKY_RESERVED_CLUSTER_NAMES
+        ]
 
     if clusters:
         # Get GLOB cluster names

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1454,9 +1454,8 @@ def start(clusters: Tuple[str], all: bool, yes: bool,
 
     if all:
         if len(clusters) > 0:
-            click.echo(
-                'Both --all and cluster(s) specified for sky start. '
-                'Letting --all take effect.')
+            click.echo('Both --all and cluster(s) specified for sky start. '
+                       'Letting --all take effect.')
 
         # Get all clusters that are not reserved names.
         clusters = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1416,7 +1416,7 @@ def autostop(
           'if we fail to start the cluster due to unavailability errors.'))
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def start(clusters: Tuple[str], all: bool, yes: bool, 
+def start(clusters: Tuple[str], all: bool, yes: bool,
           idle_minutes_to_autostop: int, retry_until_up: bool):
     """Restart cluster(s).
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1379,7 +1379,13 @@ def autostop(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
-@click.argument('clusters', nargs=-1, required=True)
+@click.argument('clusters', nargs=-1, required=False)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Start all existing clusters.')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1409,7 +1415,7 @@ def autostop(
     help=('Retry provisioning infinitely until the cluster is up, '
           'if we fail to start the cluster due to unavailability errors.'))
 @usage_lib.entrypoint
-def start(clusters: Tuple[str], yes: bool, idle_minutes_to_autostop: int,
+def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: int,
           retry_until_up: bool):
     """Restart cluster(s).
 
@@ -1433,9 +1439,21 @@ def start(clusters: Tuple[str], yes: bool, idle_minutes_to_autostop: int,
       \b
       # Restart multiple clusters.
       sky start cluster1 cluster2
+      \b
+      # Restart all clusterss.
+      sky start -a
 
     """
     to_start = []
+
+    if all:
+        if len(clusters) > 0:
+            click.echo(
+                'Both --all and cluster(s) specified for sky start. '
+                'Letting --all take effect.')
+        # Get all clusters
+        clusters = [cluster['name'] for cluster in global_user_state.get_clusters()]
+
     if clusters:
         # Get GLOB cluster names
         clusters = _get_glob_clusters(clusters)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1458,7 +1458,7 @@ def start(clusters: Tuple[str], all: bool, yes: bool,
                 'Both --all and cluster(s) specified for sky start. '
                 'Letting --all take effect.')
 
-        # Get all clusters
+        # Get all clusters that are not reserved names.
         clusters = [
             cluster['name']
             for cluster in global_user_state.get_clusters()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1446,7 +1446,7 @@ def start(clusters: Tuple[str], all: bool, yes: bool, idle_minutes_to_autostop: 
     """
     to_start = []
 
-    if not len(clusters) and not all:
+    if not clusters and not all:
         raise click.UsageError(
             f'sky start requires either a cluster name (see `sky status`) '
             'or --all.')


### PR DESCRIPTION
- Modified `start` cli.py to allow for restarting of all clusters
- Users can now use `sky start --all / -a` to restart clusters, in the same way they would use this `--all / -a` to currently down all clusters
- Addresses [Issue 1029](https://github.com/skypilot-org/skypilot/issues/1029#issue-1325020354)