### PR TITLE
docs: Remove version from docs html titles.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,12 +58,16 @@ html_theme = 'sphinx_book_theme'
 html_theme_options = {
     # 'show_toc_level': 2,
     'logo_only': True,
-    "repository_url": "https://github.com/skypilot-org/skypilot",
-    "use_repository_button": True,
-    "use_issues_button": True,
-    "use_edit_page_button": True,
-    "path_to_docs": "docs/source",
+    'repository_url': 'https://github.com/skypilot-org/skypilot',
+    'use_repository_button': True,
+    'use_issues_button': True,
+    'use_edit_page_button': True,
+    'path_to_docs': 'docs/source',
 }
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = 'SkyPilot documentation'
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'
@@ -76,13 +80,13 @@ html_show_sourcelink = False
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "images/skypilot-wide-light-1k.png"
+html_logo = 'images/skypilot-wide-light-1k.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs. This file should be a Windows icon file (.ico), 16x16 or 32x32 pixels.
-html_favicon = "_static/favicon.ico"
+html_favicon = '_static/favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = ['_static']


### PR DESCRIPTION
Removes version from docs html titles, which makes it easier to see in Google Analytics what page titles are popular across versions.

E.g., currently both `Managed Spot Jobs — SkyPilot 0.1.1 documentation` and `Managed Spot Jobs — SkyPilot 1.0.0-dev0 documentation` shows up as separate entries. This change would merge them.

Tested
- rendered locally