### PR TITLE
Fix GCP catalog bugs due to website typos

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -251,6 +251,18 @@ def get_vm_zones(url):
     # Explode the 'MachineType' column.
     df['MachineType'] = df['MachineType'].str.split(', ')
     df = df.explode('MachineType', ignore_index=True)
+
+    # FIXME(woosuk): This is a hack. Find a better way to do this.
+    # Handle the typos in the GCP web page.
+    # us-central1-b: no comma between T2A and N1
+    df = df[df['MachineType'] != 'T2A N1']
+    df = df.append({'AvailabilityZone': 'us-central1-b', 'MachineType': 'T2A'}, ignore_index=True)
+    df = df.append({'AvailabilityZone': 'us-central1-b', 'MachineType': 'N1'}, ignore_index=True)
+
+    # us-central1-c: no space between C2 and C2D
+    df = df[df['MachineType'] != 'C2,C2D']
+    df = df.append({'AvailabilityZone': 'us-central1-c', 'MachineType': 'C2'}, ignore_index=True)
+    df = df.append({'AvailabilityZone': 'us-central1-c', 'MachineType': 'C2D'}, ignore_index=True)
     return df
 
 


### PR DESCRIPTION
![Screen Shot 2022-08-13 at 6 32 58 PM](https://user-images.githubusercontent.com/46394894/184518872-1e4afb72-1591-4b57-b4c1-1a271914e3f2.png)

I found two typos in the GCP website that affect our catalog.
1. In `us-central1-b`, a comma is omitted between T2A and N1.
2. In `us-central1-c`, a space is omitted between C2 and C2D.

This PR fixes the gcp catalog crawler to handle these typos. However, the 4 instances (T2A and N1 on us-central1-b, and C2 and C2D on us-central1-c) will not be available until the next catalog update.