### PR TITLE
Check ssh is not blocked

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1384,8 +1384,7 @@ def check_network_connection():
     try:
         http.head(_TEST_IP, timeout=3)
     except requests.Timeout as e:
-        raise exceptions.NetworkError(
-            'Network seems down.') from e
+        raise exceptions.NetworkError('Network seems down.') from e
     check_if_ssh_blocked()
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1183,6 +1183,7 @@ class RetryingVmProvisioner(object):
             logger.info(
                 f'{colorama.Style.BRIGHT}Launching on {to_provision_cloud} '
                 f'{region_name}{colorama.Style.RESET_ALL} ({zone_str})')
+            backend_utils.check_if_ssh_blocked()
         start = time.time()
 
         # Edge case: /tmp/ray does not exist, so autoscaler can't create/store


### PR DESCRIPTION
This PR aims to resolve issue #1232. We check that we can access [portquiz.net](http://portquiz.net/) port 22 in `check_network_connection` and `ray_up`.

I have some concerns hardcoding `portquiz.net`, but I haven't found a better alternative. `portquiz.net` mentions they have rate limits but do not give exact numbers, so to be safe, I restrict the number of ssh port checks.

The ssh port check also raises a warning instead of raising an error. I don't want the ssh port check to exit SkyPilot if the user cannot access `portquiz.net` and I think a warning is plenty.

I haven't extensively tested this PR, but I want to get some feedback first. Any thoughts? @concretevitamin @Michaelvll @infwinston 
