### PR TITLE
Fix `sky spot status -a` for resources and region information

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -451,6 +451,8 @@ def spot_status(refresh: bool) -> List[Dict[str, Any]]:
                 'duration': (float) duration in seconds,
                 'retry_count': int Number of retries,
                 'status': sky.JobStatus status of the job,
+                'cluster_resources': (str) resources of the cluster,
+                'region': (str) region of the cluster,
             }
         ]
     Raises:

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -284,15 +284,16 @@ def dump_spot_job_queue() -> str:
         job['status'] = job['status'].value
 
         cluster_name = generate_spot_cluster_name(job['job_name'],
-                                                    job['job_id'])
+                                                  job['job_id'])
         handle = global_user_state.get_handle_from_cluster_name(cluster_name)
         if handle is not None:
-            job['cluster_resources'] = f'{handle.launched_nodes}x {handle.launched_resources}'
+            job['cluster_resources'] = (
+                f'{handle.launched_nodes}x {handle.launched_resources}')
             job['region'] = handle.launched_resources.region
         else:
             job['cluster_resources'] = '-'
             job['region'] = '-'
-            
+
     return json.dumps(jobs, indent=2)
 
 
@@ -375,7 +376,7 @@ class SpotCodeGen:
     @classmethod
     def get_job_table(cls) -> str:
         code = [
-            f'job_table = spot_utils.dump_spot_job_queue()',
+            'job_table = spot_utils.dump_spot_job_queue()',
             'print(job_table, flush=True)',
         ]
         return cls._build(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -282,6 +282,17 @@ def dump_spot_job_queue() -> str:
             job_duration = 0
         job['job_duration'] = job_duration
         job['status'] = job['status'].value
+
+        cluster_name = generate_spot_cluster_name(job['job_name'],
+                                                    job['job_id'])
+        handle = global_user_state.get_handle_from_cluster_name(cluster_name)
+        if handle is not None:
+            job['cluster_resources'] = f'{handle.launched_nodes}x {handle.launched_resources}'
+            job['region'] = handle.launched_resources.region
+        else:
+            job['cluster_resources'] = '-'
+            job['region'] = '-'
+            
     return json.dumps(jobs, indent=2)
 
 
@@ -336,17 +347,10 @@ def format_job_table(jobs: Dict[str, Any], show_all: bool) -> str:
             if started != '-':
                 started += ago_suffix
             values.append(started)
-            cluster_name = generate_spot_cluster_name(job['job_name'],
-                                                      job['job_id'])
-            handle = global_user_state.get_handle_from_cluster_name(
-                cluster_name)
-            if handle is None:
-                values.extend(['-', '-'])
-            else:
-                values.extend([
-                    f'{handle.launched_nodes}x {handle.launched_resources}',
-                    handle.launched_resources.region
-                ])
+            values.extend([
+                job['cluster_resources'],
+                job['region'],
+            ])
         job_table.add_row(values)
     status_str = ', '.join([
         f'{count} {status}' for status, count in sorted(status_counts.items())
@@ -371,7 +375,7 @@ class SpotCodeGen:
     @classmethod
     def get_job_table(cls) -> str:
         code = [
-            'job_table = spot_utils.dump_spot_job_queue()',
+            f'job_table = spot_utils.dump_spot_job_queue()',
             'print(job_table, flush=True)',
         ]
         return cls._build(code)


### PR DESCRIPTION
Caught by @concretevitamin where the resources and region are `'-'` even when the cluster and region is available.

Tested:
- [x] `sky spot launch -n test-job 'echo hi; sleep 1000'`; `sky spot status -a`