### PR TITLE
Revert "Reduce iops for aws instances"

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -26,15 +26,10 @@ available_node_types:
     node_config:
       InstanceType: {{instance_type}}
       ImageId: {{image_id}}  # Deep Learning AMI (Ubuntu 18.04); see aws.py.
-      # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            # use default Iops for gp3
-            VolumeType: gp3
-            Iops: 3000
-            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -54,9 +49,6 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            VolumeType: gp3
-            Iops: 3000
-            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot


### PR DESCRIPTION
Reverts skypilot-org/skypilot#1221

It is not back-compat, if the user has a stopped cluster. We need to keep the original configuration for the existing cluster.