### PR TITLE
Makes the local wheel dir the same hierarchy as the remote

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -64,7 +64,7 @@ SKY_REMOTE_WORKDIR = log_lib.SKY_REMOTE_WORKDIR
 SKY_REMOTE_APP_DIR = '~/.sky/sky_app'
 SKY_RAY_YAML_REMOTE_PATH = '~/.sky/sky_ray.yml'
 IP_ADDR_REGEX = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
-SKY_REMOTE_PATH = '~/.sky/sky_wheels'
+SKY_REMOTE_PATH = '~/.sky/wheels'
 SKY_USER_FILE_PATH = '~/.sky/generated'
 
 BOLD = '\033[1m'

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -25,13 +25,11 @@ SKY_PACKAGE_PATH = pathlib.Path(sky.__file__).parent.parent / 'sky'
 _PACKAGE_WHEEL_NAME = 'skypilot'
 
 
-    
 def _get_latest_wheel_and_cleanup() -> pathlib.Path:
     wheel_name = (f'**/{_PACKAGE_WHEEL_NAME}-'
                   f'{version.parse(sky.__version__)}-*.whl')
     try:
-        latest_wheel = max(WHEEL_DIR.glob(wheel_name),
-                                key=os.path.getctime)
+        latest_wheel = max(WHEEL_DIR.glob(wheel_name), key=os.path.getctime)
     except ValueError:
         raise FileNotFoundError(f'Could not find built SkyPilot wheels '
                                 f'under {WHEEL_DIR!r}') from None
@@ -49,7 +47,7 @@ def _get_latest_wheel_and_cleanup() -> pathlib.Path:
 
 def clean_up_wheel_dir():
     """Clean up the wheel directory.
-    
+
     This function will be called during `ray up` to clean up the wheel, it
     acquires the wheel lock to prevent concurrent wheel operations, by other
     `ray up` or `sky launch`.
@@ -61,6 +59,7 @@ def clean_up_wheel_dir():
         logger.error(str(e))
     except filelock.Timeout:
         logger.warning('Failed to clean up wheel directory')
+
 
 def _build_sky_wheel():
     """Build a wheel for Sky."""

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -7,6 +7,8 @@ The generated folder is like:
     ~/.sky/wheels/<hash_of_wheel>/sky-<version>-py3-none-any.whl
 
 Whenever a new wheel is built, the old ones will be removed.
+
+The ray up yaml templates under sky/templates depend on the naming of the wheel.
 """
 import hashlib
 import os

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -53,8 +53,6 @@ def _get_latest_wheel_and_remove_all_others() -> pathlib.Path:
         if f != latest_wheel_dir_name:
             if f.is_dir() and not f.is_symlink():
                 shutil.rmtree(f, ignore_errors=True)
-            else:
-                f.unlink()
     return latest_wheel
 
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -56,22 +56,6 @@ def _get_latest_wheel_and_remove_all_others() -> pathlib.Path:
     return latest_wheel
 
 
-def get_latest_wheel_and_remove_all_others() -> pathlib.Path:
-    """Get the latest wheel and remove all others.
-
-    This function will be called during `ray up` to clean up the wheel, it
-    acquires the wheel lock to prevent concurrent wheel operations, by other
-    `ray up` or `sky launch`.
-    """
-    try:
-        with filelock.FileLock(_WHEEL_LOCK_PATH, timeout=5):  # pylint: disable=E0110
-            return _get_latest_wheel_and_remove_all_others()
-    except FileNotFoundError as e:
-        logger.error(str(e))
-    except filelock.Timeout:
-        logger.warning('Failed to clean up wheel directory')
-
-
 def _build_sky_wheel():
     """Build a wheel for SkyPilot."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -1,4 +1,4 @@
-"""Utils for building sky pip wheels.
+"""Utils for building pip wheels.
 
 This module is used for building the wheel for SkyPilot under `~/.sky/wheels`,
 and the wheel will be used for installing the SkyPilot on the cluster nodes.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -439,7 +439,6 @@ def spot_launch(
                 'user_yaml_path': f.name,
                 'spot_controller': controller_name,
                 'cluster_name': name,
-                'sky_remote_path': backend_utils.SKY_REMOTE_PATH,
                 'is_dev': env_options.Options.IS_DEVELOPER.get(),
                 'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
                 'logging_user_hash': common_utils.get_user_hash(),

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -94,7 +94,7 @@ extras_require = {
     ],
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
-    'azure': ['azure-cli==2.30.0'],
+    'azure': ['azure-cli==2.31.0', 'azure-core'],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],
     'docker': ['docker'],
 }

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -85,6 +85,8 @@ install_requires = [
     'pulp',
 ]
 
+# NOTE: Change the templates/spot-controller.yaml.j2 file if any of the following
+# packages dependencies are changed.
 extras_require = {
     'aws': [
         'awscli',

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -96,7 +96,7 @@ setup_commands:
     (which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false) || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -96,7 +96,7 @@ setup_commands:
     (which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false) || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -96,7 +96,7 @@ setup_commands:
     (which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false) || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -96,7 +96,7 @@ setup_commands:
     (which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false) || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -96,7 +96,7 @@ setup_commands:
     (which conda > /dev/null 2>&1 && conda init > /dev/null && conda config --set auto_activate_base false) || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -102,7 +102,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -102,7 +102,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -102,7 +102,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -102,7 +102,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -102,7 +102,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(/home/azureuser/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[azure]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo systemctl stop unattended-upgrades;
     sudo kill -9 `sudo lsof /var/lib/dpkg/lock-frontend | awk '{print $2}' | tail -n 1` || true;
     sudo pkill -9 apt-get;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -143,7 +143,7 @@ setup_commands:
     pip3 install --upgrade google-api-python-client;
   {%- endif %}
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -143,7 +143,7 @@ setup_commands:
     pip3 install --upgrade google-api-python-client;
   {%- endif %}
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -143,7 +143,7 @@ setup_commands:
     pip3 install --upgrade google-api-python-client;
   {%- endif %}
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; find {{sky_remote_path}}/* -d ! -name "{{sky_wheel_hash}}" -delete);
+    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -143,7 +143,7 @@ setup_commands:
     pip3 install --upgrade google-api-python-client;
   {%- endif %}
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash && python3 -u -c "import sky; sky.backends.wheel_utils.get_latest_wheel_and_remove_all_others()" || exit 1);
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -143,7 +143,7 @@ setup_commands:
     pip3 install --upgrade google-api-python-client;
   {%- endif %}
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ] || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp]" || exit 1; echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash; python3 -u -c "import sky; sky.backends.wheel_utils.clean_up_wheel_dir()");
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -15,20 +15,22 @@ file_mounts:
 
 setup: |
   # Install cli dependencies
+  # Not using SkyPilot wheels because the wheel can be cleaned up by another process.
+  # TODO(zhwu): Keep the dependencies align with the ones in setup.py
   (pip list | grep boto3 2>&1 > /dev/null && \
    pip list | grep google-api-python-client 2>&1 > /dev/null) || \
-   pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[aws,gcp]" 2>&1 > /dev/null
+   pip install boto3 awscli pycryptodome==3.12.0 google-api-python-client google-cloud-storage 2>&1 > /dev/null
 
   # We do not install azure dependencies for now since our subscription does not support spot instances.
   # pip list | grep azure-cli 2>&1 > /dev/null || \
-  #  pip3 install "$(echo {{sky_remote_path}}/skypilot-{{sky_version}}*.whl)[azure]" 2>&1 > /dev/null
+  #  pip3 install azure-cli==2.31.0 azure-core
 
   gcloud --version 2>&1 > /dev/null || \
   (wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-382.0.0-linux-x86_64.tar.gz && \
     tar xzf google-cloud-sdk-382.0.0-linux-x86_64.tar.gz && \
     mv google-cloud-sdk ~/ && \
-    ~/google-cloud-sdk/install.sh -q && \
-    echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc) 2>&1 > /dev/null
+    ~/google-cloud-sdk/install.sh -q 2>&1 > /dev/null && \
+    echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc)
 
 run: |
   python -u -m sky.spot.controller \

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -17,21 +17,21 @@ setup: |
   # Install cli dependencies
   # Not using SkyPilot wheels because the wheel can be cleaned up by another process.
   # TODO(zhwu): Keep the dependencies align with the ones in setup.py
-  (pip list | grep boto3 2>&1 > /dev/null && \
-   pip list | grep google-api-python-client 2>&1 > /dev/null) || \
+  (pip list | grep boto3 > /dev/null 2>&1 && \
+   pip list | grep google-api-python-client > /dev/null 2>&1 ) || \
    pip install boto3 awscli pycryptodome==3.12.0 google-api-python-client google-cloud-storage 2>&1 > /dev/null
 
   # We do not install azure dependencies for now since our subscription does not support spot instances.
-  # pip list | grep azure-cli 2>&1 > /dev/null || \
+  # pip list | grep azure-cli > /dev/null 2>&1 || \
   #  pip3 install azure-cli==2.31.0 azure-core
 
-  gcloud --version 2>&1 > /dev/null || \
+  gcloud --help > /dev/null 2>&1 || \
   (wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-382.0.0-linux-x86_64.tar.gz && \
     tar xzf google-cloud-sdk-382.0.0-linux-x86_64.tar.gz && \
     mv google-cloud-sdk ~/ && \
-    ~/google-cloud-sdk/install.sh -q 2>&1 > /dev/null && \
-    source ~/google-cloud-sdk/path.bash.inc 2>&1 > /dev/null && \
-    echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc)
+    ~/google-cloud-sdk/install.sh -q > /dev/null 2>&1 && \
+    source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1 && \
+    echo 'source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1' >> ~/.bashrc)
 
 run: |
   python -u -m sky.spot.controller \

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -30,6 +30,7 @@ setup: |
     tar xzf google-cloud-sdk-382.0.0-linux-x86_64.tar.gz && \
     mv google-cloud-sdk ~/ && \
     ~/google-cloud-sdk/install.sh -q 2>&1 > /dev/null && \
+    source ~/google-cloud-sdk/path.bash.inc 2>&1 > /dev/null && \
     echo 'source ~/google-cloud-sdk/path.bash.inc' >> ~/.bashrc)
 
 run: |


### PR DESCRIPTION
Previously, if a user log into the remote cluster and run `sky launch`, the hash based wheel dir (introduced by #1139) will be destroyed.
This PR aligns the local wheel directory hierarchy with the remote wheel directory.

Tested:
- [x] `sky launch -c min ./examples/minimal.yaml; ssh min; sky launch -c test-build ''`
- [x] `./tests/run_smoke_tests.sh`
- [x] `sky down -p sky-spot-controller-<hash>; sky spot launch -n test 'echo hi'` 