### PR TITLE
[Release] Fix pypi description

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -55,7 +55,9 @@ def parse_readme(readme: str) -> str:
     readme = footnote_re.sub(r'<sup>[\1]</sup>', readme)
 
     # Remove the dark mode switcher
-    mode_re = re.compile(r'<picture>[\n ]*<source media=.*>[\n ]*<img(.*)>[\n ]*</picture>', re.MULTILINE)
+    mode_re = re.compile(
+        r'<picture>[\n ]*<source media=.*>[\n ]*<img(.*)>[\n ]*</picture>',
+        re.MULTILINE)
     readme = mode_re.sub(r'<img\1>', readme)
     return readme
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -47,11 +47,17 @@ def find_version(*filepath):
         raise RuntimeError('Unable to find version string.')
 
 
-def parse_footnote(readme: str) -> str:
-    """Parse the footnote from the README.md file."""
+def parse_readme(readme: str) -> str:
+    """Parse the README.md file to be pypi compatible."""
+    # Replace the footnotes.
     readme = readme.replace('<!-- Footnote -->', '#')
     footnote_re = re.compile(r'\[\^([0-9]+)\]')
-    return footnote_re.sub(r'<sup>[\1]</sup>', readme)
+    readme = footnote_re.sub(r'<sup>[\1]</sup>', readme)
+
+    # Remove the dark mode switcher
+    mode_re = re.compile(r'<picture>[\n ]*<source media=.*>[\n ]*<img(.*)>[\n ]*</picture>', re.MULTILINE)
+    readme = mode_re.sub(r'<img\1>', readme)
+    return readme
 
 
 install_requires = [

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -125,7 +125,7 @@ readme_filepath = 'README.md'
 # README.  Skip the description for that case.
 if os.path.exists(readme_filepath):
     long_description = io.open(readme_filepath, 'r', encoding='utf-8').read()
-    long_description = parse_footnote(long_description)
+    long_description = parse_readme(long_description)
 
 setuptools.setup(
     # NOTE: this affects the package.whl wheel name. When changing this (if


### PR DESCRIPTION
This PR removes the dark mode switcher for pypi description due to lack of support from PyPi.

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/6753189/201837576-eb83da31-3e57-4c0b-8e0b-c37e457cf6eb.png">

Tested:
- https://test.pypi.org/project/skypilot/0.2.1rc2/