### PR TITLE
Tag all SkyPilot AWS nodes with "skypilot-user: $USER".

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -768,14 +768,6 @@ def write_cluster_config(
 
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
-    login_user = None
-    try:
-        login_user = getpass.getuser()
-    except Exception:  # pylint: disable=broad-except
-        # https://docs.python.org/3/library/getpass.html#getpass.getuser
-        # did not specify what exceptions will be raised if all attempts fail.
-        pass
-
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -790,7 +782,7 @@ def write_cluster_config(
                 # If the current code is run by controller, propagate the real
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).
-                'user': os.environ.get('SKYPILOT_USER', login_user),
+                'user': os.environ.get('SKYPILOT_USER', getpass.getuser()),
 
                 # AWS only:
                 # Temporary measure, as deleting per-cluster SGs is too slow.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -778,6 +778,13 @@ def write_cluster_config(
                 'cluster_name': cluster_name,
                 'num_nodes': num_nodes,
                 'disk_size': to_provision.disk_size,
+                # If the current code is run by controller, propagate the real
+                # calling user which should've been passed in as the
+                # SKYPILOT_USER env var (see spot-controller.yaml.j2).
+                'user': os.environ.get('SKYPILOT_USER',
+                                       os.environ.get('USER', None)),
+
+                # AWS only:
                 # Temporary measure, as deleting per-cluster SGs is too slow.
                 # See https://github.com/skypilot-org/skypilot/pull/742.
                 # Generate the name of the security group we're looking for.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -768,7 +768,16 @@ def write_cluster_config(
 
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
-    # Use a tmp file path to avoid incomplete YAML file being re-used in the future.
+    login_user = None
+    try:
+        login_user = getpass.getuser()
+    except Exception:  # pylint: disable=broad-except
+        # https://docs.python.org/3/library/getpass.html#getpass.getuser
+        # did not specify what exceptions will be raised if all attempts fail.
+        pass
+
+    # Use a tmp file path to avoid incomplete YAML file being re-used in the
+    # future.
     tmp_yaml_path = yaml_path + '.tmp'
     tmp_yaml_path = fill_template(
         cluster_config_template,
@@ -781,8 +790,7 @@ def write_cluster_config(
                 # If the current code is run by controller, propagate the real
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).
-                'user': os.environ.get('SKYPILOT_USER',
-                                       os.environ.get('USER', None)),
+                'user': os.environ.get('SKYPILOT_USER', login_user),
 
                 # AWS only:
                 # Temporary measure, as deleting per-cluster SGs is too slow.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -527,6 +527,7 @@ def spot_launch(
                 'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
                 'logging_user_hash': common_utils.get_user_hash(),
                 'retry_until_up': retry_until_up,
+                'user': os.environ.get('USER', None),
             },
             output_prefix=spot.SPOT_CONTROLLER_YAML_PREFIX)
         controller_task = task_lib.Task.from_yaml(yaml_path)

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -43,6 +43,11 @@ available_node_types:
           #   SpotOptions:
           #       MaxPrice: MAX_HOURLY_PRICE
       {% endif %}
+      TagSpecifications:
+        - ResourceType: instance
+          Tags:
+            - Key: skypilot-user
+              Value: {{ user }}
 {% if num_nodes > 1 %}
   ray.worker.default:
     min_workers: {{num_nodes - 1}}
@@ -65,6 +70,11 @@ available_node_types:
           #   SpotOptions:
           #       MaxPrice: MAX_HOURLY_PRICE
       {% endif %}
+      TagSpecifications:
+        - ResourceType: instance
+          Tags:
+            - Key: skypilot-user
+              Value: {{ user }}
 {%- endif %}
 
 head_node_type: ray.head.default

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -39,6 +39,7 @@ run: |
 
 envs:
   SKYPILOT_USAGE_USER_ID: {{logging_user_hash}}
+  SKYPILOT_USER: {{user}}
 {% if is_dev %}
   SKYPILOT_DEV: 1
 {% endif %}


### PR DESCRIPTION
Tag all SkyPilot AWS nodes with `skypilot-user: $USER`.

This works for spot controller-launched nodes too.

NOTE
- All existing nodes will continue to function and will not be tagged
- All new nodes will be tagged

Two users have requested this, for
- seeing who launched what in a shared-account scenario
- programmatically tracking all SkyPilot-launched VMs (for cost reporting)


<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

**Tested**:

1. Two-node cluster:
<img width="526" alt="Screen Shot 2022-12-12 at 18 46 52" src="https://user-images.githubusercontent.com/592670/207033040-3dad83c6-a20d-48fa-b087-ba3ba3cf8c60.png">
<img width="557" alt="Screen Shot 2022-12-12 at 18 47 04" src="https://user-images.githubusercontent.com/592670/207033130-804d3f1b-dc83-4c74-862c-3fb0b052f6be.png">

2. A controller-launched cluster
<img width="687" alt="Screen Shot 2022-12-12 at 19 25 46" src="https://user-images.githubusercontent.com/592670/207033884-0fa77197-9aa3-40a9-8fa4-92a63c3fd447.png">

2. Backward compat:

on master
- launch a spot controller 
- wait for it to autostop

switch to this branch
- spot launch
- [x] expected: reuse the controller; controller has no tags
- [x] expected: the newly launched spot job has its VM tagged with the user tag rather than 'ubuntu' (controller)
