### PR TITLE
Add return value to `validate_region_zone` for local cloud

### DIFF
--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -157,3 +157,4 @@ class Local(clouds.Cloud):
         if region is None or region != Local.LOCAL_REGION.name:
             raise ValueError(f'Region {region!r} does not match the Local'
                              ' cloud region {Local.LOCAL_REGION.name!r}.')
+        return region, zone


### PR DESCRIPTION
Add return values to `validate_region_zone` for local cloud because it is expected. For instance, see [here](https://github.com/skypilot-org/skypilot/blob/master/sky/resources.py#L275).

@michaelzhiluo  