### PR TITLE
[AWS] Enable requested ap regions

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -32,8 +32,8 @@ ALL_REGIONS = [
     # 'me-central-1',
     # 'af-south-1',
     # 'af-south-2',
-    'ap-east-1', # enabled due to user request
-    'ap-southeast-3', # enabled due to user request
+    'ap-east-1',  # enabled due to user request
+    'ap-southeast-3',  # enabled due to user request
     'ap-south-1',
     'ap-northeast-3',
     'ap-northeast-2',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -32,8 +32,8 @@ ALL_REGIONS = [
     # 'me-central-1',
     # 'af-south-1',
     # 'af-south-2',
-    'ap-east-1',  # enabled due to user request
-    'ap-southeast-3',  # enabled due to user request
+    # 'ap-east-1',
+    # 'ap-southeast-3',
     'ap-south-1',
     'ap-northeast-3',
     'ap-northeast-2',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -32,8 +32,8 @@ ALL_REGIONS = [
     # 'me-central-1',
     # 'af-south-1',
     # 'af-south-2',
-    # 'ap-east-1',
-    # 'ap-southeast-3',
+    'ap-east-1', # enabled due to user request
+    'ap-southeast-3', # enabled due to user request
     'ap-south-1',
     'ap-northeast-3',
     'ap-northeast-2',


### PR DESCRIPTION
Previously, the `ap-east-1` region was disabled in our automatically updated catalog as it is not enabled by default on AWS. However, one of our users is trying to restart a cluster in that region. 