### PR TITLE
[Provisioner] Generate valid cluster names when username has invalid characters

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1140,7 +1140,7 @@ def get_cleaned_username() -> str:
      4. Removing any hyphens at the end of the username
 
     e.g. 1SkY-PiLot2- becomes sky-pilot2.
-    
+
     Returns:
       A cleaned username that will pass the regex in check_cluster_name_is_valid().
     """

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1127,13 +1127,28 @@ def check_local_gpus() -> bool:
 def generate_cluster_name():
     # TODO: change this ID formatting to something more pleasant.
     # User name is helpful in non-isolated accounts, e.g., GCP, Azure.
-    # We clean up the username by making it all lowercase, removing any
-    # non-alphanumeric characters (including hyphens) and removing any numbers
-    # at the start of the username. e.g. 1SkY-PiLot2 becomes skypilot2.
-    cleaned_username = re.sub(
-        r'^\d+', '', re.sub('[^a-z0-9]', '',
-                            getpass.getuser().lower()))
-    return f'sky-{uuid.uuid4().hex[:4]}-{cleaned_username}'
+    return f'sky-{uuid.uuid4().hex[:4]}-{get_cleaned_username()}'
+
+
+def get_cleaned_username() -> str:
+    """
+    Cleans the current username to be used as a cluster name.
+
+    Clean up includes:
+     1. Making all characters lowercase
+     2. Removing any non-alphanumeric characters (excluding hyphens)
+     3. Removing any numbers and/or hyphens at the start of the username.
+     4. Removing any hyphens at the end of the username
+
+    e.g. 1SkY-PiLot2- becomes sky-pilot2.
+    """
+    username = getpass.getuser()
+    username = username.lower()
+    username = re.sub(r'[^a-z0-9-]', '', username)
+    username = re.sub(r'^[0-9-]+', '', username)
+    username = re.sub(r'-$', '', username)
+    return username
+
 
 
 def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1130,8 +1130,9 @@ def generate_cluster_name():
     # We clean up the username by making it all lowercase, removing any
     # non-alphanumeric characters (including hyphens) and removing any numbers
     # at the start of the username. e.g. 1SkY-PiLot2 becomes skypilot2.
-    cleaned_username = re.sub(r'^\d+', '', re.sub('[^a-z0-9]', '',
-                                                  getpass.getuser().lower()))
+    cleaned_username = re.sub(
+        r'^\d+', '', re.sub('[^a-z0-9]', '',
+                            getpass.getuser().lower()))
     return f'sky-{uuid.uuid4().hex[:4]}-{cleaned_username}'
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1127,7 +1127,12 @@ def check_local_gpus() -> bool:
 def generate_cluster_name():
     # TODO: change this ID formatting to something more pleasant.
     # User name is helpful in non-isolated accounts, e.g., GCP, Azure.
-    return f'sky-{uuid.uuid4().hex[:4]}-{getpass.getuser()}'
+    # We clean up the username by making it all lowercase, removing any
+    # non-alphanumeric characters (including hyphens) and removing any numbers
+    # at the start of the username. e.g. 1SkY-PiLot2 becomes skypilot2.
+    cleaned_username = re.sub(r'^\d+', '', re.sub('[^a-z0-9]', '',
+                                                  getpass.getuser().lower()))
+    return f'sky-{uuid.uuid4().hex[:4]}-{cleaned_username}'
 
 
 def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1131,8 +1131,7 @@ def generate_cluster_name():
 
 
 def get_cleaned_username() -> str:
-    """
-    Cleans the current username to be used as a cluster name.
+    """Cleans the current username to be used as part of a cluster name.
 
     Clean up includes:
      1. Making all characters lowercase
@@ -1141,6 +1140,9 @@ def get_cleaned_username() -> str:
      4. Removing any hyphens at the end of the username
 
     e.g. 1SkY-PiLot2- becomes sky-pilot2.
+    
+    Returns:
+      A cleaned username that will pass the regex in check_cluster_name_is_valid().
     """
     username = getpass.getuser()
     username = username.lower()

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1150,7 +1150,6 @@ def get_cleaned_username() -> str:
     return username
 
 
-
 def query_head_ip_with_retries(cluster_yaml: str, max_attempts: int = 1) -> str:
     """Returns the ip of the head node from yaml file."""
     backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -30,7 +30,6 @@ each other.
 import copy
 import datetime
 import functools
-import getpass
 import os
 import shlex
 import subprocess

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -606,7 +606,7 @@ def _default_interactive_node_name(node_type: str):
     # same-username user.  E.g., sky-gpunode-ubuntu.  Not a problem on AWS
     # which is the current cloud for interactive nodes.
     assert node_type in _INTERACTIVE_NODE_TYPES, node_type
-    return f'sky-{node_type}-{getpass.getuser()}'
+    return f'sky-{node_type}-{backend_utils.get_cleaned_username()}'
 
 
 def _infer_interactive_node_type(resources: sky.Resources):


### PR DESCRIPTION
Closes #1161.

We now clean up the username (used as suffix in the cluster name) by:

1. Making all characters lowercase
2. Removing any non-alphanumeric characters (excluding hyphens)
3. Removing any numbers and/or hyphens at the start of the username.
4. Removing any hyphens at the end of the username

e.g. `1SkY-PiLot2-` becomes `sky-pilot2` when it is used for generating cluster name.

## Tested:

Manual tests by overriding the username read by getpass.getuser():
- [x] `LOGNAME=RomilB sky launch` - uppercase characters
- [x] `LOGNAME=romil-b sky launch` - hypen
- [x] `LOGNAME=romil_b sky launch` - underscore
- [x] `LOGNAME=1roMil-b123 sky launch` - number at start gets removed. Becomes `romilb123`
- [x] `LOGNAME=r#omIl_B sky launch`