### PR TITLE
[core] Respect the block list when failover

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1096,18 +1096,18 @@ class RetryingVmProvisioner(object):
             # yield_region_zones will return zones from a region one by one,
             # but the optimizer that does the filtering will not be involved
             # until the next region.
-            filtered_zones = copy.deepcopy(zones)
+            remaining_unblocked_zones = copy.deepcopy(zones)
             for zone in zones:
                 for blocked_resources in self._blocked_resources:
                     if to_provision.copy(region=region.name,
                                          zone=zone.name).should_be_blocked_by(
                                              blocked_resources):
-                        filtered_zones.remove(zone)
+                        remaining_unblocked_zones.remove(zone)
                         break
-            if zones and not filtered_zones:
+            if zones and not remaining_unblocked_zones:
                 # Skip the region if all zones are blocked.
                 continue
-            zones = filtered_zones
+            zones = remaining_unblocked_zones
 
             if not zones:
                 # For Azure, zones is always an empty list.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1099,11 +1099,12 @@ class RetryingVmProvisioner(object):
             for zone in zones:
                 for blocked_resources in self._blocked_resources:
                     if to_provision.copy(region=region.name,
-                                         zone=zone.name).should_be_blocked_by(
-                                             blocked_resources):
+                                        zone=zone.name).should_be_blocked_by(
+                                            blocked_resources):
                         filtered_zones.remove(zone)
                         break
-            if not filtered_zones:
+            if zones and not filtered_zones:
+                # Skip the region if all zones are blocked.
                 continue
             zones = filtered_zones
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -773,7 +773,7 @@ class RetryingVmProvisioner(object):
                 resources_lib.Resources(cloud=clouds.Azure()))
         else:
             self._blocked_launchable_resources.add(
-                    launchable_resources.copy(zone=None))
+                launchable_resources.copy(zone=None))
 
     def _update_blocklist_on_local_error(
             self, launchable_resources: 'resources_lib.Resources', region,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1092,15 +1092,16 @@ class RetryingVmProvisioner(object):
             # Filter out zones that are blocked, if any.
             # This optimize the provision loop by skipping zones that are
             # indicated to be unavailable from previous provision attempts.
-            # It can happen for the provisioning on GCP, as the yield_region_zones
-            # will return zones from a region one by one, but the optimizer that
-            # does the filtering will not be involved until the next region.
+            # It can happen for the provisioning on GCP, as the
+            # yield_region_zones will return zones from a region one by one,
+            # but the optimizer that does the filtering will not be involved
+            # until the next region.
             filtered_zones = copy.deepcopy(zones)
             for zone in zones:
                 for blocked_resources in self._blocked_resources:
                     if to_provision.copy(region=region.name,
-                                        zone=zone.name).should_be_blocked_by(
-                                            blocked_resources):
+                                         zone=zone.name).should_be_blocked_by(
+                                             blocked_resources):
                         filtered_zones.remove(zone)
                         break
             if zones and not filtered_zones:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -843,7 +843,7 @@ class RetryingVmProvisioner(object):
                 'Cloud {cloud} unknown, or has not added '
                 'support for parsing and handling provision failures.')
         handler = handlers[cloud_type]
-        handler(region, zones, stdout, stderr)
+        handler(launchable_resources, region, zones, stdout, stderr)
 
         stdout_splits = stdout.split('\n')
         stderr_splits = stderr.split('\n')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1584 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --gpus A100:8 --cloud aws`, correctly failover through the regions.
  - [x] `sky launch --gpus A100:8 --use-spot --cloud aws`, correctly failover through the zones.
  - [x] `sky launch --instance-type m3-megamem-128` failover correctly (skip the region after getting the information that the whole region does not have quota).
  - [x] `sky launch --cloud azure` failover on Azure (make some change in the `azure-ray.yml.j2` to make the image invalid, to trigger the failover).
- [x] All smoke tests: `pytest tests/test_smoke.py` (with #1587 merged) 
