### PR TITLE
Reduce the frequency of job status update and remove parallel query

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -53,7 +53,7 @@ class SkyletEvent:
 
 class JobUpdateEvent(SkyletEvent):
     """Skylet event for updating job status."""
-    EVENT_INTERVAL_SECONDS = 20
+    EVENT_INTERVAL_SECONDS = 300
 
     # Only update status of the jobs after this many seconds of job submission,
     # to avoid race condition with `ray job` to make sure it job has been

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -349,7 +349,7 @@ def update_job_status(job_owner: str,
             continue
         ray_status = ray_job_infos[ray_job_id].status
         ray_statuses.append(_RAY_TO_JOB_STATUS_MAP[ray_status])
-    
+
     assert len(ray_statuses) == len(job_ids), (ray_statuses, job_ids)
 
     statuses = []

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -346,7 +346,7 @@ def update_job_status(job_owner: str,
     ray_job_infos = job_client.list_jobs()
     job_statuses: List[JobStatus] = [None] * len(ray_job_ids)
     for i, ray_job_id in enumerate(ray_job_ids):
-        if ray_job_id not in ray_job_infos:
+        if ray_job_id in ray_job_infos:
             ray_status = ray_job_infos[ray_job_id].status
             job_statuses[i] = _RAY_TO_JOB_STATUS_MAP[ray_status]
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -415,9 +415,9 @@ def update_status(job_owner: str, submitted_gap_sec: int = 0) -> None:
     nonterminal_jobs = _get_jobs(username=None,
                                  status_list=JobStatus.nonterminal_statuses(),
                                  submitted_gap_sec=submitted_gap_sec)
-    running_job_ids = [job['job_id'] for job in nonterminal_jobs]
+    nonterminal_job_ids = [job['job_id'] for job in nonterminal_jobs]
 
-    update_job_status(job_owner, running_job_ids)
+    update_job_status(job_owner, nonterminal_job_ids)
 
 
 def is_cluster_idle() -> bool:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -413,8 +413,8 @@ def update_status(job_owner: str, submitted_gap_sec: int = 0) -> None:
     # not submitted yet. It will be then reset to PENDING / RUNNING when the
     # app starts.
     nonterminal_jobs = _get_jobs(username=None,
-                             status_list=JobStatus.nonterminal_statuses(),
-                             submitted_gap_sec=submitted_gap_sec)
+                                 status_list=JobStatus.nonterminal_statuses(),
+                                 submitted_gap_sec=submitted_gap_sec)
     running_job_ids = [job['job_id'] for job in nonterminal_jobs]
 
     update_job_status(job_owner, running_job_ids)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -116,7 +116,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]]) -> str:
         controller_status = job_lib.get_status(job_id)
         if controller_status.is_terminal():
             logger.error(f'Controller for job {job_id} have exited abnormally. '
-                         'Set the job status to FAILED.')
+                         'Set the job status to FAILED_CONTROLLER.')
             task_name = spot_state.get_task_name_by_job_id(job_id)
 
             # Tear down the abnormal spot cluster to avoid resource leakage.

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -119,7 +119,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]]) -> str:
         controller_status = job_lib.get_status(job_id)
         if controller_status.is_terminal():
             logger.error(f'Controller for job {job_id} have exited abnormally. '
-                         'Set the job status to FAILED_CONTROLLER.')
+                         'Setting the job status to FAILED_CONTROLLER.')
             task_name = spot_state.get_task_name_by_job_id(job_id)
 
             # Tear down the abnormal spot cluster to avoid resource leakage.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -207,7 +207,7 @@ def test_stale_job_manual_restart():
             f'sky launch -c {name} -y "echo hi"',
             f'sky logs {name} 1 --status',
             f'sky logs {name} 3 --status',
-            # Ensure the skylet updated the staled job status.
+            # Ensure the skylet updated the stale job status.
             f'sleep {events.JobUpdateEvent.EVENT_INTERVAL_SECONDS}',
             f's=$(sky queue {name}); printf "$s"; echo; echo; printf "$s" | grep FAILED',
         ],


### PR DESCRIPTION
This is an attempt for #1088. It reduces the parallel query through the same port for the ray job.

Profiling: (The original time is not that large (reduced by 3x), but the list_jobs can reduce the number of http requests by the number of jobs to be queried.)
```bash
$ python ./query_jobs.py 
Parallel Time spend: 0.10391879081726074
job list Time spend: 0.03846001625061035
```
```python
# query_jobs.py
# 10 jobs not exist, 11 RUNNING, 3 STARTING, 6 SUCCEEDED
from sky.skylet import job_lib
from sky.utils import subprocess_utils
import time

client = job_lib._create_ray_job_submission_client()

ray_job_ids = [f'{i}-gcpuser' for i in range(60, 90)]
def get_job_status(job_id):
    try:
        # The return value is a string, e.g. 'RUNNING', which conflicts
        # with the return type in ray code.
        ray_status = client.get_job_status(job_id)
        return job_lib._RAY_TO_JOB_STATUS_MAP[ray_status]
    except RuntimeError as e:
        # If the job does not exist or if the request to the
        # job server fails.
        if 'does not exist' in str(e):
            return None
        raise

start = time.time()
ray_statuses = subprocess_utils.run_in_parallel(
    get_job_status, ray_job_ids)
print(f'Parallel Time spend: {time.time() - start}')

client = job_lib._create_ray_job_submission_client()
start = time.time()
ray_job_infos = client.list_jobs()
job_statuses = [None] * len(ray_job_ids)
for i, ray_job_id in enumerate(ray_job_ids):
    if ray_job_id in ray_job_infos:
        ray_status = ray_job_infos[ray_job_id].status
        job_statuses[i] = job_lib._RAY_TO_JOB_STATUS_MAP[ray_status]
print(f'job list Time spend: {time.time() - start}')
```

Tested:
- [x] `pytest ./tests/test_smoke.py::test_stale_job`
- [x] `pytest ./tests/test_smoke.py::test_stale_job_manual_restart`