### PR TITLE
Fail early when spot cluster name too long occurs on GCP

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1831,9 +1831,9 @@ def check_cluster_name_is_valid(cluster_name: str,
         if len(cluster_name) > _MAX_CLUSTER_NAME_LEN_FOR_GCP:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'Cluster name {cluster_name!r} has {len(cluster_name)}'
-                    f' chars; maximum length is {_MAX_CLUSTER_NAME_LEN_FOR_GCP}'
-                    ' chars.')
+                    f'ClusterNameTooLong: Cluster name {cluster_name!r} has '
+                    f'{len(cluster_name)} chars; maximum length is '
+                    f'{_MAX_CLUSTER_NAME_LEN_FOR_GCP} chars.')
 
 
 def check_cluster_name_not_reserved(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1822,7 +1822,7 @@ def check_cluster_name_is_valid(cluster_name: str,
     valid_regex = '[a-z]([-a-z0-9]{0,61}[a-z0-9])?'
     if re.fullmatch(valid_regex, cluster_name) is None:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(
+            raise exceptions.InvalidClusterNameError(
                 f'Cluster name "{cluster_name}" is invalid; '
                 f'ensure it is fully matched by regex: {valid_regex}')
     if isinstance(cloud, clouds.GCP):
@@ -1830,7 +1830,7 @@ def check_cluster_name_is_valid(cluster_name: str,
         # clouds.
         if len(cluster_name) > _MAX_CLUSTER_NAME_LEN_FOR_GCP:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
+                raise exceptions.InvalidClusterNameError(
                     f'ClusterNameTooLong: Cluster name {cluster_name!r} has '
                     f'{len(cluster_name)} chars; maximum length is '
                     f'{_MAX_CLUSTER_NAME_LEN_FOR_GCP} chars.')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1831,9 +1831,9 @@ def check_cluster_name_is_valid(cluster_name: str,
         if len(cluster_name) > _MAX_CLUSTER_NAME_LEN_FOR_GCP:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.InvalidClusterNameError(
-                    f'ClusterNameTooLong: Cluster name {cluster_name!r} has '
-                    f'{len(cluster_name)} chars; maximum length is '
-                    f'{_MAX_CLUSTER_NAME_LEN_FOR_GCP} chars.')
+                    f'Cluster name {cluster_name!r} has {len(cluster_name)} '
+                    f'chars; maximum length is {_MAX_CLUSTER_NAME_LEN_FOR_GCP} '
+                    'chars.')
 
 
 def check_cluster_name_not_reserved(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1353,8 +1353,7 @@ class RetryingVmProvisioner(object):
                         cluster_name, to_provision.cloud)
                 except exceptions.InvalidClusterNameError as e:
                     # Let failover below handle this (i.e., block this cloud).
-                    raise exceptions.ResourcesUnavailableError(
-                        str(e)) from e
+                    raise exceptions.ResourcesUnavailableError(str(e)) from e
                 config_dict = self._retry_region_zones(
                     to_provision,
                     num_nodes,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1351,10 +1351,10 @@ class RetryingVmProvisioner(object):
                     # change the cloud assignment.
                     backend_utils.check_cluster_name_is_valid(
                         cluster_name, to_provision.cloud)
-                except ValueError as value_error:
+                except exceptions.InvalidClusterNameError as e:
                     # Let failover below handle this (i.e., block this cloud).
                     raise exceptions.ResourcesUnavailableError(
-                        str(value_error)) from value_error
+                        str(e)) from e
                 config_dict = self._retry_region_zones(
                     to_provision,
                     num_nodes,

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -128,6 +128,7 @@ class SpotUserCancelledError(Exception):
     """Raised when a spot user cancels the job."""
     pass
 
+
 class InvalidClusterNameError(Exception):
     """Raised when the cluster name is invalid."""
     pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -127,3 +127,7 @@ class ClusterStatusFetchingError(Exception):
 class SpotUserCancelledError(Exception):
     """Raised when a spot user cancels the job."""
     pass
+
+class InvalidClusterNameError(Exception):
+    """Raised when the cluster name is invalid."""
+    pass

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -165,9 +165,8 @@ class StrategyExecutor:
                         'ClusterNameTooLong: ' in str(e)):
                     # The cluster name is too long.
                     raise exceptions.ResourcesUnavailableError(str(e)) from e
-                logger.info(
-                    f'Failed to launch the spot cluster with error: {type(e)}: {e}'
-                )
+                logger.info('Failed to launch the spot cluster with error: '
+                            f'{type(e)}: {e}')
                 retry_launch = True
                 exception = e
 

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -161,8 +161,11 @@ class StrategyExecutor:
             except Exception as e:  # pylint: disable=broad-except
                 # If the launch fails, it will be recovered by the following
                 # code.
+                if isinstance(e, ValueError) and 'ClusterNameTooLong: ' in str(e):
+                    # The cluster name is too long. 
+                    raise exceptions.ResourcesUnavailableError(str(e)) from e
                 logger.info(
-                    f'Failed to launch the spot cluster with error: {e}')
+                    f'Failed to launch the spot cluster with error: {type(e)}: {e}')
                 retry_launch = True
                 exception = e
 

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -158,13 +158,12 @@ class StrategyExecutor:
                            cluster_name=self.cluster_name,
                            detach_run=True)
                 logger.info('Spot cluster launched.')
+            except exceptions.InvalidClusterNameError as e:
+                # The cluster name is too long.
+                raise exceptions.ResourcesUnavailableError(str(e)) from e
             except Exception as e:  # pylint: disable=broad-except
                 # If the launch fails, it will be recovered by the following
                 # code.
-                if (isinstance(e, ValueError) and
-                        'ClusterNameTooLong: ' in str(e)):
-                    # The cluster name is too long.
-                    raise exceptions.ResourcesUnavailableError(str(e)) from e
                 logger.info('Failed to launch the spot cluster with error: '
                             f'{type(e)}: {e}')
                 retry_launch = True

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -161,11 +161,13 @@ class StrategyExecutor:
             except Exception as e:  # pylint: disable=broad-except
                 # If the launch fails, it will be recovered by the following
                 # code.
-                if isinstance(e, ValueError) and 'ClusterNameTooLong: ' in str(e):
-                    # The cluster name is too long. 
+                if (isinstance(e, ValueError) and
+                        'ClusterNameTooLong: ' in str(e)):
+                    # The cluster name is too long.
                     raise exceptions.ResourcesUnavailableError(str(e)) from e
                 logger.info(
-                    f'Failed to launch the spot cluster with error: {type(e)}: {e}')
+                    f'Failed to launch the spot cluster with error: {type(e)}: {e}'
+                )
                 retry_launch = True
                 exception = e
 


### PR DESCRIPTION
Fixes #1178 

Tested:
- [x] `sky spot launch -n i-am-a-very-long-name-too-make-it-fail --cloud gcp 'sleep 10'`
- [x] `sky spot launch -n i-am-a-very-long-name-too-make-it-fail --cloud gcp 'sleep 10' --retry-until-up`