### PR TITLE
Fix spot recovery without cloud specified

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -340,9 +340,9 @@ class Storage(object):
         assert mode in StorageMode
         self.sync_on_reconstruction = sync_on_reconstruction
 
-        # TODO(romilb, zhwu): This is a workaround to support storage deletion for
-        # spot. Once sky storage supports forced management for external buckets,
-        # this can be deprecated.
+        # TODO(romilb, zhwu): This is a workaround to support storage deletion
+        # for spot. Once sky storage supports forced management for external
+        # buckets, this can be deprecated.
         self.force_delete = False
 
         # Validate and correct inputs if necessary

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -263,8 +263,8 @@ class Storage(object):
         def __init__(
             self,
             *,
-            storage_name: str,
-            source: str,
+            storage_name: Optional[str],
+            source: Optional[str],
             sky_stores: Optional[Dict[StoreType,
                                       AbstractStore.StoreMetadata]] = None):
             assert storage_name is not None or source is not None
@@ -339,6 +339,11 @@ class Storage(object):
         self.mode = mode
         assert mode in StorageMode
         self.sync_on_reconstruction = sync_on_reconstruction
+        
+        # TODO(romilb, zhwu): This is a workaround to support storage deletion for
+        # spot. Once sky storage supports forced management for external buckets,
+        # this can be deprecated.
+        self.force_delete = False
 
         # Validate and correct inputs if necessary
         self._validate_storage_spec()
@@ -608,12 +613,16 @@ class Storage(object):
                     global_user_state.remove_storage(self.name)
                 else:
                     global_user_state.set_storage_handle(self.name, self.handle)
+            elif self.force_delete:
+                store.delete()
             # Remove store from bookkeeping
             del self.stores[store_type]
         else:
             for _, store in self.stores.items():
                 if store.is_sky_managed:
                     self.handle.remove_store(store)
+                    store.delete()
+                elif self.force_delete:
                     store.delete()
             self.stores = {}
             # Remove storage from global_user_state if present
@@ -649,6 +658,7 @@ class Storage(object):
         source = config.pop('source', None)
         store = config.pop('store', None)
         mode_str = config.pop('mode', None)
+        force_delete = config.pop('_force_delete', False)
 
         if isinstance(mode_str, str):
             # Make mode case insensitive, if specified
@@ -667,6 +677,9 @@ class Storage(object):
                           mode=mode)
         if store is not None:
             storage_obj.add_store(StoreType(store.upper()))
+
+        # Add force deletion flag
+        storage_obj.force_delete = force_delete
         return storage_obj
 
     def to_yaml_config(self) -> Dict[str, str]:
@@ -690,6 +703,8 @@ class Storage(object):
         add_if_not_none('store', stores)
         add_if_not_none('persistent', self.persistent)
         add_if_not_none('mode', self.mode.value)
+        if self.force_delete:
+            config['_force_delete'] = True
         return config
 
 
@@ -784,14 +799,19 @@ class S3Store(AbstractStore):
         with backend_utils.safe_console_status(
                 f'[bold cyan]Syncing '
                 f'[green]{self.source} to s3://{self.name}/'):
+            # TODO(zhwu): Use log_lib.run_with_log() and redirect the output
+            # to a log file.
             with subprocess.Popen(sync_command.split(' '),
-                                  stderr=subprocess.PIPE) as process:
+                                  stderr=subprocess.PIPE,
+                                  stdout=subprocess.PIPE) as process:
+                stderr = []
                 while True:
                     line = process.stderr.readline()
                     if not line:
                         break
                     str_line = line.decode('utf-8')
                     logger.info(str_line)
+                    stderr.append(line)
                     if 'Access Denied' in str_line:
                         process.kill()
                         with ux_utils.print_exception_no_traceback():
@@ -802,7 +822,10 @@ class S3Store(AbstractStore):
                                 'the bucket is public.')
                 returncode = process.wait()
                 if returncode != 0:
+                    stderr = '\n'.join(stderr)
                     with ux_utils.print_exception_no_traceback():
+                        logger.error(
+                            f'{process.stdout.decode("utf-8")}\n{stderr}')
                         raise exceptions.StorageUploadError(
                             f'Upload to S3 failed for store {self.name} and '
                             f'source {self.source}. Please check the logs.')
@@ -1030,13 +1053,16 @@ class GcsStore(AbstractStore):
                 f'[bold cyan]Syncing '
                 f'[green]{self.source} to gs://{self.name}/'):
             with subprocess.Popen(sync_command.split(' '),
-                                  stderr=subprocess.PIPE) as process:
+                                  stderr=subprocess.PIPE,
+                                  stdout=subprocess.PIPE) as process:
+                stderr = []
                 while True:
                     line = process.stderr.readline()
                     if not line:
                         break
                     str_line = line.decode('utf-8')
                     logger.info(str_line)
+                    stderr.append(str_line)
                     if 'AccessDeniedException' in str_line:
                         process.kill()
                         with ux_utils.print_exception_no_traceback():
@@ -1048,6 +1074,9 @@ class GcsStore(AbstractStore):
                 returncode = process.wait()
                 if returncode != 0:
                     with ux_utils.print_exception_no_traceback():
+                        stderr = '\n'.join(stderr)
+                        logger.error(
+                            f'{process.stdout.decode("utf-8")}\n{stderr}')
                         raise exceptions.StorageUploadError(
                             f'Upload to GCS failed for store {self.name} and '
                             f'source {self.source}. Please check logs.')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -339,7 +339,7 @@ class Storage(object):
         self.mode = mode
         assert mode in StorageMode
         self.sync_on_reconstruction = sync_on_reconstruction
-        
+
         # TODO(romilb, zhwu): This is a workaround to support storage deletion for
         # spot. Once sky storage supports forced management for external buckets,
         # this can be deprecated.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -345,8 +345,6 @@ class Storage(object):
         # this can be deprecated.
         self.force_delete = False
 
-        self.force_delete = False
-
         # Validate and correct inputs if necessary
         self._validate_storage_spec()
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -401,7 +401,8 @@ def spot_launch(
     # Copy the local source to a bucket. The task will not be executed locally,
     # so we need to copy the files to the bucket manually here before sending to
     # the remote spot controller.
-    task.add_storage_mounts()
+    with backend_utils.suppress_output():
+        task.add_storage_mounts()
 
     # Replace the source field that is local path in all storage_mounts with
     # bucket URI and remove the name field.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -174,7 +174,8 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
 
         launched_cloud = handle.launched_resources.cloud
         launched_region = handle.launched_resources.region
-        new_resources = resources.copy(cloud=launched_cloud, region=launched_region)
+        new_resources = resources.copy(cloud=launched_cloud,
+                                       region=launched_region)
         task.set_resources({new_resources})
         launched_time = self.launch(raise_on_failure=False)
         # Restore the original dag, i.e. reset the region constraint.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -172,8 +172,9 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
         resources = list(task.resources)[0]
         original_resources = resources
 
+        launched_cloud = handle.launched_resources.cloud
         launched_region = handle.launched_resources.region
-        new_resources = resources.copy(region=launched_region)
+        new_resources = resources.copy(cloud=launched_cloud, region=launched_region)
         task.set_resources({new_resources})
         launched_time = self.launch(raise_on_failure=False)
         # Restore the original dag, i.e. reset the region constraint.


### PR DESCRIPTION
This fixes the problem caused by #1014, which disables launching the cluster with region specified but without cloud specified. That makes the spot recovery strategy fails to recover a spot task without cloud specified.