### PR TITLE
Catalog: sort by (price, region name, zone name).

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -330,7 +330,10 @@ def get_region_zones(df: pd.DataFrame,
                      use_spot: bool) -> List[cloud_lib.Region]:
     """Returns a list of regions/zones from a dataframe."""
     price_str = 'SpotPrice' if use_spot else 'Price'
-    df = df.dropna(subset=[price_str]).sort_values(price_str)
+    sort_keys = [price_str, 'Region']
+    if 'AvailabilityZone' in df.columns:
+        sort_keys.append('AvailabilityZone')
+    df = df.dropna(subset=[price_str]).sort_values(sort_keys)
     regions = [cloud_lib.Region(region) for region in df['Region'].unique()]
     if 'AvailabilityZone' in df.columns:
         zones_in_region = df.groupby('Region')['AvailabilityZone'].apply(


### PR DESCRIPTION
A few revisions ago the first region for the default AWS VM is `us-east-1`. After updating I noticed the first region becomes `us-west-2`. Both have the same on-demand price 0.384 for m6i.2xlarge. This is not a bug, but is a bit surprising to see, and it may require opening the console in a new region for debugging work.

This PR changes the sorting algorithm to sort by (price, region name, zone name) so that the same-priced regions can break ties consistently.