### PR TITLE
[Catalog] Remove hardcoded A2 pricing URL & Fix a bug in A2 machine zones

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -40,7 +40,7 @@ GPU_TYPES_TO_COUNTS = {
     'K80': [1, 2, 4, 8],
 }
 
-# VMs with 16 A100 GPUs only appear in the following zones.
+# A2 VMs that support 16 A100 GPUs only appear in the following zones.
 # Source: https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
 A2_MEGAGPU_16G_ZONES = [
     'us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f',
@@ -303,7 +303,6 @@ def get_vm_df(region_prefix: str, a100_zones: List[str]) -> pd.DataFrame:
     vm_df.drop(columns=['MachineType'], inplace=True)
 
     # Block non-US regions.
-    # FIXME(woosuk): Allow all regions.
     vm_df = vm_df[vm_df['Region'].str.startswith(region_prefix)]
     return vm_df
 
@@ -454,7 +453,6 @@ def get_gpu_df(region_prefix: str) -> pd.DataFrame:
     gpu_df['MemoryGiB'] = None
 
     # Block non-US regions.
-    # FIXME(woosuk): Allow all regions.
     gpu_df = gpu_df[gpu_df['Region'].str.startswith(region_prefix)]
     return gpu_df
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -514,7 +514,7 @@ def post_process_a2_price(catalog_df: pd.DataFrame) -> pd.DataFrame:
         else:
             return row['Price'] - a100['Price'].iloc[0]
 
-    # Deduct the A100 GPU price from the a2 price.
+    # Deduct the A100 GPU price from the A2 "total" price.
     catalog_df['Price'] = catalog_df.apply(_deduct_a100_price, axis=1)
     catalog_df['SpotPrice'] = catalog_df.apply(_deduct_a100_price,
                                                axis=1,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -40,8 +40,9 @@ GPU_TYPES_TO_COUNTS = {
     'K80': [1, 2, 4, 8],
 }
 
+# VMs with 16 A100 GPUs only appear in the following zones.
 # Source: https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
-A100_16G_ZONES = [
+A2_MEGAGPU_16G_ZONES = [
     'us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f',
     'europe-west4-a', 'europe-west4-b', 'asia-southeast1-c'
 ]
@@ -442,7 +443,7 @@ def get_gpu_df(region_prefix: str) -> pd.DataFrame:
     # 16xA100 is only supported in certain zones.
     gpu_df = gpu_df[(gpu_df['AcceleratorName'] != 'A100') |
                     (gpu_df['AcceleratorCount'] != 16) |
-                    (gpu_df['AvailabilityZone'].isin(A100_16G_ZONES))]
+                    (gpu_df['AvailabilityZone'].isin(A2_MEGAGPU_16G_ZONES))]
 
     # Add columns for the service catalog.
     gpu_df['InstanceType'] = None

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -80,8 +80,10 @@ A2_INSTANCE_TYPES = {
     },
 }
 
-# Source: https://cloud.google.com/compute/docs/gpus/gpu-regions-zones
-NO_A100_16G_ZONES = ['asia-northeast3-a', 'asia-northeast3-b', 'us-west4-b']
+# Source: https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
+NO_A100_16G_ZONES = [
+    'us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f',
+    'europe-west4-a', 'europe-west4-b', 'asia-southeast1-c']
 
 # For the TPU catalog, we maintain our own location/pricing table.
 # NOTE: The CSV files do not completely align with the data in the websites.

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -13,7 +13,6 @@ import pandas as pd
 import requests
 
 # pylint: disable=line-too-long
-GCP_URL = 'https://cloud.google.com'
 GCP_VM_PRICING_URL = 'https://cloud.google.com/compute/vm-instance-pricing'
 GCP_VM_ZONES_URL = 'https://cloud.google.com/compute/docs/regions-zones'
 GCP_GPU_PRICING_URL = 'https://cloud.google.com/compute/gpus-pricing'
@@ -265,7 +264,7 @@ def get_vm_df(region_prefix: str, a100_zones: List[str]) -> pd.DataFrame:
     # Skip the table for "Suspended VM instances".
     vm_price_table_urls = vm_price_table_urls[:-1]
 
-    vm_dfs = [get_vm_price_table(GCP_URL + url) for url in vm_price_table_urls]
+    vm_dfs = [get_vm_price_table(url) for url in vm_price_table_urls]
     vm_dfs = [
         df for df in vm_dfs if df is not None and 'InstanceType' in df.columns
     ]
@@ -409,7 +408,7 @@ def get_gpu_df(region_prefix: str) -> pd.DataFrame:
     """Generates the GCP service catalog for GPUs."""
     gpu_price_table_url = get_iframe_sources(GCP_GPU_PRICING_URL)
     assert len(gpu_price_table_url) == 1
-    gpu_pricing = get_gpu_price_table(GCP_URL + gpu_price_table_url[0])
+    gpu_pricing = get_gpu_price_table(gpu_price_table_url[0])
     gpu_zones = get_gpu_zones(GCP_GPU_ZONES_URL)
 
     # Remove zones not in the pricing data.

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -526,12 +526,12 @@ def post_process_a2_price(catalog_df: pd.DataFrame) -> pd.DataFrame:
     return catalog_df
 
 
-def get_catalog_df(region_prefix_filter: str) -> pd.DataFrame:
+def get_catalog_df(region_prefix: str) -> pd.DataFrame:
     """Generates the GCP catalog by combining CPU, GPU, and TPU catalogs."""
-    gpu_df = get_gpu_df(region_prefix_filter)
+    gpu_df = get_gpu_df(region_prefix)
     df = gpu_df[gpu_df['AcceleratorName'].isin(['A100', 'A100-80GB'])]
     a100_zones = df['AvailabilityZone'].unique().tolist()
-    vm_df = get_vm_df(region_prefix_filter, a100_zones)
+    vm_df = get_vm_df(region_prefix, a100_zones)
     tpu_df = get_tpu_df()
     catalog_df = pd.concat([vm_df, gpu_df, tpu_df])
     catalog_df = post_process_a2_price(catalog_df)
@@ -555,8 +555,8 @@ if __name__ == '__main__':
         help='Fetch all global regions, not just the U.S. ones.')
     args = parser.parse_args()
 
-    region_prefix = ALL_REGION_PREFIX if args.all_regions else US_REGION_PREFIX
-    gcp_catalog_df = get_catalog_df(region_prefix)
+    region_prefix_filter = ALL_REGION_PREFIX if args.all_regions else US_REGION_PREFIX
+    gcp_catalog_df = get_catalog_df(region_prefix_filter)
 
     os.makedirs('gcp', exist_ok=True)
     gcp_catalog_df.to_csv('gcp/vms.csv', index=False)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -273,12 +273,14 @@ def get_vm_df(region_prefix: str, a100_zones: List[str]) -> pd.DataFrame:
 
     vm_zones = get_vm_zones(GCP_VM_ZONES_URL)
     # Manually add A2 machines to the zones with A100 GPUs.
-    # This is necessary because GCP_VM_ZONES_URL is not up to date.
+    # This is necessary because GCP_VM_ZONES_URL may not be up to date.
     df = pd.DataFrame.from_dict({
         'AvailabilityZone': a100_zones,
         'MachineType': 'A2',
     })
     vm_zones = pd.concat([vm_zones, df], ignore_index=True)
+    # vm_zones alreay includes some zones with A100 GPUs.
+    # When we merge it with a100_zones, we need to remove the duplicates.
     vm_zones = vm_zones.drop_duplicates()
 
     # Remove regions not in the pricing data.


### PR DESCRIPTION
This PR removes the hardcoded URL we use for fetching A2 machine prices. Instead of directly getting A2 machine prices, we first obtain A2 machine "total" cost, which is A2 host VM price + A100 GPU price, from the GCP website (https://cloud.google.com/compute/vm-instance-pricing). Then we get the true A2 host machine price by deducting the A100 (or A100-80GB) GPU price from the total cost.

This PR also fixes a bug that our current GCP catalog does not contain the A2 machines in `us-west1-b`. This bug happens because https://cloud.google.com/compute/docs/regions-zones is not correct.

![Screen Shot 2022-11-16 at 11 49 21 PM](https://user-images.githubusercontent.com/46394894/202387244-21a05364-7e72-4c92-a018-b997ceaf371a.png)