### PR TITLE
Add all region option in catalog fetcher and speed up azure fetcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/build/
 docs/_build/
 build/
 sky_logs/
+sky/clouds/service_catalog/data_fetchers/*.csv

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -239,7 +239,8 @@ class GCP(clouds.Cloud):
                     # A100-80GB has a different name pattern.
                     resources_vars['gpu'] = 'nvidia-{}'.format(acc.lower())
                 else:
-                    resources_vars['gpu'] = 'nvidia-tesla-{}'.format(acc.lower())
+                    resources_vars['gpu'] = 'nvidia-tesla-{}'.format(
+                        acc.lower())
                 resources_vars['gpu_count'] = acc_count
                 if acc == 'K80':
                     # CUDA driver version 470.57.02, CUDA Library 11.4

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -235,7 +235,11 @@ class GCP(clouds.Cloud):
             else:
                 # Convert to GCP names:
                 # https://cloud.google.com/compute/docs/gpus
-                resources_vars['gpu'] = 'nvidia-tesla-{}'.format(acc.lower())
+                if acc == 'A100-80GB':
+                    # A100-80GB has a different name pattern.
+                    resources_vars['gpu'] = 'nvidia-{}'.format(acc.lower())
+                else:
+                    resources_vars['gpu'] = 'nvidia-tesla-{}'.format(acc.lower())
                 resources_vars['gpu_count'] = acc_count
                 if acc == 'K80':
                     # CUDA driver version 470.57.02, CUDA Library 11.4

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -68,7 +68,7 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def get_gen_version_from_instance_type(instance_type: str) -> Optional[int]:
-    return _df[_df['InstanceType'] == instance_type]['Generation']
+    return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
 
 
 def list_accelerators(gpus_only: bool,

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -3,6 +3,7 @@
 This module loads the service catalog file and can be used to query
 instance types and pricing information for Azure.
 """
+import ast
 from typing import Dict, List, Optional, Tuple
 
 from sky.clouds import cloud
@@ -67,7 +68,17 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def get_gen_version_from_instance_type(instance_type: str) -> Optional[int]:
-    return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
+    if 'Generation' in _df.columns:
+        return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
+    
+    # Backward compatibility for the older catalog.
+    cell = _df[_df['InstanceType'] == instance_type]['capabilities'].iloc[0]
+    cap_list = ast.literal_eval(cell)
+    gen_version = None
+    for cap in cap_list:
+        if cap['name'] == 'HyperVGenerations':
+            gen_version = cap['value']
+    return gen_version
 
 
 def list_accelerators(gpus_only: bool,

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -70,7 +70,7 @@ def get_region_zones_for_instance_type(instance_type: str,
 def get_gen_version_from_instance_type(instance_type: str) -> Optional[int]:
     if 'Generation' in _df.columns:
         return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
-    
+
     # Backward compatibility for the older catalog.
     cell = _df[_df['InstanceType'] == instance_type]['capabilities'].iloc[0]
     cap_list = ast.literal_eval(cell)

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -3,7 +3,6 @@
 This module loads the service catalog file and can be used to query
 instance types and pricing information for Azure.
 """
-import ast
 from typing import Dict, List, Optional, Tuple
 
 from sky.clouds import cloud

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -68,13 +68,7 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def get_gen_version_from_instance_type(instance_type: str) -> Optional[int]:
-    cell = _df[_df['InstanceType'] == instance_type]['capabilities'].iloc[0]
-    cap_list = ast.literal_eval(cell)
-    gen_version = None
-    for cap in cap_list:
-        if cap['name'] == 'HyperVGenerations':
-            gen_version = cap['value']
-    return gen_version
+    return _df[_df['InstanceType'] == instance_type]['Generation']
 
 
 def list_accelerators(gpus_only: bool,

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -3,7 +3,6 @@
 This module loads the service catalog file and can be used to query
 instance types and pricing information for Azure.
 """
-import ast
 from typing import Dict, List, Optional, Tuple
 
 from sky.clouds import cloud
@@ -68,17 +67,7 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def get_gen_version_from_instance_type(instance_type: str) -> Optional[int]:
-    if 'Generation' in _df.columns:
-        return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
-
-    # Backward compatibility for the older catalog.
-    cell = _df[_df['InstanceType'] == instance_type]['capabilities'].iloc[0]
-    cap_list = ast.literal_eval(cell)
-    gen_version = None
-    for cap in cap_list:
-        if cap['name'] == 'HyperVGenerations':
-            gen_version = cap['value']
-    return gen_version
+    return _df[_df['InstanceType'] == instance_type]['Generation'].iloc[0]
 
 
 def list_accelerators(gpus_only: bool,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -237,7 +237,7 @@ def list_accelerators_impl(
     instance types offered by this cloud.
     """
     if gpus_only:
-        df = df[~pd.isna(df['GpuInfo'])]
+        df = df[~pd.isna(df['AcceleratorName'])]
     df = df[[
         'InstanceType',
         'AcceleratorName',

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -237,7 +237,7 @@ def list_accelerators_impl(
     instance types offered by this cloud.
     """
     if gpus_only:
-        df = df[~pd.isna(df['AcceleratorName'])]
+        df = df[~pd.isna(df['GpuInfo'])]
     df = df[[
         'InstanceType',
         'AcceleratorName',

--- a/sky/clouds/service_catalog/constants.py
+++ b/sky/clouds/service_catalog/constants.py
@@ -2,5 +2,5 @@
 import os
 
 HOSTED_CATALOG_DIR_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/catalogs'  # pylint: disable=line-too-long
-CATALOG_SCHEMA_VERSION = 'v2'
+CATALOG_SCHEMA_VERSION = 'v3'
 LOCAL_CATALOG_DIR = os.path.expanduser('~/.sky/catalogs/')

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -1,0 +1,47 @@
+import copy
+from typing import Tuple
+import pandas as pd
+
+from sky.clouds.service_catalog import common
+
+
+def resource_diff(original_df: pd.DataFrame, new_df: pd.DataFrame, check_tuple: Tuple[str]) -> pd.DataFrame:
+    """Returns the difference between two dataframes."""
+    original_resources = original_df[check_tuple]
+    new_resources = new_df[check_tuple]
+    
+    return new_resources.merge(original_resources, on=check_tuple, how='left', indicator=True)[lambda x: x['_merge'] == 'left_only'].sort_values(by=check_tuple)
+    
+
+CLOUD_CHECKS = {
+    'aws': ['InstanceType', 'Region', 'AvailabilityZone'],
+    'azure': ['InstanceType', 'Region'],
+    'gcp': ['InstanceType', 'Region', 'AcceleratorName', 'AcceleratorCount']}
+
+
+
+for cloud in CLOUD_CHECKS:
+    print(f'=> Checking {cloud}')
+    original_df = common.read_catalog(f'{cloud}.csv')
+    new_df = pd.read_csv(f'{cloud}.csv')
+
+    current_check_tuple = CLOUD_CHECKS[cloud]
+    
+    diff_df = resource_diff(original_df, new_df, current_check_tuple)
+    diff_df.merge(new_df, on=current_check_tuple, how='left').to_csv(f'{cloud}_diff.csv', index=False)
+    print(f'New resources in {cloud}: {len(diff_df)}')
+
+    check_price = current_check_tuple + ['Price']
+    diff_df = resource_diff(original_df, new_df, check_price)
+    print(f'New prices in {cloud}: {len(diff_df)}')
+
+    check_price = current_check_tuple + ['SpotPrice']
+    diff_df = resource_diff(original_df, new_df, check_price)
+    print(f'New spot prices in {cloud}: {len(diff_df)}')
+
+
+
+
+
+
+

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -5,19 +5,23 @@ import pandas as pd
 from sky.clouds.service_catalog import common
 
 
-def resource_diff(original_df: pd.DataFrame, new_df: pd.DataFrame, check_tuple: Tuple[str]) -> pd.DataFrame:
+def resource_diff(original_df: pd.DataFrame, new_df: pd.DataFrame,
+                  check_tuple: Tuple[str]) -> pd.DataFrame:
     """Returns the difference between two dataframes."""
     original_resources = original_df[check_tuple]
     new_resources = new_df[check_tuple]
-    
-    return new_resources.merge(original_resources, on=check_tuple, how='left', indicator=True)[lambda x: x['_merge'] == 'left_only'].sort_values(by=check_tuple)
-    
+
+    return new_resources.merge(
+        original_resources, on=check_tuple, how='left',
+        indicator=True)[lambda x: x['_merge'] == 'left_only'].sort_values(
+            by=check_tuple)
+
 
 CLOUD_CHECKS = {
     'aws': ['InstanceType', 'Region', 'AvailabilityZone'],
     'azure': ['InstanceType', 'Region'],
-    'gcp': ['InstanceType', 'Region', 'AcceleratorName', 'AcceleratorCount']}
-
+    'gcp': ['InstanceType', 'Region', 'AcceleratorName', 'AcceleratorCount']
+}
 
 table = {}
 
@@ -28,9 +32,10 @@ for cloud in CLOUD_CHECKS:
     new_df = pd.read_csv(f'{cloud}.csv')
 
     current_check_tuple = CLOUD_CHECKS[cloud]
-    
+
     diff_df = resource_diff(original_df, new_df, current_check_tuple)
-    diff_df.merge(new_df, on=current_check_tuple, how='left').to_csv(f'{cloud}_diff.csv', index=False)
+    diff_df.merge(new_df, on=current_check_tuple,
+                  how='left').to_csv(f'{cloud}_diff.csv', index=False)
 
     result['#resources'] = len(diff_df)
 
@@ -47,10 +52,3 @@ for cloud in CLOUD_CHECKS:
 summary = pd.DataFrame(table).T
 summary.to_csv('diff_summary.csv')
 print(summary)
-
-
-
-
-
-
-

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -19,8 +19,10 @@ CLOUD_CHECKS = {
     'gcp': ['InstanceType', 'Region', 'AcceleratorName', 'AcceleratorCount']}
 
 
+table = {}
 
 for cloud in CLOUD_CHECKS:
+    result = {}
     print(f'=> Checking {cloud}')
     original_df = common.read_catalog(f'{cloud}.csv')
     new_df = pd.read_csv(f'{cloud}.csv')
@@ -29,15 +31,22 @@ for cloud in CLOUD_CHECKS:
     
     diff_df = resource_diff(original_df, new_df, current_check_tuple)
     diff_df.merge(new_df, on=current_check_tuple, how='left').to_csv(f'{cloud}_diff.csv', index=False)
-    print(f'New resources in {cloud}: {len(diff_df)}')
+
+    result['#resources'] = len(diff_df)
 
     check_price = current_check_tuple + ['Price']
     diff_df = resource_diff(original_df, new_df, check_price)
-    print(f'New prices in {cloud}: {len(diff_df)}')
+    result['#prices'] = len(diff_df)
 
     check_price = current_check_tuple + ['SpotPrice']
     diff_df = resource_diff(original_df, new_df, check_price)
-    print(f'New spot prices in {cloud}: {len(diff_df)}')
+    result['#spot_prices'] = len(diff_df)
+
+    table[cloud] = result
+
+summary = pd.DataFrame(table).T
+summary.to_csv('diff_summary.csv')
+print(summary)
 
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -167,7 +167,7 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
         # patch the GpuInfo for p4de.24xlarge
-        df[df['InstanceType'] == 'p4de.24xlarge']['GpuInfo'] = 'A100-80GB'
+        df.loc[df['InstanceType'] == 'p4de.24xlarge', 'GpuInfo'] = 'A100-80GB'
     except Exception as e:
         print(f'{region} failed with {e}')
         return region

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -166,7 +166,8 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = pd.concat(
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
-        df['GpuInfo'].fillna(df['AcceleratorName'], inplace=True)
+        # patch the GpuInfo for p4de.24xlarge
+        df[df['InstanceType'] == 'p4de.24xlarge']['GpuInfo'] = 'A100-80GB'
     except Exception as e:
         print(f'{region} failed with {e}')
         return region

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -160,6 +160,7 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = pd.concat(
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
+        df['GPUInfo'].fillna(df['AcceleratorName'], inplace=True)
     except Exception as e:
         print(f'{region} failed with {e}')
         return region

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -121,8 +121,8 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         def get_acc_info(row) -> Tuple[str, float]:
             accelerator = None
             for col, info_key in [('GpuInfo', 'Gpus'),
-                                ('InferenceAcceleratorInfo', 'Accelerators'),
-                                ('FpgaInfo', 'Fpgas')]:
+                                  ('InferenceAcceleratorInfo', 'Accelerators'),
+                                  ('FpgaInfo', 'Fpgas')]:
                 info = row.get(col)
                 if isinstance(info, dict):
                     accelerator = info[info_key][0]
@@ -153,8 +153,9 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
 
         df['Region'] = region
         df = df.merge(pd.DataFrame(zone_df), how='cross')
-        df = pd.concat([df, df.apply(get_additional_columns, axis='columns')],
-                    axis='columns')
+        df = pd.concat(
+            [df, df.apply(get_additional_columns, axis='columns')],
+            axis='columns')
     except Exception as e:
         print(f'{region} failed with {e}')
         return region
@@ -169,7 +170,7 @@ def get_all_regions_instance_types_df():
             print(f'{df} failed')
         else:
             new_dfs.append(df)
-        
+
     df = pd.concat(new_dfs)
     df.sort_values(['InstanceType', 'Region'], inplace=True)
     return df

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -40,7 +40,7 @@ REGIONS = US_REGIONS
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region'
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone'
 ]
 
 # NOTE: the hard-coded us-east-1 URL is not a typo. AWS pricing endpoint is

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -38,6 +38,11 @@ US_REGIONS = ['us-east-1', 'us-east-2', 'us-west-1', 'us-west-2']
 
 REGIONS = US_REGIONS
 
+USEFUL_COLUMNS = [
+    'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
+    'GpuInfo', 'Price', 'SpotPrice', 'Region'
+]
+
 # NOTE: the hard-coded us-east-1 URL is not a typo. AWS pricing endpoint is
 # only available in this region, but it serves pricing information for all regions.
 PRICING_TABLE_URL_FMT = 'https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/{region}/index.csv'
@@ -168,6 +173,7 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
             axis='columns')
         # patch the GpuInfo for p4de.24xlarge
         df.loc[df['InstanceType'] == 'p4de.24xlarge', 'GpuInfo'] = 'A100-80GB'
+        df = df[USEFUL_COLUMNS]
     except Exception as e:
         print(f'{region} failed with {e}')
         return region

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -160,7 +160,7 @@ def get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = pd.concat(
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
-        df['GPUInfo'].fillna(df['AcceleratorName'], inplace=True)
+        df['GpuInfo'].fillna(df['AcceleratorName'], inplace=True)
     except Exception as e:
         print(f'{region} failed with {e}')
         return region

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -72,7 +72,7 @@ def get_pricing_table(region: str) -> pd.DataFrame:
     df = pd.read_csv(url, skiprows=5, low_memory=False)
     df.rename(columns={
         'Instance Type': 'InstanceType',
-        'PricePerUnit': 'Price'
+        'PricePerUnit': 'Price',
     },
               inplace=True)
     return df[(df['TermType'] == 'OnDemand') &

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -40,7 +40,10 @@ REGION_SET = set(REGIONS)
 # We have to manually remove it.
 DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
-USEFULE_COLUMNS = ['InstanceType','AcceleratorName','AcceleratorCount','vCPUs','MemoryGiB','GpuInfo','Price','SpotPrice','Region','AvailabilityZone']
+USEFULE_COLUMNS = [
+    'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone'
+]
 
 
 def get_pricing_url(region: Optional[str] = None) -> str:
@@ -156,13 +159,21 @@ def get_all_regions_instance_types_df():
     df.drop_duplicates(inplace=True)
 
     df = df[df['unitPrice'] > 0]
-    
+
     print('Getting price df')
-    df['merge_name'] = df['armSkuName'] 
+    df['merge_name'] = df['armSkuName']
     df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
-    df.rename(columns={'armSkuName': 'InstanceType', 'armRegionName': 'Region'}, inplace=True)
-    demand_df = df[~df['skuName'].str.contains(' Spot')][['is_promo', 'InstanceType', 'Region', 'unitPrice']]
-    spot_df = df[df['skuName'].str.contains(' Spot')][['is_promo', 'InstanceType', 'Region', 'unitPrice']]
+    df.rename(columns={
+        'armSkuName': 'InstanceType',
+        'armRegionName': 'Region'
+    },
+              inplace=True)
+    demand_df = df[~df['skuName'].str.contains(' Spot')][[
+        'is_promo', 'InstanceType', 'Region', 'unitPrice'
+    ]]
+    spot_df = df[df['skuName'].str.contains(' Spot')][[
+        'is_promo', 'InstanceType', 'Region', 'unitPrice'
+    ]]
     demand_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
     spot_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
 
@@ -175,10 +186,12 @@ def get_all_regions_instance_types_df():
     df_sku['merge_name'] = df_sku['InstanceType'].str.replace('_Promo', '')
 
     print('Joining')
-    df = df_sku.join(demand_df, on=['merge_name', 'Region', 'is_promo'], how='left')
+    df = df_sku.join(demand_df,
+                     on=['merge_name', 'Region', 'is_promo'],
+                     how='left')
     df = df.join(spot_df, on=['merge_name', 'Region', 'is_promo'], how='left')
-    # df.dropna(subset=['Price', 'SpotPrice'], inplace=True, how='all')
 
+    # df.dropna(subset=['Price', 'SpotPrice'], inplace=True, how='all')
 
     def get_capabilities(row):
         gpu_name = None
@@ -214,7 +227,9 @@ def get_all_regions_instance_types_df():
     )
 
     before_drop_len = len(df_ret)
-    df_ret.dropna(subset=['InstanceType', 'AvailabilityZone'], inplace=True, how='all')
+    df_ret.dropna(subset=['InstanceType', 'AvailabilityZone'],
+                  inplace=True,
+                  how='all')
     after_drop_len = len(df_ret)
     print('Dropped {} duplicated rows'.format(before_drop_len - after_drop_len))
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -25,6 +25,7 @@ US_REGIONS = [
     # 'WestUS3',   # WestUS3 pricing table is broken as of 2021/11.
 ]
 
+# To enable all the regions, uncomment the following line.
 # def get_regions() -> Tuple[str]:
 #     """Get all available regions."""
 #     proc = subprocess.run('az account list-locations  --query "[?not_null(metadata.latitude)] .{RegionName:name , RegionDisplayName:regionalDisplayName}" -o json', shell=True, check=True, stdout=subprocess.PIPE)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -212,7 +212,8 @@ def get_all_regions_instance_types_df():
         return gpu_name, gpu_count, vcpus, memory_gb, gen_version
 
     def get_additional_columns(row):
-        gpu_name, gpu_count, vcpus, memory_gb, gen_version = get_capabilities(row)
+        gpu_name, gpu_count, vcpus, memory_gb, gen_version = get_capabilities(
+            row)
         return pd.Series({
             'AcceleratorName': gpu_name,
             'AcceleratorCount': gpu_count,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -42,7 +42,7 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone', 'Generation',
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation',
     'capabilities'
 ]
 
@@ -102,23 +102,14 @@ def get_sku_df() -> pd.DataFrame:
     )
     print(f'Done fetching SKUs')
     items = json.loads(proc.stdout.decode('ascii'))
-    new_items = []
     for item in items:
-        zones = item['locationInfo'][0]['zones']
+        # zones = item['locationInfo'][0]['zones']
         region = item['locations'][0]
         if region not in REGION_SET:
             continue
-        if len(zones) == 0:
-            # The default zone is '0'.
-            zones = ['0']
+        item['Region'] = region
 
-        for zone in zones:
-            new_item = item.copy()
-            new_item['Region'] = region
-            new_item['AvailabilityZone'] = f'{region}-{zone}'
-            new_items.append(new_item)
-
-    df = pd.DataFrame(new_items)
+    df = pd.DataFrame(items)
     df = df[(df['resourceType'] == 'virtualMachines')]
     return df
 
@@ -229,7 +220,7 @@ def get_all_regions_instance_types_df():
     )
 
     before_drop_len = len(df_ret)
-    df_ret.dropna(subset=['InstanceType', 'AvailabilityZone'],
+    df_ret.dropna(subset=['InstanceType'],
                   inplace=True,
                   how='all')
     after_drop_len = len(df_ret)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -42,7 +42,7 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation', 'capabilities'
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation'
 ]
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -42,8 +42,7 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation',
-    'capabilities'
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation', 'capabilities'
 ]
 
 
@@ -222,9 +221,7 @@ def get_all_regions_instance_types_df():
     )
 
     before_drop_len = len(df_ret)
-    df_ret.dropna(subset=['InstanceType'],
-                  inplace=True,
-                  how='all')
+    df_ret.dropna(subset=['InstanceType'], inplace=True, how='all')
     after_drop_len = len(df_ret)
     print('Dropped {} duplicated rows'.format(before_drop_len - after_drop_len))
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -3,9 +3,8 @@
 This script takes about 1 minute to finish.
 """
 import json
-import os
 import subprocess
-from typing import Optional, Tuple
+from typing import Optional
 import urllib
 
 import numpy as np
@@ -43,7 +42,8 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone', 'Generation'
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone', 'Generation',
+    'capabilities'
 ]
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -3,6 +3,7 @@
 This script takes about 1 minute to finish.
 """
 import json
+import os
 import subprocess
 from typing import Optional, Tuple
 import urllib
@@ -12,7 +13,7 @@ import pandas as pd
 import ray
 import requests
 
-REGIONS = [
+US_REGIONS = [
     'centralus',
     'eastus',
     'eastus2',
@@ -23,10 +24,23 @@ REGIONS = [
     'westus2',
     # 'WestUS3',   # WestUS3 pricing table is broken as of 2021/11.
 ]
+
+# def get_regions() -> Tuple[str]:
+#     """Get all available regions."""
+#     proc = subprocess.run('az account list-locations  --query "[?not_null(metadata.latitude)] .{RegionName:name , RegionDisplayName:regionalDisplayName}" -o json', shell=True, check=True, stdout=subprocess.PIPE)
+#     items = json.loads(proc.stdout.decode('utf-8'))
+#     regions = [item['RegionName'] for item in items if not item['RegionName'].endswith('stg')]
+#     return tuple(regions)
+# all_regions = get_regions()
+
+# REGIONS = all_regions
+REGIONS = US_REGIONS
 REGION_SET = set(REGIONS)
 # Azure secretly deprecated the M60 family which is still returned by its API.
 # We have to manually remove it.
 DEPRECATED_FAMILIES = ['standardNVSv2Family']
+
+USEFULE_COLUMNS = ['InstanceType','AcceleratorName','AcceleratorCount','vCPUs','MemoryGiB','GpuInfo','Price','SpotPrice','Region','AvailabilityZone']
 
 
 def get_pricing_url(region: Optional[str] = None) -> str:
@@ -61,6 +75,7 @@ def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
         url = content.get('NextPageLink')
     print(f'Done fetching pricing {region}')
     df = pd.DataFrame(all_items)
+    assert 'productName' in df.columns, (region, df.columns)
     return df[(~df['productName'].str.contains(' Windows')) &
               (df['unitPrice'] > 0)]
 
@@ -83,10 +98,27 @@ def get_sku_df() -> pd.DataFrame:
     )
     print(f'Done fetching SKUs')
     items = json.loads(proc.stdout.decode('ascii'))
-    df = pd.DataFrame(items)
+    new_items = []
+    for item in items:
+        zones = item['locationInfo'][0]['zones']
+        region = item['locations'][0]
+        if region not in REGION_SET:
+            continue
+        if len(zones) == 0:
+            new_item = item.copy()
+            new_item['Region'] = region
+            new_item['AvailabilityZone'] = f'{region}-0'
+            new_items.append(new_item)
+
+        for zone in zones:
+            new_item = item.copy()
+            new_item['Region'] = region
+            new_item['AvailabilityZone'] = f'{region}-{zone}'
+            new_items.append(new_item)
+
+    df = pd.DataFrame(new_items)
     df = df[(df['resourceType'] == 'virtualMachines')]
-    df['Region'] = df.apply(lambda row: row['locations'][0], axis='columns')
-    return df[df.apply(lambda row: row['Region'] in REGION_SET, axis='columns')]
+    return df
 
 
 def get_gpu_name(family: str) -> str:
@@ -120,39 +152,33 @@ def get_all_regions_instance_types_df():
         get_all_regions_pricing_df.remote(),
         get_sku_df.remote(),
     ])
-    df.drop_duplicates(inplace=True)
     print(f'Processing dataframes')
+    df.drop_duplicates(inplace=True)
 
-    def get_price(row):
-        is_promo = row['name'].endswith('_Promo')
-        sku = row['name'].replace('_Promo', '')
-        region = row['Region']
-        pricing_rows = df[(df['armSkuName'] == sku) &
-                          (df['armRegionName'] == region) &
-                          (df['unitPrice'] > 0) &
-                          (~df['skuName'].str.contains(' Spot'))]
-        if is_promo:
-            pricing_rows = pricing_rows[pricing_rows['skuName'].str.contains(
-                ' Low Priority')]
-        else:
-            pricing_rows = pricing_rows[~pricing_rows['skuName'].str.
-                                        contains(' Low Priority')]
-        assert len(pricing_rows) <= 1, (sku, pricing_rows)
-        if len(pricing_rows) == 0:
-            return np.nan
-        return pricing_rows.iloc[0]['unitPrice']
+    df = df[df['unitPrice'] > 0]
+    
+    print('Getting price df')
+    df['merge_name'] = df['armSkuName'] 
+    df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
+    df.rename(columns={'armSkuName': 'InstanceType', 'armRegionName': 'Region'}, inplace=True)
+    demand_df = df[~df['skuName'].str.contains(' Spot')][['is_promo', 'InstanceType', 'Region', 'unitPrice']]
+    spot_df = df[df['skuName'].str.contains(' Spot')][['is_promo', 'InstanceType', 'Region', 'unitPrice']]
+    demand_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
+    spot_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
 
-    def get_spot_price(row):
-        sku = row['name']
-        region = row['Region']
-        spot_pricing_rows = df[(df['armSkuName'] == sku) &
-                               (df['armRegionName'] == region) &
-                               (df['unitPrice'] > 0) &
-                               (df['skuName'].str.contains(' Spot'))]
-        assert len(spot_pricing_rows) <= 1, (sku, spot_pricing_rows)
-        if len(spot_pricing_rows) == 0:
-            return np.nan
-        return spot_pricing_rows.iloc[0]['unitPrice']
+    demand_df = demand_df.rename(columns={'unitPrice': 'Price'})
+    spot_df = spot_df.rename(columns={'unitPrice': 'SpotPrice'})
+
+    print('Getting sku df')
+    df_sku['is_promo'] = df_sku['name'].str.endswith('_Promo')
+    df_sku.rename(columns={'name': 'InstanceType'}, inplace=True)
+    df_sku['merge_name'] = df_sku['InstanceType'].str.replace('_Promo', '')
+
+    print('Joining')
+    df = df_sku.join(demand_df, on=['merge_name', 'Region', 'is_promo'], how='left')
+    df = df.join(spot_df, on=['merge_name', 'Region', 'is_promo'], how='left')
+    # df.dropna(subset=['Price', 'SpotPrice'], inplace=True, how='all')
+
 
     def get_capabilities(row):
         gpu_name = None
@@ -161,6 +187,7 @@ def get_all_regions_instance_types_df():
         memory_gb = np.nan
         caps = row['capabilities']
         for item in caps:
+            assert isinstance(item, dict), (item, caps)
             if item['name'] == 'GPUs':
                 gpu_name = get_gpu_name(row['family'])
                 if gpu_name is not None:
@@ -174,8 +201,6 @@ def get_all_regions_instance_types_df():
     def get_additional_columns(row):
         gpu_name, gpu_count, vcpus, memory_gb = get_capabilities(row)
         return pd.Series({
-            'Price': get_price(row),
-            'SpotPrice': get_spot_price(row),
             'AcceleratorName': gpu_name,
             'AcceleratorCount': gpu_count,
             'vCPUs': vcpus,
@@ -184,11 +209,18 @@ def get_all_regions_instance_types_df():
         })
 
     df_ret = pd.concat(
-        [df_sku, df_sku.apply(get_additional_columns, axis='columns')],
+        [df, df.apply(get_additional_columns, axis='columns')],
         axis='columns',
-    ).rename(columns={'name': 'InstanceType'})
+    )
+
+    before_drop_len = len(df_ret)
+    df_ret.dropna(subset=['InstanceType', 'AvailabilityZone'], inplace=True, how='all')
+    after_drop_len = len(df_ret)
+    print('Dropped {} duplicated rows'.format(before_drop_len - after_drop_len))
+
     # Filter out deprecated families
     df_ret = df_ret.loc[~df_ret['family'].isin(DEPRECATED_FAMILIES)]
+    df_ret = df_ret[USEFULE_COLUMNS]
     return df_ret
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -102,14 +102,16 @@ def get_sku_df() -> pd.DataFrame:
     )
     print(f'Done fetching SKUs')
     items = json.loads(proc.stdout.decode('ascii'))
+    filtered_items = []
     for item in items:
         # zones = item['locationInfo'][0]['zones']
         region = item['locations'][0]
         if region not in REGION_SET:
             continue
         item['Region'] = region
+        filtered_items.append(item)
 
-    df = pd.DataFrame(items)
+    df = pd.DataFrame(filtered_items)
     df = df[(df['resourceType'] == 'virtualMachines')]
     return df
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -41,7 +41,7 @@ REGION_SET = set(REGIONS)
 # We have to manually remove it.
 DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
-USEFULE_COLUMNS = [
+USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
     'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone'
 ]
@@ -109,10 +109,8 @@ def get_sku_df() -> pd.DataFrame:
         if region not in REGION_SET:
             continue
         if len(zones) == 0:
-            new_item = item.copy()
-            new_item['Region'] = region
-            new_item['AvailabilityZone'] = f'{region}-0'
-            new_items.append(new_item)
+            # The default zone is '0'.
+            zones = ['0']
 
         for zone in zones:
             new_item = item.copy()
@@ -166,7 +164,7 @@ def get_all_regions_instance_types_df():
     df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
     df.rename(columns={
         'armSkuName': 'InstanceType',
-        'armRegionName': 'Region'
+        'armRegionName': 'Region',
     },
               inplace=True)
     demand_df = df[~df['skuName'].str.contains(' Spot')][[
@@ -191,8 +189,6 @@ def get_all_regions_instance_types_df():
                      on=['merge_name', 'Region', 'is_promo'],
                      how='left')
     df = df.join(spot_df, on=['merge_name', 'Region', 'is_promo'], how='left')
-
-    # df.dropna(subset=['Price', 'SpotPrice'], inplace=True, how='all')
 
     def get_capabilities(row):
         gpu_name = None
@@ -236,7 +232,7 @@ def get_all_regions_instance_types_df():
 
     # Filter out deprecated families
     df_ret = df_ret.loc[~df_ret['family'].isin(DEPRECATED_FAMILIES)]
-    df_ret = df_ret[USEFULE_COLUMNS]
+    df_ret = df_ret[USEFUL_COLUMNS]
     return df_ret
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -43,7 +43,7 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
-    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone'
+    'GpuInfo', 'Price', 'SpotPrice', 'Region', 'AvailabilityZone', 'Generation'
 ]
 
 
@@ -195,6 +195,7 @@ def get_all_regions_instance_types_df():
         gpu_count = np.nan
         vcpus = np.nan
         memory_gb = np.nan
+        gen_version = None
         caps = row['capabilities']
         for item in caps:
             assert isinstance(item, dict), (item, caps)
@@ -206,16 +207,19 @@ def get_all_regions_instance_types_df():
                 vcpus = float(item['value'])
             elif item['name'] == 'MemoryGB':
                 memory_gb = item['value']
-        return gpu_name, gpu_count, vcpus, memory_gb
+            elif item['name'] == 'HyperVGenerations':
+                gen_version = item['value']
+        return gpu_name, gpu_count, vcpus, memory_gb, gen_version
 
     def get_additional_columns(row):
-        gpu_name, gpu_count, vcpus, memory_gb = get_capabilities(row)
+        gpu_name, gpu_count, vcpus, memory_gb, gen_version = get_capabilities(row)
         return pd.Series({
             'AcceleratorName': gpu_name,
             'AcceleratorCount': gpu_count,
             'vCPUs': vcpus,
             'MemoryGiB': memory_gb,
             'GpuInfo': gpu_name,
+            'Generation': gen_version,
         })
 
     df_ret = pd.concat(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -20,6 +20,8 @@ NOT_AVAILABLE_STR = 'Not available in this region'
 ALL_REGION_PREFIX = ''
 US_REGION_PREFIX = 'us-'
 REGION_PREFIX = US_REGION_PREFIX
+# Uncomment the following line to VM pricings from all regions.
+# REGION_PREFIX = ALL_REGION_PREFIX
 
 # Refer to: https://github.com/skypilot-org/skypilot/issues/1006
 UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
@@ -264,7 +266,7 @@ def get_vm_price_table(url):
         df = df[['Item', 'Region', 'Price', 'SpotPrice']]
         item = df['Item'].iloc[0]
         if item == 'Predefined vCPUs':
-            return get_a2_df(df)
+            df = get_a2_df(df)
     return df
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -17,8 +17,12 @@ GCP_GPU_ZONES_URL = 'https://cloud.google.com/compute/docs/gpus/gpu-regions-zone
 
 NOT_AVAILABLE_STR = 'Not available in this region'
 
+ALL_REGION_PREFIX = ''
+US_REGION_PREFIX = 'us-'
+REGION_PREFIX = US_REGION_PREFIX
+
 # Refer to: https://github.com/skypilot-org/skypilot/issues/1006
-UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
+UNSUPPORTED_VMS = ['f1-micro']
 
 # Supported GPU types and counts.
 # NOTE: GCP officially uses 'A100 40GB' and 'A100 80GB' as the names of the
@@ -370,7 +374,7 @@ def get_vm_df():
 
     # Block non-US regions.
     # FIXME(woosuk): Allow all regions.
-    vm_df = vm_df[vm_df['Region'].str.startswith('us-')]
+    vm_df = vm_df[vm_df['Region'].str.startswith(REGION_PREFIX)]
     return vm_df
 
 
@@ -526,7 +530,7 @@ def get_gpu_df():
 
     # Block non-US regions.
     # FIXME(woosuk): Allow all regions.
-    gpu_df = gpu_df[gpu_df['Region'].str.startswith('us-')]
+    gpu_df = gpu_df[gpu_df['Region'].str.startswith(REGION_PREFIX)]
     return gpu_df
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -39,7 +39,6 @@ GPU_TYPES_TO_COUNTS = {
 }
 
 # FIXME(woosuk): This URL can change.
-A2_PRICING_URL = '/compute/vm-instance-pricing_04e9ea153c2ab1ea37254107b92dc081d4459ca9fe9a46ef5b39e5d63353f089.frame'  # pylint: disable=line-too-long
 A2_INSTANCE_TYPES = {
     'a2-highgpu-1g': {
         'vCPUs': 12,
@@ -239,7 +238,7 @@ def get_vm_price_table(url):
     if 'InstanceType' in df.columns:
         # Price table for pre-defined instance types.
         instance_type = df['InstanceType'].iloc[0]
-        if instance_type == 'a2-highgpu-1g':
+        if instance_type in ['a2-highgpu-1g', 'a2-ultragpu-1g']:
             # The A2 price table includes the GPU cost.
             return None
 
@@ -263,6 +262,9 @@ def get_vm_price_table(url):
     else:
         # Others (e.g., per vCPU hour or per GB hour pricing rule table).
         df = df[['Item', 'Region', 'Price', 'SpotPrice']]
+        item = df['Item'].iloc[0]
+        if item == 'Predefined vCPUs':
+            return get_a2_df(df)
     return df
 
 
@@ -298,13 +300,12 @@ def get_vm_zones(url):
     return df
 
 
-def get_a2_df():
-    a2_pricing = get_vm_price_table(GCP_URL + A2_PRICING_URL)
-    cpu_pricing = a2_pricing[a2_pricing['Item'] == 'Predefined vCPUs']
-    memory_pricing = a2_pricing[a2_pricing['Item'] == 'Predefined Memory']
+def get_a2_df(a2_pricing_df):
+    cpu_pricing = a2_pricing_df[a2_pricing_df['Item'] == 'Predefined vCPUs']
+    memory_pricing = a2_pricing_df[a2_pricing_df['Item'] == 'Predefined Memory']
 
     table = []
-    for region in a2_pricing['Region'].unique():
+    for region in a2_pricing_df['Region'].unique():
         per_cpu_price = cpu_pricing[cpu_pricing['Region'] ==
                                     region]['Price'].values[0]
         per_cpu_spot_price = cpu_pricing[cpu_pricing['Region'] ==
@@ -348,9 +349,7 @@ def get_vm_df():
         df for df in vm_dfs if df is not None and 'InstanceType' in df.columns
     ]
 
-    # Handle A2 instance types separately.
-    a2_df = get_a2_df()
-    vm_df = pd.concat(vm_dfs + [a2_df])
+    vm_df = pd.concat(vm_dfs)
 
     vm_zones = get_vm_zones(GCP_VM_ZONES_URL)
     # Remove regions not in the pricing data.

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -22,7 +22,7 @@ US_REGION_PREFIX = 'us-'
 REGION_PREFIX = US_REGION_PREFIX
 
 # Refer to: https://github.com/skypilot-org/skypilot/issues/1006
-UNSUPPORTED_VMS = ['f1-micro']
+UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
 
 # Supported GPU types and counts.
 # NOTE: GCP officially uses 'A100 40GB' and 'A100 80GB' as the names of the

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -3,6 +3,7 @@
 For now this service catalog is manually coded. In the future it should be
 queried from GCP API.
 """
+from collections import defaultdict
 import typing
 from typing import Dict, List, Optional, Tuple
 
@@ -30,12 +31,20 @@ _DEFAULT_HOST_VM_FAMILY = 'n1'
 # TODO(zongheng): fix A100 info directly in catalog.
 # https://cloud.google.com/blog/products/compute/a2-vms-with-nvidia-a100-gpus-are-ga
 # count -> vm type
-_A100_INSTANCE_TYPES = {
+_A100_INSTANCE_TYPE_DICTS = {
+    'A100': {
     1: 'a2-highgpu-1g',
     2: 'a2-highgpu-2g',
     4: 'a2-highgpu-4g',
     8: 'a2-highgpu-8g',
     16: 'a2-megagpu-16g',
+    },
+    'A100-80GB': {
+        1: 'a2-ultragpu-1g',
+    2: 'a2-ultragpu-2g',
+    4: 'a2-ultragpu-4g',
+    8: 'a2-ultragpu-8g',
+    }
 }
 
 # Number of CPU cores per GPU based on the AWS setting.
@@ -167,10 +176,10 @@ def get_instance_type_for_accelerator(
     if instance_list is None:
         return None, fuzzy_candidate_list
 
-    if acc_name == 'A100':
+    if acc_name in _A100_INSTANCE_TYPE_DICTS:
         # If A100 is used, host VM type must be A2.
         # https://cloud.google.com/compute/docs/gpus#a100-gpus
-        return [_A100_INSTANCE_TYPES[acc_count]], []
+        return [_A100_INSTANCE_TYPE_DICTS[acc_name][acc_count]], []
     if acc_name not in _NUM_ACC_TO_NUM_CPU:
         acc_name = 'DEFAULT'
 
@@ -258,17 +267,17 @@ def list_accelerators(
     results = common.list_accelerators_impl('GCP', _df, gpus_only, name_filter,
                                             case_sensitive)
 
-    a100_infos = results.get('A100', None)
-    if a100_infos is None:
+    a100_infos = results.get('A100', []) + results.get('A100-80GB', [])
+    if not a100_infos:
         return results
 
     # Unlike other GPUs that can be attached to different sizes of N1 VMs,
     # A100 GPUs can only be attached to fixed-size A2 VMs.
     # Thus, we can show their exact cost including the host VM prices.
-    new_infos = []
+    new_infos = defaultdict(list)
     for info in a100_infos:
         assert pd.isna(info.instance_type) and pd.isna(info.memory), a100_infos
-        a100_host_vm_type = _A100_INSTANCE_TYPES[info.accelerator_count]
+        a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][info.accelerator_count]
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
         memory = df['MemoryGiB'].iloc[0]
@@ -280,7 +289,7 @@ def list_accelerators(
                                                     a100_host_vm_type,
                                                     None,
                                                     use_spot=True)
-        new_infos.append(
+        new_infos[info.accelerator_name].append(
             info._replace(
                 instance_type=a100_host_vm_type,
                 cpu_count=cpu_count,
@@ -289,7 +298,7 @@ def list_accelerators(
                 price=info.price + vm_price,
                 spot_price=info.spot_price + vm_spot_price,
             ))
-    results['A100'] = new_infos
+    results.update(new_infos)
     return results
 
 
@@ -342,7 +351,7 @@ def check_host_accelerator_compatibility(
         return
 
     # Treat A100 as a special case.
-    if acc_name == 'A100':
+    if acc_name in _A100_INSTANCE_TYPE_DICTS:
         # A100 must be attached to A2 instance type.
         if not instance_type.startswith('a2-'):
             with ux_utils.print_exception_no_traceback():
@@ -382,8 +391,8 @@ def check_accelerator_attachable_to_host(instance_type: str,
         assert instance_type == 'TPU-VM' or instance_type.startswith('n1-')
         return
 
-    if acc_name == 'A100':
-        valid_counts = list(_A100_INSTANCE_TYPES.keys())
+    if acc_name in _A100_INSTANCE_TYPE_DICTS:
+        valid_counts = list(_A100_INSTANCE_TYPE_DICTS[acc_name].keys())
     else:
         valid_counts = list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY[acc_name].keys())
     if acc_count not in valid_counts:
@@ -392,8 +401,8 @@ def check_accelerator_attachable_to_host(instance_type: str,
                 f'{acc_name}:{acc_count} is not launchable on GCP. '
                 f'The valid {acc_name} counts are {valid_counts}.')
 
-    if acc_name == 'A100':
-        a100_instance_type = _A100_INSTANCE_TYPES[acc_count]
+    if acc_name in _A100_INSTANCE_TYPE_DICTS:
+        a100_instance_type = _A100_INSTANCE_TYPE_DICTS[acc_name][acc_count]
         if instance_type != a100_instance_type:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesMismatchError(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -33,17 +33,17 @@ _DEFAULT_HOST_VM_FAMILY = 'n1'
 # count -> vm type
 _A100_INSTANCE_TYPE_DICTS = {
     'A100': {
-    1: 'a2-highgpu-1g',
-    2: 'a2-highgpu-2g',
-    4: 'a2-highgpu-4g',
-    8: 'a2-highgpu-8g',
-    16: 'a2-megagpu-16g',
+        1: 'a2-highgpu-1g',
+        2: 'a2-highgpu-2g',
+        4: 'a2-highgpu-4g',
+        8: 'a2-highgpu-8g',
+        16: 'a2-megagpu-16g',
     },
     'A100-80GB': {
         1: 'a2-ultragpu-1g',
-    2: 'a2-ultragpu-2g',
-    4: 'a2-ultragpu-4g',
-    8: 'a2-ultragpu-8g',
+        2: 'a2-ultragpu-2g',
+        4: 'a2-ultragpu-4g',
+        8: 'a2-ultragpu-8g',
     }
 }
 
@@ -277,7 +277,8 @@ def list_accelerators(
     new_infos = defaultdict(list)
     for info in a100_infos:
         assert pd.isna(info.instance_type) and pd.isna(info.memory), a100_infos
-        a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][info.accelerator_count]
+        a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][
+            info.accelerator_count]
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
         memory = df['MemoryGiB'].iloc[0]

--- a/tests/test_list_accelerators.py
+++ b/tests/test_list_accelerators.py
@@ -6,6 +6,7 @@ def test_list_accelerators():
     assert 'V100' in result, result
     assert 'tpu-v3-8' in result, result
     assert 'Inferentia' not in result, result
+    assert 'A100-80GB' in result, result
 
 
 def test_list_ccelerators_all():
@@ -13,6 +14,7 @@ def test_list_ccelerators_all():
     assert 'V100' in result, result
     assert 'tpu-v3-8' in result, result
     assert 'Inferentia' in result, result
+    assert 'A100-80GB' in result, result
 
 
 def test_list_accelerators_filters():


### PR DESCRIPTION
This PR adopts the changes of the catalog from our private experimental repo. The Azure fetching implementation is significantly faster than (roughly 10x),  by using much more efficient `join` operation instead of the row-wise `apply` method.

It also fixes #1167

This PR also adds `p4de.24xlarge` into the catalog (requested in #1201), but the `ray up` still has some problem launching the cluster.
Just identified the problem that the p4de instance require a signup for an aws account, which could be the reason that `aws ec2 describe-instance-types` cannot find the instance.

The following are the updates in the new catalog
```
       #resources  #prices  #spot_prices
aws           385      407          4486
azure          67       70          2602
gcp           264      489          1381
```

Tested:
- [x] `time ./fetch_aws.py`: 18s
- [x] `time ./fetch_gcp.py`: 19s
- [x] `time ./fetch_azure.py`: 97s
- [x] `sky launch -c test-aws ''`
- [x] `sky launch -c test-gcp --cloud gcp ''`
- [x] `sky launch -c test-azure --cloud azure ''`
- [x] `sky show-gpus`
- [x] `sky show-gpus A100-80GB`