### PR TITLE
Various UX Fixes

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1870,6 +1870,11 @@ class CloudVmRayBackend(backends.Backend):
                 return [ips[1] for ips in self.stable_internal_external_ips]
             return None
 
+        def get_hourly_price(self) -> float:
+            hourly_cost = (self.launched_resources.get_cost(3600) *
+                           self.launched_nodes)
+            return hourly_cost
+
         @property
         def cluster_yaml(self):
             return os.path.expanduser(self._cluster_yaml)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2185,11 +2185,12 @@ def _down_or_stop_clusters(
                 assert len(reserved_clusters) == 1, reserved_clusters
                 _hint_for_down_spot_controller(reserved_clusters[0])
 
-                click.confirm('Proceed?',
-                              default=False,
-                              abort=True,
-                              show_default=True)
-                no_confirm = True
+                if not no_confirm:
+                    click.confirm('Proceed?',
+                                  default=False,
+                                  abort=True,
+                                  show_default=True)
+                    no_confirm = True
         names += reserved_clusters
 
     if apply_to_all:
@@ -2939,9 +2940,15 @@ def spot_launch(
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
+@click.option('--skip-finished',
+              '-s',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Show only pending/running jobs\' information.')
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def spot_queue(all: bool, refresh: bool):
+def spot_queue(all: bool, refresh: bool, skip_finished: bool):
     """Show statuses of managed spot jobs.
 
     \b
@@ -2972,7 +2979,8 @@ def spot_queue(all: bool, refresh: bool):
     """
     click.secho('Fetching managed spot job statuses...', fg='yellow')
     try:
-        job_table = core.spot_queue(refresh=refresh)
+        job_table = core.spot_queue(refresh=refresh,
+                                    skip_finished=skip_finished)
     except exceptions.ClusterNotUpError:
         cache = spot_lib.load_job_table_cache()
         if cache is not None:

--- a/sky/core.py
+++ b/sky/core.py
@@ -15,7 +15,6 @@ from sky import spot
 from sky.backends import backend_utils
 from sky.skylet import constants
 from sky.skylet import job_lib
-from sky.spot import spot_state
 from sky.usage import usage_lib
 from sky.utils import tpu_utils
 from sky.utils import ux_utils
@@ -636,7 +635,8 @@ def spot_status(refresh: bool) -> List[Dict[str, Any]]:
 
 
 @usage_lib.entrypoint
-def spot_queue(refresh: bool, skip_finished: bool) -> List[Dict[str, Any]]:
+def spot_queue(refresh: bool,
+               skip_finished: bool = False) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -652,7 +652,7 @@ def spot_queue(refresh: bool,
                 'end_at': (float) timestamp of end,
                 'duration': (float) duration in seconds,
                 'retry_count': int Number of retries,
-                'status': spot_state.SpotStatus status of the job,
+                'status': sky.JobStatus status of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
             }

--- a/sky/core.py
+++ b/sky/core.py
@@ -700,8 +700,7 @@ def spot_queue(refresh: bool, skip_finished: bool) -> List[Dict[str, Any]]:
 
     jobs = spot.load_spot_job_queue(job_table_payload)
     if skip_finished:
-        jobs = list(
-            filter(lambda job: not job['status'].is_terminal(), jobs))
+        jobs = list(filter(lambda job: not job['status'].is_terminal(), jobs))
     return jobs
 
 

--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -7,6 +7,8 @@ import sqlite3
 import time
 from typing import Any, Dict, List, Optional
 
+import colorama
+
 from sky import sky_logging
 from sky.backends import backend_utils
 
@@ -68,6 +70,10 @@ class SpotStatus(enum.Enum):
     def is_failed(self) -> bool:
         return self in self.failure_statuses()
 
+    def colored_str(self):
+        color = _SPOT_STATUS_TO_COLOR[self]
+        return f'{color}{self.value}{colorama.Style.RESET_ALL}'
+
     @classmethod
     def terminal_statuses(cls) -> List['SpotStatus']:
         return [
@@ -79,6 +85,18 @@ class SpotStatus(enum.Enum):
     def failure_statuses(cls) -> List['SpotStatus']:
         return [cls.FAILED, cls.FAILED_NO_RESOURCE, cls.FAILED_CONTROLLER]
 
+_SPOT_STATUS_TO_COLOR = {
+    SpotStatus.PENDING: colorama.Fore.BLUE,
+    SpotStatus.SUBMITTED: colorama.Fore.BLUE,
+    SpotStatus.STARTING: colorama.Fore.BLUE,
+    SpotStatus.RUNNING: colorama.Fore.GREEN,
+    SpotStatus.RECOVERING: colorama.Fore.CYAN,
+    SpotStatus.SUCCEEDED: colorama.Fore.GREEN,
+    SpotStatus.FAILED: colorama.Fore.RED,
+    SpotStatus.FAILED_NO_RESOURCE: colorama.Fore.RED,
+    SpotStatus.FAILED_CONTROLLER: colorama.Fore.RED,
+    SpotStatus.CANCELLED: colorama.Fore.YELLOW,
+}
 
 # === Status transition functions ===
 def set_pending(job_id: int, name: str, resources_str: str):

--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -85,6 +85,7 @@ class SpotStatus(enum.Enum):
     def failure_statuses(cls) -> List['SpotStatus']:
         return [cls.FAILED, cls.FAILED_NO_RESOURCE, cls.FAILED_CONTROLLER]
 
+
 _SPOT_STATUS_TO_COLOR = {
     SpotStatus.PENDING: colorama.Fore.BLUE,
     SpotStatus.SUBMITTED: colorama.Fore.BLUE,
@@ -97,6 +98,7 @@ _SPOT_STATUS_TO_COLOR = {
     SpotStatus.FAILED_CONTROLLER: colorama.Fore.RED,
     SpotStatus.CANCELLED: colorama.Fore.YELLOW,
 }
+
 
 # === Status transition functions ===
 def set_pending(job_id: int, name: str, resources_str: str):

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -416,7 +416,7 @@ def format_job_table(jobs: List[Dict[str, Any]], show_all: bool) -> str:
                                              absolute=True),
             job_duration,
             job['recovery_count'],
-            job['status'].value,
+            job['status'].colored_str(),
         ]
         if not job['status'].is_terminal():
             status_counts[job['status'].value] += 1

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -262,9 +262,7 @@ def _get_autostop(cluster_status):
 
 
 def _get_price(cluster_status):
-    handle = cluster_status['handle']
-    hourly_cost = (handle.launched_resources.get_cost(3600) *
-                   handle.launched_nodes)
+    hourly_cost = cluster_status['handle'].get_hourly_price()
     price_str = f'$ {hourly_cost:.3f}'
     return price_str
 


### PR DESCRIPTION
Addresses #1565, #1570, #1482 and various other bug fixes/small additions:

* Add move hourly price computation from `status_utils` to `get_hourly_price` method so it can be accessed after `core.status`
* Added confirmation before cancelling jobs
* Remove confirmation when `--yes` is specified for `sky down` of spot controller
* Add `--skip-finished` flag to `sky spot queue`
* Color statuses in `sky spot queue`