### PR TITLE
Change `~/.ssh/config` permissions

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -412,6 +412,7 @@ class SSHConfigHelper(object):
             config = ['\n']
             with open(config_path, 'w') as f:
                 f.writelines(config)
+            os.chmod(config_path, 0o644)
 
         codegen = cls._get_generated_config(sky_autogen_comment, host_name, ip,
                                             username, key_path)


### PR DESCRIPTION
Set `~/.ssh/config` permissions to `644` if newly created by sky so `ray up` does not fail. This fixes #1123.

Tested: `sky launch` on Azure, with and without a `~/.ssh/config` file.