### PR TITLE
Add glob for sky storage delete

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2100,6 +2100,9 @@ def storage_delete(names: Tuple[str], all: bool):  # pylint: disable=redefined-b
         # Delete two storage objects.
         sky storage delete imagenet cifar10
         \b
+        # Delete all storage objects matching glob pattern 'imagenet*'.
+        sky storage delete "imagenet*"
+        \b
         # Delete all storage objects.
         sky storage delete -a
     """
@@ -2109,6 +2112,11 @@ def storage_delete(names: Tuple[str], all: bool):  # pylint: disable=redefined-b
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()
         names = [s['name'] for s in storages]
+    else:
+        names = [
+            name for name in _get_glob_clusters(names)
+            if name not in backend_utils.SKY_RESERVED_CLUSTER_NAMES
+        ]
     for name in names:
         sky.storage_delete(name)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -114,6 +114,18 @@ def _get_glob_clusters(clusters: List[str]) -> List[str]:
     return list(set(glob_clusters))
 
 
+def _get_glob_storages(storages: List[str]) -> List[str]:
+    """Returns a list of storages that match the glob pattern."""
+    glob_storages = []
+    for storage_object in storages:
+        glob_storage = global_user_state.get_handle_from_storage_name(
+            storage_object)
+        if len(glob_storage) == 0:
+            click.echo(f'Storage {storage_object} not found.')
+        glob_storages.extend(glob_storage)
+    return list(set(glob_storages))
+
+
 def _warn_if_local_cluster(cluster: str, local_clusters: List[str],
                            message: str) -> bool:
     """Raises warning if the cluster name is a local cluster."""

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -118,10 +118,11 @@ def _get_glob_storages(storages: List[str]) -> List[str]:
     """Returns a list of storages that match the glob pattern."""
     glob_storages = []
     for storage_object in storages:
-        glob_storage = global_user_state.get_handle_from_storage_name(
-            storage_object)
+        glob_storage = global_user_state.get_glob_storage_name(storage_object)
         if len(glob_storage) == 0:
             click.echo(f'Storage {storage_object} not found.')
+        else:
+            click.echo(f'Deleting {len(glob_storage)} storage objects.')
         glob_storages.extend(glob_storage)
     return list(set(glob_storages))
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2125,10 +2125,8 @@ def storage_delete(names: Tuple[str], all: bool):  # pylint: disable=redefined-b
         storages = sky.storage_ls()
         names = [s['name'] for s in storages]
     else:
-        names = [
-            name for name in _get_glob_clusters(names)
-            if name not in backend_utils.SKY_RESERVED_CLUSTER_NAMES
-        ]
+        names = _get_glob_storages(names)
+
     for name in names:
         sky.storage_delete(name)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -122,7 +122,8 @@ def _get_glob_storages(storages: List[str]) -> List[str]:
         if len(glob_storage) == 0:
             click.echo(f'Storage {storage_object} not found.')
         else:
-            click.echo(f'Deleting {len(glob_storage)} storage objects.')
+            plural = 's' if len(glob_storage) > 1 else ''
+            click.echo(f'Deleting {len(glob_storage)} storage object{plural}.')
         glob_storages.extend(glob_storage)
     return list(set(glob_storages))
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -361,6 +361,13 @@ def get_handle_from_storage_name(storage_name: str):
         return pickle.loads(handle)
 
 
+def get_glob_storage_name(storage_name: str) -> List[str]:
+    assert storage_name is not None, 'storage_name cannot be None'
+    rows = _DB.cursor.execute('SELECT name FROM storage WHERE name GLOB (?)',
+                              (storage_name,))
+    return [row[0] for row in rows]
+
+
 def get_storage() -> List[Dict[str, Any]]:
     rows = _DB.cursor.execute('select * from storage')
     records = []


### PR DESCRIPTION
- Modified `storage delete` in cli.py to specifying glob names for bucket
- Users can now use blobbing such as `sky down test-*` for sky storage delete, allowing for batch bucket deleting
- Addresses [960](https://github.com/skypilot-org/skypilot/issues/960#issue-1299509218)