### PR TITLE
[Storage] Disallow single files for upload to Storage

### DIFF
--- a/docs/source/examples/syncing-code-artifacts.rst
+++ b/docs/source/examples/syncing-code-artifacts.rst
@@ -64,6 +64,7 @@ scripts, access checkpoints, etc.).
     $ # cluster1 will get the updated code.
     $ sky exec cluster1 task.yaml
 
+.. _file-mounts-example:
 
 Uploading files outside of workdir
 --------------------------------------

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -4,7 +4,8 @@ SkyPilot Storage
 =================
 
 A SkyPilot Storage object represents an abstract data store containing large data
-files required by the task. Compared to file_mounts, storage is faster and
+files required by the task. Think of it as a bucket of files that can be attached
+to your task. Compared to file_mounts, storage is faster and
 can persist across runs, requiring fewer uploads from your local machine.
 Behind the scenes, storage automatically uploads all data in the source
 to a backing object store in a particular cloud (S3/GCS/Azure Blob).
@@ -174,6 +175,11 @@ and storage mounting:
     For mounts backed by SkyPilot Storage, symbolic links are not copied to remote.
     For mounts not using SkyPilot Storage (e.g., those using rsync) the symbolic links are directly copied, not their target data.
     The targets must be separately mounted or else the symlinks may break.
+
+.. note::
+    Storage only supports uploading directories (i.e., :code:`source` cannot be a file).
+    To upload a single file to a bucket, please put in a directory and specify the directory as the source.
+    To directly copy a file to a VM, please use regular :ref:`file mounts <file-mounts-example>`.
 
 Creating a shared file system
 -----------------------------

--- a/examples/storage_demo.yaml
+++ b/examples/storage_demo.yaml
@@ -94,7 +94,7 @@ file_mounts:
   # When the VM is initialized, the contents of the bucket are copied to
   # /datasets-storage. If the bucket already exists, it is fetched and re-used.
   /datasets-storage:
-    name: sky-dataset-romil # Make sure this name is unique or you own this bucket
+    name: sky-dataset-romilzz # Make sure this name is unique or you own this bucket
     source: ~/datasets
     store: s3 # Could be either of [s3, gcs]; default: None
     persistent: True  # Defaults to True, can be set to false.
@@ -110,7 +110,7 @@ file_mounts:
   # other storage mounts using the same bucket with MOUNT mode. Note that the
   # source is synced with the remote bucket everytime this task is run.
   /dataset-storage-mount:
-    name: sky-dataset-romil
+    name: sky-dataset-romilzz
     source: ~/datasets
     mode: MOUNT
 
@@ -137,7 +137,7 @@ file_mounts:
   # this approach can also be used to create a shared filesystem across workers.
   # See examples/storage/pingpong.yaml for an example.
   /outputs-mount:
-    name: romil-output-bucket
+    name: romil-output-bucketzz
     mode: MOUNT
 
 run: |

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -459,15 +459,15 @@ class Storage(object):
                         '(try "/mydir: /mydir" or "/myfile: /myfile"). '
                         f'Found source={source}')
             # Local path, check if it exists
-            expanded_source = os.path.abspath(os.path.expanduser(source))
+            full_src = os.path.abspath(os.path.expanduser(source))
             # Only check if local source exists if it is synced to the bucket
-            if not os.path.exists(expanded_source) and sync_on_reconstruction:
+            if not os.path.exists(full_src) and sync_on_reconstruction:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageSourceError(
                         'Local source path does not'
                         f' exist: {source}')
             # Check if source is a file - throw error if it is
-            if os.path.isfile(expanded_source):
+            if os.path.isfile(full_src):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageSourceError(
                         'Storage source path cannot be a file - only '
@@ -478,7 +478,7 @@ class Storage(object):
                         'section of your YAML, or\n2) Place the file in a '
                         'directory and specify the directory as the source.')
             # Raise warning if user's path is a symlink
-            elif os.path.islink(expanded_source):
+            elif os.path.islink(full_src):
                 logger.warning(f'Source path {source} is a symlink. '
                                'Referenced contents are uploaded, matching '
                                'the default behavior for S3 and GCS syncing.')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -472,11 +472,11 @@ class Storage(object):
                     raise exceptions.StorageSourceError(
                         'Storage source path cannot be a file - only '
                         'directories are supported as a source. '
-                        'To upload a single file, either\n1) Use regular file mounts by '
-                        f'writing <destination_path>: {source} in the '
-                        'file_mounts section of your YAML, or\n2) Place the file '
-                        'in a directory and specify the directory as the '
-                        'source.')
+                        'To upload a single file, either\n'
+                        '1) Use regular file mounts by writing '
+                        f'<destination_path>: {source} in the file_mounts '
+                        'section of your YAML, or\n2) Place the file in a '
+                        'directory and specify the directory as the source.')
             # Raise warning if user's path is a symlink
             elif os.path.islink(expanded_source):
                 logger.warning(f'Source path {source} is a symlink. '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -459,15 +459,26 @@ class Storage(object):
                         '(try "/mydir: /mydir" or "/myfile: /myfile"). '
                         f'Found source={source}')
             # Local path, check if it exists
-            source = os.path.abspath(os.path.expanduser(source))
+            expanded_source = os.path.abspath(os.path.expanduser(source))
             # Only check if local source exists if it is synced to the bucket
-            if not os.path.exists(source) and sync_on_reconstruction:
+            if not os.path.exists(expanded_source) and sync_on_reconstruction:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageSourceError(
                         'Local source path does not'
                         f' exist: {source}')
+            # Check if source is a file - throw error if it is
+            if os.path.isfile(expanded_source):
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageSourceError(
+                        'Storage source path cannot be a file - only '
+                        'directories are supported as a source. '
+                        'To upload a single file, either\n1) Use regular file mounts by '
+                        f'writing <destination_path>: {source} in the '
+                        'file_mounts section of your YAML, or\n2) Place the file '
+                        'in a directory and specify the directory as the '
+                        'source.')
             # Raise warning if user's path is a symlink
-            elif os.path.islink(source):
+            elif os.path.islink(expanded_source):
                 logger.warning(f'Source path {source} is a symlink. '
                                'Referenced contents are uploaded, matching '
                                'the default behavior for S3 and GCS syncing.')

--- a/sky/task.py
+++ b/sky/task.py
@@ -10,6 +10,7 @@ import yaml
 import sky
 from sky import check
 from sky import clouds
+from sky import exceptions
 from sky import global_user_state
 from sky.backends import backend_utils
 from sky.data import storage as storage_lib
@@ -260,7 +261,12 @@ class Task:
             mount_path = storage[0]
             assert mount_path, \
                 'Storage mount path cannot be empty.'
-            storage_obj = storage_lib.Storage.from_yaml_config(storage[1])
+            try:
+                storage_obj = storage_lib.Storage.from_yaml_config(storage[1])
+            except exceptions.StorageSourceError as e:
+                # Patch the error message to include the mount path, if included
+                e.args = (e.args[0].replace('<destination_path>', mount_path),) + e.args[1:]
+                raise e
             task_storage_mounts[mount_path] = storage_obj
         task.set_storage_mounts(task_storage_mounts)
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -265,7 +265,8 @@ class Task:
                 storage_obj = storage_lib.Storage.from_yaml_config(storage[1])
             except exceptions.StorageSourceError as e:
                 # Patch the error message to include the mount path, if included
-                e.args = (e.args[0].replace('<destination_path>', mount_path),) + e.args[1:]
+                e.args = (e.args[0].replace('<destination_path>',
+                                            mount_path),) + e.args[1:]
                 raise e
             task_storage_mounts[mount_path] = storage_obj
         task.set_storage_mounts(task_storage_mounts)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+import tempfile
 
 from sky import exceptions
 from sky.data import storage as storage_lib
@@ -20,6 +21,11 @@ class TestStorageSpecLocalSource:
             storage_lib.Storage(name='test', source='/bin/')
         assert 'Storage source paths cannot end with a slash' in str(e)
 
+    def test_source_single_file(self):
+        with pytest.raises(exceptions.StorageSourceError) as e:
+            with tempfile.NamedTemporaryFile() as f:
+                storage_lib.Storage(name='test', source=f.name)
+        assert 'Storage source path cannot be a file' in str(e)
 
 class TestStorageSpecValidation:
     """Storage specification validation tests"""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -27,6 +27,7 @@ class TestStorageSpecLocalSource:
                 storage_lib.Storage(name='test', source=f.name)
         assert 'Storage source path cannot be a file' in str(e)
 
+
 class TestStorageSpecValidation:
     """Storage specification validation tests"""
 


### PR DESCRIPTION
Mitigates #1226 by raising an exception if files are uploaded to sky storage.

```
(base) romilb@romilbx1yoga:$ sky launch storage_test.yaml 

Task from YAML spec: storage_test.yaml
sky.exceptions.StorageSourceError: Storage source path cannot be a file - only directories are supported as a source. To upload a single file, either
1) Use regular file mounts by writing ~/tmpfile: ~/tmpfile in the file_mounts section of your YAML, or
2) Place the file in a directory and specify the directory as the source.
```

Tested:
- [x] Example from #1226 
- [x] `sky launch examples/storage_demo.yaml`
- [x]  `pytest test_storage.py::TestStorageSpecLocalSource`
- [x] Docs rendered locally  