### PR TITLE
Relative cluster yaml

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1446,7 +1446,8 @@ class CloudVmRayBackend(backends.Backend):
                      tpu_delete_script: Optional[str] = None) -> None:
             self._version = self._VERSION
             self.cluster_name = cluster_name
-            self._cluster_yaml = cluster_yaml.replace(os.path.expanduser('~'), '~', 1)
+            self._cluster_yaml = cluster_yaml.replace(os.path.expanduser('~'),
+                                                      '~', 1)
             self.head_ip = head_ip
             self.launched_nodes = launched_nodes
             self.launched_resources = launched_resources

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1432,7 +1432,7 @@ class CloudVmRayBackend(backends.Backend):
         - (optional) Launched resources
         - (optional) If TPU(s) are managed, a path to a deletion script.
         """
-        _VERSION = 1
+        _VERSION = 2
 
         def __init__(self,
                      *,
@@ -1446,7 +1446,7 @@ class CloudVmRayBackend(backends.Backend):
                      tpu_delete_script: Optional[str] = None) -> None:
             self._version = self._VERSION
             self.cluster_name = cluster_name
-            self.cluster_yaml = cluster_yaml
+            self._cluster_yaml = cluster_yaml.replace(os.path.expanduser('~'), '~', 1)
             self.head_ip = head_ip
             self.launched_nodes = launched_nodes
             self.launched_resources = launched_resources
@@ -1530,10 +1530,16 @@ class CloudVmRayBackend(backends.Backend):
             self.launched_resources = self.launched_resources.copy(
                 region=region)
 
+        @property
+        def cluster_yaml(self):
+            return os.path.expanduser(self._cluster_yaml)
+
         def __setstate__(self, state):
             version = state.pop('_version', None)
             if version is None:
                 state.pop('cluster_region', None)
+            elif version < 2:
+                state['_cluster_yaml'] = state.pop('cluster_yaml')
 
             self.__dict__.update(state)
             self._update_cluster_region()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1535,10 +1535,13 @@ class CloudVmRayBackend(backends.Backend):
             return os.path.expanduser(self._cluster_yaml)
 
         def __setstate__(self, state):
+            self._version = self._VERSION
+
             version = state.pop('_version', None)
             if version is None:
+                version = -1
                 state.pop('cluster_region', None)
-            elif version < 2:
+            if version < 2:
                 state['_cluster_yaml'] = state.pop('cluster_yaml')
 
             self.__dict__.update(state)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -23,7 +23,7 @@ def get_user_hash():
     if os.path.exists(_USER_HASH_FILE):
         with open(_USER_HASH_FILE, 'r') as f:
             return f.read()
-    
+
     hash_str = user_and_hostname_hash()
     user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:8]
     with open(_USER_HASH_FILE, 'w') as f:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -13,13 +13,22 @@ import yaml
 
 from sky import sky_logging
 
+_USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
+
 logger = sky_logging.init_logger(__name__)
 
 
 def get_user_hash():
     """Returns a unique user-machine specific hash as a user id."""
+    if os.path.exists(_USER_HASH_FILE):
+        with open(_USER_HASH_FILE, 'r') as f:
+            return f.read()
+    
     hash_str = user_and_hostname_hash()
-    return hashlib.md5(hash_str.encode()).hexdigest()[:8]
+    user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:8]
+    with open(_USER_HASH_FILE, 'w') as f:
+        f.write(user_hash)
+    return user_hash
 
 
 class Backoff:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -26,6 +26,7 @@ def get_user_hash():
 
     hash_str = user_and_hostname_hash()
     user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:8]
+    os.path.makedirs(os.path.dirname(_USER_HASH_FILE), exist_ok=True)
     with open(_USER_HASH_FILE, 'w') as f:
         f.write(user_hash)
     return user_hash

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -26,7 +26,7 @@ def get_user_hash():
 
     hash_str = user_and_hostname_hash()
     user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:8]
-    os.path.makedirs(os.path.dirname(_USER_HASH_FILE), exist_ok=True)
+    os.makedirs(os.path.dirname(_USER_HASH_FILE), exist_ok=True)
     with open(_USER_HASH_FILE, 'w') as f:
         f.write(user_hash)
     return user_hash


### PR DESCRIPTION
Closes #1138.

Since this is also requested by @lhqing to share the `~/.sky` folder across different devices, we may want to have this PR to unblock the issue. This PR replaces the path for the cluster yaml to the relative path as suggested by @concretevitamin in https://github.com/skypilot-org/skypilot/issues/1138#issuecomment-1241083339

Tested:
- [x] `sky start existing-cluster`; `sky stop existing-cluster`; `sky down existing-cluster`
- [x] `sky launch --cloud gcp ''`; `sky launch -c test-zhwu --cloud gcp ''`; `scp ~/.sky test-zhwu:~/.sky`; `ssh test-zhwu`; `sky down sky-ea57-zhwu -y`; `sky status`