### PR TITLE
Add shell completion support for CLI

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -160,10 +160,11 @@ Enabling shell completion
 SkyPilot supports shell completion for Bash (Version 4.4 and up), Zsh and Fish.
 
 To enable shell completion after installing SkyPilot, you will need to modify your shell configuration.
-SkyPilot automates this process using the :code:`--install-shell-completion` option, which you should call using the appropriate shell name:
+SkyPilot automates this process using the :code:`--install-shell-completion` option, which you should call using the appropriate shell name or :code:`auto`:
 
 .. code-block:: console
 
-  $ sky --install-shell-completion zsh
+  $ sky --install-shell-completion auto
+  $ # sky --install-shell-completion zsh
   $ # sky --install-shell-completion bash
   $ # sky --install-shell-completion fish

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -151,3 +151,19 @@ Finally, you can stop the container with:
 .. code-block:: console
 
   $ docker stop sky
+
+.. _shell-completion:
+
+Enabling shell completion
+-------------------------
+
+SkyPilot supports shell completion for Bash (Version 4.4 and up), Zsh and Fish.
+
+To enable shell completion after installing SkyPilot, you will need to modify your shell configuration.
+SkyPilot automates this process using the :code:`--install-shell-completion` option, which you should call using the appropriate shell name:
+
+.. code-block:: console
+
+  $ sky --install-shell-completion zsh
+  $ # sky --install-shell-completion bash
+  $ # sky --install-shell-completion fish

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -169,7 +169,8 @@ SkyPilot automates this process using the :code:`--install-shell-completion` opt
   $ # sky --install-shell-completion bash
   $ # sky --install-shell-completion fish
 
-To disable shell completion after it has been installed, you can use the :code:`--uninstall-shell-completion` option, which you should similarly call using the appropriate shell name or :code:`auto`:
+Shell completion may perform poorly on certain shells and machines.
+If you experience any issues after installation, you can use the :code:`--uninstall-shell-completion` option to uninstall it, which you should similarly call using the appropriate shell name or :code:`auto`:
 
 .. code-block:: console
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -168,3 +168,12 @@ SkyPilot automates this process using the :code:`--install-shell-completion` opt
   $ # sky --install-shell-completion zsh
   $ # sky --install-shell-completion bash
   $ # sky --install-shell-completion fish
+
+To disable shell completion after it has been installed, you can use the :code:`--uninstall-shell-completion` option, which you should similarly call using the appropriate shell name or :code:`auto`:
+
+.. code-block:: console
+
+  $ sky --uninstall-shell-completion auto
+  $ # sky --uninstall-shell-completion zsh
+  $ # sky --uninstall-shell-completion bash
+  $ # sky --uninstall-shell-completion fish

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -361,8 +361,8 @@ def _complete_file_name(ctx: click.Context, param: click.Parameter,
                         incomplete: str) -> List[str]:
     """Handle shell completion for file names.
 
-    Returns a special completion marker that tells the click
-    to use the default shell file path completions.
+    Returns a special completion marker that tells click to use
+    the shell's default file completion.
     """
     del ctx, param  # Unused.
     return [click.shell_completion.CompletionItem(incomplete, type='file')]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -358,27 +358,30 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         return
 
     if value == 'bash':
-        cmd = '_SKY_COMPLETE=bash_source sky > ~/.sky-complete.bash &&'
-        cmd += 'echo "# For SkyPilot shell completion" >> ~/.bashrc &&'
-        cmd += 'echo ". ~/.sky-complete.bash\n" >> ~/.bashrc'
+        cmd = '_SKY_COMPLETE=bash_source sky > ~/.sky-complete.bash && \
+                echo "# For SkyPilot shell completion" >> ~/.bashrc && \
+                echo ". ~/.sky-complete.bash\n" >> ~/.bashrc'
+
     elif value == 'fish':
-        cmd = '_SKY_COMPLETE=fish_source sky > ~/.config/fish/completions/sky.fish'
+        cmd = '_SKY_COMPLETE=fish_source sky > \
+                ~/.config/fish/completions/sky.fish'
+
     elif value == 'zsh':
-        cmd = '_SKY_COMPLETE=zsh_source sky > ~/.sky-complete.zsh &&'
-        cmd += 'echo "# For SkyPilot shell completion" >> ~/.zshrc &&'
-        cmd += 'echo ". ~/.sky-complete.zsh\n" >> ~/.zshrc'
+        cmd = '_SKY_COMPLETE=zsh_source sky > ~/.sky-complete.zsh && \
+                echo "# For SkyPilot shell completion" >> ~/.zshrc && \
+                echo ". ~/.sky-complete.zsh\n" >> ~/.zshrc'
+
     else:
-        click.secho(f"Unsupported shell: {value}", fg="yellow")
+        click.secho(f'Unsupported shell: {value}', fg='yellow')
         ctx.exit()
 
-    click.secho(f"> {cmd}", fg="cyan")
     try:
         subprocess.run(cmd, shell=True, check=True)
-        click.secho(f"Shell completion installed for {value}", fg="green")
-        click.echo("Completion will take effect once you restart the terminal")
+        click.secho(f'Shell completion installed for {value}', fg='green')
+        click.echo('Completion will take effect once you restart the terminal')
     except subprocess.CalledProcessError as e:
-        click.secho(f"> Installation failed with code {e.returncode}",
-                    fg="yellow")
+        click.secho(f'> Installation failed with code {e.returncode}',
+                    fg='yellow')
     ctx.exit()
 
 
@@ -828,7 +831,7 @@ class _DocumentedCodeCommand(click.Command):
 
 @click.group(cls=_NaturalOrderGroup, context_settings=_CONTEXT_SETTINGS)
 @click.option('--install-shell-completion',
-              type=click.Choice(["bash", "zsh", "fish"]),
+              type=click.Choice(['bash', 'zsh', 'fish']),
               callback=_install_shell_completion,
               expose_value=False,
               is_eager=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -351,7 +351,7 @@ def _complete_cluster_name(ctx: click.Context, param: click.Parameter,
 
 
 def _install_shell_completion(ctx: click.Context, param: click.Parameter,
-                              value: Any):
+                              value: str):
     """A callback for installing shell completion for click."""
     del param  # Unused.
     if not value or ctx.resilient_parsing:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -350,6 +350,13 @@ def _complete_cluster_name(ctx: click.Context, param: click.Parameter,
     return global_user_state.get_cluster_names(incomplete)
 
 
+def _complete_storage_name(ctx: click.Context, param: click.Parameter,
+                           incomplete: str) -> List[str]:
+    """Handle shell completion for storage names."""
+    del ctx, param  # Unused.
+    return global_user_state.get_storage_names(incomplete)
+
+
 def _install_shell_completion(ctx: click.Context, param: click.Parameter,
                               value: str):
     """A callback for installing shell completion for click."""
@@ -2186,7 +2193,11 @@ def storage_ls():
 
 
 @storage.command('delete', cls=_DocumentedCodeCommand)
-@click.argument('names', required=False, type=str, nargs=-1)
+@click.argument('names',
+                required=False,
+                type=str,
+                nargs=-1,
+                shell_complete=_complete_storage_name)
 @click.option('--all',
               '-a',
               default=False,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -384,7 +384,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         if 'SHELL' not in os.environ:
             click.secho(
                 'Cannot auto-detect shell. Please specify shell explicitly.',
-                fg='yellow')
+                fg='red')
             ctx.exit()
         else:
             value = os.path.basename(os.environ['SHELL'])
@@ -415,7 +415,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         reload_cmd = _RELOAD_ZSH_CMD
 
     else:
-        click.secho(f'Unsupported shell: {value}', fg='yellow')
+        click.secho(f'Unsupported shell: {value}', fg='red')
         ctx.exit()
 
     try:
@@ -425,8 +425,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
             'Completion will take effect once you restart the terminal: ' +
             click.style(f'{reload_cmd}', bold=True))
     except subprocess.CalledProcessError as e:
-        click.secho(f'> Installation failed with code {e.returncode}',
-                    fg='yellow')
+        click.secho(f'> Installation failed with code {e.returncode}', fg='red')
     ctx.exit()
 
 
@@ -441,7 +440,7 @@ def _uninstall_shell_completion(ctx: click.Context, param: click.Parameter,
         if 'SHELL' not in os.environ:
             click.secho(
                 'Cannot auto-detect shell. Please specify shell explicitly.',
-                fg='yellow')
+                fg='red')
             ctx.exit()
         else:
             value = os.path.basename(os.environ['SHELL'])
@@ -465,7 +464,7 @@ def _uninstall_shell_completion(ctx: click.Context, param: click.Parameter,
         reload_cmd = _RELOAD_ZSH_CMD
 
     else:
-        click.secho(f'Unsupported shell: {value}', fg='yellow')
+        click.secho(f'Unsupported shell: {value}', fg='red')
         ctx.exit()
 
     try:
@@ -475,7 +474,7 @@ def _uninstall_shell_completion(ctx: click.Context, param: click.Parameter,
                    click.style(f'{reload_cmd}', bold=True))
     except subprocess.CalledProcessError as e:
         click.secho(f'> Uninstallation failed with code {e.returncode}',
-                    fg='yellow')
+                    fg='red')
     ctx.exit()
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -847,6 +847,7 @@ def cli():
               '-c',
               default=None,
               type=str,
+              shell_complete=_complete_cluster_name,
               help=_CLUSTER_FLAG_HELP)
 @click.option('--dryrun',
               default=False,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -407,7 +407,6 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         click.secho(f'Unsupported shell: {value}', fg='yellow')
         ctx.exit()
 
-    click.secho(cmd)
     try:
         subprocess.run(cmd, shell=True, check=True)
         click.secho(f'Shell completion installed for {value}', fg='green')
@@ -444,7 +443,7 @@ def _uninstall_shell_completion(ctx: click.Context, param: click.Parameter,
         reload_cmd = _RELOAD_BASH_CMD
 
     elif value == 'fish':
-        cmd = 'rm ~/.config/fish/completions/sky.fish'
+        cmd = 'rm -f ~/.config/fish/completions/sky.fish'
         reload_cmd = _RELOAD_FISH_CMD
 
     elif value == 'zsh':

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -359,12 +359,13 @@ def _complete_storage_name(ctx: click.Context, param: click.Parameter,
 
 def _complete_file_name(ctx: click.Context, param: click.Parameter,
                         incomplete: str) -> List[str]:
-    """Handle shell completion for file names in the current directory."""
+    """Handle shell completion for file names.
+
+    Returns a special completion marker that tells the click
+    to use the default shell file path completions.
+    """
     del ctx, param  # Unused.
-    return [
-        file_name for file_name in os.listdir('.')
-        if os.path.isfile(file_name) and file_name.startswith(incomplete)
-    ]
+    return [click.shell_completion.CompletionItem(incomplete, type='file')]
 
 
 _RELOAD_ZSH_CMD = 'source ~/.zshrc'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -357,6 +357,16 @@ def _complete_storage_name(ctx: click.Context, param: click.Parameter,
     return global_user_state.get_storage_names(incomplete)
 
 
+def _complete_file_name(ctx: click.Context, param: click.Parameter,
+                        incomplete: str) -> List[str]:
+    """Handle shell completion for file names in the current directory."""
+    del ctx, param  # Unused.
+    return [
+        file_name for file_name in os.listdir('.')
+        if os.path.isfile(file_name) and file_name.startswith(incomplete)
+    ]
+
+
 _RELOAD_ZSH_CMD = 'source ~/.zshrc'
 _RELOAD_FISH_CMD = 'source ~/.config/fish/config.fish'
 _RELOAD_BASH_CMD = 'source ~/.bashrc'
@@ -931,7 +941,11 @@ def cli():
 
 
 @cli.command(cls=_DocumentedCodeCommand)
-@click.argument('entrypoint', required=True, type=str, nargs=-1)
+@click.argument('entrypoint',
+                required=True,
+                type=str,
+                nargs=-1,
+                shell_complete=_complete_file_name)
 @click.option('--cluster',
               '-c',
               default=None,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -369,6 +369,15 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
     if not value or ctx.resilient_parsing:
         return
 
+    if value == 'auto':
+        if 'SHELL' not in os.environ:
+            click.secho(
+                'Cannot auto-detect shell. Please specify shell explicitly.',
+                fg='yellow')
+            ctx.exit()
+        else:
+            value = os.path.basename(os.environ['SHELL'])
+
     zshrc_diff = '# For SkyPilot shell completion\n. ~/.sky/.sky-complete.zsh'
     bashrc_diff = '# For SkyPilot shell completion\n. ~/.sky/.sky-complete.bash'
 
@@ -417,6 +426,15 @@ def _uninstall_shell_completion(ctx: click.Context, param: click.Parameter,
     del param  # Unused.
     if not value or ctx.resilient_parsing:
         return
+
+    if value == 'auto':
+        if 'SHELL' not in os.environ:
+            click.secho(
+                'Cannot auto-detect shell. Please specify shell explicitly.',
+                fg='yellow')
+            ctx.exit()
+        else:
+            value = os.path.basename(os.environ['SHELL'])
 
     if value == 'bash':
         cmd = 'sed -i"" -e "/# For SkyPilot shell completion/d" ~/.bashrc && \
@@ -897,13 +915,13 @@ class _DocumentedCodeCommand(click.Command):
 
 @click.group(cls=_NaturalOrderGroup, context_settings=_CONTEXT_SETTINGS)
 @click.option('--install-shell-completion',
-              type=click.Choice(['bash', 'zsh', 'fish']),
+              type=click.Choice(['bash', 'zsh', 'fish', 'auto']),
               callback=_install_shell_completion,
               expose_value=False,
               is_eager=True,
               help='Install shell completion for the specified shell.')
 @click.option('--uninstall-shell-completion',
-              type=click.Choice(['bash', 'zsh', 'fish']),
+              type=click.Choice(['bash', 'zsh', 'fish', 'auto']),
               callback=_uninstall_shell_completion,
               expose_value=False,
               is_eager=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -347,14 +347,14 @@ def _complete_cluster_name(ctx: click.Context, param: click.Parameter,
                            incomplete: str) -> List[str]:
     """Handle shell completion for cluster names."""
     del ctx, param  # Unused.
-    return global_user_state.get_cluster_names(incomplete)
+    return global_user_state.get_cluster_names_start_with(incomplete)
 
 
 def _complete_storage_name(ctx: click.Context, param: click.Parameter,
                            incomplete: str) -> List[str]:
     """Handle shell completion for storage names."""
     del ctx, param  # Unused.
-    return global_user_state.get_storage_names(incomplete)
+    return global_user_state.get_storage_names_start_with(incomplete)
 
 
 def _complete_file_name(ctx: click.Context, param: click.Parameter,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -280,13 +280,9 @@ def get_clusters() -> List[Dict[str, Any]]:
     return records
 
 
-def get_cluster_names(starts_with: Optional[str]) -> List[str]:
-    if starts_with:
-        rows = _DB.cursor.execute(
-            'SELECT name FROM clusters WHERE name LIKE (?)',
-            (f'{starts_with}%',))
-    else:
-        rows = _DB.cursor.execute('SELECT name FROM clusters')
+def get_cluster_names(starts_with: str) -> List[str]:
+    rows = _DB.cursor.execute('SELECT name FROM clusters WHERE name LIKE (?)',
+                              (f'{starts_with}%',))
     return [row[0] for row in rows]
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -374,6 +374,12 @@ def get_glob_storage_name(storage_name: str) -> List[str]:
     return [row[0] for row in rows]
 
 
+def get_storage_names(starts_with: str) -> List[str]:
+    rows = _DB.cursor.execute('SELECT name FROM storage WHERE name LIKE (?)',
+                              (f'{starts_with}%',))
+    return [row[0] for row in rows]
+
+
 def get_storage() -> List[Dict[str, Any]]:
     rows = _DB.cursor.execute('select * from storage')
     records = []

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -280,7 +280,7 @@ def get_clusters() -> List[Dict[str, Any]]:
     return records
 
 
-def get_cluster_names(starts_with: str) -> List[str]:
+def get_cluster_names_start_with(starts_with: str) -> List[str]:
     rows = _DB.cursor.execute('SELECT name FROM clusters WHERE name LIKE (?)',
                               (f'{starts_with}%',))
     return [row[0] for row in rows]
@@ -374,7 +374,7 @@ def get_glob_storage_name(storage_name: str) -> List[str]:
     return [row[0] for row in rows]
 
 
-def get_storage_names(starts_with: str) -> List[str]:
+def get_storage_names_start_with(starts_with: str) -> List[str]:
     rows = _DB.cursor.execute('SELECT name FROM storage WHERE name LIKE (?)',
                               (f'{starts_with}%',))
     return [row[0] for row in rows]

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -280,6 +280,16 @@ def get_clusters() -> List[Dict[str, Any]]:
     return records
 
 
+def get_cluster_names(starts_with: Optional[str]) -> List[str]:
+    if starts_with:
+        rows = _DB.cursor.execute(
+            'SELECT name FROM clusters WHERE name LIKE (?)',
+            (f'{starts_with}%',))
+    else:
+        rows = _DB.cursor.execute('SELECT name FROM clusters')
+    return [row[0] for row in rows]
+
+
 def get_enabled_clouds() -> List[clouds.Cloud]:
     rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
                               (_ENABLED_CLOUDS_KEY,))


### PR DESCRIPTION
This adds support for [shell completion using click](https://click.palletsprojects.com/en/8.1.x/shell-completion/). Under the hood, the CLI runs SQL queries against the local data store to figure out what cluster names can be used to autocomplete the command.

To enable shell completion, the user needs to modify their shell configuration as discussed [here](https://click.palletsprojects.com/en/8.1.x/shell-completion/). To simplify this process, I added a `--install-shell-completion` option to the CLI that automates this process for a specific shell. For example, to enable shell completion for `zsh`, the user will need to run `sky --install-shell-completion zsh` **once** after installing SkyPilot, and this will modify the `~/.zshrc` file accordingly. I've updated the docs to reflect this as well

Closes #887.

Tested:
- [x] bash
- [x] zsh
- [x] fish