### PR TITLE
Reduce iops for aws instances

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -31,7 +31,10 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            Iops: 3000 # use default Iops for gp3
+            # use default Iops for gp3
+            VolumeType: gp3
+            Iops: 3000
+            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -51,7 +54,9 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            Iops: 3000 # use default Iops for gp3
+            VolumeType: gp3
+            Iops: 3000
+            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -26,10 +26,12 @@ available_node_types:
     node_config:
       InstanceType: {{instance_type}}
       ImageId: {{image_id}}  # Deep Learning AMI (Ubuntu 18.04); see aws.py.
+      # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
+            Iops: 3000 # use default Iops for gp3
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -49,6 +51,7 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
+            Iops: 3000 # use default Iops for gp3
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot


### PR DESCRIPTION
Our current default instance created on the AWS has the volume with the maximum IOPs, i.e. 16000. However, by default, the instance created on the AWS console only has 3000 IOPs by default.
Our volume costs (16000-3000) * 0.005 / 30 / 24 = $0.09 / hour, which is 20% of the cost for our default CPU machine on AWS m6i.2xlarge.

Todo item: make this IOPs configurable across the clouds (probably simplify it by only having three tier: low, medium, high).

Tested:
- [x] `sky cpunode -c test-iops`
- [x] `sky launch --disk-size 1024`
- [x] `sky launch --disk-size 50`
- [x] `sky gpunode -c test-t4 --gpus t4`