### PR TITLE
Make `sky start` on the spot controller aware of autostop.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1956,7 +1956,7 @@ def check_cluster_name_not_reserved(
     return None.
     """
     if cluster_name in SKY_RESERVED_CLUSTER_NAMES:
-        msg = (f'Cluster {cluster_name!r} is reserved for '
+        msg = (f'Cluster {cluster_name!r} is reserved for the '
                f'{SKY_RESERVED_CLUSTER_NAMES[cluster_name].lower()}.')
         if operation_str is not None:
             msg += f' {operation_str} is not allowed.'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1939,7 +1939,7 @@ def start(
             raise click.UsageError(
                 'Autostop options are currently not allowed when starting the '
                 'spot controller. Use the default autostop settings by directly'
-                f' callling: {bold}sky start {reserved[0]}{reset_bold}')
+                f' calling: {bold}sky start {reserved[0]}{reset_bold}')
         idle_minutes_to_autostop = (
             spot_lib.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1174,7 +1174,7 @@ def launch(
     and they undergo job queue scheduling.
     """
     backend_utils.check_cluster_name_not_reserved(
-        cluster, operation_str='Launching task on it')
+        cluster, operation_str='Launching tasks on it')
     if backend_name is None:
         backend_name = backends.CloudVmRayBackend.NAME
 
@@ -1917,6 +1917,32 @@ def start(
     if not to_start:
         return
 
+    # Checks for reserved clusters (spot controller).
+    reserved, non_reserved = [], []
+    for name in to_start:
+        if name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
+            reserved.append(name)
+        else:
+            non_reserved.append(name)
+    if reserved and non_reserved:
+        assert len(reserved) == 1, reserved
+        # Keep this behavior the same as _down_or_stop_clusters().
+        raise click.UsageError(
+            'Starting the spot controller with other cluster(s) '
+            'is currently not supported.\n'
+            'Please start the former independently.')
+    if reserved:
+        assert len(reserved) == 1, reserved
+        bold = backend_utils.BOLD
+        reset_bold = backend_utils.RESET_BOLD
+        if idle_minutes_to_autostop is not None:
+            raise click.UsageError(
+                'Autostop options are currently not allowed when starting the '
+                'spot controller. Use the default autostop settings by directly'
+                f' callling: {bold}sky start {reserved[0]}{reset_bold}')
+        idle_minutes_to_autostop = (
+            spot_lib.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
+
     if not yes:
         cluster_str = 'clusters' if len(to_start) > 1 else 'cluster'
         cluster_list = ', '.join(to_start)
@@ -2107,13 +2133,13 @@ def _down_or_stop_clusters(
                 names_str = ', '.join(map(repr, names))
                 raise click.UsageError(
                     f'{operation} reserved cluster(s) '
-                    f'{reserved_clusters_str} with multiple other cluster(s) '
-                    f'{names_str} is not supported.\n'
+                    f'{reserved_clusters_str} with other cluster(s) '
+                    f'{names_str} is currently not supported.\n'
                     f'Please omit the reserved cluster(s) {reserved_clusters}.')
             if not down:
                 raise click.UsageError(
                     f'{operation} reserved cluster(s) '
-                    f'{reserved_clusters_str} is not supported.')
+                    f'{reserved_clusters_str} is currently not supported.')
             else:
                 # TODO(zhwu): We can only have one reserved cluster (spot
                 # controller).

--- a/sky/core.py
+++ b/sky/core.py
@@ -94,8 +94,7 @@ def _start(
             raise ValueError('Using autodown (rather than autostop) is not '
                              'supported for the spot controller. Pass '
                              '`down=False` or omit it instead.')
-        if (idle_minutes_to_autostop is not None and idle_minutes_to_autostop !=
-                spot.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP):
+        if idle_minutes_to_autostop is not None:
             raise ValueError(
                 'Passing a custom autostop setting is currently not '
                 'supported when starting the spot controller. To '
@@ -165,8 +164,8 @@ def start(
         ValueError: the specified cluster does not exist; or if ``down`` is set
           to True but ``idle_minutes_to_autostop`` is None; or if the specified
           cluster is the managed spot controller, and either
-          ``idle_minutes_to_autostop`` is set to a non-default value or
-          ``down`` is True (omit them to use the default autostop settings).
+          ``idle_minutes_to_autostop`` is not None or ``down`` is True (omit
+          them to use the default autostop settings).
         sky.exceptions.NotSupportedError: if the cluster to restart was
           launched using a non-default backend that does not support this
           operation.
@@ -629,9 +628,7 @@ def spot_queue(refresh: bool) -> List[Dict[str, Any]]:
               'Restarting controller for latest status...'
               f'{colorama.Style.RESET_ALL}')
 
-        handle = _start(spot.SPOT_CONTROLLER_NAME,
-                        idle_minutes_to_autostop=spot.
-                        SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
+        handle = _start(spot.SPOT_CONTROLLER_NAME)
 
     if handle is None or handle.head_ip is None:
         raise exceptions.ClusterNotUpError('Spot controller is not up.')

--- a/sky/core.py
+++ b/sky/core.py
@@ -161,11 +161,12 @@ def start(
             Useful for upgrading SkyPilot runtime.
 
     Raises:
-        ValueError: the specified cluster does not exist; or if ``down`` is set
-          to True but ``idle_minutes_to_autostop`` is None; or if the specified
-          cluster is the managed spot controller, and either
-          ``idle_minutes_to_autostop`` is not None or ``down`` is True (omit
-          them to use the default autostop settings).
+        ValueError: argument values are invalid: (1) the specified cluster does
+          not exist; (2) if ``down`` is set to True but
+          ``idle_minutes_to_autostop`` is None; (3) if the specified cluster is
+          the managed spot controller, and either ``idle_minutes_to_autostop``
+          is not None or ``down`` is True (omit them to use the default
+          autostop settings).
         sky.exceptions.NotSupportedError: if the cluster to restart was
           launched using a non-default backend that does not support this
           operation.

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -141,7 +141,7 @@ class TestReservedClustersOperations:
         assert result.exit_code == click.UsageError.exit_code
         assert (
             f'Stopping reserved cluster(s) \'{spot.SPOT_CONTROLLER_NAME}\' is '
-            'not supported' in result.output)
+            'currently not supported' in result.output)
 
         result = cli_runner.invoke(cli.stop, ['sky-spot-con*'])
         assert not result.exception
@@ -157,7 +157,7 @@ class TestReservedClustersOperations:
         result = cli_runner.invoke(cli.autostop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
         assert ('Scheduling autostop on reserved cluster(s) '
-                f'\'{spot.SPOT_CONTROLLER_NAME}\' is not supported'
+                f'\'{spot.SPOT_CONTROLLER_NAME}\' is currently not supported'
                 in result.output)
 
         result = cli_runner.invoke(cli.autostop, ['sky-spot-con*'])


### PR DESCRIPTION
Fixes #1447.

If controller is to be started:
 - disallow: -i, --down; disallow being specified with other clusters

Tested:

CLI
```
# Expectedly fail:
sky start sky-cpunode-zongheng sky-spot-controller-8a3968f2
sky start sky-spot-controller-8a3968f2 -i1
sky start sky-spot-controller-8a3968f2 -i1 --down
sky start sky-spot-controller-8a3968f2 --down

# Starting a stopped controller: OK. Autostop reset to 10m.
sky start sky-spot-controller-8a3968f2  

# Starting an UP controller: OK. Autostop reset to 10m.
sky start sky-spot-controller-8a3968f2 --force 
```
Python API
- [x] repeated the above and observed appropriate ValueError
- [x] manually called `core.start()` on a stopped controller; verfied autostop is set to 10m

Smoke
- [x] `bash tests/run_smoke_tests.sh test_spot`
