### PR TITLE
Fix `ResourceHandle` semantics

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1627,7 +1627,7 @@ def _update_cluster_status_no_lock(
         # in ray's get IPs vs. ray runtime failing.
         external_ips = handle.external_ips(use_cached_ips=False)
         # This happens to a stopped TPU VM as we use gcloud to query the IP.
-        if len(external_ips) == 0:
+        if external_ips is None or len(external_ips) == 0:
             raise exceptions.FetchIPError(
                 reason=exceptions.FetchIPError.Reason.HEAD)
         if handle.launched_nodes == 1:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1153,8 +1153,8 @@ def get_node_ips(cluster_yaml: str,
     ray_config = common_utils.read_yaml(cluster_yaml)
     use_tpu_vm = ray_config['provider'].get('_has_tpus', False)
     if use_tpu_vm:
-        ips = _get_tpu_vm_pod_ips(ray_config, get_internal_ips)
         assert expected_num_nodes == 1, 'TPU VM only supports single node for now.'
+        ips = _get_tpu_vm_pod_ips(ray_config, get_internal_ips)
         if len(ips) != tpu_utils.get_num_tpu_devices(handle.launched_resources):
             raise exceptions.FetchIPError(exceptions.FetchIPError.Reason.HEAD)
         return ips

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -48,6 +48,7 @@ from sky.utils import common_utils
 from sky.utils import command_runner
 from sky.utils import subprocess_utils
 from sky.utils import timeline
+from sky.utils import tpu_utils
 from sky.utils import ux_utils
 from sky.utils import validator
 from sky.usage import usage_lib
@@ -1154,8 +1155,9 @@ def get_node_ips(cluster_yaml: str,
     if use_tpu_vm:
         ips = _get_tpu_vm_pod_ips(ray_config, get_internal_ips)
         assert expected_num_nodes == 1, 'TPU VM only supports single node for now.'
-        if len(ips) != expected_num_nodes:
+        if len(ips) != tpu_utils.get_num_tpu_devices(handle.launched_resources):
             raise exceptions.FetchIPError(exceptions.FetchIPError.Reason.HEAD)
+        return ips
 
     if get_internal_ips:
         with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1693,8 +1693,10 @@ def _update_cluster_status_no_lock(
         # that the cluster is partially preempted.
         # TODO(zhwu): the definition of INIT should be audited/changed.
         # Adding a new status UNHEALTHY for abnormal status can be a choice.
-        global_user_state.set_cluster_status(
-            cluster_name, global_user_state.ClusterStatus.INIT)
+        global_user_state.add_or_update_cluster(cluster_name,
+                                                handle,
+                                                ready=False,
+                                                is_launch=False)
         return global_user_state.get_cluster_from_name(cluster_name)
     # Now is_abnormal is False: either node_statuses is empty or all nodes are STOPPED.
     backend = backends.CloudVmRayBackend()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2046,7 +2046,7 @@ class CloudVmRayBackend(backends.Backend):
         fore = colorama.Fore
         style = colorama.Style
         ip_list = handle.external_ips()
-        assert ip_list is not None, 'external_ips is not cached in the handle'
+        assert ip_list is not None, 'external_ips is not cached in handle'
         full_workdir = os.path.abspath(os.path.expanduser(workdir))
 
         # These asserts have been validated at Task construction time.
@@ -2127,7 +2127,7 @@ class CloudVmRayBackend(backends.Backend):
             setup_file = os.path.basename(setup_sh_path)
             # Sync the setup script up and run it.
             ip_list = handle.external_ips()
-            assert ip_list is not None, 'external_ips is not cached in the handle'
+            assert ip_list is not None, 'external_ips is not cached in handle'
             ssh_credentials = backend_utils.ssh_credential_from_yaml(
                 handle.cluster_yaml)
             # Disable connection sharing for setup script to avoid old
@@ -2524,7 +2524,7 @@ class CloudVmRayBackend(backends.Backend):
                         f'{style.RESET_ALL}')
 
         ip_list = handle.external_ips()
-        assert ip_list is not None, 'external_ips is not cached in the handle'
+        assert ip_list is not None, 'external_ips is not cached in handle'
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         runners = command_runner.SSHCommandRunner.make_runner_list(
@@ -2934,7 +2934,7 @@ class CloudVmRayBackend(backends.Backend):
     def _set_tpu_name(self, handle: ResourceHandle, tpu_name: str) -> None:
         """Sets TPU_NAME on all nodes."""
         ip_list = handle.external_ips()
-        assert ip_list is not None, 'external_ips is not cached in the handle'
+        assert ip_list is not None, 'external_ips is not cached in handle'
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
 
@@ -2968,7 +2968,7 @@ class CloudVmRayBackend(backends.Backend):
         logger.info(f'{fore.CYAN}Processing file mounts.{style.RESET_ALL}')
         start = time.time()
         ip_list = handle.external_ips()
-        assert ip_list is not None, 'external_ips is not cached in the handle'
+        assert ip_list is not None, 'external_ips is not cached in handle'
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         runners = command_runner.SSHCommandRunner.make_runner_list(
@@ -3113,7 +3113,7 @@ class CloudVmRayBackend(backends.Backend):
                     f'storage mount{plural}.{style.RESET_ALL}')
         start = time.time()
         ip_list = handle.external_ips()
-        assert ip_list is not None, 'external_ips is not cached in the handle'
+        assert ip_list is not None, 'external_ips is not cached in handle'
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         runners = command_runner.SSHCommandRunner.make_runner_list(
@@ -3148,7 +3148,7 @@ class CloudVmRayBackend(backends.Backend):
 
         accelerator_dict = backend_utils.get_task_demands_dict(task)
         internal_ips = handle.internal_ips()
-        assert internal_ips is not None, 'internal_ips is not cached in the handle'
+        assert internal_ips is not None, 'internal_ips is not cached in handle'
 
         codegen = RayCodeGen()
         is_local = isinstance(handle.launched_resources.cloud, clouds.Local)
@@ -3203,7 +3203,7 @@ class CloudVmRayBackend(backends.Backend):
         log_dir = os.path.join(log_dir_base, 'tasks')
         accelerator_dict = backend_utils.get_task_demands_dict(task)
         internal_ips = handle.internal_ips()
-        assert internal_ips is not None, 'internal_ips is not cached in the handle'
+        assert internal_ips is not None, 'internal_ips is not cached in handle'
 
         # If TPU VM Pods is used, #num_nodes should be #num_tpu_devices
         is_tpu_vm_pod = tpu_utils.is_tpu_vm_pod(handle.launched_resources)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1709,21 +1709,21 @@ class CloudVmRayBackend(backends.Backend):
 
         def internal_ips(self,
                          max_attempts: int = 1,
-                         use_cached_ips: bool = True):
+                         use_cached_ips: bool = True) -> List[str]:
             if not use_cached_ips:
                 self._update_stable_cluster_ips(max_attempts=max_attempts)
             if self.stable_internal_external_ips is not None:
                 return [ips[0] for ips in self.stable_internal_external_ips]
-            return None
+            return []
 
         def external_ips(self,
                          max_attempts: int = 1,
-                         use_cached_ips: bool = True):
+                         use_cached_ips: bool = True) -> List[str]:
             if not use_cached_ips:
                 self._update_stable_cluster_ips(max_attempts=max_attempts)
             if self.stable_internal_external_ips is not None:
                 return [ips[1] for ips in self.stable_internal_external_ips]
-            return None
+            return []
 
         @property
         def cluster_yaml(self):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1732,7 +1732,7 @@ class CloudVmRayBackend(backends.Backend):
         @property
         def head_ip(self):
             external_ips = self.external_ips()
-            if external_ips is not None:
+            if external_ips:
                 return external_ips[0]
             return None
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1155,7 +1155,7 @@ class RetryingVmProvisioner(object):
         run setup or launch ray cluster on TPU VM Pod nodes.
         """
         ssh_credentials = backend_utils.ssh_credential_from_yaml(cluster_yaml)
-        all_ips = cluster_handle.external_ips()
+        all_ips = cluster_handle.external_ips(use_cached_ips=False)
         num_tpu_devices = tpu_utils.get_num_tpu_devices(
             cluster_handle.launched_resources)
         if len(all_ips) != num_tpu_devices:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1709,7 +1709,7 @@ class CloudVmRayBackend(backends.Backend):
 
         def internal_ips(self,
                          max_attempts: int = 1,
-                         use_cached_ips: bool = True) -> List[str]:
+                         use_cached_ips: bool = True) -> Optional[List[str]]:
             if not use_cached_ips:
                 self._update_stable_cluster_ips(max_attempts=max_attempts)
             if self.stable_internal_external_ips is not None:
@@ -1718,7 +1718,7 @@ class CloudVmRayBackend(backends.Backend):
 
         def external_ips(self,
                          max_attempts: int = 1,
-                         use_cached_ips: bool = True) -> List[str]:
+                         use_cached_ips: bool = True) -> Optional[List[str]]:
             if not use_cached_ips:
                 self._update_stable_cluster_ips(max_attempts=max_attempts)
             if self.stable_internal_external_ips is not None:
@@ -3159,9 +3159,7 @@ class CloudVmRayBackend(backends.Backend):
                              setup_log_path=os.path.join(log_dir, 'setup.log'),
                              is_local=is_local)
         codegen.add_gang_scheduling_placement_group(
-            1,
-            accelerator_dict,
-            stable_cluster_internal_ips=internal_ips)
+            1, accelerator_dict, stable_cluster_internal_ips=internal_ips)
 
         if callable(task.run):
             run_fn_code = textwrap.dedent(inspect.getsource(task.run))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -528,7 +528,7 @@ def test_tpu_vm_pod():
     test = Test(
         'tpu_pod',
         [
-            f'sky launch -y -c {name} examples/tpu/tpuvm_mnist.yaml --gpus tpu-v2-32',
+            f'sky launch -y -c {name} examples/tpu/tpuvm_mnist.yaml --gpus tpu-v2-32 --use-spot --zone europe-west4-a',
             f'sky logs {name} 1',  # Ensure the job finished.
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
         ],

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -523,7 +523,6 @@ def test_tpu_vm():
 
 
 # ---------- TPU VM Pod. ----------
-# Mark slow because it's expensive to run.
 def test_tpu_vm_pod():
     name = _get_cluster_name()
     test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -524,7 +524,6 @@ def test_tpu_vm():
 
 # ---------- TPU VM Pod. ----------
 # Mark slow because it's expensive to run.
-@pytest.mark.slow
 def test_tpu_vm_pod():
     name = _get_cluster_name()
     test = Test(


### PR DESCRIPTION
This fixes the following issues with the new `ResourceHandle` introduced in #1380.

- For clusters from the older version that are in INIT status, `sky status -r` will not update them to the latest version, causing the IPs for these clusters to be queried on each call which is slow. This PR updates it such that these clusters will be updated to the latest version on refresh.
- #1480: fixes the handling of TPU pods 
- ~The `external_ips` and `internal_ips` methods should always return a list as that is what is expected by the rest of the code~

Tested:
- [x] test_tpu_vm_pod