### PR TITLE
Fix start spot controller bug.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1943,8 +1943,6 @@ def start(
                 'Autostop options are currently not allowed when starting the '
                 'spot controller. Use the default autostop settings by directly'
                 f' calling: {bold}sky start {reserved[0]}{reset_bold}')
-        idle_minutes_to_autostop = (
-            spot_lib.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
 
     if not yes:
         cluster_str = 'clusters' if len(to_start) > 1 else 'cluster'

--- a/sky/core.py
+++ b/sky/core.py
@@ -99,7 +99,7 @@ def _start(
                 'Passing a custom autostop setting is currently not '
                 'supported when starting the spot controller. To '
                 'fix: omit the `idle_minutes_to_autostop` argument to use the '
-                'default autostop settings.')
+                f'default autostop settings (got: {idle_minutes_to_autostop}).')
         idle_minutes_to_autostop = spot.SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
 
     # NOTE: if spot_queue() calls _start() and hits here, that entrypoint


### PR DESCRIPTION
Fixes a bug introduced in #1453 where starting the controller via the CLI raises a ValueError.

Tested:

CLI
```
# Expectedly fail:
sky start sky-cpunode-zongheng sky-spot-controller-8a3968f2
sky start sky-spot-controller-8a3968f2 -i1
sky start sky-spot-controller-8a3968f2 -i1 --down
sky start sky-spot-controller-8a3968f2 --down

# Starting a stopped controller: OK. Autostop reset to 10m.
sky start sky-spot-controller-8a3968f2  

# Starting an UP controller: OK. Autostop reset to 10m.
sky start sky-spot-controller-8a3968f2 --force 
```

Smoke
- [x] `bash tests/run_smoke_tests.sh test_spot`