### PR TITLE
[Spot] Fix race condition for spot logs

### DIFF
--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -232,9 +232,9 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
     spot_status = spot_state.get_status(job_id)
     while not spot_status.is_terminal():
         handle = global_user_state.get_handle_from_cluster_name(cluster_name)
-        # The cluster can be removed from the table before the spot state is
-        # updated by the controller. In this case, we should skip the logging,
-        # and wait for the next round of status check.
+        # Check the handle: The cluster can be removed from the table before the
+        # spot state is updated by the controller. In this case, we should skip
+        # the logging, and wait for the next round of status check.
         if handle is None or spot_status != spot_state.SpotStatus.RUNNING:
             logger.info(f'INFO: The log is not ready yet, as the spot job '
                         f'is {spot_status.value}. '

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -231,23 +231,21 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
     backend = backends.CloudVmRayBackend()
     spot_status = spot_state.get_status(job_id)
     while not spot_status.is_terminal():
-        if spot_status != spot_state.SpotStatus.RUNNING:
+        handle = global_user_state.get_handle_from_cluster_name(cluster_name)
+        # The cluster can be removed from the table before the spot state is
+        # updated by the controller. In this case, we should skip the logging,
+        # and wait for the next round of status check.
+        if handle is None or spot_status != spot_state.SpotStatus.RUNNING:
             logger.info(f'INFO: The log is not ready yet, as the spot job '
                         f'is {spot_status.value}. '
                         f'Waiting for {JOB_STATUS_CHECK_GAP_SECONDS} seconds.')
             time.sleep(JOB_STATUS_CHECK_GAP_SECONDS)
             spot_status = spot_state.get_status(job_id)
             continue
-        handle = global_user_state.get_handle_from_cluster_name(cluster_name)
-        returncode = 1
-        # The cluster can be removed from the table before the spot state is
-        # updated by the controller. In this case, we should skip the logging,
-        # and wait for the next round of status check.
-        if handle is not None:
-            returncode = backend.tail_logs(handle,
-                                           job_id=None,
-                                           spot_job_id=job_id,
-                                           follow=follow)
+        returncode = backend.tail_logs(handle,
+                                       job_id=None,
+                                       spot_job_id=job_id,
+                                       follow=follow)
         if returncode == 0:
             # If the log tailing exit successfully (the real job can be
             # SUCCEEDED or FAILED), we can safely break the loop. We use the


### PR DESCRIPTION
This PR attempts to fix #1328.

The problem could happen due to a race condition, where the cluster is removed due to the preemption, but the `spot_status` has not been set to the correct state yet. In that case, the `handle` will be `None` and fails the log tailing.

i.e., after the following lines the cluster can be already removed from the cluster table, but the `spot_status` has not been set to `RECOVERING` yet.
https://github.com/skypilot-org/skypilot/blob/a66aa263325cec34f28c36a7f16f7ca1b23d130d/sky/spot/controller.py#L101-L107

Tested:
- [x] `sky spot launch -n test-logs "echo hi; sleep 200"` and terminate the cluster manually. (it may not be exactly the same as the case in #1328, where the preemption may happen before the logging starts)