### PR TITLE
[UX] remove stacktrace for pipe and ssh info

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1997,6 +1997,8 @@ def kill_children_processes():
 def interrupt_handler(signum, frame):
     del signum, frame
     kill_children_processes()
+    # Avoid using logger here, as it will print the stack trace for broken
+    # pipe, when the output is piped to another program.
     print(f'{colorama.Style.DIM}Tip: The job will keep '
           f'running after Ctrl-C.{colorama.Style.RESET_ALL}')
     with ux_utils.print_exception_no_traceback():
@@ -2007,6 +2009,8 @@ def interrupt_handler(signum, frame):
 def stop_handler(signum, frame):
     del signum, frame
     kill_children_processes()
+    # Avoid using logger here, as it will print the stack trace for broken
+    # pipe, when the output is piped to another program.
     print(f'{colorama.Style.DIM}Tip: The job will keep '
           f'running after Ctrl-Z.{colorama.Style.RESET_ALL}')
     with ux_utils.print_exception_no_traceback():

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1996,9 +1996,9 @@ def kill_children_processes():
 # Handle ctrl-c
 def interrupt_handler(signum, frame):
     del signum, frame
-    logger.warning(f'{colorama.Style.DIM}The job will keep '
-                   f'running after Ctrl-C.{colorama.Style.RESET_ALL}')
     kill_children_processes()
+    print(f'{colorama.Style.DIM}Tip: The job will keep '
+          f'running after Ctrl-C.{colorama.Style.RESET_ALL}')
     with ux_utils.print_exception_no_traceback():
         raise KeyboardInterrupt(exceptions.KEYBOARD_INTERRUPT_CODE)
 
@@ -2006,9 +2006,9 @@ def interrupt_handler(signum, frame):
 # Handle ctrl-z
 def stop_handler(signum, frame):
     del signum, frame
-    logger.warning(f'{colorama.Style.DIM}The job will keep '
-                   f'running after Ctrl-Z.{colorama.Style.RESET_ALL}')
     kill_children_processes()
+    print(f'{colorama.Style.DIM}Tip: The job will keep '
+          f'running after Ctrl-Z.{colorama.Style.RESET_ALL}')
     with ux_utils.print_exception_no_traceback():
         raise KeyboardInterrupt(exceptions.SIGTSTP_CODE)
 

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -417,6 +417,7 @@ def tail_logs(job_owner: str,
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
         status = job_lib.update_job_status(job_owner, [job_id], silent=True)[0]
 
+    start_stream_at = 'INFO: Tip: use Ctrl-C to exit log'
     if follow and status in [
             job_lib.JobStatus.RUNNING, job_lib.JobStatus.PENDING
     ]:
@@ -428,12 +429,17 @@ def tail_logs(job_owner: str,
             for line in _follow_job_logs(
                     log_file,
                     job_id=job_id,
-                    start_streaming_at='INFO: Tip: use Ctrl-C to exit log'):
+                    start_streaming_at=start_stream_at):
                 print(line, end='', flush=True)
     else:
         try:
+            start_stream = False
             with open(log_path, 'r') as f:
-                print(f.read())
+                for line in f.readlines():
+                    if start_stream_at in line:
+                        start_stream = True
+                    if start_stream:
+                        print(line, end='', flush=True)
         except FileNotFoundError:
             print(f'{colorama.Fore.RED}ERROR: Logs for job {job_id} (status:'
                   f' {status.value}) does not exist.{colorama.Style.RESET_ALL}')

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -426,10 +426,9 @@ def tail_logs(job_owner: str,
         with open(log_path, 'r', newline='') as log_file:
             # Using `_follow` instead of `tail -f` to streaming the whole
             # log and creating a new process for tail.
-            for line in _follow_job_logs(
-                    log_file,
-                    job_id=job_id,
-                    start_streaming_at=start_stream_at):
+            for line in _follow_job_logs(log_file,
+                                         job_id=job_id,
+                                         start_streaming_at=start_stream_at):
                 print(line, end='', flush=True)
     else:
         try:

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -68,6 +68,8 @@ def ssh_options_list(ssh_private_key: Optional[str],
         'ConnectTimeout': f'{timeout}s',
         # Agent forwarding for git.
         'ForwardAgent': 'yes',
+        # Disable loggings for ssh.
+        'LogLevel': 'QUIET',
     }
     if ssh_control_name is not None:
         arg_dict.update({

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -68,8 +68,6 @@ def ssh_options_list(ssh_private_key: Optional[str],
         'ConnectTimeout': f'{timeout}s',
         # Agent forwarding for git.
         'ForwardAgent': 'yes',
-        # Disable loggings for ssh.
-        'LogLevel': 'QUIET',
     }
     if ssh_control_name is not None:
         arg_dict.update({


### PR DESCRIPTION
Closes #1169 

This PR removes the long stack trace due to the broken pipe. (The `--no-follow` is a better way to get rid of the broken pipe issue.)

Tested:
```
sky logs test-log | grep il                         
Tailing logs of the last job on cluster 'test-log'...
INFO: Tip: use Ctrl-C to exit log streaming (task will not be killed).
INFO: Waiting for task resources on 1 node. This will block if the cluster is full.
^C
Aborted!
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```