### PR TITLE
[config] Sky config

### DIFF
--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -11,8 +11,12 @@ from sky.clouds.service_catalog import common
 if typing.TYPE_CHECKING:
     from sky.clouds import cloud
 
-_df = common.read_catalog('aws/vms.csv')
-_image_df = common.read_catalog('aws/images.csv')
+_UPDATE_PERIOD_HOURS = 7
+
+_df = common.read_catalog('aws/vms.csv',
+                          update_frequency_hours=_UPDATE_PERIOD_HOURS)
+_image_df = common.read_catalog('aws/images.csv',
+                                update_frequency_hours=_UPDATE_PERIOD_HOURS)
 
 
 def instance_type_exists(instance_type: str) -> bool:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -18,6 +18,7 @@ _auto_update_frequency_hours = _UPDATE_FREQUENCY_HOURS
 if not config.sky_config.catalog.aws.auto_update:
     _auto_update_frequency_hours = None
 
+
 # Filter the dataframe to only include the preferred regions.
 def area_filter_fn(df: 'pd.DataFrame') -> 'pd.DataFrame':
     preferred_areas = config.sky_config.catalog.aws.preferred_area
@@ -33,11 +34,12 @@ def area_filter_fn(df: 'pd.DataFrame') -> 'pd.DataFrame':
     area_filters = [f'{r.lower()}-' for r in preferred_areas]
     return df[df['Region'].str.startswith(tuple(area_filters))]
 
+
 _df = common.read_catalog('aws/vms.csv',
                           update_frequency_hours=_auto_update_frequency_hours,
                           area_filter_fn=area_filter_fn)
-_image_df = common.read_catalog('aws/images.csv',
-                                update_frequency_hours=_auto_update_frequency_hours)
+_image_df = common.read_catalog(
+    'aws/images.csv', update_frequency_hours=_auto_update_frequency_hours)
 
 
 def instance_type_exists(instance_type: str) -> bool:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -6,17 +6,21 @@ instance types and pricing information for AWS.
 import typing
 from typing import Dict, List, Optional, Tuple
 
+from sky import config
 from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:
     from sky.clouds import cloud
 
-_UPDATE_PERIOD_HOURS = 7
+_UPDATE_FREQUENCY_HOURS = 7
+_auto_update_frequency_hours = _UPDATE_FREQUENCY_HOURS
+if not config.sky_config.catalog.aws.auto_update:
+    _auto_update_frequency_hours = None
 
 _df = common.read_catalog('aws/vms.csv',
-                          update_frequency_hours=_UPDATE_PERIOD_HOURS)
+                          update_frequency_hours=_auto_update_frequency_hours)
 _image_df = common.read_catalog('aws/images.csv',
-                                update_frequency_hours=_UPDATE_PERIOD_HOURS)
+                                update_frequency_hours=_auto_update_frequency_hours)
 
 
 def instance_type_exists(instance_type: str) -> bool:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -11,14 +11,31 @@ from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:
     from sky.clouds import cloud
+    import pandas as pd
 
 _UPDATE_FREQUENCY_HOURS = 7
 _auto_update_frequency_hours = _UPDATE_FREQUENCY_HOURS
 if not config.sky_config.catalog.aws.auto_update:
     _auto_update_frequency_hours = None
 
+# Filter the dataframe to only include the preferred regions.
+def area_filter_fn(df: 'pd.DataFrame') -> 'pd.DataFrame':
+    preferred_areas = config.sky_config.catalog.aws.preferred_area
+    if preferred_areas is None or preferred_areas == 'all':
+        return df
+
+    # TODO(zhwu): Move type check to config validation.
+    if isinstance(preferred_areas, str):
+        preferred_areas = [preferred_areas]
+    if not isinstance(preferred_areas, list):
+        raise ValueError('Preferred area must be a string or a list of strings')
+
+    area_filters = [f'{r.lower()}-' for r in preferred_areas]
+    return df[df['Region'].str.startswith(tuple(area_filters))]
+
 _df = common.read_catalog('aws/vms.csv',
-                          update_frequency_hours=_auto_update_frequency_hours)
+                          update_frequency_hours=_auto_update_frequency_hours,
+                          area_filter_fn=area_filter_fn)
 _image_df = common.read_catalog('aws/images.csv',
                                 update_frequency_hours=_auto_update_frequency_hours)
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -12,7 +12,6 @@ from sky import sky_logging
 from sky.backends import backend_utils
 from sky.clouds import cloud as cloud_lib
 from sky.clouds.service_catalog import constants
-from sky.config import sky_config
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -49,9 +48,11 @@ def get_catalog_path(filename: str) -> str:
     return os.path.join(_CATALOG_DIR, filename)
 
 
-def read_catalog(filename: str,
-                 update_frequency_hours: Optional[int] = None,
-                 area_filter_fn: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None) -> pd.DataFrame:
+def read_catalog(
+    filename: str,
+    update_frequency_hours: Optional[int] = None,
+    area_filter_fn: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None
+) -> pd.DataFrame:
     """Reads the catalog from a local CSV file.
 
     If the file does not exist, download the up-to-date catalog that matches

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -2,7 +2,7 @@
 import os
 import tempfile
 import time
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import difflib
 import requests
@@ -50,7 +50,8 @@ def get_catalog_path(filename: str) -> str:
 
 
 def read_catalog(filename: str,
-                 update_frequency_hours: Optional[int] = None) -> pd.DataFrame:
+                 update_frequency_hours: Optional[int] = None,
+                 area_filter_fn: Optional[Callable[[pd.DataFrame], pd.DataFrame]] = None) -> pd.DataFrame:
     """Reads the catalog from a local CSV file.
 
     If the file does not exist, download the up-to-date catalog that matches
@@ -91,6 +92,8 @@ def read_catalog(filename: str,
 
     try:
         df = pd.read_csv(catalog_path)
+        if area_filter_fn is not None:
+            df = area_filter_fn(df)
     except Exception as e:  # pylint: disable=broad-except
         # As users can manually modify the catalog, read_csv can fail.
         logger.error(f'Failed to read {catalog_path}. '

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -67,7 +67,8 @@ def read_catalog(
             return True
         if update_frequency_hours is None:
             return False
-        return (os.path.getmtime(catalog_path) + update_frequency_hours * 3600 <
+        last_update = os.path.getmtime(catalog_path)
+        return (last_update + update_frequency_hours * 3600 <
                 time.time())
 
     if _need_update():
@@ -88,7 +89,7 @@ def read_catalog(
             f.write(r.text)
             f.flush()
         os.replace(f.name, catalog_path)
-        logger.info(f'A new {cloud} catalog has been downloaded to '
+        logger.info(f'{cloud} catalog has been updated at '
                     f'{catalog_path}')
 
     try:

--- a/sky/config.py
+++ b/sky/config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 
 from sky.utils import common_utils
 
@@ -9,6 +9,7 @@ USER_CONFIG_PATH = os.path.abspath('sky_config.yaml')
 
 class BaseConfig:
     def load(self, config: Dict[str, Any], key_prefix: str = ''):
+        # TODO(zhwu): Add type check.
         for k, v in config.items():
             k = k.lower().replace('-', '_')
             if not hasattr(self, k):
@@ -31,16 +32,14 @@ class BaseConfig:
 class CatalogConfig(BaseConfig):
     class AWSConfig(BaseConfig):
         auto_update: bool = False
-        preferred_area: str = 'us'
+        preferred_area: Union[str, List[str]] = 'us'
 
     class GCPConfig(BaseConfig):
-        auto_update: bool = False
-        preferred_area: str = 'us'
+        pass
 
     class AzureConfig(BaseConfig):
-        auto_update: bool = False
-        preferred_area: str = 'us'
-    
+        pass
+
     aws: AWSConfig = AWSConfig()
     gcp: GCPConfig = GCPConfig()
     azure: AzureConfig = AzureConfig()

--- a/sky/config.py
+++ b/sky/config.py
@@ -1,3 +1,4 @@
+"""Load sky configs from file."""
 import os
 from typing import Any, Dict, List, Union
 
@@ -7,7 +8,10 @@ DEFAULT_CONFIG_PATH = os.path.expanduser(os.path.join('~/.sky', 'config.yaml'))
 # The config file under the current directory
 USER_CONFIG_PATH = os.path.abspath('sky_config.yaml')
 
+
 class BaseConfig:
+    """Abstract base class for config classes."""
+
     def load(self, config: Dict[str, Any], key_prefix: str = ''):
         # TODO(zhwu): Add type check.
         for k, v in config.items():
@@ -29,7 +33,10 @@ class BaseConfig:
                 config[k] = v
         return config
 
+
 class CatalogConfig(BaseConfig):
+    """Config for catalog."""
+
     class AWSConfig(BaseConfig):
         auto_update: bool = False
         preferred_area: Union[str, List[str]] = 'us'
@@ -47,20 +54,20 @@ class CatalogConfig(BaseConfig):
 
 class SkyConfig(BaseConfig):
     """Load the config file
-    
+
     The config file is loaded in the following order:
     1. The config file under the ~/.sky directory
     2. The config file under the current directory
 
     The config file loaded later will override the config file loaded earlier.
     """
+
     def __init__(self):
         self.catalog = CatalogConfig()
 
-        _config = self._load_config_file(DEFAULT_CONFIG_PATH)
-        _config.update(self._load_config_file(USER_CONFIG_PATH))
-        self.load(_config)
-
+        config = self._load_config_file(DEFAULT_CONFIG_PATH)
+        config.update(self._load_config_file(USER_CONFIG_PATH))
+        self.load(config)
 
     def _load_config_file(self, path: str) -> Dict[str, Any]:
         """Load the config file"""
@@ -68,5 +75,6 @@ class SkyConfig(BaseConfig):
             return {}
         with open(path, 'r') as f:
             return common_utils.read_yaml(f)
+
 
 sky_config = SkyConfig()

--- a/sky/config.py
+++ b/sky/config.py
@@ -1,0 +1,64 @@
+import os
+from typing import Any, Dict
+
+from sky.utils import common_utils
+
+DEFAULT_CONFIG_PATH = os.path.expanduser(os.path.join('~/.sky', 'config.yaml'))
+# The config file under the current directory
+USER_CONFIG_PATH = os.path.abspath('sky_config.yaml')
+
+class BaseConfig:
+    def load(self, config: Dict[str, Any], key_prefix: str = ''):
+        for k, v in config.items():
+            k = k.lower().replace('-', '_')
+            if not hasattr(self, k):
+                raise ValueError(f'Invalid config key: {key_prefix}.{k}')
+            if isinstance(v, dict):
+                self.__dict__[k].load(v, key_prefix=f'{key_prefix}.{k}')
+            else:
+                self.__dict__[k] = v
+
+    def dump(self):
+        config = {}
+        for k, v in self.__dict__.items():
+            k = k.replace('_', '-')
+            if isinstance(v, BaseConfig):
+                config[k] = v.dump()
+            elif not callable(v):
+                config[k] = v
+        return config
+
+class CatalogConfig(BaseConfig):
+    class AWSConfig(BaseConfig):
+        auto_update: bool = False
+        preferred_area: str = 'us'
+
+    def __init__(self):
+        self.preferred_area = 'us'
+        self.aws = self.AWSConfig()
+
+class SkyConfig(BaseConfig):
+    """Load the config file
+    
+    The config file is loaded in the following order:
+    1. The config file under the ~/.sky directory
+    2. The config file under the current directory
+
+    The config file loaded later will override the config file loaded earlier.
+    """
+    def __init__(self):
+        self.catalog = CatalogConfig()
+
+        _config = self._load_config_file(DEFAULT_CONFIG_PATH)
+        _config.update(self._load_config_file(USER_CONFIG_PATH))
+        self.load(_config)
+
+
+    def _load_config_file(self, path: str) -> Dict[str, Any]:
+        """Load the config file"""
+        if not os.path.exists(path):
+            return {}
+        with open(path, 'r') as f:
+            return common_utils.read_yaml(f)
+
+sky_config = SkyConfig()

--- a/sky/config.py
+++ b/sky/config.py
@@ -19,9 +19,10 @@ class BaseConfig:
             if not hasattr(self, k):
                 raise ValueError(f'Invalid config key: {key_prefix}.{k}')
             if isinstance(v, dict):
-                self.__dict__[k].load(v, key_prefix=f'{key_prefix}.{k}')
+                attr = getattr(self, k)
+                attr.load(v, key_prefix=f'{key_prefix}.{k}')
             else:
-                self.__dict__[k] = v
+                self.__setattr__(k, v)
 
     def dump(self):
         config = {}
@@ -73,8 +74,7 @@ class SkyConfig(BaseConfig):
         """Load the config file"""
         if not os.path.exists(path):
             return {}
-        with open(path, 'r') as f:
-            return common_utils.read_yaml(f)
+        return common_utils.read_yaml(path)
 
 
 sky_config = SkyConfig()

--- a/sky/config.py
+++ b/sky/config.py
@@ -33,9 +33,18 @@ class CatalogConfig(BaseConfig):
         auto_update: bool = False
         preferred_area: str = 'us'
 
-    def __init__(self):
-        self.preferred_area = 'us'
-        self.aws = self.AWSConfig()
+    class GCPConfig(BaseConfig):
+        auto_update: bool = False
+        preferred_area: str = 'us'
+
+    class AzureConfig(BaseConfig):
+        auto_update: bool = False
+        preferred_area: str = 'us'
+    
+    aws: AWSConfig = AWSConfig()
+    gcp: GCPConfig = GCPConfig()
+    azure: AzureConfig = AzureConfig()
+
 
 class SkyConfig(BaseConfig):
     """Load the config file


### PR DESCRIPTION
This PR adds config knobs so that the user can control what areas to use for the failover and other future knobs.

It only adds the preferred areas and auto-update for the AWS to unblock the user's use case in #1437, #1438.

This should go in together with https://github.com/skypilot-org/skypilot-catalog/pull/4

Tested:
- [ ] Change the catalog URL to https://github.com/Michaelvll/skypilot-catalog
- [ ] Set the `auto-update` to true in config, and `sky launch`
- [ ] Set `preferred-areas` to `eu` in config, and `sky launch`
- [ ] Set `preferred-areas` to `['ap', 'eu']` in config and `sky launch`.
- [ ] Add smoke test.