### PR TITLE
[AWS] Support per-region ssh proxy command

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -788,13 +788,14 @@ def write_cluster_config(
             str(cloud).lower(), None)
         if cloud_ssh_proxy_command_config is None:
             ssh_proxy_command = None
-            logger.warning(
-                    f'No ssh_proxy_command found for cloud {cloud}. '
-                    f'Do not use ssh_proxy_command.')
+            logger.warning(f'No ssh_proxy_command found for cloud {cloud}. '
+                           f'Do not use ssh_proxy_command.')
         elif isinstance(cloud_ssh_proxy_command_config, dict):
-            ssh_proxy_command = cloud_ssh_proxy_command_config.get(region_name, None)
+            ssh_proxy_command = cloud_ssh_proxy_command_config.get(
+                region_name, None)
             if ssh_proxy_command is None:
-                ssh_proxy_command = list(cloud_ssh_proxy_command_config.values())[0]
+                ssh_proxy_command = list(
+                    cloud_ssh_proxy_command_config.values())[0]
                 logger.warning(
                     f'No ssh_proxy_command found for region {region_name}.'
                     f' Using default ssh_proxy_command: {ssh_proxy_command!r}')
@@ -802,7 +803,8 @@ def write_cluster_config(
             ssh_proxy_command = cloud_ssh_proxy_command_config
         else:
             raise ValueError(
-                f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}')
+                f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}'
+            )
     else:
         ssh_proxy_command = ssh_proxy_command_config
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -744,7 +744,7 @@ def write_cluster_config(
         - 'tpu-delete-script' (if TPU is requested)
     Raises:
         ResourceUnavailableError: if the region/zones requested does not appear
-            in the catalog.
+            in the catalog or the ssh proxy command is not available.
     """
     # task.best_resources may not be equal to to_provision if the user
     # is running a job with less resources than the cluster has.
@@ -786,6 +786,8 @@ def write_cluster_config(
     if isinstance(ssh_proxy_command_config, dict):
         ssh_proxy_command = ssh_proxy_command_config.get(region_name, None)
         if ssh_proxy_command is None:
+            # Skip this region. The upper layer will handle the failover to
+            # other regions.
             raise exceptions.ResourcesUnavailableError(
                 f'No ssh_proxy_command provided for region {region_name}. Skip.'
             )

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -744,7 +744,7 @@ def write_cluster_config(
         - 'tpu-delete-script' (if TPU is requested)
     Raises:
         ResourceUnavailableError: if the region/zones requested does not appear
-            in the catalog or the ssh proxy command is not available.
+            in the catalog, or an ssh_proxy_command is specified but not for the given region.
     """
     # task.best_resources may not be equal to to_provision if the user
     # is running a job with less resources than the cluster has.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -796,11 +796,14 @@ def write_cluster_config(
             )
         elif not isinstance(ssh_proxy_command, str):
             raise ValueError(
-                f'Invalid ssh_proxy_command config (expected a str): {ssh_proxy_command_config!r}'
+                'Invalid ssh_proxy_command config (expected a str): '
+                f'{ssh_proxy_command_config!r}'
             )
     else:
         raise ValueError(
-            f'Invalid ssh_proxy_command config (expected a str or a dict with region names as keys): {ssh_proxy_command_config!r}')
+            'Invalid ssh_proxy_command config (expected a str or a dict with '
+            f'region names as keys): {ssh_proxy_command_config!r}'
+        )
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -800,7 +800,7 @@ def write_cluster_config(
             )
     else:
         raise ValueError(
-            f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}')
+            f'Invalid ssh_proxy_command config (expected a str or a dict with region names as keys): {ssh_proxy_command_config!r}')
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -784,7 +784,7 @@ def write_cluster_config(
     ssh_proxy_command_config = skypilot_config.get_nested(
         (str(cloud).lower(), 'ssh_proxy_command'), None)
     if (isinstance(ssh_proxy_command_config, str) or
-          ssh_proxy_command_config is None):
+            ssh_proxy_command_config is None):
         ssh_proxy_command = ssh_proxy_command_config
     elif isinstance(ssh_proxy_command_config, dict):
         ssh_proxy_command = ssh_proxy_command_config.get(region_name, None)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -780,6 +780,20 @@ def write_cluster_config(
 
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
+    # Retrieve the ssh_proxy_command for the given region.
+    ssh_proxy_command_config = skypilot_config.get_nested(
+        ('auth', 'ssh_proxy_command'), None)
+    if isinstance(ssh_proxy_command_config, dict):
+        ssh_proxy_command = ssh_proxy_command_config.get(region_name, None)
+        if ssh_proxy_command is None:
+            ssh_proxy_command = list(ssh_proxy_command_config.values())[0]
+            logger.warning(
+                f'No ssh_proxy_command found for region {region_name}.'
+                f' Using default ssh_proxy_command: {ssh_proxy_command!r}')
+    else:
+        ssh_proxy_command = ssh_proxy_command_config
+    logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
+
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -811,8 +825,7 @@ def write_cluster_config(
                     ('aws', 'use_internal_ips'), False),
                 # Not exactly AWS only, but we only test it's supported on AWS
                 # for now:
-                'ssh_proxy_command': skypilot_config.get_nested(
-                    ('auth', 'ssh_proxy_command'), None),
+                'ssh_proxy_command': ssh_proxy_command,
 
                 # Azure only:
                 'azure_subscription_id': azure_subscription_id,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -781,6 +781,8 @@ def write_cluster_config(
     yaml_path = _get_yaml_path_from_cluster_name(cluster_name)
 
     # Retrieve the ssh_proxy_command for the given region.
+    # TODO(zhwu/zongheng): This may need to distinguish between different
+    # cloud providers, i.e. the dict should take cloud + region as key.
     ssh_proxy_command_config = skypilot_config.get_nested(
         ('auth', 'ssh_proxy_command'), None)
     if isinstance(ssh_proxy_command_config, dict):

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -797,13 +797,11 @@ def write_cluster_config(
         elif not isinstance(ssh_proxy_command, str):
             raise ValueError(
                 'Invalid ssh_proxy_command config (expected a str): '
-                f'{ssh_proxy_command_config!r}'
-            )
+                f'{ssh_proxy_command_config!r}')
     else:
         raise ValueError(
             'Invalid ssh_proxy_command config (expected a str or a dict with '
-            f'region names as keys): {ssh_proxy_command_config!r}'
-        )
+            f'region names as keys): {ssh_proxy_command_config!r}')
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -792,7 +792,7 @@ def write_cluster_config(
             # Skip this region. The upper layer will handle the failover to
             # other regions.
             raise exceptions.ResourcesUnavailableError(
-                f'No ssh_proxy_command provided for region {region_name}. Skip.'
+                f'No ssh_proxy_command provided for region {region_name}. Skipped.'
             )
         elif not isinstance(ssh_proxy_command, str):
             raise ValueError(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -783,7 +783,10 @@ def write_cluster_config(
     # Retrieve the ssh_proxy_command for the given cloud / region.
     ssh_proxy_command_config = skypilot_config.get_nested(
         (str(cloud).lower(), 'ssh_proxy_command'), None)
-    if isinstance(ssh_proxy_command_config, dict):
+    if (isinstance(ssh_proxy_command_config, str) or
+          ssh_proxy_command_config is None):
+        ssh_proxy_command = ssh_proxy_command_config
+    elif isinstance(ssh_proxy_command_config, dict):
         ssh_proxy_command = ssh_proxy_command_config.get(region_name, None)
         if ssh_proxy_command is None:
             # Skip this region. The upper layer will handle the failover to
@@ -795,9 +798,6 @@ def write_cluster_config(
             raise ValueError(
                 f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}'
             )
-    elif isinstance(ssh_proxy_command_config,
-                    str) or ssh_proxy_command_config is None:
-        ssh_proxy_command = ssh_proxy_command_config
     else:
         raise ValueError(
             f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -796,7 +796,7 @@ def write_cluster_config(
             )
         elif not isinstance(ssh_proxy_command, str):
             raise ValueError(
-                f'Invalid ssh_proxy_command config: {ssh_proxy_command_config!r}'
+                f'Invalid ssh_proxy_command config (expected a str): {ssh_proxy_command_config!r}'
             )
     else:
         raise ValueError(

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -554,8 +554,11 @@ def spot_launch(
             # controller VPC (or name) == the spot job's VPC (or name). It may
             # not be a sufficient check (as it's always possible that peering
             # is not set up), but it may catch some obvious errors.
+            # TODO(zhwu): hacky. We should pop the proxy command of the cloud
+            # where the controller is launched (currently, only aws user uses
+            # proxy_command).
             config_dict = skypilot_config.pop_nested(
-                ('auth', 'ssh_proxy_command'))
+                ('aws', 'ssh_proxy_command'))
             with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmpfile:
                 common_utils.dump_yaml(tmpfile.name, config_dict)
                 vars_to_fill.update({


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Per user request, this PR supports per-region ssh proxy command.

Here is the new `~/.sky/config.yaml`:
```
aws:
  # The VPC to use in each region.
  #
  # If this is set, any region without a unique VPC with this name will not be
  # able to launch SkyPilot nodes. SkyPilot's failover will still properly
  # function to look for such an eligible region.
  #
  # Optional; default: None (SkyPilot will use the default VPC in each region).
  vpc_name: skypilot-vpc

  # Set to true to use private IPs to communicate between the local client and
  # any SkyPilot nodes. This requires the networking stack is properly set up;
  # in particular, this flag requires the existence of subnets with name tags
  # containing the substring "private", which will be used to hold SkyPilot
  # nodes.
  #
  # This flag is typically set together with 'vpc_name' above and
  # 'auth.ssh_proxy_command'.
  #
  # Optional; default: False.
  use_internal_ips: True

  # If set, this is passed as the '-o ProxyCommand' option for any SSH
  # connections (including rsync) used to communicate between the local client
  # and any SkyPilot nodes. This option is not used between SkyPilot nodes,
  # since they may not have such a proxy set up.
  #
  # Useful for using a jump server to communicate with SkyPilot nodes hosted in
  # private subnets without public IPs.
  #
  # Optional; default: None.
  # use the same proxy command for all the regions
  # ssh_proxy_command: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@ip1
  #
  # Or, it is possible to specify per-region proxy command
  ssh_proxy_command:
      us-east-1: ssh -W %h:%p -i ~/.ssh/key1 -o StrictHostKeyChecking=no ec2-user@ip1
      us-east-2: ssh -W %h:%p -i ~/.ssh/key2 -o StrictHostKeyChecking=no ec2-user@ip2
```

TODO:
- [x] distinguish the cloud providers for the per-region proxy command.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Launch jump servers on us-east-1 and us-east-2, and add them in the config file.
- [x] `sky launch -c test-private-east-1 -t t3.xlarge --cloud aws --region us-east-1 echo hi`
- [x] `sky launch -c test-private-east-2 -t t3.xlarge --cloud aws --region us-east-1 echo hi`
- [x] `sky launch -c test-private-no-region -t t3.xlarge --cloud aws echo hi`
- [x] `sky spot launch -n test-private echo hi`
- [x] `sky launch -c test-public --gpus A100:8 -- cloud AWS` the failover works.