### PR TITLE
Fix Logging for `sky launch` on new machine

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2057,8 +2057,8 @@ def validate_schema(obj, schema, err_msg_prefix=''):
             raise ValueError(err_msg)
 
 
-# Checks if there is public cloud enabled.
 def is_public_cloud_disabled():
+    """Checks if none of the public clouds are enabled."""
     enabled_clouds = global_user_state.get_enabled_clouds()
     return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
                                                    clouds.Local)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2055,3 +2055,10 @@ def validate_schema(obj, schema, err_msg_prefix=''):
     if err_msg:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(err_msg)
+
+
+# Checks if there is public cloud enabled.
+def is_public_cloud_disabled():
+    enabled_clouds = global_user_state.get_enabled_clouds()
+    return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
+                                                   clouds.Local)

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -11,6 +11,7 @@ import click
 import rich.console as rich_console
 import yaml
 
+from sky import clouds
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
@@ -479,6 +480,7 @@ def check_local_cloud_args(cloud: Optional[str] = None,
         yaml_config: User's task yaml loaded into a JSON dictionary.
     """
     yaml_cloud = None
+    enabled_clouds = global_user_state.get_enabled_clouds()
     if yaml_config is not None and 'resources' in yaml_config:
         yaml_cloud = yaml_config['resources'].get('cloud')
 
@@ -492,7 +494,9 @@ def check_local_cloud_args(cloud: Optional[str] = None,
                 '`cloud: local` or no cloud in YAML or CLI args.')
         return True
     else:
-        if cloud == 'local' or yaml_cloud == 'local':
+        if (cloud == 'local' or yaml_cloud == 'local' or
+            (len(enabled_clouds) == 1 and
+             isinstance(enabled_clouds, clouds.Local))):
             if cluster_name is not None:
                 raise click.UsageError(
                     f'Local cluster \'{cluster_name}\' does not exist. \n'

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -12,7 +12,6 @@ import rich.console as rich_console
 import yaml
 
 from sky import check
-from sky import clouds
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
@@ -469,13 +468,6 @@ def save_distributable_yaml(cluster_config: Dict[str, Dict[str, Any]]) -> None:
     common_utils.dump_yaml(abs_yaml_path, cluster_config)
 
 
-# Checks if there is public cloud enabled.
-def _is_public_cloud_disabled():
-    enabled_clouds = global_user_state.get_enabled_clouds()
-    return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
-                                                   clouds.Local)
-
-
 # Currently, programmatic API doesn't check this.
 def check_local_cloud_args(cloud: Optional[str] = None,
                            cluster_name: Optional[str] = None,
@@ -501,9 +493,9 @@ def check_local_cloud_args(cloud: Optional[str] = None,
                 '`cloud: local` or no cloud in YAML or CLI args.')
         return True
     else:
-        if _is_public_cloud_disabled():
+        if backend_utils.is_public_cloud_disabled():
             check.check(quiet=True)
-            if _is_public_cloud_disabled():
+            if backend_utils.is_public_cloud_disabled():
                 raise click.UsageError('Cloud access is not set up. '
                                        'Run: `sky check`')
         if cloud == 'local' or yaml_cloud == 'local':

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -494,9 +494,12 @@ def check_local_cloud_args(cloud: Optional[str] = None,
                 '`cloud: local` or no cloud in YAML or CLI args.')
         return True
     else:
-        if (cloud == 'local' or yaml_cloud == 'local' or
-            (len(enabled_clouds) == 1 and
-             isinstance(enabled_clouds, clouds.Local))):
+        if (len(enabled_clouds) == 1 and
+                isinstance(enabled_clouds[0], clouds.Local)):
+            cloud = 'local'
+            click.secho('Defaulting to local cloud as there are no enabled '
+                        'public clouds in `sky check`.')
+        if cloud == 'local' or yaml_cloud == 'local':
             if cluster_name is not None:
                 raise click.UsageError(
                     f'Local cluster \'{cluster_name}\' does not exist. \n'

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -496,8 +496,8 @@ def check_local_cloud_args(cloud: Optional[str] = None,
         if backend_utils.is_public_cloud_disabled():
             check.check(quiet=True)
             if backend_utils.is_public_cloud_disabled():
-                raise click.UsageError('Cloud access is not set up. '
-                                       'Run: `sky check`')
+                raise RuntimeError('Cloud access is not set up. '
+                                   'Run: `sky check`')
         if cloud == 'local' or yaml_cloud == 'local':
             if cluster_name is not None:
                 raise click.UsageError(

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -496,9 +496,8 @@ def check_local_cloud_args(cloud: Optional[str] = None,
     else:
         if (len(enabled_clouds) == 1 and
                 isinstance(enabled_clouds[0], clouds.Local)):
-            cloud = 'local'
-            click.secho('Defaulting to local cloud as there are no enabled '
-                        'public clouds in `sky check`.')
+            raise click.UsageError('Cloud access is not set up. '
+                                   'Run: `sky check`')
         if cloud == 'local' or yaml_cloud == 'local':
             if cluster_name is not None:
                 raise click.UsageError(

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -15,6 +15,7 @@ from sky import global_user_state
 from sky import resources as resources_lib
 from sky import sky_logging
 from sky import task as task_lib
+from sky.backends import backend_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
 from sky.utils import log_utils
@@ -832,7 +833,7 @@ def _fill_in_launchable_resources(
 ) -> Tuple[Dict[resources_lib.Resources, List[resources_lib.Resources]],
            _PerCloudCandidates]:
     enabled_clouds = global_user_state.get_enabled_clouds()
-    if _is_public_cloud_disabled(enabled_clouds) and try_fix_with_sky_check:
+    if backend_utils.is_public_cloud_disabled() and try_fix_with_sky_check:
         check.check(quiet=True)
         return _fill_in_launchable_resources(task, blocked_launchable_resources,
                                              False)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -53,6 +53,12 @@ def _create_table(field_names: List[str]) -> prettytable.PrettyTable:
     return log_utils.create_table(field_names, **table_kwargs)
 
 
+# Checks if there is public cloud enabled.
+def _is_public_cloud_disabled(enabled_clouds: List[clouds.Cloud]):
+    return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
+                                                   clouds.Local)
+
+
 class Optimizer:
     """Optimizer: assigns best resources to user tasks."""
 
@@ -826,7 +832,7 @@ def _fill_in_launchable_resources(
 ) -> Tuple[Dict[resources_lib.Resources, List[resources_lib.Resources]],
            _PerCloudCandidates]:
     enabled_clouds = global_user_state.get_enabled_clouds()
-    if len(enabled_clouds) == 0 and try_fix_with_sky_check:
+    if _is_public_cloud_disabled(enabled_clouds) and try_fix_with_sky_check:
         check.check(quiet=True)
         return _fill_in_launchable_resources(task, blocked_launchable_resources,
                                              False)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -54,12 +54,6 @@ def _create_table(field_names: List[str]) -> prettytable.PrettyTable:
     return log_utils.create_table(field_names, **table_kwargs)
 
 
-# Checks if there is public cloud enabled.
-def _is_public_cloud_disabled(enabled_clouds: List[clouds.Cloud]):
-    return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
-                                                   clouds.Local)
-
-
 class Optimizer:
     """Optimizer: assigns best resources to user tasks."""
 


### PR DESCRIPTION
Fixes #1381.

## Tests

- `sky launch` on a manually provisioned AWS machine (with no credentials).

```
ubuntu@ip-172-31-37-168:~/skypilot/sky$ sky launch
Defaulting to local cloud as there are no enabled public clouds in `sky check`.
Error: Specify -c [local_cluster] to launch on a local cluster.
See `sky status` for local cluster name(s).
```