### PR TITLE
Fix bugs in GCP A100 prices

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -41,7 +41,7 @@ GPU_TYPES_TO_COUNTS = {
 }
 
 # FIXME(woosuk): This URL can change.
-A2_PRICING_URL = '/compute/vm-instance-pricing_34568c2efd1858a89d6f5b0f1cdd171bbea1cdcba646e9771e6ef4028238086f.frame' # pylint: disable=line-too-long
+A2_PRICING_URL = '/compute/vm-instance-pricing_34568c2efd1858a89d6f5b0f1cdd171bbea1cdcba646e9771e6ef4028238086f.frame'  # pylint: disable=line-too-long
 A2_INSTANCE_TYPES = {
     'a2-highgpu-1g': {
         'vCPUs': 12,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -41,6 +41,7 @@ GPU_TYPES_TO_COUNTS = {
 }
 
 # FIXME(woosuk): This URL can change.
+A2_PRICING_URL = '/compute/vm-instance-pricing_34568c2efd1858a89d6f5b0f1cdd171bbea1cdcba646e9771e6ef4028238086f.frame' # pylint: disable=line-too-long
 A2_INSTANCE_TYPES = {
     'a2-highgpu-1g': {
         'vCPUs': 12,
@@ -264,9 +265,6 @@ def get_vm_price_table(url):
     else:
         # Others (e.g., per vCPU hour or per GB hour pricing rule table).
         df = df[['Item', 'Region', 'Price', 'SpotPrice']]
-        item = df['Item'].iloc[0]
-        if item == 'Predefined vCPUs':
-            df = get_a2_df(df)
     return df
 
 
@@ -302,12 +300,13 @@ def get_vm_zones(url):
     return df
 
 
-def get_a2_df(a2_pricing_df):
-    cpu_pricing = a2_pricing_df[a2_pricing_df['Item'] == 'Predefined vCPUs']
-    memory_pricing = a2_pricing_df[a2_pricing_df['Item'] == 'Predefined Memory']
+def get_a2_df():
+    a2_pricing = get_vm_price_table(GCP_URL + A2_PRICING_URL)
+    cpu_pricing = a2_pricing[a2_pricing['Item'] == 'Predefined vCPUs']
+    memory_pricing = a2_pricing[a2_pricing['Item'] == 'Predefined Memory']
 
     table = []
-    for region in a2_pricing_df['Region'].unique():
+    for region in a2_pricing['Region'].unique():
         per_cpu_price = cpu_pricing[cpu_pricing['Region'] ==
                                     region]['Price'].values[0]
         per_cpu_spot_price = cpu_pricing[cpu_pricing['Region'] ==
@@ -351,7 +350,9 @@ def get_vm_df():
         df for df in vm_dfs if df is not None and 'InstanceType' in df.columns
     ]
 
-    vm_df = pd.concat(vm_dfs)
+    # Handle A2 instance types separately.
+    a2_df = get_a2_df()
+    vm_df = pd.concat(vm_dfs + [a2_df])
 
     vm_zones = get_vm_zones(GCP_VM_ZONES_URL)
     # Remove regions not in the pricing data.


### PR DESCRIPTION
Fixes #1367 
This PR basically rolls back the changes in our GCP crawler by PR #1204. When using the new catalog, the GCP A100 prices will be correct.

Tested:

- [x] sky gpunode --gpus a100:1
- [x] sky gpunode --gpus a100:8
- [x] sky gpunode --gpus a100-80gb:1
- [x] sky gpunode --gpus a100-80gb:8
- [x] sky show-gpus --all