### PR TITLE
[UX/Programmatic API] Support task in launch/exec/spot_launch

### DIFF
--- a/examples/multi_echo.py
+++ b/examples/multi_echo.py
@@ -27,11 +27,10 @@ def run(cluster: Optional[str] = None):
 
     # Submit multiple tasks in parallel to trigger queueing behaviors.
     def _exec(i):
-        with sky.Dag() as dag:
-            task = sky.Task(run=f'echo {i}; sleep 5')
-            resources = sky.Resources(accelerators={'K80': 0.5})
-            task.set_resources(resources)
-        sky.exec(dag, cluster_name=cluster, detach_run=True)
+        task = sky.Task(run=f'echo {i}; sleep 5')
+        resources = sky.Resources(accelerators={'K80': 0.5})
+        task.set_resources(resources)
+        sky.exec(task, cluster_name=cluster, detach_run=True)
 
     with pool.ThreadPool(8) as p:
         list(p.imap(_exec, range(32)))

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -13,14 +13,15 @@ setup = """\
     set -e
     pip install --upgrade pip
     conda init bash
-    conda activate resnet
-    if [ $? -ne 0 ]; then
+    conda activate resnet && exists=1 || exists=0
+    if [ $exists -ne 0 ]; then
         conda create -n resnet python=3.7 -y
         conda activate resnet
         conda install cudatoolkit=11.0 -y
         pip install tensorflow==2.4.0 pyyaml
         pip install protobuf==3.20
         cd models && pip install -e .
+    fi
     """
 
 # The command to run.  Will be run under the working directory.

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -4,9 +4,7 @@ import sky
 
 # The working directory contains all code and will be synced to remote.
 workdir = '~/Downloads/tpu'
-subprocess.run(f'cd {workdir} && git checkout 222cc86',
-                shell=True,
-                check=True)
+subprocess.run(f'cd {workdir} && git checkout 222cc86', shell=True, check=True)
 
 # The setup command.  Will be run under the working directory.
 setup = """\
@@ -14,7 +12,7 @@ setup = """\
     pip install --upgrade pip
     conda init bash
     conda activate resnet && exists=1 || exists=0
-    if [ $exists -ne 0 ]; then
+    if [ $exists -eq 0 ]; then
         conda create -n resnet python=3.7 -y
         conda activate resnet
         conda install cudatoolkit=11.0 -y
@@ -56,7 +54,7 @@ task = sky.Task(
 task.set_file_mounts(file_mounts)
 # TODO: allow option to say (or detect) no download/egress cost.
 task.set_inputs('gs://cloud-tpu-test-datasets/fake_imagenet',
-                    estimated_size_gigabytes=70)
+                estimated_size_gigabytes=70)
 task.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
 task.set_resources({
     ##### Fully specified
@@ -86,5 +84,5 @@ task.set_resources({
 # Optionally, specify a time estimator: Resources -> time in seconds.
 # task.set_time_estimator(time_estimators.resnet50_estimate_runtime)
 
-# sky.launch(dag, dryrun=True)
+# sky.launch(task, dryrun=True)
 sky.launch(task)

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -2,83 +2,88 @@ import subprocess
 
 import sky
 
-with sky.Dag() as dag:
-    # The working directory contains all code and will be synced to remote.
-    workdir = '~/Downloads/tpu'
-    subprocess.run(f'cd {workdir} && git checkout 222cc86',
-                   shell=True,
-                   check=True)
+# The working directory contains all code and will be synced to remote.
+workdir = '~/Downloads/tpu'
+subprocess.run(f'cd {workdir} && git checkout 222cc86',
+                shell=True,
+                check=True)
 
-    # The setup command.  Will be run under the working directory.
-    setup = 'pip install --upgrade pip && \
-        conda init bash && \
-        conda activate resnet || \
-          (conda create -n resnet python=3.7 -y && \
-           conda activate resnet && \
-           conda install cudatoolkit=11.0 -y && \
-           pip install tensorflow==2.4.0 pyyaml && \
-           pip install protobuf==3.20 && \
-           cd models && pip install -e .)'
+# The setup command.  Will be run under the working directory.
+setup = """\
+    set -e
+    pip install --upgrade pip
+    conda init bash
+    conda activate resnet
+    if [ $? -ne 0 ]; then
+        conda create -n resnet python=3.7 -y
+        conda activate resnet
+        conda install cudatoolkit=11.0 -y
+        pip install tensorflow==2.4.0 pyyaml
+        pip install protobuf==3.20
+        cd models && pip install -e .
+    """
 
-    # The command to run.  Will be run under the working directory.
-    run = 'conda activate resnet && \
-        export XLA_FLAGS=\'--xla_gpu_cuda_data_dir=/usr/local/cuda/\' && \
-        python -u models/official/resnet/resnet_main.py --use_tpu=False \
+# The command to run.  Will be run under the working directory.
+run = """\
+    conda activate resnet
+    export XLA_FLAGS=\'--xla_gpu_cuda_data_dir=/usr/local/cuda/\'
+    python -u models/official/resnet/resnet_main.py --use_tpu=False \
         --mode=train --train_batch_size=256 --train_steps=250 \
         --iterations_per_loop=125 \
         --data_dir=gs://cloud-tpu-test-datasets/fake_imagenet \
         --model_dir=resnet-model-dir \
-        --amp --xla --loss_scale=128'
+        --amp --xla --loss_scale=128
+    """
 
-    ### Optional: download data to VM's local disks. ###
-    # Format: {VM paths: local paths / cloud URLs}.
-    file_mounts = {
-        # Download from GCS before training starts.
-        # '/tmp/fake_imagenet': 'gs://cloud-tpu-test-datasets/fake_imagenet',
-    }
-    # Refer to the VM local path.
-    # run = run.replace('gs://cloud-tpu-test-datasets/fake_imagenet',
-    #                   '/tmp/fake_imagenet')
-    ### Optional end ###
+### Optional: download data to VM's local disks. ###
+# Format: {VM paths: local paths / cloud URLs}.
+file_mounts = {
+    # Download from GCS before training starts.
+    # '/tmp/fake_imagenet': 'gs://cloud-tpu-test-datasets/fake_imagenet',
+}
+# Refer to the VM local path.
+# run = run.replace('gs://cloud-tpu-test-datasets/fake_imagenet',
+#                   '/tmp/fake_imagenet')
+### Optional end ###
 
-    train = sky.Task(
-        'train',
-        workdir=workdir,
-        setup=setup,
-        run=run,
-    )
-    train.set_file_mounts(file_mounts)
-    # TODO: allow option to say (or detect) no download/egress cost.
-    train.set_inputs('gs://cloud-tpu-test-datasets/fake_imagenet',
-                     estimated_size_gigabytes=70)
-    train.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
-    train.set_resources({
-        ##### Fully specified
-        # sky.Resources(sky.AWS(), 'p3.2xlarge'),
-        # sky.Resources(sky.GCP(), 'n1-standard-16'),
-        # sky.Resources(
-        #     sky.GCP(),
-        #     'n1-standard-8',
-        #     # Options: 'V100', {'V100': <num>}.
-        #     'V100',
-        # ),
-        ##### Partially specified
-        # sky.Resources(accelerators='T4'),
-        # sky.Resources(accelerators={'T4': 8}, use_spot=True),
-        # sky.Resources(sky.AWS(), accelerators={'T4': 8}, use_spot=True),
-        # sky.Resources(sky.AWS(), accelerators='K80'),
-        # sky.Resources(sky.AWS(), accelerators='K80', use_spot=True),
-        # sky.Resources(accelerators='tpu-v3-8'),
-        # sky.Resources(accelerators='V100', use_spot=True),
-        # sky.Resources(accelerators={'T4': 4}),
-        sky.Resources(sky.AWS(), accelerators='V100'),
-        # sky.Resources(sky.GCP(), accelerators={'V100': 4}),
-        # sky.Resources(sky.AWS(), accelerators='V100', use_spot=True),
-        # sky.Resources(sky.AWS(), accelerators={'V100': 8}),
-    })
+task = sky.Task(
+    'train',
+    workdir=workdir,
+    setup=setup,
+    run=run,
+)
+task.set_file_mounts(file_mounts)
+# TODO: allow option to say (or detect) no download/egress cost.
+task.set_inputs('gs://cloud-tpu-test-datasets/fake_imagenet',
+                    estimated_size_gigabytes=70)
+task.set_outputs('resnet-model-dir', estimated_size_gigabytes=0.1)
+task.set_resources({
+    ##### Fully specified
+    # sky.Resources(sky.AWS(), 'p3.2xlarge'),
+    # sky.Resources(sky.GCP(), 'n1-standard-16'),
+    # sky.Resources(
+    #     sky.GCP(),
+    #     'n1-standard-8',
+    #     # Options: 'V100', {'V100': <num>}.
+    #     'V100',
+    # ),
+    ##### Partially specified
+    # sky.Resources(accelerators='T4'),
+    # sky.Resources(accelerators={'T4': 8}, use_spot=True),
+    # sky.Resources(sky.AWS(), accelerators={'T4': 8}, use_spot=True),
+    # sky.Resources(sky.AWS(), accelerators='K80'),
+    # sky.Resources(sky.AWS(), accelerators='K80', use_spot=True),
+    # sky.Resources(accelerators='tpu-v3-8'),
+    # sky.Resources(accelerators='V100', use_spot=True),
+    # sky.Resources(accelerators={'T4': 4}),
+    sky.Resources(sky.AWS(), accelerators='V100'),
+    # sky.Resources(sky.GCP(), accelerators={'V100': 4}),
+    # sky.Resources(sky.AWS(), accelerators='V100', use_spot=True),
+    # sky.Resources(sky.AWS(), accelerators={'V100': 8}),
+})
 
-    # Optionally, specify a time estimator: Resources -> time in seconds.
-    # train.set_time_estimator(time_estimators.resnet50_estimate_runtime)
+# Optionally, specify a time estimator: Resources -> time in seconds.
+# task.set_time_estimator(time_estimators.resnet50_estimate_runtime)
 
 # sky.launch(dag, dryrun=True)
-sky.launch(dag)
+sky.launch(task)

--- a/examples/resnet_distributed_torch_app.py
+++ b/examples/resnet_distributed_torch_app.py
@@ -2,52 +2,53 @@ from typing import List, Optional
 
 import sky
 
-with sky.Dag() as dag:
-    # Total Nodes, INCLUDING Head Node
-    num_nodes = 2
+# Total Nodes, INCLUDING Head Node
+num_nodes = 2
 
-    # The setup command.  Will be run under the working directory.
-    setup = 'echo \"alias python=python3\" >> ~/.bashrc && pip3 install --upgrade pip && \
-      [ -d pytorch-distributed-resnet ] || \
-      (git clone https://github.com/michaelzhiluo/pytorch-distributed-resnet && \
-      cd pytorch-distributed-resnet && pip3 install -r requirements.txt && \
-      mkdir -p data  && mkdir -p saved_models && cd data && \
-      wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz && \
-      tar -xvzf cifar-10-python.tar.gz)'
+# The setup command.  Will be run under the working directory.
+setup = 'echo \"alias python=python3\" >> ~/.bashrc && pip3 install --upgrade pip && \
+    [ -d pytorch-distributed-resnet ] || \
+    (git clone https://github.com/michaelzhiluo/pytorch-distributed-resnet && \
+    cd pytorch-distributed-resnet && pip3 install -r requirements.txt && \
+    mkdir -p data  && mkdir -p saved_models && cd data && \
+    wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz && \
+    tar -xvzf cifar-10-python.tar.gz)'
 
-    # The command to run.  Will be run under the working directory.
-    def run_fn(node_rank: int, ip_list: List[str]) -> Optional[str]:
-        num_nodes = len(ip_list)
-        return f"""\
-        cd pytorch-distributed-resnet
-        python3 -m torch.distributed.launch --nproc_per_node=1 \
-        --nnodes={num_nodes} --node_rank={node_rank} --master_addr={ip_list[0]} \
-        --master_port=8008 resnet_ddp.py --num_epochs 20
-        """
 
-    train = sky.Task(
-        'train',
-        setup=setup,
-        num_nodes=num_nodes,
-        run=run_fn,
-    )
+# The command to run.  Will be run under the working directory.
+def run_fn(node_rank: int, ip_list: List[str]) -> Optional[str]:
+    num_nodes = len(ip_list)
+    return f"""\
+    cd pytorch-distributed-resnet
+    python3 -m torch.distributed.launch --nproc_per_node=1 \
+    --nnodes={num_nodes} --node_rank={node_rank} --master_addr={ip_list[0]} \
+    --master_port=8008 resnet_ddp.py --num_epochs 20
+    """
 
-    train.set_resources({
-        ##### Fully specified
-        sky.Resources(sky.AWS(), 'p3.2xlarge'),
-        # sky.Resources(sky.GCP(), 'n1-standard-16'),
-        #sky.Resources(
-        #     sky.GCP(),
-        #     'n1-standard-8',
-        # Options: 'V100', {'V100': <num>}.
-        #     'V100',
-        #),
-        ##### Partially specified
-        #sky.Resources(accelerators='V100'),
-        # sky.Resources(accelerators='tpu-v3-8'),
-        # sky.Resources(sky.AWS(), accelerators={'V100': 4}),
-        # sky.Resources(sky.AWS(), accelerators='V100'),
-    })
 
-sky.launch(dag, cluster_name='dth')
-# sky.exec(dag, cluster_name='dth')
+train = sky.Task(
+    'train',
+    setup=setup,
+    num_nodes=num_nodes,
+    run=run_fn,
+)
+
+train.set_resources({
+    ##### Fully specified
+    sky.Resources(sky.AWS(), 'p3.2xlarge'),
+    # sky.Resources(sky.GCP(), 'n1-standard-16'),
+    #sky.Resources(
+    #     sky.GCP(),
+    #     'n1-standard-8',
+    # Options: 'V100', {'V100': <num>}.
+    #     'V100',
+    #),
+    ##### Partially specified
+    #sky.Resources(accelerators='V100'),
+    # sky.Resources(accelerators='tpu-v3-8'),
+    # sky.Resources(sky.AWS(), accelerators={'V100': 4}),
+    # sky.Resources(sky.AWS(), accelerators='V100'),
+})
+
+sky.launch(train, cluster_name='dth')
+# sky.exec(train, cluster_name='dth')

--- a/examples/resnet_distributed_torch_with_script.yaml
+++ b/examples/resnet_distributed_torch_with_script.yaml
@@ -7,10 +7,10 @@ resources:
 
 num_nodes: 2
 
-workdir: .
+workdir: ./examples/resnet_distributed_torch_scripts
 
 setup: |
-    bash examples/resnet_distributed_torch_scripts/setup.sh
+    bash ./setup.sh
 
 run: |
-    bash examples/resnet_distributed_torch_scripts/run.sh
+    bash ./run.sh

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -607,7 +607,7 @@ def _check_resources_match(backend: backends.Backend,
 
 
 def _launch_with_confirm(
-    dag: sky.Dag,
+    task: sky.Task,
     backend: backends.Backend,
     cluster: str,
     *,
@@ -621,7 +621,9 @@ def _launch_with_confirm(
     node_type: Optional[str] = None,
     is_local_cloud: Optional[bool] = False,
 ):
-    """Launch a cluster with a DAG."""
+    """Launch a cluster with a Task."""
+    with sky.Dag() as dag:
+        dag.add(task)
     if cluster is None:
         cluster = backend_utils.generate_cluster_name()
     maybe_status, _ = backend_utils.refresh_cluster_status_handle(cluster)
@@ -701,17 +703,17 @@ def _create_and_ssh_into_node(
         raise click.BadParameter(
             f'Name {cluster_name!r} taken by a local cluster and cannot '
             f'be used for a {node_type}.')
-    with sky.Dag() as dag:
-        # TODO: Add conda environment replication
-        # should be setup =
-        # 'conda env export | grep -v "^prefix: " > environment.yml'
-        # && conda env create -f environment.yml
-        task = sky.Task(
-            node_type,
-            workdir=None,
-            setup=None,
-        )
-        task.set_resources(resources)
+
+    # TODO: Add conda environment replication
+    # should be setup =
+    # 'conda env export | grep -v "^prefix: " > environment.yml'
+    # && conda env create -f environment.yml
+    task = sky.Task(
+        node_type,
+        workdir=None,
+        setup=None,
+    )
+    task.set_resources(resources)
 
     backend = backend if backend is not None else backends.CloudVmRayBackend()
     maybe_status, _ = backend_utils.refresh_cluster_status_handle(cluster_name)
@@ -726,7 +728,7 @@ def _create_and_ssh_into_node(
             f'sky {node_type}{name_arg}{colorama.Style.RESET_ALL}')
 
     _launch_with_confirm(
-        dag,
+        task,
         backend,
         cluster_name,
         dryrun=False,
@@ -812,7 +814,7 @@ def _check_yaml(entrypoint: str) -> Tuple[bool, dict]:
     return is_yaml, config
 
 
-def _make_dag_from_entrypoint_with_overrides(
+def _make_task_from_entrypoint_with_overrides(
     entrypoint: List[str],
     *,
     name: Optional[str] = None,
@@ -830,69 +832,68 @@ def _make_dag_from_entrypoint_with_overrides(
     env: List[Dict[str, str]] = None,
     # spot launch specific
     spot_recovery: Optional[str] = None,
-) -> sky.Dag:
+) -> sky.Task:
     entrypoint = ' '.join(entrypoint)
-    with sky.Dag() as dag:
-        is_yaml, yaml_config = _check_yaml(entrypoint)
-        if is_yaml:
-            # Treat entrypoint as a yaml.
-            click.secho('Task from YAML spec: ', fg='yellow', nl=False)
+    is_yaml, yaml_config = _check_yaml(entrypoint)
+    if is_yaml:
+        # Treat entrypoint as a yaml.
+        click.secho('Task from YAML spec: ', fg='yellow', nl=False)
+        click.secho(entrypoint, bold=True)
+    else:
+        if not entrypoint:
+            entrypoint = None
+        else:
+            # Treat entrypoint as a bash command.
+            click.secho('Task from command: ', fg='yellow', nl=False)
             click.secho(entrypoint, bold=True)
+
+    if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
+        cloud = 'local'
+
+    if is_yaml:
+        usage_lib.messages.usage.update_user_task_yaml(entrypoint)
+        task = sky.Task.from_yaml(entrypoint)
+    else:
+        task = sky.Task(name='sky-cmd', run=entrypoint)
+        task.set_resources({sky.Resources()})
+
+    # Override.
+    if workdir is not None:
+        task.workdir = workdir
+
+    override_params = _parse_override_params(cloud=cloud,
+                                             region=region,
+                                             zone=zone,
+                                             gpus=gpus,
+                                             instance_type=instance_type,
+                                             use_spot=use_spot,
+                                             image_id=image_id,
+                                             disk_size=disk_size)
+    # Spot launch specific.
+    if spot_recovery is not None:
+        if spot_recovery.lower() == 'none':
+            override_params['spot_recovery'] = None
         else:
-            if not entrypoint:
-                entrypoint = None
-            else:
-                # Treat entrypoint as a bash command.
-                click.secho('Task from command: ', fg='yellow', nl=False)
-                click.secho(entrypoint, bold=True)
+            override_params['spot_recovery'] = spot_recovery
 
-        if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
-            cloud = 'local'
+    assert len(task.resources) == 1
+    old_resources = list(task.resources)[0]
+    new_resources = old_resources.copy(**override_params)
 
-        if is_yaml:
-            usage_lib.messages.usage.update_user_task_yaml(entrypoint)
-            task = sky.Task.from_yaml(entrypoint)
-        else:
-            task = sky.Task(name='sky-cmd', run=entrypoint)
-            task.set_resources({sky.Resources()})
+    task.set_resources({new_resources})
 
-        # Override.
-        if workdir is not None:
-            task.workdir = workdir
-
-        override_params = _parse_override_params(cloud=cloud,
-                                                 region=region,
-                                                 zone=zone,
-                                                 gpus=gpus,
-                                                 instance_type=instance_type,
-                                                 use_spot=use_spot,
-                                                 image_id=image_id,
-                                                 disk_size=disk_size)
-        # Spot launch specific.
-        if spot_recovery is not None:
-            if spot_recovery.lower() == 'none':
-                override_params['spot_recovery'] = None
-            else:
-                override_params['spot_recovery'] = spot_recovery
-
-        assert len(task.resources) == 1
-        old_resources = list(task.resources)[0]
-        new_resources = old_resources.copy(**override_params)
-
-        task.set_resources({new_resources})
-
-        if num_nodes is not None:
-            task.num_nodes = num_nodes
-        if name is not None:
-            task.name = name
-        task.set_envs(env)
-        # TODO(wei-lin): move this validation into Python API.
-        if new_resources.accelerators is not None:
-            acc, _ = list(new_resources.accelerators.items())[0]
-            if acc.startswith('tpu-') and task.num_nodes > 1:
-                raise ValueError('Multi-node TPU cluster is not supported. '
-                                 f'Got num_nodes={task.num_nodes}.')
-    return dag
+    if num_nodes is not None:
+        task.num_nodes = num_nodes
+    if name is not None:
+        task.name = name
+    task.set_envs(env)
+    # TODO(wei-lin): move this validation into Python API.
+    if new_resources.accelerators is not None:
+        acc, _ = list(new_resources.accelerators.items())[0]
+        if acc.startswith('tpu-') and task.num_nodes > 1:
+            raise ValueError('Multi-node TPU cluster is not supported. '
+                             f'Got num_nodes={task.num_nodes}.')
+    return task
 
 
 def _start_cluster(cluster_name: str,
@@ -1076,7 +1077,7 @@ def launch(
     if backend_name is None:
         backend_name = backends.CloudVmRayBackend.NAME
 
-    dag = _make_dag_from_entrypoint_with_overrides(
+    task = _make_task_from_entrypoint_with_overrides(
         entrypoint=entrypoint,
         name=name,
         cluster=cluster,
@@ -1102,7 +1103,7 @@ def launch(
             raise ValueError(f'{backend_name} backend is not supported.')
 
     _launch_with_confirm(
-        dag,
+        task,
         backend,
         cluster,
         dryrun=dryrun,
@@ -1217,7 +1218,7 @@ def exec(
                                  'Use `sky launch` to provision first.')
     backend = backend_utils.get_backend_from_handle(handle)
 
-    dag = _make_dag_from_entrypoint_with_overrides(
+    task = _make_task_from_entrypoint_with_overrides(
         entrypoint=entrypoint,
         name=name,
         cluster=cluster,
@@ -1234,7 +1235,7 @@ def exec(
     )
 
     click.secho(f'Executing task on cluster {cluster}...', fg='yellow')
-    sky.exec(dag, backend=backend, cluster_name=cluster, detach_run=detach_run)
+    sky.exec(task, backend=backend, cluster_name=cluster, detach_run=detach_run)
 
 
 @cli.command()
@@ -2679,7 +2680,7 @@ def spot_launch(
     else:
         backend_utils.check_cluster_name_is_valid(name)
 
-    dag = _make_dag_from_entrypoint_with_overrides(
+    task = _make_task_from_entrypoint_with_overrides(
         entrypoint,
         name=name,
         workdir=workdir,
@@ -2701,7 +2702,7 @@ def spot_launch(
         if prompt is not None:
             click.confirm(prompt, default=True, abort=True, show_default=True)
 
-    sky.spot_launch(dag,
+    sky.spot_launch(task,
                     name,
                     detach_run=detach_run,
                     retry_until_up=retry_until_up)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -118,10 +118,10 @@ def _execute(
     idle_minutes_to_autostop: Optional[int] = None,
     no_setup: bool = False,
 ) -> None:
-    """Execute an entrypoint.
+    """Execute a entrypoint.
 
-    If the DAG has not been optimized yet, this will call sky.optimize() for
-    the caller.
+    If sky.Task is given or DAG has not been optimized yet, this will call 
+    sky.optimize() for the caller.
 
     Args:
       entrypoint: sky.Task or sky.Dag.
@@ -280,7 +280,7 @@ def _execute(
 @timeline.event
 @usage_lib.entrypoint
 def launch(
-    entrypoint: Union['sky.Task', 'sky.Dag'],
+    task: Union['sky.Task', 'sky.Dag'],
     cluster_name: Optional[str] = None,
     retry_until_up: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
@@ -292,10 +292,10 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
 ):
-    """Launch an entrypoint (sky.Task or sky.Dag; rerun setup if cluster exists)
+    """Launch a sky.Task or sky.Dag (rerun setup if cluster exists).
 
     Args:
-        entrypoint: sky.Task or sky.DAG to launch.
+        task: sky.Task or sky.DAG to launch.
         cluster_name: name of the cluster to create/reuse.  If None,
             auto-generate a name.
         retry_until_up: whether to retry launching the cluster until it is
@@ -338,7 +338,7 @@ def launch(
     backend_utils.check_cluster_name_not_reserved(cluster_name,
                                                   operation_str='sky.launch')
     _execute(
-        entrypoint=entrypoint,
+        entrypoint=task,
         dryrun=dryrun,
         down=down,
         stream_logs=stream_logs,
@@ -355,7 +355,7 @@ def launch(
 
 @usage_lib.entrypoint
 def exec(  # pylint: disable=redefined-builtin
-    entrypoint: Union['sky.Task', 'sky.Dag'],
+    task: Union['sky.Task', 'sky.Dag'],
     cluster_name: str,
     dryrun: bool = False,
     down: bool = False,
@@ -364,6 +364,7 @@ def exec(  # pylint: disable=redefined-builtin
     optimize_target: OptimizeTarget = OptimizeTarget.COST,
     detach_run: bool = False,
 ):
+    entrypoint = task
     if isinstance(entrypoint, sky.Dag):
         logger.warning(
             f'{colorama.Fore.YELLOW}Use a sky.Dag as an entrypoint in '
@@ -380,7 +381,7 @@ def exec(  # pylint: disable=redefined-builtin
         if status != global_user_state.ClusterStatus.UP:
             raise ValueError(f'Cluster {cluster_name!r} is not up.  '
                              'Use `sky status` to check the status.')
-    _execute(entrypoint=entrypoint,
+    _execute(task=entrypoint,
              dryrun=dryrun,
              down=down,
              stream_logs=stream_logs,
@@ -397,7 +398,7 @@ def exec(  # pylint: disable=redefined-builtin
 
 @usage_lib.entrypoint
 def spot_launch(
-    entrypoint: Union['sky.Task', 'sky.Dag'],
+    task: Union['sky.Task', 'sky.Dag'],
     name: Optional[str] = None,
     stream_logs: bool = True,
     detach_run: bool = False,
@@ -416,6 +417,7 @@ def spot_launch(
         ValueError: cluster does not exist.
         sky.exceptions.NotSupportedError: the feature is not supported.
     """
+    entrypoint = task
     if name is None:
         name = backend_utils.generate_cluster_name()
 
@@ -471,7 +473,7 @@ def spot_launch(
               f'{colorama.Style.RESET_ALL}')
         print('Launching spot controller...')
         _execute(
-            entrypoint=spot_dag,
+            task=spot_dag,
             stream_logs=stream_logs,
             cluster_name=controller_name,
             detach_run=detach_run,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -299,8 +299,9 @@ def launch(
     (when specified, it is synced to remote cluster).  The task undergoes job
     queue scheduling on the cluster.
 
-    Currently, the first argument must be a single-node DAG (i.e., a single
-    task). Support for pipelines/general DAGs are in experimental branches.
+    Currently, the first argument must be a sky.Task, or (more advanced usage)
+    a sky.Dag; in the latter case, currently it must be a single task).
+    Support for pipelines/general DAGs are in experimental branches.
 
     Args:
         task: sky.Task or sky.Dag to launch.
@@ -417,8 +418,8 @@ def exec(  # pylint: disable=redefined-builtin
     entrypoint = task
     if isinstance(entrypoint, sky.Dag):
         logger.warning(
-            f'{colorama.Fore.YELLOW}Use a sky.Dag as an entrypoint in '
-            '`sky.exec` is deprecated. Please use sky.Task instead.'
+            f'{colorama.Fore.YELLOW}Passing a sky.Dag to sky.exec() is '
+            'deprecated. Pass sky.Task instead.'
             f'{colorama.Style.RESET_ALL}')
     backend_utils.check_cluster_name_not_reserved(cluster_name,
                                                   operation_str='sky.exec')

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -78,8 +78,9 @@ def _convert_to_dag(entrypoint: Any) -> 'sky.Dag':
     if isinstance(entrypoint, str):
         raise TypeError(_ENTRYPOINT_STRING_AS_DAG_MESSAGE)
     elif isinstance(entrypoint, sky.Dag):
-        return entrypoint
+        return copy.deepcopy(entrypoint)
     elif isinstance(entrypoint, task_lib.Task):
+        entrypoint = copy.deepcopy(entrypoint)
         with sky.Dag() as dag:
             dag.add(entrypoint)
         return dag

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -463,7 +463,7 @@ def spot_launch(
               f'{colorama.Style.RESET_ALL}')
         print('Launching spot controller...')
         _execute(
-            dag=spot_dag,
+            dag_or_task=spot_dag,
             stream_logs=stream_logs,
             cluster_name=controller_name,
             detach_run=detach_run,


### PR DESCRIPTION
This PR is a proposal to support `sky.Task` in launch/exec/spot_launch directly in addition to our previous `sky.Dag` API. That is because none of our users is using the dag abstraction for now and we do not support dag with more than 1 task in our programmatic API.

Tested:
- [x] `sky launch -c min echo hi`
- [x] `python ./examples/resnet_app.py`
- [x] `tests/run_smoke_tests.sh`