### PR TITLE
[Spot] Show spot controller in sky status and simplify tearing down

### DIFF
--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -206,13 +206,13 @@ Spot controller (Advanced)
 -------------------------------
 
 There will be a single spot controller VM (a small on-demand CPU VM) running in the background to manage all the spot jobs.
-It will be autostopped after all spot jobs finished and no new spot job is submitted for 30 minutes. Typically **no user intervention** is needed. 
-You can find the controller with :code:`sky status -a`, and refresh the status with :code:`sky status -ar`.
+It will be autostopped after all spot jobs finished and no new spot job is submitted for 10 minutes. Typically **no user intervention** is needed. 
+You can find the controller with :code:`sky status`, and refresh the status with :code:`sky status -r`.
 
 Although, the cost of the spot controller is negligible (~$0.4/hour when running and less than $0.004/hour when stopped), 
 you can still tear it down manually with 
-:code:`sky down -p sky-spot-controller-<hash>`, where the ``<hash>`` can be found in the output of :code:`sky status -a`.
+:code:`sky down <spot-controller-name>`, where the ``<spot-controller-name>`` can be found in the output of :code:`sky status`.
 
 .. note::
-  Tearing down the spot controller when there are still spot jobs running will cause resource leakage of those spot VMs.
+  Tearing down the spot controller will lose all logs and status information for the spot jobs and can cause resource leakage when there are still in-progress spot jobs.
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -101,7 +101,9 @@ _MAX_CLUSTER_NAME_LEN_FOR_GCP = 35
 # Note: This value cannot be too small, otherwise OOM issue may occur.
 DEFAULT_TASK_CPU_DEMAND = 0.5
 
-SKY_RESERVED_CLUSTER_NAMES = [spot_lib.SPOT_CONTROLLER_NAME]
+SKY_RESERVED_CLUSTER_NAMES = {
+    spot_lib.SPOT_CONTROLLER_NAME: 'Managed spot controller'
+}
 
 # Filelocks for the cluster status change.
 CLUSTER_STATUS_LOCK_PATH = os.path.expanduser('~/.sky/.{}.lock')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -101,6 +101,8 @@ _MAX_CLUSTER_NAME_LEN_FOR_GCP = 35
 # Note: This value cannot be too small, otherwise OOM issue may occur.
 DEFAULT_TASK_CPU_DEMAND = 0.5
 
+# Mapping from reserved cluster names to the corresponding group name (logging purpose).
+# NOTE: each group can only have one reserved cluster name for now.
 SKY_RESERVED_CLUSTER_NAMES = {
     spot_lib.SPOT_CONTROLLER_NAME: 'Managed spot controller'
 }
@@ -1929,13 +1931,11 @@ def check_cluster_name_not_reserved(
     If the cluster name is reserved, return the error message. Otherwise,
     return None.
     """
-    usage = 'internal use'
-    if cluster_name == spot_lib.SPOT_CONTROLLER_NAME:
-        usage = 'spot controller'
-    msg = f'Cluster {cluster_name!r} is reserved for {usage}.'
-    if operation_str is not None:
-        msg += f' {operation_str} is not allowed.'
     if cluster_name in SKY_RESERVED_CLUSTER_NAMES:
+        msg = (f'Cluster {cluster_name!r} is reserved for '
+               f'{SKY_RESERVED_CLUSTER_NAMES[cluster_name].lower()}.')
+        if operation_str is not None:
+            msg += f' {operation_str} is not allowed.'
         with ux_utils.print_exception_no_traceback():
             raise ValueError(msg)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1875,7 +1875,7 @@ def down(
                            purge=purge)
 
 
-def _hints_for_down_spot_controller(controller_name: str):
+def _hint_for_down_spot_controller(controller_name: str):
     # spot_jobs will be empty when the spot cluster is not running.
     cluster_status, _ = backend_utils.refresh_cluster_status_handle(
         controller_name)
@@ -1887,7 +1887,7 @@ def _hints_for_down_spot_controller(controller_name: str):
            f'spot controller ({cluster_status.value}). Please be '
            f'aware of the following:{colorama.Style.RESET_ALL}'
            '\n * All logs and status information of the spot '
-           'jobs will be lost.')
+           'jobs (output of sky spot status) will be lost.')
     if cluster_status == global_user_state.ClusterStatus.UP:
         try:
             spot_jobs = core.spot_status(refresh=False)
@@ -1907,8 +1907,7 @@ def _hints_for_down_spot_controller(controller_name: str):
         if (cluster_status == global_user_state.ClusterStatus.UP and
                 non_terminal_jobs):
             msg += ('\n * In-progress spot jobs found, their resources '
-                    'will not be terminated and require manual cleanup '
-                    '(sky spot cancel --all):\n')
+                    'will not be terminated and require manual cleanup:\n')
             job_table = spot_lib.format_job_table(non_terminal_jobs,
                                                   show_all=False)
             # Add prefix to each line to align with the bullet point.
@@ -1987,7 +1986,7 @@ def _down_or_stop_clusters(
                 # TODO(zhwu): We can only have one reserved cluster (spot
                 # controller).
                 assert len(reserved_clusters) == 1, reserved_clusters
-                _hints_for_down_spot_controller(reserved_clusters[0])
+                _hint_for_down_spot_controller(reserved_clusters[0])
 
                 click.confirm('Proceed?',
                               default=False,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1907,7 +1907,7 @@ def _hints_for_down_spot_controller(controller_name: str):
         if (cluster_status == global_user_state.ClusterStatus.UP and
                 non_terminal_jobs):
             msg += ('\n * In-progress spot jobs found, their resources '
-                    'will not be terminated and require manual cleanup'
+                    'will not be terminated and require manual cleanup '
                     '(sky spot cancel --all):\n')
             job_table = spot_lib.format_job_table(non_terminal_jobs,
                                                   show_all=False)

--- a/sky/core.py
+++ b/sky/core.py
@@ -30,7 +30,7 @@ logger = sky_logging.init_logger(__name__)
 
 
 @usage_lib.entrypoint
-def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
+def status(refresh: bool) -> List[Dict[str, Any]]:
     """Get the cluster status in dict.
 
     Please refer to the sky.cli.status for the document.
@@ -52,7 +52,7 @@ def status(all: bool, refresh: bool) -> List[Dict[str, Any]]:
         ]
 
     """
-    cluster_records = backend_utils.get_clusters(all, refresh)
+    cluster_records = backend_utils.get_clusters(True, refresh)
     return cluster_records
 
 
@@ -167,10 +167,6 @@ def down(cluster_name: str, purge: bool = False):
         ValueError: cluster does not exist.
         sky.exceptions.NotSupportedError: the cluster is not supported.
     """
-    if (cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES and not purge):
-        raise exceptions.NotSupportedError(
-            f'Tearing down sky reserved cluster {cluster_name!r} '
-            f'is not supported.')
     handle = global_user_state.get_handle_from_cluster_name(cluster_name)
     if handle is None:
         raise ValueError(f'Cluster {cluster_name!r} does not exist.')

--- a/sky/core.py
+++ b/sky/core.py
@@ -52,7 +52,8 @@ def status(refresh: bool) -> List[Dict[str, Any]]:
         ]
 
     """
-    cluster_records = backend_utils.get_clusters(True, refresh)
+    cluster_records = backend_utils.get_clusters(include_reserved=True,
+                                                 refresh=refresh)
     return cluster_records
 
 

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -1,6 +1,6 @@
 """Constants used for Managed Spot."""
 
-SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP = 30
+SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP = 10
 
 SPOT_CONTROLLER_TEMPLATE = 'spot-controller.yaml.j2'
 SPOT_CONTROLLER_YAML_PREFIX = '~/.sky/spot_controller'

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -1,5 +1,5 @@
 """Utilities for sky status."""
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 import click
 import colorama
 
@@ -34,8 +34,12 @@ class StatusColumn:
 
 def show_status_table(cluster_records: List[Dict[str, Any]],
                       show_all: bool,
-                      is_reserved: bool = False):
-    """Compute cluster table values and display."""
+                      reserved_group_name: Optional[str] = None) -> int:
+    """Compute cluster table values and display.
+
+    Returns:
+        Number of pending autostop clusters.
+    """
     # TODO(zhwu): Update the information for autostop clusters.
 
     status_columns = [
@@ -70,25 +74,19 @@ def show_status_table(cluster_records: List[Dict[str, Any]],
         pending_autostop += _is_pending_autostop(record)
 
     if cluster_records:
-        name = 'Clusters'
-        if is_reserved:
-            click.echo()
-            name = 'Reserved Clusters'
-        click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}{name}: '
-                   f'{colorama.Style.RESET_ALL}')
-        click.echo(cluster_table)
-        if is_reserved:
+        if reserved_group_name is not None:
             click.echo(
-                f'{colorama.Style.DIM}Reserved clusters will be autostopped '
-                'when inactive. Refresh statuses with: sky status --refresh'
+                f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+                f'{reserved_group_name}: {colorama.Style.RESET_ALL}'
+                f'{colorama.Style.DIM}(will be autostopped when inactive)'
                 f'{colorama.Style.RESET_ALL}')
-        elif pending_autostop:
-            click.echo(
-                '\n'
-                f'You have {pending_autostop} clusters with auto{{stop,down}} '
-                'scheduled. Refresh statuses with: sky status --refresh')
+        else:
+            click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters: '
+                       f'{colorama.Style.RESET_ALL}')
+        click.echo(cluster_table)
     else:
         click.echo('No existing clusters.')
+    return pending_autostop
 
 
 def show_local_status_table(local_clusters: List[str]):

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -38,7 +38,7 @@ def show_status_table(cluster_records: List[Dict[str, Any]],
     """Compute cluster table values and display.
 
     Returns:
-        Number of pending autostop clusters.
+        Number of pending auto{stop,down} clusters.
     """
     # TODO(zhwu): Update the information for autostop clusters.
 
@@ -78,7 +78,7 @@ def show_status_table(cluster_records: List[Dict[str, Any]],
             click.echo(
                 f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                 f'{reserved_group_name}: {colorama.Style.RESET_ALL}'
-                f'{colorama.Style.DIM}(will be autostopped when inactive)'
+                f'{colorama.Style.DIM}(will be autostopped if idle for 30min)'
                 f'{colorama.Style.RESET_ALL}')
         else:
             click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters: '

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -32,7 +32,9 @@ class StatusColumn:
         return val
 
 
-def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
+def show_status_table(cluster_records: List[Dict[str, Any]],
+                      show_all: bool,
+                      is_reserved: bool = False):
     """Compute cluster table values and display."""
     # TODO(zhwu): Update the information for autostop clusters.
 
@@ -68,12 +70,23 @@ def show_status_table(cluster_records: List[Dict[str, Any]], show_all: bool):
         pending_autostop += _is_pending_autostop(record)
 
     if cluster_records:
+        name = 'Clusters'
+        if is_reserved:
+            click.echo()
+            name = 'Reserved Clusters'
+        click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}{name}: '
+                   f'{colorama.Style.RESET_ALL}')
         click.echo(cluster_table)
-        if pending_autostop:
+        if is_reserved:
+            click.echo(
+                f'{colorama.Style.DIM}Reserved clusters will be autostopped '
+                'when inactive. Refresh statuses with: sky status --refresh'
+                f'{colorama.Style.RESET_ALL}')
+        elif pending_autostop:
             click.echo(
                 '\n'
                 f'You have {pending_autostop} clusters with auto{{stop,down}} '
-                'scheduled. Refresh statuses with: `sky status --refresh`.')
+                'scheduled. Refresh statuses with: sky status --refresh')
     else:
         click.echo('No existing clusters.')
 

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -97,7 +97,8 @@ class TestReservedClustersOperations:
     def test_down_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
 
-        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME], input='n')
+        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME],
+                                   input='n')
         assert 'WARNING: Tearing down a SkyPilot reserved cluster.' in result.output
         assert isinstance(result.exception, SystemExit), result.exception
 

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -94,13 +94,29 @@ class TestReservedClustersOperations:
                                                 ready=True)
 
     @pytest.mark.timeout(60)
-    def test_down_spot_controller(self, _mock_cluster_state):
-        cli_runner = cli_testing.CliRunner()
+    def test_down_spot_controller(self, _mock_cluster_state, monkeypatch):
 
+        def mock_cluster_refresh_up(
+            cluster_name: str,
+            *,
+            force_refresh: bool = False,
+            acquire_per_cluster_status_lock: bool = True,
+        ):
+            record = global_user_state.get_cluster_from_name(cluster_name)
+            return record['status'], record['handle']
+
+        monkeypatch.setattr(
+            'sky.backends.backend_utils.refresh_cluster_status_handle',
+            mock_cluster_refresh_up)
+
+        monkeypatch.setattr('sky.core.spot_status', lambda refresh: [])
+
+        cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME],
                                    input='n')
-        assert 'WARNING: Tearing down a SkyPilot reserved cluster.' in result.output
-        assert isinstance(result.exception, SystemExit), result.exception
+        assert 'WARNING: Tearing down the managed spot controller (UP).' in result.output
+        assert isinstance(result.exception,
+                          SystemExit), (result.exception, result.output)
 
         result = cli_runner.invoke(cli.down, ['sky-spot-con*'])
         assert not result.exception

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -97,11 +97,9 @@ class TestReservedClustersOperations:
     def test_down_spot_controller(self, _mock_cluster_state):
         cli_runner = cli_testing.CliRunner()
 
-        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME])
-        assert result.exit_code == click.UsageError.exit_code
-        assert (
-            f'Terminating reserved cluster(s) \'{spot.SPOT_CONTROLLER_NAME}\' '
-            'is not supported' in result.output)
+        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME], input='n')
+        assert 'WARNING: Tearing down a SkyPilot reserved cluster.' in result.output
+        assert isinstance(result.exception, SystemExit), result.exception
 
         result = cli_runner.invoke(cli.down, ['sky-spot-con*'])
         assert not result.exception


### PR DESCRIPTION
According to the offline discussion with @concretevitamin, we decided to add the spot controller in the `sky status` to avoid confusion caused by the controller in the cloud console. (Part of the efforts for fixing #1269)

After this PR, the `sky status` will be:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/6753189/196364410-60e9e45b-8ef3-468b-a095-b4f598041c4c.png">

When tearing down the controller, the output would be (no `--purge` required, as purging can lead to resource leakage):
<img width="745" alt="image" src="https://user-images.githubusercontent.com/6753189/196364589-cf44b6c4-3fa8-4480-a5e0-638a1780a76a.png">

TODO:
- [x] Merge #1269 
- [x] Add docs for the modification in this PR.

