### PR TITLE
Optimize dashboard patching

### DIFF
--- a/sky/skylet/ray_patches/job_manager.py.patch
+++ b/sky/skylet/ray_patches/job_manager.py.patch
@@ -3,7 +3,18 @@
 > # Fixed the problem where the _monitor_job thread is leaked, due to `await job_supervisor.ping.remote()`
 > # does not raise an exception after the job_supervisor is exited, causing the dashboard to hang.
 > 
-334c338
+334c338,349
 <                 await job_supervisor.ping.remote()
 ---
->                 ray.get(job_supervisor.ping.remote())
+>                 # Simulate the await behavior, in case some unexpected exception happens
+>                 # and block the program.
+>                 # https://ray-distributed.slack.com/archives/CP950VC76/p1661206198489669?thread_ts=1660955297.652409&cid=CP950VC76
+>                 ref = job_supervisor.ping.remote()
+>                 not_ready = [ref]
+>                 while not_ready:
+>                     ready, not_ready = ray.wait(ref, timeout=0.1)
+>                     if ready:
+>                         ray.get(ready)
+>                     else:
+>                         await asyncio.sleep(0)
+> 

--- a/sky/skylet/ray_patches/job_manager.py.patch
+++ b/sky/skylet/ray_patches/job_manager.py.patch
@@ -7,7 +7,7 @@
 <                 await job_supervisor.ping.remote()
 ---
 >                 # Simulate the await behavior, in case some unexpected exception happens
->                 # and block the program.
+>                 # and this will not yield for other coroutines.
 >                 # https://ray-distributed.slack.com/archives/CP950VC76/p1661206198489669?thread_ts=1660955297.652409&cid=CP950VC76
 >                 ref = job_supervisor.ping.remote()
 >                 not_ready = [ref]

--- a/sky/skylet/ray_patches/job_manager.py.patch
+++ b/sky/skylet/ray_patches/job_manager.py.patch
@@ -9,8 +9,8 @@
 >                 # Simulate the await behavior, in case some unexpected exception happens
 >                 # and this will not yield for other coroutines.
 >                 # https://ray-distributed.slack.com/archives/CP950VC76/p1661206198489669?thread_ts=1660955297.652409&cid=CP950VC76
->                 ref = job_supervisor.ping.remote()
->                 not_ready = [ref]
+>                 ref = [job_supervisor.ping.remote()]
+>                 not_ready = ref
 >                 while not_ready:
 >                     ready, not_ready = ray.wait(ref, timeout=0.1)
 >                     if ready:


### PR DESCRIPTION
This is an optimization of #1109, suggested by Sanbin Cho from the ray team.

In the thread: https://ray-distributed.slack.com/archives/CP950VC76/p1660955297652409

This should also closes #1127 .

TL;DR:
If any bad thing happens, the new code can yield for the other coroutines, instead of blocking it as the `ray.get` did. It will not affect the happy path, e.g. the job_supervisor normally ends.

Tested:
- [x] `tests/run_smoke_tests.sh`
- [x] Reproduce code from #1088.
- [x] code in #1127. 
