### PR TITLE
Exclude .git for cloud storage

### DIFF
--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -42,7 +42,7 @@ We can launch it with the following:
 
   # Assume your working directory is under `~/transformers`.
   # To make this example work, please run the following command:
-  # git clone https://github.com/huggingface/transformers.git ~/transformers
+  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
   workdir: ~/transformers
 
   setup: |
@@ -51,7 +51,6 @@ We can launch it with the following:
     # to pass the key in the command line, during `sky spot launch`.
     echo export WANDB_API_KEY=[YOUR-WANDB-API-KEY] >> ~/.bashrc
 
-    git checkout v4.18.0
     pip install -e .
     cd examples/pytorch/question-answering/
     pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
@@ -117,7 +116,7 @@ Below we show an `example <https://github.com/skypilot-org/skypilot/blob/master/
 
   # Assume your working directory is under `~/transformers`.
   # To make this example work, please run the following command:
-  # git clone https://github.com/huggingface/transformers.git ~/transformers
+  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
   workdir: ~/transformers
 
   file_mounts:
@@ -131,7 +130,6 @@ Below we show an `example <https://github.com/skypilot-org/skypilot/blob/master/
     # to pass the key in the command line, during `sky spot launch`.
     echo export WANDB_API_KEY=[YOUR-WANDB-API-KEY] >> ~/.bashrc
 
-    git checkout v4.18.0
     pip install -e .
     cd examples/pytorch/question-answering/
     pip install -r requirements.txt

--- a/examples/spot/bert_qa.yaml
+++ b/examples/spot/bert_qa.yaml
@@ -5,7 +5,7 @@ resources:
 
 # Assume your working directory is under `~/transformers`.
 # To make this example work, please run the following command:
-# git clone https://github.com/huggingface/transformers.git ~/transformers
+# git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
 workdir: ~/transformers
 
 file_mounts:
@@ -17,7 +17,6 @@ setup: |
     # Fill in your wandb key: copy from https://wandb.ai/authorize
     echo export WANDB_API_KEY=[YOUR-WANDB-API-KEY] >> ~/.bashrc
 
-    git checkout v4.18.0
     pip install -e .
     cd examples/pytorch/question-answering/
     pip install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -906,9 +906,10 @@ class S3Store(AbstractStore):
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
-            sync_command = ('aws s3 sync --no-follow-symlinks '
-                            f'{src_dir_path} '
-                            f's3://{self.name}/{dest_dir_name}')
+            sync_command = (
+                'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
+                f'{src_dir_path} '
+                f's3://{self.name}/{dest_dir_name}')
             return sync_command
 
         # Generate message for upload

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -721,6 +721,9 @@ class Storage(object):
     def _sync_store(self, store: AbstractStore):
         """Runs the upload routine for the store and handles failures"""
         try:
+            if os.path.exists(os.path.join(self.source, '.git')):
+                logger.warning(f'\'.git\' directory under \'{self.source}\' '
+                               'is excluded during sync')
             store.upload()
         except exceptions.StorageUploadError:
             logger.error(f'Could not upload {self.source} to store '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -721,7 +721,8 @@ class Storage(object):
     def _sync_store(self, store: AbstractStore):
         """Runs the upload routine for the store and handles failures"""
         try:
-            if os.path.isdir(os.path.join(self.source, '.git')):
+            if self.source is not None and os.path.isdir(
+                    os.path.join(self.source, '.git')):
                 logger.warning(f'\'.git\' directory under \'{self.source}\' '
                                'is excluded during sync.')
             store.upload()

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -906,6 +906,7 @@ class S3Store(AbstractStore):
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
+            # we exclude .git directory from the sync
             sync_command = (
                 'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
                 f'{src_dir_path} '
@@ -1220,6 +1221,7 @@ class GcsStore(AbstractStore):
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
+            # we exclude .git directory from the sync
             sync_command = (f'gsutil -m rsync -r -x \'.git/*\' {src_dir_path} '
                             f'gs://{self.name}/{dest_dir_name}')
             return sync_command

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1220,7 +1220,7 @@ class GcsStore(AbstractStore):
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
-            sync_command = (f'gsutil -m rsync -r {src_dir_path} '
+            sync_command = (f'gsutil -m rsync -r -x \'.git/*\' {src_dir_path} '
                             f'gs://{self.name}/{dest_dir_name}')
             return sync_command
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -721,9 +721,9 @@ class Storage(object):
     def _sync_store(self, store: AbstractStore):
         """Runs the upload routine for the store and handles failures"""
         try:
-            if os.path.exists(os.path.join(self.source, '.git')):
+            if os.path.isdir(os.path.join(self.source, '.git')):
                 logger.warning(f'\'.git\' directory under \'{self.source}\' '
-                               'is excluded during sync')
+                               'is excluded during sync.')
             store.upload()
         except exceptions.StorageUploadError:
             logger.error(f'Could not upload {self.source} to store '


### PR DESCRIPTION
This is a quick patch to make s3 exclude `.git` for https://github.com/skypilot-org/skypilot/issues/1485. However, this might be a surprising behavior to some users.
Alternative is to implement our own code to read `.gitignore` and generate corresponding directories to exclude (i.e., parsing those `**/*.pyc` syntax ourselves)
Should we implement that?

Note `sky launch` will respect `.gitignore` and putting `.git/` inside is enough to exclude the directory. or should we make it default for all `rsync`?

Tested
- [x] `sky spot launch` a workdir containing `.git`
- [x] mounted storage with S3, GCS