### PR TITLE
Fix SKY_NODE_RANK environment variable

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1143,9 +1143,6 @@ def get_node_ips(cluster_yaml: str,
             handle.head_ip is not None):
         return [handle.head_ip]
 
-    # If get_internal_ips is True, we create a temporary config file
-    # with config[provider][use_internal_ips] set to True for
-    # "ray get-worker-ips"
     if get_internal_ips:
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
             ray_config['provider']['use_internal_ips'] = True

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1144,7 +1144,8 @@ def get_node_ips(cluster_yaml: str,
         return [handle.head_ip]
 
     # If get_internal_ips is True, we create a temporary config file
-    # with config[provider][use_internal_ips] set to True.
+    # with config[provider][use_internal_ips] set to True for
+    # "ray get-worker-ips"
     if get_internal_ips:
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
             ray_config['provider']['use_internal_ips'] = True

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1125,7 +1125,8 @@ def get_node_ips(cluster_yaml: str,
                  expected_num_nodes: int,
                  handle: Optional[backends.Backend.ResourceHandle] = None,
                  head_ip_max_attempts: int = 1,
-                 worker_ip_max_attempts: int = 1) -> List[str]:
+                 worker_ip_max_attempts: int = 1,
+                 get_internal_ips: bool = False) -> List[str]:
     """Returns the IPs of all nodes in the cluster."""
 
     # When ray up launches TPU VM Pod, Pod workers (except for the head)
@@ -1141,6 +1142,14 @@ def get_node_ips(cluster_yaml: str,
     if (expected_num_nodes == 1 and handle is not None and
             handle.head_ip is not None):
         return [handle.head_ip]
+
+    # If get_internal_ips is True, we create a temporary config file
+    # with config[provider][use_internal_ips] set to True.
+    if get_internal_ips:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            ray_config['provider']['use_internal_ips'] = True
+            yaml.dump(ray_config, f)
+            cluster_yaml = f.name
 
     # Check the network connection first to avoid long hanging time for
     # ray get-head-ip below, if a long-lasting network connection failure


### PR DESCRIPTION
As discussed in #1206, this PR ensures that SKY_NODE_RANK is always 0 on the head node, and that it is assigned to the worker nodes in a stable fashion when executing tasks on multi-node clusters. 

To accomplish this, in each call to `_execute_task_n_nodes`, we create a map of internal node ips to their correct rank, and pass this map into the Ray code generator, which assigns to correct rank to each node.

Tested:
- [x] Single-node cluster
- [x] Multi-node cluster using the following config
```
resources:
  cloud: aws
  disk_size: 1024
  instance_type: m6i.large

workdir: .

num_nodes: 4

run: |
  echo $SKY_NODE_RANK
```

