### PR TITLE
[Spot] Distinguish spot controller names for different users (!! backward incompatible for spot controller !!)

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2317,7 +2317,8 @@ def spot_status(all: bool, refresh: bool):
     - CANCELLED: The job was cancelled by the user.
 
     If the job failed, either due to user code or spot unavailability, the error
-    log can be found with ``sky logs sky-spot-controller job_id``.
+    log can be found with ``sky logs sky-spot-controller-<user_hash> job_id``.
+    Please find your exact spot controller name with ``sky status -a``.
 
     (Tip) To fetch job statuses every 60 seconds, use ``watch``:
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -541,7 +541,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int]):
     # TODO(zhwu): Automatically restart the spot controller
     _, handle = _is_spot_controller_up(
         'Please restart the spot controller with '
-        '`sky start sky-spot-controller -i 5`.')
+        f'`sky start {spot.SPOT_CONTROLLER_NAME} -i 5`.')
     if handle is None or handle.head_ip is None:
         raise exceptions.ClusterNotUpError('All jobs finished.')
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -441,7 +441,7 @@ def spot_launch(
                 'sky_remote_path': backend_utils.SKY_REMOTE_PATH,
                 'is_dev': env_options.Options.IS_DEVELOPER.get(),
                 'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
-                'logging_user_hash': usage_lib.get_logging_user_hash()
+                'logging_user_hash': common_utils.get_user_hash()
             },
             output_prefix=spot.SPOT_CONTROLLER_YAML_PREFIX)
         with sky.Dag() as spot_dag:

--- a/sky/spot/__init__.py
+++ b/sky/spot/__init__.py
@@ -3,7 +3,6 @@ import pathlib
 
 from sky.spot.constants import (
     SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
-    SPOT_CONTROLLER_NAME,
     SPOT_CONTROLLER_TEMPLATE,
     SPOT_CONTROLLER_YAML_PREFIX,
     SPOT_TASK_YAML_PREFIX,
@@ -12,6 +11,7 @@ from sky.spot.controller import SpotController
 from sky.spot.recovery_strategy import SPOT_STRATEGIES
 from sky.spot.recovery_strategy import SPOT_DEFAULT_STRATEGY
 from sky.spot.spot_utils import SpotCodeGen
+from sky.spot.spot_utils import SPOT_CONTROLLER_NAME
 from sky.spot.spot_utils import dump_job_table_cache
 from sky.spot.spot_utils import load_job_table_cache
 from sky.spot.spot_utils import format_job_table
@@ -24,8 +24,8 @@ __all__ = [
     'SpotController',
     'SPOT_STRATEGIES',
     'SPOT_DEFAULT_STRATEGY',
-    # Constants
     'SPOT_CONTROLLER_NAME',
+    # Constants
     'SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP',
     'SPOT_CONTROLLER_TEMPLATE',
     'SPOT_CONTROLLER_YAML_PREFIX',

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -1,7 +1,6 @@
 """Constants used for Managed Spot."""
 
 SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP = 30
-SPOT_CONTROLLER_NAME = 'sky-spot-controller'
 
 SPOT_CONTROLLER_TEMPLATE = 'spot-controller.yaml.j2'
 SPOT_CONTROLLER_YAML_PREFIX = '~/.sky/spot_controller'

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -23,6 +23,8 @@ from sky.utils import subprocess_utils
 
 logger = sky_logging.init_logger(__name__)
 
+# Add user hash so that two users don't have the same controller VM on
+# shared-account clouds such as GCP.
 SPOT_CONTROLLER_NAME = f'sky-spot-controller-{common_utils.get_user_hash()}'
 SIGNAL_FILE_PREFIX = '/tmp/sky_spot_controller_signal_{}'
 # Controller checks its job's status every this many seconds.

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -16,13 +16,14 @@ from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
 from sky.skylet import job_lib
+from sky.utils import common_utils
 from sky.utils import log_utils
-from sky.spot import constants
 from sky.spot import spot_state
 from sky.utils import subprocess_utils
 
 logger = sky_logging.init_logger(__name__)
 
+SPOT_CONTROLLER_NAME = f'sky-spot-controller-{common_utils.get_user_hash()}'
 SIGNAL_FILE_PREFIX = '/tmp/sky_spot_controller_signal_{}'
 # Controller checks its job's status every this many seconds.
 JOB_STATUS_CHECK_GAP_SECONDS = 20
@@ -200,7 +201,7 @@ def stream_logs_by_id(job_id: int) -> str:
         if job_status.is_failed():
             job_msg = ('\nFor detailed error message, please check: '
                        f'{colorama.Style.BRIGHT}sky logs '
-                       f'{constants.SPOT_CONTROLLER_NAME} {job_id}'
+                       f'{SPOT_CONTROLLER_NAME} {job_id}'
                        f'{colorama.Style.RESET_ALL}')
         return (
             f'Job {job_id} is already in terminal state {job_status.value}. '

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -43,7 +43,7 @@ def _get_current_timestamp_ns() -> int:
     return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1e9)
 
 
-def get_user_hash():
+def _get_user_hash():
     """Returns a unique user-machine specific hash as a user id for logging."""
     user_id = os.getenv(constants.USAGE_USER_ENV)
     if user_id and len(user_id) == 8:
@@ -87,7 +87,7 @@ class UsageMessageToReport(MessageToReport):
     def __init__(self) -> None:
         super().__init__(constants.USAGE_MESSAGE_SCHEMA_VERSION)
         # Message identifier.
-        self.user: str = get_user_hash()
+        self.user: str = _get_user_hash()
         self.run_id: str = _get_logging_run_id()
         self.sky_version: str = sky.__version__
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -4,7 +4,6 @@ import enum
 import click
 import contextlib
 import datetime
-import hashlib
 import inspect
 import json
 import os
@@ -44,13 +43,12 @@ def _get_current_timestamp_ns() -> int:
     return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1e9)
 
 
-def get_logging_user_hash():
-    """Returns a unique user-machine specific hash as a user id."""
+def get_user_hash():
+    """Returns a unique user-machine specific hash as a user id for logging."""
     user_id = os.getenv(constants.USAGE_USER_ENV)
     if user_id and len(user_id) == 8:
         return user_id
-    hash_str = common_utils.user_and_hostname_hash()
-    return hashlib.md5(hash_str.encode()).hexdigest()[:8]
+    return common_utils.get_user_hash()
 
 
 class MessageType(enum.Enum):
@@ -89,7 +87,7 @@ class UsageMessageToReport(MessageToReport):
     def __init__(self) -> None:
         super().__init__(constants.USAGE_MESSAGE_SCHEMA_VERSION)
         # Message identifier.
-        self.user: str = get_logging_user_hash()
+        self.user: str = get_user_hash()
         self.run_id: str = _get_logging_run_id()
         self.sky_version: str = sky.__version__
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -16,6 +16,26 @@ from sky import sky_logging
 logger = sky_logging.init_logger(__name__)
 
 
+def get_user_hash():
+    """Returns a unique user-machine specific hash as a user id."""
+    hash_str = user_and_hostname_hash()
+    return hashlib.md5(hash_str.encode()).hexdigest()[:8]
+
+
+def docstr_param(*substitutions):
+    """Decorator to add docstring parameter substitution.
+
+    Args:
+        substitutions: The substitutions to be made in the docstring.
+    """
+
+    def _docstr_param(func):
+        func.__doc__ = func.__doc__.format(*substitutions)
+        return func
+
+    return _docstr_param
+
+
 class Backoff:
     """Exponential backoff with jittering."""
     MULTIPLIER = 1.6

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -22,20 +22,6 @@ def get_user_hash():
     return hashlib.md5(hash_str.encode()).hexdigest()[:8]
 
 
-def docstr_param(*substitutions):
-    """Decorator to add docstring parameter substitution.
-
-    Args:
-        substitutions: The substitutions to be made in the docstring.
-    """
-
-    def _docstr_param(func):
-        func.__doc__ = func.__doc__.format(*substitutions)
-        return func
-
-    return _docstr_param
-
-
 class Backoff:
     """Exponential backoff with jittering."""
     MULTIPLIER = 1.6

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -97,10 +97,11 @@ class TestReservedClustersOperations:
     def test_down_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
 
-        result = cli_runner.invoke(cli.down, ['sky-spot-controller'])
+        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
-        assert ('Terminating reserved cluster(s) \'sky-spot-controller\' '
-                'is not supported' in result.output)
+        assert (
+            f'Terminating reserved cluster(s) \'{spot.SPOT_CONTROLLER_NAME}\' '
+            'is not supported' in result.output)
 
         result = cli_runner.invoke(cli.down, ['sky-spot-con*'])
         assert not result.exception
@@ -121,10 +122,11 @@ class TestReservedClustersOperations:
     @pytest.mark.timeout(60)
     def test_stop_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
-        result = cli_runner.invoke(cli.stop, ['sky-spot-controller'])
+        result = cli_runner.invoke(cli.stop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
-        assert ('Stopping reserved cluster(s) \'sky-spot-controller\' is '
-                'not supported' in result.output)
+        assert (
+            f'Stopping reserved cluster(s) \'{spot.SPOT_CONTROLLER_NAME}\' is '
+            'not supported' in result.output)
 
         result = cli_runner.invoke(cli.stop, ['sky-spot-con*'])
         assert not result.exception
@@ -137,10 +139,11 @@ class TestReservedClustersOperations:
     @pytest.mark.timeout(60)
     def test_autostop_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
-        result = cli_runner.invoke(cli.autostop, ['sky-spot-controller'])
+        result = cli_runner.invoke(cli.autostop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
         assert ('Scheduling auto-stop on reserved cluster(s) '
-                '\'sky-spot-controller\' is not supported' in result.output)
+                f'\'{spot.SPOT_CONTROLLER_NAME}\' is not supported'
+                in result.output)
 
         result = cli_runner.invoke(cli.autostop, ['sky-spot-con*'])
         assert not result.exception
@@ -152,6 +155,7 @@ class TestReservedClustersOperations:
 
     def test_cancel_on_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
-        result = cli_runner.invoke(cli.cancel, ['sky-spot-controller', '-a'])
+        result = cli_runner.invoke(cli.cancel,
+                                   [spot.SPOT_CONTROLLER_NAME, '-a'])
         assert result.exit_code == click.UsageError.exit_code
         assert 'Cancelling jobs is not allowed' in str(result.output)


### PR DESCRIPTION
Closes #1100.

Warning: This will be not backward compatible. Please `sky down -p sky-spot-controller` first before updating to this commit to avoid leakage of the old `sky-spot-controller`.

Tested:
- [x] spot related tests in smoke test