### PR TITLE
Remove extra colorama.init() causing task logging prefix to have no color.

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -22,7 +22,6 @@ from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
-colorama.init()
 logger = sky_logging.init_logger(__name__)
 
 # TODO: Should tolerate if gcloud is not installed. Also,


### PR DESCRIPTION
Fixes #1240.

Tested:
- Launched a new task, observed color
- Observed https://github.com/skypilot-org/skypilot/blob/master/sky/authentication.py#L217-L230 is still printed with colors on a new GCP project