### PR TITLE
Refactor the file_mounts optimization and oslogin

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -204,35 +204,33 @@ def setup_gcp_authentication(config):
          if item['key'] == 'enable-oslogin'), {}).get('value', 'False')
 
     config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
-    sky_backup_config_path = os.path.expanduser(
-        GCP_CONFIGURE_SKY_BACKUP_PATH)
+    sky_backup_config_path = os.path.expanduser(GCP_CONFIGURE_SKY_BACKUP_PATH)
 
-    # Read the account information from the credential file, since the user
-    # should be set according the account, when the oslogin is enabled.
-    if not os.path.exists(sky_backup_config_path):
-        if not os.path.exists(config_path):
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    'GCP authentication failed, as the oslogin is enabled '
-                    f'but the file {config_path} is not found.')
-
-        # Create a backup of the config_default file in the same folder (the
-        # folder will be uploaded by `sky launch`), as the original file can
-        # be modified on the remote cluster by ray causing failure of
-        # launching GCP cluster on a remote cluster.
-        subprocess.run(f'cp {config_path} {sky_backup_config_path}',
-                        shell=True,
-                        check=True)
-    new_file_mounts = config.get('file_mounts', {})
-    new_file_mounts[GCP_CONFIGURE_SKY_BACKUP_PATH] = GCP_CONFIGURE_SKY_BACKUP_PATH
-    config['file_mounts'] = new_file_mounts
-    # config['file_mounts'] = 
     if project_oslogin.lower() == 'true':
         # project.
         logger.info(
             f'OS Login is enabled for GCP project {project_id}. Running '
             'additional authentication steps.')
+        # Read the account information from the credential file, since the user
+        # should be set according the account, when the oslogin is enabled.
+        if not os.path.exists(sky_backup_config_path):
+            if not os.path.exists(config_path):
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'GCP authentication failed, as the oslogin is enabled '
+                        f'but the file {config_path} is not found.')
 
+            # Create a backup of the config_default file in the same folder (the
+            # folder will be uploaded by `sky launch`), as the original file can
+            # be modified on the remote cluster by ray causing failure of
+            # launching GCP cluster on a remote cluster.
+            subprocess.run(f'cp {config_path} {sky_backup_config_path}',
+                           shell=True,
+                           check=True)
+        new_file_mounts = config.get('file_mounts', {})
+        new_file_mounts[
+            GCP_CONFIGURE_SKY_BACKUP_PATH] = GCP_CONFIGURE_SKY_BACKUP_PATH
+        config['file_mounts'] = new_file_mounts
         with open(sky_backup_config_path, 'r') as infile:
             for line in infile:
                 if line.startswith('account'):

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -31,6 +31,8 @@ MAX_TRIALS = 64
 PRIVATE_SSH_KEY_PATH = '~/.ssh/sky-key'
 
 GCP_CONFIGURE_PATH = '~/.config/gcloud/configurations/config_default'
+# Do not place the backup under the gcloud config directory, as ray
+# autoscaler can overwrite that directory on the remote nodes.
 GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.sky/.sky_gcp_config_default'
 
 
@@ -203,9 +205,6 @@ def setup_gcp_authentication(config):
         (item for item in project['commonInstanceMetadata'].get('items', [])
          if item['key'] == 'enable-oslogin'), {}).get('value', 'False')
 
-    config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
-    sky_backup_config_path = os.path.expanduser(GCP_CONFIGURE_SKY_BACKUP_PATH)
-
     if project_oslogin.lower() == 'true':
         # project.
         logger.info(
@@ -213,6 +212,9 @@ def setup_gcp_authentication(config):
             'additional authentication steps.')
         # Read the account information from the credential file, since the user
         # should be set according the account, when the oslogin is enabled.
+        config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
+        sky_backup_config_path = os.path.expanduser(
+            GCP_CONFIGURE_SKY_BACKUP_PATH)
         if not os.path.exists(sky_backup_config_path):
             if not os.path.exists(config_path):
                 with ux_utils.print_exception_no_traceback():

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -31,7 +31,7 @@ MAX_TRIALS = 64
 PRIVATE_SSH_KEY_PATH = '~/.ssh/sky-key'
 
 GCP_CONFIGURE_PATH = '~/.config/gcloud/configurations/config_default'
-GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.config/gcloud/configurations/.sky_config_default'  # pylint: disable=line-too-long
+GCP_CONFIGURE_SKY_BACKUP_PATH = '~/.sky/.sky_gcp_config_default'
 
 
 def generate_rsa_key_pair():
@@ -202,31 +202,36 @@ def setup_gcp_authentication(config):
     project_oslogin = next(
         (item for item in project['commonInstanceMetadata'].get('items', [])
          if item['key'] == 'enable-oslogin'), {}).get('value', 'False')
+
+    config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
+    sky_backup_config_path = os.path.expanduser(
+        GCP_CONFIGURE_SKY_BACKUP_PATH)
+
+    # Read the account information from the credential file, since the user
+    # should be set according the account, when the oslogin is enabled.
+    if not os.path.exists(sky_backup_config_path):
+        if not os.path.exists(config_path):
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(
+                    'GCP authentication failed, as the oslogin is enabled '
+                    f'but the file {config_path} is not found.')
+
+        # Create a backup of the config_default file in the same folder (the
+        # folder will be uploaded by `sky launch`), as the original file can
+        # be modified on the remote cluster by ray causing failure of
+        # launching GCP cluster on a remote cluster.
+        subprocess.run(f'cp {config_path} {sky_backup_config_path}',
+                        shell=True,
+                        check=True)
+    new_file_mounts = config.get('file_mounts', {})
+    new_file_mounts[GCP_CONFIGURE_SKY_BACKUP_PATH] = GCP_CONFIGURE_SKY_BACKUP_PATH
+    config['file_mounts'] = new_file_mounts
+    # config['file_mounts'] = 
     if project_oslogin.lower() == 'true':
         # project.
         logger.info(
             f'OS Login is enabled for GCP project {project_id}. Running '
             'additional authentication steps.')
-        config_path = os.path.expanduser(GCP_CONFIGURE_PATH)
-        sky_backup_config_path = os.path.expanduser(
-            GCP_CONFIGURE_SKY_BACKUP_PATH)
-
-        # Read the account information from the credential file, since the user
-        # should be set according the account, when the oslogin is enabled.
-        if not os.path.exists(sky_backup_config_path):
-            if not os.path.exists(config_path):
-                with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'GCP authentication failed, as the oslogin is enabled '
-                        f'but the file {config_path} is not found.')
-
-            # Create a backup of the config_default file in the same folder (the
-            # folder will be uploaded by `sky launch`), as the original file can
-            # be modified on the remote cluster by ray causing failure of
-            # launching GCP cluster on a remote cluster.
-            subprocess.run(f'cp {config_path} {sky_backup_config_path}',
-                           shell=True,
-                           check=True)
 
         with open(sky_backup_config_path, 'r') as infile:
             for line in infile:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -205,7 +205,8 @@ def _optimize_file_mounts(yaml_path: str):
 
     setup_commands = yaml_config.get('setup_commands', [])
     if setup_commands:
-        setup_commands[0] = f'{postprocess_runtime_files_command}; {setup_commands[0]}'
+        setup_commands[
+            0] = f'{postprocess_runtime_files_command}; {setup_commands[0]}'
     else:
         setup_commands = [postprocess_runtime_files_command]
 
@@ -217,7 +218,8 @@ def _optimize_file_mounts(yaml_path: str):
     all_local_sources = ' '.join(
         local_src for local_src in file_mounts.values())
     # Takes 10-20 ms on laptop incl. 3 clouds' credentials.
-    subprocess.run(f'cp -r {all_local_sources} {local_runtime_files_dir}/', shell=True)
+    subprocess.run(f'cp -r {all_local_sources} {local_runtime_files_dir}/',
+                   shell=True)
 
     common_utils.dump_yaml(yaml_path, yaml_config)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -734,9 +734,9 @@ def write_cluster_config(to_provision: 'resources.Resources',
         return config_dict
     _add_auth_to_cluster_config(cloud, yaml_path)
     # Delay the optimization of the config until the authentication files is added.
-    if isinstance(cloud, clouds.GCP):
-        # Only optimize the file mounts for GCP now, as it has not been fully tested
-        # for other clouds yet.
+    if not isinstance(cloud, clouds.Local):
+        # Only optimize the file mounts for public clouds now, as it has not been
+        # fully tested local yet.
         _optimize_file_mounts(yaml_path)
 
     usage_lib.messages.usage.update_ray_yaml(yaml_path)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -10,7 +10,6 @@ import os
 import pathlib
 import re
 import subprocess
-import sys
 import tempfile
 import textwrap
 import threading
@@ -219,7 +218,8 @@ def _optimize_file_mounts(yaml_path: str):
         local_src for local_src in file_mounts.values())
     # Takes 10-20 ms on laptop incl. 3 clouds' credentials.
     subprocess.run(f'cp -r {all_local_sources} {local_runtime_files_dir}/',
-                   shell=True)
+                   shell=True,
+                   check=True)
 
     common_utils.dump_yaml(yaml_path, yaml_config)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -137,6 +137,9 @@ def fill_template(template_name: str,
         output_path = str(output_path)
     output_path = os.path.abspath(output_path)
 
+    # Add yaml file path to the template variables.
+    variables['sky_ray_yaml_remote_path'] = SKY_RAY_YAML_REMOTE_PATH
+    variables['sky_ray_yaml_local_path'] = output_path
     # Write out yaml config.
     template = jinja2.Template(template)
     content = template.render(**variables)

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -104,7 +104,11 @@ head_node_type: ray_head_default
 
 # Format: `REMOTE_PATH : LOCAL_PATH`
 file_mounts: {
-  "{{remote_runtime_files_dir}}": "{{local_runtime_files_dir}}",
+  "{{sky_ray_yaml_remote_path}}": "{{sky_ray_yaml_local_path}}",
+  "{{sky_remote_path}}": "{{sky_local_path}}",
+{%- for remote_path, local_path in credentials.items() %}
+  "{{remote_path}}": "{{local_path}}",
+{%- endfor %}
 }
 
 rsync_exclude: []
@@ -125,8 +129,7 @@ setup_commands:
   # default. 'source ~/.bashrc' is needed so conda takes effect for the next
   # commands.
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  - {{postprocess_runtime_files_command}};
-    mkdir -p ~/.ssh; touch ~/.ssh/config;
+  - mkdir -p ~/.ssh; touch ~/.ssh/config;
     pip3 --version > /dev/null 2>&1 || (curl -sSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && echo "PATH=$HOME/.local/bin:$PATH" >> ~/.bashrc); (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc; (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/gcpuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -82,6 +82,8 @@ def run_one_test(test: Test) -> Tuple[int, str, str]:
             log_file.flush()
             test.echo(f'Timeout after {test.timeout} seconds.')
             test.echo(e)
+            log_file.write(f'Timeout after {test.timeout} seconds.\n')
+            log_file.flush()
             # Kill the current process.
             proc.terminate()
             proc.returncode = 1  # None if we don't set it.


### PR DESCRIPTION
This PR refactors the file_mounts optimization to make it lazy until all the file mounts are added. The file_mounts optimization will be applied to all clouds now.
It should also fix the oslogin issue mentioned in https://github.com/skypilot-org/skypilot/pull/1106#issuecomment-1221455039 , as previously we place the backup file in the same directory as `config_default` whose parent directory will be overwritten by ray autoscaler, instead we now place the backup file in `~/.sky/.sky_gcp_config_default` on the remote instance.

Hey @lhqing, would you like to switch to this branch `git checkout refactor-file-mount-optimization; pip install -e ".[gcp]"` and try if this solves the problem?

Tested:
- [x] `./tests/run_smoke_tests.sh`