### PR TITLE
Fix bug when .sky absolute path contains space (continue)

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1102,8 +1102,9 @@ def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:
     backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
     for i in range(max_attempts):
         try:
+            full_cluster_yaml = str(pathlib.Path(cluster_yaml).expanduser())
             out = subprocess_utils.run(
-                f'ray get-head-ip {cluster_yaml}',
+                f'ray get-head-ip {full_cluster_yaml!r}',
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL).stdout.decode().strip()
             head_ip = re.findall(IP_ADDR_REGEX, out)
@@ -1157,8 +1158,9 @@ def get_node_ips(cluster_yaml: str,
 
         for retry_cnt in range(worker_ip_max_attempts):
             try:
+                full_cluster_yaml = str(pathlib.Path(cluster_yaml).expanduser())
                 proc = subprocess_utils.run(
-                    f'ray get-worker-ips {cluster_yaml}',
+                    f'ray get-worker-ips {full_cluster_yaml!r}',
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
                 out = proc.stdout.decode()


### PR DESCRIPTION
This PR fixes the incomplete https://github.com/skypilot-org/skypilot/pull/1247 as reported in https://github.com/skypilot-org/skypilot/issues/1246. This time I'm doing a complete test to avoid the same issue recurring again.

- [x] Smoke test with `.sky` softlink to a directory path with space.