### PR TITLE
[Tests] Fix github CI

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    # Need to specify 20.04, because ubuntu-latest does not work with
+    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6"]

--- a/.github/workflows/pytest-generic.yml
+++ b/.github/workflows/pytest-generic.yml
@@ -1,6 +1,6 @@
 # This is needed for GitHub Actions for the "Waiting for status to be reported" problem,
 # according to https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks
-name: Run Python Tests
+name: Python Tests
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch
@@ -13,7 +13,9 @@ on:
       - master
       - 'releases/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  python-test:
+    # Need to specify 20.04, because ubuntu-latest does not work with
+    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
+    runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No tests to run"'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Run Python Tests
+name: Python Tests
 on:
   # Trigger the workflow on push or pull request,
   # but only for the main branch
@@ -11,10 +11,9 @@ on:
       - master
       - 'releases/**'
 jobs:
-  test:
+  python-test:
     strategy:
       matrix:
-        os: ["ubuntu-latest"]
         python-version: [3.6]
         test-path:
           - tests/test_cli.py
@@ -26,7 +25,9 @@ jobs:
           - tests/test_storage.py
           - tests/test_wheels.py
           - tests/test_spot.py
-    runs-on: ${{ matrix.os }}
+    # Need to specify 20.04, because ubuntu-latest does not work with
+    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -44,7 +45,6 @@ jobs:
           key: ${{ runner.os }}-pip-pytest-${{ matrix.python-version }}
           restore-keys: |
             ${{ runner.os }}-pip-pytest-${{ matrix.python-version }}
-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -13,7 +13,9 @@ on:
       - 'releases/**'
 jobs:
   yapf:
-    runs-on: ubuntu-latest
+    # Need to specify 20.04, because ubuntu-latest does not work with
+    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.6"]


### PR DESCRIPTION
This fixes the GitHub CI, because the GitHub runner recently updated the OS used by `ubuntu-latest` to `ubuntu-22.04`, which does not support python 3.6 anymore, as mentioned in https://github.com/actions/runner-images/issues/6399.
https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/

PS, we may also want to consider deprecating the Python 3.6 support #609 

This PR separates the CI fix from #1493 and #1489. 

Tested:
- the github CI is green now.