### PR TITLE
Clean up preempted resources for TPU

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1226,11 +1226,8 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
 
     cluster_name = ray_config['cluster_name']
     zone = ray_config['provider']['availability_zone']
-    # Excluding preempted VMs is safe as they are already terminated and
-    # do not charge.
     query_cmd = (f'gcloud compute tpus tpu-vm list --filter='
-                 f'"(labels.ray-cluster-name={cluster_name} AND '
-                 f'state!=PREEMPTED)" '
+                 f'\\(labels.ray-cluster-name={cluster_name}\\) '
                  f'--zone={zone} --format=value\\(name\\)')
     if not get_internal_ips:
         tpuvm_cmd = (f'gcloud compute tpus tpu-vm describe $({query_cmd})'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1343,6 +1343,9 @@ class RetryingVmProvisioner(object):
             logger.info(f'{style.BRIGHT}Setting up TPU VM Pod workers...'
                         f'{style.RESET_ALL}')
             self._tpu_pod_setup(cluster_config_file, cluster_handle)
+            logger.info(
+                f'{style.BRIGHT}Finished setting up TPU VM Pod workers...'
+                f'{style.RESET_ALL}')
 
         # Only 1 node or head node provisioning failure.
         if cluster_handle.launched_nodes == 1 and returncode == 0:
@@ -2680,12 +2683,9 @@ class CloudVmRayBackend(backends.Backend):
                     # check if gcloud includes TPU VM API
                     backend_utils.check_gcp_cli_include_tpu_vm()
 
-                    # Excluding preempted VMs is safe as they are already
-                    # terminated and do not charge.
                     query_cmd = (
                         f'gcloud compute tpus tpu-vm list --filter='
-                        f'"(labels.ray-cluster-name={cluster_name} AND '
-                        f'state!=PREEMPTED)" '
+                        f'\\(labels.ray-cluster-name={cluster_name}\\) '
                         f'--zone={zone} --format=value\\(name\\)')
                     terminate_cmd = (
                         f'gcloud compute tpus tpu-vm delete --zone={zone}'

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1343,9 +1343,6 @@ class RetryingVmProvisioner(object):
             logger.info(f'{style.BRIGHT}Setting up TPU VM Pod workers...'
                         f'{style.RESET_ALL}')
             self._tpu_pod_setup(cluster_config_file, cluster_handle)
-            logger.info(
-                f'{style.BRIGHT}Finished setting up TPU VM Pod workers...'
-                f'{style.RESET_ALL}')
 
         # Only 1 node or head node provisioning failure.
         if cluster_handle.launched_nodes == 1 and returncode == 0:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -12,7 +12,6 @@ from sky.skylet import job_lib
 from sky.spot import spot_utils
 from sky.usage import usage_lib
 from sky.utils import common_utils
-from sky.utils import tpu_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
@@ -307,11 +306,6 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
                                                region=launched_region)
                 task.set_resources({new_resources})
 
-                # Note: Preempted TPU VM cannot be reused and needs to be
-                # cleaned up. Otherwise, it will occupy the quota.
-                is_tpuvm = tpu_utils.is_tpu_vm(new_resources)
-                if is_tpuvm:
-                    self.terminate_cluster()
                 # Not using self.launch to avoid the retry until up logic.
                 launched_time = self._launch(raise_on_failure=False)
                 # Restore the original dag, i.e. reset the region constraint.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -305,7 +305,6 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
                 new_resources = resources.copy(cloud=launched_cloud,
                                                region=launched_region)
                 task.set_resources({new_resources})
-
                 # Not using self.launch to avoid the retry until up logic.
                 launched_time = self._launch(raise_on_failure=False)
                 # Restore the original dag, i.e. reset the region constraint.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -12,6 +12,7 @@ from sky.skylet import job_lib
 from sky.spot import spot_utils
 from sky.usage import usage_lib
 from sky.utils import common_utils
+from sky.utils import tpu_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
@@ -305,6 +306,12 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
                 new_resources = resources.copy(cloud=launched_cloud,
                                                region=launched_region)
                 task.set_resources({new_resources})
+
+                # Note: Preempted TPU VM needs to be cleaned up first.
+                # Otherwise, it will occupy the quota.
+                is_tpuvm = tpu_utils.is_tpu_vm(new_resources)
+                if is_tpuvm:
+                    self.terminate_cluster()
                 # Not using self.launch to avoid the retry until up logic.
                 launched_time = self._launch(raise_on_failure=False)
                 # Restore the original dag, i.e. reset the region constraint.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -307,8 +307,8 @@ class FailoverStrategyExecutor(StrategyExecutor, name='FAILOVER', default=True):
                                                region=launched_region)
                 task.set_resources({new_resources})
 
-                # Note: Preempted TPU VM needs to be cleaned up first.
-                # Otherwise, it will occupy the quota.
+                # Note: Preempted TPU VM cannot be reused and needs to be
+                # cleaned up. Otherwise, it will occupy the quota.
                 is_tpuvm = tpu_utils.is_tpu_vm(new_resources)
                 if is_tpuvm:
                     self.terminate_cluster()


### PR DESCRIPTION
This PR implements a better fix for https://github.com/skypilot-org/skypilot/issues/1468.
The preempted VM has to be cleaned up otherwise it'd occupy the quota.

Another choice is to modify the Autoscaler node provider, but I think that might complicate the semantic of `create_node` function. because for normal compute VM, we instead want to keep and reuse the preempted resources.
https://github.com/skypilot-org/skypilot/blob/1955bee5a337508af67de28615ed03a594fa30cf/sky/skylet/providers/gcp/node_provider.py#L178

Explicitly calling `terminate_cluster` on higher level might be better. @Michaelvll wdyt?
https://github.com/skypilot-org/skypilot/blob/1955bee5a337508af67de28615ed03a594fa30cf/sky/spot/recovery_strategy.py#L99

TODO
- [x] Spot related smoke tests
- [x] Test the recovery from real preemption (in progress)

