### PR TITLE
Fixes ray dashboard hanging problem (#1088)

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -77,10 +77,7 @@ class Azure(clouds.Cloud):
         return isinstance(other, Azure)
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  accelerators: Optional[Dict[str, int]] = None
-                                 ) -> str:
-        del accelerators
+    def get_default_instance_type(cls) -> str:
         # 8 vCpus, 32 GB RAM.  Prev-gen (as of 2021) general purpose.
         return 'Standard_D8_v4'
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -149,9 +149,7 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  accelerators: Optional[Dict[str, int]] = None
-                                 ) -> str:
+    def get_default_instance_type(cls) -> str:
         raise NotImplementedError
 
     @classmethod

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -66,6 +66,9 @@ def patch() -> None:
     from ray.dashboard.modules.job import cli
     _run_patch(cli.__file__, _to_absolute('cli.py.patch'))
 
+    from ray.dashboard.modules.job import job_manager
+    _run_patch(job_manager.__file__, _to_absolute('job_manager.py.patch'))
+
     from ray.autoscaler._private import autoscaler
     _run_patch(autoscaler.__file__, _to_absolute('autoscaler.py.patch'))
 

--- a/sky/skylet/ray_patches/job_manager.py.patch
+++ b/sky/skylet/ray_patches/job_manager.py.patch
@@ -1,0 +1,9 @@
+0a1,4
+> # Adapted from https://github.com/ray-project/ray/blob/ray-1.13.0/dashboard/modules/job/job_manager.py
+> # Fixed the problem where the _monitor_job thread is leaked, due to `await job_supervisor.ping.remote()`
+> # does not raise an exception after the job_supervisor is exited, causing the dashboard to hang.
+> 
+334c338
+<                 await job_supervisor.ping.remote()
+---
+>                 ray.get(job_supervisor.ping.remote())


### PR DESCRIPTION
Closes #1088.

This fixes the ray dashboard hanging problem. By checking the `py-spy dump --locals --pid <dashboard.py pid>`, we found that the dashboard has some leaked thread `_monitor_job` in the `dashboard/modules/job/job_manager.py`. The problem is caused by `await job_supervisor.ping.remote()`, which may not normally raise the exception after the actor `job_supervisor` is exited.
After switching the `await` to `ray.get`, it seems the problem is solved.

Tested:
- [x] Run the reproduce code in the issue description and the problem does not occur.
- [x] Tried on the user's program and it did not stuck after submitting 500 spot jobs during the night. (Previously, it would stuck after 100-200 jobs)