### PR TITLE
Minor fix for yapf warnings

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -237,7 +237,7 @@ def list_accelerators_impl(
     instance types offered by this cloud.
     """
     if gpus_only:
-        df = df[~pd.isna(df['GpuInfo'])]
+        df = df[~df['GpuInfo'].isna()]
     df = df[[
         'InstanceType',
         'AcceleratorName',


### PR DESCRIPTION
Currently, our style checker prints the below messages:
```
Sky Pylint:
************* Module sky.clouds.service_catalog.common
sky/clouds/service_catalog/common.py:240:16: E1130: bad operand type for unary ~: NoneType (invalid-unary-operand-type)
sky/clouds/service_catalog/common.py:240:16: E1130: bad operand type for unary ~: NoneType (invalid-unary-operand-type)
sky/clouds/service_catalog/common.py:240:16: E1130: bad operand type for unary ~: NoneType (invalid-unary-operand-type)
sky/clouds/service_catalog/common.py:240:16: E1130: bad operand type for unary ~: NoneType (invalid-unary-operand-type)
sky/clouds/service_catalog/common.py:240:16: E1130: bad operand type for unary ~: NoneType (invalid-unary-operand-type)
```
This PR fixes it.