### PR TITLE
[setup] Allow newer version of azure cli and ray

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2079,6 +2079,7 @@ def get_clusters(
                 force_refresh=True,
                 acquire_per_cluster_status_lock=True)
         except (exceptions.ClusterStatusFetchingError,
+                exceptions.CloudUserIdentityError,
                 exceptions.ClusterOwnerIdentityMismatchError,
                 exceptions.ClusterStatusFetchingError) as e:
             record = {'status': 'UNKNOWN', 'error': e}

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -80,7 +80,7 @@ install_requires = [
     'PrettyTable',
     # Lower local ray version is not fully supported, due to the
     # autoscaler issues (also tracked in #537).
-    'ray[default]>=1.9.0,<=2.0.1',
+    'ray[default]>=1.9.0,<=2.2.0',
     'rich',
     'tabulate',
     'filelock',  # TODO(mraheja): Enforce >=3.6.0 when python version is >= 3.7

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -108,9 +108,8 @@ extras_require = {
     ],
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
-    # azure-cli need to be pinned to 2.31.0 due to later versions
-    # do not have azure-identity (used in node_provider) installed
-    'azure': ['azure-cli==2.31.0', 'azure-core'],
+    # azure-identity is needed in node_provider.
+    'azure': ['azure-cli>=2.31.0', 'azure-core', 'azure-identity'],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],
     'docker': ['docker'],
 }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Describe the changes in this PR:
This is to update the azure cli and ray version to avoid strict version pinning.

<!-- Describe tests ran in a "Tested:" section -->
<!-- Unit tests (tests/test_*.py) are part of Github CI; the below are additional tests. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this the PR
  - Create a docker container and install skypilot; `az login`; `sky launch -c azure-test --cloud azure`
- [x] `bash tests/run_smoke_tests.sh` in a new docker container
