### PR TITLE
[Example] Minimal containerized app example

### DIFF
--- a/examples/docker/echo_app.py
+++ b/examples/docker/echo_app.py
@@ -16,9 +16,8 @@ with sky.Dag() as dag:
     setup = 'docker build -t echo:v0 /echo_app'
 
     # The command to run - runs the container and mounts volumes
-    run = ('docker run --rm ',
-           '--volume="/inputs:/inputs:ro" ',
-           '--volume="/outputs:/outputs:rw" ',
+    run = ('docker run --rm --volume="/inputs:/inputs:ro" '
+           '--volume="/outputs:/outputs:rw" '
            'echo:v0 /inputs/README.md /outputs/output.txt')
 
     echo_app = sky.Task(

--- a/examples/docker/echo_app.py
+++ b/examples/docker/echo_app.py
@@ -16,10 +16,10 @@ with sky.Dag() as dag:
     setup = 'docker build -t echo:v0 /echo_app'
 
     # The command to run - runs the container and mounts volumes
-    run = 'docker run --rm ' \
-          '--volume="/inputs:/inputs:ro" ' \
-          '--volume="/outputs:/outputs:rw" ' \
-          'echo:v0 /inputs/README.md /outputs/output.txt'
+    run = ('docker run --rm ',
+           '--volume="/inputs:/inputs:ro" ',
+           '--volume="/outputs:/outputs:rw" ',
+           'echo:v0 /inputs/README.md /outputs/output.txt')
 
     echo_app = sky.Task(
         setup=setup,

--- a/examples/docker/echo_app.py
+++ b/examples/docker/echo_app.py
@@ -34,7 +34,8 @@ with sky.Dag() as dag:
 
     # Configure outputs for the task - we'll write to a bucket using Sky Storage
     output_bucket_name = ''.join(random.choices(string.ascii_lowercase, k=15))
-    output_storage = sky.Storage(name=output_bucket_name)
+    output_storage = sky.Storage(name=output_bucket_name,
+                                 mode=sky.StorageMode.MOUNT)
     echo_app.set_storage_mounts({
         '/outputs': output_storage,
     })

--- a/examples/docker/echo_app.py
+++ b/examples/docker/echo_app.py
@@ -1,0 +1,52 @@
+# Example using SkyPilot python API to run the echo app in a container.
+#
+# The echo example ingests a file, prints the contents and writes it back out.
+# In this YAML, the output is mapped to a Sky Storage object, which writes to a
+# cloud bucket.
+#
+# Usage:
+#   python echo_app.py
+
+import random
+import sky
+import string
+
+with sky.Dag() as dag:
+    # The setup command to build the container image
+    setup = 'docker build -t echo:v0 /echo_app'
+
+    # The command to run - runs the container and mounts volumes
+    run = 'docker run --rm ' \
+          '--volume="/inputs:/inputs:ro" ' \
+          '--volume="/outputs:/outputs:rw" ' \
+          'echo:v0 /inputs/README.md /outputs/output.txt'
+
+    echo_app = sky.Task(
+        setup=setup,
+        run=run,
+    )
+
+    # Configure file mounts to copy local contents to remote
+    echo_app.set_file_mounts({
+        '/inputs': './echo_app',
+        '/echo_app': './echo_app',
+    })
+
+    # Configure outputs for the task - we'll write to a bucket using Sky Storage
+    output_bucket_name = ''.join(random.choices(string.ascii_lowercase, k=15))
+    output_storage = sky.Storage(name=output_bucket_name)
+    echo_app.set_storage_mounts({
+        '/outputs': output_storage,
+    })
+
+    # Set resources if required
+    # echo_app.set_resources({
+    #     sky.Resources(accelerators='V100'),
+    # })
+
+sky.launch(dag)
+
+print('Remember to clean up resources after this script is done!\n'
+      'Run sky status and sky storage ls to list current resources.\n'
+      'Run sky down <cluster_name> and sky storage delete <storage_name> to '
+      'delete resources.')

--- a/examples/docker/echo_app.yaml
+++ b/examples/docker/echo_app.yaml
@@ -1,0 +1,27 @@
+# Runs the echo example app in a container with custom inputs and outputs
+#
+# The echo example ingests a file, prints the contents and writes it back out.
+# In this YAML, the output is mapped to a Sky Storage object, which writes to a
+# cloud bucket.
+#
+# Usage:
+#   sky launch -c myclus echo_app.yaml
+#   sky exec myclus echo_app.yaml
+#   sky down myclus
+
+file_mounts:
+  /inputs: ./echo_app
+  /echo_app: ./echo_app
+  /outputs:
+    name: # Set unique bucket name here!
+    mode: MOUNT
+
+setup: |
+  # Build docker image. If pushed to a registry, can also do docker pull here
+  docker build -t echo:v0 /echo_app
+
+run: |
+  docker run --rm \
+    --volume="/inputs:/inputs:ro" \
+    --volume="/outputs:/outputs:rw" \
+    echo:v0 /inputs/README.md /outputs/output.txt

--- a/examples/docker/echo_app/Dockerfile
+++ b/examples/docker/echo_app/Dockerfile
@@ -1,0 +1,7 @@
+FROM python
+
+ADD echo.py /app/echo.py
+
+WORKDIR /app
+
+ENTRYPOINT ["python", "echo.py"]

--- a/examples/docker/echo_app/README.md
+++ b/examples/docker/echo_app/README.md
@@ -1,0 +1,3 @@
+# Echo App
+
+A simple app that ingests a file and writes it out back to a specified path.

--- a/examples/docker/echo_app/echo.py
+++ b/examples/docker/echo_app/echo.py
@@ -1,0 +1,26 @@
+"""Echo app
+
+Reads a file, echoes it and writes back to a specified path.
+"""
+import argparse
+
+
+def main():
+    """Main function"""
+    parser = argparse.ArgumentParser(description='Echo app')
+    parser.add_argument('input', type=str)
+    parser.add_argument('output', type=str)
+    args = parser.parse_args()
+
+    with open(args.input, 'r') as input_file:
+        content = input_file.read()
+    print("===== echo app =====")
+    print("Input file content:")
+    print(content)
+    with open(args.output, 'w') as output_file:
+        output_file.write(content)
+    print("Output written to {}".format(args.output))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a simple example for a containerized app for demonstrating how to build run containers and write their outputs to an object store with SkyPilot. This PR is motivated by recent interactions with users and is intended to be the introductory example for users thinking about running containers with SkyPilot. Our existing container examples were either too complex (`detectron2_docker.yaml`), did not demonstrate how the container can be built with SkyPilot (`containerized_app.py`) or did not mention how file/storage mounts can be used to write outputs.

In this PR, we:

1. Add a simple echo app that reads a file and writes to an output directory.
2. Containerize this app by defining a simple Dockerfile.
3. Add SkyPilot YAML demonstrating how this app container can be built remotely and deployed.
4. Add SkyPilot python API example of the same YAML

tested:
- [x] `sky launch echo_app.yaml`
- [x] `python echo_app.py` 