### PR TITLE
Hotfix for spot TPU pod recovery

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1221,7 +1221,8 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
     cluster_name = ray_config['cluster_name']
     zone = ray_config['provider']['availability_zone']
     query_cmd = (f'gcloud compute tpus tpu-vm list --filter='
-                 f'\\(labels.ray-cluster-name={cluster_name}\\) '
+                 f'"(labels.ray-cluster-name={cluster_name} AND '
+                 f'state!=PREEMPTED)" '
                  f'--zone={zone} --format=value\\(name\\)')
     if not get_internal_ips:
         tpuvm_cmd = (f'gcloud compute tpus tpu-vm describe $({query_cmd})'
@@ -1242,10 +1243,14 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
                            '**** STDOUT ****\n'
                            '{stdout}\n'
                            '**** STDERR ****\n'
-                           '{stderr}')
+                           '{stderr}\n'
+                           '**** CMD ****\n'
+                           '{tpuvm_cmd}')
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
-                failure_massage.format(stdout=stdout, stderr=stderr))
+                failure_massage.format(stdout=stdout,
+                                       stderr=stderr,
+                                       tpuvm_cmd=tpuvm_cmd))
     all_ips = re.findall(IP_ADDR_REGEX, stdout)
     return all_ips
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1220,6 +1220,8 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
 
     cluster_name = ray_config['cluster_name']
     zone = ray_config['provider']['availability_zone']
+    # Excluding preempted VMs is safe as they are already terminated and
+    # do not charge.
     query_cmd = (f'gcloud compute tpus tpu-vm list --filter='
                  f'"(labels.ray-cluster-name={cluster_name} AND '
                  f'state!=PREEMPTED)" '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2621,6 +2621,8 @@ class CloudVmRayBackend(backends.Backend):
                     # check if gcloud includes TPU VM API
                     backend_utils.check_gcp_cli_include_tpu_vm()
 
+                    # Excluding preempted VMs is safe as they are already
+                    # terminated and do not charge.
                     query_cmd = (
                         f'gcloud compute tpus tpu-vm list --filter='
                         f'"(labels.ray-cluster-name={cluster_name} AND '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2623,7 +2623,8 @@ class CloudVmRayBackend(backends.Backend):
 
                     query_cmd = (
                         f'gcloud compute tpus tpu-vm list --filter='
-                        f'\\(labels.ray-cluster-name={cluster_name}\\) '
+                        f'"(labels.ray-cluster-name={cluster_name} AND '
+                        f'state!=PREEMPTED)" '
                         f'--zone={zone} --format=value\\(name\\)')
                     terminate_cmd = (
                         f'gcloud compute tpus tpu-vm delete --zone={zone}'


### PR DESCRIPTION
A hotfix to temporarily close https://github.com/skypilot-org/skypilot/issues/1468. We may need to modify the controller logic to make it more future proof. 

The issue is: When preemption happens, our spot controller won't cleanup preempted VMs before running another `sky launch`. This causes two VMs to co-exist and both the preempted one and the recovered one will be returned. 