### PR TITLE
[Storage] Fix public bucket source check in SkyPilot Storage

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -854,21 +854,18 @@ class S3Store(AbstractStore):
             # This line does not error out if the bucket is an external public
             # bucket or if it is a user's bucket that is publicly
             # accessible.
-            self.client.get_public_access_block(Bucket=self.name)
+            self.client.head_bucket(Bucket=self.name)
             return bucket, False
         except aws.client_exception() as e:
             error_code = e.response['Error']['Code']
             # AccessDenied error for buckets that are private and not owned by
             # user.
-            if error_code == 'AccessDenied':
+            if error_code == '403':
                 command = f'aws s3 ls {self.name}'
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
                             name=self.name, command=command)) from e
-            # Try private bucket case.
-            if data_utils.verify_s3_bucket(self.name):
-                return bucket, False
 
         if self.source is not None and self.source.startswith('s3://'):
             with ux_utils.print_exception_no_traceback():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -839,6 +839,15 @@ class TestStorageWithCredentials:
         with pytest.raises(sky.exceptions.StorageBucketGetError, match='Attempted to connect to a non-existent bucket'):
             storage_obj = storage_lib.Storage(source=nonexist_bucket)
 
+    @pytest.mark.parametrize(
+        'nonexist_bucket', [f's3://imagenet', f'gs://imagenet'])
+    def test_private_bucket(self, nonexist_bucket):
+        # Attempts to access private buckets not belonging to the user.
+        # These buckets are known to be private, but may need to be updated if
+        # they are removed by their owners.
+        with pytest.raises(sky.exceptions.StorageBucketGetError, match='the bucket name is taken'):
+            storage_obj = storage_lib.Storage(source=nonexist_bucket)
+
     @staticmethod
     def cli_ls_cmd(store_type, bucket_name):
         if store_type == storage_lib.StoreType.S3:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -833,14 +833,46 @@ class TestStorageWithCredentials:
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.parametrize(
-        'nonexist_bucket',
-        [f's3://{str(uuid.uuid4())}', f'gs://{str(uuid.uuid4())}'])
-    def test_nonexistent_bucket(self, nonexist_bucket):
+        'nonexist_bucket_url',
+        ['s3://{random_name}', 'gs://{random_name}'])
+    def test_nonexistent_bucket(self, nonexist_bucket_url):
         # Attempts to create fetch a stroage with a non-existent source.
+        # Generate a random bucket name and verify it doesn't exist:
+        retry_count = 0
+        while True:
+            nonexist_bucket_name = str(uuid.uuid4())
+            if nonexist_bucket_url.startswith('s3'):
+                command = ['aws', 's3api', 'head-bucket', '--bucket',
+                           nonexist_bucket_name]
+                expected_output = '404'
+            elif nonexist_bucket_url.startswith('gs'):
+                command = ['gsutil', 'ls', nonexist_bucket_url.format(
+                    random_name=nonexist_bucket_name)]
+                expected_output = 'BucketNotFoundException'
+            else:
+                raise ValueError('Unsupported bucket type '
+                                 f'{nonexist_bucket_url}')
+
+            # Check if bucket exists using the cli:
+            try:
+                out = subprocess.check_output(command, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as e:
+                out = e.output
+            out = out.decode('utf-8')
+            if expected_output in out:
+                break
+            else:
+                retry_count += 1
+                if retry_count > 3:
+                    raise RuntimeError('Could find a nonexistent bucket to use.'
+                                       ' This is higly unlikely to happen - '
+                                       'check if the tests are correct.')
+
         with pytest.raises(
                 sky.exceptions.StorageBucketGetError,
                 match='Attempted to connect to a non-existent bucket'):
-            storage_obj = storage_lib.Storage(source=nonexist_bucket)
+            storage_obj = storage_lib.Storage(source=nonexist_bucket_url.format(
+                random_name=nonexist_bucket_name))
 
     @pytest.mark.parametrize('private_bucket',
                              [f's3://imagenet', f'gs://imagenet'])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -868,8 +868,8 @@ class TestStorageWithCredentials:
             else:
                 retry_count += 1
                 if retry_count > 3:
-                    raise RuntimeError('Could find a nonexistent bucket to use.'
-                                       ' This is higly unlikely to happen - '
+                    raise RuntimeError('Unable to find a nonexistent bucket '
+                                       'to use. This is higly unlikely - '
                                        'check if the tests are correct.')
 
         with pytest.raises(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -842,15 +842,15 @@ class TestStorageWithCredentials:
                 match='Attempted to connect to a non-existent bucket'):
             storage_obj = storage_lib.Storage(source=nonexist_bucket)
 
-    @pytest.mark.parametrize('nonexist_bucket',
+    @pytest.mark.parametrize('private_bucket',
                              [f's3://imagenet', f'gs://imagenet'])
-    def test_private_bucket(self, nonexist_bucket):
+    def test_private_bucket(self, private_bucket):
         # Attempts to access private buckets not belonging to the user.
         # These buckets are known to be private, but may need to be updated if
         # they are removed by their owners.
         with pytest.raises(sky.exceptions.StorageBucketGetError,
                            match='the bucket name is taken'):
-            storage_obj = storage_lib.Storage(source=nonexist_bucket)
+            storage_obj = storage_lib.Storage(source=private_bucket)
 
     @staticmethod
     def cli_ls_cmd(store_type, bucket_name):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -820,7 +820,7 @@ class TestStorageWithCredentials:
 
     @pytest.mark.parametrize(
         'tmp_public_storage_obj, store_type',
-        [('s3://tcga-2-open', storage_lib.StoreType.S3),
+        [('s3://digitalcorpora', storage_lib.StoreType.S3),
          ('gs://gcp-public-data-sentinel-2', storage_lib.StoreType.GCS)],
         indirect=['tmp_public_storage_obj'])
     def test_public_bucket(self, tmp_public_storage_obj, store_type):
@@ -831,6 +831,13 @@ class TestStorageWithCredentials:
         # Run sky storage ls to check if storage object exists in the output
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
+
+    @pytest.mark.parametrize(
+        'nonexist_bucket', [f's3://{str(uuid.uuid4())}', f'gs://{str(uuid.uuid4())}'])
+    def test_nonexistent_bucket(self, nonexist_bucket):
+        # Attempts to create fetch a stroage with a non-existent source.
+        with pytest.raises(sky.exceptions.StorageBucketGetError, match='Attempted to connect to a non-existent bucket'):
+            storage_obj = storage_lib.Storage(source=nonexist_bucket)
 
     @staticmethod
     def cli_ls_cmd(store_type, bucket_name):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -820,7 +820,8 @@ class TestStorageWithCredentials:
 
     @pytest.mark.parametrize(
         'tmp_public_storage_obj, store_type',
-        [('s3://digitalcorpora', storage_lib.StoreType.S3),
+        [('s3://tcga-2-open', storage_lib.StoreType.S3),
+         ('s3://digitalcorpora', storage_lib.StoreType.S3),
          ('gs://gcp-public-data-sentinel-2', storage_lib.StoreType.GCS)],
         indirect=['tmp_public_storage_obj'])
     def test_public_bucket(self, tmp_public_storage_obj, store_type):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -833,19 +833,23 @@ class TestStorageWithCredentials:
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.parametrize(
-        'nonexist_bucket', [f's3://{str(uuid.uuid4())}', f'gs://{str(uuid.uuid4())}'])
+        'nonexist_bucket',
+        [f's3://{str(uuid.uuid4())}', f'gs://{str(uuid.uuid4())}'])
     def test_nonexistent_bucket(self, nonexist_bucket):
         # Attempts to create fetch a stroage with a non-existent source.
-        with pytest.raises(sky.exceptions.StorageBucketGetError, match='Attempted to connect to a non-existent bucket'):
+        with pytest.raises(
+                sky.exceptions.StorageBucketGetError,
+                match='Attempted to connect to a non-existent bucket'):
             storage_obj = storage_lib.Storage(source=nonexist_bucket)
 
-    @pytest.mark.parametrize(
-        'nonexist_bucket', [f's3://imagenet', f'gs://imagenet'])
+    @pytest.mark.parametrize('nonexist_bucket',
+                             [f's3://imagenet', f'gs://imagenet'])
     def test_private_bucket(self, nonexist_bucket):
         # Attempts to access private buckets not belonging to the user.
         # These buckets are known to be private, but may need to be updated if
         # they are removed by their owners.
-        with pytest.raises(sky.exceptions.StorageBucketGetError, match='the bucket name is taken'):
+        with pytest.raises(sky.exceptions.StorageBucketGetError,
+                           match='the bucket name is taken'):
             storage_obj = storage_lib.Storage(source=nonexist_bucket)
 
     @staticmethod

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -832,9 +832,8 @@ class TestStorageWithCredentials:
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
 
-    @pytest.mark.parametrize(
-        'nonexist_bucket_url',
-        ['s3://{random_name}', 'gs://{random_name}'])
+    @pytest.mark.parametrize('nonexist_bucket_url',
+                             ['s3://{random_name}', 'gs://{random_name}'])
     def test_nonexistent_bucket(self, nonexist_bucket_url):
         # Attempts to create fetch a stroage with a non-existent source.
         # Generate a random bucket name and verify it doesn't exist:
@@ -842,12 +841,16 @@ class TestStorageWithCredentials:
         while True:
             nonexist_bucket_name = str(uuid.uuid4())
             if nonexist_bucket_url.startswith('s3'):
-                command = ['aws', 's3api', 'head-bucket', '--bucket',
-                           nonexist_bucket_name]
+                command = [
+                    'aws', 's3api', 'head-bucket', '--bucket',
+                    nonexist_bucket_name
+                ]
                 expected_output = '404'
             elif nonexist_bucket_url.startswith('gs'):
-                command = ['gsutil', 'ls', nonexist_bucket_url.format(
-                    random_name=nonexist_bucket_name)]
+                command = [
+                    'gsutil', 'ls',
+                    nonexist_bucket_url.format(random_name=nonexist_bucket_name)
+                ]
                 expected_output = 'BucketNotFoundException'
             else:
                 raise ValueError('Unsupported bucket type '


### PR DESCRIPTION
Closes #977.

`GetPublicAccessBlock` is no longer a reliable method to check if a s3 bucket is public. Buckets can be publicly readable yet not allow access to `GetPublicAccessBlock`. I'm not sure what caused it (and I can't find a clear reason). 

Some buckets still allow it (e.g., `s3://tcga-2-open`, which is used in our smoke tests and thus was passing), but others have blocked it (e.g., `s3://digitalcorpora`, `s3://imagenet-bucket`). 

Using `head_bucket` API now, as recommended by [boto3 docs](https://docs.aws.amazon.com/cli/latest/reference/s3api/head-bucket.html#head-bucket).

Also added storage tests for non-existent and private buckets.

Tested:

- [x] `pytest test_smoke.py::TestStorageWithCredentials`
- [x] YAML in #977
- [x] All smoke tests

