### PR TITLE
Fix GCP VM leak issue

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -508,6 +508,9 @@ class RetryingVmProvisioner(object):
                     # However, UNSUPPORTED_OPERATION is observed empirically when VM is preempted during creation.
                     # This seems to be not documented by GCP.
                     self._blocked_zones.add(zone.name)
+                elif code in ['RESOURCE_NOT_READY']:
+                    # This code is returned when the VM is still STOPPING.
+                    self._blocked_zones.add(zone.name)
                 elif code == 8:
                     # Error code 8 means TPU resources is out of capacity. Example:
                     # {'code': 8, 'message': 'There is no more capacity in the zone "europe-west4-a"; you can try in another zone where Cloud TPU Nodes are offered (see https://cloud.google.com/tpu/docs/regions) [EID: 0x1bc8f9d790be9142]'} # pylint: disable=line-too-long

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -48,6 +48,8 @@ MAX_POLLS = 12
 # considerably - this probably could be smaller
 # TPU deletion uses MAX_POLLS
 MAX_POLLS_TPU = MAX_POLLS * 8
+# Stopping instances can take several minutes, so we increase the timeout
+MAX_POLLS_STOP =  MAX_POLLS * 8
 POLL_INTERVAL = 5
 
 

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -134,6 +134,8 @@ class GCPNode(UserDict, metaclass=abc.ABCMeta):
 
     NON_TERMINATED_STATUSES = None
     RUNNING_STATUSES = None
+    STOPPED_STATUSES = None
+    STOPPING_STATUSES = None
     STATUS_FIELD = None
 
     def __init__(self, base_dict: dict, resource: "GCPResource", **kwargs) -> None:
@@ -146,6 +148,12 @@ class GCPNode(UserDict, metaclass=abc.ABCMeta):
 
     def is_terminated(self) -> bool:
         return self.get(self.STATUS_FIELD) not in self.NON_TERMINATED_STATUSES
+
+    def is_stopped(self) -> bool:
+        return self.get(self.STATUS_FIELD) in self.STOPPED_STATUSES
+
+    def is_stopping(self) -> bool:
+        return self.get(self.STATUS_FIELD) in self.STOPPING_STATUSES
 
     @property
     def id(self) -> str:
@@ -173,6 +181,8 @@ class GCPComputeNode(GCPNode):
     # https://cloud.google.com/compute/docs/instances/instance-life-cycle
     NON_TERMINATED_STATUSES = {"PROVISIONING", "STAGING", "RUNNING"}
     RUNNING_STATUSES = {"RUNNING"}
+    STOPPED_STATUSES = {"TERMINATED"}
+    STOPPING_STATUSES = {"STOPPING"}
     STATUS_FIELD = "status"
 
     def get_labels(self) -> dict:
@@ -196,12 +206,13 @@ class GCPTPUNode(GCPNode):
 
     NON_TERMINATED_STATUSES = {"CREATING", "STARTING", "RESTARTING", "READY"}
     RUNNING_STATUSES = {"READY"}
+    STOPPED_STATUSES = {"STOPPED"}
+    STOPPING_STATUSES = {"STOPPING"}
     STATUS_FIELD = "state"
 
     # SKY: get status of TPU VM for status filtering
     def get_status(self) -> str:
         return self.get(self.STATUS_FIELD)
-
 
     def get_labels(self) -> dict:
         return self.get("labels", {})

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -29,6 +29,8 @@ from sky.skylet.providers.gcp.node import (  # noqa
     GCPNodeType,
     INSTANCE_NAME_MAX_LEN,
     INSTANCE_NAME_UUID_LEN,
+    MAX_POLLS_STOP,
+    POLL_INTERVAL,
 )
 
 logger = logging.getLogger(__name__)
@@ -232,8 +234,6 @@ class GCPNodeProvider(NodeProvider):
 
                     # Check if the instance is actually stopped.
                     # GCP does not fully stop an instance even after the stop operation is finished.
-                    MAX_POLLS_STOP = 8
-                    POLL_INTERVAL = 8
                     for _ in range(MAX_POLLS_STOP):
                         instance = resource.get_instance(node_id=node_id)
                         if instance.is_stopped():

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -235,19 +235,24 @@ class GCPNodeProvider(NodeProvider):
                     result = resource.stop_instance(node_id=node_id)
 
                     # Check if the instance is actually stopped.
-                    # GCP does not fully stop an instance even after the stop operation is finished.
+                    # GCP does not fully stop an instance even after
+                    # the stop operation is finished.
                     for _ in range(MAX_POLLS_STOP):
                         instance = resource.get_instance(node_id=node_id)
                         if instance.is_stopped():
-                            logger.info(f'Instance {node_id} is stopped.')
+                            logger.info(f"Instance {node_id} is stopped.")
                             break
                         elif instance.is_stopping():
                             time.sleep(POLL_INTERVAL)
                         else:
-                            raise RuntimeError(f'Unexpected instance status. Details: {instance}')
+                            raise RuntimeError(f"Unexpected instance status."
+                                               " Details: {instance}")
 
                     if instance.is_stopping():
-                        raise RuntimeError(f'Maximum number of polls: {MAX_POLLS_STOP} reached. Instance {node_id} is still not terminated.')
+                        raise RuntimeError(f"Maximum number of polls: "
+                                           f"{MAX_POLLS_STOP} reached. "
+                                           f"Instance {node_id} is still in "
+                                           "STOPPING status.")
                 else:
                     result = resource.delete_instance(
                         node_id=node_id,

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -193,11 +193,11 @@ class GCPNodeProvider(NodeProvider):
                     filters[TAG_RAY_USER_NODE_TYPE] = labels[TAG_RAY_USER_NODE_TYPE]
                 # SKY: "TERMINATED" for compute VM, "STOPPED" for TPU VM
                 if isinstance(resource, GCPCompute):
-                    STOPPED_STATUS = ["TERMINATED"]
+                    TO_BE_STARTED_STATUS = ["TERMINATED", "STOPPING"]
                 else:
-                    STOPPED_STATUS = ["STOPPED"]
+                    TO_BE_STARTED_STATUS = ["STOPPED", "STOPPING"]
                 reuse_nodes = resource._list_instances(
-                    filters, STOPPED_STATUS)[:count]
+                    filters, TO_BE_STARTED_STATUS)[:count]
                 reuse_node_ids = [n.id for n in reuse_nodes]
                 if reuse_nodes:
                     # TODO(suquark): Some instances could still be stopping.

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -192,12 +192,14 @@ class GCPNodeProvider(NodeProvider):
                 if TAG_RAY_USER_NODE_TYPE in labels:
                     filters[TAG_RAY_USER_NODE_TYPE] = labels[TAG_RAY_USER_NODE_TYPE]
                 # SKY: "TERMINATED" for compute VM, "STOPPED" for TPU VM
+                # "STOPPING" means the VM is being stopped, which needs
+                # to be included to avoid creating a new VM.
                 if isinstance(resource, GCPCompute):
-                    TO_BE_STARTED_STATUS = ["TERMINATED", "STOPPING"]
+                    STOPPED_STATUS = ["TERMINATED", "STOPPING"]
                 else:
-                    TO_BE_STARTED_STATUS = ["STOPPED", "STOPPING"]
+                    STOPPED_STATUS = ["STOPPED", "STOPPING"]
                 reuse_nodes = resource._list_instances(
-                    filters, TO_BE_STARTED_STATUS)[:count]
+                    filters, STOPPED_STATUS)[:count]
                 reuse_node_ids = [n.id for n in reuse_nodes]
                 if reuse_nodes:
                     # TODO(suquark): Some instances could still be stopping.

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -181,8 +181,6 @@ _get_launched = (lambda cluster_status: log_utils.readable_time_duration(
     cluster_status['launched_at']))
 _get_region = (
     lambda clusters_status: clusters_status['handle'].launched_resources.region)
-_get_zone = (
-    lambda clusters_status: clusters_status['handle'].launched_resources.zone)
 _get_status = (lambda cluster_status: cluster_status['status'].value)
 _get_duration = (lambda cluster_status: log_utils.readable_time_duration(
     cluster_status['launched_at']))
@@ -203,6 +201,13 @@ def _get_resources(cluster_status):
     else:
         raise ValueError(f'Unknown handle type {type(handle)} encountered.')
     return resources_str
+
+
+def _get_zone(cluster_status):
+    zone_str = cluster_status['handle'].launched_resources.zone
+    if zone_str is None:
+        zone_str = '-'
+    return zone_str
 
 
 def _get_autostop(cluster_status):


### PR DESCRIPTION
Fix a long existing resource leak issue on GCP triggered by `test_stale_job` smoke test.

This bug happened because GCP doesn't fully stop an instance even after a stop operation is finished.

This PR make `sky stop` wait until the instance actually stopped.
I tried to benchmark whether adding this status check for loop increases the running time of `sky stop`.
Turns out the running time is almost the same as before (~40s) for normal use cases. Only if you create a VM and immediately stop it then it'd take 2mins to finish (like what happened in our smoke test).

On the other hand, I also add safe guard to `sky start` to avoid launching new VM. Now if user `sky start` a STOPPING VM (this only happens when user stops the VM on web console) then it'd return below error message.
```
sky start test-stale-job-4da3f903-f7 -y
...
I 08-18 22:28:32 cloud_vm_ray_backend.py:1075] Launching on GCP us-central1 (us-central1-a)
D 08-18 22:29:34 cloud_vm_ray_backend.py:1137] Ray up takes 62.20364475250244 seconds with 1 retries.
W 08-18 22:29:34 cloud_vm_ray_backend.py:485] Got return code RESOURCE_NOT_READY in us-central1-a (message: The resource 'projects/intercloud-320520/zones/us-central1-a/instances/ray-test-s
tale-job-4da3f903-f7-head-4819c50c-compute' is not ready)
sky.exceptions.ResourcesUnavailableError: Failed to acquire resources to restart the stopped cluster test-stale-job-4da3f903-f7 on Region(name='us-central1'). Please retry again later.
To keep retrying until the cluster is up, use the `--retry-until-up` flag.
```

- [x] passed `test_stale_job` smoke test