### PR TITLE
Optimize GCP provisioning speed: bundle all runtime file_mounts.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -120,7 +120,8 @@ def is_ip(s: str) -> bool:
 def fill_template(template_name: str,
                   variables: Dict,
                   output_path: Optional[str] = None,
-                  output_prefix: str = SKY_USER_FILE_PATH) -> str:
+                  output_prefix: str = SKY_USER_FILE_PATH,
+                  dryrun: bool = False) -> str:
     """Create a file from a Jinja template and return the filename."""
     assert template_name.endswith('.j2'), template_name
     template_path = os.path.join(sky.__root_dir__, 'templates', template_name)
@@ -207,10 +208,11 @@ def fill_template(template_name: str,
 
     # (For local) Move all runtime files, including the just-written yaml, to
     # local_runtime_files_dir/.
-    all_local_sources = ' '.join(
-        local_src for local_src in file_mounts.values())
-    subprocess_utils.run(
-        f'cp -r {all_local_sources} {local_runtime_files_dir}/')
+    if not dryrun:
+        all_local_sources = ' '.join(
+            local_src for local_src in file_mounts.values())
+        subprocess_utils.run(
+            f'cp -r {all_local_sources} {local_runtime_files_dir}/')
 
     return output_path
 
@@ -717,7 +719,9 @@ def write_cluster_config(to_provision: 'resources.Resources',
                     (None if auth_config is None else auth_config['ssh_user']),
                 'ssh_private_key': (None if auth_config is None else
                                     auth_config['ssh_private_key']),
-            }))
+            }),
+        dryrun=dryrun,
+    )
     config_dict['cluster_name'] = cluster_name
     config_dict['ray'] = yaml_path
     if dryrun:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -144,12 +144,15 @@ def fill_template(template_name: str,
     #   - wheel
     #   - credentials
     # Format is {dst: src}.
-    file_mounts = {
-        SKY_RAY_YAML_REMOTE_PATH: output_path,
-        variables['sky_remote_path']: variables['sky_local_path'],
-    }
-    file_mounts.update(variables['credentials'])
-    variables['credentials'] = {}
+    file_mounts = {SKY_RAY_YAML_REMOTE_PATH: output_path}
+
+    # fill_template() is also called to fill TPU/spot controller templates,
+    # which don't have all variables.
+    if 'sky_remote_path' in variables and 'sky_local_path' in variables:
+        file_mounts[variables['sky_remote_path']] = variables['sky_local_path']
+    if 'credentials' in variables:
+        file_mounts.update(variables['credentials'])
+        variables['credentials'] = {}
     # Putting these in file_mounts hurts provisioning speed, as each file
     # opens/closes an SSH connection.  Instead, we:
     #  - cp locally them into a directory

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -211,6 +211,7 @@ def fill_template(template_name: str,
     if not dryrun:
         all_local_sources = ' '.join(
             local_src for local_src in file_mounts.values())
+        # Takes 10-20 ms on laptop incl. 3 clouds' credentials.
         subprocess_utils.run(
             f'cp -r {all_local_sources} {local_runtime_files_dir}/')
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1686,7 +1686,7 @@ class CloudVmRayBackend(backends.Backend):
             # Get actual zone info and save it into handle.
             # NOTE: querying zones is expensive, observed 1node GCP >=4s.
             zones = config_dict['zones']
-            if len(zones) == 1:
+            if zones is not None and len(zones) == 1:  # zones is None for Azure
                 # Optimization for if the provision request was for 1 zone
                 # (currently happens only for GCP since it uses per-zone
                 # provisioning), then we know the exact zone already.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2893,13 +2893,6 @@ class CloudVmRayBackend(backends.Backend):
             )
 
         codegen.add_epilogue()
-
-        # Logger.
-        colorama.init()
-        fore = colorama.Fore
-        style = colorama.Style
-        logger.info(f'\n{fore.CYAN}Starting Task execution.{style.RESET_ALL}')
-
         # TODO(zhanghao): Add help info for downloading logs.
         self._exec_code_on_head(handle,
                                 codegen.build(),

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -104,11 +104,7 @@ head_node_type: ray_head_default
 
 # Format: `REMOTE_PATH : LOCAL_PATH`
 file_mounts: {
-  "{{sky_ray_yaml_remote_path}}": "{{sky_ray_yaml_local_path}}",
-  "{{sky_remote_path}}": "{{sky_local_path}}",
-{%- for remote_path, local_path in credentials.items() %}
-  "{{remote_path}}": "{{local_path}}",
-{%- endfor %}
+  "{{remote_runtime_files_dir}}": "{{local_runtime_files_dir}}",
 }
 
 rsync_exclude: []
@@ -129,13 +125,14 @@ setup_commands:
   # default. 'source ~/.bashrc' is needed so conda takes effect for the next
   # commands.
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  - mkdir -p ~/.ssh; touch ~/.ssh/config;
+  - {{postprocess_runtime_files_command}};
+    mkdir -p ~/.ssh; touch ~/.ssh/config;
     pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc); (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc; (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     pip3 uninstall skypilot -y &> /dev/null;
-    pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[gcp]";
+    pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1;
     python3 -c "from sky.skylet.ray_patches import patch; patch()"; [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `gcsfuse`;
   {%- if tpu_vm %}
   - pip3 install --upgrade google-api-python-client;

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -436,9 +436,11 @@ def test_autostop():
         [
             f'sky launch -y -d -c {name} --num-nodes 2 examples/minimal.yaml',
             f'sky autostop -y {name} -i 1',
-            f'sky status | grep {name} | grep "1 min"',  # Ensure autostop is set.
+            # Ensure autostop is set.
+            f'sky status | grep {name} | grep "1 min"',
             'sleep 180',
-            f'sky status --refresh | grep {name} | grep STOPPED',  # Ensure the cluster is STOPPED.
+            # Ensure the cluster is STOPPED.
+            f'sky status --refresh | grep {name} | grep STOPPED',
             f'sky start -y {name}',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} examples/minimal.yaml',


### PR DESCRIPTION
File mounting our runtime files hurts provisioning speed. This PR bundles them into 1 file mount. Copying them locally takes 10-20ms.

Currently for GCP only. Will be ported to other clouds later.


Before (taken from #1092) - median 2:40
```
sky launch -c opt --cloud gcp -y ''  13.89s user 3.17s system 10% cpu 2:43.79 total
sky launch -c opt2 --cloud gcp -y ''  11.78s user 2.37s system 8% cpu 2:40.32 total
sky launch -c opt9 --cloud gcp -y ''  11.49s user 2.37s system 9% cpu 2:31.00 total
```

After - median 2:05 (22% speedup)
```
sky launch -c opt6 --cloud gcp -y ''  12.54s user 2.62s system 12% cpu 2:05.92 total
sky launch -c opt7 --cloud gcp -y ''  11.73s user 2.29s system 11% cpu 2:02.68 total
sky launch -c opt8 --cloud gcp -y ''  10.92s user 2.06s system 10% cpu 2:05.78 total
```

Breakdown of the current overheads, updating the one recorded in #1092 (main change is the file mount part):
Total: ~2min 5s
- `_add_auth_to_cluster_config()`: ~1.5-2s
- **Launch VM till SSH ready: ~55s-1min**
  - Includes: check head node first + provision & wait for ssh + update status
  - [ ] Note that ray autoscale's "update status" using tags is expensive, 4-7s
- **Preparing SkyPilot runtime: ~1min 5s**
  - **File mount our runtime files bundle: ~5s**
    - see the timestamp between `[2/7] Processing file mounts` to `[3/7] No worker file mounts to sync`
  - **Setup_commands: ~31s**
    - between `[6/7] Running setup commands` and `[7/7] Starting the Ray runtime`
   - **Starting Ray: ~16s**
     - between `[7/7] Starting the Ray runtime` and last line of provision.log
 - some other overheads (e.g., update-status 6 times!)
```
» grep '\/7\]'  /Users/zongheng/sky_logs/sky-2022-08-19-08-36-20-887250/provision.log    2 ↵
2022-08-19 08:36:47,959 INFO updater.py:241 -- [1/7] Waiting for SSH to become available
2022-08-19 08:37:24,795 INFO updater.py:219 -- [2/7] Processing file mounts
2022-08-19 08:37:29,605 INFO updater.py:236 -- [3/7] No worker file mounts to sync
2022-08-19 08:37:36,038 INFO updater.py:397 -- [4/7] No initialization commands to run.
2022-08-19 08:37:36,038 INFO updater.py:401 -- [5/7] Initalizing command runner
2022-08-19 08:37:36,038 INFO updater.py:410 -- [6/7] Running setup commands
2022-08-19 08:38:07,074 INFO updater.py:450 -- [7/7] Starting the Ray runtime
```

Tested
- [x] smoke tests except the 4 known failures documented in #1092
