### PR TITLE
[Autodown] Support for autodown

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1589,7 +1589,9 @@ def _update_cluster_status_no_lock(
             backend.set_autostop(handle, -1, stream_logs=False)
         except (Exception, SystemExit):  # pylint: disable=broad-except
             logger.debug('Failed to reset autostop.')
-        global_user_state.set_cluster_autostop_value(handle.cluster_name, -1)
+        global_user_state.set_cluster_autostop_value(handle.cluster_name,
+                                                     -1,
+                                                     to_down=False)
 
         # If the user starts part of a STOPPED cluster, we still need a status to
         # represent the abnormal status. For spot cluster, it can also represent

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1137,14 +1137,14 @@ class RetryingVmProvisioner(object):
                 # Reduce BOTO_MAX_RETRIES from 12 to 5 to avoid long hanging
                 # time during 'ray up' if insufficient capacity occurs.
                 env=dict(
+                    os.environ,
                     BOTO_MAX_RETRIES='5',
                     # Use environment variables to disable the ray usage stats
                     # (to avoid the 10 second wait for usage collection
                     # confirmation), as the ray version on the user's machine
                     # may be lower version that does not support the
                     # `--disable-usage-stats` flag.
-                    RAY_USAGE_STATS_ENABLED='0',
-                    **os.environ),
+                    RAY_USAGE_STATS_ENABLED='0'),
                 require_outputs=True,
                 # Disable stdin to avoid ray outputs mess up the terminal with
                 # misaligned output when multithreading/multiprocessing are used
@@ -1353,7 +1353,7 @@ class RetryingVmProvisioner(object):
             # (avoid the 10 second wait for usage collection confirmation),
             # as the ray version on the user's machine may be lower version
             # that does not support the `--disable-usage-stats` flag.
-            env=dict(RAY_USAGE_STATS_ENABLED='0', **os.environ),
+            env=dict(os.environ, RAY_USAGE_STATS_ENABLED='0'),
             # Disable stdin to avoid ray outputs mess up the terminal with
             # misaligned output when multithreading/multiprocessing is used.
             # Refer to: https://github.com/ray-project/ray/blob/d462172be7c5779abf37609aed08af112a533e1e/python/ray/autoscaler/_private/subprocess_output_util.py#L264 # pylint: disable=line-too-long

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1116,6 +1116,11 @@ class RetryingVmProvisioner(object):
             # different order from directly running in the console. The
             # `--log-style` and `--log-color` flags do not work. To reproduce,
             # `ray up --log-style pretty --log-color true | tee tmp.out`.
+
+            # Use environment variables to disable the ray usage collection (to
+            # avoid the 10 second wait for usage collection confirmation), as
+            # the ray version on the user's machine may be lower version that
+            # does not support the `--disable-usage-stats` flag.
             returncode, stdout, stderr = log_lib.run_with_log(
                 # NOTE: --no-restart solves the following bug.  Without it, if
                 # 'ray up' (sky launch) twice on a cluster with >1 node, the
@@ -1133,7 +1138,9 @@ class RetryingVmProvisioner(object):
                 line_processor=log_utils.RayUpLineProcessor(),
                 # Reduce BOTO_MAX_RETRIES from 12 to 5 to avoid long hanging
                 # time during 'ray up' if insufficient capacity occurs.
-                env=dict(os.environ, BOTO_MAX_RETRIES='5'),
+                env=dict(BOTO_MAX_RETRIES='5',
+                         RAY_USAGE_STATS_ENABLED='0',
+                         **os.environ),
                 require_outputs=True,
                 # Disable stdin to avoid ray outputs mess up the terminal with
                 # misaligned output when multithreading/multiprocessing are used
@@ -1333,10 +1340,18 @@ class RetryingVmProvisioner(object):
                 'of the local cluster. Check if ray[default]==1.13.0 '
                 'is installed or running correctly.')
         backend.run_on_head(handle, 'ray stop', use_cached_head_ip=False)
+
+        # Use environment variables to disable the ray usage collection (avoid
+        # the 10 second wait for usage collection confirmation), as the ray
+        # version on the user's machine may be lower version that does not
+        # support the `--disable-usage-stats` flag.
+        env = os.environ.copy()
+        env['RAY_USAGE_STATS_ENABLED'] = '0'
         log_lib.run_with_log(
             ['ray', 'up', '-y', '--restart-only', handle.cluster_yaml],
             log_abs_path,
             stream_logs=False,
+            env=dict(RAY_USAGE_STATS_ENABLED='0', **os.environ),
             # Disable stdin to avoid ray outputs mess up the terminal with
             # misaligned output when multithreading/multiprocessing is used.
             # Refer to: https://github.com/ray-project/ray/blob/d462172be7c5779abf37609aed08af112a533e1e/python/ray/autoscaler/_private/subprocess_output_util.py#L264 # pylint: disable=line-too-long
@@ -2623,7 +2638,7 @@ class CloudVmRayBackend(backends.Backend):
                                                stderr=stderr,
                                                stream_logs=stream_logs)
             global_user_state.set_cluster_autostop_value(
-                handle.cluster_name, idle_minutes_to_autostop)
+                handle.cluster_name, idle_minutes_to_autostop, down)
 
     # TODO(zhwu): Refactor this to a CommandRunner class, so different backends
     # can support its own command runner.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2608,11 +2608,11 @@ class CloudVmRayBackend(backends.Backend):
     def set_autostop(self,
                      handle: ResourceHandle,
                      idle_minutes_to_autostop: Optional[int],
-                     terminate: bool = False,
+                     down: bool = False,
                      stream_logs: bool = True) -> None:
         if idle_minutes_to_autostop is not None:
             code = autostop_lib.AutostopCodeGen.set_autostop(
-                idle_minutes_to_autostop, self.NAME, terminate)
+                idle_minutes_to_autostop, self.NAME, down)
             returncode, _, stderr = self.run_on_head(handle,
                                                      code,
                                                      require_outputs=True,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2608,7 +2608,7 @@ class CloudVmRayBackend(backends.Backend):
     def set_autostop(self,
                      handle: ResourceHandle,
                      idle_minutes_to_autostop: Optional[int],
-                     terminate: bool = True,
+                     terminate: bool = False,
                      stream_logs: bool = True) -> None:
         if idle_minutes_to_autostop is not None:
             code = autostop_lib.AutostopCodeGen.set_autostop(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2608,10 +2608,11 @@ class CloudVmRayBackend(backends.Backend):
     def set_autostop(self,
                      handle: ResourceHandle,
                      idle_minutes_to_autostop: Optional[int],
+                     teardown: bool = True,
                      stream_logs: bool = True) -> None:
         if idle_minutes_to_autostop is not None:
             code = autostop_lib.AutostopCodeGen.set_autostop(
-                idle_minutes_to_autostop, self.NAME)
+                idle_minutes_to_autostop, self.NAME, teardown)
             returncode, _, stderr = self.run_on_head(handle,
                                                      code,
                                                      require_outputs=True,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2608,11 +2608,11 @@ class CloudVmRayBackend(backends.Backend):
     def set_autostop(self,
                      handle: ResourceHandle,
                      idle_minutes_to_autostop: Optional[int],
-                     teardown: bool = True,
+                     terminate: bool = True,
                      stream_logs: bool = True) -> None:
         if idle_minutes_to_autostop is not None:
             code = autostop_lib.AutostopCodeGen.set_autostop(
-                idle_minutes_to_autostop, self.NAME, teardown)
+                idle_minutes_to_autostop, self.NAME, terminate)
             returncode, _, stderr = self.run_on_head(handle,
                                                      code,
                                                      require_outputs=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1000,7 +1000,7 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after all jobs completed (successfully or '
+    ('Tear down the cluster after all jobs finish (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the specified idle time. '
      'Note that if errors occur during provisioning/data syncing/setting up, '
@@ -1514,11 +1514,13 @@ def stop(
               default=None,
               required=False,
               help='Set the idle minutes before autostopping the cluster.')
-@click.option('--cancel',
-              default=False,
-              is_flag=True,
-              required=False,
-              help='Cancel the autostopping.')
+@click.option(
+    '--cancel',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Cancel the currently active autostop/autodown setting for the '
+    'cluster.')
 @click.option(
     '--down',
     default=False,
@@ -1559,6 +1561,9 @@ def autostop(
 
     If ``--idle-minutes`` and ``--cancel`` are not specified, default to 5
     minutes.
+
+    When multiple configurations are specified for the same cluster, e.g. using
+    ``sky autostop`` or ``sky launch -i``, the last one takes precedence.
 
     Examples:
 
@@ -1623,7 +1628,7 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after all jobs completed (successfully or '
+    ('Tear down the cluster after all jobs finish (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the specified idle time.'),
 )
@@ -1862,7 +1867,7 @@ def _down_or_stop_clusters(
         verb = 'Cancelling' if is_cancel else 'Scheduling'
         option_str = 'down' if down else 'stop'
         if is_cancel:
-            option_str = 'stop(down)'
+            option_str = '{stop,down}'
         operation = f'{verb} auto{option_str} on'
 
     if len(names) > 0:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -993,7 +993,7 @@ def cli():
           'job queue. '
           'Setting this flag is equivalent to '
           'running ``sky launch -d ...`` and then ``sky autostop -i <minutes>``'
-          '. If not set, the cluster will not be auto-stopped.'))
+          '. If not set, the cluster will not be autostopped.'))
 @click.option(
     '--down',
     default=False,
@@ -1002,7 +1002,9 @@ def cli():
     help=
     ('Tear down the cluster after all jobs completed (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
-     'be torn down after the specified idle time.'),
+     'be torn down after the specified idle time. '
+     'Note that if errors occur during provisioning/data syncing/setting up, '
+     'the cluster will not be torn down for debugging purposes.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1261,10 +1263,9 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
     - STOPPED: The cluster is stopped and the storage is persisted. Use
       ``sky start`` to restart the cluster.
 
-    The autostop column indicates how long the cluster will be auto-stopped
+    The autostop column indicates how long the cluster will be autostopped
     after idling (no jobs running). If the time is followed by '(down)', e.g.
-    '1 min (down)', the cluster will be auto-downed, rather than auto-stopped.
-
+    '1 min (down)', the cluster will be autodowned, rather than autostopped.
     """
     cluster_records = core.status(all=all, refresh=refresh)
     local_clusters = onprem_utils.check_and_get_local_clusters(
@@ -1511,19 +1512,19 @@ def stop(
               type=int,
               default=None,
               required=False,
-              help='Set the idle minutes before auto-stopping the cluster.')
+              help='Set the idle minutes before autostopping the cluster.')
 @click.option('--cancel',
               default=False,
               is_flag=True,
               required=False,
-              help='Cancel the auto-stopping.')
+              help='Cancel the autostopping.')
 @click.option(
     '--down',
     default=False,
     is_flag=True,
     required=False,
-    help='Tear down the cluster instead of stopping it, when auto-stopping '
-    '(i.e., auto-down rather than auto-stop).')
+    help='Use autodown (tear down the cluster; non-restartable), instead '
+    'of autostop (restartable).')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1539,7 +1540,7 @@ def autostop(
     down: bool,  # pylint: disable=redefined-outer-name
     yes: bool,
 ):
-    """Schedule or cancel an auto-stop or auto-down for cluster(s).
+    """Schedule or cancel an autostop or autodown for cluster(s).
 
     CLUSTERS are the name (or glob pattern) of the clusters to stop.  If both
     CLUSTERS and ``--all`` are supplied, the latter takes precedence.
@@ -1614,7 +1615,7 @@ def autostop(
           'job queue. '
           'Setting this flag is equivalent to '
           'running ``sky launch -d ...`` and then ``sky autostop -i <minutes>``'
-          '. If not set, the cluster will not be auto-stopped.'))
+          '. If not set, the cluster will not be autostopped.'))
 @click.option(
     '--down',
     default=False,
@@ -1858,7 +1859,7 @@ def _down_or_stop_clusters(
     if idle_minutes_to_autostop is not None:
         verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
         option_str = 'down' if down else 'stop'
-        operation = f'{verb} auto-{option_str} on'
+        operation = f'{verb} auto{option_str} on'
 
     if len(names) > 0:
         reserved_clusters = [
@@ -2838,7 +2839,7 @@ def bench():
     help=('Automatically stop the cluster after this many minutes '
           'of idleness after setup/file_mounts. This is equivalent to '
           'running `sky launch -d ...` and then `sky autostop -i <minutes>`. '
-          'If not set, the cluster will not be auto-stopped.'))
+          'If not set, the cluster will not be autostopped.'))
 @click.option('--yes',
               '-y',
               is_flag=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1262,6 +1262,10 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
     - STOPPED: The cluster is stopped and the storage is persisted. Use
       ``sky start`` to restart the cluster.
 
+    The autostop column indicates how long the cluster will be auto-stopped
+    after idling (no jobs running). If the time is followed by '(down)', e.g.
+    '1 min (down)', the cluster will be auto-downed, rather than auto-stopped.
+
     """
     cluster_records = core.status(all=all, refresh=refresh)
     local_clusters = onprem_utils.check_and_get_local_clusters(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -604,7 +604,7 @@ def _launch_with_confirm(
     detach_run: bool,
     no_confirm: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
-    teardown: bool = False,
+    terminate: bool = False,
     retry_until_up: bool = False,
     no_setup: bool = False,
     node_type: Optional[str] = None,
@@ -655,7 +655,7 @@ def _launch_with_confirm(
             detach_run=detach_run,
             backend=backend,
             idle_minutes_to_autostop=idle_minutes_to_autostop,
-            teardown=teardown,
+            terminate=terminate,
             retry_until_up=retry_until_up,
             no_setup=no_setup,
         )
@@ -995,12 +995,13 @@ def cli():
           'running ``sky launch -d ...`` and then ``sky autostop -i <minutes>``'
           '. If not set, the cluster will not be auto-stopped.'))
 @click.option(
-    '--idle-minutes-to-autodown',
-    '-I',
-    default=None,
-    type=int,
+    '--terminate',
+    default=False,
+    type=bool,
     required=False,
-    help=('Same as --idle-minutes-to-autostop, but tears down the cluster.'),
+    help=(
+        'Terminate the cluster after execution. If --idle-minutes-to-autostop '
+        'is set, the cluster will be torn down after the idle time.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1043,7 +1044,7 @@ def launch(
     env: List[Dict[str, str]],
     disk_size: Optional[int],
     idle_minutes_to_autostop: Optional[int],
-    idle_minutes_to_autodown: Optional[int],
+    terminate: bool,
     retry_until_up: bool,
     yes: bool,
     no_setup: bool,
@@ -1056,14 +1057,6 @@ def launch(
     In both cases, the commands are run under the task's workdir (if specified)
     and they undergo job queue scheduling.
     """
-    autodown = False
-    if idle_minutes_to_autostop is not None and idle_minutes_to_autodown is not None:
-        raise click.UsageError(
-            'Only one of --idle-minutes-to-autostop and --idle-minutes-to-autodown should be specified. '
-            f'autostop: {idle_minutes_to_autostop}, autodown: {idle_minutes_to_autodown}')
-    if idle_minutes_to_autodown is not None:
-        idle_minutes_to_autostop = idle_minutes_to_autodown
-        autodown = True
     backend_utils.check_cluster_name_not_reserved(
         cluster, operation_str='Launching task on it')
     if backend_name is None:
@@ -1102,7 +1095,7 @@ def launch(
         detach_run=detach_run,
         no_confirm=yes,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
-        teardown=autodown,
+        terminate=terminate,
         retry_until_up=retry_until_up,
         no_setup=no_setup,
         is_local_cloud=onprem_utils.check_if_local_cloud(cluster))
@@ -1519,11 +1512,12 @@ def stop(
               is_flag=True,
               required=False,
               help='Cancel the auto-stopping.')
-@click.option('--down',
-            default=False, 
-            is_flag=True, 
-            required=False, 
-            help='Tear down the cluster instead of stopping it, when auto-stopping.')
+@click.option(
+    '--terminate',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Terminate the cluster instead of stopping it, when auto-stopping.')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1536,8 +1530,8 @@ def autostop(
     all: Optional[bool],  # pylint: disable=redefined-builtin
     idle_minutes: Optional[int],
     cancel: bool,  # pylint: disable=redefined-outer-name
+    terminate: bool,
     yes: bool,
-    down: bool,
 ):
     """Schedule or cancel auto-stopping for cluster(s).
 
@@ -1574,7 +1568,7 @@ def autostop(
         idle_minutes = 5
     _terminate_or_stop_clusters(clusters,
                                 apply_to_all=all,
-                                terminate=down,
+                                terminate=terminate,
                                 no_confirm=yes,
                                 idle_minutes_to_autostop=idle_minutes)
 
@@ -1611,12 +1605,13 @@ def autostop(
           'running ``sky launch -d ...`` and then ``sky autostop -i <minutes>``'
           '. If not set, the cluster will not be auto-stopped.'))
 @click.option(
-    '--idle-minutes-to-autodown',
-    '-I',
-    default=None,
-    type=int,
+    '--terminate',
+    default=False,
+    type=bool,
     required=False,
-    help=('Same as --idle-minutes-to-autostop, but tears down the cluster.'),
+    help=(
+        'Terminate the cluster after execution. If --idle-minutes-to-autostop '
+        'is set, the cluster will be torn down after the idle time.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1629,7 +1624,8 @@ def autostop(
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def start(clusters: Tuple[str], all: bool, yes: bool,
-          idle_minutes_to_autostop: Optional[int], idle_minutes_to_autodown: Optional[int], retry_until_up: bool):
+          idle_minutes_to_autostop: Optional[int], terminate: bool,
+          retry_until_up: bool):
     """Restart cluster(s).
 
     If a cluster is previously stopped (status is STOPPED) or failed in
@@ -1657,12 +1653,6 @@ def start(clusters: Tuple[str], all: bool, yes: bool,
       sky start -a
 
     """
-    if idle_minutes_to_autostop is not None and idle_minutes_to_autodown is not None:
-        raise click.UsageError(
-            'Only one of --idle-minutes-to-autostop and --idle-minutes-to-autodown should be specified. '
-            f'autostop: {idle_minutes_to_autostop}, autodown: {idle_minutes_to_autodown}')
-    autodown = idle_minutes_to_autodown is not None
-
     to_start = []
 
     if not clusters and not all:
@@ -1751,7 +1741,10 @@ def start(clusters: Tuple[str], all: bool, yes: bool,
 
     for name in to_start:
         try:
-            core.start(name, idle_minutes_to_autostop, retry_until_up, autodown=autodown)
+            core.start(name,
+                       idle_minutes_to_autostop,
+                       retry_until_up,
+                       terminate=terminate)
         except exceptions.NotSupportedError as e:
             click.echo(str(e))
         click.secho(f'Cluster {name} started.', fg='green')
@@ -1845,7 +1838,7 @@ def _terminate_or_stop_clusters(
     operation = 'Terminating' if terminate else 'Stopping'
     if idle_minutes_to_autostop is not None:
         verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-        down_str = f' (tear down)' if terminate else ''
+        down_str = ' (terminate)' if terminate else ''
         operation = f'{verb} auto-stop{down_str} on'
 
     if len(names) > 0:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1780,7 +1780,7 @@ def start(
               '-a',
               default=None,
               is_flag=True,
-              help='Terminate all existing clusters.')
+              help='Tear down all existing clusters.')
 @click.option('--yes',
               '-y',
               is_flag=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1000,10 +1000,9 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution finishes (successfully or '
+    ('Tear down the cluster after all jobs completed (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
-     'be torn down after the idle time, rather than immediately after execution'
-     ' finishes.'),
+     'be torn down after the specified idle time.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1622,10 +1621,9 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution finishes (successfully or '
+    ('Tear down the cluster after all jobs completed (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
-     'be torn down after the idle time, rather than immediately after execution'
-     ' finishes.'),
+     'be torn down after the specified idle time.'),
 )
 @click.option(
     '--retry-until-up',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1000,9 +1000,10 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution (successfully or abnormally). If '
-     '--idle-minutes-to-autostop is set, the cluster will be torn down after '
-     'the idle time.'),
+    ('Tear down the cluster after execution finishes (successfully or '
+     'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
+     'be torn down after the idle time, rather than immediately after execution'
+     ' finishes.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1519,7 +1520,7 @@ def stop(
     is_flag=True,
     required=False,
     help='Tear down the cluster instead of stopping it, when auto-stopping '
-    '(i.e., autodown rather than autostop).')
+    '(i.e., auto-down rather than auto-stop).')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1535,10 +1536,13 @@ def autostop(
     down: bool,  # pylint: disable=redefined-outer-name
     yes: bool,
 ):
-    """Schedule or cancel auto-stopping for cluster(s).
+    """Schedule or cancel an auto-stop or auto-down for cluster(s).
 
     CLUSTERS are the name (or glob pattern) of the clusters to stop.  If both
     CLUSTERS and ``--all`` are supplied, the latter takes precedence.
+
+    If --down is passed, autodown (tear down the cluster; non-restartable) is
+    used, rather than autostop (restartable).
 
     ``--idle-minutes`` is the number of minutes of idleness (no pending/running
     jobs) after which the cluster will be stopped automatically.
@@ -1614,9 +1618,10 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution (successfully or abnormally). If '
-     '--idle-minutes-to-autostop is set, the cluster will be torn down after '
-     'the idle time.'),
+    ('Tear down the cluster after execution finishes (successfully or '
+     'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
+     'be torn down after the idle time, rather than immediately after execution'
+     ' finishes.'),
 )
 @click.option(
     '--retry-until-up',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -997,7 +997,7 @@ def cli():
 @click.option(
     '--terminate',
     default=False,
-    type=bool,
+    is_flag=True,
     required=False,
     help=(
         'Terminate the cluster after execution. If --idle-minutes-to-autostop '
@@ -1607,7 +1607,7 @@ def autostop(
 @click.option(
     '--terminate',
     default=False,
-    type=bool,
+    is_flag=True,
     required=False,
     help=(
         'Terminate the cluster after execution. If --idle-minutes-to-autostop '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -13,10 +13,10 @@ Example usage:
   # Show the list of running clusters.
   >> sky status
 
-  # Terminate a specific cluster.
+  # Tear down a specific cluster.
   >> sky down cluster_name
 
-  # Terminate all existing clusters.
+  # Tear down all existing clusters.
   >> sky down -a
 
 TODO:
@@ -747,7 +747,7 @@ def _create_and_ssh_into_node(
     click.secho(f'sky {node_type}{option}', bold=True)
     click.echo('To stop the node:\t', nl=False)
     click.secho(f'sky stop {cluster_name}', bold=True)
-    click.echo('To terminate the node:\t', nl=False)
+    click.echo('To tear down the node:\t', nl=False)
     click.secho(f'sky down {cluster_name}', bold=True)
     click.echo('To upload a folder:\t', nl=False)
     click.secho(f'rsync -rP /local/path {cluster_name}:/remote/path', bold=True)
@@ -1000,7 +1000,7 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Terminate the cluster after execution finishes (successfully or '
+    ('Tear down the cluster after execution finishes (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the idle time, rather than immediately after execution'
      ' finishes.'),
@@ -1523,7 +1523,7 @@ def stop(
     default=False,
     is_flag=True,
     required=False,
-    help='Terminate the cluster instead of stopping it, when auto-stopping '
+    help='Tear down the cluster instead of stopping it, when auto-stopping '
     '(i.e., auto-down rather than auto-stop).')
 @click.option('--yes',
               '-y',
@@ -1545,7 +1545,7 @@ def autostop(
     CLUSTERS are the name (or glob pattern) of the clusters to stop.  If both
     CLUSTERS and ``--all`` are supplied, the latter takes precedence.
 
-    If --down is passed, autodown (terminate the cluster; non-restartable) is
+    If --down is passed, autodown (tear down the cluster; non-restartable) is
     used, rather than autostop (restartable).
 
     ``--idle-minutes`` is the number of minutes of idleness (no pending/running
@@ -1622,7 +1622,7 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Terminate the cluster after execution finishes (successfully or '
+    ('Tear down the cluster after execution finishes (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the idle time, rather than immediately after execution'
      ' finishes.'),
@@ -1801,9 +1801,9 @@ def down(
     yes: bool,
     purge: bool,
 ):
-    """Terminate cluster(s).
+    """Tear down cluster(s).
 
-    CLUSTER is the name of the cluster (or glob pattern) to terminate.  If both
+    CLUSTER is the name of the cluster (or glob pattern) to tear down.  If both
     CLUSTER and ``--all`` are supplied, the latter takes precedence.
 
     Terminating a cluster will delete all associated resources (all billing
@@ -1817,16 +1817,16 @@ def down(
 
     .. code-block:: bash
 
-      # Terminate a specific cluster.
+      # Tear down a specific cluster.
       sky down cluster_name
       \b
-      # Terminate multiple clusters.
+      # Tear down multiple clusters.
       sky down cluster1 cluster2
       \b
-      # Terminate all clusters matching glob pattern 'cluster*'.
+      # Tear down all clusters matching glob pattern 'cluster*'.
       sky down "cluster*"
       \b
-      # Terminate all existing clusters.
+      # Tear down all existing clusters.
       sky down -a
 
     """
@@ -3233,7 +3233,7 @@ def benchmark_down(
     clusters_to_exclude: List[str],
     yes: bool,
 ) -> None:
-    """Terminate all clusters belonging to a benchmark."""
+    """Tear down all clusters belonging to a benchmark."""
     record = benchmark_state.get_benchmark_from_name(benchmark)
     if record is None:
         raise click.BadParameter(f'Benchmark {benchmark} does not exist.')
@@ -3259,7 +3259,7 @@ def benchmark_down(
               '-a',
               default=None,
               is_flag=True,
-              help='Terminate all existing clusters.')
+              help='Delete all benchmark reports from the history.')
 @click.option('--yes',
               '-y',
               is_flag=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1806,7 +1806,7 @@ def down(
     CLUSTER is the name of the cluster (or glob pattern) to tear down.  If both
     CLUSTER and ``--all`` are supplied, the latter takes precedence.
 
-    Terminating a cluster will delete all associated resources (all billing
+    Tearing down a cluster will delete all associated resources (all billing
     stops), and any data on the attached disks will be lost. For local clusters,
     `sky down` does not terminate the local cluster, but instead removes the
     cluster from `sky status` and terminates the calling user's running jobs.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -13,10 +13,10 @@ Example usage:
   # Show the list of running clusters.
   >> sky status
 
-  # Tear down a specific cluster.
+  # Terminate a specific cluster.
   >> sky down cluster_name
 
-  # Tear down all existing clusters.
+  # Terminate all existing clusters.
   >> sky down -a
 
 TODO:
@@ -747,7 +747,7 @@ def _create_and_ssh_into_node(
     click.secho(f'sky {node_type}{option}', bold=True)
     click.echo('To stop the node:\t', nl=False)
     click.secho(f'sky stop {cluster_name}', bold=True)
-    click.echo('To tear down the node:\t', nl=False)
+    click.echo('To terminate the node:\t', nl=False)
     click.secho(f'sky down {cluster_name}', bold=True)
     click.echo('To upload a folder:\t', nl=False)
     click.secho(f'rsync -rP /local/path {cluster_name}:/remote/path', bold=True)
@@ -1000,7 +1000,7 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution finishes (successfully or '
+    ('Terminate the cluster after execution finishes (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the idle time, rather than immediately after execution'
      ' finishes.'),
@@ -1450,7 +1450,7 @@ def cancel(cluster: str, all: bool, jobs: List[int]):  # pylint: disable=redefin
               '-a',
               default=None,
               is_flag=True,
-              help='Tear down all existing clusters.')
+              help='Stop all existing clusters.')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1523,7 +1523,7 @@ def stop(
     default=False,
     is_flag=True,
     required=False,
-    help='Tear down the cluster instead of stopping it, when auto-stopping '
+    help='Terminate the cluster instead of stopping it, when auto-stopping '
     '(i.e., auto-down rather than auto-stop).')
 @click.option('--yes',
               '-y',
@@ -1545,7 +1545,7 @@ def autostop(
     CLUSTERS are the name (or glob pattern) of the clusters to stop.  If both
     CLUSTERS and ``--all`` are supplied, the latter takes precedence.
 
-    If --down is passed, autodown (tear down the cluster; non-restartable) is
+    If --down is passed, autodown (terminate the cluster; non-restartable) is
     used, rather than autostop (restartable).
 
     ``--idle-minutes`` is the number of minutes of idleness (no pending/running
@@ -1622,7 +1622,7 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after execution finishes (successfully or '
+    ('Terminate the cluster after execution finishes (successfully or '
      'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
      'be torn down after the idle time, rather than immediately after execution'
      ' finishes.'),
@@ -1780,7 +1780,7 @@ def start(
               '-a',
               default=None,
               is_flag=True,
-              help='Tear down all existing clusters.')
+              help='Terminate all existing clusters.')
 @click.option('--yes',
               '-y',
               is_flag=True,
@@ -1801,9 +1801,9 @@ def down(
     yes: bool,
     purge: bool,
 ):
-    """Tear down cluster(s).
+    """Terminate cluster(s).
 
-    CLUSTER is the name of the cluster (or glob pattern) to tear down.  If both
+    CLUSTER is the name of the cluster (or glob pattern) to terminate.  If both
     CLUSTER and ``--all`` are supplied, the latter takes precedence.
 
     Terminating a cluster will delete all associated resources (all billing
@@ -1817,16 +1817,16 @@ def down(
 
     .. code-block:: bash
 
-      # Tear down a specific cluster.
+      # Terminate a specific cluster.
       sky down cluster_name
       \b
-      # Tear down multiple clusters.
+      # Terminate multiple clusters.
       sky down cluster1 cluster2
       \b
-      # Tear down all clusters matching glob pattern 'cluster*'.
+      # Terminate all clusters matching glob pattern 'cluster*'.
       sky down "cluster*"
       \b
-      # Tear down all existing clusters.
+      # Terminate all existing clusters.
       sky down -a
 
     """
@@ -3233,7 +3233,7 @@ def benchmark_down(
     clusters_to_exclude: List[str],
     yes: bool,
 ) -> None:
-    """Tear down all clusters belonging to a benchmark."""
+    """Terminate all clusters belonging to a benchmark."""
     record = benchmark_state.get_benchmark_from_name(benchmark)
     if record is None:
         raise click.BadParameter(f'Benchmark {benchmark} does not exist.')
@@ -3259,7 +3259,7 @@ def benchmark_down(
               '-a',
               default=None,
               is_flag=True,
-              help='Tear down all existing clusters.')
+              help='Terminate all existing clusters.')
 @click.option('--yes',
               '-y',
               is_flag=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1858,8 +1858,11 @@ def _down_or_stop_clusters(
 
     operation = 'Terminating' if down else 'Stopping'
     if idle_minutes_to_autostop is not None:
-        verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
+        is_cancel = idle_minutes_to_autostop < 0
+        verb = 'Cancelling' if is_cancel else 'Scheduling'
         option_str = 'down' if down else 'stop'
+        if is_cancel:
+            option_str = 'stop(down)'
         operation = f'{verb} auto{option_str} on'
 
     if len(names) > 0:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1519,7 +1519,7 @@ def stop(
     default=False,
     is_flag=True,
     required=False,
-    help='Cancel the currently active autostop/autodown setting for the '
+    help='Cancel the currently active auto{stop,down} setting for the '
     'cluster.')
 @click.option(
     '--down',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -999,10 +999,10 @@ def cli():
     default=False,
     is_flag=True,
     required=False,
-    help=(
-        'Terminate the cluster after execution (successfully or abnormally). If '
-        '--idle-minutes-to-autostop is set, the cluster will be torn down after '
-        'the idle time.'),
+    help=
+    ('Terminate the cluster after execution (successfully or abnormally). If '
+     '--idle-minutes-to-autostop is set, the cluster will be torn down after '
+     'the idle time.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1613,10 +1613,10 @@ def autostop(
     default=False,
     is_flag=True,
     required=False,
-    help=(
-        'Terminate the cluster after execution (successfully or abnormally). If '
-        '--idle-minutes-to-autostop is set, the cluster will be torn down after '
-        'the idle time.'),
+    help=
+    ('Terminate the cluster after execution (successfully or abnormally). If '
+     '--idle-minutes-to-autostop is set, the cluster will be torn down after '
+     'the idle time.'),
 )
 @click.option(
     '--retry-until-up',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1264,8 +1264,9 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
       ``sky start`` to restart the cluster.
 
     The autostop column indicates how long the cluster will be autostopped
-    after idling (no jobs running). If the time is followed by '(down)', e.g.
-    '1 min (down)', the cluster will be autodowned, rather than autostopped.
+    after minutes of idling (no jobs running). If the time is followed by
+    '(down)', e.g. '1m (down)', the cluster will be autodowned, rather than
+    autostopped.
     """
     cluster_records = core.status(all=all, refresh=refresh)
     local_clusters = onprem_utils.check_and_get_local_clusters(

--- a/sky/core.py
+++ b/sky/core.py
@@ -51,10 +51,12 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
     return cluster_records
 
 
-def _start(cluster_name: str,
-           idle_minutes_to_autostop: Optional[int] = None,
-           retry_until_up: bool = False,
-           terminate: bool = False) -> backends.Backend.ResourceHandle:
+def _start(
+        cluster_name: str,
+        idle_minutes_to_autostop: Optional[int] = None,
+        retry_until_up: bool = False,
+        down: bool = False,  #pylint: disable=redefined-outer-name
+) -> backends.Backend.ResourceHandle:
 
     cluster_status, handle = backend_utils.refresh_cluster_status_handle(
         cluster_name)
@@ -80,16 +82,16 @@ def _start(cluster_name: str,
                                cluster_name=cluster_name,
                                retry_until_up=retry_until_up)
     if idle_minutes_to_autostop is not None:
-        backend.set_autostop(handle,
-                             idle_minutes_to_autostop,
-                             terminate=terminate)
+        backend.set_autostop(handle, idle_minutes_to_autostop, down=down)
     return handle
 
 
-def start(cluster_name: str,
-          idle_minutes_to_autostop: Optional[int] = None,
-          retry_until_up: bool = False,
-          terminate: bool = False):
+def start(
+        cluster_name: str,
+        idle_minutes_to_autostop: Optional[int] = None,
+        retry_until_up: bool = False,
+        down: bool = False,  #pylint: disable=redefined-outer-name
+):
     """Start the cluster.
 
     Please refer to the sky.cli.start for the document.
@@ -97,7 +99,7 @@ def start(cluster_name: str,
     Raises:
         sky.exceptions.NotSupportedError: the cluster is not supported.
     """
-    _start(cluster_name, idle_minutes_to_autostop, retry_until_up, terminate)
+    _start(cluster_name, idle_minutes_to_autostop, retry_until_up, down)
 
 
 def stop(cluster_name: str, purge: bool = False):
@@ -160,9 +162,11 @@ def down(cluster_name: str, purge: bool = False):
     backend.teardown(handle, terminate=True, purge=purge)
 
 
-def autostop(cluster_name: str,
-             idle_minutes_to_autostop: int,
-             terminate: bool = False):
+def autostop(
+        cluster_name: str,
+        idle_minutes_to_autostop: int,
+        down: bool = False,  #pylint: disable=redefined-outer-name
+):
     """Set the autostop time of the cluster.
 
     Please refer to the sky.cli.autostop for the document.
@@ -176,7 +180,7 @@ def autostop(cluster_name: str,
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-    option_str = 'stop' if terminate else 'down'
+    option_str = 'stop' if down else 'down'
     operation = f'{verb} auto-{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
@@ -209,7 +213,7 @@ def autostop(cluster_name: str,
                 f'{colorama.Style.RESET_ALL}'
                 '\n  Auto-stop can only be set/unset for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.')
-    backend.set_autostop(handle, idle_minutes_to_autostop, terminate)
+    backend.set_autostop(handle, idle_minutes_to_autostop, down)
 
 
 # ==================

--- a/sky/core.py
+++ b/sky/core.py
@@ -53,7 +53,8 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
 
 def _start(cluster_name: str,
            idle_minutes_to_autostop: Optional[int] = None,
-           retry_until_up: bool = False) -> backends.Backend.ResourceHandle:
+           retry_until_up: bool = False,
+           autodown: bool=False) -> backends.Backend.ResourceHandle:
 
     cluster_status, handle = backend_utils.refresh_cluster_status_handle(
         cluster_name)
@@ -79,13 +80,14 @@ def _start(cluster_name: str,
                                cluster_name=cluster_name,
                                retry_until_up=retry_until_up)
     if idle_minutes_to_autostop is not None:
-        backend.set_autostop(handle, idle_minutes_to_autostop)
+        backend.set_autostop(handle, idle_minutes_to_autostop, teardown=autodown)
     return handle
 
 
 def start(cluster_name: str,
           idle_minutes_to_autostop: Optional[int] = None,
-          retry_until_up: bool = False):
+          retry_until_up: bool = False,
+          autodown: bool = False):
     """Start the cluster.
 
     Please refer to the sky.cli.start for the document.
@@ -93,7 +95,7 @@ def start(cluster_name: str,
     Raises:
         sky.exceptions.NotSupportedError: the cluster is not supported.
     """
-    _start(cluster_name, idle_minutes_to_autostop, retry_until_up)
+    _start(cluster_name, idle_minutes_to_autostop, retry_until_up, autodown)
 
 
 def stop(cluster_name: str, purge: bool = False):
@@ -156,7 +158,7 @@ def down(cluster_name: str, purge: bool = False):
     backend.teardown(handle, terminate=True, purge=purge)
 
 
-def autostop(cluster_name: str, idle_minutes_to_autostop: int):
+def autostop(cluster_name: str, idle_minutes_to_autostop: int, terminate: bool=False):
     """Set the autostop time of the cluster.
 
     Please refer to the sky.cli.autostop for the document.
@@ -170,7 +172,8 @@ def autostop(cluster_name: str, idle_minutes_to_autostop: int):
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-    operation = f'{verb} auto-stop on'
+    down_str = f' (tear down)' if terminate else ''
+    operation = f'{verb} auto-stop{down_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
             f'{operation} sky reserved cluster {cluster_name!r} '
@@ -202,7 +205,7 @@ def autostop(cluster_name: str, idle_minutes_to_autostop: int):
                 f'{colorama.Style.RESET_ALL}'
                 '\n  Auto-stop can only be set/unset for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.')
-    backend.set_autostop(handle, idle_minutes_to_autostop)
+    backend.set_autostop(handle, idle_minutes_to_autostop, terminate)
 
 
 # ==================

--- a/sky/core.py
+++ b/sky/core.py
@@ -181,8 +181,11 @@ def autostop(
         sky.exceptions.NotSupportedError: the cluster is not supported.
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
-    verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
+    is_cancel = idle_minutes_to_autostop < 0
+    verb = 'Cancelling' if is_cancel else 'Scheduling'
     option_str = 'down' if down else 'stop'
+    if is_cancel:
+        option_str = 'stop(down)'
     operation = f'{verb} auto{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(

--- a/sky/core.py
+++ b/sky/core.py
@@ -185,7 +185,7 @@ def autostop(
     verb = 'Cancelling' if is_cancel else 'Scheduling'
     option_str = 'down' if down else 'stop'
     if is_cancel:
-        option_str = 'stop(down)'
+        option_str = '{stop,down}'
     operation = f'{verb} auto{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(

--- a/sky/core.py
+++ b/sky/core.py
@@ -42,6 +42,8 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
                 'last_use': (int) timestamp of last use,
                 'status': (sky.ClusterStatus) cluster status,
                 'autostop': (int) idle time before autostop,
+                'to_down': (bool) whether to tear down the cluster after
+                            execution (autostop),
                 'metadata': (dict) metadata of the cluster,
             }
         ]
@@ -55,7 +57,7 @@ def _start(
         cluster_name: str,
         idle_minutes_to_autostop: Optional[int] = None,
         retry_until_up: bool = False,
-        down: bool = False,  #pylint: disable=redefined-outer-name
+        down: bool = False,  # pylint: disable=redefined-outer-name
 ) -> backends.Backend.ResourceHandle:
 
     cluster_status, handle = backend_utils.refresh_cluster_status_handle(
@@ -90,7 +92,7 @@ def start(
         cluster_name: str,
         idle_minutes_to_autostop: Optional[int] = None,
         retry_until_up: bool = False,
-        down: bool = False,  #pylint: disable=redefined-outer-name
+        down: bool = False,  # pylint: disable=redefined-outer-name
 ):
     """Start the cluster.
 
@@ -165,7 +167,7 @@ def down(cluster_name: str, purge: bool = False):
 def autostop(
         cluster_name: str,
         idle_minutes_to_autostop: int,
-        down: bool = False,  #pylint: disable=redefined-outer-name
+        down: bool = False,  # pylint: disable=redefined-outer-name
 ):
     """Set the autostop time of the cluster.
 
@@ -180,7 +182,7 @@ def autostop(
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-    option_str = 'stop' if down else 'down'
+    option_str = 'down' if down else 'stop'
     operation = f'{verb} auto-{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
@@ -203,7 +205,7 @@ def autostop(
             raise exceptions.NotSupportedError(
                 f'{colorama.Fore.YELLOW}{operation} cluster '
                 f'{cluster_name!r}... skipped{colorama.Style.RESET_ALL}'
-                '\n  Auto-stopping is only supported by backend: '
+                f'\n  Auto-{option_str} is only supported by backend: '
                 f'{backends.CloudVmRayBackend.NAME}')
     if cluster_status != global_user_state.ClusterStatus.UP:
         with ux_utils.print_exception_no_traceback():
@@ -211,7 +213,7 @@ def autostop(
                 f'{colorama.Fore.YELLOW}{operation} cluster '
                 f'{cluster_name!r} (status: {cluster_status.value})... skipped'
                 f'{colorama.Style.RESET_ALL}'
-                '\n  Auto-stop can only be set/unset for '
+                f'\n  Auto-{option_str} can only be set/unset for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.')
     backend.set_autostop(handle, idle_minutes_to_autostop, down)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -176,8 +176,8 @@ def autostop(cluster_name: str,
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-    down_str = ' (tear down)' if terminate else ''
-    operation = f'{verb} auto-stop{down_str} on'
+    option_str = 'stop' if terminate else 'down'
+    operation = f'{verb} auto-{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
             f'{operation} sky reserved cluster {cluster_name!r} '

--- a/sky/core.py
+++ b/sky/core.py
@@ -54,7 +54,7 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
 def _start(cluster_name: str,
            idle_minutes_to_autostop: Optional[int] = None,
            retry_until_up: bool = False,
-           autodown: bool=False) -> backends.Backend.ResourceHandle:
+           terminate: bool = False) -> backends.Backend.ResourceHandle:
 
     cluster_status, handle = backend_utils.refresh_cluster_status_handle(
         cluster_name)
@@ -80,14 +80,16 @@ def _start(cluster_name: str,
                                cluster_name=cluster_name,
                                retry_until_up=retry_until_up)
     if idle_minutes_to_autostop is not None:
-        backend.set_autostop(handle, idle_minutes_to_autostop, teardown=autodown)
+        backend.set_autostop(handle,
+                             idle_minutes_to_autostop,
+                             terminate=terminate)
     return handle
 
 
 def start(cluster_name: str,
           idle_minutes_to_autostop: Optional[int] = None,
           retry_until_up: bool = False,
-          autodown: bool = False):
+          terminate: bool = False):
     """Start the cluster.
 
     Please refer to the sky.cli.start for the document.
@@ -95,7 +97,7 @@ def start(cluster_name: str,
     Raises:
         sky.exceptions.NotSupportedError: the cluster is not supported.
     """
-    _start(cluster_name, idle_minutes_to_autostop, retry_until_up, autodown)
+    _start(cluster_name, idle_minutes_to_autostop, retry_until_up, terminate)
 
 
 def stop(cluster_name: str, purge: bool = False):
@@ -158,7 +160,9 @@ def down(cluster_name: str, purge: bool = False):
     backend.teardown(handle, terminate=True, purge=purge)
 
 
-def autostop(cluster_name: str, idle_minutes_to_autostop: int, terminate: bool=False):
+def autostop(cluster_name: str,
+             idle_minutes_to_autostop: int,
+             terminate: bool = False):
     """Set the autostop time of the cluster.
 
     Please refer to the sky.cli.autostop for the document.
@@ -172,7 +176,7 @@ def autostop(cluster_name: str, idle_minutes_to_autostop: int, terminate: bool=F
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
-    down_str = f' (tear down)' if terminate else ''
+    down_str = ' (tear down)' if terminate else ''
     operation = f'{verb} auto-stop{down_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(

--- a/sky/core.py
+++ b/sky/core.py
@@ -42,8 +42,8 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
                 'last_use': (int) timestamp of last use,
                 'status': (sky.ClusterStatus) cluster status,
                 'autostop': (int) idle time before autostop,
-                'to_down': (bool) whether to tear down the cluster after
-                            execution (autostop),
+                'to_down': (bool) whether autodown is used instead of
+                    autostop,
                 'metadata': (dict) metadata of the cluster,
             }
         ]
@@ -183,7 +183,7 @@ def autostop(
     """
     verb = 'Scheduling' if idle_minutes_to_autostop >= 0 else 'Cancelling'
     option_str = 'down' if down else 'stop'
-    operation = f'{verb} auto-{option_str} on'
+    operation = f'{verb} auto{option_str} on'
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
             f'{operation} sky reserved cluster {cluster_name!r} '
@@ -205,7 +205,7 @@ def autostop(
             raise exceptions.NotSupportedError(
                 f'{colorama.Fore.YELLOW}{operation} cluster '
                 f'{cluster_name!r}... skipped{colorama.Style.RESET_ALL}'
-                f'\n  Auto-{option_str} is only supported by backend: '
+                f'\n  auto{option_str} is only supported by backend: '
                 f'{backends.CloudVmRayBackend.NAME}')
     if cluster_status != global_user_state.ClusterStatus.UP:
         with ux_utils.print_exception_no_traceback():
@@ -213,7 +213,7 @@ def autostop(
                 f'{colorama.Fore.YELLOW}{operation} cluster '
                 f'{cluster_name!r} (status: {cluster_status.value})... skipped'
                 f'{colorama.Style.RESET_ALL}'
-                f'\n  Auto-{option_str} can only be set/unset for '
+                f'\n  auto{option_str} can only be set/unset for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.')
     backend.set_autostop(handle, idle_minutes_to_autostop, down)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -121,8 +121,8 @@ def _execute(
       dryrun: bool; if True, only print the provision info (e.g., cluster
         yaml).
       terminate: bool; whether to terminate the launched resources after
-        execution. If idle_minutes_to_autostop is set, the cluster will be
-        terminated after the specified idle time.
+        execution (successfully or abnormally). If idle_minutes_to_autostop
+        is set, the cluster will be terminated after the specified idle time.
       stream_logs: bool; whether to stream all tasks' outputs to the client.
       handle: Any; if provided, execution will use an existing backend cluster
         handle instead of provisioning a new one.
@@ -226,12 +226,12 @@ def _execute(
             finally:
                 # Enables post_execute() to be run after KeyboardInterrupt.
                 backend.post_execute(handle, terminate)
-
+    finally:
         if stages is None or Stage.TERMINATE in stages:
             if terminate and idle_minutes_to_autostop is None:
                 backend.teardown_ephemeral_storage(task)
                 backend.teardown(handle, terminate=True)
-    finally:
+
         if cluster_name != spot.SPOT_CONTROLLER_NAME:
             # UX: print live clusters to make users aware (to save costs).
             #

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -169,11 +169,16 @@ def _execute(
             idle_minutes_to_autostop = 0
         if idle_minutes_to_autostop is not None:
             if idle_minutes_to_autostop == 0:
+                # idle_minutes_to_autostop=0 can cause the following problem:
+                # After we set the autostop in the PRE_EXEC stage with -i 0,
+                # it could be possible that the cluster immediately found
+                # itself have no task running and start the auto{stop,down}
+                # process, before the task is submitted in the EXEC stage.
                 verb = 'torn down' if down else 'stopped'
-                logger.warning(f'{colorama.Fore.LIGHTBLACK_EX}Setting '
-                               'idle_minutes_to_autostop to 1, to avoid '
-                               f'cluster being {verb} during task submission.'
-                               f'{colorama.Style.RESET_ALL}')
+                logger.info(f'{colorama.Fore.LIGHTBLACK_EX}The cluster will '
+                            f'be {verb} after 1 minutes of idleness '
+                            '(after all jobs finish).'
+                            f'{colorama.Style.RESET_ALL}')
                 idle_minutes_to_autostop = 1
             stages.remove(Stage.DOWN)
     elif idle_minutes_to_autostop is not None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -226,12 +226,12 @@ def _execute(
             finally:
                 # Enables post_execute() to be run after KeyboardInterrupt.
                 backend.post_execute(handle, down)
-    finally:
+
         if stages is None or Stage.DOWN in stages:
             if down and idle_minutes_to_autostop is None:
                 backend.teardown_ephemeral_storage(task)
                 backend.teardown(handle, terminate=True)
-
+    finally:
         if cluster_name != spot.SPOT_CONTROLLER_NAME:
             # UX: print live clusters to make users aware (to save costs).
             #

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -214,7 +214,7 @@ def _execute(
 
         if stages is None or Stage.PRE_EXEC in stages:
             if idle_minutes_to_autostop is not None:
-                backend.set_autostop(handle, idle_minutes_to_autostop)
+                backend.set_autostop(handle, idle_minutes_to_autostop, teardown=teardown)
 
         if stages is None or Stage.EXEC in stages:
             try:
@@ -225,7 +225,7 @@ def _execute(
                 backend.post_execute(handle, teardown)
 
         if stages is None or Stage.TEARDOWN in stages:
-            if teardown:
+            if teardown and idle_minutes_to_autostop is None:
                 backend.teardown_ephemeral_storage(task)
                 backend.teardown(handle, terminate=True)
     finally:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -171,8 +171,10 @@ def _execute(
         if idle_minutes_to_autostop is not None:
             if idle_minutes_to_autostop == 0:
                 verb = 'torn down' if down else 'stopped'
-                logger.debug('Setting idle_minutes_to_autostop to 1, to avoid '
-                             f'cluster being {verb} during task submission.')
+                logger.warning(f'{colorama.Fore.LIGHTBLACK_EX}Setting '
+                               'idle_minutes_to_autostop to 1, to avoid '
+                               f'cluster being {verb} during task submission.'
+                               f'{colorama.Style.RESET_ALL}')
                 idle_minutes_to_autostop = 1
             stages.remove(Stage.DOWN)
     elif idle_minutes_to_autostop is not None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -121,7 +121,8 @@ def _execute(
       dryrun: bool; if True, only print the provision info (e.g., cluster
         yaml).
       terminate: bool; whether to terminate the launched resources after
-        execution.
+        execution. If idle_minutes_to_autostop is set, the cluster will be
+        terminated after the specified idle time.
       stream_logs: bool; whether to stream all tasks' outputs to the client.
       handle: Any; if provided, execution will use an existing backend cluster
         handle instead of provisioning a new one.

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -16,16 +16,16 @@ class AutostopConfig:
                  autostop_idle_minutes: int,
                  boot_time: int,
                  backend: Optional[str],
-                 terminate: bool = False):
+                 down: bool = False):
         assert autostop_idle_minutes < 0 or backend is not None, (
             autostop_idle_minutes, backend)
         self.autostop_idle_minutes = autostop_idle_minutes
         self.boot_time = boot_time
         self.backend = backend
-        self.terminate = terminate
+        self.down = down
 
     def __set_state__(self, state: dict):
-        state.setdefault('terminate', False)
+        state.setdefault('down', False)
         self.__dict__.update(state)
 
 
@@ -36,11 +36,9 @@ def get_autostop_config() -> Optional[AutostopConfig]:
     return pickle.loads(config_str)
 
 
-def set_autostop(idle_minutes: int, backend: Optional[str],
-                 terminate: bool) -> None:
+def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
     boot_time = psutil.boot_time()
-    autostop_config = AutostopConfig(idle_minutes, boot_time, backend,
-                                     terminate)
+    autostop_config = AutostopConfig(idle_minutes, boot_time, backend, down)
     configs.set_config(AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
 
 
@@ -54,11 +52,10 @@ class AutostopCodeGen:
     _PREFIX = ['from sky.skylet import autostop_lib']
 
     @classmethod
-    def set_autostop(cls, idle_minutes: int, backend: str,
-                     terminate: bool) -> str:
+    def set_autostop(cls, idle_minutes: int, backend: str, down: bool) -> str:
         code = [
             f'autostop_lib.set_autostop({idle_minutes}, {backend!r},'
-            f' {terminate})',
+            f' {down})',
         ]
         return cls._build(code)
 

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -10,18 +10,22 @@ AUTOSTOP_CONFIG_KEY = 'autostop_config'
 
 
 class AutostopConfig:
+    """Autostop configuration."""
 
-    def __init__(self, autostop_idle_minutes: int, boot_time: int,
-                 backend: Optional[str], teardown: bool = False):
+    def __init__(self,
+                 autostop_idle_minutes: int,
+                 boot_time: int,
+                 backend: Optional[str],
+                 terminate: bool = False):
         assert autostop_idle_minutes < 0 or backend is not None, (
             autostop_idle_minutes, backend)
         self.autostop_idle_minutes = autostop_idle_minutes
         self.boot_time = boot_time
         self.backend = backend
-        self.teardown = teardown
+        self.terminate = terminate
 
     def __set_state__(self, state: dict):
-        state.setdefault('teardown', False)
+        state.setdefault('terminate', False)
         self.__dict__.update(state)
 
 
@@ -32,9 +36,11 @@ def get_autostop_config() -> Optional[AutostopConfig]:
     return pickle.loads(config_str)
 
 
-def set_autostop(idle_minutes: int, backend: Optional[str], teardown: bool) -> None:
+def set_autostop(idle_minutes: int, backend: Optional[str],
+                 terminate: bool) -> None:
     boot_time = psutil.boot_time()
-    autostop_config = AutostopConfig(idle_minutes, boot_time, backend, teardown)
+    autostop_config = AutostopConfig(idle_minutes, boot_time, backend,
+                                     terminate)
     configs.set_config(AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
 
 
@@ -48,9 +54,11 @@ class AutostopCodeGen:
     _PREFIX = ['from sky.skylet import autostop_lib']
 
     @classmethod
-    def set_autostop(cls, idle_minutes: int, backend: str, teardown: bool) -> str:
+    def set_autostop(cls, idle_minutes: int, backend: str,
+                     terminate: bool) -> str:
         code = [
-            f'autostop_lib.set_autostop({idle_minutes}, {backend!r}, {teardown})',
+            f'autostop_lib.set_autostop({idle_minutes}, {backend!r},'
+            f' {terminate})',
         ]
         return cls._build(code)
 

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -12,12 +12,17 @@ AUTOSTOP_CONFIG_KEY = 'autostop_config'
 class AutostopConfig:
 
     def __init__(self, autostop_idle_minutes: int, boot_time: int,
-                 backend: Optional[str]):
+                 backend: Optional[str], teardown: bool = False):
         assert autostop_idle_minutes < 0 or backend is not None, (
             autostop_idle_minutes, backend)
         self.autostop_idle_minutes = autostop_idle_minutes
         self.boot_time = boot_time
         self.backend = backend
+        self.teardown = teardown
+
+    def __set_state__(self, state: dict):
+        state.setdefault('teardown', False)
+        self.__dict__.update(state)
 
 
 def get_autostop_config() -> Optional[AutostopConfig]:
@@ -27,9 +32,9 @@ def get_autostop_config() -> Optional[AutostopConfig]:
     return pickle.loads(config_str)
 
 
-def set_autostop(idle_minutes: int, backend: Optional[str]) -> None:
+def set_autostop(idle_minutes: int, backend: Optional[str], teardown: bool) -> None:
     boot_time = psutil.boot_time()
-    autostop_config = AutostopConfig(idle_minutes, boot_time, backend)
+    autostop_config = AutostopConfig(idle_minutes, boot_time, backend, teardown)
     configs.set_config(AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
 
 
@@ -43,9 +48,9 @@ class AutostopCodeGen:
     _PREFIX = ['from sky.skylet import autostop_lib']
 
     @classmethod
-    def set_autostop(cls, idle_minutes: int, backend: str) -> str:
+    def set_autostop(cls, idle_minutes: int, backend: str, teardown: bool) -> str:
         code = [
-            f'autostop_lib.set_autostop({idle_minutes}, {backend!r})',
+            f'autostop_lib.set_autostop({idle_minutes}, {backend!r}, {teardown})',
         ]
         return cls._build(code)
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -119,7 +119,8 @@ class AutostopEvent(SkyletEvent):
     def _stop_cluster(self, autostop_config):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
-            self._replace_yaml_for_stopping(self.ray_yaml_path, autostop_config.teardown)
+            self._replace_yaml_for_stopping(self.ray_yaml_path,
+                                            autostop_config.teardown)
             # `ray up` is required to reset the upscaling speed and min/max
             # workers. Otherwise, `ray down --workers-only` will continuously
             # scale down and up.
@@ -142,9 +143,11 @@ class AutostopEvent(SkyletEvent):
         yaml_str = self._NUM_WORKER_PATTERN.sub(r'\g<1>_workers: 0', yaml_str)
         yaml_str = self._UPSCALING_PATTERN.sub(r'upscaling_speed: 0', yaml_str)
         if teardown:
-            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: false', yaml_str)
+            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: false',
+                                             yaml_str)
         else:
-            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: true', yaml_str)
+            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: true',
+                                             yaml_str)
         config = yaml.safe_load(yaml_str)
         # Set the private key with the existed key on the remote instance.
         config['auth']['ssh_private_key'] = '~/ray_bootstrap_key.pem'

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -120,7 +120,7 @@ class AutostopEvent(SkyletEvent):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
             self._replace_yaml_for_stopping(self.ray_yaml_path,
-                                            autostop_config.teardown)
+                                            autostop_config.terminate)
             # `ray up` is required to reset the upscaling speed and min/max
             # workers. Otherwise, `ray down --workers-only` will continuously
             # scale down and up.
@@ -136,13 +136,13 @@ class AutostopEvent(SkyletEvent):
         else:
             raise NotImplementedError
 
-    def _replace_yaml_for_stopping(self, yaml_path: str, teardown: bool):
+    def _replace_yaml_for_stopping(self, yaml_path: str, terminate: bool):
         with open(yaml_path, 'r') as f:
             yaml_str = f.read()
         # Update the number of workers to 0.
         yaml_str = self._NUM_WORKER_PATTERN.sub(r'\g<1>_workers: 0', yaml_str)
         yaml_str = self._UPSCALING_PATTERN.sub(r'upscaling_speed: 0', yaml_str)
-        if teardown:
+        if terminate:
             yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: false',
                                              yaml_str)
         else:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -120,7 +120,7 @@ class AutostopEvent(SkyletEvent):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
             self._replace_yaml_for_stopping(self.ray_yaml_path,
-                                            autostop_config.terminate)
+                                            autostop_config.down)
             # `ray up` is required to reset the upscaling speed and min/max
             # workers. Otherwise, `ray down --workers-only` will continuously
             # scale down and up.
@@ -136,13 +136,13 @@ class AutostopEvent(SkyletEvent):
         else:
             raise NotImplementedError
 
-    def _replace_yaml_for_stopping(self, yaml_path: str, terminate: bool):
+    def _replace_yaml_for_stopping(self, yaml_path: str, down: bool):
         with open(yaml_path, 'r') as f:
             yaml_str = f.read()
         # Update the number of workers to 0.
         yaml_str = self._NUM_WORKER_PATTERN.sub(r'\g<1>_workers: 0', yaml_str)
         yaml_str = self._UPSCALING_PATTERN.sub(r'upscaling_speed: 0', yaml_str)
-        if terminate:
+        if down:
             yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: false',
                                              yaml_str)
         else:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -119,7 +119,7 @@ class AutostopEvent(SkyletEvent):
     def _stop_cluster(self, autostop_config):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
-            self._replace_yaml_for_stopping(self.ray_yaml_path)
+            self._replace_yaml_for_stopping(self.ray_yaml_path, autostop_config.teardown)
             # `ray up` is required to reset the upscaling speed and min/max
             # workers. Otherwise, `ray down --workers-only` will continuously
             # scale down and up.
@@ -135,13 +135,16 @@ class AutostopEvent(SkyletEvent):
         else:
             raise NotImplementedError
 
-    def _replace_yaml_for_stopping(self, yaml_path: str):
+    def _replace_yaml_for_stopping(self, yaml_path: str, teardown: bool):
         with open(yaml_path, 'r') as f:
             yaml_str = f.read()
         # Update the number of workers to 0.
         yaml_str = self._NUM_WORKER_PATTERN.sub(r'\g<1>_workers: 0', yaml_str)
         yaml_str = self._UPSCALING_PATTERN.sub(r'upscaling_speed: 0', yaml_str)
-        yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: true', yaml_str)
+        if teardown:
+            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: false', yaml_str)
+        else:
+            yaml_str = self._CATCH_NODES.sub(r'cache_stopped_nodes: true', yaml_str)
         config = yaml.safe_load(yaml_str)
         # Set the private key with the existed key on the remote instance.
         config['auth']['ssh_private_key'] = '~/ray_bootstrap_key.pem'

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -123,9 +123,11 @@ class AutostopEvent(SkyletEvent):
             # `ray up` is required to reset the upscaling speed and min/max
             # workers. Otherwise, `ray down --workers-only` will continuously
             # scale down and up.
-            subprocess.run(
-                ['ray', 'up', '-y', '--restart-only', '--disable-usage-stats', self.ray_yaml_path],
-                check=True)
+            subprocess.run([
+                'ray', 'up', '-y', '--restart-only', '--disable-usage-stats',
+                self.ray_yaml_path
+            ],
+                           check=True)
             # Stop the workers first to avoid orphan workers.
             subprocess.run(
                 ['ray', 'down', '-y', '--workers-only', self.ray_yaml_path],
@@ -152,4 +154,3 @@ class AutostopEvent(SkyletEvent):
         config['file_mounts'] = dict()
         common_utils.dump_yaml(yaml_path, config)
         logger.debug('Replaced upscaling speed to 0.')
-

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -208,10 +208,17 @@ def _get_zone(cluster_status):
 
 
 def _get_autostop(cluster_status):
-    autostop_str = '-'
+    autostop_str = ''
+    separtion = ''
     if cluster_status['autostop'] >= 0:
         # TODO(zhwu): check the status of the autostop cluster.
         autostop_str = str(cluster_status['autostop']) + ' min'
+        separtion = ' '
+
+    if cluster_status['to_down']:
+        autostop_str += f'{separtion}(down)'
+    if autostop_str == '':
+        autostop_str = '-'
     return autostop_str
 
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -72,7 +72,7 @@ def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
         if pending_autostop:
             click.echo(
                 '\n'
-                f'You have {pending_autostop} clusters with autostop(down) '
+                f'You have {pending_autostop} clusters with auto{{stop,down}} '
                 'scheduled. Refresh statuses with: `sky status --refresh`.')
     else:
         click.echo('No existing clusters.')

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -72,8 +72,8 @@ def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
         if pending_autostop:
             click.echo(
                 '\n'
-                f'You have {pending_autostop} clusters with autostop scheduled.'
-                ' Refresh statuses with: `sky status --refresh`.')
+                f'You have {pending_autostop} clusters with autostop(down) '
+                'scheduled. Refresh statuses with: `sky status --refresh`.')
     else:
         click.echo('No existing clusters.')
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -34,7 +34,7 @@ class StatusColumn:
 
 def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
     """Compute cluster table values and display."""
-    # TODO(zhwu): Update the information for auto-stop clusters.
+    # TODO(zhwu): Update the information for autostop clusters.
 
     status_columns = [
         StatusColumn('NAME', _get_name),
@@ -212,7 +212,7 @@ def _get_autostop(cluster_status):
     separtion = ''
     if cluster_status['autostop'] >= 0:
         # TODO(zhwu): check the status of the autostop cluster.
-        autostop_str = str(cluster_status['autostop']) + ' min'
+        autostop_str = str(cluster_status['autostop']) + 'm'
         separtion = ' '
 
     if cluster_status['to_down']:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -539,7 +539,7 @@ def test_autodown():
             'sleep 240',
             # Ensure the cluster is terminated.
             f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
-            f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 -i 1 --down examples/minimal.yaml',
+            f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             'sleep 240',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -535,16 +535,22 @@ def test_autodown():
             f'sky launch -y -d -c {name} --num-nodes 2 --cloud gcp examples/minimal.yaml',
             f'sky autostop -y {name} --down -i 1',
             # Ensure autostop is set.
-            f'sky status | grep {name} | grep "1 min"',
+            f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
             f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
+            f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
             f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
+            f'sky autostop -y {name} --cancel',
+            'sleep 240',
+            # Ensure the cluster is still UP.
+            f's=$(sky status --refresh) && printf "$s" && echo $s | grep {name} | grep UP',
         ],
         f'sky down -y {name}',
         timeout=20 * 60,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -538,19 +538,19 @@ def test_autodown():
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky autostop -y {name} --cancel',
             'sleep 240',
             # Ensure the cluster is still UP.
-            f's=$(sky status --refresh) && printf "$s" && echo $s | grep {name} | grep UP',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && echo $s | grep {name} | grep UP',
         ],
         f'sky down -y {name}',
         timeout=20 * 60,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -536,14 +536,14 @@ def test_autodown():
             f'sky autostop -y {name} --down -i 1',
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "1 min"',
-            'sleep 180',
+            'sleep 240',
             # Ensure the cluster is STOPPED.
-            f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
-            f'sky launch -y -d -c {name} --cloud gcp -i 2 --down examples/minimal.yaml',
+            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
+            f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 -i 1 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
-            f'sky exec {name} --cloud gcp examples/minimal.yaml',
-            'sleep 180',
-            f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
+            f'sky exec {name} --cloud aws examples/minimal.yaml',
+            'sleep 240',
+            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
         ],
         f'sky down -y {name}',
         timeout=20 * 60,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -532,7 +532,7 @@ def test_autodown():
     test = Test(
         'autodown',
         [
-            f'sky launch -y -d -c {name} --num-nodes 2 --cloud aws examples/minimal.yaml',
+            f'sky launch -y -d -c {name} --num-nodes 2 --cloud gcp examples/minimal.yaml',
             f'sky autostop -y {name} --down -i 1',
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "1 min"',
@@ -541,7 +541,7 @@ def test_autodown():
             f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
             f'sky launch -y -d -c {name} --cloud gcp -i 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
-            f'sky exec {name} examples/minimal.yaml',
+            f'sky exec {name} --cloud gcp examples/minimal.yaml',
             f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
         ],
         f'sky down -y {name}',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -763,7 +763,7 @@ def test_inline_spot_env():
         [
             f'sky spot launch -n {name} -y --env TEST_ENV="hello world" -- "([[ ! -z \\"\$TEST_ENV\\" ]] && [[ ! -z \\"\$SKY_NODE_IPS\\" ]] && [[ ! -z \\"\$SKY_NODE_RANK\\" ]]) || exit 1"',
             'sleep 10',
-            f'sky spot status | grep {name} | grep SUCCEEDED',
+            f's=$(sky spot status) && printf "$s" && echo "$s"  | grep {name} | grep SUCCEEDED',
         ],
         f'sky spot cancel -y -n {name}',
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -525,6 +525,29 @@ def test_autostop():
     )
     run_one_test(test)
 
+# ---------- Testing Autostopping ----------
+def test_autodown():
+    name = _get_cluster_name()
+    test = Test(
+        'autodown',
+        [
+            f'sky launch -y -d -c {name} --num-nodes 2 --cloud gcp examples/minimal.yaml',
+            f'sky autostop -y {name} --down -i 1',
+            # Ensure autostop is set.
+            f'sky status | grep {name} | grep "1 min"',
+            'sleep 180',
+            # Ensure the cluster is STOPPED.
+            f's=$(sky status --refresh) && {{echo $s |grep {name} | grep "was terminated";}} || {{echo $s | grep {name} && exit 1 || exit 0;}}', # Ensure the cluster is DOWN.
+            f'sky launch -y -d -c {name} --cloud gcp -i 2 --down examples/minimal.yaml',
+            f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
+            f'sky exec {name} examples/minimal.yaml',
+            f's=$(sky status --refresh) && {{echo $s |grep {name} | grep "was terminated";}} || {{echo $s | grep {name} && exit 1 || exit 0;}}', # Ensure the cluster is DOWN.
+        ],
+        f'sky down -y {name}',
+        timeout=20 * 60,
+    )
+    run_one_test(test)
+
 
 def _get_cancel_task_with_cloud(name, cloud, timeout=15 * 60):
     test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -525,23 +525,24 @@ def test_autostop():
     )
     run_one_test(test)
 
+
 # ---------- Testing Autostopping ----------
 def test_autodown():
     name = _get_cluster_name()
     test = Test(
         'autodown',
         [
-            f'sky launch -y -d -c {name} --num-nodes 2 --cloud gcp examples/minimal.yaml',
+            f'sky launch -y -d -c {name} --num-nodes 2 --cloud aws examples/minimal.yaml',
             f'sky autostop -y {name} --down -i 1',
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "1 min"',
             'sleep 180',
             # Ensure the cluster is STOPPED.
-            f's=$(sky status --refresh) && {{echo $s |grep {name} | grep "was terminated";}} || {{echo $s | grep {name} && exit 1 || exit 0;}}', # Ensure the cluster is DOWN.
+            f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
             f'sky launch -y -d -c {name} --cloud gcp -i 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} examples/minimal.yaml',
-            f's=$(sky status --refresh) && {{echo $s |grep {name} | grep "was terminated";}} || {{echo $s | grep {name} && exit 1 || exit 0;}}', # Ensure the cluster is DOWN.
+            f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
         ],
         f'sky down -y {name}',
         timeout=20 * 60,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -512,7 +512,7 @@ def test_autostop():
             f'sky launch -y -d -c {name} --num-nodes 2 examples/minimal.yaml',
             f'sky autostop -y {name} -i 1',
             # Ensure autostop is set.
-            f'sky status | grep {name} | grep "1 min"',
+            f'sky status | grep {name} | grep "1m"',
             'sleep 180',
             # Ensure the cluster is STOPPED.
             f'sky status --refresh | grep {name} | grep STOPPED',
@@ -539,14 +539,14 @@ def test_autodown():
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky autostop -y {name} --cancel',
             'sleep 240',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -542,6 +542,7 @@ def test_autodown():
             f'sky launch -y -d -c {name} --cloud gcp -i 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud gcp examples/minimal.yaml',
+            'sleep 180',
             f's=$(sky status --refresh) && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
         ],
         f'sky down -y {name}',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -526,7 +526,7 @@ def test_autostop():
     run_one_test(test)
 
 
-# ---------- Testing Autostopping ----------
+# ---------- Testing Autodowning ----------
 def test_autodown():
     name = _get_cluster_name()
     test = Test(
@@ -537,13 +537,14 @@ def test_autodown():
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "1 min"',
             'sleep 240',
-            # Ensure the cluster is STOPPED.
-            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
+            # Ensure the cluster is terminated.
+            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 -i 1 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             'sleep 240',
-            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',  # Ensure the cluster is DOWN.
+            # Ensure the cluster is terminated.
+            f's=$(sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "was terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
         ],
         f'sky down -y {name}',
         timeout=20 * 60,

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -141,7 +141,7 @@ class TestReservedClustersOperations:
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.autostop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
-        assert ('Scheduling auto-stop on reserved cluster(s) '
+        assert ('Scheduling autostop on reserved cluster(s) '
                 f'\'{spot.SPOT_CONTROLLER_NAME}\' is not supported'
                 in result.output)
 


### PR DESCRIPTION
Closes #954.

Please refer to the following tests for the design of the CLI.
Main changes:
1. Add an option `--terminate` for`sky launch` and `sky start`
2. Add an option `--terminate` for `sky autostop`
3. `sky.launch` replaces the `teardown` option with `terminate`.


Tested:
- [x] `sky launch -c test-autodown -i 1 --terminate`; `sky status -r`
- [x] `sky cpunode -c test-autodown --cloud gcp`; `sky autostop  --terminate test-autodown`; `sky status -r`
- [x] `sky cpunode -c test-autodown`; `sky stop test-autodown`; `sky start test-autodown -i 1 --terminate`; `sky status -r`
- [x] `tests/run_smoke_tests.sh test_autodown`
- [x] `sky launch -c test-autodown -i 2 --terminate`; `sky status`
```
NAME             LAUNCHED        RESOURCES             STATUS   AUTOSTOP      COMMAND                         
test-autodown    a few secs ago  1x AWS(m6i.2xlarge)   UP       2 min (down)  sky launch -c test-autodown...  
smoke-test-zhwu  4 days ago      1x GCP(n1-highmem-8)  STOPPED  -             sky start smoke-test-zhwu      
```