### PR TITLE
Fix `using_file_mounts` to use `readlink -e`

### DIFF
--- a/examples/using_file_mounts.yaml
+++ b/examples/using_file_mounts.yaml
@@ -120,4 +120,4 @@ run: |
   # Symlinks should be copied, but they will be broken
   # Assumes symlink named circle-link in /tmp/workdir (created by test_smoke.py)
   ls /tmp/workdir/circle-link
-  ! readlink -f /tmp/workdir/circle-link
+  ! readlink -e /tmp/workdir/circle-link


### PR DESCRIPTION
[Issue and fix identified thanks to excellent debugging by @Michaelvll]

Our `using_file_mounts` test fails at `readlink -e /tmp/workdir/circle-link` when the test is run as user `ubuntu`. This is because `readlink -f` tests for the existence of all but the last component in the symlink target (i.e., `/home/ubuntu` should exist, existence of `/home/ubuntu/tmp-workdir` does not matter). When the test is run as ubuntu user, `readlink -f` passes because `/home/ubuntu` exists on the new VM.

A simple fix is to change it to `readlink -e`, which checks for the existence of all components, including the last one.

Tested:
- [x] `test_file_mounts` smoke test run from a `sky cpunode` with username `ubuntu`