### PR TITLE
[Onprem] Support for Different Type of GPUs + Small Bugfix

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -157,12 +157,8 @@ def fill_template(template_name: str,
         cluster_name = variables.get('cluster_name')
         output_path = _get_yaml_path_from_cluster_name(cluster_name,
                                                        output_prefix)
-
     output_path = os.path.abspath(output_path)
 
-    # Add yaml file path to the template variables.
-    variables['sky_ray_yaml_remote_path'] = SKY_RAY_YAML_REMOTE_PATH
-    variables['sky_ray_yaml_local_path'] = output_path
     # Write out yaml config.
     template = jinja2.Template(template)
     content = template.render(**variables)
@@ -759,10 +755,7 @@ def write_cluster_config(
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the future.
-    if isinstance(cloud, clouds.Local):
-        tmp_yaml_path = yaml_path
-    else:
-        tmp_yaml_path = yaml_path + '.tmp'
+    tmp_yaml_path = yaml_path + '.tmp'
     tmp_yaml_path = fill_template(
         cluster_config_template,
         dict(
@@ -790,6 +783,11 @@ def write_cluster_config(
                 # Sky remote utils.
                 'sky_remote_path': SKY_REMOTE_PATH,
                 'sky_local_path': str(local_wheel_path),
+                # Add yaml file path to the template variables.
+                'sky_ray_yaml_remote_path': SKY_RAY_YAML_REMOTE_PATH,
+                'sky_ray_yaml_local_path':
+                    tmp_yaml_path
+                    if not isinstance(cloud, clouds.Local) else yaml_path,
                 'sky_version': str(version.parse(sky.__version__)),
                 'sky_wheel_hash': wheel_hash,
                 # Local IP handling (optional).

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -157,6 +157,7 @@ def fill_template(template_name: str,
         cluster_name = variables.get('cluster_name')
         output_path = _get_yaml_path_from_cluster_name(cluster_name,
                                                        output_prefix)
+
     output_path = os.path.abspath(output_path)
 
     # Add yaml file path to the template variables.
@@ -758,7 +759,10 @@ def write_cluster_config(
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the future.
-    tmp_yaml_path = yaml_path + '.tmp'
+    if isinstance(cloud, clouds.Local):
+        tmp_yaml_path = yaml_path
+    else:
+        tmp_yaml_path = yaml_path + '.tmp'
     tmp_yaml_path = fill_template(
         cluster_config_template,
         dict(
@@ -2047,3 +2051,16 @@ def validate_schema(obj, schema, err_msg_prefix=''):
     if err_msg:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(err_msg)
+
+
+def supported_ray_accs():
+    # List of supported ray accelerators (w/out importing ray).
+    # https://github.com/ray-project/ray/blob/8be5f016afefb2e199fa45416a8c2021e05805e0/python/ray/util/accelerators/accelerators.py
+    return [
+        'V100',
+        'P100',
+        'T4',
+        'P4',
+        'K80',
+        'A100',
+    ]

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2051,16 +2051,3 @@ def validate_schema(obj, schema, err_msg_prefix=''):
     if err_msg:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(err_msg)
-
-
-def supported_ray_accs():
-    # List of supported ray accelerators (w/out importing ray).
-    # https://github.com/ray-project/ray/blob/8be5f016afefb2e199fa45416a8c2021e05805e0/python/ray/util/accelerators/accelerators.py
-    return [
-        'V100',
-        'P100',
-        'T4',
-        'P4',
-        'K80',
-        'A100',
-    ]

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -231,15 +231,10 @@ class RayCodeGen:
             'CPU': backend_utils.DEFAULT_TASK_CPU_DEMAND
         } for _ in range(num_nodes)]
 
-        ray_supported_accs = backend_utils.supported_ray_accs()
-
         if accelerator_dict is not None:
             acc_name = list(accelerator_dict.keys())[0]
             acc_count = list(accelerator_dict.values())[0]
-            if acc_name in ray_supported_accs:
-                gpu_dict = {'GPU': acc_count}
-            else:
-                gpu_dict = {}
+            gpu_dict = {'GPU': acc_count}
             # gpu_dict should be empty when the accelerator is not GPU.
             # FIXME: This is a hack to make sure that we do not reserve
             # GPU when requesting TPU.
@@ -351,17 +346,13 @@ class RayCodeGen:
             assert len(ray_resources_dict) == 1, \
                 ('There can only be one type of accelerator per instance.'
                  f' Found: {ray_resources_dict}.')
-            acc_type = list(ray_resources_dict.keys())[0]
+            num_gpus = list(ray_resources_dict.values())[0]
             resources_str = f', resources={json.dumps(ray_resources_dict)}'
 
             # Passing this ensures that the Ray remote task gets
             # CUDA_VISIBLE_DEVICES set correctly.  If not passed, that flag
             # would be force-set to empty by Ray.
-            if acc_type in backend_utils.supported_ray_accs():
-                num_gpus = list(ray_resources_dict.values())[0]
-                num_gpus_str = f', num_gpus={num_gpus}'
-            else:
-                num_gpus_str = ''
+            num_gpus_str = f', num_gpus={num_gpus}'
             # `num_gpus` should be empty when the accelerator is not GPU.
             # FIXME: use a set of GPU types.
             resources_key = list(ray_resources_dict.keys())[0]

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -266,7 +266,11 @@ def get_local_cluster_accelerators(
                             'T4',
                             'P4',
                             'K80',
-                            'A100',]
+                            'A100',
+                            '1080',
+                            '2080',
+                            'A5000'
+                            'A6000']
         accelerators_dict = {}
         for acc in all_accelerators:
             output_str = os.popen(f'lspci | grep \\'{acc}\\'').read()

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -362,9 +362,10 @@ def launch_ray_on_local_cluster(
 
     # Launching Ray on the head node.
     head_resources = json.dumps(custom_resources[0], separators=(',', ':'))
+    head_gpu_count = sum(list(custom_resources[0].values()))
     head_cmd = ('ray start --head --port=6379 '
                 '--object-manager-port=8076 --dashboard-port 8265 '
-                f'--resources={head_resources!r}')
+                f'--resources={head_resources!r} --num-gpus={head_gpu_count}')
 
     with console.status('[bold cyan]Launching ray cluster on head'):
         backend_utils.run_command_and_handle_ssh_failure(
@@ -403,9 +404,11 @@ def launch_ray_on_local_cluster(
 
             worker_resources = json.dumps(custom_resources[idx + 1],
                                           separators=(',', ':'))
+            worker_gpu_count = sum(list(custom_resources[idx + 1].values()))
             worker_cmd = (f'ray start --address={head_ip}:6379 '
                           '--object-manager-port=8076 --dashboard-port 8265 '
-                          f'--resources={worker_resources!r}')
+                          f'--resources={worker_resources!r} '
+                          f'--num-gpus={worker_gpu_count}')
             backend_utils.run_command_and_handle_ssh_failure(
                 runner,
                 worker_cmd,

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -204,7 +204,12 @@ class Resources:
                     except ValueError:
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(parse_error) from None
-            assert len(accelerators) == 1, accelerators
+
+            # Ignore check for the local cloud case.
+            # It is possible the accelerators dict can contain multiple
+            # types of accelerators for some on-prem clusters.
+            if not isinstance(self._cloud, clouds.Local):
+                assert len(accelerators) == 1, accelerators
 
             # Canonicalize the accelerator names.
             accelerators = {


### PR DESCRIPTION
Adds support for the 1080, 2080, A5000, A6000 GPU types (GPUs NOT supported by Ray's backend) and allows scheduling for such types.

Also, fixes the bug introduced in #1287.

## Test:

`sky status`

```
Local clusters:
NAME                USER    HEAD_IP        RESOURCES                 COMMAND                         
shelby              ubuntu  3.144.21.13    [{'V100': 1}]             sky exec shelby --gpus V1...    
thomas              ubuntu  3.94.208.15    [{'1080': 1, '2080': 1}]  sky launch -c thomas --gpus... 
```

- `sky launch -c thomas --gpus 1080:1 -- 'echo hi'` works and occupies the right placement groups
- `sky launch -c shelby --gpus V100:1 -- 'echo hi'` still works and occupies the right placement group (+ Ray's automatic `GPU` placement group)