### PR TITLE
Improve error messages for cloud import errors

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -21,7 +21,7 @@ def import_package(func):
                 botocore = _botocore
             except ImportError:
                 raise ImportError('Fail to import dependencies for AWS.'
-                                  'See README for how to install it.') from None
+                                'Try pip install "skypilot[aws]"') from None
         return func(*args, **kwargs)
 
     return wrapper

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -17,7 +17,7 @@ def import_package(func):
                 azure = _azure
             except ImportError:
                 raise ImportError('Fail to import dependencies for Azure.'
-                                  'See README for how to install it.') from None
+                                'Try pip install "skypilot[azure]"') from None
         return func(*args, **kwargs)
 
     return wrapper

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -20,7 +20,7 @@ def import_package(func):
                 google = _google
             except ImportError:
                 raise ImportError('Fail to import dependencies for GCP.'
-                                  'See README for how to install it.') from None
+                                'Try pip install "skypilot[gcp]"') from None
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Changes:
- Made message more actionable/descriptive
- (e.g. Fail to import dependencies for Azure. See README for how to install it -> Fail to import dependencies for Azure. Try pip install "skypilot[azure]")