### PR TITLE
Fix the line limitation for query of loki

### DIFF
--- a/sky/usage/loki-s3-config.yaml
+++ b/sky/usage/loki-s3-config.yaml
@@ -51,6 +51,7 @@ limits_config:
   max_global_streams_per_user: 5000
   max_query_length: 0h # Default: 721h
   max_query_parallelism: 32 # Old Default: 14
+  max_entries_limit_per_query: 1000000
   max_streams_per_user: 0 # Old Default: 10000
   reject_old_samples: true
   reject_old_samples_max_age: 168h
@@ -65,3 +66,4 @@ chunk_store_config:
 table_manager:
   retention_deletes_enabled: false
   retention_period: 0s
+


### PR DESCRIPTION
This fixes the problem where our dashboard fails to get all the users as the number latest operations for some users grows too large which exceeds the original query limitation.