### PR TITLE
UX: remove DURATION, move HOURLY_PRICE in status table (-a)

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1040,9 +1040,11 @@ def exec(
 def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
     """Show clusters.
 
-    The following metadata for each cluster is stored: cluster name, time since
-    last launch, resources, region, status, duration, autostop, command, hourly
-    price. Display all metadata using ``sky status -a``.
+    The following fields for each cluster are recorded: cluster name, time
+    since last launch, resources, region, zone, hourly price, status, autostop,
+    command.
+
+    Display all fields using ``sky status -a``.
 
     \b
     Each cluster can have one of the following statuses:
@@ -1057,6 +1059,7 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
       live.  (The most recent ``sky launch`` has completed successfully.)
     - STOPPED: The cluster is stopped and the storage is persisted. Use
       ``sky start`` to restart the cluster.
+
     """
     cluster_records = core.status(all=all, refresh=refresh)
     local_clusters = onprem_utils.check_and_get_local_clusters(

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -44,13 +44,12 @@ def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
                      trunc_length=70 if not show_all else 0),
         StatusColumn('REGION', _get_region, show_by_default=False),
         StatusColumn('ZONE', _get_zone, show_by_default=False),
+        StatusColumn('HOURLY_PRICE', _get_price, show_by_default=False),
         StatusColumn('STATUS', _get_status),
-        StatusColumn('DURATION', _get_duration, show_by_default=False),
         StatusColumn('AUTOSTOP', _get_autostop),
         StatusColumn('COMMAND',
                      _get_command,
                      trunc_length=_COMMAND_TRUNC_LENGTH if not show_all else 0),
-        StatusColumn('HOURLY_PRICE', _get_price, show_by_default=False)
     ]
 
     columns = []
@@ -182,8 +181,6 @@ _get_launched = (lambda cluster_status: log_utils.readable_time_duration(
 _get_region = (
     lambda clusters_status: clusters_status['handle'].launched_resources.region)
 _get_status = (lambda cluster_status: cluster_status['status'].value)
-_get_duration = (lambda cluster_status: log_utils.readable_time_duration(
-    cluster_status['launched_at']))
 _get_command = (lambda cluster_status: cluster_status['last_use'])
 
 


### PR DESCRIPTION
DURATION is the same as LAUNCHED.

Moving HOURLY_PRICE next to region/zone looks better, and is easier to read for clusters with long COMMAND.

For the truncated output `sky status` I'm still keeping COMMAND, as it seems arguably useful.