### PR TITLE
[Spot] Add retry-until-up for spot jobs and improve the responsiveness for cancelling

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -105,7 +105,7 @@ SKY_RESERVED_CLUSTER_NAMES = [spot_lib.SPOT_CONTROLLER_NAME]
 
 # Filelocks for the cluster status change.
 CLUSTER_STATUS_LOCK_PATH = os.path.expanduser('~/.sky/.{}.lock')
-CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS = 10
+CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS = 20
 
 
 def fill_template(template_name: str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2274,6 +2274,16 @@ def spot():
               is_flag=True,
               help='If True, run setup first (blocking), '
               'then detach from the job\'s execution.')
+@click.option(
+    '--retry-until-up',
+    '-r',
+    default=False,
+    is_flag=True,
+    required=False,
+    help=('Whether to retry provisioning infinitely until the cluster is up, '
+          'if we fail to launch the cluster on any possible region/cloud due '
+          'to unavailability errors. This applies to recovery after preemption '
+          'as well.'))
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -2298,6 +2308,7 @@ def spot_launch(
     env: List[Dict[str, str]],
     disk_size: Optional[int],
     detach_run: bool,
+    retry_until_up: bool,
     yes: bool,
 ):
     """Launch a managed spot job."""
@@ -2328,7 +2339,10 @@ def spot_launch(
         if prompt is not None:
             click.confirm(prompt, default=True, abort=True, show_default=True)
 
-    sky.spot_launch(dag, name, detach_run=detach_run)
+    sky.spot_launch(dag,
+                    name,
+                    detach_run=detach_run,
+                    retry_until_up=retry_until_up)
 
 
 @spot.command('status', cls=_DocumentedCodeCommand)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2282,8 +2282,8 @@ def spot():
     required=False,
     help=('Whether to retry provisioning infinitely until the cluster is up, '
           'if we fail to launch the cluster on any possible region/cloud due '
-          'to unavailability errors. This applies to recovery after preemption '
-          'as well.'))
+          'to unavailability errors. This applies to launching the the spot '
+          'clusters (both initial and recovery attempts).'))
 @click.option('--yes',
               '-y',
               is_flag=True,

--- a/sky/core.py
+++ b/sky/core.py
@@ -539,11 +539,15 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int]):
         sky.exceptions.ClusterNotUpError: the spot controller is not up.
     """
     # TODO(zhwu): Automatically restart the spot controller
-    _, handle = _is_spot_controller_up(
+    controller_status, handle = _is_spot_controller_up(
         'Please restart the spot controller with '
         '`sky start sky-spot-controller -i 5`.')
     if handle is None or handle.head_ip is None:
-        raise exceptions.ClusterNotUpError('All jobs finished.')
+        msg = 'All jobs finished.'
+        if controller_status == global_user_state.ClusterStatus.INIT:
+            msg = ''
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.ClusterNotUpError(msg)
 
     if name is not None and job_id is not None:
         raise ValueError('Cannot specify both name and job_id.')

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -128,6 +128,7 @@ class SpotUserCancelledError(Exception):
     """Raised when a spot user cancels the job."""
     pass
 
+
 class SpotUnknownSignalError(Exception):
     """Raised when a spot user sends an unknown signal."""
     pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -122,3 +122,12 @@ class NetworkError(Exception):
 class ClusterStatusFetchingError(Exception):
     """Raised when fetching the cluster status fails."""
     pass
+
+
+class SpotUserCancelledError(Exception):
+    """Raised when a spot user cancels the job."""
+    pass
+
+class SpotUnknownSignalError(Exception):
+    """Raised when a spot user sends an unknown signal."""
+    pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -127,4 +127,3 @@ class ClusterStatusFetchingError(Exception):
 class SpotUserCancelledError(Exception):
     """Raised when a spot user cancels the job."""
     pass
-

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -128,7 +128,3 @@ class SpotUserCancelledError(Exception):
     """Raised when a spot user cancels the job."""
     pass
 
-
-class SpotUnknownSignalError(Exception):
-    """Raised when a spot user sends an unknown signal."""
-    pass

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -335,6 +335,7 @@ def spot_launch(
     name: Optional[str] = None,
     stream_logs: bool = True,
     detach_run: bool = False,
+    retry_until_up: bool = False,
 ):
     """Launch a managed spot job.
 
@@ -441,7 +442,8 @@ def spot_launch(
                 'sky_remote_path': backend_utils.SKY_REMOTE_PATH,
                 'is_dev': env_options.Options.IS_DEVELOPER.get(),
                 'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
-                'logging_user_hash': usage_lib.get_logging_user_hash()
+                'logging_user_hash': usage_lib.get_logging_user_hash(),
+                'retry_until_up': retry_until_up,
             },
             output_prefix=spot.SPOT_CONTROLLER_YAML_PREFIX)
         with sky.Dag() as spot_dag:

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -167,7 +167,7 @@ class SpotController:
                     signal = spot_utils.UserSignal(signal)
                 # Remove the signal file, after reading the signal.
                 signal_file.unlink()
-        if signal is not None:
+        if signal is None:
             return
         if signal == spot_utils.UserSignal.CANCEL:
             raise exceptions.SpotUserCancelledError(

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -172,7 +172,7 @@ class SpotController:
         if signal == spot_utils.UserSignal.CANCEL:
             raise exceptions.SpotUserCancelledError(
                 f'User sent {signal.value} signal.')
-        
+
         raise exceptions.SpotUnknownSignalError(
             f'Unknown signal received: {signal.value}.')
 

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -110,9 +110,8 @@ class SpotController:
                         failure_type=spot_state.SpotStatus.FAILED,
                         end_time=end_time)
                     break
-                assert (cluster_status == global_user_state.ClusterStatus.
-                        STOPPED), ('The cluster should be STOPPED, but is '
-                                   f'{cluster_status.value}.')
+            # cluster can be down, INIT or STOPPED, based on the interruption
+            # behavior of the cloud.
             # Failed to connect to the cluster or the cluster is partially down.
             # job_status is None or job_status == job_lib.JobStatus.FAILED
             logger.info('The cluster is preempted.')

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -3,7 +3,6 @@ import argparse
 import pathlib
 import time
 import traceback
-from typing import Optional
 
 import colorama
 import filelock
@@ -25,10 +24,12 @@ logger = sky_logging.init_logger(__name__)
 class SpotController:
     """Each spot controller manages the life cycle of one spot cluster (job)."""
 
-    def __init__(self, job_id: int, task_yaml: str) -> None:
+    def __init__(self, job_id: int, task_yaml: str,
+                 retry_until_up: bool) -> None:
         self._job_id = job_id
         self._task_name = pathlib.Path(task_yaml).stem
         self._task = sky.Task.from_yaml(task_yaml)
+        self._retry_until_up = retry_until_up
         # TODO(zhwu): this assumes the specific backend.
         self.backend = cloud_vm_ray_backend.CloudVmRayBackend()
 
@@ -40,7 +41,8 @@ class SpotController:
         self._cluster_name = spot_utils.generate_spot_cluster_name(
             self._task_name, self._job_id)
         self._strategy_executor = recovery_strategy.StrategyExecutor.make(
-            self._cluster_name, self.backend, self._task)
+            self._cluster_name, self.backend, self._task, retry_until_up,
+            self._check_signal)
 
     def _run(self):
         """Busy loop monitoring spot cluster status and handling recovery."""
@@ -53,11 +55,7 @@ class SpotController:
         while True:
             time.sleep(spot_utils.JOB_STATUS_CHECK_GAP_SECONDS)
             # Handle the signal if it is sent by the user.
-            user_signal = self._check_signal()
-            if user_signal == spot_utils.UserSignal.CANCEL:
-                logger.info(f'User sent {user_signal.value} signal.')
-                spot_state.set_cancelled(self._job_id)
-                break
+            self._check_signal()
 
             # Check the network connection to avoid false alarm for job failure.
             # Network glitch was observed even in the VM.
@@ -127,6 +125,9 @@ class SpotController:
         """Start the controller."""
         try:
             self._run()
+        except exceptions.SpotUserCancelledError as e:
+            logger.info(e)
+            spot_state.set_cancelled(self._job_id)
         except exceptions.ResourcesUnavailableError as e:
             logger.error(f'Resources unavailable: {colorama.Fore.RED}{e}'
                          f'{colorama.Style.RESET_ALL}')
@@ -149,7 +150,7 @@ class SpotController:
             # Clean up Storages with persistent=False.
             self.backend.teardown_ephemeral_storage(self._task)
 
-    def _check_signal(self) -> Optional[spot_utils.UserSignal]:
+    def _check_signal(self):
         """Check if the user has sent down signal."""
         signal_file = pathlib.Path(
             spot_utils.SIGNAL_FILE_PREFIX.format(self._job_id))
@@ -166,7 +167,14 @@ class SpotController:
                     signal = spot_utils.UserSignal(signal)
                 # Remove the signal file, after reading the signal.
                 signal_file.unlink()
-        return signal
+        if signal is not None:
+            return
+        if signal == spot_utils.UserSignal.CANCEL:
+            raise exceptions.SpotUserCancelledError(
+                f'User sent {signal.value} signal.')
+        
+        raise exceptions.SpotUnknownSignalError(
+            f'Unknown signal received: {signal.value}.')
 
 
 if __name__ == '__main__':
@@ -175,10 +183,17 @@ if __name__ == '__main__':
                         required=True,
                         type=int,
                         help='Job id for the controller job.')
+    parser.add_argument('--retry-until-up',
+                        action='store_true',
+                        help='Retry until the cluster is up.')
+    parser.add_argument('--no-retry-until-up',
+                        dest='retry-until-up',
+                        action='store_false')
     parser.add_argument('task_yaml',
                         type=str,
                         help='The path to the user spot task yaml file. '
                         'The file name is the spot task name.')
     args = parser.parse_args()
-    controller = SpotController(args.job_id, args.task_yaml)
+    controller = SpotController(args.job_id, args.task_yaml,
+                                args.retry_until_up)
     controller.start()

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -186,9 +186,6 @@ if __name__ == '__main__':
     parser.add_argument('--retry-until-up',
                         action='store_true',
                         help='Retry until the cluster is up.')
-    parser.add_argument('--no-retry-until-up',
-                        dest='retry-until-up',
-                        action='store_false')
     parser.add_argument('task_yaml',
                         type=str,
                         help='The path to the user spot task yaml file. '

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -172,8 +172,7 @@ class SpotController:
             raise exceptions.SpotUserCancelledError(
                 f'User sent {signal.value} signal.')
 
-        raise RuntimeError(
-            f'Unknown signal received: {signal.value}.')
+        raise RuntimeError(f'Unknown SkyPilot signal received: {signal.value}.')
 
 
 if __name__ == '__main__':

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -33,12 +33,7 @@ setup: |
 run: |
   python -u -m sky.spot.controller \
     {{remote_user_yaml_prefix}}/{{cluster_name}}.yaml \
-    --job-id $SKY_JOB_ID \
-{% if retry_until_up %}
-    --retry-until-up
-{% else %}
-    --no-retry-until-up
-{% endif %}
+    --job-id $SKY_JOB_ID {% if retry_until_up %}--retry-until-up{% endif %}
 
 envs:
   SKYPILOT_USAGE_USER_ID: {{logging_user_hash}}

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -33,7 +33,12 @@ setup: |
 run: |
   python -u -m sky.spot.controller \
     {{remote_user_yaml_prefix}}/{{cluster_name}}.yaml \
-    --job-id $SKY_JOB_ID
+    --job-id $SKY_JOB_ID \
+{% if retry_until_up %}
+    --retry-until-up
+{% else %}
+    --no-retry-until-up
+{% endif %}
 
 envs:
   SKYPILOT_USAGE_USER_ID: {{logging_user_hash}}


### PR DESCRIPTION
This fixes #1097.

Main changes:
1. Add the `--retry-until-up` option for the `sky spot launch`, i.e. the controller will retry launching/recovering for the request resources forever until the cluster is UP.
2. Improve the responsiveness for job cancelling for spot jobs. Previously, when the spot controller is retrying to launch or recovering the cluster (especially recovering which can take more than 4 hours), it will ignore the cancel signal from the user until the cluster is UP. Now, instead, we will check the signal at the beginning of each retry.

Tested:
- [x] `pytest ./tests/test_smoke.py::test_gcp_spot`
- [x] `pytest ./tests/test_smoke.py::test_spot`
- [x] `pytest ./tests/test_smoke.py::test_spot_recovery`
- [x] `pytest ./tests/test_smoke.py::test_spot_storage`
- [x] `pytest ./tests/test_smoke.py::test_inline_spot_env`
- [x] `sky spot launch -n test-retry --gpus A100:8 --cloud aws 'echo hi'` showed FAILED_NO_RESOURCES.
- [x] `sky spot launch -n test-retry --gpus A100:8 --cloud aws --retry-until-up 'echo hi'` retry forever; 
- [x] `sky spot cancel -a` cancels the retry forever job.
