### PR TITLE
[Backward Compatibility][Spot] Avoid cluster leakage by ray yaml overwritten and reduce spot controller cost on AWS

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -925,7 +925,8 @@ class RetryingVmProvisioner(object):
                 region=region,
                 zones=zones,
                 dryrun=dryrun,
-                force_overwrite=prev_cluster_status is None)
+                keep_launch_fields_in_existing_config=prev_cluster_status
+                is not None)
             if dryrun:
                 return
             cluster_config_file = config_dict['ray']

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -924,7 +924,8 @@ class RetryingVmProvisioner(object):
                 self._wheel_hash,
                 region=region,
                 zones=zones,
-                dryrun=dryrun)
+                dryrun=dryrun,
+                force_overwrite=prev_cluster_status is None)
             if dryrun:
                 return
             cluster_config_file = config_dict['ray']

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -31,7 +31,10 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            Iops: 3000 # use default Iops for gp3
+            # use default Iops for gp3
+            VolumeType: gp3
+            Iops: 3000
+            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -51,7 +54,9 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            Iops: 3000 # use default Iops for gp3
+            VolumeType: gp3
+            Iops: 3000
+            Throughput: 125 
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -26,10 +26,12 @@ available_node_types:
     node_config:
       InstanceType: {{instance_type}}
       ImageId: {{image_id}}  # Deep Learning AMI (Ubuntu 18.04); see aws.py.
+      # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
+            Iops: 3000 # use default Iops for gp3
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -49,6 +51,7 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
+            Iops: 3000 # use default Iops for gp3
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -13,6 +13,7 @@ import sys
 import time
 import uuid
 from typing import Dict, List, Union
+
 import yaml
 
 from sky import sky_logging

--- a/tests/backward_comaptibility_tests.sh
+++ b/tests/backward_comaptibility_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -ev
 
 source ~/.bashrc 
 CLUSTER_NAME="test-back-compat-$USER"

--- a/tests/backward_comaptibility_tests.sh
+++ b/tests/backward_comaptibility_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-CLUSTER_NAME="test-back-compat"
+CLUSTER_NAME="test-back-compat-$USER"
 . $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh
 
 git clone https://github.com/skypilot-org/skypilot.git sky-master || true
@@ -35,8 +35,10 @@ sky launch --cloud gcp -c ${CLUSTER_NAME} examples/minimal.yaml
 conda activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky exec --cloud gcp ${CLUSTER_NAME} examples/minimal.yaml
-sky launch --cloud gcp -c ${CLUSTER_NAME} examples/minimal.yaml
-sky queue
+s=$(sky launch --cloud gcp -d -c ${CLUSTER_NAME} examples/minimal.yaml)
+echo $s
+echo $s | grep "Job ID: 3"
+sky queue ${CLUSTER_NAME}
 
 # sky stop + sky start + sky exec
 conda activate sky-back-compat-master
@@ -46,7 +48,9 @@ conda activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky stop -y ${CLUSTER_NAME}-2
 sky start -y ${CLUSTER_NAME}-2
-sky exec --cloud gcp ${CLUSTER_NAME}-2 examples/minimal.yaml
+s=$(sky exec --cloud gcp -d ${CLUSTER_NAME}-2 examples/minimal.yaml)
+echo $s
+echo $s | grep "Job ID: 2"
 
 # `sky autostop` + `sky status -r`
 conda activate sky-back-compat-master

--- a/tests/backward_comaptibility_tests.sh
+++ b/tests/backward_comaptibility_tests.sh
@@ -12,7 +12,7 @@ conda create -n sky-back-compat-master -y --clone sky-dev
 conda create -n sky-back-compat-current -y --clone sky-dev
 
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 pip uninstall skypilot -y
 
 cd sky-master
@@ -21,39 +21,39 @@ pip install -e ".[all]"
 cd -
 
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 pip uninstall -y skypilot
 pip install -e ".[all]"
 
 
 # exec + launch
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 which sky
 sky launch --cloud gcp -c ${CLUSTER_NAME} examples/minimal.yaml
 
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky exec --cloud gcp ${CLUSTER_NAME} examples/minimal.yaml
 sky launch --cloud gcp -c ${CLUSTER_NAME} examples/minimal.yaml
 sky queue
 
 # sky stop + sky start + sky exec
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-2 examples/minimal.yaml
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky stop -y ${CLUSTER_NAME}-2
 sky start -y ${CLUSTER_NAME}-2
 sky exec --cloud gcp ${CLUSTER_NAME}-2 examples/minimal.yaml
 
 # `sky autostop` + `sky status -r`
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-3 examples/minimal.yaml
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky autostop -y -i0 ${CLUSTER_NAME}-3
 sleep 100
 sky status -r | grep ${CLUSTER_NAME}-3 | grep STOPPED
@@ -61,11 +61,11 @@ sky status -r | grep ${CLUSTER_NAME}-3 | grep STOPPED
 
 # (1 node) sky launch + sky exec + sky queue + sky logs
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-4 examples/minimal.yaml
 sky stop -y ${CLUSTER_NAME}-4
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-4 examples/minimal.yaml
 sky queue ${CLUSTER_NAME}-4
 sky logs ${CLUSTER_NAME}-4 1 --status
@@ -75,11 +75,11 @@ sky logs ${CLUSTER_NAME}-4 2
 
 # (1 node) sky start + sky exec + sky queue + sky logs
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-5 examples/minimal.yaml
 sky stop -y ${CLUSTER_NAME}-5
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky start -y ${CLUSTER_NAME}-5
 sky queue ${CLUSTER_NAME}-5
 sky logs ${CLUSTER_NAME}-5 1 --status
@@ -91,11 +91,11 @@ sky logs ${CLUSTER_NAME}-5 2
 
 # (2 nodes) sky launch + sky exec + sky queue + sky logs
 conda activate sky-back-compat-master
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-6 examples/multi_hostname.yaml
 sky stop -y ${CLUSTER_NAME}-6
 conda activate sky-back-compat-current
-rm -r  ~/.sky/sky_wheels || true
+rm -r  ~/.sky/wheels || true
 sky start -y ${CLUSTER_NAME}-6
 sky queue ${CLUSTER_NAME}-6
 sky logs ${CLUSTER_NAME}-6 1 --status

--- a/tests/backward_comaptibility_tests.sh
+++ b/tests/backward_comaptibility_tests.sh
@@ -1,38 +1,41 @@
 #!/bin/bash
 set -ex
 
+source ~/.bashrc 
 CLUSTER_NAME="test-back-compat-$USER"
-. $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh
+source $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh
 
 git clone https://github.com/skypilot-org/skypilot.git sky-master || true
 
 
 # Create environment for compatibility tests
-conda create -n sky-back-compat-master -y --clone sky-dev
-conda create -n sky-back-compat-current -y --clone sky-dev
+mamba > /dev/null 2>&1 || conda install -n base -c conda-forge mamba -y
+mamba init
+source ~/.bashrc
+mamba env list | grep sky-back-compat-master || mamba create -n sky-back-compat-master -y python=3.9
 
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
+mamba install -c conda-forge google-cloud-sdk -y
 rm -r  ~/.sky/wheels || true
-pip uninstall skypilot -y
-
 cd sky-master
 git pull origin master
 pip install -e ".[all]"
 cd -
 
-conda activate sky-back-compat-current
+mamba env list | grep sky-back-compat-current || mamba create -n sky-back-compat-current -y --clone sky-back-compat-master
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 pip uninstall -y skypilot
 pip install -e ".[all]"
 
 
 # exec + launch
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 which sky
-sky launch --cloud gcp -c ${CLUSTER_NAME} examples/minimal.yaml
+sky launch --cloud gcp -y -c ${CLUSTER_NAME} examples/minimal.yaml
 
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky exec --cloud gcp ${CLUSTER_NAME} examples/minimal.yaml
 s=$(sky launch --cloud gcp -d -c ${CLUSTER_NAME} examples/minimal.yaml)
@@ -41,10 +44,10 @@ echo $s | grep "Job ID: 3"
 sky queue ${CLUSTER_NAME}
 
 # sky stop + sky start + sky exec
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-2 examples/minimal.yaml
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky stop -y ${CLUSTER_NAME}-2
 sky start -y ${CLUSTER_NAME}-2
@@ -53,10 +56,10 @@ echo $s
 echo $s | grep "Job ID: 2"
 
 # `sky autostop` + `sky status -r`
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-3 examples/minimal.yaml
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky autostop -y -i0 ${CLUSTER_NAME}-3
 sleep 100
@@ -64,11 +67,11 @@ sky status -r | grep ${CLUSTER_NAME}-3 | grep STOPPED
 
 
 # (1 node) sky launch + sky exec + sky queue + sky logs
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-4 examples/minimal.yaml
 sky stop -y ${CLUSTER_NAME}-4
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-4 examples/minimal.yaml
 sky queue ${CLUSTER_NAME}-4
@@ -78,11 +81,11 @@ sky logs ${CLUSTER_NAME}-4 1
 sky logs ${CLUSTER_NAME}-4 2
 
 # (1 node) sky start + sky exec + sky queue + sky logs
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-5 examples/minimal.yaml
 sky stop -y ${CLUSTER_NAME}-5
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky start -y ${CLUSTER_NAME}-5
 sky queue ${CLUSTER_NAME}-5
@@ -94,11 +97,11 @@ sky logs ${CLUSTER_NAME}-5 2 --status
 sky logs ${CLUSTER_NAME}-5 2
 
 # (2 nodes) sky launch + sky exec + sky queue + sky logs
-conda activate sky-back-compat-master
+mamba activate sky-back-compat-master
 rm -r  ~/.sky/wheels || true
 sky launch --cloud gcp -y -c ${CLUSTER_NAME}-6 examples/multi_hostname.yaml
 sky stop -y ${CLUSTER_NAME}-6
-conda activate sky-back-compat-current
+mamba activate sky-back-compat-current
 rm -r  ~/.sky/wheels || true
 sky start -y ${CLUSTER_NAME}-6
 sky queue ${CLUSTER_NAME}-6
@@ -108,3 +111,5 @@ sky exec --cloud gcp ${CLUSTER_NAME}-6 examples/multi_hostname.yaml
 sky queue ${CLUSTER_NAME}-6
 sky logs ${CLUSTER_NAME}-6 2 --status
 sky logs ${CLUSTER_NAME}-6 2
+
+sky down ${CLUSTER_NAME}* -y


### PR DESCRIPTION
It resubmits #1221 , and add backward compatibility for it.

Update (Oct 13th):
* this fixes https://github.com/skypilot-org/skypilot/issues/640, ensuring restarting stopped clusters would not create new duplicate ones
* this reduces spot controller cost by 20%

Our current default instance created on the AWS has the volume with the maximum IOPs, i.e. 16000. However, by default, the instance created on the AWS console only has 3000 IOPs by default.
Our volume costs (16000-3000) * 0.005 / 30 / 24 = $0.09 / hour, which is 20% of the cost for our default CPU machine on AWS m6i.2xlarge.

Todo item: make this IOPs configurable across the clouds (probably simplify it by only having three tiers: low, medium, high).

Tested:
- [x] `sky cpunode -c test-iops`
- [x] `sky launch --disk-size 1024`
- [x] `sky launch --disk-size 50`
- [x] `sky gpunode -c test-t4 --gpus t4`
- [x] `sky launch -c bk-iops --num-nodes 2` (before this PR); `sky stop bk-iops`; `sky start bk-iops` it starts the same 2 instances. 