### PR TITLE
Minor logging fix.

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -439,7 +439,7 @@ def exec(  # pylint: disable=redefined-builtin
 
     handle = backend_utils.check_cluster_available(
         cluster_name,
-        operation='executing tasks on',
+        operation='executing tasks',
         check_cloud_vm_ray_backend=False)
     _execute(entrypoint=entrypoint,
              dryrun=dryrun,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before
```
» sky exec dbg2 echo hi                                                                                                                                                          1 ↵
Task from command: echo hi
Executing task on cluster dbg2...
sky.exceptions.ClusterNotUpError: Executing tasks on: skipped for cluster 'dbg2' (status: INIT). It is only allowed for UP clusters.
```

After
```
» sky exec dbg2 echo hi
Task from command: echo hi
Executing task on cluster dbg2...
sky.exceptions.ClusterNotUpError: Executing tasks: skipped for cluster 'dbg2' (status: STOPPED). It is only allowed for UP clusters.
```


<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this the PR: above
- [ ] All smoke tests: `bash tests/run_smoke_tests.sh` 
- [ ] Relevant individual smoke tests: `bash tests/run_smoke_tests.sh test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
