### PR TITLE
Add --no-setup option to sky launch to allow for remounting of files without having to go through setup instructions again

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -604,6 +604,7 @@ def _launch_with_confirm(
     no_confirm: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
     retry_until_up: bool = False,
+    no_setup: bool = False,
     node_type: Optional[str] = None,
     is_local_cloud: Optional[bool] = False,
 ):
@@ -651,7 +652,8 @@ def _launch_with_confirm(
                    detach_run=detach_run,
                    backend=backend,
                    idle_minutes_to_autostop=idle_minutes_to_autostop,
-                   retry_until_up=retry_until_up)
+                   retry_until_up=retry_until_up,
+                   no_setup=no_setup,)
 
 
 # TODO: skip installing ray to speed up provisioning.
@@ -1002,6 +1004,12 @@ def cli():
               default=False,
               required=False,
               help='Skip confirmation prompt.')
+@click.option('--no-setup',
+              '-n',
+              is_flag=True,
+              default=False,
+              required=False,
+              help='Skip setup phase when re-launching cluster.')
 @usage_lib.entrypoint
 def launch(
     entrypoint: str,
@@ -1024,6 +1032,7 @@ def launch(
     idle_minutes_to_autostop: Optional[int],
     retry_until_up: bool,
     yes: bool,
+    no_setup: bool,
 ):
     """Launch a task from a YAML or a command (rerun setup if cluster exists).
 
@@ -1072,6 +1081,7 @@ def launch(
         no_confirm=yes,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
         retry_until_up=retry_until_up,
+        no_setup=no_setup,
         is_local_cloud=onprem_utils.check_if_local_cloud(cluster))
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1011,7 +1011,7 @@ def cli():
               is_flag=True,
               default=False,
               required=False,
-              help='Skip setup phase when re-launching cluster.')
+              help='Skip setup phase when (re)-launching cluster.')
 @usage_lib.entrypoint
 def launch(
     entrypoint: str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -645,15 +645,17 @@ def _launch_with_confirm(
 
     if node_type is None or maybe_status != global_user_state.ClusterStatus.UP:
         # No need to sky.launch again when interactive node is already up.
-        sky.launch(dag,
-                   dryrun=dryrun,
-                   stream_logs=True,
-                   cluster_name=cluster,
-                   detach_run=detach_run,
-                   backend=backend,
-                   idle_minutes_to_autostop=idle_minutes_to_autostop,
-                   retry_until_up=retry_until_up,
-                   no_setup=no_setup,)
+        sky.launch(
+            dag,
+            dryrun=dryrun,
+            stream_logs=True,
+            cluster_name=cluster,
+            detach_run=detach_run,
+            backend=backend,
+            idle_minutes_to_autostop=idle_minutes_to_autostop,
+            retry_until_up=retry_until_up,
+            no_setup=no_setup,
+        )
 
 
 # TODO: skip installing ray to speed up provisioning.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1011,7 +1011,7 @@ def cli():
               is_flag=True,
               default=False,
               required=False,
-              help='Skip setup phase when (re)-launching cluster.')
+              help='Skip setup phase when (re-)launching cluster.')
 @usage_lib.entrypoint
 def launch(
     entrypoint: str,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -135,6 +135,7 @@ def _execute(
       detach_run: bool; whether to detach the process after the job submitted.
       autostop_idle_minutes: int; if provided, the cluster will be set to
         autostop after this many minutes of idleness.
+      no_setup: bool; whether to skip setup commands or not when (re)-launching.
     """
     _type_check_dag(dag)
     assert len(dag) == 1, f'We support 1 task for now. {dag}'
@@ -203,9 +204,8 @@ def _execute(
                                      task.storage_mounts)
 
         if no_setup:
-            logger.info('Setup instructions skipped.')
-
-        if not no_setup and (stages is None or Stage.SETUP in stages):
+            logger.info('Setup commands skipped.')
+        elif stages is None or Stage.SETUP in stages:
             backend.setup(handle, task)
 
         if stages is None or Stage.PRE_EXEC in stages:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -105,6 +105,7 @@ def _execute(
     cluster_name: Optional[str] = None,
     detach_run: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
+    no_setup: bool = False,
 ) -> None:
     """Runs a DAG.
 
@@ -192,6 +193,7 @@ def _execute(
         if dryrun:
             logger.info('Dry run finished.')
             return
+        
 
         if stages is None or Stage.SYNC_WORKDIR in stages:
             if task.workdir is not None:
@@ -201,7 +203,10 @@ def _execute(
             backend.sync_file_mounts(handle, task.file_mounts,
                                      task.storage_mounts)
 
-        if stages is None or Stage.SETUP in stages:
+        if no_setup:
+            logger.info('Setup instructions skipped.')
+
+        if not no_setup and (stages is None or Stage.SETUP in stages):
             backend.setup(handle, task)
 
         if stages is None or Stage.PRE_EXEC in stages:
@@ -251,6 +256,7 @@ def launch(
     backend: Optional[backends.Backend] = None,
     optimize_target: OptimizeTarget = OptimizeTarget.COST,
     detach_run: bool = False,
+    no_setup: bool = False,
 ):
     """Launch a sky.DAG (rerun setup if cluster exists).
 
@@ -262,6 +268,7 @@ def launch(
             up.
         idle_minutes_to_autostop: if provided, the cluster will be auto-stop
             after this many minutes of idleness.
+        no_setup: if true, the cluster will not re-run setup instructions
 
     Examples:
         >>> import sky
@@ -290,6 +297,7 @@ def launch(
         cluster_name=cluster_name,
         detach_run=detach_run,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
+        no_setup=no_setup,
     )
 
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -193,7 +193,6 @@ def _execute(
         if dryrun:
             logger.info('Dry run finished.')
             return
-        
 
         if stages is None or Stage.SYNC_WORKDIR in stages:
             if task.workdir is not None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -135,7 +135,7 @@ def _execute(
       detach_run: bool; whether to detach the process after the job submitted.
       autostop_idle_minutes: int; if provided, the cluster will be set to
         autostop after this many minutes of idleness.
-      no_setup: bool; whether to skip setup commands or not when (re)-launching.
+      no_setup: bool; whether to skip setup commands or not when (re-)launching.
     """
     _type_check_dag(dag)
     assert len(dag) == 1, f'We support 1 task for now. {dag}'


### PR DESCRIPTION
Added --no-setup to sky launch in cli.py and propagated changes to _execute in execution.py. If --no-setup flag is set, then backend.setup() call is skipped and logger informs user that setup was skipped. Did simple testing by attempting to relaunch a stopped cluster using the --no-setup flag. Meant to address issue #1157.