### PR TITLE
UX: hint for unmanaged spot; spot queue logging.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3013,8 +3013,11 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
                 table_str = cache[1]
                 # Show a helpful hint at the end, if cached table is non-empty.
                 cached_hint = (
-                    '\n\nNOTE: displaying the cached job status table '
-                    f'[last updated: {readable_time}]')
+                    '\n\nNOTE: cached job table is being shown '
+                    f'[last updated: {readable_time}].\nUse '
+                    f'{colorama.Style.BRIGHT}--refresh / -r'
+                    f'{colorama.Style.RESET_ALL} to restart the spot '
+                    'controller and see the latest job table.')
             table_message = (
                 f'\n{colorama.Fore.YELLOW}Cached job status table '
                 f'[last updated: {readable_time}]:{colorama.Style.RESET_ALL}\n'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3000,7 +3000,9 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
         job_table = core.spot_queue(refresh=refresh,
                                     skip_finished=skip_finished)
     except exceptions.ClusterNotUpError:
-        # TODO(mehul): respect skip_finished here?
+        # TODO(mehul): handle skip_finished for the cached case. E.g., change
+        # {load,dump}_job_table_cache() to use structured data, and let
+        # format_job_table() to take skip_finished.
         cache = spot_lib.load_job_table_cache()
         if cache is not None:
             readable_time = log_utils.readable_time_duration(cache[0])

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3010,8 +3010,9 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
             else:
                 table_str = cache[1]
                 # Show a helpful hint at the end, if cached table is non-empty.
-                cached_hint = ('\n\nNOTE: displaying the cached job status table '
-                               f'[last updated: {readable_time}]')
+                cached_hint = (
+                    '\n\nNOTE: displaying the cached job status table '
+                    f'[last updated: {readable_time}]')
             table_message = (
                 f'\n{colorama.Fore.YELLOW}Cached job status table '
                 f'[last updated: {readable_time}]:{colorama.Style.RESET_ALL}\n'

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -120,6 +120,7 @@ def _execute(
     idle_minutes_to_autostop: Optional[int] = None,
     no_setup: bool = False,
     # Internal only:
+    # pylint: disable=invalid-name
     _is_launched_by_spot_controller: bool = False,
 ) -> None:
     """Execute a entrypoint.
@@ -312,6 +313,7 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
     # Internal only:
+    # pylint: disable=invalid-name
     _is_launched_by_spot_controller: bool = False,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -119,6 +119,8 @@ def _execute(
     detach_run: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
     no_setup: bool = False,
+    # Internal only:
+    _is_launched_by_spot_controller: bool = False,
 ) -> None:
     """Execute a entrypoint.
 
@@ -167,6 +169,16 @@ def _execute(
             raise ValueError(
                 'Spot recovery is specified in the task. To launch the '
                 'managed spot job, please use: sky spot launch')
+    if task.use_spot and not _is_launched_by_spot_controller:
+        yellow = colorama.Fore.YELLOW
+        bold = colorama.Style.BRIGHT
+        reset = colorama.Style.RESET_ALL
+        logger.info(
+            f'{yellow}Launching an unmanaged spot task, which does not '
+            f'automatically recover from preemptions.{reset}\n{yellow}To get '
+            'automatic recovery, use managed spot instead: '
+            f'{reset}{bold}sky spot launch{reset} {yellow}or{reset} '
+            f'{bold}sky.spot_launch(){reset}.')
 
     cluster_exists = False
     if cluster_name is not None:
@@ -299,6 +311,8 @@ def launch(
     detach_setup: bool = False,
     detach_run: bool = False,
     no_setup: bool = False,
+    # Internal only:
+    _is_launched_by_spot_controller: bool = False,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a task.
@@ -373,6 +387,7 @@ def launch(
         detach_run=detach_run,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
         no_setup=no_setup,
+        _is_launched_by_spot_controller=_is_launched_by_spot_controller,
     )
 
 

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -154,7 +154,8 @@ class StrategyExecutor:
                 usage_lib.messages.usage.set_internal()
                 sky.launch(self.dag,
                            cluster_name=self.cluster_name,
-                           detach_run=True)
+                           detach_run=True,
+                           _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
             except exceptions.InvalidClusterNameError as e:
                 # The cluster name is too long.

--- a/sky/task.py
+++ b/sky/task.py
@@ -381,6 +381,10 @@ class Task:
     def need_spot_recovery(self) -> bool:
         return any(r.spot_recovery is not None for r in self.resources)
 
+    @property
+    def use_spot(self) -> bool:
+        return any(r.use_spot for r in self.resources)
+
     @num_nodes.setter
     def num_nodes(self, num_nodes: Optional[int]) -> None:
         if num_nodes is None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1553.

- Hint for unmanaged spot
- Some logging changes in `sky spot queue [-s]`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

`spot queue` logging:

<img width="679" alt="Screen Shot 2023-01-13 at 09 22 22" src="https://user-images.githubusercontent.com/592670/212381792-41e58bed-a97a-46a1-8369-b1300a424341.png">

Checked that `sky launch --use-spot` (unmanaged) prints:

<img width="1132" alt="Screen Shot 2023-01-13 at 09 23 14" src="https://user-images.githubusercontent.com/592670/212381778-969a3f02-f011-4a31-a9d5-591e77529d39.png">


Checked that `sky spot launch` then `sky logs <controller>` (managed) does not print the above.

