### PR TITLE
UX change to status table display.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1890,7 +1890,7 @@ def _hint_for_down_spot_controller(controller_name: str):
            f'spot controller ({cluster_status.value}). Please be '
            f'aware of the following:{colorama.Style.RESET_ALL}'
            '\n * All logs and status information of the spot '
-           'jobs (output of sky spot status) will be lost.')
+           'jobs (output of `sky spot status`) will be lost.')
     if cluster_status == global_user_state.ClusterStatus.UP:
         try:
             spot_jobs = core.spot_status(refresh=False)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1302,9 +1302,9 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
     if num_pending_autostop > 0:
         click.echo(
             '\n'
-            f'{colorama.Style.DIM}You have {num_pending_autostop} clusters '
-            'with auto{stop,down} scheduled. Refresh statuses with: '
-            f'sky status --refresh{colorama.Style.RESET_ALL}')
+            f'{num_pending_autostop} clusters have '
+            'auto{stop,down} scheduled. Refresh statuses with: '
+            f'sky status --refresh')
     status_utils.show_local_status_table(local_clusters)
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1300,11 +1300,14 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
         num_pending_autostop += status_utils.show_status_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
     if num_pending_autostop > 0:
-        click.echo(
-            '\n'
-            f'{num_pending_autostop} clusters have '
-            'auto{stop,down} scheduled. Refresh statuses with: '
-            f'sky status --refresh')
+        plural = ' has'
+        if num_pending_autostop > 1:
+            plural = 's have'
+        click.echo('\n'
+                   f'{num_pending_autostop} cluster{plural} '
+                   'auto{stop,down} scheduled. Refresh statuses with: '
+                   f'{colorama.Style.BRIGHT}sky status --refresh'
+                   f'{colorama.Style.RESET_ALL}')
     status_utils.show_local_status_table(local_clusters)
 
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -77,11 +77,11 @@ def show_status_table(cluster_records: List[Dict[str, Any]],
         if reserved_group_name is not None:
             click.echo(
                 f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                f'{reserved_group_name}: {colorama.Style.RESET_ALL}'
-                f'{colorama.Style.DIM}(will be autostopped if idle for 30min)'
+                f'{reserved_group_name}{colorama.Style.RESET_ALL}'
+                f'{colorama.Style.DIM} (will be autostopped if idle for 30min)'
                 f'{colorama.Style.RESET_ALL}')
         else:
-            click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters: '
+            click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
                        f'{colorama.Style.RESET_ALL}')
         click.echo(cluster_table)
     else:

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -4,6 +4,7 @@ import click
 import colorama
 
 from sky import backends
+from sky import spot
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils.cli_utils import cli_utils
@@ -75,11 +76,12 @@ def show_status_table(cluster_records: List[Dict[str, Any]],
 
     if cluster_records:
         if reserved_group_name is not None:
-            click.echo(
-                f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                f'{reserved_group_name}{colorama.Style.RESET_ALL}'
-                f'{colorama.Style.DIM} (will be autostopped if idle for 30min)'
-                f'{colorama.Style.RESET_ALL}')
+            autostop_minutes = spot.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
+            click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+                       f'{reserved_group_name}{colorama.Style.RESET_ALL}'
+                       f'{colorama.Style.DIM} (will be autostopped if idle for '
+                       f'{autostop_minutes}min)'
+                       f'{colorama.Style.RESET_ALL}')
         else:
             click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
                        f'{colorama.Style.RESET_ALL}')


### PR DESCRIPTION
Previously, the hint about auto{stop,down} was too dim to easily notice on a dark scheme terminal. This changes it to normal font, as it's an important message.

@Michaelvll could you help check if this looks OK on a light theme?

Also reworded some messages.

<img width="833" alt="Screen Shot 2022-10-21 at 09 14 50" src="https://user-images.githubusercontent.com/592670/197241812-3e30944c-8107-4872-8f40-a1eb17c44e37.png">
