### PR TITLE
Fix K80 gpunode by correcting GCP image version

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -28,7 +28,7 @@ _CREDENTIAL_FILES = [
 ]
 
 _IMAGE_ID_PREFIX = (
-    'projects/deeplearning-platform-release/global/images/family/')
+    'projects/deeplearning-platform-release/global/images/')
 
 
 def _run_output(cmd):
@@ -216,8 +216,12 @@ class GCP(clouds.Cloud):
                 # https://cloud.google.com/compute/docs/gpus
                 resources_vars['gpu'] = 'nvidia-tesla-{}'.format(acc.lower())
                 resources_vars['gpu_count'] = acc_count
-                # CUDA driver version 470.103.01, CUDA Library 11.3
-                image_id = _IMAGE_ID_PREFIX + 'common-cu113'
+                if acc == 'K80':
+                    # CUDA driver version 470.57.02, CUDA Library 11.4
+                    image_id = _IMAGE_ID_PREFIX + 'common-cu113-v20220701'
+                else:
+                    # CUDA driver version 510.47.03, CUDA Library 11.6
+                    image_id = _IMAGE_ID_PREFIX + 'common-cu113-v20220806'
 
         if resources.image_id is not None:
             image_id = resources.image_id

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -27,8 +27,7 @@ _CREDENTIAL_FILES = [
     'legacy_credentials',
 ]
 
-_IMAGE_ID_PREFIX = (
-    'projects/deeplearning-platform-release/global/images/')
+_IMAGE_ID_PREFIX = ('projects/deeplearning-platform-release/global/images/')
 
 
 def _run_output(cmd):


### PR DESCRIPTION
Bug report from Daniel: `nvidia-smi` doesn't work on `sky gpunode --cloud gcp`.
```
NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running.
```


Reason: K80 requires nvidia-driver version to be <=470. (see details [here](https://cloud.google.com/compute/docs/gpus/install-drivers-gpu))
Before it worked fine as the cuda version was older on GCP images but several days ago GCP upgrades the driver version to 510 for all the deep learning images (see release note [here](https://cloud.google.com/deep-learning-vm/docs/release-notes)). From the note
```
The latest NVIDIA driver version does not support K80 GPUs. To use K80 GPUs, you must use an M94 or earlier environment.
```

This PR fixes this issue by using a previous version of `common-cu113` for K80.
For others, I'm not sure whether we should continue using the latest version of `common-cu113` which is subject to change or choose a static one. May need more discussion.


Note: to query older versions of GCP image try:
```
gcloud compute images list --project deeplearning-platform-release --show-deprecated
```