### PR TITLE
[API] Add support for specifying the clusters to query

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -14,7 +14,7 @@ import textwrap
 import threading
 import time
 import typing
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 import uuid
 
 import colorama
@@ -2018,12 +2018,14 @@ def get_clusters(
     include_reserved: bool,
     refresh: bool,
     cloud_filter: str = CloudFilter.CLOUDS_AND_DOCKER,
-    cluster_names: Optional[Union[str, List[str]]] = None,
+    cluster_names: Optional[Union[str, Sequence[str]]] = None,
 ) -> List[Dict[str, Any]]:
-    """Returns a list of cached cluster records.
+    """Returns a list of cached or optionally refreshed cluster records.
 
     Combs through the database (in ~/.sky/state.db) to get a list of records
-    corresponding to launched clusters.
+    corresponding to launched clusters (filtered by `cluster_names` if it is
+    specified). The refresh flag can be used to force a refresh of the status
+    of the clusters.
 
     Args:
         include_reserved: Whether to include reserved clusters, e.g. spot
@@ -2033,9 +2035,12 @@ def get_clusters(
         cloud_filter: Sets which clouds to filer through from the global user
             state. Supports three values, 'all' for all clouds, 'public' for
             public clouds only, and 'local' for only local clouds.
+        cluster_names: If provided, only return records for the given cluster
+            names.
 
     Returns:
-        A list of cluster records.
+        A list of cluster records. If the cluster does not exist or has been
+        terminated, the record will be omitted from the returned list.
     """
     records = global_user_state.get_clusters()
 
@@ -2049,7 +2054,7 @@ def get_clusters(
     bright = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
 
-    if cluster_names:
+    if cluster_names is not None:
         if isinstance(cluster_names, str):
             cluster_names = [cluster_names]
         new_records = []

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1861,7 +1861,7 @@ def _update_cluster_status(
         return global_user_state.get_cluster_from_name(cluster_name)
 
 
-def _refresh_cluster_record(
+def refresh_cluster_record(
         cluster_name: str,
         *,
         force_refresh: bool = False,
@@ -1924,7 +1924,7 @@ def refresh_cluster_status_handle(
     handle of the cluster.
     Please refer to the docstring of refresh_cluster_record for the details.
     """
-    record = _refresh_cluster_record(
+    record = refresh_cluster_record(
         cluster_name,
         force_refresh=force_refresh,
         acquire_per_cluster_status_lock=acquire_per_cluster_status_lock)
@@ -2073,7 +2073,7 @@ def get_clusters(
 
     def _refresh_cluster(cluster_name):
         try:
-            record = _refresh_cluster_record(
+            record = refresh_cluster_record(
                 cluster_name,
                 force_refresh=True,
                 acquire_per_cluster_status_lock=True)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1861,7 +1861,7 @@ def _update_cluster_status(
         return global_user_state.get_cluster_from_name(cluster_name)
 
 
-def refresh_cluster_record(
+def _refresh_cluster_record(
         cluster_name: str,
         *,
         force_refresh: bool = False,
@@ -1924,7 +1924,7 @@ def refresh_cluster_status_handle(
     handle of the cluster.
     Please refer to the docstring of refresh_cluster_record for the details.
     """
-    record = refresh_cluster_record(
+    record = _refresh_cluster_record(
         cluster_name,
         force_refresh=force_refresh,
         acquire_per_cluster_status_lock=acquire_per_cluster_status_lock)
@@ -2095,7 +2095,7 @@ def get_clusters(
 
     def _refresh_cluster(cluster_name):
         try:
-            record = refresh_cluster_record(
+            record = _refresh_cluster_record(
                 cluster_name,
                 force_refresh=True,
                 acquire_per_cluster_status_lock=True)

--- a/sky/core.py
+++ b/sky/core.py
@@ -2,7 +2,7 @@
 import colorama
 import getpass
 import sys
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from sky import dag
 from sky import task
@@ -30,7 +30,7 @@ logger = sky_logging.init_logger(__name__)
 
 
 @usage_lib.entrypoint
-def status(cluster_names: Optional[Union[str, List[str]]] = None,
+def status(cluster_names: Optional[Union[str, Sequence[str]]] = None,
            refresh: bool = False) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster statuses.
@@ -94,8 +94,8 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
 
     Returns:
         A list of dicts, with each dict containing the information of a
-        cluster. If the cluster is not found/terminated, it will be omitted from
-        the returned list.
+        cluster. If a cluster is found to be terminated or not found, it will
+        be omitted from the returned list.
     """
     return backend_utils.get_clusters(include_reserved=True,
                                       refresh=refresh,

--- a/sky/core.py
+++ b/sky/core.py
@@ -94,8 +94,8 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
 
     Returns:
         A list of dicts, with each dict containing the information of a
-        cluster. If the cluster is not found, it will be omitted from the
-        returned list.
+        cluster. If the cluster is not found/terminated, it will be omitted from
+        the returned list.
     """
     return backend_utils.get_clusters(include_reserved=True,
                                       refresh=refresh,

--- a/sky/core.py
+++ b/sky/core.py
@@ -97,19 +97,9 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
         cluster. If the cluster is not found, it will be omitted from the
         returned list.
     """
-    if cluster_names is None:
-        return backend_utils.get_clusters(include_reserved=True,
-                                          refresh=refresh)
-    if isinstance(cluster_names, str):
-        cluster_names = [cluster_names]
-
-    cluster_records = []
-    for cluster_name in cluster_names:
-        record = backend_utils.refresh_cluster_record(cluster_name,
-                                                      force_refresh=refresh)
-        if record is not None:
-            cluster_records.append(record)
-    return cluster_records
+    return backend_utils.get_clusters(include_reserved=True,
+                                      refresh=refresh,
+                                      cluster_names=cluster_names)
 
 
 def _start(

--- a/sky/core.py
+++ b/sky/core.py
@@ -94,7 +94,8 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
 
     Returns:
         A list of dicts, with each dict containing the information of a
-        cluster.
+        cluster. If the cluster is not found, it will be omitted from the
+        returned list.
     """
     if cluster_names is None:
         return backend_utils.get_clusters(include_reserved=True,

--- a/sky/core.py
+++ b/sky/core.py
@@ -105,9 +105,10 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
 
     cluster_records = []
     for cluster_name in cluster_names:
-        cluster_records.append(
-            backend_utils.refresh_cluster_record(cluster_name,
-                                                 force_refresh=refresh))
+        record = backend_utils.refresh_cluster_record(cluster_name,
+                                                      force_refresh=refresh)
+        if record is not None:
+            cluster_records.append(record)
     return cluster_records
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Required by our user. This Pr adds `cluster_names` argument to `sky.status`, so the user can query/refresh the status for part of the clusters.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - `sky.status('non-exist')` returns empty list
  - `sky.status('sky-spot-controller-...')  returns the stopped status
  - `sky.status(['mycluster1', 'mycluster2'], refresh=True)` where both clusters exist
  - `sky.status(['mycluster1', 'non-exists'], refresh=True)`
