### PR TITLE
docs: document core programmatic APIs, and add them to docs website.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,9 +81,10 @@ Use the clouds **easily** and **cost effectively**, without needing cloud infra 
 
 .. toctree::
    :maxdepth: 1
-   :caption: SkyPilot CLI
+   :caption: API References
 
    reference/cli
+   reference/api
 
 
 .. .. toctree::

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -27,20 +27,15 @@ sky.exec
 
 .. autofunction:: sky.exec
 
-
-
-
-sky.start
-~~~~~~~~~~~~~
-
-.. autofunction:: sky.start
-
-
 sky.stop
 ~~~~~~~~~
 
 .. autofunction:: sky.stop
 
+sky.start
+~~~~~~~~~~~~~
+
+.. autofunction:: sky.start
 
 sky.down
 ~~~~~~~~~
@@ -52,12 +47,10 @@ sky.status
 
 .. autofunction:: sky.status
 
-
 sky.autostop
 ~~~~~~~~~~~~~
 
 .. autofunction:: sky.autostop
-
 
 .. _sky-dag-ref:
 

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -1,0 +1,78 @@
+.. _pythonapi:
+
+Python API
+=================
+
+SkyPilot offers a programmatic API in Python, which is used under the hood by the :ref:`CLI <cli>`.
+
+.. note::
+
+  The Python API contains more experimental functions/classes than the CLI. That
+  said, it has been used to develop several Python libraries by users.
+
+  For questions or request for support, please reach out to the development team.
+  Your feedback is much appreciated in evolving this API!
+
+
+Core API
+-----------
+
+sky.launch
+~~~~~~~~
+
+.. autofunction:: sky.launch
+
+sky.exec
+~~~~~~~~
+
+.. autofunction:: sky.exec
+
+
+
+
+sky.start
+~~~~~~~~~~~~~
+
+.. autofunction:: sky.start
+
+
+sky.stop
+~~~~~~~~~
+
+.. autofunction:: sky.stop
+
+
+sky.down
+~~~~~~~~~
+
+.. autofunction:: sky.down
+
+sky.status
+~~~~~~~~~~~~~
+
+.. autofunction:: sky.status
+
+
+sky.autostop
+~~~~~~~~~~~~~
+
+.. autofunction:: sky.autostop
+
+
+.. _sky-dag-ref:
+
+Task and DAG
+-----------------
+
+
+sky.Task
+~~~~~~~~~
+
+.. autoclass:: sky.Task
+    :members:
+
+sky.Dag
+~~~~~~~~~
+
+.. autoclass:: sky.Dag
+    :members:

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -14,12 +14,12 @@ Core CLI
    :prog: sky exec
    :nested: full
 
-.. click:: sky.cli:start
-   :prog: sky start
-   :nested: full
-
 .. click:: sky.cli:stop
    :prog: sky stop
+   :nested: full
+
+.. click:: sky.cli:start
+   :prog: sky start
    :nested: full
 
 .. click:: sky.cli:down

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -1,6 +1,6 @@
 .. _cli:
 
-CLI Reference
+Command Line Interface
 =============
 
 Core CLI

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1746,17 +1746,17 @@ def get_clusters(
 ) -> List[Dict[str, Any]]:
     """Returns a list of cached cluster records.
 
-    Combs through the Sky database (in ~/.sky/state.db) to get a list of records
+    Combs through the database (in ~/.sky/state.db) to get a list of records
     corresponding to launched clusters.
 
     Args:
-        include_reserved: Whether to include sky-reserved clusters, e.g. spot
+        include_reserved: Whether to include reserved clusters, e.g. spot
             controller.
         refresh: Whether to refresh the status of the clusters. (Refreshing will
             set the status to STOPPED if the cluster cannot be pinged.)
         cloud_filter: Sets which clouds to filer through from the global user
-            state. Supports three values, 'all' for all clouds, 'public' for public
-            clouds only, and 'local' for only local clouds.
+            state. Supports three values, 'all' for all clouds, 'public' for
+            public clouds only, and 'local' for only local clouds.
 
     Returns:
         A list of cluster records.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1063,6 +1063,7 @@ def launch(
     yes: bool,
     no_setup: bool,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a task from a YAML or a command (rerun setup if cluster exists).
 
     If ENTRYPOINT points to a valid YAML file, it is read in as the task
@@ -1150,6 +1151,7 @@ def exec(
     image_id: Optional[str],
     env: List[Dict[str, str]],
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Execute a task or a command on a cluster (skip setup).
 
     If ENTRYPOINT points to a valid YAML file, it is read in as the task
@@ -1253,6 +1255,7 @@ def exec(
     help='Query the latest cluster statuses from the cloud provider(s).')
 @usage_lib.entrypoint
 def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show clusters.
 
     The following fields for each cluster are recorded: cluster name, time
@@ -1332,6 +1335,7 @@ def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
                 **_get_shell_complete_args(_complete_cluster_name))
 @usage_lib.entrypoint
 def queue(clusters: Tuple[str], skip_finished: bool, all_users: bool):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show the job queue for cluster(s)."""
     click.secho('Fetching and parsing job queue...', fg='yellow')
     show_local_clusters = False
@@ -1405,6 +1409,7 @@ def logs(
     status: bool,  # pylint: disable=redefined-outer-name
     follow: bool,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the log of a job.
 
     If JOB_ID is not provided, the latest job on the cluster will be used.
@@ -1472,6 +1477,7 @@ def logs(
 @click.argument('jobs', required=False, type=int, nargs=-1)
 @usage_lib.entrypoint
 def cancel(cluster: str, all: bool, jobs: List[int]):  # pylint: disable=redefined-builtin
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancel job(s)."""
     try:
         core.cancel(cluster, all, jobs)
@@ -1501,6 +1507,7 @@ def stop(
     all: Optional[bool],  # pylint: disable=redefined-builtin
     yes: bool,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Stop cluster(s).
 
     CLUSTER is the name (or glob pattern) of the cluster to stop.  If both
@@ -1580,6 +1587,7 @@ def autostop(
     down: bool,  # pylint: disable=redefined-outer-name
     yes: bool,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Schedule or cancel an autostop or autodown for cluster(s).
 
     CLUSTERS are the name (or glob pattern) of the clusters to stop.  If both
@@ -1686,6 +1694,7 @@ def start(
         idle_minutes_to_autostop: Optional[int],
         down: bool,  # pylint: disable=redefined-outer-name
         retry_until_up: bool):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Restart cluster(s).
 
     If a cluster is previously stopped (status is STOPPED) or failed in
@@ -1843,6 +1852,7 @@ def down(
     yes: bool,
     purge: bool,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tear down cluster(s).
 
     CLUSTER is the name of the cluster (or glob pattern) to tear down.  If both

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1011,9 +1011,9 @@ def cli():
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after all jobs finish (successfully or '
-     'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
-     'be torn down after the specified idle time. '
+    ('Autodown the cluster: tear down the cluster after all jobs finish '
+     '(successfully or abnormally). If --idle-minutes-to-autostop is also set, '
+     'the cluster will be torn down after the specified idle time. '
      'Note that if errors occur during provisioning/data syncing/setting up, '
      'the cluster will not be torn down for debugging purposes.'),
 )
@@ -1244,12 +1244,13 @@ def exec(
               is_flag=True,
               required=False,
               help='Show all information in full.')
-@click.option('--refresh',
-              '-r',
-              default=False,
-              is_flag=True,
-              required=False,
-              help='Query cluster status from the cloud provider.')
+@click.option(
+    '--refresh',
+    '-r',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Query the latest cluster statuses from the cloud provider(s).')
 @usage_lib.entrypoint
 def status(all: bool, refresh: bool):  # pylint: disable=redefined-builtin
     """Show clusters.
@@ -1506,8 +1507,8 @@ def stop(
     CLUSTER and ``--all`` are supplied, the latter takes precedence.
 
     Data on attached disks is not lost when a cluster is stopped.  Billing for
-    the instances will stop while the disks will still be charged.  Those disks
-    will be reattached when restarting the cluster.
+    the instances will stop, while the disks will still be charged.  Those
+    disks will be reattached when restarting the cluster.
 
     Currently, spot instance clusters cannot be stopped.
 
@@ -1664,9 +1665,9 @@ def autostop(
     is_flag=True,
     required=False,
     help=
-    ('Tear down the cluster after all jobs finish (successfully or '
-     'abnormally). If --idle-minutes-to-autostop is also set, the cluster will '
-     'be torn down after the specified idle time.'),
+    ('Autodown the cluster: tear down the cluster after specified minutes of '
+     'idle time after all jobs finish (successfully or abnormally). Requires '
+     ' --idle-minutes-to-autostop to be set.'),
 )
 @click.option(
     '--retry-until-up',
@@ -1692,11 +1693,11 @@ def start(
     start the cluster.  (In the second case, any failed setup steps are not
     performed and only a request to start the machines is attempted.)
 
-    Auto-failover provisioning is not used when restarting stopped
-    clusters. They will be started on the same cloud and region that was chosen
-    before.
+    Auto-failover provisioning is not used when restarting a stopped
+    cluster. It will be started on the same cloud, region, and zone that were
+    chosen before.
 
-    If a cluster is already in the UP status, this command has no effect on it.
+    If a cluster is already in the UP status, this command has no effect.
 
     Examples:
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1689,9 +1689,9 @@ def start(
     """Restart cluster(s).
 
     If a cluster is previously stopped (status is STOPPED) or failed in
-    provisioning/runtime setup (status is INIT), this command will attempt to
-    start the cluster.  (In the second case, any failed setup steps are not
-    performed and only a request to start the machines is attempted.)
+    provisioning/runtime installation (status is INIT), this command will
+    attempt to start the cluster.  In the latter case, provisioning and runtime
+    installation will be retried.
 
     Auto-failover provisioning is not used when restarting a stopped
     cluster. It will be started on the same cloud, region, and zone that were

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1849,11 +1849,12 @@ def down(
     CLUSTER and ``--all`` are supplied, the latter takes precedence.
 
     Tearing down a cluster will delete all associated resources (all billing
-    stops), and any data on the attached disks will be lost. For local clusters,
-    `sky down` does not terminate the local cluster, but instead removes the
-    cluster from `sky status` and terminates the calling user's running jobs.
+    stops), and any data on the attached disks will be lost.  Accelerators
+    (e.g., TPUs) that are part of the cluster will be deleted too.
 
-    Accelerators (e.g., TPUs) that are part of the cluster will be deleted too.
+    For local on-prem clusters, this command does not terminate the local
+    cluster, but instead removes the cluster from the status table and
+    terminates the calling user's running jobs.
 
     Examples:
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -31,6 +31,7 @@ logger = sky_logging.init_logger(__name__)
 
 @usage_lib.entrypoint
 def status(refresh: bool = False) -> List[Dict[str, Any]]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster statuses.
 
     Each returned value has the following fields:
@@ -111,6 +112,7 @@ def start(
         retry_until_up: bool = False,
         down: bool = False,  # pylint: disable=redefined-outer-name
 ) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Restart a cluster.
 
     If a cluster is previously stopped (status is STOPPED) or failed in
@@ -155,6 +157,7 @@ def start(
 
 @usage_lib.entrypoint
 def stop(cluster_name: str, purge: bool = False) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Stop a cluster.
 
     Data on attached disks is not lost when a cluster is stopped.  Billing for
@@ -205,6 +208,7 @@ def stop(cluster_name: str, purge: bool = False) -> None:
 
 @usage_lib.entrypoint
 def down(cluster_name: str, purge: bool = False) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tear down a cluster.
 
     Tearing down a cluster will delete all associated resources (all billing
@@ -239,6 +243,7 @@ def autostop(
         idle_minutes: int,
         down: bool = False,  # pylint: disable=redefined-outer-name
 ) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Schedule or cancel an autostop/autodown for a cluster.
 
     When multiple configurations are specified for the same cluster (e.g., this
@@ -342,6 +347,7 @@ def _check_cluster_available(cluster_name: str,
 def queue(cluster_name: str,
           skip_finished: bool = False,
           all_users: bool = False) -> List[dict]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get the job queue of a cluster.
 
     Please refer to the sky.cli.queue for the document.
@@ -392,6 +398,7 @@ def queue(cluster_name: str,
 def cancel(cluster_name: str,
            all: bool = False,
            job_ids: Optional[List[int]] = None) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancel jobs on a cluster.
 
     Please refer to the sky.cli.cancel for the document.
@@ -432,6 +439,7 @@ def cancel(cluster_name: str,
 def tail_logs(cluster_name: str,
               job_id: Optional[str],
               follow: bool = True) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the logs of a job.
 
     Please refer to the sky.cli.tail_logs for the document.
@@ -461,6 +469,7 @@ def download_logs(
         cluster_name: str,
         job_ids: Optional[List[str]],
         local_dir: str = constants.SKY_LOGS_DIRECTORY) -> Dict[str, str]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Download the logs of jobs.
 
     Args:
@@ -489,6 +498,7 @@ def job_status(
         cluster_name: str,
         job_ids: Optional[List[str]],
         stream_logs: bool = False) -> Dict[str, Optional[job_lib.JobStatus]]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get the status of jobs.
 
     Args:
@@ -543,6 +553,7 @@ def _is_spot_controller_up(
 
 @usage_lib.entrypoint
 def spot_status(refresh: bool) -> List[Dict[str, Any]]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
 
     Please refer to the sky.cli.spot_status for the document.
@@ -614,7 +625,8 @@ def spot_status(refresh: bool) -> List[Dict[str, Any]]:
 def spot_cancel(name: Optional[str] = None,
                 job_ids: Optional[Tuple[int]] = None,
                 all: bool = False) -> None:
-    """Cancel managed spot jobs
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
+    """Cancel managed spot jobs.
 
     Please refer to the sky.cli.spot_cancel for the document.
 
@@ -666,6 +678,7 @@ def spot_cancel(name: Optional[str] = None,
 @usage_lib.entrypoint
 def spot_tail_logs(name: Optional[str], job_id: Optional[int],
                    follow: bool) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail logs of managed spot jobs.
 
     Please refer to the sky.cli.spot_logs for the document.
@@ -697,6 +710,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 # ======================
 @usage_lib.entrypoint
 def storage_ls() -> List[Dict[str, Any]]:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get the storages.
 
     Returns:
@@ -718,6 +732,7 @@ def storage_ls() -> List[Dict[str, Any]]:
 
 @usage_lib.entrypoint
 def storage_delete(name: str) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Delete a storage.
 
     Raises:

--- a/sky/core.py
+++ b/sky/core.py
@@ -30,27 +30,32 @@ logger = sky_logging.init_logger(__name__)
 
 
 @usage_lib.entrypoint
-def status(refresh: bool) -> List[Dict[str, Any]]:
-    """Get the cluster status in dict.
+def status(refresh: bool = False) -> List[Dict[str, Any]]:
+    """Get all cluster statuses.
 
-    Please refer to the sky.cli.status for the document.
+    Each returned value has the following fields:
+
+    .. code-block:: python
+
+        {
+            'name': (str) cluster name,
+            'launched_at': (int) timestamp of last launch on this cluster,
+            'handle': (ResourceHandle) an internal handle to the cluster,
+            'last_use': (str) the last command/entrypoint that affected this
+              cluster,
+            'status': (sky.ClusterStatus) cluster status,
+            'autostop': (int) idle time before autostop,
+            'to_down': (bool) whether autodown is used instead of autostop,
+            'metadata': (dict) metadata of the cluster,
+        }
+
+    Args:
+        refresh: whether to query the latest cluster statuses from the cloud
+            provider(s).
 
     Returns:
-        A list of dicts, each dict contains the information of a cluster.
-
-        [
-            {
-                'name': (str) cluster name,
-                'launched_at': (int) timestamp of launched,
-                'last_use': (int) timestamp of last use,
-                'status': (sky.ClusterStatus) cluster status,
-                'autostop': (int) idle time before autostop,
-                'to_down': (bool) whether autodown is used instead of
-                    autostop,
-                'metadata': (dict) metadata of the cluster,
-            }
-        ]
-
+        A list of dicts, with each dict containing the information of a
+        cluster.
     """
     cluster_records = backend_utils.get_clusters(include_reserved=True,
                                                  refresh=refresh)
@@ -105,28 +110,68 @@ def start(
         idle_minutes_to_autostop: Optional[int] = None,
         retry_until_up: bool = False,
         down: bool = False,  # pylint: disable=redefined-outer-name
-):
-    """Start a cluster.
+) -> None:
+    """Restart a cluster.
 
-    Please refer to the sky.cli.start for the document.
+    If a cluster is previously stopped (status is STOPPED) or failed in
+    provisioning/runtime setup (status is INIT), this function will attempt to
+    start the cluster.  (In the second case, any failed setup steps are not
+    performed and only a request to start the machines is attempted.)
+
+    Auto-failover provisioning is not used when restarting a stopped
+    cluster. It will be started on the same cloud, region, and zone that were
+    chosen before.
+
+    If a cluster is already in the UP status, this function has no effect.
+
+    Args:
+        cluster_name: name of the cluster to start.
+        idle_minutes_to_autostop: automatically stop the cluster after this
+            many minute of idleness, i.e., no running or pending jobs in the
+            cluster's job queue. Idleness starts counting after
+            setup/file_mounts are done; the clock gets reset whenever there
+            are running/pending jobs in the job queue. Setting this flag is
+            equivalent to running ``sky.launch(..., detach_run=True, ...)``
+            and then ``sky.autostop(idle_minutes=<minutes>)``. If not set,
+            the cluster will not be autostopped.
+        retry_until_up: whether to retry launching the cluster until it is
+            up.
+        down: Autodown the cluster: tear down the cluster after specified
+            minutes of idle time after all jobs finish (successfully or
+            abnormally). Requires ``idle_minutes_to_autostop`` to be set.
 
     Raises:
-        ValueError: cluster does not exist.
-        sky.exceptions.NotSupportedError: the cluster is not supported.
+        ValueError: the specified cluster does not exist; or if ``down`` is set
+          to True but ``idle_minutes_to_autostop`` is None.
+        sky.exceptions.NotSupportedError: if the cluster to restart was
+          launched using a non-default backend that does not support this
+          operation.
     """
+    if down and idle_minutes_to_autostop is None:
+        raise ValueError(
+            '`idle_minutes_to_autostop` must be set if `down` is True.')
     _start(cluster_name, idle_minutes_to_autostop, retry_until_up, down)
 
 
 @usage_lib.entrypoint
-def stop(cluster_name: str, purge: bool = False):
+def stop(cluster_name: str, purge: bool = False) -> None:
     """Stop a cluster.
 
-    Please refer to the sky.cli.stop for the document.
+    Data on attached disks is not lost when a cluster is stopped.  Billing for
+    the instances will stop, while the disks will still be charged.  Those
+    disks will be reattached when restarting the cluster.
+
+    Currently, spot instance clusters cannot be stopped.
+
+    Args:
+        cluster_name: name of the cluster to stop.
+        purge: whether to ignore cloud provider errors (if any).
 
     Raises:
-        ValueError: cluster does not exist.
-        RuntimeError: Fail to stop the cluster.
-        sky.exceptions.NotSupportedError: the cluster is not supported.
+        ValueError: the specified cluster does not exist.
+        RuntimeError: failed to stop the cluster.
+        sky.exceptions.NotSupportedError: if the specified cluster is a spot
+          cluster, or a TPU VM Pod cluster, or the managed spot controller.
     """
     if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
         raise exceptions.NotSupportedError(
@@ -159,14 +204,25 @@ def stop(cluster_name: str, purge: bool = False):
 
 
 @usage_lib.entrypoint
-def down(cluster_name: str, purge: bool = False):
-    """Down a cluster.
+def down(cluster_name: str, purge: bool = False) -> None:
+    """Tear down a cluster.
 
-    Please refer to the sky.cli.down for the document.
+    Tearing down a cluster will delete all associated resources (all billing
+    stops), and any data on the attached disks will be lost. For local
+    clusters, this function does not terminate the local cluster, but instead
+    removes the cluster from `sky status` and terminates the calling user's
+    running jobs.
+
+    Accelerators (e.g., TPUs) that are part of the cluster will be deleted too.
+
+    Args:
+        cluster_name: name of the cluster to down.
+        purge: whether to ignore cloud provider errors (if any).
 
     Raises:
-        ValueError: cluster does not exist.
-        sky.exceptions.NotSupportedError: the cluster is not supported.
+        ValueError: the specified cluster does not exist.
+        sky.exceptions.NotSupportedError: the specified cluster is the managed
+          spot controller.
     """
     handle = global_user_state.get_handle_from_cluster_name(cluster_name)
     if handle is None:
@@ -180,22 +236,30 @@ def down(cluster_name: str, purge: bool = False):
 @usage_lib.entrypoint
 def autostop(
         cluster_name: str,
-        idle_minutes_to_autostop: int,
+        idle_minutes: int,
         down: bool = False,  # pylint: disable=redefined-outer-name
-):
-    """Set the autostop time of a cluster.
+) -> None:
+    """Schedule or cancel an autostop/autodown for a cluster.
 
-    Please refer to the sky.cli.autostop for the document.
+    When multiple configurations are specified for the same cluster (e.g., this
+    function is called multiple times), the last one takes precedence.
 
     Args:
-        cluster_name (str): name of the cluster.
-        autostop_time (int): autostop time in minutes.
+        cluster_name: name of the cluster.
+        idle_minutes: the number of minutes of idleness (no pending/running
+          jobs) after which the cluster will be stopped automatically. Setting
+          to a negative number means cancel any autostop/autodown setting.
+        down: if true, use autodown (tear down the cluster; non-restartable),
+          rather than autostop (restartable).
+
     Raises:
-        ValueError: cluster does not exist.
-        sky.exceptions.NotSupportedError: the cluster is not supported.
+        ValueError: the specified cluster does not exist.
+        sky.exceptions.NotSupportedError: if the specified cluster is a TPU VM
+          Pod cluster, or the managed spot controller, or was launched using a
+          non-default backend.
         sky.exceptions.ClusterNotUpError: the cluster is not UP.
     """
-    is_cancel = idle_minutes_to_autostop < 0
+    is_cancel = idle_minutes < 0
     verb = 'Cancelling' if is_cancel else 'Scheduling'
     option_str = 'down' if down else 'stop'
     if is_cancel:
@@ -233,7 +297,7 @@ def autostop(
                 f'\n  auto{option_str} can only be set/unset for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.')
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.set_autostop(handle, idle_minutes_to_autostop, down)
+    backend.set_autostop(handle, idle_minutes, down)
 
 
 # ==================
@@ -327,7 +391,7 @@ def queue(cluster_name: str,
 # pylint: disable=redefined-builtin
 def cancel(cluster_name: str,
            all: bool = False,
-           job_ids: Optional[List[int]] = None):
+           job_ids: Optional[List[int]] = None) -> None:
     """Cancel jobs on a cluster.
 
     Please refer to the sky.cli.cancel for the document.
@@ -365,7 +429,9 @@ def cancel(cluster_name: str,
 
 
 @usage_lib.entrypoint
-def tail_logs(cluster_name: str, job_id: Optional[str], follow: bool = True):
+def tail_logs(cluster_name: str,
+              job_id: Optional[str],
+              follow: bool = True) -> None:
     """Tail the logs of a job.
 
     Please refer to the sky.cli.tail_logs for the document.
@@ -547,7 +613,7 @@ def spot_status(refresh: bool) -> List[Dict[str, Any]]:
 # pylint: disable=redefined-builtin
 def spot_cancel(name: Optional[str] = None,
                 job_ids: Optional[Tuple[int]] = None,
-                all: bool = False):
+                all: bool = False) -> None:
     """Cancel managed spot jobs
 
     Please refer to the sky.cli.spot_cancel for the document.
@@ -598,7 +664,8 @@ def spot_cancel(name: Optional[str] = None,
 
 
 @usage_lib.entrypoint
-def spot_tail_logs(name: Optional[str], job_id: Optional[int], follow: bool):
+def spot_tail_logs(name: Optional[str], job_id: Optional[int],
+                   follow: bool) -> None:
     """Tail logs of managed spot jobs.
 
     Please refer to the sky.cli.spot_logs for the document.
@@ -650,7 +717,7 @@ def storage_ls() -> List[Dict[str, Any]]:
 
 
 @usage_lib.entrypoint
-def storage_delete(name: str):
+def storage_delete(name: str) -> None:
     """Delete a storage.
 
     Raises:

--- a/sky/core.py
+++ b/sky/core.py
@@ -114,9 +114,9 @@ def start(
     """Restart a cluster.
 
     If a cluster is previously stopped (status is STOPPED) or failed in
-    provisioning/runtime setup (status is INIT), this function will attempt to
-    start the cluster.  (In the second case, any failed setup steps are not
-    performed and only a request to start the machines is attempted.)
+    provisioning/runtime installation (status is INIT), this function will
+    attempt to start the cluster.  In the latter case, provisioning and runtime
+    installation will be retried.
 
     Auto-failover provisioning is not used when restarting a stopped
     cluster. It will be started on the same cloud, region, and zone that were

--- a/sky/core.py
+++ b/sky/core.py
@@ -106,7 +106,7 @@ def start(
         retry_until_up: bool = False,
         down: bool = False,  # pylint: disable=redefined-outer-name
 ):
-    """Start the cluster.
+    """Start a cluster.
 
     Please refer to the sky.cli.start for the document.
 
@@ -119,7 +119,7 @@ def start(
 
 @usage_lib.entrypoint
 def stop(cluster_name: str, purge: bool = False):
-    """Stop the cluster.
+    """Stop a cluster.
 
     Please refer to the sky.cli.stop for the document.
 
@@ -160,7 +160,7 @@ def stop(cluster_name: str, purge: bool = False):
 
 @usage_lib.entrypoint
 def down(cluster_name: str, purge: bool = False):
-    """Down the cluster.
+    """Down a cluster.
 
     Please refer to the sky.cli.down for the document.
 
@@ -183,7 +183,7 @@ def autostop(
         idle_minutes_to_autostop: int,
         down: bool = False,  # pylint: disable=redefined-outer-name
 ):
-    """Set the autostop time of the cluster.
+    """Set the autostop time of a cluster.
 
     Please refer to the sky.cli.autostop for the document.
 
@@ -278,7 +278,7 @@ def _check_cluster_available(cluster_name: str,
 def queue(cluster_name: str,
           skip_finished: bool = False,
           all_users: bool = False) -> List[dict]:
-    """Get the job queue in List[dict].
+    """Get the job queue of a cluster.
 
     Please refer to the sky.cli.queue for the document.
 
@@ -328,7 +328,7 @@ def queue(cluster_name: str,
 def cancel(cluster_name: str,
            all: bool = False,
            job_ids: Optional[List[int]] = None):
-    """Cancel jobs.
+    """Cancel jobs on a cluster.
 
     Please refer to the sky.cli.cancel for the document.
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -208,12 +208,12 @@ def down(cluster_name: str, purge: bool = False) -> None:
     """Tear down a cluster.
 
     Tearing down a cluster will delete all associated resources (all billing
-    stops), and any data on the attached disks will be lost. For local
-    clusters, this function does not terminate the local cluster, but instead
-    removes the cluster from `sky status` and terminates the calling user's
-    running jobs.
+    stops), and any data on the attached disks will be lost.  Accelerators
+    (e.g., TPUs) that are part of the cluster will be deleted too.
 
-    Accelerators (e.g., TPUs) that are part of the cluster will be deleted too.
+    For local on-prem clusters, this function does not terminate the local
+    cluster, but instead removes the cluster from the status table and
+    terminates the calling user's running jobs.
 
     Args:
         cluster_name: name of the cluster to down.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -284,6 +284,7 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
 ) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a task.
 
     The task's setup and run commands are executed under the task's workdir
@@ -363,6 +364,7 @@ def exec(  # pylint: disable=redefined-builtin
     backend: Optional[backends.Backend] = None,
     detach_run: bool = False,
 ) -> None:
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Execute a task on an existing cluster.
 
     This function performs two actions:
@@ -437,6 +439,7 @@ def spot_launch(
     detach_run: bool = False,
     retry_until_up: bool = False,
 ):
+    # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed spot job.
 
     Please refer to the sky.cli.spot_launch for the document.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -284,7 +284,14 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
 ):
-    """Launch a sky.DAG (rerun setup if cluster exists).
+    """Launch a task.
+
+    Currently, only single-node DAGs are supported. (Support for
+    pipelines/general DAGs are in experimental branches.)
+
+    The task's setup and run commands are executed under the task's workdir
+    (when specified, it is synced to remote cluster).  The task undergoes job
+    queue scheduling on the cluster.
 
     Args:
         dag: sky.DAG to launch.
@@ -313,9 +320,9 @@ def launch(
             OptimizeTarget.TIME.
         detach_run: If True, run setup first (blocking), then detach from the
             job's execution.
-        no_setup: if true, the cluster will not re-run setup instructions
+        no_setup: if True, do not re-run setup commands.
 
-    Examples:
+    Example:
         >>> import sky
         >>> with sky.Dag() as dag:
         >>>     task = sky.Task(run='echo hello SkyPilot')


### PR DESCRIPTION
This PR only handles the Core APIs -- the 7 functions backing https://skypilot.readthedocs.io/en/latest/reference/cli.html#core-cli. It does not properly go through core classes Task, Dag, etc. yet, which will be done in future PRs.

Made some minor changes to core funcs signatures; ran smoke tests to confirm they are working.

Tested
- [x] smoke tests
- [x] rendered HTMLs locally