### PR TITLE
Fix GCP A100 launch error

### DIFF
--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -400,6 +400,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
                     f'A100:{acc_count} cannot be attached to {instance_type}. '
                     f'Use {a100_instance_type} instead. Please refer to '
                     'https://cloud.google.com/compute/docs/gpus#a100-gpus')
+        return
 
     # Check maximum vCPUs and memory.
     max_cpus, max_memory = _NUM_ACC_TO_MAX_CPU_AND_MEMORY[acc_name][acc_count]


### PR DESCRIPTION
Currently, `sky launch --gpus A100:1 --instance-type a2-highgpu-1g  "gpustat"` raises the error:
```
  File "/Users/woosuk/workspace/sky-proj/skypilot/sky/clouds/service_catalog/gcp_catalog.py", line 405, in check_accelerator_attachable_to_host
    max_cpus, max_memory = _NUM_ACC_TO_MAX_CPU_AND_MEMORY[acc_name][acc_count]
KeyError: 'A100'
```

This is a bug introduced by #989, and this PR fixes it.