### PR TITLE
[Azure] Patch azure cli timeout issue

### DIFF
--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -27,6 +27,8 @@ Example workflow:
 import os
 import subprocess
 
+import pkg_resources
+
 from sky.skylet import constants
 
 
@@ -34,11 +36,12 @@ def _to_absolute(pwd_file):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), pwd_file)
 
 
-def _run_patch(target_file, patch_file):
+def _run_patch(target_file,
+               patch_file,
+               version=constants.SKY_REMOTE_RAY_VERSION):
     """Applies a patch if it has not been applied already."""
     # .orig is the original file that is not patched.
-    orig_file = os.path.abspath(
-        f'{target_file}-v{constants.SKY_REMOTE_RAY_VERSION}.orig')
+    orig_file = os.path.abspath(f'{target_file}-v{version}.orig')
     script = f"""\
     which patch >/dev/null 2>&1 || sudo yum install -y patch || true
     which patch >/dev/null 2>&1 || (echo "`patch` is not found. Failed to setup ray." && exit 1)
@@ -86,6 +89,8 @@ def patch() -> None:
     try:
         import azure
         from azure.identity._credentials import azure_cli
-        _run_patch(azure_cli.__file__, _to_absolute('azure_cli.py.patch'))
+        version = pkg_resources.get_distribution('azure-cli').version
+        _run_patch(azure_cli.__file__, _to_absolute('azure_cli.py.patch'),
+                   version)
     except ImportError:
         pass

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -87,9 +87,6 @@ def patch() -> None:
         import azure
         from azure.identity._credentials import azure_cli
         # Applying the patch multiple times is fine.
-        subprocess.run(
-            f'sed -i \'s/kwargs\["timeout"\] = 10/kwargs["timeout"] = 30/g\' {azure_cli.__file__}',
-            shell=True,
-            check=True)
+        _run_patch(azure_cli.__file__, _to_absolute('azure_cli.py.patch'))
     except ImportError:
         pass

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -79,7 +79,7 @@ def patch() -> None:
     _run_patch(resource_demand_scheduler.__file__,
                _to_absolute('resource_demand_scheduler.py.patch'))
 
-    # Fix the Azure get-access-token (used by ray azure node_provider) timeout issue, 
+    # Fix the Azure get-access-token (used by ray azure node_provider) timeout issue,
     # by increasing the timeout.
     # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
     # Only patch it if azure cli is installed.

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -86,7 +86,6 @@ def patch() -> None:
     try:
         import azure
         from azure.identity._credentials import azure_cli
-        # Applying the patch multiple times is fine.
         _run_patch(azure_cli.__file__, _to_absolute('azure_cli.py.patch'))
     except ImportError:
         pass

--- a/sky/skylet/ray_patches/azure_cli.py.patch
+++ b/sky/skylet/ray_patches/azure_cli.py.patch
@@ -1,4 +1,4 @@
 147c147
-<             kwargs["timeout"] = 30
+<             kwargs["timeout"] = 10
 ---
->             kwargs["timeout"] = 10
+>             kwargs["timeout"] = 30

--- a/sky/skylet/ray_patches/azure_cli.py.patch
+++ b/sky/skylet/ray_patches/azure_cli.py.patch
@@ -1,0 +1,4 @@
+147c147
+<             kwargs["timeout"] = 30
+---
+>             kwargs["timeout"] = 10


### PR DESCRIPTION
Fixes #1273 

Before this PR, the error is deterministic. We patch the timeout by replacing the timeout value in the `azure.identity._credentials.azure_cli` from 10 to 30 (from https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110)

Tested:
- [x] `sky launch -c test-azure --cloud azure echo hi`
- [x] `sky exec test-azure echo hi`
- [x] `sky launch -c test-azure --cloud azure echo hi`