### PR TITLE
[State] Disable WAL when running on WSL

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -29,10 +29,17 @@ _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 
 
+def is_wsl() -> bool:
+    """Detect if running under WSL"""
+    import platform
+    return 'microsoft' in platform.uname()[3].lower()
+
+
 def create_table(cursor, conn):
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
-    conn.execute('PRAGMA journal_mode=WAL')
+    if not is_wsl():
+        conn.execute('PRAGMA journal_mode=WAL')
     # Table for Clusters
     cursor.execute("""\
         CREATE TABLE IF NOT EXISTS clusters (

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -29,16 +29,10 @@ _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 
 
-def is_wsl() -> bool:
-    """Detect if running under WSL"""
-    import platform
-    return 'microsoft' in platform.uname()[3].lower()
-
-
 def create_table(cursor, conn):
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
-    if not is_wsl():
+    if not common_utils.is_wsl():
         conn.execute('PRAGMA journal_mode=WAL')
     # Table for Clusters
     cursor.execute("""\

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -352,3 +352,9 @@ def remove_file_if_exists(path: str):
     except FileNotFoundError:
         logger.debug(f'Tried to remove {path} but failed to find it. Skip.')
         pass
+
+
+def is_wsl() -> bool:
+    """Detect if running under WSL"""
+    import platform
+    return 'microsoft' in platform.uname()[3].lower()


### PR DESCRIPTION
We enabled write ahead logging for state.db in #1513, but it breaks compatibility for WSL (`sqlite3.OperationalError: locking protocol`; see [wsl issue](https://github.com/microsoft/WSL/issues/2395#issuecomment-339913847)), particularly when running tests.

This PR puts a check for WSL before enabling WAL on `state.db`.

Note that this "fix" is a band-aid. We _may_ still see issues when WSL users try to access state.db concurrently from multiple processes.

This PR does not touch WAL for `skylet_config.db`.  

Tested (run the relevant ones):

- [x] A small smoke test (`bash tests/run_smoke_tests.sh using_file_mounts`) on WSL to ensure fix works
- [ ] Snippet from #1509 on ubuntu machine
- [ ] Can someone help test mac (by running snippet from #1509)?