### PR TITLE
Fix version number for GCP CPU image

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -180,7 +180,7 @@ class GCP(clouds.Cloud):
         region_name = region.name
         zones = [zones[0].name]
 
-        image_id = _IMAGE_ID_PREFIX + 'common-cpu'
+        image_id = _IMAGE_ID_PREFIX + 'common-cpu-v20220806'
 
         r = resources
         # Find GPU spec, if any.


### PR DESCRIPTION
As suggested by @infwinston, we should add version after CPU image, due to the change in #1090.

Tested:
- [x] `sky cpunode --cloud gcp`