### PR TITLE
[Spot] Fix oslogin username in clusters

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -216,6 +216,10 @@ def setup_gcp_authentication(config):
                     'GCP authentication failed, as the oslogin is enabled but '
                     f'the file {config_path} is not found.')
 
+        # Create a backup of the config_default file in the same folder (the
+        # folder will be uploaded by `sky launch`), as the original file can
+        # be modified on the remote cluster by ray causing failure of launching
+        # GCP cluster on a remote cluster.
         if not os.path.exists(sky_backup_config_path):
             subprocess.run(f'cp {config_path} {sky_backup_config_path}',
                            shell=True,

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -210,17 +210,20 @@ def setup_gcp_authentication(config):
         config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
         sky_backup_config_path = os.path.expanduser(
             GCP_CONFIGURE_SKY_BACKUP_PATH)
-        if not os.path.exists(config_path):
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    'GCP authentication failed, as the oslogin is enabled but '
-                    f'the file {config_path} is not found.')
 
-        # Create a backup of the config_default file in the same folder (the
-        # folder will be uploaded by `sky launch`), as the original file can
-        # be modified on the remote cluster by ray causing failure of launching
-        # GCP cluster on a remote cluster.
+        # Read the account information from the credential file, since the user
+        # should be set according the account, when the oslogin is enabled.
         if not os.path.exists(sky_backup_config_path):
+            if not os.path.exists(config_path):
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'GCP authentication failed, as the oslogin is enabled but '
+                        f'the file {config_path} is not found.')
+
+            # Create a backup of the config_default file in the same folder (the
+            # folder will be uploaded by `sky launch`), as the original file can
+            # be modified on the remote cluster by ray causing failure of launching
+            # GCP cluster on a remote cluster.
             subprocess.run(f'cp {config_path} {sky_backup_config_path}',
                            shell=True,
                            check=True)

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -31,6 +31,7 @@ MAX_TRIALS = 64
 PRIVATE_SSH_KEY_PATH = '~/.ssh/sky-key'
 
 GCP_CONFIGURE_PATH = '~/.config/gcloud/configurations/config_default'
+GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.config/gcloud/configurations/.sky_config_default'
 
 
 def generate_rsa_key_pair():
@@ -207,12 +208,20 @@ def setup_gcp_authentication(config):
             f'OS Login is enabled for GCP project {project_id}. Running '
             'additional authentication steps.')
         config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
+        sky_backup_config_path = os.path.expanduser(
+            GCP_CONFIGURE_SKY_BACKUP_PATH)
         if not os.path.exists(config_path):
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(
                     'GCP authentication failed, as the oslogin is enabled but '
                     f'the file {config_path} is not found.')
-        with open(config_path, 'r') as infile:
+
+        if not os.path.exists(sky_backup_config_path):
+            subprocess.run(f'cp {config_path} {sky_backup_config_path}',
+                           shell=True,
+                           check=True)
+
+        with open(sky_backup_config_path, 'r') as infile:
             for line in infile:
                 if line.startswith('account'):
                     account = line.split('=')[1].strip()

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -31,7 +31,7 @@ MAX_TRIALS = 64
 PRIVATE_SSH_KEY_PATH = '~/.ssh/sky-key'
 
 GCP_CONFIGURE_PATH = '~/.config/gcloud/configurations/config_default'
-GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.config/gcloud/configurations/.sky_config_default'
+GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.config/gcloud/configurations/.sky_config_default'  # pylint: disable=line-too-long
 
 
 def generate_rsa_key_pair():

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -217,13 +217,13 @@ def setup_gcp_authentication(config):
             if not os.path.exists(config_path):
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
-                        'GCP authentication failed, as the oslogin is enabled but '
-                        f'the file {config_path} is not found.')
+                        'GCP authentication failed, as the oslogin is enabled '
+                        f'but the file {config_path} is not found.')
 
             # Create a backup of the config_default file in the same folder (the
             # folder will be uploaded by `sky launch`), as the original file can
-            # be modified on the remote cluster by ray causing failure of launching
-            # GCP cluster on a remote cluster.
+            # be modified on the remote cluster by ray causing failure of
+            # launching GCP cluster on a remote cluster.
             subprocess.run(f'cp {config_path} {sky_backup_config_path}',
                            shell=True,
                            check=True)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -199,7 +199,7 @@ def fill_template(template_name: str,
             # directly copy the folder will create a subfolder under the dst.
             mkdir_parent = f'mkdir -p {dst}'
             src_basename = f'{src_basename}/*'
-        mv = (f'rsync -az {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
+        mv = (f'cp -r {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
               f'{dst_parent_dir}/{dst_basename}')
         fragment = f'({mkdir_parent} && {mv})'
         commands.append(fragment)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -194,7 +194,12 @@ def fill_template(template_name: str,
         assert dst_parent_dir, f'Found relative destination path: {dst}'
 
         mkdir_parent = f'mkdir -p {dst_parent_dir}'
-        mv = (f'cp -r {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
+        if os.path.isdir(os.path.expanduser(src)):
+            # Special case for directories. If the dst already exists as a folder,
+            # directly copy the folder will create a subfolder under the dst.
+            mkdir_parent = f'mkdir -p {dst}'
+            src_basename = f'{src_basename}/*'
+        mv = (f'rsync -az {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
               f'{dst_parent_dir}/{dst_basename}')
         fragment = f'({mkdir_parent} && {mv})'
         commands.append(fragment)


### PR DESCRIPTION
In the GCP cluster launched by `ray up`, our uploaded GCP credentials `~/.config/gcloud/configurations/config_default` will be reset to empty, probably because `ray` needs to use the service account instead of the user's account. This will affect our spot controller, as it requires that file to decide the username used for the spot clusters, when oslogin is enabled in the user project. https://github.com/skypilot-org/skypilot/blob/783adc9d6685de24a30408704a437108880de57a/sky/authentication.py#L201-L226

To solve the problem, we make a backup of that file in the same folder, which will be uploaded by the credential uploads. SkyPilot will read the backup file instead.

Hey @lhqing, please check out if this can fix your problem with the `sky spot launch` when you get time. ; )