### PR TITLE
Add a faster way of launching Stable Diffusion example by pulling Docker image from GCR

### DIFF
--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -4,9 +4,9 @@
 
 2. Run: `git clone https://github.com/skypilot-org/skypilot.git && cd examples/stable_diffusion`.
 
-3. Run `sky launch -c stable-diffusion stable_diffusion_docker.yaml`.
+3. Run `sky launch -c stableDiffusion faster_stable_diffusion_docker.yaml`  
 
-4. Run `ssh -L 7860:localhost:7860 stable-diffusion`.
+4. Run `ssh -L 7860:localhost:7860 stableDiffusion`.
 
 5. Open [`http://localhost:7860/`](http://localhost:7860/) in browser.
 

--- a/examples/stable_diffusion/docker-compose.yml
+++ b/examples/stable_diffusion/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+
+services:
+  model:
+    image: gcr.io/intercloud-320520/stable_diffusion_webui
+    restart: on-failure
+    ports:
+      - "7860:7860"
+    volumes:
+      - ./cache:/cache
+      - ./output:/output
+      - ./models:/models
+    environment:
+      - CLI_ARGS=--extra-models-cpu --optimized-turbo
+    deploy:
+      resources:
+        reservations:
+          devices:
+              - driver: nvidia
+                device_ids: ['0']
+                capabilities: [gpu]

--- a/examples/stable_diffusion/faster_stable_diffusion_docker.yaml
+++ b/examples/stable_diffusion/faster_stable_diffusion_docker.yaml
@@ -1,0 +1,25 @@
+#SkyPilot YAML to run stable diffusion web tool on 1 V100 GPU.
+
+resources:
+  cloud: gcp
+  accelerators: V100:1
+
+file_mounts:
+  /faster_stable_diffusion: .
+
+setup: |
+  sudo rm -r stable-diffusion-webui-docker
+  git clone https://github.com/AbdBarho/stable-diffusion-webui-docker.git
+  sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  sudo chmod +x /usr/local/bin/docker-compose
+  cd stable-diffusion-webui-docker
+  git reset --hard 0d8b7d4ac8f9ba99e041ca332547eab9d65e6360
+  wget https://www.googleapis.com/storage/v1/b/aai-blog-files/o/sd-v1-4.ckpt?alt=media -P models
+  mv models/'sd-v1-4.ckpt?alt=media' models/model.ckpt
+  docker pull gcr.io/intercloud-320520/stable_diffusion_webui
+  rm docker-compose.yml
+  cp /faster_stable_diffusion/docker-compose.yml .
+
+run: |
+  cd stable-diffusion-webui-docker
+  docker-compose up


### PR DESCRIPTION
Added a new yaml to launch stable diffusion instance that pulls existing docker image from GCR.
Brings total time needed to launch stable diffusion (from scratch) from 15-20 mins to ~5 mins. 