### PR TITLE
AWS/private VPC: make no-usable-subnet errors trigger failover.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1603,7 +1603,8 @@ def _ray_launch_hash(cluster_name: str,
         # TODO(zongheng): is this safe? Could it be node(s) are live but somehow a
         # separate status refresh hits such errors?
         if 'SKYPILOT_ERROR_NO_NODES_LAUNCHED' in str(e):
-            logger.error(e)
+            logger.error('Error found when refreshing cluster status: ' +
+                         str(e))
             return None
         raise e
     # Adopted from https://github.com/ray-project/ray/blob/ray-2.0.1/python/ray/autoscaler/_private/node_launcher.py#L87-L97

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1603,8 +1603,7 @@ def _ray_launch_hash(cluster_name: str,
         # TODO(zongheng): is this safe? Could it be node(s) are live but somehow a
         # separate status refresh hits such errors?
         if 'SKYPILOT_ERROR_NO_NODES_LAUNCHED' in str(e):
-            logger.error('Error found when refreshing cluster status: ' +
-                         str(e))
+            logger.error(f'Error found when refreshing cluster status: {e}')
             return None
         raise e
     # Adopted from https://github.com/ray-project/ray/blob/ray-2.0.1/python/ray/autoscaler/_private/node_launcher.py#L87-L97

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1904,10 +1904,11 @@ def _update_cluster_status_no_lock(
         # We have not experienced the above; adding as a safeguard.
         #
         # Since we failed to refresh, warn and return old record.
-        logger.warn(f'Failed to refresh status for cluster {cluster_name!r} '
-                    f'due to {len(node_statuses)} nodes being found with the '
-                    'same name tag, but the cluster should have '
-                    f'{handle.launched_nodes} nodes. Keeping the old status.')
+        logger.warning(
+            f'Failed to refresh status for cluster {cluster_name!r} '
+            f'due to {len(node_statuses)} nodes being found with the '
+            'same name tag, but the cluster should have '
+            f'{handle.launched_nodes} nodes. Keeping the old status.')
         return record
     assert len(node_statuses) <= handle.launched_nodes
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1580,8 +1580,15 @@ def _process_cli_query(
     ]
 
 
-def _ray_launch_hash(cluster_name: str, ray_config: Dict[str, Any]) -> Set[str]:
-    """Returns a set of Ray launch config hashes, one per node type."""
+def _ray_launch_hash(cluster_name: str,
+                     ray_config: Dict[str, Any]) -> Optional[Set[str]]:
+    """Returns a set of Ray launch config hashes, one per node type.
+
+    This returns None if ray's _bootstrap_config() failed to return, which can
+    happen if node providers' bootstrapping phase (config.py) raises an error
+    (which *should* only happen on errors prior to nodes launching, e.g.,
+    VPC/subnet setup).
+    """
     # Use the cached Ray launch hashes if they exist.
     metadata = global_user_state.get_cluster_metadata(cluster_name)
     assert metadata is not None, cluster_name
@@ -1589,8 +1596,16 @@ def _ray_launch_hash(cluster_name: str, ray_config: Dict[str, Any]) -> Set[str]:
     if ray_launch_hashes is not None:
         logger.debug('Using cached launch_hashes.')
         return set(ray_launch_hashes)
-    with ux_utils.suppress_output():
-        ray_config = ray_commands._bootstrap_config(ray_config)  # pylint: disable=protected-access
+    try:
+        with ux_utils.suppress_output():
+            ray_config = ray_commands._bootstrap_config(ray_config)  # pylint: disable=protected-access
+    except RuntimeError as e:
+        # TODO(zongheng): is this safe? Could it be node(s) are live but somehow a
+        # separate status refresh hits such errors?
+        if 'SKYPILOT_ERROR_NO_NODES_LAUNCHED' in str(e):
+            logger.error(e)
+            return None
+        raise e
     # Adopted from https://github.com/ray-project/ray/blob/ray-2.0.1/python/ray/autoscaler/_private/node_launcher.py#L87-L97
     # TODO(zhwu): this logic is duplicated from the ray code above (keep in
     # sync).
@@ -1644,10 +1659,15 @@ def _query_status_aws(
     }
     region = ray_config['provider']['region']
     launch_hashes = _ray_launch_hash(cluster, ray_config)
-    hash_filter_str = ','.join(launch_hashes)
+    if launch_hashes is not None:
+        hash_filter_str = ','.join(launch_hashes)
+        hash_filter_line = (
+            f'Name=tag:ray-launch-config,Values={hash_filter_str} ')
+    else:
+        hash_filter_line = ''
     query_cmd = ('aws ec2 describe-instances --filters '
                  f'Name=tag:ray-cluster-name,Values={cluster} '
-                 f'Name=tag:ray-launch-config,Values={hash_filter_str} '
+                 f'{hash_filter_line}'
                  f'--region {region} '
                  '--query "Reservations[].Instances[].State.Name" '
                  '--output text')
@@ -1659,6 +1679,7 @@ def _query_status_gcp(
     ray_config: Dict[str, Any],
 ) -> List[global_user_state.ClusterStatus]:
     launch_hashes = _ray_launch_hash(cluster, ray_config)
+    assert launch_hashes is not None
     hash_filter_str = ' '.join(launch_hashes)
 
     use_tpu_vm = ray_config['provider'].get('_has_tpus', False)
@@ -1745,6 +1766,7 @@ def _query_status_azure(
         'VM deallocated': global_user_state.ClusterStatus.STOPPED,
     }
     launch_hashes = _ray_launch_hash(cluster, ray_config)
+    assert launch_hashes is not None
     hash_filter_str = ', '.join(f'\\"{h}\\"' for h in launch_hashes)
     query_cmd = (
         'az vm show -d --ids $(az vm list --query '
@@ -1865,6 +1887,29 @@ def _update_cluster_status_no_lock(
                      f'{cluster_name!r}, trying to fetch from provider.')
     # For all code below, ray fails to get IPs for the cluster.
     node_statuses = _get_cluster_status_via_cloud_cli(handle)
+
+    if len(node_statuses) > handle.launched_nodes:
+        # Unexpected: this could mean ray launch hash is not calculated and we
+        # used the cluster name as the only filter when querying the cloud
+        # provider, and in the queried region more than 1 cluster with the same
+        # constructed name tag returned. This will typically not happen unless
+        # users manually create a cluster with that constructed name.
+        #
+        # (Technically speaking, even if returned num nodes <= num
+        # handle.launched_nodes), not including the launch hash could mean the
+        # returned nodes contain some nodes that do not belong to the logical
+        # skypilot cluster. Doesn't seem to be a good way to handle this for
+        # now?)
+        #
+        # We have not experienced the above; adding as a safeguard.
+        #
+        # Since we failed to refresh, warn and return old record.
+        logger.warn(f'Failed to refresh status for cluster {cluster_name!r} '
+                    f'due to {len(node_statuses)} nodes being found with the '
+                    'same name tag, but the cluster should have '
+                    f'{handle.launched_nodes} nodes. Keeping the old status.')
+        return record
+    assert len(node_statuses) <= handle.launched_nodes
 
     # If the node_statuses is empty, all the nodes are terminated. We can
     # safely set the cluster status to TERMINATED. This handles the edge case

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -72,7 +72,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = 90
 _RETRY_UNTIL_UP_INIT_GAP_SECONDS = 60
 
 # The maximum retry count for fetching IP address.
-_FETCH_IP_MAX_ATTEMPTS = 5
+_FETCH_IP_MAX_ATTEMPTS = 3
 
 _TEARDOWN_FAILURE_MESSAGE = (
     f'\n{colorama.Fore.RED}Failed to terminate '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1224,7 +1224,6 @@ class RetryingVmProvisioner(object):
                                  if terminate_or_stop else 'Stopping')
                 logger.error(f'*** {terminate_str} the failed cluster. ***')
 
-            backend = CloudVmRayBackend()
             # If these conditions hold, it *should* be safe to skip the cleanup
             # action.
             #
@@ -1233,26 +1232,19 @@ class RetryingVmProvisioner(object):
             # down the non-existent cluster will itself error out with the same
             # error message.  This was found to be confusing. In that case we
             # skip termination.
+            skip_cleanup = not cluster_exists and definitely_no_nodes_launched
+            if skip_cleanup:
+                continue
+
+            # There may exist partial nodes (e.g., head node) so we must
+            # terminate or stop before moving on to other regions.
             #
-            # However, we should still call post_teardown_cleanup() to remove
-            # the cluster record from the status table. Otherwise, failover
-            # will soon call _query_status_<cloud>, which calls into
-            # _ray_launch_hash, which calls node provider bootstrapping again,
-            # exiting the whole program.
-            post_teardown_cleanup_only = (not cluster_exists and
-                                          definitely_no_nodes_launched)
-            if post_teardown_cleanup_only:
-                backend.post_teardown_cleanup(handle,
-                                              terminate=terminate_or_stop)
-            else:
-                # There may exist partial nodes (e.g., head node) so we must
-                # terminate or stop before moving on to other regions.
-                #
-                # NOTE: even HEAD_FAILED could've left a live head node there,
-                # so we must terminate/stop here too. E.g., node is up, and ray
-                # autoscaler proceeds to setup commands, which may fail:
-                #   ERR updater.py:138 -- New status: update-failed
-                backend.teardown_no_lock(handle, terminate=terminate_or_stop)
+            # NOTE: even HEAD_FAILED could've left a live head node there,
+            # so we must terminate/stop here too. E.g., node is up, and ray
+            # autoscaler proceeds to setup commands, which may fail:
+            #   ERR updater.py:138 -- New status: update-failed
+            CloudVmRayBackend().teardown_no_lock(handle,
+                                                 terminate=terminate_or_stop)
 
         if to_provision.zone is not None:
             message = (

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1225,7 +1225,7 @@ class RetryingVmProvisioner(object):
                 logger.error(f'*** {terminate_str} the failed cluster. ***')
 
             # If these conditions hold, it *should* be safe to skip the cleanup
-            # action.
+            # action. This is a UX optimization.
             #
             # We want to skip mainly for VPC/subnets errors thrown during node
             # provider bootstrapping: if users encountered "No VPC with name

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1227,11 +1227,12 @@ class RetryingVmProvisioner(object):
             # If these conditions hold, it *should* be safe to skip the cleanup
             # action.
             #
-            # We want to skip mainly for custom VPC: if users encountered "No
-            # VPC with name 'xxx' is found in <region>.", then going ahead to
-            # down the non-existent cluster will itself error out with the same
-            # error message.  This was found to be confusing. In that case we
-            # skip termination.
+            # We want to skip mainly for VPC/subnets errors thrown during node
+            # provider bootstrapping: if users encountered "No VPC with name
+            # 'xxx' is found in <region>.", then going ahead to down the
+            # non-existent cluster will itself print out a (caught, harmless)
+            # error with the same message.  This was found to be
+            # confusing. Thus we skip termination.
             skip_cleanup = not cluster_exists and definitely_no_nodes_launched
             if skip_cleanup:
                 continue

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -629,7 +629,7 @@ def _usable_subnet_ids(
                 "availability zone or try manually creating an instance in "
                 "your specified region to populate the list of subnets and "
                 "trying this again. If you have set `use_internal_ips`, check "
-                "that this zone has a subnet that (1) has the substring 'private' in its name tag "
+                "that this zone has a subnet that (1) has the word 'private' in its name tag "
                 "and (2) does not assign public IPs (`map_public_ip_on_launch` is False)."
             )
         elif _are_user_subnets_pruned(subnets):

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -286,7 +286,9 @@ def _configure_iam_role(config, skypilot_iam_role: bool):
             # SkyPilot: let the workers use the same role as the head node, so that they
             # can access private S3 buckets.
             for node_type in config["available_node_types"].values():
-                node_type["node_config"]["IamInstanceProfile"] = head_node_config['IamInstanceProfile']
+                node_type["node_config"]["IamInstanceProfile"] = head_node_config[
+                    "IamInstanceProfile"
+                ]
         return config
     _set_config_info(head_instance_profile_src="default")
 
@@ -337,7 +339,6 @@ def _configure_iam_role(config, skypilot_iam_role: bool):
                     "arn:aws:iam::aws:policy/AmazonS3FullAccess",
                 ],
             )
-            
 
             iam.create_role(
                 RoleName=role_name, AssumeRolePolicyDocument=json.dumps(policy_doc)
@@ -369,10 +370,10 @@ def _configure_iam_role(config, skypilot_iam_role: bool):
                         "Effect": "Allow",
                         "Action": "iam:GetInstanceProfile",
                         "Resource": profile.arn,
-                    }
+                    },
                 ]
             }
-            if skypilot_iam_role:       
+            if skypilot_iam_role:
                 role.Policy("SkyPilotPassRolePolicy").put(
                     PolicyDocument=json.dumps(skypilot_pass_role_policy_doc)
                 )
@@ -456,7 +457,7 @@ def _configure_key_pair(config):
             break
 
     if not key:
-        cli_logger.abort(
+        _skypilot_log_error_and_exit_for_failover(
             "No matching local key file for any of the key pairs in this "
             "account with ids from 0..{}. "
             "Consider deleting some unused keys pairs from your account.",
@@ -599,16 +600,16 @@ def _usable_subnet_ids(
         raise exc
 
     if not subnets:
-        cli_logger.abort(
+        _skypilot_log_error_and_exit_for_failover(
             f"No usable subnets found for node type {node_type_key}, try "
             "manually creating an instance in your specified region to "
-            "populate the list of subnets and trying this again.\n"
+            "populate the list of subnets and trying this again. "
             "Note that the subnet must map public IPs "
             "on instance launch unless you set `use_internal_ips: true` in "
             "the `provider` config."
         )
     elif _are_user_subnets_pruned(subnets):
-        cli_logger.abort(
+        _skypilot_log_error_and_exit_for_failover(
             f"The specified subnets for node type {node_type_key} are not "
             f"usable: {_get_pruned_subnets(subnets)}"
         )
@@ -622,18 +623,20 @@ def _usable_subnet_ids(
             if s.availability_zone == az
         ]
         if not subnets:
-            cli_logger.abort(
+            _skypilot_log_error_and_exit_for_failover(
                 f"No usable subnets matching availability zone {azs} found "
-                f"for node type {node_type_key}.\nChoose a different "
+                f"for node type {node_type_key}. Choose a different "
                 "availability zone or try manually creating an instance in "
                 "your specified region to populate the list of subnets and "
-                "trying this again."
+                "trying this again. If you have set `use_internal_ips`, check "
+                "that this zone has a subnet that (1) has the word 'private' in its name tag "
+                "and (2) does not assign public IPs (`map_public_ip_on_launch` is False)."
             )
         elif _are_user_subnets_pruned(subnets):
-            cli_logger.abort(
+            _skypilot_log_error_and_exit_for_failover(
                 f"MISMATCH between specified subnets and Availability Zones! "
                 "The following Availability Zones were specified in the "
-                f"`provider section`: {azs}.\n The following subnets for node "
+                f"`provider section`: {azs}. The following subnets for node "
                 f"type `{node_type_key}` have no matching availability zone: "
                 f"{list(_get_pruned_subnets(subnets))}."
             )
@@ -647,11 +650,10 @@ def _usable_subnet_ids(
     subnets = [s.subnet_id for s in subnets if s.vpc_id == subnets[0].vpc_id]
     if _are_user_subnets_pruned(subnets):
         subnet_vpcs = {s.subnet_id: s.vpc_id for s in user_specified_subnets}
-        cli_logger.abort(
+        _skypilot_log_error_and_exit_for_failover(
             f"Subnets specified in more than one VPC for node type `{node_type_key}`! "
             f"Please ensure that all subnets share the same VPC and retry your "
-            "request. Subnet VPCs: {}",
-            subnet_vpcs,
+            f"request. Subnet VPCs: {subnet_vpcs}"
         )
     return subnets, first_subnet_vpc_id
 
@@ -724,6 +726,18 @@ def _configure_subnet(config):
     return config
 
 
+def _skypilot_log_error_and_exit_for_failover(error: str) -> None:
+    """Log an error message then sys.exit(1) to trigger failover.
+
+    This is mainly used for handling VPC/subnet errors before nodes are launched.
+    """
+    # NOTE: keep. The backend looks for this to know no nodes are launched.
+    prefix = "SKYPILOT_ERROR_NO_NODES_LAUNCHED: "
+    logger.error(prefix + error)
+    # Raising would exit the caller, while exit triggers SkyPilot failover.
+    sys.exit(1)
+
+
 def _get_vpc_id_by_name(vpc_name: str, config: Dict[str, Any]) -> str:
     """Returns the VPC ID of the unique VPC with a given name.
 
@@ -736,22 +750,18 @@ def _get_vpc_id_by_name(vpc_name: str, config: Dict[str, Any]) -> str:
     filters = [{"Name": "tag:Name", "Values": [vpc_name]}]
     vpcs = [vpc for vpc in ec2.vpcs.filter(Filters=filters)]
     if not vpcs:
-        logger.error(
-            f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: No VPC with name {vpc_name!r} is found "
+        _skypilot_log_error_and_exit_for_failover(
+            f"No VPC with name {vpc_name!r} is found "
             f'in {config["provider"]["region"]}. '
             "To fix: specify a correct VPC name."
         )
-        # Raising would exit the caller, while exit triggers SkyPilot failover.
-        sys.exit(1)
     elif len(vpcs) > 1:
-        logger.error(
-            f"SKYPILOT_ERROR_NO_NODES_LAUNCHED: Multiple VPCs with name {vpc_name!r} "
+        _skypilot_log_error_and_exit_for_failover(
+            f"Multiple VPCs with name {vpc_name!r} "
             f'found in {config["provider"]["region"]}: {vpcs}. '
             "It is ambiguous as to which VPC to use. To fix: specify a "
             "VPC name that is uniquely identifying."
         )
-        # Raising would exit the caller, while exit triggers SkyPilot failover.
-        sys.exit(1)
     assert len(vpcs) == 1, vpcs
     return vpcs[0].id
 
@@ -838,7 +848,7 @@ def _check_ami(config):
         node_ami = node_config.get("ImageId", "").lower()
         if node_ami in ["", "latest_dlami"]:
             if not default_ami:
-                cli_logger.abort(
+                _skypilot_log_error_and_exit_for_failover(
                     f"Node type `{key}` has no ImageId in its node_config "
                     f"and no default AMI is available for the region `{region}`. "
                     "ImageId will need to be set manually in your cluster config."

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -3,7 +3,6 @@ import itertools
 import json
 import logging
 import os
-import sys
 import time
 from distutils.version import StrictVersion
 from functools import lru_cache, partial

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -629,7 +629,7 @@ def _usable_subnet_ids(
                 "availability zone or try manually creating an instance in "
                 "your specified region to populate the list of subnets and "
                 "trying this again. If you have set `use_internal_ips`, check "
-                "that this zone has a subnet that (1) has the word 'private' in its name tag "
+                "that this zone has a subnet that (1) has the substring 'private' in its name tag "
                 "and (2) does not assign public IPs (`map_public_ip_on_launch` is False)."
             )
         elif _are_user_subnets_pruned(subnets):

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -37,7 +37,6 @@ SKYPILOT = "skypilot"
 DEFAULT_SKYPILOT_INSTANCE_PROFILE = SKYPILOT + "-v1"
 DEFAULT_SKYPILOT_IAM_ROLE = SKYPILOT + "-v1"
 
-
 # V61.0 has CUDA 11.2
 DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"
 
@@ -629,7 +628,7 @@ def _usable_subnet_ids(
                 "availability zone or try manually creating an instance in "
                 "your specified region to populate the list of subnets and "
                 "trying this again. If you have set `use_internal_ips`, check "
-                "that this zone has a subnet that (1) has the word 'private' in its name tag "
+                "that this zone has a subnet that (1) has the substring 'private' in its name tag "
                 "and (2) does not assign public IPs (`map_public_ip_on_launch` is False)."
             )
         elif _are_user_subnets_pruned(subnets):
@@ -727,15 +726,13 @@ def _configure_subnet(config):
 
 
 def _skypilot_log_error_and_exit_for_failover(error: str) -> None:
-    """Log an error message then sys.exit(1) to trigger failover.
+    """Logs an message then raises a specific RuntimeError to trigger failover.
 
-    This is mainly used for handling VPC/subnet errors before nodes are launched.
+    Mainly used for handling VPC/subnet errors before nodes are launched.
     """
     # NOTE: keep. The backend looks for this to know no nodes are launched.
     prefix = "SKYPILOT_ERROR_NO_NODES_LAUNCHED: "
-    logger.error(prefix + error)
-    # Raising would exit the caller, while exit triggers SkyPilot failover.
-    sys.exit(1)
+    raise RuntimeError(prefix + error)
 
 
 def _get_vpc_id_by_name(vpc_name: str, config: Dict[str, Any]) -> str:

--- a/sky/skylet/providers/aws/node_provider.py
+++ b/sky/skylet/providers/aws/node_provider.py
@@ -98,9 +98,10 @@ def list_ec2_instances(
 
 class AWSNodeProvider(NodeProvider):
     """Deprecated for SkyPilot and kept for backward compatibility.
-    
+
     The cluster launch template has been updated to use AWSNodeProviderV2.
     """
+
     max_terminate_nodes = 1000
 
     def __init__(self, provider_config, cluster_name):
@@ -671,9 +672,9 @@ class AWSNodeProvider(NodeProvider):
 class AWSNodeProviderV2(AWSNodeProvider):
     """Same as V1, except head and workers use a SkyPilot IAM role.
 
-    The new version of the AWS node provider supports AWS SSO 
-    (see #1489), by using a new IAM role with different permissions 
-    than the original ray-autoscaler-v1 for both the head node and 
+    The new version of the AWS node provider supports AWS SSO
+    (see #1489), by using a new IAM role with different permissions
+    than the original ray-autoscaler-v1 for both the head node and
     worker nodes.
 
     We did not overwrite the original AWSNodeProvider class to avoid
@@ -681,6 +682,7 @@ class AWSNodeProviderV2(AWSNodeProvider):
     have a new launch_hash and will have new node(s) launched, causing
     the existing nodes to leak.
     """
+
     @staticmethod
     def bootstrap_config(cluster_config):
         return bootstrap_aws(cluster_config, skypilot_iam_role=True)

--- a/sky/utils/accelerator_registry.py
+++ b/sky/utils/accelerator_registry.py
@@ -76,5 +76,5 @@ def canonicalize_accelerator_name(accelerator: str) -> str:
     # different names (e.g., A10g and A10G).
     assert len(names) > 1
     with ux_utils.print_exception_no_traceback():
-        raise ValueError(f'Accelerator name {accelerator} is ambiguous. '
+        raise ValueError(f'Accelerator name {accelerator!r} is ambiguous. '
                          f'Please choose one of {names}.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User trying out private VPC triggered the following error, because it hits a zone that doesn't have a private subnet, and the node provider threw `cli_logger.abort()` that crashed the whole program rather than triggering failover.

```
I 01-04 21:07:45 cloud_vm_ray_backend.py:1377] Launching on AWS us-east-1 (us-east-1c)
I 01-04 21:07:50 cloud_vm_ray_backend.py:733] ====== stdout ======
2023-01-04 21:07:46,516	INFO commands.py:270 -- Cluster: generate-embeddings
2023-01-04 21:07:47,009	INFO commands.py:349 -- Checking External environment settings
2023-01-04 21:07:47,009	VINFO utils.py:150 -- Creating AWS resource `ec2` in `us-east-1`
2023-01-04 21:07:49,416	VINFO utils.py:150 -- Creating AWS resource `iam` in `us-east-1`
2023-01-04 21:07:49,818	VINFO utils.py:150 -- Creating AWS resource `ec2` in `us-east-1`

I 01-04 21:07:50 cloud_vm_ray_backend.py:736] ====== stderr ======
Dropping the empty legacy field head_node. head_nodeis not supported for ray>=2.0.0. It is recommended to removehead_node from the cluster config.
Dropping the empty legacy field worker_nodes. worker_nodesis not supported for ray>=2.0.0. It is recommended to removeworker_nodes from the cluster config.
2023-01-04 21:07:50,644	PANIC config.py:626 -- No usable subnets matching availability zone ['us-east-1c'] found for node type ray.head.default.
Choose a different availability zone or try manually creating an instance in your specified region to populate the list of subnets and trying this again.
```
Moreover, user cannot `sky down` as it triggers the same error due to this being thrown in the bootstrapping stage of the node provider.

This PR changes all such abort() into triggering failover.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] (Requesting private IPs in `~/.sky/config.yaml`) Went to `us-east-1a` and changed the `private` substr in subnet name to `TYPO`; then `sky launch -c dbg --zone us-east-1a  -i2 --cloud aws  -t t3.xlarge`. This properly triggered an error, and `sky down` now on it works.
    - [x] `sky launch -c dbg --region us-east-1 -i2 --cloud aws  -t t3.xlarge` succeeded, skipping the problematic zone 
  - [x] (Not using `~/.sky/config.yaml`) A normal launch works `sky launch -c dbg --region us-east-1 -i2 --cloud aws  -t t3.xlarge
