### PR TITLE
[Spot] Show FAILED_CONTROLLER when controller exit abnormally

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -13,6 +13,7 @@ import yaml
 from sky import sky_logging
 from sky.backends import backend_utils, cloud_vm_ray_backend
 from sky.skylet import autostop_lib, job_lib
+from sky.spot import spot_utils
 from sky.utils import common_utils
 
 # Seconds of sleep between the processing of skylet events.
@@ -65,6 +66,14 @@ class JobUpdateEvent(SkyletEvent):
         job_owner = getpass.getuser()
         job_lib.update_status(job_owner,
                               submitted_gap_sec=self._SUBMITTED_GAP_SECONDS)
+
+
+class SpotJobUpdateEvent(SkyletEvent):
+    """Skylet event for updating spot job status."""
+    EVENT_INTERVAL_SECONDS = 300
+
+    def _run(self):
+        spot_utils.update_spot_job_status()
 
 
 class AutostopEvent(SkyletEvent):

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -11,6 +11,7 @@ logger.info('skylet started')
 EVENTS = [
     events.JobUpdateEvent(),
     events.AutostopEvent(),
+    events.SpotJobUpdateEvent(),
 ]
 
 while True:

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -9,8 +9,11 @@ logger = sky_logging.init_logger(__name__)
 logger.info('skylet started')
 
 EVENTS = [
-    events.JobUpdateEvent(),
     events.AutostopEvent(),
+    events.JobUpdateEvent(),
+    # The spot job update event should be after the job update event.
+    # Otherwise, the abnormal spot job status update will be delayed
+    # until the next job update event.
     events.SpotJobUpdateEvent(),
 ]
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -68,6 +68,41 @@ def get_job_status(backend: 'backends.CloudVmRayBackend',
     return status
 
 
+def update_spot_job_status(job_id: Optional[int] = None):
+    """Update spot job status if the controller failed abnormally.
+
+    Check the status of the controller. If it is not running, it must be
+    exited abnormally, and we should set the job status to FAILED.
+    """
+    if job_id is None:
+        job_ids = spot_state.get_nonterminal_job_ids_by_name(None)
+    else:
+        job_ids = [job_id]
+    for job in job_ids:
+        controller_status = job_lib.get_status(job)
+        if controller_status.is_terminal():
+            logger.error(f'Controller for job {job} have exited abnormally. '
+                         'Setting the job status to FAILED_CONTROLLER.')
+            task_name = spot_state.get_task_name_by_job_id(job)
+
+            # Tear down the abnormal spot cluster to avoid resource leakage.
+            cluster_name = generate_spot_cluster_name(task_name, job)
+            handle = global_user_state.get_handle_from_cluster_name(
+                cluster_name)
+            if handle is not None:
+                backend = backend_utils.get_backend_from_handle(handle)
+                try:
+                    backend.teardown(handle, terminate=True)
+                except RuntimeError:
+                    logger.error('Failed to tear down the spot cluster '
+                                 f'{cluster_name!r}.')
+
+            # The controller process for this job is not running: it must
+            # have exited abnormally, and we should set the job status to
+            # FAILED_CONTROLLER.
+            spot_state.set_failed(job, spot_state.SpotStatus.FAILED_CONTROLLER)
+
+
 def get_job_timestamp(backend: 'backends.CloudVmRayBackend', cluster_name: str,
                       get_end_time: bool) -> float:
     """Get the started/ended time of the job."""
@@ -80,6 +115,8 @@ def get_job_timestamp(backend: 'backends.CloudVmRayBackend', cluster_name: str,
     subprocess_utils.handle_returncode(returncode, code,
                                        'Failed to get job time.',
                                        stdout + stderr)
+    if 'None' in stdout:
+        return -1
     return float(stdout)
 
 
@@ -112,34 +149,7 @@ def cancel_jobs_by_id(job_ids: Optional[List[int]]) -> str:
                         f'{job_status.value}. Skipped.')
             continue
 
-        # Check the status of the controller. If it is not running, it must be
-        # exited abnormally, and we should set the job status to FAILED.
-        # TODO(zhwu): instead of having the liveness check here, we may need
-        # to make it as a event in skylet.
-        controller_status = job_lib.get_status(job_id)
-        if controller_status.is_terminal():
-            logger.error(f'Controller for job {job_id} have exited abnormally. '
-                         'Setting the job status to FAILED_CONTROLLER.')
-            task_name = spot_state.get_task_name_by_job_id(job_id)
-
-            # Tear down the abnormal spot cluster to avoid resource leakage.
-            cluster_name = generate_spot_cluster_name(task_name, job_id)
-            handle = global_user_state.get_handle_from_cluster_name(
-                cluster_name)
-            if handle is not None:
-                backend = backend_utils.get_backend_from_handle(handle)
-                try:
-                    backend.teardown(handle, terminate=True)
-                except RuntimeError:
-                    logger.error('Failed to tear down the spot cluster '
-                                 f'{cluster_name!r}.')
-
-            # The controller process for this job is not running: it must
-            # have exited abnormally, and we should set the job status to
-            # FAILED_CONTROLLER.
-            spot_state.set_failed(job_id,
-                                  spot_state.SpotStatus.FAILED_CONTROLLER)
-            continue
+        update_spot_job_status(job_id)
 
         # Send the signal to the spot job controller.
         signal_file = pathlib.Path(SIGNAL_FILE_PREFIX.format(job_id))
@@ -274,11 +284,13 @@ def dump_spot_job_queue() -> str:
         if job['status'] == spot_state.SpotStatus.RECOVERING:
             # When job is recovering, the duration is exact job['job_duration']
             job_duration = job['job_duration']
-        elif job_start_at > 0:
+        elif job_start_at > 0 and end_at > 0:
             job_duration = end_at - job_start_at
         else:
             # When job_start_at <= 0, that means the last_recovered_at is not
             # set yet, i.e. the job is not started.
+            # When end_at <= 0, that means there is some problem fetching the
+            # end_at time, so we use 0.
             job_duration = 0
         job['job_duration'] = job_duration
         job['status'] = job['status'].value


### PR DESCRIPTION
Fixes #1141

Previously, if the controller failed abnormally, the spot status of the job will only be updated if the user run `sky spot cancel <job_id>`. 

Now we move the status update to the skylet, so that the spot status will be updated automatically.

Tested:
- [x] `sky spot launch -n test-status 'echo hi; sleep 100000'`; `ssh sky-spot-controller-<hash>`; `ray job stop --address http://127.0.0.1:8265 <job_id>-ubuntu`; Check the `sky spot status` and the `~/.sky/skylet.log` after a while.