### PR TITLE
[Onprem] Fix `run.log` not appearing during `run` when laptop = local cluster

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -15,7 +15,6 @@ import textwrap
 import time
 import typing
 from typing import Dict, List, Optional, Tuple, Union
-import uuid
 
 import colorama
 import filelock
@@ -2331,7 +2330,10 @@ class CloudVmRayBackend(backends.Backend):
         with tempfile.NamedTemporaryFile('w', prefix='sky_local_app_') as fp:
             fp.write(ray_command)
             fp.flush()
-            remote_run_file = f'/tmp/sky_local_job_{uuid.uuid4().hex[:8]}'
+            run_file = os.path.basename(fp.name)
+            remote_run_file = f'/tmp/sky_local/{run_file}'
+            # Ensures remote_run_file directory is created.
+            runner.run(f'mkdir -p {os.path.dirname(remote_run_file)}')
             # We choose to sync code + exec, so that Ray job submission API will
             # work for the multitenant case.
             runner.rsync(source=fp.name,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2333,7 +2333,8 @@ class CloudVmRayBackend(backends.Backend):
             run_file = os.path.basename(fp.name)
             remote_run_file = f'/tmp/sky_local/{run_file}'
             # Ensures remote_run_file directory is created.
-            runner.run(f'mkdir -p {os.path.dirname(remote_run_file)}')
+            runner.run(f'mkdir -p {os.path.dirname(remote_run_file)}',
+                       stream_logs=False)
             # We choose to sync code + exec, so that Ray job submission API will
             # work for the multitenant case.
             runner.rsync(source=fp.name,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -15,6 +15,7 @@ import textwrap
 import time
 import typing
 from typing import Dict, List, Optional, Tuple, Union
+import uuid
 
 import colorama
 import filelock
@@ -2330,8 +2331,7 @@ class CloudVmRayBackend(backends.Backend):
         with tempfile.NamedTemporaryFile('w', prefix='sky_local_app_') as fp:
             fp.write(ray_command)
             fp.flush()
-            run_file = os.path.basename(fp.name)
-            remote_run_file = f'/tmp/{run_file}'
+            remote_run_file = f'/tmp/sky_local_job_{uuid.uuid4().hex[:8]}'
             # We choose to sync code + exec, so that Ray job submission API will
             # work for the multitenant case.
             runner.rsync(source=fp.name,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1527. It will now rsync to a file that will not be deleted.


<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this the PR
- [ ] All smoke tests: `bash tests/run_smoke_tests.sh` 
- [x] Relevant individual smoke tests: `bash tests/run_smoke_tests.sh test_fill_in_the_name` 
- [x] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
