### PR TITLE
Simple documentation fix

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -91,7 +91,7 @@ and storage mounting:
       # *** Copying files from S3 ***
       #
       # This re-uses a predefined bucket (public bucket used here, but can be
-      # private) and copies it's contents directly to /datasets-s3.
+      # private) and copies its contents directly to /datasets-s3.
       /datasets-s3: s3://enriched-topical-chat
 
       # *** Copying files from GCS ***

--- a/examples/storage/pingpong.yaml
+++ b/examples/storage/pingpong.yaml
@@ -3,7 +3,7 @@
 # This program implements coordination between processes using a shared file
 # system they can access. Each process reads data from <process-id>.txt, prints
 # it, and writes to <process-id + 1>.txt. This creates a synchronization between
-# processes where process i continues only after process i-1 has written it's
+# processes where process i continues only after process i-1 has written its
 # output.
 #
 # Usage:

--- a/examples/storage_demo.yaml
+++ b/examples/storage_demo.yaml
@@ -73,7 +73,7 @@ file_mounts:
   # *** Copying files from S3 ***
   #
   # This re-uses a predefined bucket (public bucket used here, but can be
-  # private) and copies it's contents directly to /datasets-s3.
+  # private) and copies its contents directly to /datasets-s3.
   /datasets-s3: s3://enriched-topical-chat
 
   # *** Copying files from GCS ***

--- a/sky/design_docs/onprem-design.md
+++ b/sky/design_docs/onprem-design.md
@@ -15,7 +15,7 @@
 
 ## Registering clusters as a regular user
 - Registering clusters can be done in two steps:
-  - Creating a cluster config in `~/.sky/local/`. This cluster is uninitialized, as SkyPilot has not registered the cluster into it's database.
+  - Creating a cluster config in `~/.sky/local/`. This cluster is uninitialized, as SkyPilot has not registered the cluster into its database.
   - Running `sky launch -c [LOCAL_CLUSTER_NAME] ''` for the first time. This will intialize the cluster and register it into SkyPilot's database.
 - `sky status` shows both initialized and uninitialized local clusters.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Simple documentation fix.

"it's" = "it is"

"its" = possessive