### PR TITLE
Pin `torch` in various examples to avoid cuda version issues.

### DIFF
--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -54,7 +54,7 @@ We can launch it with the following:
     git checkout v4.18.0
     pip install -e .
     cd examples/pytorch/question-answering/
-    pip install -r requirements.txt
+    pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
     pip install wandb
 
   run: |
@@ -215,4 +215,3 @@ you can still tear it down manually with
 
 .. note::
   Tearing down the spot controller will lose all logs and status information for the spot jobs and can cause resource leakage when there are still in-progress spot jobs.
-

--- a/docs/source/getting-started/tutorial.rst
+++ b/docs/source/getting-started/tutorial.rst
@@ -31,17 +31,16 @@ and the commands to run:
 
   setup: |
     set -e  # Exit if any command failed.
-    conda install pytorch==1.12.1 cudatoolkit=11.3 -c pytorch -y
     git clone https://github.com/huggingface/transformers/ || true
     cd transformers
-    pip3 install .
+    pip install .
     cd examples/pytorch/text-classification
-    pip3 install -r requirements.txt
+    pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
 
   run: |
     set -e  # Exit if any command failed.
     cd transformers/examples/pytorch/text-classification
-    python3 run_glue.py \
+    python run_glue.py \
       --model_name_or_path bert-base-cased \
       --dataset_name imdb  \
       --do_train \

--- a/examples/spot/bert_qa.yaml
+++ b/examples/spot/bert_qa.yaml
@@ -20,7 +20,7 @@ setup: |
     git checkout v4.18.0
     pip install -e .
     cd examples/pytorch/question-answering/
-    pip install -r requirements.txt
+    pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
     pip install wandb
 
 run: |


### PR DESCRIPTION
Tested:
- Ran on both AWS and GCP.