### PR TITLE
[TPU VM] Avoid infinite recursion when cleaning up spot TPU VM

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1609,17 +1609,19 @@ def _query_status_gcp(
     # TODO(wei-lin): handle multi-node cases.
     if use_tpu_vm and len(status_list) == 0:
         logger.debug(f'Terminating preempted TPU VM cluster {cluster}')
-        # Do not use CloudVMRayBackend.teardown_no_lock, as that will
+        backend = backends.CloudVmRayBackend()
+        handle = global_user_state.get_handle_from_cluster_name(cluster)
+        # Do not use refresh cluster status during teardown, as that will
         # cause inifinite recursion by calling cluster status refresh
         # again.
-        terminate_cmd = tpu_utils.terminate_tpu_vm_cluster_cmd(cluster, zone)
-        returncode, stdout, stderr = log_lib.run_with_log(terminate_cmd,
-                                                          os.devnull,
-                                                          shell=True,
-                                                          stream_logs=False,
-                                                          require_outputs=True)
-        subprocess_utils.handle_returncode(returncode, terminate_cmd,
-                                           stdout + stderr)
+        # The only caller of this function, `_get_cluster_status_via_cloud_cli`,
+        # will do the post teardown cleanup, which will remove the cluster entry
+        # from the status table & the ssh config file.
+        backend.teardown_no_lock(handle,
+                                 terminate=True,
+                                 purge=False,
+                                 post_teardown_cleanup=False,
+                                 refresh_status=False)
     return status_list
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1621,7 +1621,7 @@ def _query_status_gcp(
                                  terminate=True,
                                  purge=False,
                                  post_teardown_cleanup=False,
-                                 refresh_status=False)
+                                 refresh_cluster_status=False)
     return status_list
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -46,7 +46,6 @@ from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import command_runner
 from sky.utils import env_options
-from sky.utils import log_utils
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import tpu_utils
@@ -1695,8 +1694,8 @@ def check_owner_identity(cluster_name: str) -> None:
     elif owner_identity != current_user_identity:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterOwnerIdentityMismatchError(
-                f'Cluster {cluster_name!r} ({cloud}) is owned by account '
-                f'{owner_identity!r}, but the currently activated account '
+                f'{cluster_name!r} ({cloud}) is owned by account '
+                f'{owner_identity!r}, but the activated account '
                 f'is {current_user_identity!r}.')
 
 
@@ -1818,13 +1817,23 @@ def _update_cluster_status(
     design of the cluster status and transition, please refer to the
     sky/design_docs/cluster_status.md
 
+    Args:
+        cluster_name: The name of the cluster.
+        acquire_per_cluster_status_lock: Whether to acquire the per-cluster lock
+            before updating the status.
+        need_owner_identity_check: Whether to check the owner identity before updating
+
     Returns:
-      If the cluster is terminated or does not exist, return None.
-      Otherwise returns the input record with status and ip potentially updated.
+        If the cluster is terminated or does not exist, return None.
+        Otherwise returns the input record with status and handle potentially updated.
 
     Raises:
+        exceptions.ClusterOwnerIdentityMismatchError: if the current user is not the
+        same as the user who created the cluster.
+        exceptions.CloudUserIdentityError: if we fail to get the current user
+        identity.
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
-          fetched from the cloud provider.
+        fetched from the cloud provider.
     """
     if not acquire_per_cluster_status_lock:
         return _update_cluster_status_no_lock(cluster_name)
@@ -1843,20 +1852,27 @@ def _update_cluster_status(
         return global_user_state.get_cluster_from_name(cluster_name)
 
 
-@timeline.event
-def refresh_cluster_status_handle(
-    cluster_name: str,
-    *,
-    force_refresh: bool = False,
-    acquire_per_cluster_status_lock: bool = True,
-    suppress_error: bool = False
-) -> Tuple[Optional[global_user_state.ClusterStatus],
-           Optional[backends.Backend.ResourceHandle]]:
-    """Refresh the cluster status and return the status and handle.
+def _refresh_cluster_record(
+        cluster_name: str,
+        *,
+        force_refresh: bool = False,
+        acquire_per_cluster_status_lock: bool = True
+) -> Optional[Dict[str, Any]]:
+    """Refresh the cluster, and return the possibly updated record.
 
     This function will also check the owner identity of the cluster, and raise
     exceptions if the current user is not the same as the user who created the
     cluster.
+
+    Args:
+        cluster_name: The name of the cluster.
+        force_refresh: refresh the cluster status as long as the cluster exists.
+        acquire_per_cluster_status_lock: Whether to acquire the per-cluster lock
+            before updating the status.
+
+    Returns:
+        If the cluster is terminated or does not exist, return None.
+        Otherwise returns the cluster record.
 
     Raises:
         exceptions.ClusterOwnerIdentityMismatchError: if the current user is not the
@@ -1866,9 +1882,10 @@ def refresh_cluster_status_handle(
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
           fetched from the cloud provider.
     """
+
     record = global_user_state.get_cluster_from_name(cluster_name)
     if record is None:
-        return None, None
+        return None
     check_owner_identity(cluster_name)
 
     handle = record['handle']
@@ -1878,21 +1895,32 @@ def refresh_cluster_status_handle(
             record['status'] != global_user_state.ClusterStatus.STOPPED and
             record['autostop'] >= 0)
         if force_refresh or has_autostop or use_spot:
-            try:
-                record = _update_cluster_status(cluster_name,
-                                                acquire_per_cluster_status_lock=
-                                                acquire_per_cluster_status_lock)
-                if record is None:
-                    return None, None
-            except (exceptions.ClusterOwnerIdentityMismatchError,
-                    exceptions.CloudUserIdentityError,
-                    exceptions.ClusterStatusFetchingError) as e:
-                if suppress_error:
-                    logger.debug(
-                        f'Failed to refresh cluster {cluster_name!r} due to {e}'
-                    )
-                    return None, None
-                raise
+            record = _update_cluster_status(
+                cluster_name,
+                acquire_per_cluster_status_lock=acquire_per_cluster_status_lock)
+    return record
+
+
+@timeline.event
+def refresh_cluster_status_handle(
+    cluster_name: str,
+    *,
+    force_refresh: bool = False,
+    acquire_per_cluster_status_lock: bool = True,
+) -> Tuple[Optional[global_user_state.ClusterStatus],
+           Optional[backends.Backend.ResourceHandle]]:
+    """Refresh the cluster, and return the possibly updated status and handle.
+
+    This is a wrapper of refresh_cluster_record, which returns the status and
+    handle of the cluster.
+    Please refer to the docstring of refresh_cluster_record for the details.
+    """
+    record = _refresh_cluster_record(
+        cluster_name,
+        force_refresh=force_refresh,
+        acquire_per_cluster_status_lock=acquire_per_cluster_status_lock)
+    if record is None:
+        return None, None
     return record['status'], record['handle']
 
 
@@ -2036,10 +2064,13 @@ def get_clusters(
 
     def _refresh_cluster(cluster_name):
         try:
-            record = _update_cluster_status(
-                cluster_name, acquire_per_cluster_status_lock=True)
+            record = _refresh_cluster_record(
+                cluster_name,
+                force_refresh=True,
+                acquire_per_cluster_status_lock=True)
         except (exceptions.ClusterStatusFetchingError,
-                exceptions.ClusterOwnerIdentityMismatchError) as e:
+                exceptions.ClusterOwnerIdentityMismatchError,
+                exceptions.ClusterStatusFetchingError) as e:
             record = {'status': 'UNKNOWN', 'error': e}
         progress.update(task, advance=1)
         return record
@@ -2085,11 +2116,8 @@ def get_clusters(
         plural = 's' if len(failed_clusters) > 1 else ''
         logger.warning(f'{yellow}Failed to refresh status for '
                        f'{len(failed_clusters)} cluster{plural}:{reset}')
-        table = log_utils.create_table(['Cluster', 'Error'])
         for cluster_name, e in failed_clusters:
-            table.add_row([cluster_name, str(e)])
-        logger.warning(table)
-
+            logger.warning(f'  {bright}{cluster_name}{reset}: {e}')
     return kept_records
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2654,7 +2654,8 @@ class CloudVmRayBackend(backends.Backend):
                          handle: ResourceHandle,
                          terminate: bool,
                          purge: bool = False,
-                         post_teardown_cleanup: bool = True) -> bool:
+                         post_teardown_cleanup: bool = True,
+                         refresh_status: bool = True) -> bool:
         """Teardown the cluster without acquiring the cluster status lock.
 
         NOTE: This method should not be called without holding the cluster
@@ -2665,8 +2666,13 @@ class CloudVmRayBackend(backends.Backend):
         log_abs_path = os.path.abspath(log_path)
         cloud = handle.launched_resources.cloud
         config = common_utils.read_yaml(handle.cluster_yaml)
-        prev_status, _ = backend_utils.refresh_cluster_status_handle(
-            handle.cluster_name, acquire_per_cluster_status_lock=False)
+        if refresh_status:
+            prev_status, _ = backend_utils.refresh_cluster_status_handle(
+                handle.cluster_name, acquire_per_cluster_status_lock=False)
+        else:
+            record = global_user_state.get_cluster_from_name(
+                handle.cluster_name)
+            prev_status = record['status']
         cluster_name = handle.cluster_name
         use_tpu_vm = config['provider'].get('_has_tpus', False)
         if terminate and isinstance(cloud, clouds.Azure):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2655,18 +2655,21 @@ class CloudVmRayBackend(backends.Backend):
                          terminate: bool,
                          purge: bool = False,
                          post_teardown_cleanup: bool = True,
-                         refresh_status: bool = True) -> bool:
+                         refresh_cluster_status: bool = True) -> bool:
         """Teardown the cluster without acquiring the cluster status lock.
 
         NOTE: This method should not be called without holding the cluster
         status lock already.
+
+        refresh_cluster_status is only used internally in the status refresh
+        process, and should not be set to False in other cases.
         """
         log_path = os.path.join(os.path.expanduser(self.log_dir),
                                 'teardown.log')
         log_abs_path = os.path.abspath(log_path)
         cloud = handle.launched_resources.cloud
         config = common_utils.read_yaml(handle.cluster_yaml)
-        if refresh_status:
+        if refresh_cluster_status:
             prev_status, _ = backend_utils.refresh_cluster_status_handle(
                 handle.cluster_name, acquire_per_cluster_status_lock=False)
         else:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -550,6 +550,10 @@ class GCP(clouds.Cloud):
             return 'dryrun-project-id'
         from google import auth  # pylint: disable=import-outside-toplevel
         _, project_id = auth.default()
+        if project_id is None:
+            raise exceptions.CloudUserIdentityError(
+                'Failed to get GCP project id. Please make sure you have '
+                'run: gcloud init')
         return project_id
 
     @staticmethod

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -8,6 +8,7 @@ from sky import spot
 from sky.backends import backend_utils
 from sky.utils import accelerator_registry
 from sky.utils import schemas
+from sky.utils import tpu_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -233,7 +234,7 @@ class Resources:
                     accelerator_args = {}
                 use_tpu_vm = accelerator_args.get('tpu_vm', False)
                 if use_tpu_vm:
-                    backend_utils.check_gcp_cli_include_tpu_vm()
+                    tpu_utils.check_gcp_cli_include_tpu_vm()
                 if self.instance_type is not None and use_tpu_vm:
                     if self.instance_type != 'TPU-VM':
                         with ux_utils.print_exception_no_traceback():

--- a/sky/utils/tpu_utils.py
+++ b/sky/utils/tpu_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for TPUs."""
 import json
+import os
 from typing import Optional
 
 from packaging import version
@@ -42,7 +43,7 @@ def check_gcp_cli_include_tpu_vm() -> None:
     # TPU VM API available with gcloud version >= 382.0.0
     version_cmd = 'gcloud version --format=json'
     rcode, stdout, stderr = log_lib.run_with_log(version_cmd,
-                                                 '/dev/null',
+                                                 os.devnull,
                                                  shell=True,
                                                  stream_logs=False,
                                                  require_outputs=True)
@@ -74,7 +75,7 @@ def check_gcp_cli_include_tpu_vm() -> None:
 
 def terminate_tpu_vm_cluster_cmd(cluster_name: str,
                                  zone: str,
-                                 log_path: Optional[str] = None) -> str:
+                                 log_path: str = os.devnull) -> str:
     check_gcp_cli_include_tpu_vm()
     query_cmd = (f'gcloud compute tpus tpu-vm list --filter='
                  f'\\(labels.ray-cluster-name={cluster_name}\\) '

--- a/sky/utils/tpu_utils.py
+++ b/sky/utils/tpu_utils.py
@@ -1,7 +1,12 @@
 """Utility functions for TPUs."""
+import json
 from typing import Optional
 
+from packaging import version
+
 from sky import resources as resources_lib
+from sky.skylet import log_lib
+from sky.utils import ux_utils
 
 
 def is_tpu(resources: Optional[resources_lib.Resources]) -> bool:
@@ -31,3 +36,68 @@ def get_num_tpu_devices(
     acc, _ = list(resources.accelerators.items())[0]
     num_tpu_devices = int(int(acc.split('-')[2]) / 8)
     return num_tpu_devices
+
+
+def check_gcp_cli_include_tpu_vm() -> None:
+    # TPU VM API available with gcloud version >= 382.0.0
+    version_cmd = 'gcloud version --format=json'
+    rcode, stdout, stderr = log_lib.run_with_log(version_cmd,
+                                                 '/dev/null',
+                                                 shell=True,
+                                                 stream_logs=False,
+                                                 require_outputs=True)
+
+    if rcode != 0:
+        failure_massage = ('Failed to run "gcloud version".\n'
+                           '**** STDOUT ****\n'
+                           '{stdout}\n'
+                           '**** STDERR ****\n'
+                           '{stderr}')
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                failure_massage.format(stdout=stdout, stderr=stderr))
+
+    sdk_ver = json.loads(stdout).get('Google Cloud SDK', None)
+
+    if sdk_ver is None:
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError('Failed to get Google Cloud SDK version from'
+                               f' "gcloud version": {stdout}')
+    else:
+        major_ver = version.parse(sdk_ver).major
+        if major_ver < 382:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(
+                    'Google Cloud SDK version must be >= 382.0.0 to use'
+                    ' TPU VM APIs, check "gcloud version" for details.')
+
+
+def terminate_tpu_vm_cluster_cmd(cluster_name: str,
+                                 zone: str,
+                                 log_path: Optional[str] = None) -> str:
+    check_gcp_cli_include_tpu_vm()
+    query_cmd = (f'gcloud compute tpus tpu-vm list --filter='
+                 f'\\(labels.ray-cluster-name={cluster_name}\\) '
+                 f'--zone={zone} --format=value\\(name\\)')
+    returncode, stdout, stderr = log_lib.run_with_log(query_cmd,
+                                                      log_path,
+                                                      shell=True,
+                                                      stream_logs=False,
+                                                      require_outputs=True)
+
+    # Skip the termination command, if the TPU ID
+    # query command fails.
+    if returncode != 0:
+        terminate_cmd = (f'echo "cmd: {query_cmd}" && '
+                         f'echo "{stdout}" && '
+                         f'echo "{stderr}" >&2 && '
+                         f'exit {returncode}')
+    else:
+        # Needs to create a list as GCP does not allow deleting
+        # multiple TPU VMs at once.
+        tpu_terminate_cmds = []
+        for tpu_id in stdout.splitlines():
+            tpu_terminate_cmds.append('gcloud compute tpus tpu-vm delete '
+                                      f'--zone={zone} --quiet {tpu_id}')
+        terminate_cmd = ' && '.join(tpu_terminate_cmds)
+    return terminate_cmd


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:

Our user observe that terminating an TPU VM can cause a infinite recursion (checked with py-spy) for status refreshing and tearing down the cluster. The reason could be the following:
1. The spot TPU VM is in the local cluster cache table, but already terminated in the console.
2. When the user try to terminate the cluster with `sky down cluster-name`, SkyPilot tries to refresh the cluster status using gcloud and try to clean up the TPU VM as we cannot find the cluster in the console. https://github.com/skypilot-org/skypilot/blob/1ad086874dc51751232ea7fa540c975709d915a5/sky/backends/backend_utils.py#L1610-L1613
3. In the `teardown_no_lock`, we will call the refresh again causing the infinite recursion. https://github.com/skypilot-org/skypilot/blob/1ad086874dc51751232ea7fa540c975709d915a5/sky/backends/cloud_vm_ray_backend.py#L2668-L2669

The bug is introduced since we enforce the cluster refresh for the spot instances when the `refresh_cluster_status_handle ` is called in #1513

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] `sky launch -c tpu-vm --use-spot test-tpuvm.yaml`; delete the tpu vm from the console; `sky status -r` (with the current master branch 1ad0868, it will loop infinitely)
  ```
  # test-tpuvm.yaml
  resources:
    accelerators: tpu-v3
    accelerator_args:
      tpu_vm: true
    use_spot: true
  ```
