### PR TITLE
[Storage] add `--implicit-dirs` for gcsfuse

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1188,6 +1188,7 @@ class GcsStore(AbstractStore):
                        '-O /tmp/gcsfuse.deb && '
                        'sudo dpkg --install /tmp/gcsfuse.deb')
         mount_cmd = ('gcsfuse -o allow_other '
+                     '--implicit-dirs '
                      f'--stat-cache-capacity {self._STAT_CACHE_CAPACITY} '
                      f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
                      f'--type-cache-ttl {self._TYPE_CACHE_TTL} '


### PR DESCRIPTION
Closes #1154.

`--implicit-dirs` flag for gcsfuse allows [implicitly defined directories](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#implicit-directories) to show up in mounts. 

The [gcsfuse documentation](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#implicit-directories) suggests this may have performance and cost implications. I did some simple performance measurements with and without `--implicit-dirs`. See benchmark numbers at the end.

* I don't see a significant performance difference with `--implicit-dirs` on or off. 
* It is hard to measure the cost implications, but I expect them to be [small](https://cloud.google.com/storage/pricing#operations-by-class).
* There exists an [alternative solution](https://github.com/GoogleCloudPlatform/gcsfuse/issues/7#issuecomment-264221351), which creates the directory objects right after mounting: 
```
BUCKET=my-bucket MOUNTED_AT=/path/to/mount; gsutil ls "gs://$BUCKET/*/*/**" | xargs dirname | sort | uniq | sed "s/gs:\/\/$BUCKET\///" | xargs -I % mkdir -p "$MOUNTED_AT/%"
```
* However, this alternative solution won't work for public bucket since the user may not have permissions to create directory objects on the bucket.

**Conclusion** - It should be okay to enable `--implicit-dirs`.


### Benchmark numbers
Using fio to measure sequential read performance:
```
fio --name=64kseqreads --rw=read --direct=1 --ioengine=libaio --bs=64k --numjobs=4 --iodepth=128 --size=1G --group_reporting --directory=/noimplicit/ --output-format=json > ~/perf_read_noimplicit.json
```
|                                   | With --implicit-dirs | Without --implicit-dirs |
|-----------------------------------|----------------------|-------------------------|
| Sequential Read Throughput (MB/s) | 267.13               | 262                     |
| Sequential Read IOPS              | 4076                 | 3994.25                 |

Using simple shell commands to test 100 small file read/write makespan:
```
time for i in {0..100}; do echo 'test' > "test${i}.txt"; done # Write
time for i in {0..100}; do cat "test${i}.txt" > /dev/null; done # Read
ls -la # stat operation
```
|                    | With --implicit-dirs | Without --implicit-dirs |
|--------------------|----------------------|-------------------------|
| Write Makespan (s) | 58.2s                | 57.1s                   |
| Read Makespan (s)  | 2.8s                 | 2.9s                    |
| ls Makespan (s)    | 7.3                  | 6.9                     |