### PR TITLE
Bugfix for spot controller

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -262,9 +262,7 @@ class Resources:
 
     def need_cleanup_after_preemption(self) -> bool:
         """Returns whether a spot resource needs cleanup after preeemption."""
-        if self.cloud is None:
-            logger.info('self.cloud is None, assuming no cleanup is needed.')
-            return False
+        assert self.is_launchable(), self
         return self.cloud.need_cleanup_after_preemption(self)
 
     def _set_region_zone(self, region: Optional[str],

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -262,6 +262,9 @@ class Resources:
 
     def need_cleanup_after_preemption(self) -> bool:
         """Returns whether a spot resource needs cleanup after preeemption."""
+        if self.cloud is None:
+            logger.info('self.cloud is None, assuming no cleanup is needed.')
+            return False
         return self.cloud.need_cleanup_after_preemption(self)
 
     def _set_region_zone(self, region: Optional[str],

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -145,13 +145,14 @@ class SpotController:
                             'cluster is healthy. Try to recover the job '
                             '(the cluster will not be restarted).')
 
-            resources = self._strategy_executor.launched_resources
-            if (resources is not None and
-                    resources.need_cleanup_after_preemption()):
-                # Some spot resource (e.g., Spot TPU VM) may need to be
-                # cleaned up after preemption.
-                logger.info('Cleaning up the preempted spot cluster...')
-                self._strategy_executor.terminate_cluster()
+            if handle is not None:
+                resources = handle.launched_resources
+                assert resources is not None, handle
+                if resources.need_cleanup_after_preemption():
+                    # Some spot resource (e.g., Spot TPU VM) may need to be
+                    # cleaned up after preemption.
+                    logger.info('Cleaning up the preempted spot cluster...')
+                    self._strategy_executor.terminate_cluster()
 
             # Try to recover the spot jobs, when the cluster is preempted
             # or the job status is failed to be fetched.

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -145,6 +145,7 @@ class SpotController:
                             'cluster is healthy. Try to recover the job '
                             '(the cluster will not be restarted).')
 
+            # When the handle is None, the cluster should be cleaned up already.
             if handle is not None:
                 resources = handle.launched_resources
                 assert resources is not None, handle

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -145,8 +145,9 @@ class SpotController:
                             'cluster is healthy. Try to recover the job '
                             '(the cluster will not be restarted).')
 
-            resources = list(self._task.resources)[0]
-            if resources.need_cleanup_after_preemption():
+            resources = self._strategy_executor.launched_resources
+            if (resources is not None and
+                    resources.need_cleanup_after_preemption()):
                 # Some spot resource (e.g., Spot TPU VM) may need to be
                 # cleaned up after preemption.
                 logger.info('Cleaning up the preempted spot cluster...')

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -49,8 +49,6 @@ class StrategyExecutor:
         self.backend = backend
         self.retry_until_up = retry_until_up
 
-        self.launched_resources = None
-
     def __init_subclass__(cls, name: str, default: bool = False):
         SPOT_STRATEGIES[name] = cls
         if default:
@@ -155,9 +153,6 @@ class StrategyExecutor:
                 sky.launch(self.dag,
                            cluster_name=self.cluster_name,
                            detach_run=True)
-                handle = global_user_state.get_handle_from_cluster_name(
-                    self.cluster_name)
-                self.launched_resources = handle.launched_resources
                 logger.info('Spot cluster launched.')
             except exceptions.InvalidClusterNameError as e:
                 # The cluster name is too long.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -49,6 +49,8 @@ class StrategyExecutor:
         self.backend = backend
         self.retry_until_up = retry_until_up
 
+        self.launched_resources = None
+
     def __init_subclass__(cls, name: str, default: bool = False):
         SPOT_STRATEGIES[name] = cls
         if default:
@@ -153,6 +155,9 @@ class StrategyExecutor:
                 sky.launch(self.dag,
                            cluster_name=self.cluster_name,
                            detach_run=True)
+                handle = global_user_state.get_handle_from_cluster_name(
+                    self.cluster_name)
+                self.launched_resources = handle.launched_resources
                 logger.info('Spot cluster launched.')
             except exceptions.InvalidClusterNameError as e:
                 # The cluster name is too long.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -906,6 +906,22 @@ def test_spot_recovery():
     run_one_test(test)
 
 
+def test_spot_recovery_default():
+    """Test managed spot recovery for default spot launch."""
+    name = _get_cluster_name()
+    test = Test(
+        'managed-spot-recovery-default',
+        [
+            f'sky spot launch -n {name} "sleep 30 && sudo shutdown now && sleep 1000" -y -d',
+            'sleep 360',
+            f's=$(sky spot queue); printf "$s"; echo; echo; printf "$s" | grep {name} | head -n1 | grep "RUNNING\|RECOVERING"',
+        ],
+        f'sky spot cancel -y -n {name}',
+        timeout=20 * 60,
+    )
+    run_one_test(test)
+
+
 def test_spot_recovery_multi_node():
     """Test managed spot recovery."""
     name = _get_cluster_name()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -906,11 +906,11 @@ def test_spot_recovery():
     run_one_test(test)
 
 
-def test_spot_recovery_default():
-    """Test managed spot recovery for default spot launch."""
+def test_spot_recovery_default_resources():
+    """Test managed spot recovery for default resources."""
     name = _get_cluster_name()
     test = Test(
-        'managed-spot-recovery-default',
+        'managed-spot-recovery-default-resources',
         [
             f'sky spot launch -n {name} "sleep 30 && sudo shutdown now && sleep 1000" -y -d',
             'sleep 360',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:

https://github.com/skypilot-org/skypilot/pull/1500 didn't consider the case when `cloud` is not specified by users and a bug will be triggered during recovery.
This PR fixes it by checking the `launched_resources` in `handle` to make sure cloud is not `None`.

====

Details:

The reason why I introduce `self.launched_resources` in `StrategyExecutor` is because the `handle` returns by
```
(cluster_status,
             handle) = backend_utils.refresh_cluster_status_handle(
                 self._cluster_name, force_refresh=True)
```
in `controller.py` could be `None` if the spot VM is preempted. I thought adding `self.launched_resources` under `StrategyExecutor` would be a better design.
Please let me know if there's a better alternative.

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

====

Tested (run the relevant ones):

- [x] Any manual or new tests for this the PR
  - Add a new smoke test for spot recovery in which cloud is not specified
- [ ] All smoke tests: `bash tests/run_smoke_tests.sh` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`