### PR TITLE
[autostop] setstate instead of set_state

### DIFF
--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -33,7 +33,7 @@ class AutostopConfig:
         self.backend = backend
         self.down = down
 
-    def __set_state__(self, state: dict):
+    def __setstate__(self, state: dict):
         state.setdefault('down', False)
         self.__dict__.update(state)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

It looks like `__set_state__` is being used for setting `down=False` during deserialization. However, this is a typo so it never works (https://docs.python.org/3/library/pickle.html#object.__setstate__). Also it does not look like `state.setdefault` will work as `self.down` is always set.

@Michaelvll could you confirm its the original intention is for deserialization? Otherwise, we should remove it as it is not been used in other places.

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this the PR
- [ ] All smoke tests: `bash tests/run_smoke_tests.sh` 
- [ ] Relevant individual smoke tests: `bash tests/run_smoke_tests.sh test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
