### PR TITLE
[autostop] Support restarting the autostop timer.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -183,6 +183,7 @@ class RayCodeGen:
             import ray
             import ray.util as ray_util
 
+            from sky.skylet import autostop_lib
             from sky.skylet import constants
             from sky.skylet import job_lib
             from sky.utils import log_utils
@@ -202,8 +203,17 @@ class RayCodeGen:
             inspect.getsource(log_lib.add_ray_env_vars),
             inspect.getsource(log_lib.run_bash_command_with_log),
             'run_bash_command_with_log = ray.remote(run_bash_command_with_log)',
-            f'setup_cmd = {setup_cmd!r}'
+            f'setup_cmd = {setup_cmd!r}',
         ]
+        # Currently, the codegen program is/can only be submitted to the head
+        # node, due to using job_lib for updating job statuses, and using
+        # autostop_lib here.
+        self._code.append(
+            # Use hasattr to handle backward compatibility.
+            textwrap.dedent("""\
+              if hasattr(autostop_lib, 'set_last_active_time_to_now'):
+                  autostop_lib.set_last_active_time_to_now()
+            """))
         if setup_cmd is not None:
             self._code += [
                 textwrap.dedent(f"""\
@@ -301,7 +311,7 @@ class RayCodeGen:
                 pg = ray_util.placement_group({json.dumps(bundles)}, 'STRICT_SPREAD')
                 plural = 's' if {num_nodes} > 1 else ''
                 node_str = f'{num_nodes} node{{plural}}'
-                
+
                 message = '' if setup_cmd is not None else {_CTRL_C_TIP_MESSAGE!r} + '\\n'
                 message += f'INFO: Waiting for task resources on {{node_str}}. This will block if the cluster is full.'
                 print(message,
@@ -447,7 +457,7 @@ class RayCodeGen:
             sky_env_vars_dict['SKYPILOT_NODE_RANK'] = ip_rank_map[ip]
             # Environment starting with `SKY_` is deprecated.
             sky_env_vars_dict['SKY_NODE_RANK'] = ip_rank_map[ip]
-            
+
             sky_env_vars_dict['SKYPILOT_INTERNAL_JOB_ID'] = {self.job_id}
             # Environment starting with `SKY_` is deprecated.
             sky_env_vars_dict['SKY_INTERNAL_JOB_ID'] = {self.job_id}

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -210,6 +210,7 @@ class RayCodeGen:
         # autostop_lib here.
         self._code.append(
             # Use hasattr to handle backward compatibility.
+            # TODO(zongheng): remove in ~1-2 minor releases (currently 0.2.x).
             textwrap.dedent("""\
               if hasattr(autostop_lib, 'set_last_active_time_to_now'):
                   autostop_lib.set_last_active_time_to_now()

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -1,12 +1,21 @@
-"""Sky autostop utility function."""
+"""Autostop utilities."""
 import pickle
 import psutil
 import shlex
+import time
 from typing import List, Optional
 
+from sky import sky_logging
 from sky.skylet import configs
 
-AUTOSTOP_CONFIG_KEY = 'autostop_config'
+logger = sky_logging.init_logger(__name__)
+
+_AUTOSTOP_CONFIG_KEY = 'autostop_config'
+
+# This key-value is stored inside the 'configs' sqlite3 database, because both
+# user-issued commands (this module) and the Skylet process running the
+# AutostopEvent need to access that state.
+_AUTOSTOP_LAST_ACTIVE_TIME = 'autostop_last_active_time'
 
 
 class AutostopConfig:
@@ -29,8 +38,8 @@ class AutostopConfig:
         self.__dict__.update(state)
 
 
-def get_autostop_config() -> Optional[AutostopConfig]:
-    config_str = configs.get_config(AUTOSTOP_CONFIG_KEY)
+def get_autostop_config() -> AutostopConfig:
+    config_str = configs.get_config(_AUTOSTOP_CONFIG_KEY)
     if config_str is None:
         return AutostopConfig(-1, -1, None)
     return pickle.loads(config_str)
@@ -39,7 +48,27 @@ def get_autostop_config() -> Optional[AutostopConfig]:
 def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
     boot_time = psutil.boot_time()
     autostop_config = AutostopConfig(idle_minutes, boot_time, backend, down)
-    configs.set_config(AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
+    prev_autostop_config = get_autostop_config()
+    configs.set_config(_AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
+    logger.info(f'set_autostop(): idle_minutes {idle_minutes}, down {down}.')
+    if (prev_autostop_config.autostop_idle_minutes < 0 or
+            prev_autostop_config.boot_time != psutil.boot_time()):
+        # Either autostop never set, or has been canceled. Reset timer.
+        set_last_active_time_to_now()
+
+
+def get_last_active_time() -> float:
+    """Returns the last active time, or -1 if none has been set."""
+    result = configs.get_config(_AUTOSTOP_LAST_ACTIVE_TIME)
+    if result is not None:
+        return float(result)
+    return -1
+
+
+def set_last_active_time_to_now() -> None:
+    """Sets the last active time to time.time()."""
+    logger.info('Setting last active time.')
+    configs.set_config(_AUTOSTOP_LAST_ACTIVE_TIME, str(time.time()))
 
 
 class AutostopCodeGen:

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -50,7 +50,7 @@ def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
     autostop_config = AutostopConfig(idle_minutes, boot_time, backend, down)
     prev_autostop_config = get_autostop_config()
     configs.set_config(_AUTOSTOP_CONFIG_KEY, pickle.dumps(autostop_config))
-    logger.info(f'set_autostop(): idle_minutes {idle_minutes}, down {down}.')
+    logger.debug(f'set_autostop(): idle_minutes {idle_minutes}, down {down}.')
     if (prev_autostop_config.autostop_idle_minutes < 0 or
             prev_autostop_config.boot_time != psutil.boot_time()):
         # Either autostop never set, or has been canceled. Reset timer.
@@ -67,7 +67,7 @@ def get_last_active_time() -> float:
 
 def set_last_active_time_to_now() -> None:
     """Sets the last active time to time.time()."""
-    logger.info('Setting last active time.')
+    logger.debug('Setting last active time.')
     configs.set_config(_AUTOSTOP_LAST_ACTIVE_TIME, str(time.time()))
 
 

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -22,8 +22,8 @@ def _safe_cursor():
         conn.close()
 
 
-with _safe_cursor() as cursor:
-    cursor.execute("""\
+with _safe_cursor() as c:  # Call it 'c' to avoid pylint complaining.
+    c.execute("""\
         CREATE TABLE IF NOT EXISTS config (
             key TEXT PRIMARY KEY,
             value TEXT)""")

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -1,4 +1,4 @@
-"""skylet configs"""
+"""Skylet configs."""
 import os
 import pathlib
 import sqlite3

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -120,7 +120,7 @@ class AutostopEvent(SkyletEvent):
                 'Not idle. Reset idle minutes.'
                 f'AutoStop config: {autostop_config.autostop_idle_minutes}')
         if idle_minutes >= autostop_config.autostop_idle_minutes:
-            logger.debug(
+            logger.info(
                 f'{idle_minutes} idle minutes reached; threshold: '
                 f'{autostop_config.autostop_idle_minutes} minutes. Stopping.')
             self._stop_cluster(autostop_config)

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -79,15 +79,13 @@ class SpotJobUpdateEvent(SkyletEvent):
 class AutostopEvent(SkyletEvent):
     """Skylet event for autostop.
 
-    Semantics:
-    - Idleness timer gets reset whenever
-      - A first autostop setting is set. By "first", we mean either there's
-        never any autostop setting set, or the last autostop setting is a
-        cancel (idle minutes < 0).
-      - Or, whenever this event wakes up and job_lib.is_cluster_idle() returns
-        False.
-      - TODO(zongheng): what about if the cluster has restarted? The
-        autostop_config.boot_time != psutil.boot_time() check below.
+    Idleness timer gets set to 0 whenever:
+      - A first autostop setting is set. By "first", either there's never any
+        autostop setting set, or the last autostop setting is a cancel (idle
+        minutes < 0); or
+      - This event wakes up and job_lib.is_cluster_idle() returns False; or
+      - The cluster has restarted; or
+      - A job is submitted (handled in the backend; not here).
     """
     EVENT_INTERVAL_SECONDS = 60
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -110,7 +110,7 @@ class AutostopEvent(SkyletEvent):
         if job_lib.is_cluster_idle():
             idle_minutes = (time.time() -
                             autostop_lib.get_last_active_time()) // 60
-            logger.debug(
+            logger.info(
                 f'Idle minutes: {idle_minutes}, '
                 f'AutoStop config: {autostop_config.autostop_idle_minutes}')
         else:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -110,7 +110,7 @@ class AutostopEvent(SkyletEvent):
         if job_lib.is_cluster_idle():
             idle_minutes = (time.time() -
                             autostop_lib.get_last_active_time()) // 60
-            logger.info(
+            logger.debug(
                 f'Idle minutes: {idle_minutes}, '
                 f'AutoStop config: {autostop_config.autostop_idle_minutes}')
         else:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -106,23 +106,23 @@ class AutostopEvent(SkyletEvent):
         if (autostop_config.autostop_idle_minutes < 0 or
                 autostop_config.boot_time != psutil.boot_time()):
             autostop_lib.set_last_active_time_to_now()
-            logger.info('autostop_config not set. Skipped.')
+            logger.debug('autostop_config not set. Skipped.')
             return
 
         if job_lib.is_cluster_idle():
             idle_minutes = (time.time() -
                             autostop_lib.get_last_active_time()) // 60
-            logger.info(
+            logger.debug(
                 f'Idle minutes: {idle_minutes}, '
                 f'AutoStop config: {autostop_config.autostop_idle_minutes}')
         else:
             autostop_lib.set_last_active_time_to_now()
             idle_minutes = -1
-            logger.info(
+            logger.debug(
                 'Not idle. Reset idle minutes.'
                 f'AutoStop config: {autostop_config.autostop_idle_minutes}')
         if idle_minutes >= autostop_config.autostop_idle_minutes:
-            logger.info(
+            logger.debug(
                 f'{idle_minutes} idle minutes reached; threshold: '
                 f'{autostop_config.autostop_idle_minutes} minutes. Stopping.')
             self._stop_cluster(autostop_config)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -660,7 +660,7 @@ def test_autostop():
             f'sky status | grep {name} | grep -E "UP\s+-"',
             f'sky autostop -y {name} -i 1',  # Idleness starts counting.
             'sleep 45',  # Almost reached the threshold.
-            'sky exec {name} echo hi',  # Should restart the timer.
+            f'sky exec {name} echo hi',  # Should restart the timer.
             'sleep 45',
             f'sky status --refresh | grep {name} | grep UP',
             'sleep 90',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -686,7 +686,7 @@ def test_autodown():
             'sleep 45',
             f'sky status --refresh | grep {name} | grep UP',
             # Ensure the cluster is terminated.
-            'sleep 240',
+            'sleep 200',
             f's=$(SKYPILOT_DEBUG=0 sky status --refresh) && printf "$s" && {{ echo "$s" | grep {name} | grep "Autodowned cluster\|terminated on the cloud"; }} || {{ echo "$s" | grep {name} && exit 1 || exit 0; }}',
             f'sky launch -y -d -c {name} --cloud aws --num-nodes 2 --down examples/minimal.yaml',
             f'sky status | grep {name} | grep UP',  # Ensure the cluster is UP.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -654,6 +654,17 @@ def test_autostop():
             f'sky status --refresh | grep {name} | grep UP',
             'sleep 90',
             f'sky status --refresh | grep {name} | grep STOPPED',
+
+            # Test restarting the idleness timer via exec:
+            f'sky start -y {name}',
+            f'sky status | grep {name} | grep -E "UP\s+-"',
+            f'sky autostop -y {name} -i 1',  # Idleness starts counting.
+            'sleep 45',  # Almost reached the threshold.
+            'sky exec {name} echo hi',  # Should restart the timer.
+            'sleep 45',
+            f'sky status --refresh | grep {name} | grep UP',
+            'sleep 90',
+            f'sky status --refresh | grep {name} | grep STOPPED',
         ],
         f'sky down -y {name}',
         timeout=20 * 60,


### PR DESCRIPTION
Support restarting the autostop timer via
- `sky autostop --cancel` then `sky autostop -i <minutes>`
- submitting a job

This is requested by a user, and possibly also can close #1418 (TBD).

Tested:

- [x] smoke tests: `test_autostop`, `test_autodown`
- [x] Test DB has no concurrency issue: 
```
» cat test_db.py
from sky.skylet.autostop_lib import set_last_active_time_to_now
set_last_active_time_to_now()

» for i in {1..200}; do python -u test_db.py &; done; wait
```
- [x] Test that each job will set idle-time-so-far to 0 (passes on this PR, fails on master)
```
» sky launch -i1 -c autostop     
» for i in {1..30}; do sky exec autostop echo hi; done
```

- [ ] add some docs to user facing places (pending #1455)