### PR TITLE
Set `--rename-dir-limit` for gcsfuse to allow dir renames

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -108,6 +108,7 @@ class AbstractStore:
     _STAT_CACHE_TTL = '5s'
     _STAT_CACHE_CAPACITY = 4096
     _TYPE_CACHE_TTL = '5s'
+    _RENAME_DIR_LIMIT = 10000
 
     class StoreMetadata:
         """A pickle-able representation of Store
@@ -1190,6 +1191,7 @@ class GcsStore(AbstractStore):
                      f'--stat-cache-capacity {self._STAT_CACHE_CAPACITY} '
                      f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
                      f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
+                     f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)


### PR DESCRIPTION
Closes #1281. 

The problem was stemming from gcsfuse not allowing directory renames, which is used by tensorflow-dataset. From gcsfuse docs:

> Renaming directories is by default not supported. A directory rename cannot be performed atomically in GCS and would therefore be arbitrarily expensive in terms of GCS operations, and for large directories would have high probability of failure, leaving the two directories in an inconsistent state.
> 
> However, if your application can tolerate the risks, you may enable renaming directories in a non-atomic way in gcsfuse starting v0.35.0, by setting --rename-dir-limit. If a directory contains fewer files than this limit and no subdirectory, it can be renamed.

This is a tradeoff between (cost, consistency) and functionality - you can have low cost and good consistency but you must disallow renames for large dirs.

SkyPilot now uses `--rename-dir-limit 10000`, which allows renames for dirs containing up to 10000 files. By setting this limit to 10000, we cap the max cost to $0.05 per dir rename to avoid users accidentally running a big storage bill if they are running frequent renames. 

The downside is any dir larger than 10000 files would raise a cryptic `Too many open files` error like in #1281.  I chose 10000 because most common datasets are only a few tens of large files. Lmk if you think we should use a different limit, happy to change. 

Tested:
- [x] YAML from #1281
- [x] `test_smoke::TestStorageWithCredentials` 