### PR TITLE
Logging fixes.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3038,7 +3038,7 @@ def spot_logs(name: Optional[str], job_id: Optional[int], follow: bool):
         core.spot_tail_logs(name=name, job_id=job_id, follow=follow)
     except exceptions.ClusterNotUpError:
         # Hint messages already printed by the call above.
-        pass
+        sys.exit(1)
 
 
 # ==============================

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1025,8 +1025,11 @@ def _add_command_alias_to_group(group, command, name, hidden):
     new_command = copy.deepcopy(command)
     new_command.hidden = hidden
     new_command.name = name
-    new_command.invoke = _with_deprecation_warning(new_command.invoke,
-                                                   command.name, name)
+
+    orig = f'sky {group.name} {command.name}'
+    alias = f'sky {group.name} {name}'
+    new_command.invoke = _with_deprecation_warning(new_command.invoke, orig,
+                                                   alias)
     group.add_command(new_command, name=name)
 
 
@@ -3031,7 +3034,11 @@ def spot_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool):
 @usage_lib.entrypoint
 def spot_logs(name: Optional[str], job_id: Optional[int], follow: bool):
     """Tail the log of a managed spot job."""
-    core.spot_tail_logs(name=name, job_id=job_id, follow=follow)
+    try:
+        core.spot_tail_logs(name=name, job_id=job_id, follow=follow)
+    except exceptions.ClusterNotUpError:
+        # Hint messages already printed by the call above.
+        pass
 
 
 # ==============================

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -129,8 +129,9 @@ class StrategyExecutor:
             # Ignore the failure as the cluster can be totally stopped, and the
             # job canceling can get connection error.
             logger.info(
-                f'Ignoring the job cancellation failure (Exception: {e}); '
-                'the spot cluster is likely completely stopped.')
+                'Ignoring the job cancellation failure; '
+                'the spot cluster is likely completely stopped.'
+                f'\n  Detailed exception: {e}')
 
     def _launch(self, max_retry=3, raise_on_failure=True) -> Optional[float]:
         """Implementation of launch().

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -128,10 +128,9 @@ class StrategyExecutor:
         except Exception as e:  # pylint: disable=broad-except
             # Ignore the failure as the cluster can be totally stopped, and the
             # job canceling can get connection error.
-            logger.info(
-                'Ignoring the job cancellation failure; '
-                'the spot cluster is likely completely stopped.'
-                f'\n  Detailed exception: {e}')
+            logger.info('Ignoring the job cancellation failure; '
+                        'the spot cluster is likely completely stopped.'
+                        f'\n  Detailed exception: {e}')
 
     def _launch(self, max_retry=3, raise_on_failure=True) -> Optional[float]:
         """Implementation of launch().


### PR DESCRIPTION
Fix a few logging UX issues:

1. Previously:
```
» sky spot logs 3                                                                                                                 
Spot controller sky-spot-controller-8a3968f2 is INIT.
Please wait for the controller to be ready.
sky.exceptions.ClusterNotUpError
```

This PR removes the last line.

2. Previously, the controller log for a preempted spot job shows:
<img width="1725" alt="Screen Shot 2022-11-27 at 11 08 29" src="https://user-images.githubusercontent.com/592670/204117941-5b859286-d22a-435d-8268-031cedaf3479.png">

The red text is part of the "Exception" in the line above, but looks weird when joining with `)`. This PR rearranges it a bit.

3. Previously `sky spot status` shows:
```
WARNING: `status` is deprecated and will be removed in a future release. Please use `queue` instead.
```
This may be a bit confusing as to whether it also refers to `sky status`. This PR makes it more clear.
