### PR TITLE
[Spot] Make sure the cluster status is not None when showing

### DIFF
--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -96,7 +96,12 @@ class SpotController:
                          self._cluster_name, force_refresh=True)
                     if cluster_status != global_user_state.ClusterStatus.UP:
                         # recover the cluster if it is not up.
-                        logger.info(f'Cluster status {cluster_status.value}. '
+                        # The status could be None when the cluster is preempted
+                        # right after the job was found FAILED.
+                        cluster_status_str = ('is preempted'
+                                              if cluster_status is None else
+                                              f'status {cluster_status.value}')
+                        logger.info(f'Cluster {cluster_status_str}. '
                                     'Recovering...')
                         need_recovery = True
                 if not need_recovery:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -258,14 +258,16 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
         # first retry in the same cloud/region. (we cannot use handle, as it
         # can be None if the cluster is preempted)
         self.launched_cloud_region = None
-    
+
     def launch(self) -> Optional[float]:
         launch_time = super().launch()
         handle = global_user_state.get_cluster_from_name(self.cluster_name)
+        assert handle is not None, 'Cluster should be launched.'
         launched_resources = handle.launched_resources
-        self.launched_cloud_region = (launched_resources.cloud, launched_resources.region)
+        self.launched_cloud_region = (launched_resources.cloud,
+                                      launched_resources.region)
         return launch_time
-    
+
     def terminate_cluster(self, max_retry: int = 3) -> None:
         super().terminate_cluster(max_retry)
         self.launched_resources = None

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -273,7 +273,7 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
             assert handle is not None, 'Cluster should be launched.'
             launched_resources = handle.launched_resources
             self._launched_cloud_region = (launched_resources.cloud,
-                                        launched_resources.region)
+                                           launched_resources.region)
         return launch_time
 
     def terminate_cluster(self, max_retry: int = 3) -> None:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -261,7 +261,7 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
 
     def launch(self) -> Optional[float]:
         launch_time = super().launch()
-        handle = global_user_state.get_cluster_from_name(self.cluster_name)
+        handle = global_user_state.get_handle_from_cluster_name(self.cluster_name)
         assert handle is not None, 'Cluster should be launched.'
         launched_resources = handle.launched_resources
         self.launched_cloud_region = (launched_resources.cloud,

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -278,7 +278,7 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
 
     def terminate_cluster(self, max_retry: int = 3) -> None:
         super().terminate_cluster(max_retry)
-        self.launched_resources = None
+        self._launched_cloud_region = None
 
     def recover(self) -> float:
         # 1. Cancel the jobs and launch the cluster with the STOPPED status,

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -261,7 +261,8 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
 
     def launch(self) -> Optional[float]:
         launch_time = super().launch()
-        handle = global_user_state.get_handle_from_cluster_name(self.cluster_name)
+        handle = global_user_state.get_handle_from_cluster_name(
+            self.cluster_name)
         assert handle is not None, 'Cluster should be launched.'
         launched_resources = handle.launched_resources
         self.launched_cloud_region = (launched_resources.cloud,

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -136,8 +136,8 @@ class StrategyExecutor:
         Args:
             max_retry: The maximum number of retries. If None, retry forever.
             raise_on_failure: Whether to raise an exception if the launch fails.
-        
-        Returns: 
+
+        Returns:
             The job's start timestamp, or None if failed to start and
             raise_on_failure is False.
         """

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -903,11 +903,12 @@ def test_spot_cancellation():
             'sleep 10',
             f's=$(sky spot queue); printf "$s"; echo; echo; printf "$s" | grep {name}-3 | head -n1 | grep "CANCELLED"',
             'sleep 90',
+            # The cluster should be terminated (shutting-down) after cancellation. We don't use the `=` operator here because
+            # there can be multiple VM with the same name due to the recovery.
             (f's=$(aws ec2 describe-instances --region {region} '
              f'--filters Name=tag:ray-cluster-name,Values={name}-3* '
              f'--query Reservations[].Instances[].State[].Name '
-             '--output text) && printf "$s" && echo; [[ -z "$s" ]] || [[ "$s" = "terminated" ]] || [[ "$s" = "shutting-down" ]]'
-            ),
+             '--output text) && printf "$s" && echo; [[ -z "$s" ]] || echo "$s" | grep -v -E "pending|running|stopped|stopping"'),
         ])
     run_one_test(test)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -908,7 +908,8 @@ def test_spot_cancellation():
             (f's=$(aws ec2 describe-instances --region {region} '
              f'--filters Name=tag:ray-cluster-name,Values={name}-3* '
              f'--query Reservations[].Instances[].State[].Name '
-             '--output text) && printf "$s" && echo; [[ -z "$s" ]] || echo "$s" | grep -v -E "pending|running|stopped|stopping"'),
+             '--output text) && printf "$s" && echo; [[ -z "$s" ]] || echo "$s" | grep -v -E "pending|running|stopped|stopping"'
+            ),
         ])
     run_one_test(test)
 


### PR DESCRIPTION
A user found the `cluster_status` to be `None`, at the place we modified. It seems to be a very rare case, where the controller can connect to the spot cluster with ssh to check the job status, but found the whole cluster is preempted right after the succeeded ssh. However, it is good to make sure that won't cause a problem.

The following is the error from the user:
```
(segm-4-nodes pid=2494) I 11-28 14:41:32 spot_utils.py:67] ==================================
(segm-4-nodes pid=2494) I 11-28 14:41:54 spot_utils.py:58] === Checking the job status... ===
(segm-4-nodes pid=2494) I 11-28 14:41:57 spot_utils.py:64] Job status: JobStatus.RUNNING
(segm-4-nodes pid=2494) I 11-28 14:41:57 spot_utils.py:67] ==================================
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163] Traceback (most recent call last):
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163]   File "/home/ubuntu/.local/lib/python3.9/site-packages/sky/spot/controller.py", line 151, in run
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163]     self._run()
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163]   File "/home/ubuntu/.local/lib/python3.9/site-packages/sky/spot/controller.py", line 99, in _run
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163]     logger.info(f'Cluster status {cluster_status.value}. '
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163] AttributeError: 'NoneType' object has no attribute 'value'
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:163]
(segm-4-nodes pid=2494) E 11-28 14:41:59 controller.py:164] Unexpected error occurred: AttributeError: 'NoneType' object has no attribute 'value'
(segm-4-nodes pid=2494) I 11-28 14:41:59 controller.py:171] Previous spot job status: RUNNING
(segm-4-nodes pid=2494) I 11-28 14:41:59 spot_state.py:198] Job failed due to unexpected controller failure.
```