### PR TITLE
Correct ray version

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -68,7 +68,7 @@ install_requires = [
     'PrettyTable',
     # Lower local ray version is not fully supported, due to the
     # autoscaler issues (also tracked in #537).
-    'ray[default]>=1.9.0',
+    'ray[default]>=1.9.0,<=1.13.0',
     'rich',
     'tabulate',
     'filelock',  # TODO(mraheja): Enforce >=3.6.0 when python version is >= 3.7


### PR DESCRIPTION
Now installing SkyPilot would trigger below error due to a recent update of Ray 2.0.
```
  File "/Users/weichiang/opt/miniconda3/envs/tmp/lib/python3.8/site-packages/sky/skylet/providers/aws/__init__.py", line 2, in <module>
    from sky.skylet.providers.aws.node_provider import AWSNodeProvider
  File "/Users/weichiang/opt/miniconda3/envs/tmp/lib/python3.8/site-packages/sky/skylet/providers/aws/node_provider.py", line 28, in <module>
    import ray.ray_constants as ray_constants
ModuleNotFoundError: No module named 'ray.ray_constants'
```
Temp fix to force the ray version to be `>=1.9.0,<=1.13.0`.