### PR TITLE
Docs: polish `sky.Task` doc strings.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,17 +52,22 @@ pygments_style = None
 autosummary_generate = True
 napolean_use_rtype = False
 
+# -- Options for autodoc
+
+# Python methods should be presented in source code order
+autodoc_member_order = 'bysource'
+
 # -- Options for HTML output
 
 html_theme = 'sphinx_book_theme'
 html_theme_options = {
     # 'show_toc_level': 2,
     'logo_only': True,
-    "repository_url": "https://github.com/skypilot-org/skypilot",
-    "use_repository_button": True,
-    "use_issues_button": True,
-    "use_edit_page_button": True,
-    "path_to_docs": "docs/source",
+    'repository_url': 'https://github.com/skypilot-org/skypilot',
+    'use_repository_button': True,
+    'use_issues_button': True,
+    'use_edit_page_button': True,
+    'path_to_docs': 'docs/source',
 }
 
 # -- Options for EPUB output
@@ -76,13 +81,13 @@ html_show_sourcelink = False
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "images/skypilot-wide-light-1k.png"
+html_logo = 'images/skypilot-wide-light-1k.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs. This file should be a Windows icon file (.ico), 16x16 or 32x32 pixels.
-html_favicon = "_static/favicon.ico"
+html_favicon = '_static/favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# so a file named 'default.css' will overwrite the builtin 'default.css'.
+html_static_path = ['_static']

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -18,7 +18,7 @@ Core API
 -----------
 
 sky.launch
-~~~~~~~~
+~~~~~~~~~~
 
 .. autofunction:: sky.launch
 
@@ -54,21 +54,11 @@ sky.autostop
 
 .. _sky-dag-ref:
 
-Task and DAG
+Task
 -----------------
-
-
-sky.Task
-~~~~~~~~~
 
 .. autoclass:: sky.Task
     :members:
-    :exclude-members: estimate_runtime
+    :exclude-members: estimate_runtime, get_inputs_cloud, set_time_estimator, sync_storage_mounts
 
     .. automethod:: __init__
-
-sky.Dag
-~~~~~~~~~
-
-.. autoclass:: sky.Dag
-    :members:

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -59,6 +59,6 @@ Task
 
 .. autoclass:: sky.Task
     :members:
-    :exclude-members: estimate_runtime, get_inputs_cloud, set_time_estimator, sync_storage_mounts
+    :exclude-members: estimate_runtime, get_cloud_to_remote_file_mounts, get_inputs_cloud, get_local_to_remote_file_mounts, set_time_estimator, sync_storage_mounts, to_yaml_config
 
     .. automethod:: __init__

--- a/docs/source/reference/api.rst
+++ b/docs/source/reference/api.rst
@@ -63,6 +63,9 @@ sky.Task
 
 .. autoclass:: sky.Task
     :members:
+    :exclude-members: estimate_runtime
+
+    .. automethod:: __init__
 
 sky.Dag
 ~~~~~~~~~

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -34,24 +34,6 @@ Core CLI
    :prog: sky autostop
    :nested: full
 
-
-Interactive Node CLI
------------------------
-
-.. click:: sky.cli:cpunode
-   :prog: sky cpunode
-   :nested: full
-
-.. _sky-gpunode:
-.. click:: sky.cli:gpunode
-   :prog: sky gpunode
-   :nested: full
-
-.. click:: sky.cli:tpunode
-   :prog: sky tpunode
-   :nested: full
-
-
 Job Queue CLI
 --------------
 
@@ -67,17 +49,6 @@ Job Queue CLI
    :prog: sky cancel
    :nested: full
 
-
-Storage CLI
-------------
-
-.. click:: sky.cli:storage_ls
-   :prog: sky storage ls
-   :nested: full
-
-.. click:: sky.cli:storage_delete
-   :prog: sky storage delete
-   :nested: full
 
 Managed Spot Jobs CLI
 ---------------------------
@@ -98,14 +69,42 @@ Managed Spot Jobs CLI
    :prog: sky spot logs
    :nested: full
 
-Miscellaneous
--------------
+Interactive Node CLI
+-----------------------
 
-.. click:: sky.cli:check
-   :prog: sky check
+.. click:: sky.cli:cpunode
+   :prog: sky cpunode
    :nested: full
+
+.. _sky-gpunode:
+.. click:: sky.cli:gpunode
+   :prog: sky gpunode
+   :nested: full
+
+.. click:: sky.cli:tpunode
+   :prog: sky tpunode
+   :nested: full
+
+
+Storage CLI
+------------
+
+.. click:: sky.cli:storage_ls
+   :prog: sky storage ls
+   :nested: full
+
+.. click:: sky.cli:storage_delete
+   :prog: sky storage delete
+   :nested: full
+
+Utils: ``show-gpus``, ``check``
+---------------------------------------
 
 
 .. click:: sky.cli:show_gpus
    :prog: sky show-gpus
+   :nested: full
+
+.. click:: sky.cli:check
+   :prog: sky check
    :nested: full

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -1,7 +1,7 @@
 .. _cli:
 
 Command Line Interface
-=============
+==========================
 
 Core CLI
 ---------

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2361,10 +2361,15 @@ def check():
 def show_gpus(gpu_name: Optional[str], all: bool, cloud: Optional[str]):  # pylint: disable=redefined-builtin
     """Show supported GPU/TPU/accelerators.
 
+    The names and counts shown can be set in the ``accelerators`` field in task
+    YAMLs, or in the ``--gpus`` flag in CLI commands. For example, if this
+    table shows 8x V100s are supported, then the string ``V100:8`` will be
+    accepted by the above.
+
     To show the detailed information of a GPU/TPU type (which clouds offer it,
     the quantity in each VM type, etc.), use ``sky show-gpus <gpu>``.
 
-    To show all GPUs, including less common ones and their detailed
+    To show all accelerators, including less common ones and their detailed
     information, use ``sky show-gpus --all``.
 
     NOTE: The price displayed for each instance type is the lowest across all
@@ -2691,7 +2696,20 @@ def spot_launch(
     retry_until_up: bool,
     yes: bool,
 ):
-    """Launch a managed spot job."""
+    """Launch a managed spot job from a YAML or a command.
+
+    If ENTRYPOINT points to a valid YAML file, it is read in as the task
+    specification. Otherwise, it is interpreted as a bash command.
+
+    Examples:
+
+    .. code-block:: bash
+
+      # You can use normal task YAMLs.
+      sky spot launch task.yaml
+
+      sky spot launch 'echo hello!'
+    """
     if name is None:
         name = backend_utils.generate_cluster_name()
     else:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -333,15 +333,13 @@ def launch(
         no_setup: if True, do not re-run setup commands.
 
     Example:
-        >>> import sky
-        >>> task = sky.Task(run='echo hello SkyPilot')
-        >>> task.set_resources(
-        ...         sky.Resources(
-        ...             cloud=sky.AWS(),
-        ...             accelerators='V100:4'
-        ...         )
-        ... )
-        >>> sky.launch(task, cluster_name='my-cluster')
+        .. code-block:: python
+
+            import sky
+            task = sky.Task(run='echo hello SkyPilot')
+            task.set_resources(
+                sky.Resources(cloud=sky.AWS(), accelerators='V100:4'))
+            sky.launch(task, cluster_name='my-cluster')
 
     """
     entrypoint = task

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -299,12 +299,12 @@ def launch(
     (when specified, it is synced to remote cluster).  The task undergoes job
     queue scheduling on the cluster.
 
-    Currently, the first argument must be a sky.Task, or (more advanced usage)
-    a sky.Dag; in the latter case, currently it must be a single task).
-    Support for pipelines/general DAGs are in experimental branches.
+    Currently, the first argument must be a sky.Task, or (EXPERIMENTAL advanced
+    usage) a sky.Dag. In the latter case, currently it must contain a single
+    task; support for pipelines/general DAGs are in experimental branches.
 
     Args:
-        task: sky.Task or sky.Dag to launch.
+        task: sky.Task, or sky.Dag (experimental; 1-task only) to launch.
         cluster_name: name of the cluster to create/reuse.  If None,
             auto-generate a name.
         retry_until_up: whether to retry launching the cluster until it is
@@ -397,7 +397,8 @@ def exec(  # pylint: disable=redefined-builtin
       Use ``ssh my_cluster`` instead.
 
     Args:
-        task: sky.Task or sky.Dag containing the task to execute.
+        task: sky.Task, or sky.Dag (experimental; 1-task only) containing the
+          task to execute.
         cluster_name: name of an existing cluster to execute the task.
         down: Tear down the cluster after all jobs finish (successfully or
             abnormally). If --idle-minutes-to-autostop is also set, the
@@ -460,7 +461,8 @@ def spot_launch(
     Please refer to the sky.cli.spot_launch for the document.
 
     Args:
-        task: sky.Task or sky.Dag to launch as a managed spot job.
+        task: sky.Task, or sky.Dag (experimental; 1-task only) to launch as a
+          managed spot job.
         name: Name of the spot job.
         detach_run: Whether to detach the run.
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -229,6 +229,10 @@ class Task:
     def from_yaml(yaml_path: str) -> 'Task':
         """Initializes a task from a task YAML.
 
+        Example:
+
+            >>> task = sky.Task.from_yaml('/path/to/task.yaml')
+
         Args:
           yaml_path: file path to a valid task yaml file.
 
@@ -336,6 +340,10 @@ class Task:
                               Dict[str, str]]) -> 'Task':
         """Sets the environment variables for use inside the setup/run commands.
 
+        Args:
+          envs: (optional) either a list of ``(env_name, value)`` or a dict
+            ``{env_name: value}``.
+
         Returns:
           self: The current task, with envs set.
 
@@ -426,8 +434,8 @@ class Task:
 
         Args:
           resources: either a sky.Resources, or a set of them.  The latter case
-            is EXPERIMENTAL and indicates asking the optimizer to "pick any one
-            of these resources" to run this task.
+            is EXPERIMENTAL and indicates asking the optimizer to "pick the
+            best of these resources" to run this task.
 
         Returns:
           self: The current task, with resources set.
@@ -440,7 +448,8 @@ class Task:
     def get_resources(self):
         return self.resources
 
-    def set_time_estimator(self, func) -> 'Task':
+    def set_time_estimator(self, func: Callable[['sky.Resources'],
+                                                int]) -> 'Task':
         """Sets a func mapping resources to estimated time (secs).
 
         This is EXPERIMENTAL.
@@ -576,7 +585,8 @@ class Task:
 
         Example:
             >>> task.set_storage_mounts({
-            >>>     '/tmp/imagenet/': sky.Storage(source='/data/imagenet'),
+            >>>     '/remote/imagenet/': sky.Storage(name='my-bucket',
+            >>>                                      source='/local/imagenet'),
             >>> })
 
         Args:
@@ -729,6 +739,8 @@ class Task:
 
         Any cloud object store URIs (gs://, s3://, etc.), either as source or
         destination, are not included.
+
+        INTERNAL: this method is internal-facing.
         """
         if self.file_mounts is None:
             return None
@@ -744,6 +756,8 @@ class Task:
 
         Local-to-remote file mounts are excluded (handled by
         get_local_to_remote_file_mounts()).
+
+        INTERNAL: this method is internal-facing.
         """
         if self.file_mounts is None:
             return None
@@ -755,7 +769,10 @@ class Task:
         return d
 
     def to_yaml_config(self) -> Dict[str, Any]:
-        """Returns a yaml-style dict representation of the task."""
+        """Returns a yaml-style dict representation of the task.
+
+        INTERNAL: this method is internal-facing.
+        """
         config = dict()
 
         def add_if_not_none(key, value):

--- a/sky/task.py
+++ b/sky/task.py
@@ -98,17 +98,19 @@ class Task:
         they are fluent APIs and can be chained together.
 
         Example:
-            >>> # A Task that will sync up local workdir '.', containing
-            >>> # requirements.txt and train.py.
-            >>> sky.Task(setup='pip install requirements.txt',
-            >>>          run='python train.py',
-            >>>          workdir='.')
-            >>>
-            >>> # An empty Task for provisioning a cluster.
-            >>> task = sky.Task(num_nodes=n).set_resources(...)
-            >>>
-            >>> # Chaining setters.
-            >>> sky.Task().set_resources(...).set_file_mounts(...)
+            .. code-block:: python
+
+                # A Task that will sync up local workdir '.', containing
+                # requirements.txt and train.py.
+                sky.Task(setup='pip install requirements.txt',
+                         run='python train.py',
+                         workdir='.')
+
+                # An empty Task for provisioning a cluster.
+                task = sky.Task(num_nodes=n).set_resources(...)
+
+                # Chaining setters.
+                sky.Task().set_resources(...).set_file_mounts(...)
 
         Args:
           name: A string name for the Task for display purposes.
@@ -230,8 +232,9 @@ class Task:
         """Initializes a task from a task YAML.
 
         Example:
+            .. code-block:: python
 
-            >>> task = sky.Task.from_yaml('/path/to/task.yaml')
+                task = sky.Task.from_yaml('/path/to/task.yaml')
 
         Args:
           yaml_path: file path to a valid task yaml file.
@@ -480,12 +483,13 @@ class Task:
         Neither source or destimation paths can end with a slash.
 
         Example:
+            .. code-block:: python
 
-            >>> task.set_file_mounts({
-            >>>     '~/.dotfile': '/local/.dotfile',
-            >>>     # /remote/dir/ will contain the contents of /local/dir/.
-            >>>     '/remote/dir': '/local/dir',
-            >>> })
+                task.set_file_mounts({
+                    '~/.dotfile': '/local/.dotfile',
+                    # /remote/dir/ will contain the contents of /local/dir/.
+                    '/remote/dir': '/local/dir',
+                })
 
         Args:
           file_mounts: an optional dict of ``{remote_path: local_path/cloud
@@ -546,11 +550,12 @@ class Task:
         This should be called before provisioning in order to take effect.
 
         Example:
+            .. code-block:: python
 
-            >>> task.update_file_mounts({
-            >>>     '~/.config': '~/Documents/config',
-            >>>     '/tmp/workdir': '/local/workdir/cnn-cifar10',
-            >>> })
+                task.update_file_mounts({
+                    '~/.config': '~/Documents/config',
+                    '/tmp/workdir': '/local/workdir/cnn-cifar10',
+                })
 
         Args:
           file_mounts: a dict of ``{remote_path: local_path/cloud URI}``, where
@@ -584,10 +589,12 @@ class Task:
         ``name`` to the bucket name; or setting ``source`` to the bucket URI).
 
         Example:
-            >>> task.set_storage_mounts({
-            >>>     '/remote/imagenet/': sky.Storage(name='my-bucket',
-            >>>                                      source='/local/imagenet'),
-            >>> })
+            .. code-block:: python
+
+                task.set_storage_mounts({
+                    '/remote/imagenet/': sky.Storage(name='my-bucket',
+                                                     source='/local/imagenet'),
+                })
 
         Args:
           storage_mounts: an optional dict of ``{mount_path: sky.Storage


### PR DESCRIPTION
Changes
- Expose a subset of methods of `sky.Task` to docs
  - Excluded:
    - Experimental/internal-facing: `:exclude-members: estimate_runtime, get_inputs_cloud, set_time_estimator, sync_storage_mounts`
    - Some undocumented methods
    - "Hidden" methods `__rshift__, __repr__`

- CLI docs: tweak order.

Tested:
- rendered locally