### PR TITLE
Fix bug with retrieving node IPs

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1185,6 +1185,7 @@ def get_node_ips(cluster_yaml: str,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE)
                 out = proc.stdout.decode()
+                break
             except subprocess.CalledProcessError as e:
                 if retry_cnt == worker_ip_max_attempts - 1:
                     raise exceptions.FetchIPError(


### PR DESCRIPTION
Currently, in `get_node_ips`, we continue retrying even if the call to `ray get-worker-ip` succeeds. This PR fixes that.