### PR TITLE
[Storage] Bump gcsfuse version to 0.41.10

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1313,7 +1313,7 @@ class GcsStore(AbstractStore):
           mount_path: str; Path to mount the bucket to.
         """
         install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
-                       '/releases/download/v0.41.2/gcsfuse_0.41.2_amd64.deb '
+                       '/releases/download/v0.41.10/gcsfuse_0.41.10_amd64.deb '
                        '-O /tmp/gcsfuse.deb && '
                        'sudo dpkg --install /tmp/gcsfuse.deb')
         mount_cmd = ('gcsfuse -o allow_other '


### PR DESCRIPTION
Switch to using a newer version of GCSFuse to address issue from slack:

> user observed that when they tried to continuously read from the mounted GCS bucket with multiple processes (about 40, each process may read different files), the gcsfuse seems stuck causing failure for reading files (ls also stuck in the folder).


Tested (run the relevant ones):
- [x] Relevant individual smoke tests: `bash tests/run_smoke_tests.sh test_storage_mount ` 
