### PR TITLE
[User identity] Fix identity check

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1829,8 +1829,7 @@ def _update_cluster_status(
         exceptions.CloudUserIdentityError: if we fail to get the current user
           identity.
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
-          fetched from the cloud provider.
-        
+          fetched from the cloud provider.        
     """
     if need_owner_identity_check:
         check_owner_identity(cluster_name)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1695,8 +1695,8 @@ def check_owner_identity(cluster_name: str) -> None:
     elif owner_identity != current_user_identity:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterOwnerIdentityMismatchError(
-                f'Cluster {cluster_name!r} ({cloud}) is owned by account '
-                f'{owner_identity!r}, but the currently activated account '
+                f'{cluster_name!r} ({cloud}) is owned by '
+                f'{owner_identity!r}, but the activated account '
                 f'is {current_user_identity!r}.')
 
 
@@ -2117,11 +2117,8 @@ def get_clusters(
         plural = 's' if len(failed_clusters) > 1 else ''
         logger.warning(f'{yellow}Failed to refresh status for '
                        f'{len(failed_clusters)} cluster{plural}:{reset}')
-        table = log_utils.create_table(['Cluster', 'Error'])
         for cluster_name, e in failed_clusters:
-            table.add_row([cluster_name, str(e)])
-        logger.warning(table)
-
+            logger.warning(f'  {bright}{cluster_name}{reset}: {e}')
     return kept_records
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -46,7 +46,6 @@ from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import command_runner
 from sky.utils import env_options
-from sky.utils import log_utils
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import tpu_utils

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1829,7 +1829,7 @@ def _update_cluster_status(
         exceptions.CloudUserIdentityError: if we fail to get the current user
           identity.
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
-          fetched from the cloud provider.        
+          fetched from the cloud provider.
     """
     if need_owner_identity_check:
         check_owner_identity(cluster_name)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2053,7 +2053,8 @@ def get_clusters(
             record = _update_cluster_status(
                 cluster_name, acquire_per_cluster_status_lock=True)
         except (exceptions.ClusterStatusFetchingError,
-                exceptions.ClusterOwnerIdentityMismatchError) as e:
+                exceptions.ClusterOwnerIdentityMismatchError,
+                exceptions.ClusterStatusFetchingError) as e:
             record = {'status': 'UNKNOWN', 'error': e}
         progress.update(task, advance=1)
         return record

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1809,7 +1809,8 @@ def _update_cluster_status_no_lock(
 
 def _update_cluster_status(
         cluster_name: str,
-        acquire_per_cluster_status_lock: bool) -> Optional[Dict[str, Any]]:
+        acquire_per_cluster_status_lock: bool,
+        need_owner_identity_check: bool = True) -> Optional[Dict[str, Any]]:
     """Update the cluster status.
 
     The cluster status is updated by checking ray cluster and real status from cloud.
@@ -1823,9 +1824,17 @@ def _update_cluster_status(
       Otherwise returns the input record with status and ip potentially updated.
 
     Raises:
+        exceptions.ClusterOwnerIdentityMismatchError: if the current user is not the
+          same as the user who created the cluster.
+        exceptions.CloudUserIdentityError: if we fail to get the current user
+          identity.
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
           fetched from the cloud provider.
+        
     """
+    if need_owner_identity_check:
+        check_owner_identity(cluster_name)
+
     if not acquire_per_cluster_status_lock:
         return _update_cluster_status_no_lock(cluster_name)
 
@@ -1881,7 +1890,8 @@ def refresh_cluster_status_handle(
             try:
                 record = _update_cluster_status(cluster_name,
                                                 acquire_per_cluster_status_lock=
-                                                acquire_per_cluster_status_lock)
+                                                acquire_per_cluster_status_lock,
+                                                need_owner_identity_check=False)
                 if record is None:
                     return None, None
             except (exceptions.ClusterOwnerIdentityMismatchError,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1694,7 +1694,7 @@ def check_owner_identity(cluster_name: str) -> None:
     elif owner_identity != current_user_identity:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterOwnerIdentityMismatchError(
-                f'{cluster_name!r} ({cloud}) is owned by '
+                f'{cluster_name!r} ({cloud}) is owned by account '
                 f'{owner_identity!r}, but the activated account '
                 f'is {current_user_identity!r}.')
 
@@ -1824,8 +1824,8 @@ def _update_cluster_status(
         need_owner_identity_check: Whether to check the owner identity before updating
 
     Returns:
-    If the cluster is terminated or does not exist, return None.
-    Otherwise returns the input record with status and handle potentially updated.
+        If the cluster is terminated or does not exist, return None.
+        Otherwise returns the input record with status and handle potentially updated.
 
     Raises:
         exceptions.ClusterOwnerIdentityMismatchError: if the current user is not the
@@ -1852,13 +1852,13 @@ def _update_cluster_status(
         return global_user_state.get_cluster_from_name(cluster_name)
 
 
-def refresh_cluster_record(
+def _refresh_cluster_record(
         cluster_name: str,
         *,
         force_refresh: bool = False,
         acquire_per_cluster_status_lock: bool = True
 ) -> Optional[Dict[str, Any]]:
-    """Refresh the cluster record.
+    """Refresh the cluster, and return the possibly updated record.
 
     This function will also check the owner identity of the cluster, and raise
     exceptions if the current user is not the same as the user who created the
@@ -1909,13 +1909,13 @@ def refresh_cluster_status_handle(
     acquire_per_cluster_status_lock: bool = True,
 ) -> Tuple[Optional[global_user_state.ClusterStatus],
            Optional[backends.Backend.ResourceHandle]]:
-    """Refresh the cluster status and return the status and handle.
+    """Refresh the cluster, and return the possibly updated status and handle.
 
     This is a wrapper of refresh_cluster_record, which returns the status and
     handle of the cluster.
     Please refer to the docstring of refresh_cluster_record for the details.
     """
-    record = refresh_cluster_record(
+    record = _refresh_cluster_record(
         cluster_name,
         force_refresh=force_refresh,
         acquire_per_cluster_status_lock=acquire_per_cluster_status_lock)
@@ -2064,7 +2064,7 @@ def get_clusters(
 
     def _refresh_cluster(cluster_name):
         try:
-            record = refresh_cluster_record(
+            record = _refresh_cluster_record(
                 cluster_name,
                 force_refresh=True,
                 acquire_per_cluster_status_lock=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:
(related to #1513) This PR fixes the identity check for the `sky status -r` as it does not go through `refresh_cluster_status_handle`.

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] `sky launch -c test -t t3.micro`; `AWS_PROFILE=admin-user sky status -r`