### PR TITLE
[Spot] Fix the retry logic for spot cluster launching

### DIFF
--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -121,11 +121,12 @@ class StrategyExecutor:
             self.cluster_name)
         try:
             self.backend.cancel_jobs(handle, jobs=None)
-        except exceptions.CommandError:
+        except Exception as e:  # pylint: disable=broad-except
             # Ignore the failure as the cluster can be totally stopped, and the
             # job canceling can get connection error.
-            logger.info('Ignoring the job cancellation failure; the spot '
-                        'cluster is likely completely stopped. Recovering.')
+            logger.info(
+                f'Ignoring the job cancellation failure (Exception: {e}); '
+                'the spot cluster is likely completely stopped. Recovering.')
 
     def _launch(self, max_retry=3, raise_on_failure=True) -> Optional[float]:
         """Implementation of launch().

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -195,6 +195,8 @@ class StrategyExecutor:
                     # In this case, we will leave the recovery to the caller.
                     logger.info('The cluster is preempted before the job'
                                 'starts.')
+                    # TODO(zhwu): we should recover the preemption with the
+                    # recovery strategy instead of the current while loop.
                     is_preemption = True
                     retry_launch = True
                     break

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -126,7 +126,7 @@ class StrategyExecutor:
             # job canceling can get connection error.
             logger.info(
                 f'Ignoring the job cancellation failure (Exception: {e}); '
-                'the spot cluster is likely completely stopped. Recovering.')
+                'the spot cluster is likely completely stopped.')
 
     def _launch(self, max_retry=3, raise_on_failure=True) -> Optional[float]:
         """Implementation of launch().

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -193,7 +193,7 @@ class StrategyExecutor:
                 if cluster_status != global_user_state.ClusterStatus.UP:
                     # The cluster can be preempted before the job is launched.
                     # In this case, we will leave the recovery to the caller.
-                    logger.info('The cluster is preempted before the job'
+                    logger.info('The cluster is preempted before the job '
                                 'starts.')
                     # TODO(zhwu): we should recover the preemption with the
                     # recovery strategy instead of the current while loop.
@@ -231,7 +231,7 @@ class StrategyExecutor:
                 time.sleep(spot_utils.JOB_STARTED_STATUS_CHECK_GAP_SECONDS)
 
             assert retry_launch
-                
+
             self._try_cancel_all_jobs()
             if is_preemption:
                 self.terminate_cluster()

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -187,8 +187,8 @@ class StrategyExecutor:
                 if status not in [
                         None, job_lib.JobStatus.INIT, job_lib.JobStatus.PENDING
                 ]:
-                    # The job has been transit into a non-initial status. We can
-                    # continue the logic.
+                    # The job has been transited into a non-initial status. We
+                    # can continue the logic.
                     break
                 # Wait the job to be started
                 time.sleep(spot_utils.JOB_STARTED_STATUS_CHECK_GAP_SECONDS)

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -177,7 +177,6 @@ class StrategyExecutor:
                 return launch_time
 
 
-
 class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
     """Failover strategy: wait in same region and failover after timout."""
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -32,6 +32,7 @@ JOB_STATUS_CHECK_GAP_SECONDS = 20
 
 # Controller checks if its job has started every this many seconds.
 JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
+MAX_JOB_CHECKING_RETRY = 50
 
 _SPOT_STATUS_CACHE = '~/.sky/spot_status_cache.txt'
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -32,7 +32,6 @@ JOB_STATUS_CHECK_GAP_SECONDS = 20
 
 # Controller checks if its job has started every this many seconds.
 JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
-MAX_JOB_CHECKING_RETRY = 50
 
 _SPOT_STATUS_CACHE = '~/.sky/spot_status_cache.txt'
 

--- a/tests/run_smoke_tests.sh
+++ b/tests/run_smoke_tests.sh
@@ -13,9 +13,7 @@ if [ -z "$test" ]
 then
     test_spec=tests/test_smoke.py
 else
-    for t in "$@"; do
-        test_spec="$test_spec tests/test_smoke.py::${t}"
-    done
+    test_spec="$test_spec tests/test_smoke.py::${test}"
 fi
 
 pytest -s -n 16 -q --tb=short --disable-warnings "$test_spec"

--- a/tests/run_smoke_tests.sh
+++ b/tests/run_smoke_tests.sh
@@ -13,7 +13,9 @@ if [ -z "$test" ]
 then
     test_spec=tests/test_smoke.py
 else
-    test_spec=tests/test_smoke.py::"$test"
+    for t in "$@"; do
+        test_spec="$test_spec tests/test_smoke.py::${t}"
+    done
 fi
 
 pytest -s -n 16 -q --tb=short --disable-warnings "$test_spec"

--- a/tests/run_smoke_tests.sh
+++ b/tests/run_smoke_tests.sh
@@ -13,7 +13,7 @@ if [ -z "$test" ]
 then
     test_spec=tests/test_smoke.py
 else
-    test_spec="tests/test_smoke.py::${test}"
+    test_spec=tests/test_smoke.py::"${test}"
 fi
 
 pytest -s -n 16 -q --tb=short --disable-warnings "$test_spec"

--- a/tests/run_smoke_tests.sh
+++ b/tests/run_smoke_tests.sh
@@ -13,7 +13,7 @@ if [ -z "$test" ]
 then
     test_spec=tests/test_smoke.py
 else
-    test_spec="$test_spec tests/test_smoke.py::${test}"
+    test_spec="tests/test_smoke.py::${test}"
 fi
 
 pytest -s -n 16 -q --tb=short --disable-warnings "$test_spec"


### PR DESCRIPTION
Attempt for solving #1132 

Previously, the retry for the spot cluster launching has a bug, where even if the cluster is failed to launch (cluster is UP, but the task is failed to be submitted), we will still start checking the job status until it is RUNNING. The job status checking will keep the program stuck forever, as no job was submitted.

Tested:
- [x] spot related tests.