### PR TITLE
[Spot] Make get_job_timestamp fetching more robust

### DIFF
--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -72,7 +72,8 @@ class JobStatus(enum.Enum):
     """Job status"""
     # 3 in-flux states: each can transition to any state below it.
     # The `job_id` has been generated, but the generated ray program has
-    # not started yet.
+    # not started yet. skylet can transit the state from INIT to FAILED
+    # directly, if the ray program fails to start.
     INIT = 'INIT'
     # The job is waiting for the required resources. (`ray job status`
     # shows RUNNING as the generated ray program has started, but blocked

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -55,7 +55,7 @@ def create_table(cursor, conn):
         submitted_at FLOAT,
         status TEXT,
         run_timestamp TEXT CANDIDATE KEY,
-        start_at FLOAT)""")
+        start_at FLOAT DEFAULT -1)""")
 
     db_utils.add_column_to_table(cursor, conn, 'jobs', 'end_at', 'FLOAT')
     db_utils.add_column_to_table(cursor, conn, 'jobs', 'resources', 'TEXT')


### PR DESCRIPTION
Previously, our `start_at` for each job is default to NULL. When the job is set to FAILED by skylet, the `get_job_timestamp` below will fail, due to cannot convert `None` to float. We now make the `start_at` default to -1, so that the value will always be available. 

https://github.com/skypilot-org/skypilot/blob/b36bbcffa2d3ea3adedb78a9f7ca7e80c1a32a89/sky/spot/recovery_strategy.py#L159


The problem was caught by @concretevitamin  in spot jobs:
```
(zongheng-107 pid=467225) I 09-01 18:39:30 recovery_strategy.py:147] Failed to launch the spot cluster with error: Command rsync -Pavz --filter='dir-merge,- .gitignore' -e "ssh -i ~/.ssh/sky-key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=5 -o ServerAliveCountMax=3 -o ConnectTimeout=30s -o ForwardAgent=yes -o ControlMaster=auto -o ControlPath=/tmp/skypilot_ssh_ubuntu/985053b910/%C -o ControlPersist=300s" /tmp/sky_app_gvkun05j gcpuser@34.162.255.162:~/.sky/sky_app/sky_job_1 failed with return code 3.
(zongheng-107 pid=467225) I 09-01 18:39:30 recovery_strategy.py:147] Failed to rsync up: /tmp/sky_app_gvkun05j -> ~/.sky/sky_app/sky_job_1

ValueError: could not convert string to float: 'None\n'
```


Note: Our `log_utils.readable_time_duration` will handle the case where the `start_at < 0` just as `start_at is None`. 
https://github.com/skypilot-org/skypilot/blob/2505fb1c8a5d71f658537b4d249b58f423ef705a/sky/utils/log_utils.py#L86-L87