### PR TITLE
[Usage] Robustify the user hash to avoid empty string

### DIFF
--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -35,7 +35,7 @@ def _get_current_timestamp_ns() -> int:
 def _get_user_hash():
     """Returns a unique user-machine specific hash as a user id for logging."""
     user_id = os.getenv(constants.USAGE_USER_ENV)
-    if user_id and len(user_id) == 8:
+    if user_id and len(user_id) == common_utils.USER_HASH_LENGTH:
         return user_id
     return common_utils.get_user_hash()
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -35,9 +35,7 @@ def _get_current_timestamp_ns() -> int:
 def _get_user_hash():
     """Returns a unique user-machine specific hash as a user id for logging."""
     user_id = os.getenv(constants.USAGE_USER_ENV)
-    if user_id and len(user_id) == common_utils.USER_HASH_LENGTH:
-        return user_id
-    return common_utils.get_user_hash()
+    return common_utils.get_user_hash(default_value=user_id)
 
 
 class MessageType(enum.Enum):

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -42,7 +42,11 @@ def get_usage_run_id() -> str:
 
 
 def get_user_hash(default_value: Optional[str] = None) -> str:
-    """Returns a unique user-machine specific hash as a user id."""
+    """Returns a unique user-machine specific hash as a user id.
+    
+    We cache the user hash in a file to avoid potential user_name or
+    hostname changes causing a new user hash to be generated.
+    """
 
     def _is_valid_user_hash(user_hash: Optional[str]) -> bool:
         try:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -18,6 +18,7 @@ import yaml
 from sky import sky_logging
 
 _USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
+USER_HASH_LENGTH = 8
 
 _PAYLOAD_PATTERN = re.compile(r'<sky-payload>(.*)</sky-payload>')
 _PAYLOAD_STR = '<sky-payload>{}</sky-payload>'
@@ -44,10 +45,12 @@ def get_user_hash() -> str:
     """Returns a unique user-machine specific hash as a user id."""
     if os.path.exists(_USER_HASH_FILE):
         with open(_USER_HASH_FILE, 'r') as f:
-            return f.read()
+            user_hash = f.read()
+            if user_hash and len(user_hash) == USER_HASH_LENGTH:
+                return user_hash
 
     hash_str = user_and_hostname_hash()
-    user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:8]
+    user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:USER_HASH_LENGTH]
     os.makedirs(os.path.dirname(_USER_HASH_FILE), exist_ok=True)
     with open(_USER_HASH_FILE, 'w') as f:
         f.write(user_hash)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -47,7 +47,7 @@ def get_user_hash(default_value: Optional[str] = None) -> str:
     def _is_valid_user_hash(user_hash: Optional[str]) -> bool:
         try:
             int(user_hash, 16)
-        except ValueError:
+        except (TypeError, ValueError):
             return False
         return len(user_hash) == USER_HASH_LENGTH
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -65,7 +65,9 @@ def get_user_hash(default_value: Optional[str] = None) -> str:
 
     hash_str = user_and_hostname_hash()
     user_hash = hashlib.md5(hash_str.encode()).hexdigest()[:USER_HASH_LENGTH]
-    assert _is_valid_user_hash(user_hash), user_hash
+    if not _is_valid_user_hash(user_hash):
+        # A fallback in case the hash is invalid.
+        user_hash = uuid.uuid4().hex[:USER_HASH_LENGTH]
     os.makedirs(os.path.dirname(_USER_HASH_FILE), exist_ok=True)
     with open(_USER_HASH_FILE, 'w') as f:
         f.write(user_hash)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -46,7 +46,7 @@ def get_user_hash() -> str:
     if os.path.exists(_USER_HASH_FILE):
         with open(_USER_HASH_FILE, 'r') as f:
             user_hash = f.read()
-            if user_hash and len(user_hash) == USER_HASH_LENGTH:
+            if len(user_hash) == USER_HASH_LENGTH:
                 return user_hash
 
     hash_str = user_and_hostname_hash()

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -43,7 +43,7 @@ def get_usage_run_id() -> str:
 
 def get_user_hash(default_value: Optional[str] = None) -> str:
     """Returns a unique user-machine specific hash as a user id.
-    
+
     We cache the user hash in a file to avoid potential user_name or
     hostname changes causing a new user hash to be generated.
     """

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -43,6 +43,7 @@ def get_usage_run_id() -> str:
 
 def get_user_hash(default_value: Optional[str] = None) -> str:
     """Returns a unique user-machine specific hash as a user id."""
+
     def _is_valid_user_hash(user_hash: Optional[str]) -> bool:
         try:
             int(user_hash, 16)


### PR DESCRIPTION
This PR is to robustify the user hash, to avoid getting empty user hash from the file. It could happen before when the program crashed before writing to the file.
https://github.com/skypilot-org/skypilot/blob/48d4a84865821b468d0a608ef4860d7f352859f0/sky/utils/common_utils.py#L55-L56
