### PR TITLE
[Autodown] Better logging for `sky status -r` for autodown cluster

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1808,18 +1808,18 @@ def get_clusters(
                 remaining_clusters.append(cluster_names[i])
 
     yellow = colorama.Fore.YELLOW
-    light = colorama.Fore.LIGHTBLACK_EX
+    bright = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
     if autodown_clusters:
         plural = 's' if len(autodown_clusters) > 1 else ''
         cluster_str = ', '.join(autodown_clusters)
         logger.info(f'Autodowned cluster{plural}: '
-                    f'{light}{cluster_str}{reset}')
+                    f'{bright}{cluster_str}{reset}')
     if remaining_clusters:
         plural = 's' if len(remaining_clusters) > 1 else ''
         cluster_str = ', '.join(name for name in remaining_clusters)
         logger.warning(f'{yellow}Cluster{plural} terminated on '
-                       f'the cloud: {light}{cluster_str}{reset}')
+                       f'the cloud: {reset}{bright}{cluster_str}{reset}')
 
     # Filter out removed clusters.
     updated_records = [
@@ -1987,7 +1987,7 @@ def kill_children_processes():
 # Handle ctrl-c
 def interrupt_handler(signum, frame):
     del signum, frame
-    logger.warning(f'{colorama.Fore.LIGHTBLACK_EX}The job will keep '
+    logger.warning(f'{colorama.Style.DIM}The job will keep '
                    f'running after Ctrl-C.{colorama.Style.RESET_ALL}')
     kill_children_processes()
     with ux_utils.print_exception_no_traceback():
@@ -1997,7 +1997,7 @@ def interrupt_handler(signum, frame):
 # Handle ctrl-z
 def stop_handler(signum, frame):
     del signum, frame
-    logger.warning(f'{colorama.Fore.LIGHTBLACK_EX}The job will keep '
+    logger.warning(f'{colorama.Style.DIM}The job will keep '
                    f'running after Ctrl-Z.{colorama.Style.RESET_ALL}')
     kill_children_processes()
     with ux_utils.print_exception_no_traceback():

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1787,7 +1787,6 @@ def get_clusters(
         f'[bold cyan]Refreshing status for {len(records)} cluster{plural}[/]',
         total=len(records))
 
-
     def _refresh_cluster(cluster_name):
         record = _update_cluster_status(cluster_name,
                                         acquire_per_cluster_status_lock=True)
@@ -1798,7 +1797,7 @@ def get_clusters(
     with progress:
         updated_records = subprocess_utils.run_in_parallel(
             _refresh_cluster, cluster_names)
-        
+
     # Show information for removed clusters.
     autodown_clusters, remaining_clusters = [], []
     for i, record in enumerate(records):
@@ -1819,10 +1818,9 @@ def get_clusters(
     if remaining_clusters:
         plural = 's' if len(remaining_clusters) > 1 else ''
         cluster_str = ', '.join(name for name in remaining_clusters)
-        logger.warning(
-            f'{yellow}Cluster{plural} terminated on '
-            f'the cloud: {light}{cluster_str}{reset}')
-    
+        logger.warning(f'{yellow}Cluster{plural} terminated on '
+                       f'the cloud: {light}{cluster_str}{reset}')
+
     # Filter out removed clusters.
     updated_records = [
         record for record in updated_records if record is not None

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1648,8 +1648,8 @@ def _update_cluster_status_no_lock(
         try:
             backend = backends.CloudVmRayBackend()
             backend.set_autostop(handle, -1, stream_logs=False)
-        except (Exception, SystemExit):  # pylint: disable=broad-except
-            logger.debug('Failed to reset autostop.')
+        except (Exception, SystemExit) as e:  # pylint: disable=broad-except
+            logger.debug(f'Failed to reset autostop. Due to {type(e)}: {e}')
         global_user_state.set_cluster_autostop_value(handle.cluster_name,
                                                      -1,
                                                      to_down=False)
@@ -1812,17 +1812,16 @@ def get_clusters(
     light = colorama.Fore.LIGHTBLACK_EX
     reset = colorama.Style.RESET_ALL
     if autodown_clusters:
-        plural = 's were' if len(autodown_clusters) > 1 else ' was'
+        plural = 's' if len(autodown_clusters) > 1 else ''
         cluster_str = ', '.join(autodown_clusters)
-        logger.info(f'The following cluster{plural} autodowned and removed '
-                    f'from the cluster table: {light}{cluster_str}{reset}')
+        logger.info(f'Autodowned cluster{plural}: '
+                    f'{light}{cluster_str}{reset}')
     if remaining_clusters:
-        plural = 's were' if len(remaining_clusters) > 1 else ' was'
-        cluster_str = ', '.join(repr(name) for name in remaining_clusters)
+        plural = 's' if len(remaining_clusters) > 1 else ''
+        cluster_str = ', '.join(name for name in remaining_clusters)
         logger.warning(
-            f'{yellow}The following cluster{plural} terminated on '
-            'the cloud and removed from the cluster table: '
-            f'{light}{cluster_str}{reset}')
+            f'{yellow}Cluster{plural} terminated on '
+            f'the cloud: {light}{cluster_str}{reset}')
     
     # Filter out removed clusters.
     updated_records = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1975,7 +1975,7 @@ def _down_or_stop_clusters(
                     option_str = 'down' if down else 'stop'
                     plural = 's' if idle_minutes_to_autostop != 1 else ''
                     message += (
-                        f'\n  The cluster will be stopped after '
+                        f'\n  The cluster will be auto{option_str}\'ed after '
                         f'{idle_minutes_to_autostop} minute{plural} of idleness.'
                         f'\n  To cancel the auto{option_str}, run: '
                         f'{colorama.Style.BRIGHT}'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1973,9 +1973,10 @@ def _down_or_stop_clusters(
                            f'cluster {name!r}...done{colorama.Style.RESET_ALL}')
                 if idle_minutes_to_autostop >= 0:
                     option_str = 'down' if down else 'stop'
+                    passive_str = 'downed' if down else 'stopped'
                     plural = 's' if idle_minutes_to_autostop != 1 else ''
                     message += (
-                        f'\n  The cluster will be auto{option_str}ed after '
+                        f'\n  The cluster will be auto{passive_str} after '
                         f'{idle_minutes_to_autostop} minute{plural} of '
                         'idleness.'
                         f'\n  To cancel the auto{option_str}, run: '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1975,7 +1975,7 @@ def _down_or_stop_clusters(
                     option_str = 'down' if down else 'stop'
                     plural = 's' if idle_minutes_to_autostop != 1 else ''
                     message += (
-                        f'\n  The cluster will be auto{option_str}\'ed after '
+                        f'\n  The cluster will be auto{option_str}ed after '
                         f'{idle_minutes_to_autostop} minute{plural} of '
                         'idleness.'
                         f'\n  To cancel the auto{option_str}, run: '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1972,10 +1972,12 @@ def _down_or_stop_clusters(
                 message = (f'{colorama.Fore.GREEN}{operation} '
                            f'cluster {name!r}...done{colorama.Style.RESET_ALL}')
                 if idle_minutes_to_autostop >= 0:
+                    option_str = 'down' if down else 'stop'
+                    plural = 's' if idle_minutes_to_autostop != 1 else ''
                     message += (
                         f'\n  The cluster will be stopped after '
-                        f'{idle_minutes_to_autostop} minutes of idleness.'
-                        '\n  To cancel the autostop, run: '
+                        f'{idle_minutes_to_autostop} minute{plural} of idleness.'
+                        f'\n  To cancel the auto{option_str}, run: '
                         f'{colorama.Style.BRIGHT}'
                         f'sky autostop {name} --cancel'
                         f'{colorama.Style.RESET_ALL}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1976,7 +1976,8 @@ def _down_or_stop_clusters(
                     plural = 's' if idle_minutes_to_autostop != 1 else ''
                     message += (
                         f'\n  The cluster will be auto{option_str}\'ed after '
-                        f'{idle_minutes_to_autostop} minute{plural} of idleness.'
+                        f'{idle_minutes_to_autostop} minute{plural} of '
+                        'idleness.'
                         f'\n  To cancel the auto{option_str}, run: '
                         f'{colorama.Style.BRIGHT}'
                         f'sky autostop {name} --cancel'

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -175,7 +175,7 @@ def _execute(
                 # itself have no task running and start the auto{stop,down}
                 # process, before the task is submitted in the EXEC stage.
                 verb = 'torn down' if down else 'stopped'
-                logger.info(f'{colorama.Fore.LIGHTBLACK_EX}The cluster will '
+                logger.info(f'{colorama.Style.DIM}The cluster will '
                             f'be {verb} after 1 minutes of idleness '
                             '(after all jobs finish).'
                             f'{colorama.Style.RESET_ALL}')

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -539,14 +539,14 @@ def test_autodown():
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "autodowned"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "autodowned"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky autostop -y {name} --cancel',
             'sleep 240',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -539,14 +539,14 @@ def test_autodown():
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster\|terminated on the cloud"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "Autodowned cluster\|terminated on the cloud"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky autostop -y {name} --cancel',
             'sleep 240',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -539,14 +539,14 @@ def test_autodown():
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "autodowned"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.
             f'sky exec {name} --cloud aws examples/minimal.yaml',
             f'sky status | grep {name} | grep "1m (down)"',
             'sleep 240',
             # Ensure the cluster is terminated.
-            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "terminated"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
+            f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo $s | grep {name} | grep "The following cluster" | grep "autodowned"; }} || {{ echo $s | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky autostop -y {name} --cancel',
             'sleep 240',


### PR DESCRIPTION
As mentioned by @concretevitamin, the current logging. for `sky status -r` is a bit scary, when the cluster with autodown is terminated. This PR handles the logging for the clusters with autodown differently against the normal clusters.

The new logging for the clusters with autodown:
```
sky status -r                                                                                                                                          ✈ ✱
I 10-14 13:17:38 backend_utils.py:1819] The following cluster was autodowned and removed from the cluster table: test-autodown
NAME             LAUNCHED  RESOURCES             STATUS  AUTOSTOP  COMMAND                    
smoke-test-zhwu  1 hr ago  1x GCP(n1-highmem-8)  UP      -         sky start smoke-test-zhwu 
```