### PR TITLE
GCP: make `sky check` enable the 3 required APIs & optional TPU API.

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -4,13 +4,17 @@ import functools
 import hashlib
 import os
 import pathlib
+import re
 import subprocess
+import sys
 import time
 import uuid
 
+import colorama
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
+import googleapiclient
 
 from sky import clouds
 from sky import sky_logging
@@ -19,8 +23,7 @@ from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
-logger = sky_logging.init_logger(__name__)
-
+colorama.init()
 logger = sky_logging.init_logger(__name__)
 
 # TODO: Should tolerate if gcloud is not installed. Also,
@@ -195,7 +198,37 @@ def setup_gcp_authentication(config):
                         credentials=None,
                         cache_discovery=False)
     user = config['auth']['ssh_user']
-    project = compute.projects().get(project=project_id).execute()
+
+    try:
+        project = compute.projects().get(project=project_id).execute()
+    except googleapiclient.errors.HttpError as e:
+        # Can happen for a new project where Compute Engine API is disabled.
+        # Ex:
+        # 'Compute Engine API has not been used in project 123456 before
+        # or it is disabled. Enable it by visiting
+        # https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=123456
+        # then retry. If you enabled this API recently, wait a few minutes for
+        # the action to propagate to our systems and retry.'
+        if ' API has not been used in project' in e.reason:
+            match = re.fullmatch('(.+)(https://.*project=\d+) (.+)', e.reason)
+            if match is None:
+                raise  # This should not happen.
+            yellow = colorama.Fore.YELLOW
+            reset = colorama.Style.RESET_ALL
+            bright = colorama.Style.BRIGHT
+            dim = colorama.Style.DIM
+            logger.error(
+                f'{yellow}Certain GCP APIs are disabled for the GCP project '
+                f'{project_id}.{reset}')
+            logger.error(f'{yellow}Enable them by running:{reset} '
+                         f'{bright}sky check{reset}')
+            logger.error('Details:')
+            logger.error(f'{dim}{match.group(1)}{reset}\n'
+                         f'{dim}    {match.group(2)}{reset}\n'
+                         f'{dim}{match.group(3)}{reset}')
+            sys.exit(1)
+        else:
+            raise
 
     project_oslogin = next(
         (item for item in project['commonInstanceMetadata'].get('items', [])

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -203,7 +203,8 @@ def setup_gcp_authentication(config):
         project = compute.projects().get(project=project_id).execute()
     except googleapiclient.errors.HttpError as e:
         # Can happen for a new project where Compute Engine API is disabled.
-        # Ex:
+        #
+        # Example message:
         # 'Compute Engine API has not been used in project 123456 before
         # or it is disabled. Enable it by visiting
         # https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=123456

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -210,7 +210,7 @@ def setup_gcp_authentication(config):
         # then retry. If you enabled this API recently, wait a few minutes for
         # the action to propagate to our systems and retry.'
         if ' API has not been used in project' in e.reason:
-            match = re.fullmatch('(.+)(https://.*project=\d+) (.+)', e.reason)
+            match = re.fullmatch(r'(.+)(https://.*project=\d+) (.+)', e.reason)
             if match is None:
                 raise  # This should not happen.
             yellow = colorama.Fore.YELLOW

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -65,6 +65,7 @@ def _run_output(cmd):
 def is_api_disabled(endpoint: str, project_id: str) -> bool:
     proc = subprocess.run((f'gcloud services list --project {project_id} '
                            f' | grep {endpoint}.googleapis.com'),
+                          check=False,
                           shell=True,
                           stderr=subprocess.PIPE,
                           stdout=subprocess.PIPE)
@@ -379,6 +380,7 @@ class GCP(clouds.Cloud):
                 proc = subprocess.run(
                     f'gcloud services enable {endpoint}.googleapis.com '
                     f'--project {project_id}',
+                    check=False,
                     shell=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT)

--- a/sky/templates/gcp-tpu-create.sh.j2
+++ b/sky/templates/gcp-tpu-create.sh.j2
@@ -3,7 +3,10 @@ export PROJECT_ID={{gcp_project_id}}
 
 gcloud config set project $PROJECT_ID
 
-gcloud compute tpus create {{tpu_name}} \
+# NOTE: we pipe yes to this command, as users who have not enabled the TPU API
+# can hit this call and get stuck forever in:
+#  API [tpu.googleapis.com] not enabled on project [123456]. Would you like to enable and retry (this will take a few minutes)? (y/N)?
+yes | gcloud compute tpus create {{tpu_name}} \
 --zone={{zones}} \
 --version={{runtime_version}} \
 --accelerator-type={{tpu_type}}


### PR DESCRIPTION
Fixes #1019 by making `sky check` automatically enable the 3 required APIs & optional TPU API.

Tested:

Create a new project on GCP console.

Run `gcloud init` to choose the new project. Run `gcloud auth application-default login`.

`sky cpunode --cloud gcp` would trigger a hint:

<img width="1257" alt="Screen Shot 2022-10-04 at 18 15 38" src="https://user-images.githubusercontent.com/592670/193959616-173208fd-b3f1-462e-8520-9c5381465ca8.png">

First run

```
» sky check                                                                              
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled
  Azure: enabled
  Checking GCP...
Enabling Compute Engine API (may take a minute)...
Done. Took 54.8 secs.

Enabling Cloud Resource Manager API...
Done. Took 1.8 secs.

Enabling Identity and Access Management (IAM) API...
Done. Took 4.2 secs.
Hint: Enabled GCP API(s) may take a few minutes to take effect. If any SkyPilot commands/calls failed, retry after some time.
  GCP: enabled

SkyPilot will use only the enabled clouds to run tasks. To change this, configure cloud credentials, and run sky check.
```

At this point, after a few minutes `sky cpunode --cloud gcp -c dbg -y` succeeds.

Second run

```
» sky check
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled
  Azure: enabled
  GCP: enabled

SkyPilot will use only the enabled clouds to run tasks. To change this, configure cloud credentials, and run sky check.
```


If we disabled the APIs (`gcloud services disable compute.googleapis.com cloudresourcemanager.googleapis.com iam.googleapis.com`) just a few seconds a go, `sky check` would correctly show an error (due to GCP error) and keep GCP as disabled:

```
» sky check                                                                               
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled
  Azure: enabled
  Checking GCP...
Enabling Compute Engine API (may take a minutes)...
Failed; please manually enable the API. Log:
ERROR: (gcloud.services.enable) The operation "operations/acf.p2-1059686784451-81d94d84-7747-4115-84c3-9d9b2ee49c89" resulted in a failure "[Error in service 'compute.googleapis.com': The service is currently being deactivated and deactivation must complete before activation can occur.
Help Token: AWzfkCOcwCQn6uEAOnI6vTCyA_X0NHZTLZaeW0q52SKVF5u5WH-WPmn-6IuTHB1pL6-7wxM84Noij7OEP2SXhM-grw1HwfW_QwUfd1QXzDPr-7TU] with failed services [compute.googleapis.com]".
Details: "[<DetailsValueListEntry
 additionalProperties: [<AdditionalProperty
 key: '@type'
 value: <JsonValue
 string_value: 'type.googleapis.com/google.rpc.PreconditionFailure'>>, <AdditionalProperty
 key: 'violations'
 value: <JsonValue
 array_value: <JsonArray
 entries: [<JsonValue
 object_value: <JsonObject
 properties: [<Property
 key: 'type'
 value: <JsonValue
 string_value: 'googleapis.com'>>, <Property
 key: 'subject'
 value: <JsonValue
 string_value: '160008'>>]>>]>>>]>]".

  GCP: disabled
    Reason: Compute Engine API is disabled. Please retry `sky check` in a few minutes, or manually enable it.

SkyPilot will use only the enabled clouds to run tasks. To change this, configure cloud credentials, and run sky check.
```



