### PR TITLE
Optimize provision speed a bit, focusing on 1-node GCP

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -11,7 +11,6 @@ import uuid
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
-from Crypto.PublicKey import RSA
 
 from sky import sky_logging
 from sky.adaptors import aws, gcp
@@ -93,6 +92,7 @@ def get_or_generate_keys(private_key_path: str, public_key_path: str):
 # https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/_private/aws/config.py
 # Takes in config, a yaml dict and outputs a postprocessed dict
 def setup_aws_authentication(config):
+    from Crypto.PublicKey import RSA  # pylint: disable=import-outside-toplevel
     config = copy.deepcopy(config)
     private_key_path = config['auth'].get('ssh_private_key', None)
     if private_key_path is None:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -805,9 +805,9 @@ def wait_until_ray_cluster_ready(
                   nodes_so_far != num_nodes):
                 worker_status.stop()
                 logger.error(
-                    'Timed out: waited for workers to be provisioned '
-                    f'for more than {nodes_launching_progress_timeout} seconds.'
-                )
+                    'Timed out: waited for more than '
+                    f'{nodes_launching_progress_timeout} seconds for new '
+                    'workers to be provisioned, but no progress.')
                 return False  # failed
 
             if '(no pending nodes)' in output and '(no failures)' in output:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -108,6 +108,11 @@ CLUSTER_STATUS_LOCK_PATH = os.path.expanduser('~/.sky/.{}.lock')
 CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS = 10
 
 
+def is_ip(s: str) -> bool:
+    """Returns whether this string matches IP_ADDR_REGEX."""
+    return len(re.findall(IP_ADDR_REGEX, s)) == 1
+
+
 def fill_template(template_name: str,
                   variables: Dict,
                   output_path: Optional[str] = None,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2065,6 +2065,7 @@ class CloudVmRayBackend(backends.Backend):
         detach_run: bool,
     ) -> None:
         if task.run is None:
+            logger.info('Run commands not specified or empty.')
             return
         # Check the task resources vs the cluster resources. Since `sky exec`
         # will not run the provision and _check_existing_cluster

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2580,7 +2580,9 @@ class CloudVmRayBackend(backends.Backend):
             # Use the existing cluster.
             assert handle.launched_resources is not None, (cluster_name, handle)
             return RetryingVmProvisioner.ToProvisionConfig(
-                cluster_name, handle.launched_resources, handle.launched_nodes,
+                cluster_name,
+                handle.launched_resources,
+                handle.launched_nodes,
                 cluster_exists=True)
         usage_lib.messages.usage.set_new_cluster()
         assert len(task.resources) == 1, task.resources

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -505,11 +505,13 @@ class RetryingVmProvisioner(object):
                         'UNSUPPORTED_OPERATION'
                 ]:  # Per zone.
                     # Return codes can be found at https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation # pylint: disable=line-too-long
-                    # However, UNSUPPORTED_OPERATION is observed empirically when VM is preempted during creation.
-                    # This seems to be not documented by GCP.
+                    # However, UNSUPPORTED_OPERATION is observed empirically
+                    # when VM is preempted during creation.  This seems to be
+                    # not documented by GCP.
                     self._blocked_zones.add(zone.name)
                 elif code == 8:
-                    # Error code 8 means TPU resources is out of capacity. Example:
+                    # Error code 8 means TPU resources is out of
+                    # capacity. Example:
                     # {'code': 8, 'message': 'There is no more capacity in the zone "europe-west4-a"; you can try in another zone where Cloud TPU Nodes are offered (see https://cloud.google.com/tpu/docs/regions) [EID: 0x1bc8f9d790be9142]'} # pylint: disable=line-too-long
                     self._blocked_zones.add(zone.name)
                 else:
@@ -517,7 +519,8 @@ class RetryingVmProvisioner(object):
         elif len(httperror_str) >= 1:
             # Parse HttpError for unauthorized regions. Example:
             # googleapiclient.errors.HttpError: <HttpError 403 when requesting ... returned "Location us-east1-d is not found or access is unauthorized.". # pylint: disable=line-too-long
-            # Details: "Location us-east1-d is not found or access is unauthorized.">
+            # Details: "Location us-east1-d is not found or access is
+            # unauthorized.">
             logger.info(f'Got {httperror_str[0]}')
             self._blocked_zones.add(zone.name)
         else:
@@ -945,25 +948,40 @@ class RetryingVmProvisioner(object):
                 'region_name': region.name,
                 'zone_str': zone_str,
             }
-            status, stdout, stderr = self._gang_schedule_ray_up(
+            status, stdout, stderr, head_ip = self._gang_schedule_ray_up(
                 to_provision.cloud, num_nodes, cluster_config_file,
                 log_abs_path, stream_logs, logging_info, to_provision.use_spot)
 
-            # The cluster is not ready.
             if status == self.GangSchedulingStatus.CLUSTER_READY:
-                # However, ray processes may not be up due to 'ray up
-                # --no-restart' flag.  Ensure so.
-                self._ensure_cluster_ray_started(handle, log_abs_path)
+                if cluster_exists:
+                    # Guard against the case where there's an existing cluster
+                    # with ray runtime messed up (e.g., manually killed) by (1)
+                    # querying ray status (2) restarting ray if needed.
+                    #
+                    # The above 'ray up' will not restart it automatically due
+                    # to 'ray up # --no-restart' flag.
+                    #
+                    # NOTE: this is performance sensitive and has been observed
+                    # to take 9s. Only do this for existing clusters, not
+                    # freshly launched ones (which should have ray runtime
+                    # started).
+                    self._ensure_cluster_ray_started(handle, log_abs_path)
 
                 cluster_name = config_dict['cluster_name']
                 config_dict['launched_resources'] = to_provision.copy(
                     region=region.name)
                 config_dict['launched_nodes'] = num_nodes
+                # Optimizations: head_ip and zones may or may not be None. In
+                # the latter case, the caller doesn't need to query them again.
+                config_dict['head_ip'] = head_ip
+                config_dict['zones'] = zones
                 plural = '' if num_nodes == 1 else 's'
                 if not isinstance(to_provision.cloud, clouds.Local):
                     logger.info(f'{fore.GREEN}Successfully provisioned or found'
                                 f' existing VM{plural}.{style.RESET_ALL}')
                 return config_dict
+
+            # The cluster is not ready.
 
             # If cluster was previously UP or STOPPED, stop it; otherwise
             # terminate.
@@ -1017,12 +1035,12 @@ class RetryingVmProvisioner(object):
     def _gang_schedule_ray_up(
             self, to_provision_cloud: clouds.Cloud, num_nodes: int,
             cluster_config_file: str, log_abs_path: str, stream_logs: bool,
-            logging_info: dict,
-            use_spot: bool) -> Tuple[GangSchedulingStatus, str, str]:
+            logging_info: dict, use_spot: bool
+    ) -> Tuple[GangSchedulingStatus, str, str, Optional[str]]:
         """Provisions a cluster via 'ray up' and wait until fully provisioned.
 
         Returns:
-          (GangSchedulingStatus; stdout; stderr).
+          (GangSchedulingStatus; stdout; stderr; optional head_ip).
         """
         # FIXME(zhwu,zongheng): ray up on multiple nodes ups the head node then
         # waits for all workers; turn it into real gang scheduling.
@@ -1137,9 +1155,24 @@ class RetryingVmProvisioner(object):
 
         # Only 1 node or head node provisioning failure.
         if num_nodes == 1 and returncode == 0:
-            return self.GangSchedulingStatus.CLUSTER_READY, stdout, stderr
+            # Optimization: Try parse head ip from 'ray up' stdout.
+            # Last line looks like: 'ssh ... <user>@<head_ip>\n'
+            position = stdout.rfind('@')
+            if position == -1:
+                # Something's wrong. Ok to not return a head_ip.
+                head_ip = None
+            else:
+                head_ip = stdout[position + 1:].strip()
+                # Basic check: it should have at most 3*4 + 3 chars.
+                if len(head_ip) > 15:
+                    # Something's wrong. Ok to not return a head_ip.
+                    head_ip = None
+
+            return (self.GangSchedulingStatus.CLUSTER_READY, stdout, stderr,
+                    head_ip)
+
         if returncode != 0:
-            return self.GangSchedulingStatus.HEAD_FAILED, stdout, stderr
+            return self.GangSchedulingStatus.HEAD_FAILED, stdout, stderr, None
 
         provision_str = 'Successfully provisioned or found existing head VM.'
         if isinstance(to_provision_cloud, clouds.Local):
@@ -1179,13 +1212,14 @@ class RetryingVmProvisioner(object):
                 logger.debug(
                     f'Upscaling reset takes {time.time() - start} seconds.')
                 if returncode != 0:
-                    return self.GangSchedulingStatus.GANG_FAILED, stdout, stderr
+                    return (self.GangSchedulingStatus.GANG_FAILED, stdout,
+                            stderr, None)
         else:
             cluster_status = self.GangSchedulingStatus.GANG_FAILED
 
         # Do not need stdout/stderr if gang scheduling failed.
         # gang_succeeded = False, if head OK, but workers failed.
-        return cluster_status, '', ''
+        return cluster_status, '', '', None
 
     def _ensure_cluster_ray_started(self,
                                     handle: 'CloudVmRayBackend.ResourceHandle',
@@ -1557,6 +1591,7 @@ class CloudVmRayBackend(backends.Backend):
 
             # TODO(suquark): once we have sky on PyPI, we should directly
             # install sky from PyPI.
+            # NOTE: can take ~2s.
             with timeline.Event('backend.provision.wheel_build'):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
@@ -1624,13 +1659,21 @@ class CloudVmRayBackend(backends.Backend):
                                    config_dict['launched_nodes'],
                                    config_dict['tpu_name'])
 
-            with timeline.Event('backend.provision.get_node_ips'):
-                ip_list = backend_utils.get_node_ips(
-                    cluster_config_file,
-                    config_dict['launched_nodes'],
-                    head_ip_max_attempts=_HEAD_IP_MAX_ATTEMPTS,
-                    worker_ip_max_attempts=_WORKER_IP_MAX_ATTEMPTS)
-                head_ip = ip_list[0]
+            if config_dict['launched_nodes'] == 1 and config_dict[
+                    'head_ip'] is not None:
+                # Optimization for 1-node: we may have parsed the stdout of
+                # 'ray up' to get the head_ip already.
+                head_ip = config_dict['head_ip']
+                ip_list = [head_ip]
+            else:
+                # NOTE: querying node_ips is expensive, observed 1node GCP >=4s.
+                with timeline.Event('backend.provision.get_node_ips'):
+                    ip_list = backend_utils.get_node_ips(
+                        cluster_config_file,
+                        config_dict['launched_nodes'],
+                        head_ip_max_attempts=_HEAD_IP_MAX_ATTEMPTS,
+                        worker_ip_max_attempts=_WORKER_IP_MAX_ATTEMPTS)
+                    head_ip = ip_list[0]
 
             handle = self.ResourceHandle(
                 cluster_name=cluster_name,
@@ -1643,19 +1686,34 @@ class CloudVmRayBackend(backends.Backend):
                 tpu_create_script=config_dict.get('tpu-create-script'),
                 tpu_delete_script=config_dict.get('tpu-delete-script'))
 
-            # Get actual zone info and save it into handle
-            get_zone_cmd = handle.launched_resources.cloud.get_zone_shell_cmd()
-            if get_zone_cmd is not None:
-                # We leave the zone field to None for multi-node cases
-                # if zone is not specified because head and worker nodes
-                # can be launched in different zones.
-                if (task.num_nodes == 1 or
-                        handle.launched_resources.zone is not None):
-                    returncode, stdout, _ = self.run_on_head(
-                        handle, get_zone_cmd, require_outputs=True)
-                    # zone will be checked during Resources cls initialization.
-                    handle.launched_resources = handle.launched_resources.copy(
-                        zone=stdout.strip())
+            # Get actual zone info and save it into handle.
+            if (handle.launched_nodes == 1 and
+                    handle.launched_resources.cloud.is_same_cloud(
+                        clouds.GCP())):
+                # Optimization for 1-node + GCP: 'zones' will contain the exact
+                # zone since GCP uses per-zone provisioning.
+                zones = config_dict['zones']
+                assert len(zones) == 1, zones
+                handle.launched_resources = handle.launched_resources.copy(
+                    zone=zones[0].name)
+            else:
+                # NOTE: querying zones is expensive, observed 1node GCP >=4s.
+                logger.info('get actual zone')
+                get_zone_cmd = (
+                    handle.launched_resources.cloud.get_zone_shell_cmd())
+                if get_zone_cmd is not None:
+                    # We leave the zone field to None for multi-node cases
+                    # if zone is not specified because head and worker nodes
+                    # can be launched in different zones.
+                    if (task.num_nodes == 1 or
+                            handle.launched_resources.zone is not None):
+                        returncode, stdout, _ = self.run_on_head(
+                            handle, get_zone_cmd, require_outputs=True)
+                        # zone will be checked during Resources cls
+                        # initialization.
+                        handle.launched_resources = (
+                            handle.launched_resources.copy(zone=stdout.strip()))
+                logger.info('done get actual zone')
 
             usage_lib.messages.usage.update_cluster_resources(
                 handle.launched_nodes, handle.launched_resources)
@@ -2013,14 +2071,11 @@ class CloudVmRayBackend(backends.Backend):
         task: task_lib.Task,
         detach_run: bool,
     ) -> None:
+        if task.run is None:
+            return
         # Check the task resources vs the cluster resources. Since `sky exec`
         # will not run the provision and _check_existing_cluster
         self.check_resources_fit_cluster(handle, task)
-
-        # Otherwise, handle a basic Task.
-        if task.run is None:
-            logger.info('Nothing to run (Task.run not specified).')
-            return
 
         resources_str = backend_utils.get_task_resources_str(task)
         job_id = self._add_job(handle, task.name, resources_str)
@@ -2526,7 +2581,7 @@ class CloudVmRayBackend(backends.Backend):
             assert handle.launched_resources is not None, (cluster_name, handle)
             return RetryingVmProvisioner.ToProvisionConfig(
                 cluster_name, handle.launched_resources, handle.launched_nodes,
-                True)
+                cluster_exists=True)
         usage_lib.messages.usage.set_new_cluster()
         assert len(task.resources) == 1, task.resources
         resources = list(task.resources)[0]

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1156,18 +1156,12 @@ class RetryingVmProvisioner(object):
         # Only 1 node or head node provisioning failure.
         if num_nodes == 1 and returncode == 0:
             # Optimization: Try parse head ip from 'ray up' stdout.
-            # Last line looks like: 'ssh ... <user>@<head_ip>\n'
+            # Last line looks like: 'ssh ... <user>@<public head_ip>\n'
             position = stdout.rfind('@')
-            if position == -1:
+            head_ip = stdout[position + 1:].strip()
+            if not backend_utils.is_ip(head_ip):
                 # Something's wrong. Ok to not return a head_ip.
                 head_ip = None
-            else:
-                head_ip = stdout[position + 1:].strip()
-                # Basic check: it should have at most 3*4 + 3 chars.
-                if len(head_ip) > 15:
-                    # Something's wrong. Ok to not return a head_ip.
-                    head_ip = None
-
             return (self.GangSchedulingStatus.CLUSTER_READY, stdout, stderr,
                     head_ip)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -446,7 +446,7 @@ def _launch_with_confirm(
     dryrun: bool,
     detach_run: bool,
     no_confirm: bool = False,
-    idle_minutes_to_autostop: int = -1,
+    idle_minutes_to_autostop: Optional[int] = None,
     retry_until_up: bool = False,
     node_type: Optional[str] = None,
     is_local_cloud: Optional[bool] = False,
@@ -536,7 +536,6 @@ def _create_and_ssh_into_node(
             node_type,
             workdir=None,
             setup=None,
-            run='',
         )
         task.set_resources(resources)
 
@@ -2369,6 +2368,12 @@ def spot_status(all: bool, refresh: bool):
 
     If the job failed, either due to user code or spot unavailability, the error
     log can be found with ``sky logs sky-spot-controller job_id``.
+
+    (Tip) To fetch job statuses every 60 seconds, use ``watch``:
+
+    .. code-block:: bash
+
+      watch -n60 sky spot status
     """
     click.secho('Fetching managed spot job statuses...', fg='yellow')
     try:

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -1,14 +1,16 @@
 """SkyPilot.
 
-SkyPilot is a framework for easily running machine learning* workloads on any cloud
-through a unified interface. No knowledge of cloud offerings is required or expected –
-you simply define the workload and its resource requirements, and SkyPilot will
-automatically execute it on AWS, Google Cloud Platform or Microsoft Azure.
+SkyPilot is a framework for easily running machine learning* workloads on any
+cloud through a unified interface. No knowledge of cloud offerings is required
+or expected – you simply define the workload and its resource requirements, and
+SkyPilot will automatically execute it on AWS, Google Cloud Platform or
+Microsoft Azure.
 
-*: SkyPilot is primarily targeted at machine learning workloads, but it can also
-support many general workloads. We're excited to hear about your use case and would
-love to hear more about how we can better support your requirements - please join us
-in [this discussion](https://github.com/skypilot-org/skypilot/discussions/1016)
+*: SkyPilot is primarily targeted at machine learning workloads, but it can
+also support many general workloads. We're excited to hear about your use case
+and would love to hear more about how we can better support your requirements -
+please join us in [this
+discussion](https://github.com/skypilot-org/skypilot/discussions/1016)
 """
 
 import io
@@ -35,7 +37,8 @@ if system == 'Darwin':
 
 def find_version(*filepath):
     # Extract version information from filepath
-    # Adapted from: https://github.com/ray-project/ray/blob/master/python/setup.py
+    # Adapted from:
+    #  https://github.com/ray-project/ray/blob/master/python/setup.py
     with open(os.path.join(ROOT_DIR, *filepath)) as fp:
         version_match = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]',
                                   fp.read(), re.M)
@@ -61,7 +64,6 @@ install_requires = [
     'networkx',
     'oauth2client',
     'pandas',
-    'pycryptodome==3.12.0',
     'pendulum',
     'PrettyTable',
     # Lower local ray version is not fully supported, due to the
@@ -84,7 +86,12 @@ install_requires = [
 ]
 
 extras_require = {
-    'aws': ['awscli', 'boto3'],
+    'aws': [
+        'awscli',
+        'boto3',
+        # 'Crypto' module used in authentication.py for AWS.
+        'pycryptodome==3.12.0',
+    ],
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
     'azure': ['azure-cli==2.30.0'],
@@ -100,8 +107,8 @@ install_requires += extras_require['aws']
 
 long_description = ''
 readme_filepath = 'README.md'
-# When sky/backends/wheel_utils.py builds wheels, it will not contain the README.
-# Skip the description for that case.
+# When sky/backends/wheel_utils.py builds wheels, it will not contain the
+# README.  Skip the description for that case.
 if os.path.exists(readme_filepath):
     long_description = io.open(readme_filepath, 'r', encoding='utf-8').read()
     long_description = parse_footnote(long_description)

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -12,8 +12,17 @@ To get original versions, go to the Ray branch with version:
 
   sky.constants.SKY_REMOTE_RAY_VERSION
 
-Example:
-- https://raw.githubusercontent.com/ray-project/ray/releases/1.13.0/python/ray/worker.py
+Example workflow:
+
+  >> wget https://raw.githubusercontent.com/ray-project/ray/releases/1.13.0/python/ray/autoscaler/_private/command_runner.py
+  >> cp command_runner.py command_runner.py.1
+
+  >> # Make some edits to command_runner.py.1...
+
+  >> diff command_runner.py command_runner.py.1 >command_runner.py.patch
+
+  >> # Inspect command_runner.py.patch.
+  >> # Edit this file to include command_runner.py.patch.
 """
 import os
 import subprocess
@@ -57,9 +66,12 @@ def patch() -> None:
     from ray.dashboard.modules.job import cli
     _run_patch(cli.__file__, _to_absolute('cli.py.patch'))
 
+    from ray.autoscaler._private import autoscaler
+    _run_patch(autoscaler.__file__, _to_absolute('autoscaler.py.patch'))
+
+    from ray.autoscaler._private import command_runner
+    _run_patch(command_runner.__file__, _to_absolute('command_runner.py.patch'))
+
     from ray.autoscaler._private import resource_demand_scheduler
     _run_patch(resource_demand_scheduler.__file__,
                _to_absolute('resource_demand_scheduler.py.patch'))
-
-    from ray.autoscaler._private import autoscaler
-    _run_patch(autoscaler.__file__, _to_absolute('autoscaler.py.patch'))

--- a/sky/skylet/ray_patches/command_runner.py.patch
+++ b/sky/skylet/ray_patches/command_runner.py.patch
@@ -1,0 +1,4 @@
+330c330
+<                     "ControlPersist": "10s",
+---
+>                     "ControlPersist": "300s",

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -116,45 +116,54 @@ rsync_exclude: []
 initialization_commands: []
 
 # List of shell commands to run to set up nodes.
+# NOTE: these are very performance-sensitive. Each new item opens/closes an SSH
+# connection, which is expensive. Try your best to co-locate commands into fewer
+# items!
+#
+# Increment the following for catching performance bugs easier:
+#   current num items (num SSH connections): 1  (+1 if tpu_vm)
 setup_commands:
-  # Create ~/.ssh/config file in case the file does not exist in the custom image.
-  # Make sure python3 & pip3 are available on this image.
+  # Line 'mkdir -p ..': Create ~/.ssh/config file in case the file does not exist in the custom image.
+  # Line 'pip3 --v ..': Make sure python3 & pip3 are available on this image.
+  # Line 'which conda ..': GCP TPU VM image does not install conda by default.
+  # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
-    pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc);
-    (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
-    (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
-  # GCP TPU VM image does not install conda by default.
-  - which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
-  # patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  - (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
+    pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc); (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc; (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
+    which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
+    (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     pip3 uninstall skypilot -y &> /dev/null;
     pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[gcp]";
-    python3 -c "from sky.skylet.ray_patches import patch; patch()";
-    [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `gcsfuse`;
+    python3 -c "from sky.skylet.ray_patches import patch; patch()"; [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `gcsfuse`;
   # For TPU VM
   {%- if tpu_vm %}
   - pip3 install --upgrade google-api-python-client
   {%- endif %}
 
 # Command to start ray on the head node. You don't need to change this.
+# NOTE: these are very performance-sensitive. Each new item opens/closes an SSH
+# connection, which is expensive. Try your best to co-locate commands into fewer
+# items! The same comment applies for worker_start_ray_commands.
+#
+# Increment the following for catching performance bugs easier:
+#   current num items (num SSH connections): 2
 head_start_ray_commands:
   # Set the ulimit as suggested by ray docs for performance. https://docs.ray.io/en/latest/cluster/guide.html?highlight=ulimit#system-configuration
   # Solution from https://discuss.ray.io/t/setting-ulimits-on-ec2-instances/590
   # This line is intentionally separated from the next line to reload the session after the ulimit is set.
   - sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 65535" >> /etc/security/limits.conf; echo "* hard nofile 65535" >> /etc/security/limits.conf;';
     (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
-  - (ps aux | grep "-m sky.skylet.skylet" | grep -q python3) || nohup python3 -m sky.skylet.skylet >> ~/.sky/skylet.log 2>&1 & # Start skylet daemon. (Should not place it in the head_setup_commands, otherwise it will run before sky is installed.)
-  - SKY_NUM_GPUS=0 && which nvidia-smi > /dev/null && SKY_NUM_GPUS=$(nvidia-smi --query-gpu=index,name --format=csv,noheader | wc -l);
-    grep "export SKY_NUM_GPUS" ~/.bashrc > /dev/null || echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
-  - ray stop; ray start --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
+  # Start skylet daemon. (Should not place it in the head_setup_commands, otherwise it will run before sky is installed.)
+  # NOTE: --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
+  - ((ps aux | grep "-m sky.skylet.skylet" | grep -q python3) || nohup python3 -m sky.skylet.skylet >> ~/.sky/skylet.log 2>&1 &);
+    export SKY_NUM_GPUS=0 && which nvidia-smi > /dev/null && SKY_NUM_GPUS=$(nvidia-smi --query-gpu=index,name --format=csv,noheader | wc -l);
+    ray stop; ray start --disable-usage-stats --head --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
 
 {%- if num_nodes > 1 %}
 worker_start_ray_commands:
   - sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 65535" >> /etc/security/limits.conf; echo "* hard nofile 65535" >> /etc/security/limits.conf;';
     (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
   - SKY_NUM_GPUS=0 && which nvidia-smi > /dev/null && SKY_NUM_GPUS=$(nvidia-smi --query-gpu=index,name --format=csv,noheader | wc -l);
-    grep "export SKY_NUM_GPUS" ~/.bashrc > /dev/null || echo "export SKY_NUM_GPUS=$SKY_NUM_GPUS" >> ~/.bashrc
-  - ray stop; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076 {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
+    ray stop; ray start --disable-usage-stats --address=$RAY_HEAD_IP:6379 --object-manager-port=8076 {{"--resources='%s'" % custom_resources if custom_resources}} --num-gpus=$SKY_NUM_GPUS
 {%- else %}
 worker_start_ray_commands: []
 {%- endif %}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -123,21 +123,23 @@ initialization_commands: []
 # Increment the following for catching performance bugs easier:
 #   current num items (num SSH connections): 1  (+1 if tpu_vm)
 setup_commands:
-  # Line 'which conda ..': GCP TPU VM image does not install conda by default.
-  # conda needs to be a separate login, so the next item of the list has access to it.
-  {%- if tpu_vm %}
-  - pip3 install --upgrade google-api-python-client;
-    which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
-  {%- endif %}
   # Line 'mkdir -p ..': Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Line 'pip3 --v ..': Make sure python3 & pip3 are available on this image.
+  # Line 'which conda ..': some images (TPU VM) do not install conda by
+  # default. 'source ~/.bashrc' is needed so conda takes effect for the next
+  # commands.
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
     pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc); (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc; (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
+    which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
+    source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     pip3 uninstall skypilot -y &> /dev/null;
     pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[gcp]";
     python3 -c "from sky.skylet.ray_patches import patch; patch()"; [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `gcsfuse`;
+  {%- if tpu_vm %}
+  - pip3 install --upgrade google-api-python-client;
+  {%- endif %}
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -123,21 +123,21 @@ initialization_commands: []
 # Increment the following for catching performance bugs easier:
 #   current num items (num SSH connections): 1  (+1 if tpu_vm)
 setup_commands:
+  # Line 'which conda ..': GCP TPU VM image does not install conda by default.
+  # conda needs to be a separate login, so the next item of the list has access to it.
+  {%- if tpu_vm %}
+  - pip3 install --upgrade google-api-python-client;
+    which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
+  {%- endif %}
   # Line 'mkdir -p ..': Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Line 'pip3 --v ..': Make sure python3 & pip3 are available on this image.
-  # Line 'which conda ..': GCP TPU VM image does not install conda by default.
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
     pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc); (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc; (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
-    which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     pip3 uninstall skypilot -y &> /dev/null;
     pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[gcp]";
     python3 -c "from sky.skylet.ray_patches import patch; patch()"; [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `gcsfuse`;
-  # For TPU VM
-  {%- if tpu_vm %}
-  - pip3 install --upgrade google-api-python-client
-  {%- endif %}
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -75,7 +75,7 @@ def ssh_options_list(ssh_private_key: Optional[str],
             # sky.launch().
             'ControlMaster': 'auto',
             'ControlPath': f'{_ssh_control_path(ssh_control_name)}/%C',
-            'ControlPersist': '120s',
+            'ControlPersist': '300s',
         })
     ssh_key_option = [
         '-i',

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -1,4 +1,4 @@
-"""Sky logging utils."""
+"""Logging utils."""
 import enum
 from typing import List, Optional
 

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -124,10 +124,10 @@ def _save_timeline(file_path: str):
         'traceEvents': _events,
         'displayTimeUnit': 'ms',
         'otherData': {
-            'log_dir': os.path.dirname(file_path),
+            'log_dir': os.path.dirname(os.path.abspath(file_path)),
         }
     }
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    os.makedirs(os.path.dirname(os.path.abspath(file_path)), exist_ok=True)
     with open(file_path, 'w') as f:
         json.dump(json_output, f)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -177,7 +177,7 @@ def test_stale_job():
             f'sky launch -y -c {name} --cloud gcp "echo hi"',
             f'sky exec {name} --cloud gcp -d "echo start; sleep 10000"',
             f'sky stop {name} -y',
-            'sleep 40',
+            'sleep 100',  # Ensure this is large enough, else GCP leaks.
             f'sky start {name} -y',
             f'sky logs {name} 1 --status',
             f's=$(sky queue {name}); printf "$s"; echo; echo; printf "$s" | grep FAILED',


### PR DESCRIPTION
# Before vs after
`sky launch --cloud gcp`

Before, master 054402e3d77 - median 3:02
```
  sky launch -c no-opt --cloud gcp -y ''  22.03s user 4.66s system 14% cpu 3:02.50 total
  sky launch -c no-opt1 --cloud gcp -y ''  19.38s user 3.81s system 12% cpu 3:06.32 total
  sky launch -c no-opt2 --cloud gcp -y ''  19.02s user 3.73s system 12% cpu 2:58.92 total
```
After - median 2:40 (12% speed up)
```
sky launch -c opt --cloud gcp -y ''  13.89s user 3.17s system 10% cpu 2:43.79 total
sky launch -c opt2 --cloud gcp -y ''  11.78s user 2.37s system 8% cpu 2:40.32 total
sky launch -c opt9 --cloud gcp -y ''  11.49s user 2.37s system 9% cpu 2:31.00 total
```

After, but **additionally comment out any credentials upload** (see below) - median 2:13 (27% speedup)
```
  sky launch -c test1 --cloud gcp -y ''  12.68s user 2.68s system 11% cpu 2:13.05 total
  sky launch -c test2 --cloud gcp -y ''  11.15s user 2.10s system 9% cpu 2:16.99 total
  sky launch -c test3 --cloud gcp -y ''  11.06s user 2.09s system 10% cpu 2:05.38 total
```

**Lesson**: **`file_mounts` in generated Ray yaml are very expensive**. 

Each mount = 1 SSH open/disconnect. We can consider 
- zipping them
- using an env var to turn off uploading

I decided to not do this as the target user may be GCP-only, so they may be better than what I have:
```yaml
file_mounts:
  ~/.sky/sky_ray.yml: /Users/zongheng/.sky/generated/opt2.yml
  ~/.sky/sky_wheels: /var/folders/8f/56gzvwkd3n3293xjlrztr6600000gp/T/08d9c1b43ad1c22d17325787d7dae62d
  ~/.aws/credentials: ~/.aws/credentials
  ~/.azure/azureProfile.json: ~/.azure/azureProfile.json
  ~/.azure/clouds.config: ~/.azure/clouds.config
  ~/.azure/config: ~/.azure/config
  ~/.azure/msal_token_cache.json: ~/.azure/msal_token_cache.json
  ~/.config/gcloud/credentials.db: ~/.config/gcloud/credentials.db
  ~/.config/gcloud/application_default_credentials.json: ~/.config/gcloud/application_default_credentials.json
  ~/.config/gcloud/access_tokens.db: ~/.config/gcloud/access_tokens.db
  ~/.config/gcloud/configurations: ~/.config/gcloud/configurations
  ~/.config/gcloud/legacy_credentials: ~/.config/gcloud/legacy_credentials

```

# Breakdown of current overheads

Note for future: **The best way to see these breakdowns** is to read the various timestamps in 
```
I 08-17 13:13:30 cloud_vm_ray_backend.py:888] To view detailed progress: tail -n100 -f /Users/zongheng/sky_logs/sky-2022-08-17-13-13-30-385888/provision.log
```
as well as reading
```
I 08-17 13:13:32 cloud_vm_ray_backend.py:1092] Launching on GCP us-central1 (us-central1-a)
I 08-17 13:14:26 log_utils.py:45] Head node is up.
I 08-17 13:15:58 cloud_vm_ray_backend.py:980] Successfully provisioned or found existing VM.
```

**Breakdown, with this PR**

- `_add_auth_to_cluster_config()`: ~1.5-2s
- **Launch VM till SSH ready: ~55s-1min**
  - Includes: check head node first + provision & wait for ssh + update status
  - [ ] Note that ray autoscale's "update status" using tags is expensive, 4-7s
- **Preparing SkyPilot runtime: ~1min 30s**
  - **File mounts with 3 clouds credentials: ~30s**
    - see the timestamp between `[2/7] Processing file mounts` to `[3/7] No worker file mounts to sync`
  - **Setup_commands: ~32s**
    - between `[6/7] Running setup commands` and `[7/7] Starting the Ray runtime`
   - **Starting Ray: ~19s**
     - between `[7/7] Starting the Ray runtime` and last line of provision.log
 - some other overheads (e.g., update-status 6 times!)
   
# Breakdown of optimizations
- Optimize interactive nodes: saves 6s (no autostop=-1), 9s (no run='').
- in cloud_vm_ray_backend 
  - (Saves 4s) Do not query IP for 1-node clusters; get head IP from `ray up` stdout
  - (Saves 4s) Do not query zone for 1-node, GCP clusters
  - (Saves 9s) Do not _ensure_cluster_ray_started() for fresh clusters
- in gcp-ray.yml.j2 
  - (Saves 10s) --disable-usage-stats in `ray start`
  - (Saves 7s) shorten start_commands from 3 to 2 SSH connections
  - (not much change) shorten setup_commands from 3 to 1 SSH connection
- [ ] (NOT INCLUDED in this PR) skip credentials in file_mounts: 30s

# What to optimize in the future 
1. file_mounts, see above.
2. Port these to other clouds.


# Tested
- [ ] smoke tests, passed except unrelated failures
  - `TestStorageWithCredentials`: failed on master for me
  - `test_spot_storage`: known access denied
  - `test_spot`, `test_use_spot`: AWS related, tracked in #1026 -- they passed when using a non-problematic region