### PR TITLE
Print errors for GCP timeout.

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -3,6 +3,7 @@ import copy
 import functools
 import os
 import re
+import socket
 import subprocess
 import sys
 import textwrap
@@ -174,6 +175,10 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
             sys.exit(1)
         else:
             raise
+    except socket.timeout:
+        logger.error('Socket timed out when trying to get the GCP project. '
+                     'Please check your network connection.')
+        raise
 
     project_oslogin = next(
         (item for item in project['commonInstanceMetadata'].get('items', [])

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -246,9 +246,9 @@ def retry(method, max_retries=3, initial_backoff=1):
             try:
                 return method(*args, **kwargs)
             except Exception as e:  # pylint: disable=broad-except
-                logger.warning(f'Caught {e}. Retrying.')
                 try_count += 1
                 if try_count < max_retries:
+                    logger.warning(f'Caught {e}. Retrying.')
                     time.sleep(backoff.current_backoff())
                 else:
                     raise


### PR DESCRIPTION
I'm in a network where pinging Google results in 100% packet loss:
```
» ping google.com
PING google.com (172.217.163.46): 56 data bytes
Request timeout for icmp_seq 0
Request timeout for icmp_seq 1
Request timeout for icmp_seq 2
Request timeout for icmp_seq 3
Request timeout for icmp_seq 4
^C
--- google.com ping statistics ---
6 packets transmitted, 0 packets received, 100.0% packet loss
```

This means I can't launch GCP clusters. This PR adds some error messages to hint at what's up:
```
» sky cpunode -t n2d-highmem-96 --down -y                                                                                130 ↵
...
I 11-28 07:48:51 cloud_vm_ray_backend.py:988] To view detailed progress: tail -n100 -f /Users/zongheng/sky_logs/sky-2022-11-28-07-48-50-387576/provision.log
E 11-28 07:49:52 authentication.py:179] Socket timed out when trying to get the GCP project. Please check your network connection.
W 11-28 07:49:52 common_utils.py:251] Caught timed out. Retrying.
E 11-28 07:50:54 authentication.py:179] Socket timed out when trying to get the GCP project. Please check your network connection.
W 11-28 07:50:54 common_utils.py:251] Caught timed out. Retrying.
E 11-28 07:51:57 authentication.py:179] Socket timed out when trying to get the GCP project. Please check your network connection.
...
<large stacktrace>
  File "/Users/zongheng/anaconda/envs/py37/lib/python3.7/site-packages/httplib2/__init__.py", line 1343, in _conn_request
    conn.connect()
  File "/Users/zongheng/anaconda/envs/py37/lib/python3.7/site-packages/httplib2/__init__.py", line 1133, in connect
    sock.connect((self.host, self.port))
socket.timeout: timed out
```