### PR TITLE
[Bug fix] head_ip extraction from Ray stdout

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1341,12 +1341,13 @@ class RetryingVmProvisioner(object):
             # Last line looks like: 'ssh ... <user>@<public head_ip>\n'
             position = stdout.rfind('@')
             # Use a regex to extract the IP address.
-            head_ip = re.search(
-                r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})',
-                stdout[position + 1:]).group(1)
-            if not backend_utils.is_ip(head_ip):
-                # Something's wrong. Ok to not return a head_ip.
-                head_ip = None
+            ip_list = re.findall(
+                backend_utils.IP_ADDR_REGEX,
+                stdout[position + 1:])
+            # If something's wrong. Ok to not return a head_ip.
+            head_ip = None
+            if len(ip_list) == 1:
+                head_ip = ip_list[0]
             return (self.GangSchedulingStatus.CLUSTER_READY, stdout, stderr,
                     head_ip)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1340,7 +1340,11 @@ class RetryingVmProvisioner(object):
             # Optimization: Try parse head ip from 'ray up' stdout.
             # Last line looks like: 'ssh ... <user>@<public head_ip>\n'
             position = stdout.rfind('@')
-            head_ip = stdout[position + 1:].strip()
+            # Use a regex to extract the IP address.
+            head_ip = re.search(
+                r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})',
+                stdout[position + 1:]).group(1)
+            # head_ip = stdout[position + 1:].strip()
             if not backend_utils.is_ip(head_ip):
                 # Something's wrong. Ok to not return a head_ip.
                 head_ip = None

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1341,9 +1341,8 @@ class RetryingVmProvisioner(object):
             # Last line looks like: 'ssh ... <user>@<public head_ip>\n'
             position = stdout.rfind('@')
             # Use a regex to extract the IP address.
-            ip_list = re.findall(
-                backend_utils.IP_ADDR_REGEX,
-                stdout[position + 1:])
+            ip_list = re.findall(backend_utils.IP_ADDR_REGEX,
+                                 stdout[position + 1:])
             # If something's wrong. Ok to not return a head_ip.
             head_ip = None
             if len(ip_list) == 1:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1344,7 +1344,6 @@ class RetryingVmProvisioner(object):
             head_ip = re.search(
                 r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})',
                 stdout[position + 1:]).group(1)
-            # head_ip = stdout[position + 1:].strip()
             if not backend_utils.is_ip(head_ip):
                 # Something's wrong. Ok to not return a head_ip.
                 head_ip = None


### PR DESCRIPTION
When Skypilot infers the head_ip from the Ray output message, it can capture a few extra characters (“’\n\x1b[0m”) which end up beinbg appended to the IP, which causes failures if you try to use the command runner. This PR replaces that capture with a regex to exactly match the IP.