### PR TITLE
[Usage] Increase timeout for queries

### DIFF
--- a/sky/usage/loki-s3-config.yaml
+++ b/sky/usage/loki-s3-config.yaml
@@ -2,6 +2,8 @@ auth_enabled: false
 
 server:
   http_listen_port: 9090
+  http_server_read_timeout: 300s
+  http_server_write_timeout: 300s
 
 schema_config:
   configs:
@@ -39,6 +41,9 @@ storage_config:
     shared_store: s3
     cache_location: /loki/boltdb-cache
 
+querier:
+  query_timeout: 10m
+  max_concurrent: 32
 query_scheduler:
   max_outstanding_requests_per_tenant: 4096
 frontend:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This fix the issue that our hosted loki server cannot be executed on a smaller instance. After increasing the timeout, the loki server can now be run on a1.xlarge instance, which is 73% cheaper than the previous m6i.2xlarge.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] The grafana dashboard works
