### PR TITLE
Minor spot logs fix: don't print job id not provided on spot launch.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2499,7 +2499,7 @@ class CloudVmRayBackend(backends.Backend):
                                                job_id,
                                                spot_job_id=spot_job_id,
                                                follow=follow)
-        if job_id is None:
+        if job_id is None and spot_job_id is None:
             logger.info(
                 'Job ID not provided. Streaming the logs of the latest job.')
 


### PR DESCRIPTION
Previously, a `sky spot launch echo hi` will show an extra line (see `***` line):
```
...
I 11-18 18:05:20 cloud_vm_ray_backend.py:2128] Setup completed.
I 11-18 18:05:24 cloud_vm_ray_backend.py:2193] Job submitted with Job ID: 12
I 11-19 02:08:05 cloud_vm_ray_backend.py:2500] Job ID not provided. Streaming the logs of the latest job. ***
I 11-19 02:08:06 log_lib.py:388] Start streaming logs for spot job 12.
INFO: Tip: use Ctrl-C to exit log streaming (task will not be killed).
INFO: Waiting for task resources on 1 node. This will block if the cluster is full.
```

This seems a bit confusing. This PR removes it.