### PR TITLE
[sqlite] Do not run sqlite when autostop is imported to avoid database locked

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -34,7 +34,7 @@ pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 def create_table(cursor, conn):
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
-    conn.execute('PRAGMA journal_mode=WAL')
+    cursor.execute('PRAGMA journal_mode=WAL')
     # Table for Clusters
     cursor.execute("""\
         CREATE TABLE IF NOT EXISTS clusters (

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -9,6 +9,8 @@ from typing import Optional
 _DB_PATH = os.path.expanduser('~/.sky/skylet_config.db')
 os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
+_table_created = False
+
 
 @contextlib.contextmanager
 def _safe_cursor():
@@ -22,20 +24,28 @@ def _safe_cursor():
         conn.commit()
         conn.close()
 
+
 def ensure_table(func: callable):
     """Ensure the table exists before calling the function."""
+
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with _safe_cursor() as c:  # Call it 'c' to avoid pylint complaining.
-            # Use WAL mode to avoid locking problem in #1507.
-            # Reference: https://stackoverflow.com/a/39265148
-            c.execute('PRAGMA journal_mode=WAL')
-            c.execute("""\
-                CREATE TABLE IF NOT EXISTS config (
-                    key TEXT PRIMARY KEY,
-                    value TEXT)""")
+        global _table_created
+        if not _table_created:
+            with _safe_cursor(
+            ) as c:  # Call it 'c' to avoid pylint complaining.
+                # Use WAL mode to avoid locking problem in #1507.
+                # Reference: https://stackoverflow.com/a/39265148
+                c.execute('PRAGMA journal_mode=WAL')
+                c.execute("""\
+                    CREATE TABLE IF NOT EXISTS config (
+                        key TEXT PRIMARY KEY,
+                        value TEXT)""")
+        _table_created = True
         return func(*args, **kwargs)
+
     return wrapper
+
 
 @ensure_table
 def get_config(key: str) -> Optional[str]:
@@ -43,6 +53,7 @@ def get_config(key: str) -> Optional[str]:
         rows = cursor.execute('SELECT value FROM config WHERE key = ?', (key,))
         for (value,) in rows:
             return value
+
 
 @ensure_table
 def set_config(key: str, value: str) -> None:

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -11,7 +11,6 @@ os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
 _table_created = False
 
-
 @contextlib.contextmanager
 def _safe_cursor():
     """A newly created, auto-commiting, auto-closing cursor."""
@@ -26,7 +25,14 @@ def _safe_cursor():
 
 
 def ensure_table(func: callable):
-    """Ensure the table exists before calling the function."""
+    """Ensure the table exists before calling the function.
+    
+    Since this module will be imported whenever `sky` is imported (due to
+    Python's package importing logic), we should avoid creating the table
+    until it's actually needed to avoid too many concurrent commit to the
+    database.
+    It solves the database locked problem in #1576.
+    """
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -27,7 +27,7 @@ def _safe_cursor():
 
 def ensure_table(func: callable):
     """Ensure the table exists before calling the function.
-    
+
     Since this module will be imported whenever `sky` is imported (due to
     Python's package importing logic), we should avoid creating the table
     until it's actually needed to avoid too many concurrent commit to the

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -11,6 +11,7 @@ os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
 _table_created = False
 
+
 @contextlib.contextmanager
 def _safe_cursor():
     """A newly created, auto-commiting, auto-closing cursor."""

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -1,5 +1,6 @@
 """Skylet configs."""
 import contextlib
+import functools
 import os
 import pathlib
 import sqlite3
@@ -13,9 +14,6 @@ os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 def _safe_cursor():
     """A newly created, auto-commiting, auto-closing cursor."""
     conn = sqlite3.connect(_DB_PATH)
-    # Use WAL mode to avoid locking problem in #1507.
-    # Reference: https://stackoverflow.com/a/39265148
-    conn.execute('PRAGMA journal_mode=WAL')
     cursor = conn.cursor()
     try:
         yield cursor
@@ -24,21 +22,29 @@ def _safe_cursor():
         conn.commit()
         conn.close()
 
+def ensure_table(func: callable):
+    """Ensure the table exists before calling the function."""
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with _safe_cursor() as c:  # Call it 'c' to avoid pylint complaining.
+            # Use WAL mode to avoid locking problem in #1507.
+            # Reference: https://stackoverflow.com/a/39265148
+            c.execute('PRAGMA journal_mode=WAL')
+            c.execute("""\
+                CREATE TABLE IF NOT EXISTS config (
+                    key TEXT PRIMARY KEY,
+                    value TEXT)""")
+        return func(*args, **kwargs)
+    return wrapper
 
-with _safe_cursor() as c:  # Call it 'c' to avoid pylint complaining.
-    c.execute("""\
-        CREATE TABLE IF NOT EXISTS config (
-            key TEXT PRIMARY KEY,
-            value TEXT)""")
-
-
+@ensure_table
 def get_config(key: str) -> Optional[str]:
     with _safe_cursor() as cursor:
         rows = cursor.execute('SELECT value FROM config WHERE key = ?', (key,))
         for (value,) in rows:
             return value
 
-
+@ensure_table
 def set_config(key: str, value: str) -> None:
     with _safe_cursor() as cursor:
         cursor.execute(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user experienced the database locked problem for her spot jobs again #1509 ([detailed logs](https://gist.github.com/Michaelvll/ef9757fa4752300c6714a734c322cf85))

The problem is caused by the sqlite command is called whenever the `autostop_lib`  module is imported, even though it is not used, creating a lot of concurrent sqlite commands.

To mitigate the problem, this PR ensures the commands are only called when needed. Also, we changed to using `cursor` to run the command for setting WAL mode instead of `connection`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - `sky launch --use-spot --cloud gcp -i 1 echo hi` and check the `~/.sky/skylet.log`
  - `sky status -r`
  - `sky spot launch -n test-autostop --cloud gcp "echo hi; sleep 1800; echo bye"` and check `sky logs sky-spot-controller...` no database locked problem.
- [x] User's own workload.