### PR TITLE
[AWS] Add regions requested by the user

### DIFF
--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -52,7 +52,10 @@ def _apply_az_mapping(df: 'pd.DataFrame') -> 'pd.DataFrame':
         az_mappings.to_csv(az_mapping_path, index=False)
     else:
         az_mappings = pd.read_csv(az_mapping_path)
-    df = df.merge(az_mappings, on=['AvailabilityZone'], how='left')
+    # Use inner join to drop rows with unknown AZ IDs, which are likely
+    # because the user does not have access to that Region. Otherwise,
+    # there will be rows with NaN in the AvailabilityZone column.
+    df = df.merge(az_mappings, on=['AvailabilityZone'], how='inner')
     df = df.drop(columns=['AvailabilityZone']).rename(
         columns={'AvailabilityZoneName': 'AvailabilityZone'})
     return df

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -31,10 +31,10 @@ ALL_REGIONS = [
     # 'me-south-1',
     # 'me-central-1',
     # 'af-south-1',
-    # 'af-south-2',
     'ap-east-1',  # enabled due to user request
     'ap-southeast-3',  # enabled due to user request
     'ap-south-1',
+    # 'ap-south-2',
     'ap-northeast-3',
     'ap-northeast-2',
     'ap-southeast-1',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -32,8 +32,8 @@ ALL_REGIONS = [
     # 'me-central-1',
     # 'af-south-1',
     # 'af-south-2',
-    # 'ap-east-1',
-    # 'ap-southeast-3',
+    'ap-east-1',  # enabled due to user request
+    'ap-southeast-3',  # enabled due to user request
     'ap-south-1',
     'ap-northeast-3',
     'ap-northeast-2',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -32,7 +32,7 @@ ALL_REGIONS = [
     # 'me-central-1',
     # 'af-south-1',
     'ap-east-1',  # enabled due to user request
-    'ap-southeast-3',  # enabled due to user request
+    # 'ap-southeast-3',
     'ap-south-1',
     # 'ap-south-2',
     'ap-northeast-3',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -31,7 +31,7 @@ ALL_REGIONS = [
     # 'me-south-1',
     # 'me-central-1',
     # 'af-south-1',
-    'ap-east-1',  # enabled due to user request
+    'ap-east-1',  # enable this non-default region due to user request
     # 'ap-southeast-3',
     'ap-south-1',
     # 'ap-south-2',


### PR DESCRIPTION
Our user requested to use `ap-east-1` region, we now enable this for the user so that the auto-updated catalog works.