### PR TITLE
[Dependency] Fix colorama dependency issue with awscli

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -753,7 +753,6 @@ def storage_delete(name: str) -> None:
     if handle is None:
         raise ValueError(f'Storage name {name!r} not found.')
     else:
-        print(f'Deleting storage object {name!r}.')
         store_object = data.Storage(name=handle.storage_name,
                                     source=handle.source,
                                     sync_on_reconstruction=False)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1006,7 +1006,7 @@ class S3Store(AbstractStore):
         remove_command = f'aws s3 rb s3://{bucket_name} --force'
         try:
             with backend_utils.safe_console_status(
-                    f'[bold cyan]Deleting [green]bucket {bucket_name}'):
+                    f'[bold cyan]Deleting S3 bucket {bucket_name}[/]'):
                 subprocess.check_output(remove_command.split(' '))
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
@@ -1251,7 +1251,7 @@ class GcsStore(AbstractStore):
 
         try:
             with backend_utils.safe_console_status(
-                    f'[bold cyan]Deleting [green]bucket {bucket_name}'):
+                    f'[bold cyan]Deleting GCS bucket {bucket_name}[/]'):
                 remove_obj_command = ('gsutil -m rm -r'
                                       f' gs://{bucket_name}')
                 subprocess.check_output(remove_obj_command.split(' '),

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -6,6 +6,8 @@ import time
 from typing import Any, Dict, Optional, Tuple, Union
 import urllib.parse
 
+import colorama
+
 from sky import clouds
 from sky.adaptors import aws
 from sky.adaptors import gcp
@@ -399,8 +401,8 @@ class Storage(object):
         self.handle = global_user_state.get_handle_from_storage_name(self.name)
         if self.handle:
             # Reconstruct the Storage object from the global_user_state
-            logger.info('Detected existing storage object, '
-                        f'loading Storage: {self.name}')
+            logger.debug('Detected existing storage object, '
+                         f'loading Storage: {self.name}')
             for s_type, s_metadata in self.handle.sky_stores.items():
                 # When initializing from global_user_state, we override the
                 # source from the YAML
@@ -835,7 +837,8 @@ class S3Store(AbstractStore):
 
     def delete(self) -> None:
         self._delete_s3_bucket(self.name)
-        logger.info(f'Deleted S3 bucket {self.name}.')
+        logger.info(f'{colorama.Fore.GREEN}Deleted S3 bucket {self.name}.'
+                    f'{colorama.Style.RESET_ALL}')
 
     def get_handle(self) -> StorageHandle:
         return aws.resource('s3').Bucket(self.name)
@@ -1089,7 +1092,8 @@ class GcsStore(AbstractStore):
 
     def delete(self) -> None:
         self._delete_gcs_bucket(self.name)
-        logger.info(f'Deleted GCS bucket {self.name}.')
+        logger.info(f'{colorama.Fore.GREEN}Deleted GCS bucket {self.name}.'
+                    f'{colorama.Style.RESET_ALL}')
 
     def get_handle(self) -> StorageHandle:
         return self.client.get_bucket(self.name)
@@ -1250,7 +1254,8 @@ class GcsStore(AbstractStore):
                     f'[bold cyan]Deleting [green]bucket {bucket_name}'):
                 remove_obj_command = ('gsutil -m rm -r'
                                       f' gs://{bucket_name}')
-                subprocess.check_output(remove_obj_command.split(' '))
+                subprocess.check_output(remove_obj_command.split(' '),
+                                        stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             logger.error(e.output)
             with ux_utils.print_exception_no_traceback():

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -59,7 +59,9 @@ install_requires = [
     # NOTE: ray 2.0.1 requires click<=8.0.4,>=7.0; We disable the
     # shell completion for click<8.0 for backward compatibility.
     'click<=8.0.4,>=7.0',
-    'colorama',
+    # NOTE: required by awscli. To avoid ray automatically installing
+    # the latest version.
+    'colorama<0.4.5',
     'cryptography',
     'jinja2',
     'jsonschema',


### PR DESCRIPTION
Closes #1321 

The is caused by ray installing `colorama` for third-party packages without version constraint ([here](https://github.com/ray-project/ray/blob/03b6bc7b5a305877501110ec04710a9c57011479/python/setup.py#L529)), which somehow breaks the dependency of `awscli==1.25.8`, which is used in our storage. 

After this fix, the user may need to install again with `pip install .` to make the dependency take effect.

This PR also fixes a little bit of the UX for the `sky storage delete`

Tested:
- [x] `pip install ray[default]==2.0.1; pip install -e .; sky storage delete skypilot-filemounts-*` (there are multiple S3 buckets named `skypilot-filemounts-*`)