### PR TITLE
Minor UX fix: `sky cancel` should not print stacktraces.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1584,6 +1584,7 @@ def cancel(cluster: str, all: bool, jobs: List[int]):  # pylint: disable=redefin
         raise click.UsageError(str(e))
     except (exceptions.NotSupportedError, exceptions.ClusterNotUpError) as e:
         click.echo(str(e))
+        sys.exit(1)
 
 
 @cli.command(cls=_DocumentedCodeCommand)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1582,6 +1582,8 @@ def cancel(cluster: str, all: bool, jobs: List[int]):  # pylint: disable=redefin
         core.cancel(cluster, all, jobs)
     except ValueError as e:
         raise click.UsageError(str(e))
+    except (exceptions.NotSupportedError, exceptions.ClusterNotUpError) as e:
+        click.echo(str(e))
 
 
 @cli.command(cls=_DocumentedCodeCommand)

--- a/sky/core.py
+++ b/sky/core.py
@@ -320,7 +320,7 @@ def _check_cluster_available(cluster_name: str,
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterNotUpError(
                 f'{colorama.Fore.YELLOW}Cluster {cluster_name!r} does not '
-                f'exist.{colorama.Style.RESET_ALL} skipped.')
+                f'exist; skipped.{colorama.Style.RESET_ALL}')
     backend = backend_utils.get_backend_from_handle(handle)
     if isinstance(backend, backends.LocalDockerBackend):
         # LocalDockerBackend does not support job queues


### PR DESCRIPTION
Before:
```
» sky cancel stopped-cluster 2    
....
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/cli.py", line 1586, in cancel
    raise e
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/cli.py", line 1582, in cancel
    core.cancel(cluster, all, jobs)
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/utils/common_utils.py", line 209, in _record
    return f(*args, **kwargs)
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py", line 422, in cancel
    handle = _check_cluster_available(cluster_name, 'cancelling jobs')
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py", line 336, in _check_cluster_available
    f'{colorama.Fore.YELLOW}Cluster {cluster_name!r} is not up '
sky.exceptions.ClusterNotUpError: Cluster 'stopped-cluster' is not up (status: STOPPED); skipped.
```

Now:
```
» sky cancel stopped-cluster 2    
Cluster 'stopped-cluster' is not up (status: STOPPED); skipped.
```

Tested: above.