### PR TITLE
[Storage] Add lazy unmount flag

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -34,7 +34,7 @@ def get_mounting_command(
         # Check if path is already mounted
         if grep -q $MOUNT_PATH /proc/mounts ; then
             echo "Path already mounted - unmounting..."
-            fusermount -u "$MOUNT_PATH"
+            fusermount -uz "$MOUNT_PATH"
             echo "Successfully unmounted $MOUNT_PATH."
         fi
 


### PR DESCRIPTION
Closes #1319.

This is caused when a process holds onto a file on the mounted path. Our fix makes the unmounting lazy (similar to `umount -l`), which will detach the filesystem from the filesystem hierarchy immediately, and cleanup all references to the filesystem as soon as it is released by the offending process.

Tested:
```yaml
file_mounts:
  /data:
    name: sky-romilb-test

run: |
  tail -f /dev/null > /data/myfile &
```
- [x] Multiple `sky launch` on both gcp and aws