### PR TITLE
Fix placement group not scheduled issue (issue #1130)

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -145,10 +145,18 @@ class RayCodeGen:
 
     def add_prologue(self,
                      job_id: int,
-                     spot_task: Optional['task_lib.Task'] = None) -> None:
+                     spot_task: Optional['task_lib.Task'] = None,
+                     is_local: bool = False) -> None:
         assert not self._has_prologue, 'add_prologue() called twice?'
         self._has_prologue = True
         self.job_id = job_id
+        # Should use 'auto' or 'ray://<internal_head_ip>:10001' rather than
+        # 'ray://localhost:10001', or 'ray://127.0.0.1:10001', for public cloud.
+        # Otherwise, it will a bug of ray job failed to get the placement group
+        # in ray <= 2.0.0.
+        # TODO(mluo): Check why 'auto' not working with on-prem cluster and whether
+        # the placement group issue also occurs in on-prem cluster.
+        ray_address = 'ray://localhost:10001' if is_local else 'auto'
         self._code = [
             textwrap.dedent(f"""\
             import getpass
@@ -173,10 +181,7 @@ class RayCodeGen:
             SKY_REMOTE_WORKDIR = {log_lib.SKY_REMOTE_WORKDIR!r}
             job_lib.set_status({job_id!r}, job_lib.JobStatus.PENDING)
 
-            # Should use 'auto' or 'ray://<internal_head_ip>:10001' rather than 
-            # 'ray://localhost:10001', or 'ray://127.0.0.1:10001'. Otherwise, it will
-            # trigger a bug of ray job failed to get the placement group in ray 2.0.0.
-            ray.init(address='auto', namespace='__sky__{job_id}__', log_to_driver=True)
+            ray.init(address={ray_address!r}, namespace='__sky__{job_id}__', log_to_driver=True)
 
             run_fn = None
             futures = []"""),
@@ -2834,7 +2839,10 @@ class CloudVmRayBackend(backends.Backend):
         accelerator_dict = backend_utils.get_task_demands_dict(task)
 
         codegen = RayCodeGen()
-        codegen.add_prologue(job_id, spot_task=task.spot_task)
+        is_local = isinstance(handle.launched_resources.cloud, clouds.Local)
+        codegen.add_prologue(job_id,
+                             spot_task=task.spot_task,
+                             is_local=is_local)
         codegen.add_gang_scheduling_placement_group(1, accelerator_dict)
 
         if callable(task.run):
@@ -2871,7 +2879,10 @@ class CloudVmRayBackend(backends.Backend):
         accelerator_dict = backend_utils.get_task_demands_dict(task)
 
         codegen = RayCodeGen()
-        codegen.add_prologue(job_id, spot_task=task.spot_task)
+        is_local = isinstance(handle.launched_resources.cloud, clouds.Local)
+        codegen.add_prologue(job_id,
+                             spot_task=task.spot_task,
+                             is_local=is_local)
         codegen.add_gang_scheduling_placement_group(task.num_nodes,
                                                     accelerator_dict)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -154,8 +154,8 @@ class RayCodeGen:
         # 'ray://localhost:10001', or 'ray://127.0.0.1:10001', for public cloud.
         # Otherwise, it will a bug of ray job failed to get the placement group
         # in ray <= 2.0.0.
-        # TODO(mluo): Check why 'auto' not working with on-prem cluster and whether
-        # the placement group issue also occurs in on-prem cluster.
+        # TODO(mluo): Check why 'auto' not working with on-prem cluster and
+        # whether the placement group issue also occurs in on-prem cluster.
         ray_address = 'ray://localhost:10001' if is_local else 'auto'
         self._code = [
             textwrap.dedent(f"""\

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -173,7 +173,10 @@ class RayCodeGen:
             SKY_REMOTE_WORKDIR = {log_lib.SKY_REMOTE_WORKDIR!r}
             job_lib.set_status({job_id!r}, job_lib.JobStatus.PENDING)
 
-            ray.init(address = 'ray://localhost:10001', namespace='__sky__{job_id}__', log_to_driver=True)
+            # Should use 'auto' or 'ray://<internal_head_ip>:10001' rather than 
+            # 'ray://localhost:10001', or 'ray://127.0.0.1:10001'. Otherwise, it will
+            # trigger a bug of ray job failed to get the placement group in ray 2.0.0.
+            ray.init(address='auto', namespace='__sky__{job_id}__', log_to_driver=True)
 
             run_fn = None
             futures = []"""),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -319,7 +319,8 @@ def test_large_job_queue():
             f'sky cancel {name} 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
             # Each job takes 0.5 CPU and the default VM has 8 CPUs, so there should be 8 / 0.5 = 16 jobs running.
-            f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',
+            # The first 16 jobs are canceled, so there should be 75 - 32 = 43 jobs PENDING.
+            f'sky queue {name} | grep -v grep | grep PENDING | wc -l | grep 43',
         ],
         f'sky down -y {name}',
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -313,7 +313,7 @@ def test_large_job_queue():
         'job_queue_large',
         [
             f'sky launch -y -c {name} --cloud gcp ""',
-            f'for i in {{1..100}}; do sky exec {name} -d "echo $i; sleep 100000000"; done',
+            f'for i in `seq 1 100`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
             f'sky cancel repr 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
             f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -290,6 +290,7 @@ def test_job_queue():
     )
     run_one_test(test)
 
+
 def test_n_node_job_queue():
     name = _get_cluster_name()
     test = Test(
@@ -306,6 +307,7 @@ def test_n_node_job_queue():
         f'sky down -y {name}',
     )
     run_one_test(test)
+
 
 def test_large_job_queue():
     name = _get_cluster_name()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -318,7 +318,7 @@ def test_large_job_queue():
             f'for i in `seq 1 75`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
             f'sky cancel {name} 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
-            # Each job takes 0.5 CPU and the default VM has 8 CPUs, so there should be 8 / 0.5 = 16 jobs running. 
+            # Each job takes 0.5 CPU and the default VM has 8 CPUs, so there should be 8 / 0.5 = 16 jobs running.
             f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',
         ],
         f'sky down -y {name}',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -313,7 +313,7 @@ def test_large_job_queue():
         'job_queue_large',
         [
             f'sky launch -y -c {name} --cloud gcp ""',
-            f'for i in `seq 1 100`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
+            f'for i in `seq 1 60`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
             f'sky cancel repr 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
             f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -274,23 +274,6 @@ def test_logs():
 
 
 # ---------- Job Queue. ----------
-def test_job_queue():
-    name = _get_cluster_name()
-    test = Test(
-        'job_queue',
-        [
-            f'sky launch -y -c {name} examples/job_queue/cluster.yaml',
-            f'sky exec {name} -d examples/job_queue/job.yaml',
-            f'sky exec {name} -d examples/job_queue/job.yaml',
-            f'sky exec {name} -d examples/job_queue/job.yaml',
-            f'sky logs {name} 2',
-            f'sky queue {name}',
-        ],
-        f'sky down -y {name}',
-    )
-    run_one_test(test)
-
-
 def test_n_node_job_queue():
     name = _get_cluster_name()
     test = Test(
@@ -303,6 +286,21 @@ def test_n_node_job_queue():
             f'sky cancel {name} 1',
             f'sky logs {name} 2',
             f'sky queue {name}',
+        ],
+        f'sky down -y {name}',
+    )
+    run_one_test(test)
+
+def test_large_job_queue():
+    name = _get_cluster_name()
+    test = Test(
+        'job_queue_large',
+        [
+            f'sky launch -y -c {name} --cloud gcp ""',
+            f'for i in {{1..100}}; do sky exec {name} -d "echo $i; sleep 100000000"; done',
+            f'sky cancel repr 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
+            'sleep 20',
+            f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',
         ],
         f'sky down -y {name}',
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -313,7 +313,7 @@ def test_large_job_queue():
         'job_queue_large',
         [
             f'sky launch -y -c {name} --cloud gcp ""',
-            f'for i in `seq 1 60`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
+            f'for i in `seq 1 75`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
             f'sky cancel repr 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
             f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -274,6 +274,22 @@ def test_logs():
 
 
 # ---------- Job Queue. ----------
+def test_job_queue():
+    name = _get_cluster_name()
+    test = Test(
+        'job_queue',
+        [
+            f'sky launch -y -c {name} examples/job_queue/cluster.yaml',
+            f'sky exec {name} -d examples/job_queue/job.yaml',
+            f'sky exec {name} -d examples/job_queue/job.yaml',
+            f'sky exec {name} -d examples/job_queue/job.yaml',
+            f'sky logs {name} 2',
+            f'sky queue {name}',
+        ],
+        f'sky down -y {name}',
+    )
+    run_one_test(test)
+
 def test_n_node_job_queue():
     name = _get_cluster_name()
     test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -312,12 +312,13 @@ def test_n_node_job_queue():
 def test_large_job_queue():
     name = _get_cluster_name()
     test = Test(
-        'job_queue_large',
+        'large_job_queue',
         [
             f'sky launch -y -c {name} --cloud gcp ""',
             f'for i in `seq 1 75`; do sky exec {name} -d "echo $i; sleep 100000000"; done',
-            f'sky cancel repr 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
+            f'sky cancel {name} 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
             'sleep 20',
+            # Each job takes 0.5 CPU and the default VM has 8 CPUs, so there should be 8 / 0.5 = 16 jobs running. 
             f'sky queue {name} | grep -v grep | grep RUNNING | wc -l | grep 16',
         ],
         f'sky down -y {name}',


### PR DESCRIPTION
Fixes #1130 

Using `localhost` or `127.0.0.1` in the `ray.init` will cause `ray.get(pg.ready())` fail to unblock. The problem should be a ray bug, but setting the address to `auto` or `internal_ip_address` will solve the problem. (PS: ray gets the internal ip when the `auto` is specified by the following function, which read the file `/tmp/ray/current_ray_cluster` https://github.com/ray-project/ray/blob/cba26cc83f6b5b8a2ff166594a65cb74c0ec8740/python/ray/_private/utils.py#L84).

@michaelzhiluo Can you remind me why you change the address from `auto` to `localhost` in https://github.com/skypilot-org/skypilot/pull/763 ?

Tested:
- [x] `tests/run_smoke_tests.sh test_large_job_queue`
- [x] reproducible code in #1130 