### PR TITLE
[Logs] Fix logs download

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -299,16 +299,18 @@ class SSHCommandRunner:
         rsync_command.append(RSYNC_FILTER_OPTION)
 
         # --exclude-from
-        resolved_source = pathlib.Path(source).expanduser().resolve()
-        if (resolved_source / GIT_EXCLUDE).exists():
-            # Ensure file exists; otherwise, rsync will error out.
-            rsync_command.append(
-                RSYNC_EXCLUDE_OPTION.format(str(resolved_source / GIT_EXCLUDE)))
+        if up:
+            # The source is a local path, so we need to resolve it.
+            resolved_source = pathlib.Path(source).expanduser().resolve()
+            if (resolved_source / GIT_EXCLUDE).exists():
+                # Ensure file exists; otherwise, rsync will error out.
+                rsync_command.append(
+                    RSYNC_EXCLUDE_OPTION.format(str(resolved_source / GIT_EXCLUDE)))
 
-        # rsync doesn't support '~' in a quoted target path. need to expand it.
-        full_source_str = str(resolved_source)
-        if resolved_source.is_dir():
-            full_source_str = os.path.join(full_source_str, '')
+            # rsync doesn't support '~' in a quoted target path. need to expand it.
+            full_source_str = str(resolved_source)
+            if resolved_source.is_dir():
+                full_source_str = os.path.join(full_source_str, '')
 
         ssh_options = ' '.join(
             ssh_options_list(self.ssh_private_key, self.ssh_control_name))
@@ -321,8 +323,8 @@ class SSHCommandRunner:
             ])
         else:
             rsync_command.extend([
-                f'{self.ssh_user}@{self.ip}:{full_source_str!r}',
-                f'{target!r}',
+                f'{self.ssh_user}@{self.ip}:{source!r}',
+                f'{os.path.expanduser(target)!r}',
             ])
         command = ' '.join(rsync_command)
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -312,9 +312,9 @@ class SSHCommandRunner:
             ssh_options_list(self.ssh_private_key, self.ssh_control_name))
         rsync_command.append(f'-e "ssh {ssh_options}"')
         # To support spaces in the path, we need to quote source and target.
+        # rsync doesn't support '~' in a quoted local path, but it is ok to
+        # have '~' in a quoted remote path.
         if up:
-            # rsync doesn't support '~' in a quoted target path. need to
-            # expand it.
             full_source_str = str(resolved_source)
             if resolved_source.is_dir():
                 full_source_str = os.path.join(full_source_str, '')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -305,7 +305,8 @@ class SSHCommandRunner:
             if (resolved_source / GIT_EXCLUDE).exists():
                 # Ensure file exists; otherwise, rsync will error out.
                 rsync_command.append(
-                    RSYNC_EXCLUDE_OPTION.format(str(resolved_source / GIT_EXCLUDE)))
+                    RSYNC_EXCLUDE_OPTION.format(
+                        str(resolved_source / GIT_EXCLUDE)))
 
             # rsync doesn't support '~' in a quoted target path. need to expand it.
             full_source_str = str(resolved_source)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -308,7 +308,8 @@ class SSHCommandRunner:
                     RSYNC_EXCLUDE_OPTION.format(
                         str(resolved_source / GIT_EXCLUDE)))
 
-            # rsync doesn't support '~' in a quoted target path. need to expand it.
+            # rsync doesn't support '~' in a quoted target path. need to
+            # expand it.
             full_source_str = str(resolved_source)
             if resolved_source.is_dir():
                 full_source_str = os.path.join(full_source_str, '')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -298,9 +298,9 @@ class SSHCommandRunner:
         # --filter
         rsync_command.append(RSYNC_FILTER_OPTION)
 
-        # --exclude-from
         if up:
             # The source is a local path, so we need to resolve it.
+            # --exclude-from
             resolved_source = pathlib.Path(source).expanduser().resolve()
             if (resolved_source / GIT_EXCLUDE).exists():
                 # Ensure file exists; otherwise, rsync will error out.
@@ -308,17 +308,16 @@ class SSHCommandRunner:
                     RSYNC_EXCLUDE_OPTION.format(
                         str(resolved_source / GIT_EXCLUDE)))
 
-            # rsync doesn't support '~' in a quoted target path. need to
-            # expand it.
-            full_source_str = str(resolved_source)
-            if resolved_source.is_dir():
-                full_source_str = os.path.join(full_source_str, '')
-
         ssh_options = ' '.join(
             ssh_options_list(self.ssh_private_key, self.ssh_control_name))
         rsync_command.append(f'-e "ssh {ssh_options}"')
         # To support spaces in the path, we need to quote source and target.
         if up:
+            # rsync doesn't support '~' in a quoted target path. need to
+            # expand it.
+            full_source_str = str(resolved_source)
+            if resolved_source.is_dir():
+                full_source_str = os.path.join(full_source_str, '')
             rsync_command.extend([
                 f'{full_source_str!r}',
                 f'{self.ssh_user}@{self.ip}:{target!r}',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -138,6 +138,8 @@ def test_minimal():
             f'sky launch -y -c {name} examples/minimal.yaml',
             f'sky logs {name} 2 --status',
             f'sky logs {name} --status | grep "Job 2: SUCCEEDED"',  # Equivalent.
+            # Check the logs downloading
+            f'log_path=$(sky logs {name} 2 --sync-down | tail -n 1 | sed -E "s/^.*Job 2 logs: (.*)\\x1b\\[0m/\\1/g") && echo $log_path && test -f $log_path/run.log',
             # Ensure the raylet process has the correct file descriptor limit.
             f'sky exec {name} "prlimit -n --pid=\$(pgrep -f \'raylet/raylet --raylet_socket_name\') | grep \'"\'1048576 1048576\'"\'"',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:

#1190 introduced a bug for downloading the logs from the remote cluster, as we are giving the `runner.rsync` the wrong source path (resolved the path locally, though it is a remote path). This PR fixes the issue.

Reproducible code:

```
sky launch -i10 -c master-branch "echo hi"
sky logs master-branch 1 -s  
```
The downloaded folder does not contain any `run.log`.

TODO:
- [x] Add the reproducible snippets to the smoke test

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] The reproducible code above
- [x] `./tests/run_smoke_tests.sh test_minimal`
