### PR TITLE
Update `SKY_NODE_RANK` docs

### DIFF
--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -49,5 +49,8 @@ SkyPilot exposes these environment variables that can be accessed in a task's ``
   You can retrieve the number of nodes by :code:`echo "$SKY_NODE_IPS" | wc -l`
   and the IP address of the third node by :code:`echo "$SKY_NODE_IPS" | sed -n
   3p`.
+
+  To manipulate these IP addresses, you can also store them to a file in the
+  :code:`run` command with :code:`echo $SKY_NODE_IPS >> ~/sky_node_ips``.
 - :code:`SKY_NUM_GPUS_PER_NODE`: number of GPUs reserved on each node to execute the
   task; the same as the count in ``accelerators: <name>:<count>`` (rounded up if a fraction).

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -46,11 +46,11 @@ SkyPilot exposes these environment variables that can be accessed in a task's ``
 - :code:`SKY_NODE_IPS`: a string of IP addresses of the nodes reserved to execute
   the task, where each line contains one IP address.
 
-  You can retrieve the number of nodes by :code:`echo "$SKY_NODE_IPS" | wc -l`
+  - You can retrieve the number of nodes by :code:`echo "$SKY_NODE_IPS" | wc -l`
   and the IP address of the third node by :code:`echo "$SKY_NODE_IPS" | sed -n
   3p`.
 
-  To manipulate these IP addresses, you can also store them to a file in the
-  :code:`run` command with :code:`echo $SKY_NODE_IPS >> ~/sky_node_ips``.
+  - To manipulate these IP addresses, you can also store them to a file in the
+  :code:`run` command with :code:`echo $SKY_NODE_IPS >> ~/sky_node_ips`.
 - :code:`SKY_NUM_GPUS_PER_NODE`: number of GPUs reserved on each node to execute the
   task; the same as the count in ``accelerators: <name>:<count>`` (rounded up if a fraction).

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -47,10 +47,10 @@ SkyPilot exposes these environment variables that can be accessed in a task's ``
   the task, where each line contains one IP address.
 
   - You can retrieve the number of nodes by :code:`echo "$SKY_NODE_IPS" | wc -l`
-  and the IP address of the third node by :code:`echo "$SKY_NODE_IPS" | sed -n
-  3p`.
+    and the IP address of the third node by :code:`echo "$SKY_NODE_IPS" | sed -n
+    3p`.
 
   - To manipulate these IP addresses, you can also store them to a file in the
-  :code:`run` command with :code:`echo $SKY_NODE_IPS >> ~/sky_node_ips`.
+    :code:`run` command with :code:`echo $SKY_NODE_IPS >> ~/sky_node_ips`.
 - :code:`SKY_NUM_GPUS_PER_NODE`: number of GPUs reserved on each node to execute the
   task; the same as the count in ``accelerators: <name>:<count>`` (rounded up if a fraction).


### PR DESCRIPTION
As discussed in #1336, this updates the docs to include a tip for how to store the cluster IPs to a file so that users can access it via SSH or manipulate it via other methods. 