### PR TITLE
Add fallback option for GCP active account

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1462,9 +1462,13 @@ def _query_status_gcp(
         # If there is no account activated, we try our best to fix the issue
         # by falling back to the ray's service account.
         status_list = _process_cli_query(
-            'GCP', cluster,
-            query_cmd.format(account_option=f'--account {ray_service_account} '),
-            '\n', status_map)
+            'GCP',
+            cluster,
+            query_cmd.format(
+                account_option=f'--account {ray_service_account} '),
+            '\n',
+            status_map,
+        )
 
     # GCP does not clean up preempted TPU VMs. We remove it ourselves.
     # TODO(wei-lin): handle multi-node cases.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1445,7 +1445,7 @@ def _query_status_gcp(
 
         # TODO(zhwu): The status of the TPU attached to the cluster should also be
         # checked, since TPUs are not part of the VMs.
-        query_cmd = ('gcloud compute instances list {account_option} '
+        query_cmd = ('gcloud compute instances list {account_option}'
                      f'--filter="(labels.ray-cluster-name={cluster} AND '
                      f'labels.ray-launch-config=({hash_filter_str}))" '
                      '--format="value(status)"')
@@ -1463,7 +1463,7 @@ def _query_status_gcp(
         # by falling back to the ray's service account.
         status_list = _process_cli_query(
             'GCP', cluster,
-            query_cmd.format(account_option=f'--account {ray_service_account}'),
+            query_cmd.format(account_option=f'--account {ray_service_account} '),
             '\n', status_map)
 
     # GCP does not clean up preempted TPU VMs. We remove it ourselves.


### PR DESCRIPTION
This PR is an attempt for fixing #1142.

We will now fallback to ray service account and retry if the `ERROR: (gcloud.compute.instances.list) You do not currently have an active account selected.` error occurs.

Tested:
- [x] `sky cpunode --cloud gcp`; `sky status -r` 
- [x] on the cpunode `sky launch -c test-refresh --cloud gcp ''`; `sky status -r`
- [ ] `tests/run_smoke_tests.sh`