### PR TITLE
Add `--retry-until-up`, `--region`, `--zone`, and `--idle-minutes-to-autostop` for interactive nodes

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -212,7 +212,11 @@ def _interactive_node_cli_command(cli_func):
                                   is_flag=True,
                                   default=False,
                                   required=False,
-                                  help='Retry until up.')
+                                  help=('Whether to retry provisioning '
+                                        'infinitely until the cluster is up '
+                                        'if we fail to launch the cluster on '
+                                        'any possible region/cloud due to '
+                                        'unavailability errors.'))
     region_option = click.option('--region',
                                  default=None,
                                  type=str,
@@ -228,8 +232,15 @@ def _interactive_node_cli_command(cli_func):
                                  default=None,
                                  type=int,
                                  required=False,
-                                 help=('Automatically stop the cluster after'
-                                       'this many minutes of idleness.'))
+                                 help=('Automatically stop the cluster after '
+                                       'this many minutes of idleness, i.e. '
+                                       'no running or pending jobs in the '
+                                       'cluster\'s job queue. Idleness starts '
+                                       'counting after setup/file_mounts are '
+                                       'done; the clock gets reset whenever '
+                                       'there are running/pending jobs in the '
+                                       'job queue. If not set, the cluster '
+                                       'will not be auto-stopped.'))
 
     click_decorators = [
         cli.command(cls=_DocumentedCodeCommand),
@@ -710,9 +721,14 @@ def _create_and_ssh_into_node(
         session_manager: Attach session manager: { 'screen', 'tmux' }.
         user_requested_resources: If true, user requested resources explicitly.
         no_confirm: If true, skips confirmation prompt presented to user.
-        idle_minutes_to_autostop: Automatically stop the cluster after this
-                                  many minutes of idleness.
-        retry_until_up: Retry until up when true.
+        idle_minutes_to_autostop: Automatically stop the cluster after
+                                  specified minutes of idleness. Idleness
+                                  starts counting after setup/file_mounts are
+                                  done; the clock gets reset whenever there
+                                  are running/pending jobs in the job queue.
+        retry_until_up: Whether to retry provisioning infinitely until the
+                        cluster is up if we fail to launch due to
+                        unavailability errors.
     """
     assert node_type in _INTERACTIVE_NODE_TYPES, node_type
     assert session_manager in (None, 'screen', 'tmux'), session_manager

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -213,6 +213,10 @@ def _interactive_node_cli_command(cli_func):
                                   default=False,
                                   required=False,
                                   help='Retry until up.')
+    region_option = click.option('--region',
+                                 default=None,
+                                 type=str,
+                                 help='The region to use.')
 
     click_decorators = [
         cli.command(cls=_DocumentedCodeCommand),
@@ -222,6 +226,7 @@ def _interactive_node_cli_command(cli_func):
 
         # Resource options
         *([cloud_option] if cli_func.__name__ != 'tpunode' else []),
+        region_option,
         instance_type_option,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
@@ -1967,10 +1972,11 @@ def _terminate_or_stop_clusters(
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            cloud: Optional[str], instance_type: Optional[str],
-            gpus: Optional[str], use_spot: Optional[bool],
-            screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], retry_until_up: bool):
+            cloud: Optional[str], region: Optional[str],
+            instance_type: Optional[str], gpus: Optional[str],
+            use_spot: Optional[bool], screen: Optional[bool],
+            tmux: Optional[bool], disk_size: Optional[int],
+            retry_until_up: bool):
     """Launch or attach to an interactive GPU node.
 
     Examples:
@@ -2018,6 +2024,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
     if use_spot is None:
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=cloud_provider,
+                              region=region,
                               instance_type=instance_type,
                               accelerators=gpus,
                               use_spot=use_spot,
@@ -2039,10 +2046,10 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            cloud: Optional[str], instance_type: Optional[str],
-            use_spot: Optional[bool], screen: Optional[bool],
-            tmux: Optional[bool], disk_size: Optional[int],
-            retry_until_up: bool):
+            cloud: Optional[str], region: Optional[str],
+            instance_type: Optional[str], use_spot: Optional[bool],
+            screen: Optional[bool], tmux: Optional[bool],
+            disk_size: Optional[int], retry_until_up: bool):
     """Launch or attach to an interactive CPU node.
 
     Examples:
@@ -2087,6 +2094,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
     if use_spot is None:
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=cloud_provider,
+                              region=region,
                               instance_type=instance_type,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2107,10 +2115,11 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            instance_type: Optional[str], tpus: Optional[str],
-            use_spot: Optional[bool], tpu_vm: Optional[bool],
-            screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], retry_until_up: bool):
+            region: Optional[str], instance_type: Optional[str],
+            tpus: Optional[str], use_spot: Optional[bool],
+            tpu_vm: Optional[bool], screen: Optional[bool],
+            tmux: Optional[bool], disk_size: Optional[int],
+            retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
 
     Examples:
@@ -2160,6 +2169,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
     if use_spot is None:
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=sky.GCP(),
+                              region=region,
                               instance_type=instance_type,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -207,6 +207,20 @@ def _interactive_node_cli_command(cli_func):
                               default=False,
                               required=False,
                               help='Skip confirmation prompt.')
+    idle_autostop = click.option('--idle-minutes-to-autostop',
+                                 '-i',
+                                 default=None,
+                                 type=int,
+                                 required=False,
+                                 help=('Automatically stop the cluster after '
+                                       'this many minutes of idleness, i.e. '
+                                       'no running or pending jobs in the '
+                                       'cluster\'s job queue. Idleness starts '
+                                       'counting after setup/file_mounts are '
+                                       'done; the clock gets reset whenever '
+                                       'there are running/pending jobs in the '
+                                       'job queue. If not set, the cluster '
+                                       'will not be auto-stopped.'))
     retry_until_up = click.option('--retry-until-up',
                                   '-r',
                                   is_flag=True,
@@ -227,20 +241,6 @@ def _interactive_node_cli_command(cli_func):
                                type=str,
                                required=False,
                                help='The zone to use.')
-    idle_autostop = click.option('--idle-minutes-to-autostop',
-                                 '-i',
-                                 default=None,
-                                 type=int,
-                                 required=False,
-                                 help=('Automatically stop the cluster after '
-                                       'this many minutes of idleness, i.e. '
-                                       'no running or pending jobs in the '
-                                       'cluster\'s job queue. Idleness starts '
-                                       'counting after setup/file_mounts are '
-                                       'done; the clock gets reset whenever '
-                                       'there are running/pending jobs in the '
-                                       'job queue. If not set, the cluster '
-                                       'will not be auto-stopped.'))
 
     click_decorators = [
         cli.command(cls=_DocumentedCodeCommand),

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -207,6 +207,12 @@ def _interactive_node_cli_command(cli_func):
                               default=False,
                               required=False,
                               help='Skip confirmation prompt.')
+    retry_until_up = click.option('--retry-until-up',
+                                  '-r',
+                                  is_flag=True,
+                                  default=False,
+                                  required=False,
+                                  help='Retry until up.')
 
     click_decorators = [
         cli.command(cls=_DocumentedCodeCommand),
@@ -226,6 +232,7 @@ def _interactive_node_cli_command(cli_func):
         screen_option,
         tmux_option,
         disk_size,
+        retry_until_up,
     ]
     decorator = functools.reduce(lambda res, f: f(res),
                                  reversed(click_decorators), cli_func)
@@ -669,6 +676,7 @@ def _create_and_ssh_into_node(
     session_manager: Optional[str] = None,
     user_requested_resources: Optional[bool] = False,
     no_confirm: bool = False,
+    retry_until_up: bool = False,
 ):
     """Creates and attaches to an interactive node.
 
@@ -681,6 +689,7 @@ def _create_and_ssh_into_node(
         session_manager: Attach session manager: { 'screen', 'tmux' }.
         user_requested_resources: If true, user requested resources explicitly.
         no_confirm: If true, skips confirmation prompt presented to user.
+        retry_until_up: Retry until up when true.
     """
     assert node_type in _INTERACTIVE_NODE_TYPES, node_type
     assert session_manager in (None, 'screen', 'tmux'), session_manager
@@ -719,6 +728,7 @@ def _create_and_ssh_into_node(
         dryrun=False,
         detach_run=True,
         no_confirm=no_confirm,
+        retry_until_up=retry_until_up,
         node_type=node_type,
     )
     handle = global_user_state.get_handle_from_cluster_name(cluster_name)
@@ -1960,7 +1970,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], instance_type: Optional[str],
             gpus: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int]):
+            disk_size: Optional[int], retry_until_up: bool):
     """Launch or attach to an interactive GPU node.
 
     Examples:
@@ -2021,6 +2031,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         session_manager=session_manager,
         user_requested_resources=user_requested_resources,
         no_confirm=yes,
+        retry_until_up=retry_until_up,
     )
 
 
@@ -2030,7 +2041,8 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], instance_type: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
-            tmux: Optional[bool], disk_size: Optional[int]):
+            tmux: Optional[bool], disk_size: Optional[int],
+            retry_until_up: bool):
     """Launch or attach to an interactive CPU node.
 
     Examples:
@@ -2087,6 +2099,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         session_manager=session_manager,
         user_requested_resources=user_requested_resources,
         no_confirm=yes,
+        retry_until_up=retry_until_up,
     )
 
 
@@ -2097,7 +2110,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             instance_type: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int]):
+            disk_size: Optional[int], retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
 
     Examples:
@@ -2161,6 +2174,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         session_manager=session_manager,
         user_requested_resources=user_requested_resources,
         no_confirm=yes,
+        retry_until_up=retry_until_up,
     )
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -218,6 +218,11 @@ def _interactive_node_cli_command(cli_func):
                                  type=str,
                                  required=False,
                                  help='The region to use.')
+    zone_option = click.option('--zone',
+                               default=None,
+                               type=str,
+                               required=False,
+                               help='The zone to use.')
     idle_autostop = click.option('--idle-minutes-to-autostop',
                                  '-i',
                                  default=None,
@@ -237,6 +242,7 @@ def _interactive_node_cli_command(cli_func):
         # Resource options
         *([cloud_option] if cli_func.__name__ != 'tpunode' else []),
         region_option,
+        zone_option,
         instance_type_option,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
@@ -1985,7 +1991,7 @@ def _terminate_or_stop_clusters(
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            cloud: Optional[str], region: Optional[str],
+            cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
@@ -2038,6 +2044,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=cloud_provider,
                               region=region,
+                              zone=zone,
                               instance_type=instance_type,
                               accelerators=gpus,
                               use_spot=use_spot,
@@ -2060,7 +2067,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            cloud: Optional[str], region: Optional[str],
+            cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
@@ -2110,6 +2117,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=cloud_provider,
                               region=region,
+                              zone=zone,
                               instance_type=instance_type,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2131,11 +2139,12 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 @usage_lib.entrypoint
 # pylint: disable=redefined-outer-name
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
-            region: Optional[str], instance_type: Optional[str],
-            tpus: Optional[str], use_spot: Optional[bool],
-            tpu_vm: Optional[bool], screen: Optional[bool],
-            tmux: Optional[bool], disk_size: Optional[int],
-            idle_minutes_to_autostop: Optional[int], retry_until_up: bool):
+            region: Optional[str], zone: Optional[str],
+            instance_type: Optional[str], tpus: Optional[str],
+            use_spot: Optional[bool], tpu_vm: Optional[bool],
+            screen: Optional[bool], tmux: Optional[bool],
+            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
+            retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
 
     Examples:
@@ -2186,6 +2195,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         use_spot = default_resources.use_spot
     resources = sky.Resources(cloud=sky.GCP(),
                               region=region,
+                              zone=zone,
                               instance_type=instance_type,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,


### PR DESCRIPTION
Add `--retry-until-up`, `--region`, and `--idle-minutes-to-autostop` for interactive nodes. This fixes #1131 and #1205.

Tested: `sky {cpunode, gpunode}` on Azure:
- [x] With and without `--idle-minutes-to-autostop`
- [x] With varying regions (`--region`)

I also used print statements to verify `_launch_with_confirm` is called with the correct `retry_until_up` argument. Not sure how else to test that on Azure.