### PR TITLE
[sqlite] Mitigate the database locked problem for skylet config

### DIFF
--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -13,12 +13,15 @@ os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 def _safe_cursor():
     """A newly created, auto-commiting, auto-closing cursor."""
     conn = sqlite3.connect(_DB_PATH)
+    # Use WAL mode to avoid locking problem in #1507.
+    # Reference: https://stackoverflow.com/a/39265148
+    conn.execute("PRAGMA journal_mode=WAL")
     cursor = conn.cursor()
     try:
         yield cursor
     finally:
-        conn.commit()
         cursor.close()
+        conn.commit()
         conn.close()
 
 

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -15,7 +15,7 @@ def _safe_cursor():
     conn = sqlite3.connect(_DB_PATH)
     # Use WAL mode to avoid locking problem in #1507.
     # Reference: https://stackoverflow.com/a/39265148
-    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute('PRAGMA journal_mode=WAL')
     cursor = conn.cursor()
     try:
         yield cursor

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -17,8 +17,8 @@ def _safe_cursor():
     try:
         yield cursor
     finally:
-        cursor.close()
         conn.commit()
+        cursor.close()
         conn.close()
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:

This PR is to mitigate the problem in #1507

Enable the WAL mode for the database we are using for autostop to eliminate the undesired locking.

After this PR, the snippet in #1507 fails 1/30, while it fails 30/30 when using the current master branch.

```
import time
from multiprocessing.pool import Pool

def import_skylet_config(i):
    from sky.skylet import configs
    print('Process', i)
    configs.set_config('autostop_last_active_time', str(time.time()))

if __name__ == '__main__':
    cnt = 0
    total = 30
    for i in range(total):
        try:
            with Pool(100) as p:
                p.map(import_skylet_config, range(10000))
        except Exception as e:
            print(e)
            cnt += 1
    print('Failed', cnt, 'times out of', total)
```

Future TODO:
- [ ] Adopt the WAL mode to all the database we are using?

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] `sky launch -c min -i 10 examples/minimal.yaml`
- [x] Confirmed by our user in https://github.com/skypilot-org/skypilot/issues/1507#issuecomment-1347175235