### PR TITLE
[Storage] Add `StorageMode` to __init__

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -16,7 +16,7 @@ from sky.execution import launch, exec, spot_launch  # pylint: disable=redefined
 from sky.resources import Resources
 from sky.task import Task
 from sky.optimizer import Optimizer, OptimizeTarget
-from sky.data import Storage, StoreType
+from sky.data import Storage, StorageMode, StoreType
 from sky.global_user_state import ClusterStatus
 from sky.skylet.job_lib import JobStatus
 from sky.core import (status, start, stop, down, autostop, queue, cancel,
@@ -43,6 +43,7 @@ __all__ = [
     'list_accelerators',
     '__root_dir__',
     'Storage',
+    'StorageMode'
     'StoreType',
     'ClusterStatus',
     'JobStatus',

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -43,7 +43,7 @@ __all__ = [
     'list_accelerators',
     '__root_dir__',
     'Storage',
-    'StorageMode'
+    'StorageMode',
     'StoreType',
     'ClusterStatus',
     'JobStatus',

--- a/sky/data/__init__.py
+++ b/sky/data/__init__.py
@@ -1,4 +1,4 @@
 """Sky Data."""
-from sky.data.storage import Storage, StoreType
+from sky.data.storage import Storage, StorageMode, StoreType
 
-__all__ = ['Storage', 'StoreType']
+__all__ = ['Storage', 'StorageMode', 'StoreType']


### PR DESCRIPTION
Adds `StorageMode` enum to the `sky` module to make using Storage programmatic API easier.

Before:
```
sky.Storage(source='s3://example/', mode=sky.data.storage.StorageMode.MOUNT)
```

After:
```
sky.Storage(source='s3://example/', mode=sky.StorageMode.MOUNT)
```

Tested:
- [x] Smoke tests