### PR TITLE
[UX] fix the error for the first time `sky launch`

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2066,8 +2066,9 @@ def check_public_cloud_enabled():
 
     def _no_public_cloud():
         enabled_clouds = global_user_state.get_enabled_clouds()
-        return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
-                                                       clouds.Local)
+        return (len(enabled_clouds) == 0 or
+                (len(enabled_clouds) == 1 and
+                 isinstance(enabled_clouds[0], clouds.Local)))
 
     if not _no_public_cloud():
         return

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2061,8 +2061,19 @@ def validate_schema(obj, schema, err_msg_prefix=''):
             raise ValueError(err_msg)
 
 
-def is_public_cloud_disabled():
-    """Checks if none of the public clouds are enabled."""
-    enabled_clouds = global_user_state.get_enabled_clouds()
-    return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
-                                                   clouds.Local)
+def check_public_cloud_enabled():
+    """Checks if any of the public clouds is enabled."""
+
+    def _no_public_cloud():
+        enabled_clouds = global_user_state.get_enabled_clouds()
+        return len(enabled_clouds) == 1 and isinstance(enabled_clouds[0],
+                                                       clouds.Local)
+
+    if not _no_public_cloud():
+        return
+
+    sky_check.check(quiet=True)
+    if _no_public_cloud():
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError('Cloud access is not set up. '
+                               'Run: `sky check`')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2076,5 +2076,6 @@ def check_public_cloud_enabled():
     sky_check.check(quiet=True)
     if _no_public_cloud():
         with ux_utils.print_exception_no_traceback():
-            raise RuntimeError('Cloud access is not set up. Run: '
+            raise RuntimeError(
+                'Cloud access is not set up. Run: '
                 f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2076,5 +2076,5 @@ def check_public_cloud_enabled():
     sky_check.check(quiet=True)
     if _no_public_cloud():
         with ux_utils.print_exception_no_traceback():
-            raise RuntimeError('Cloud access is not set up. '
-                               'Run: `sky check`')
+            raise RuntimeError('Cloud access is not set up. Run: '
+                f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -492,7 +492,6 @@ def check_local_cloud_args(cloud: Optional[str] = None,
                 '`cloud: local` or no cloud in YAML or CLI args.')
         return True
     else:
-        backend_utils.check_public_cloud_enabled()
         if cloud == 'local' or yaml_cloud == 'local':
             if cluster_name is not None:
                 raise click.UsageError(

--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -11,7 +11,6 @@ import click
 import rich.console as rich_console
 import yaml
 
-from sky import check
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends import backend_utils
@@ -493,11 +492,7 @@ def check_local_cloud_args(cloud: Optional[str] = None,
                 '`cloud: local` or no cloud in YAML or CLI args.')
         return True
     else:
-        if backend_utils.is_public_cloud_disabled():
-            check.check(quiet=True)
-            if backend_utils.is_public_cloud_disabled():
-                raise RuntimeError('Cloud access is not set up. '
-                                   'Run: `sky check`')
+        backend_utils.check_public_cloud_enabled()
         if cloud == 'local' or yaml_cloud == 'local':
             if cluster_name is not None:
                 raise click.UsageError(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -687,7 +687,7 @@ def _launch_with_confirm(
         except RuntimeError as e:
             # Catch the exception where the public cloud is not enabled, and
             # only print the error message without the error type.
-            click.echo(e)
+            click.secho(e, fg='yellow')
             sys.exit(1)
         dag = sky.optimize(dag)
     task = dag.tasks[0]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -682,6 +682,13 @@ def _launch_with_confirm(
     maybe_status, _ = backend_utils.refresh_cluster_status_handle(cluster)
     if maybe_status is None:
         # Show the optimize log before the prompt if the cluster does not exist.
+        try:
+            backend_utils.check_public_cloud_enabled()
+        except RuntimeError as e:
+            # Catch the exception where the public cloud is not enabled, and
+            # only print the error message without the error type.
+            click.echo(e)
+            sys.exit(1)
         dag = sky.optimize(dag)
     task = dag.tasks[0]
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -826,8 +826,8 @@ def _fill_in_launchable_resources(
     try_fix_with_sky_check: bool = True,
 ) -> Tuple[Dict[resources_lib.Resources, List[resources_lib.Resources]],
            _PerCloudCandidates]:
-    enabled_clouds = global_user_state.get_enabled_clouds()
     backend_utils.check_public_cloud_enabled()
+    enabled_clouds = global_user_state.get_enabled_clouds()
     launchable = collections.defaultdict(list)
     cloud_candidates = collections.defaultdict(resources_lib.Resources)
     if blocked_launchable_resources is None:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -842,8 +842,9 @@ def _fill_in_launchable_resources(
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
                     f'Task {task} requires {resources.cloud} which is not '
-                    'enabled. Run `sky check` to enable access to it, '
-                    'or change the cloud requirement.')
+                    'enabled. To enable access, or change the cloud '
+                    f'requirement, run {colorama.StyleBRIGHT}sky check '
+                    f'{colorama.Style.RESET_ALL}')
         elif resources.is_launchable():
             if isinstance(resources.cloud, clouds.GCP):
                 # Check if the host VM satisfies the max vCPU and memory limits.

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -827,10 +827,7 @@ def _fill_in_launchable_resources(
 ) -> Tuple[Dict[resources_lib.Resources, List[resources_lib.Resources]],
            _PerCloudCandidates]:
     enabled_clouds = global_user_state.get_enabled_clouds()
-    if backend_utils.is_public_cloud_disabled() and try_fix_with_sky_check:
-        check.check(quiet=True)
-        return _fill_in_launchable_resources(task, blocked_launchable_resources,
-                                             False)
+    backend_utils.check_public_cloud_enabled()
     launchable = collections.defaultdict(list)
     cloud_candidates = collections.defaultdict(resources_lib.Resources)
     if blocked_launchable_resources is None:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -842,9 +842,9 @@ def _fill_in_launchable_resources(
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
                     f'Task {task} requires {resources.cloud} which is not '
-                    'enabled. To enable access, or change the cloud '
-                    f'requirement, run {colorama.Style.BRIGHT}sky check '
-                    f'{colorama.Style.RESET_ALL}')
+                    f'enabled. To enable access, run {colorama.Style.BRIGHT}'
+                    f'sky check {colorama.Style.RESET_ALL}, or change the '
+                    'cloud requirement')
         elif resources.is_launchable():
             if isinstance(resources.cloud, clouds.GCP):
                 # Check if the host VM satisfies the max vCPU and memory limits.

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -843,7 +843,7 @@ def _fill_in_launchable_resources(
                 raise exceptions.ResourcesUnavailableError(
                     f'Task {task} requires {resources.cloud} which is not '
                     'enabled. To enable access, or change the cloud '
-                    f'requirement, run {colorama.StyleBRIGHT}sky check '
+                    f'requirement, run {colorama.Style.BRIGHT}sky check '
                     f'{colorama.Style.RESET_ALL}')
         elif resources.is_launchable():
             if isinstance(resources.cloud, clouds.GCP):


### PR DESCRIPTION
Related to #1382

The following are tested in `docker run -it continuumio/miniconda`:

Previously, 
```
# Drop the config table in ~/.sky/state.db first
> sky launch
sky launch
I 11-12 09:38:00 optimizer.py:881] No resource satisfying None on [].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task sky-cmd. To fix: relax its resource requirements.
Hint: 'sky show-gpus --all' to list available accelerators.
      'sky check' to check the enabled clouds.

> sky launch -c test
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task sky-cmd. To fix: relax its resource requirements.
Hint: 'sky show-gpus --all' to list available accelerators.
      'sky check' to check the enabled clouds.

> sky check
> sky launch
Traceback (most recent call last):
  File "/opt/conda/envs/sky/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/skypilot/sky/utils/common_utils.py", line 188, in _record
    return f(*args, **kwargs)
  File "/skypilot/sky/cli.py", line 988, in invoke
    return super().invoke(ctx)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/skypilot/sky/utils/common_utils.py", line 209, in _record
    return f(*args, **kwargs)
  File "/skypilot/sky/cli.py", line 1174, in launch
    task = _make_task_from_entrypoint_with_overrides(
  File "/skypilot/sky/cli.py", line 928, in _make_task_from_entrypoint_with_overrides
    if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
  File "/skypilot/sky/backends/onprem_utils.py", line 499, in check_local_cloud_args
    raise RuntimeError('Cloud access is not set up. '
RuntimeError: Cloud access is not set up. Run: `sky check`
> sky launch -c test
Traceback (most recent call last):
  File "/opt/conda/envs/sky/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/skypilot/sky/utils/common_utils.py", line 188, in _record
    return f(*args, **kwargs)
  File "/skypilot/sky/cli.py", line 988, in invoke
    return super().invoke(ctx)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/envs/sky/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/skypilot/sky/utils/common_utils.py", line 209, in _record
    return f(*args, **kwargs)
  File "/skypilot/sky/cli.py", line 1174, in launch
    task = _make_task_from_entrypoint_with_overrides(
  File "/skypilot/sky/cli.py", line 928, in _make_task_from_entrypoint_with_overrides
    if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
  File "/skypilot/sky/backends/onprem_utils.py", line 499, in check_local_cloud_args
    raise RuntimeError('Cloud access is not set up. '
RuntimeError: Cloud access is not set up. Run: `sky check`
```


After this PR,
```
# Drop the config table in ~/.sky/state.db first
> sky launch
RuntimeError: Cloud access is not set up. Run: `sky check`
> sky launch -c test
RuntimeError: Cloud access is not set up. Run: `sky check`
> sky check
> sky launch
RuntimeError: Cloud access is not set up. Run: `sky check`
> sky launch -c test
RuntimeError: Cloud access is not set up. Run: `sky check`
```

TODO:
- [ ] Cherry-pick to releases/v0.2.1