### PR TITLE
GCP/Azure: add `skypilot-user` tags to VMs on these clouds.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1180,6 +1180,14 @@ def launch(
     if backend_name is None:
         backend_name = backends.CloudVmRayBackend.NAME
 
+    # A basic check. Programmatic calls will have a proper (but less
+    # informative) error from optimizer.
+    if cloud.lower() == 'azure' and use_spot:
+        raise click.UsageError(
+            'SkyPilot currently has not implemented '
+            'support for spot instances on Azure. Please file '
+            'an issue if you need this feature.')
+
     task = _make_task_from_entrypoint_with_overrides(
         entrypoint=entrypoint,
         name=name,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1182,7 +1182,8 @@ def launch(
 
     # A basic check. Programmatic calls will have a proper (but less
     # informative) error from optimizer.
-    if cloud.lower() == 'azure' and use_spot:
+    if (cloud is not None and cloud.lower() == 'azure' and
+            use_spot is not None and use_spot):
         raise click.UsageError(
             'SkyPilot currently has not implemented '
             'support for spot instances on Azure. Please file '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -930,8 +930,8 @@ def _fill_in_launchable_resources(
             launchable[resources] = _make_launchables_for_valid_region_zones(
                 resources)
         else:
-            clouds_list = [resources.cloud
-                          ] if resources.cloud is not None else enabled_clouds
+            clouds_list = ([resources.cloud]
+                           if resources.cloud is not None else enabled_clouds)
             # Hack: When >=2 cloud candidates, always remove local cloud from
             # possible candidates. This is so the optimizer will consider
             # public clouds, except local. Local will be included as part of
@@ -943,8 +943,8 @@ def _fill_in_launchable_resources(
                 ]
             all_fuzzy_candidates = set()
             for cloud in clouds_list:
-                (feasible_resources, fuzzy_candidate_list
-                ) = cloud.get_feasible_launchable_resources(resources)
+                (feasible_resources, fuzzy_candidate_list) = (
+                    cloud.get_feasible_launchable_resources(resources))
                 if len(feasible_resources) > 0:
                     # Assume feasible_resources is sorted by prices.
                     cheapest = feasible_resources[0]
@@ -955,7 +955,7 @@ def _fill_in_launchable_resources(
                 else:
                     all_fuzzy_candidates.update(fuzzy_candidate_list)
             if len(launchable[resources]) == 0:
-                logger.info(f'No resource satisfying {resources.accelerators} '
+                logger.info(f'No resource satisfying {resources} '
                             f'on {clouds_list}.')
                 if len(all_fuzzy_candidates) > 0:
                     logger.info('Did you mean: '

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -28,6 +28,8 @@ available_node_types:
     ray.head.default:
       resources: {}
       node_config:
+        tags:
+          skypilot-user: {{ user }}
         azure_arm_parameters:
             vmSize: {{instance_type}}
             # List images https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage
@@ -50,6 +52,8 @@ available_node_types:
       max_workers: {{num_nodes - 1}}
       resources: {}
       node_config:
+        tags:
+          skypilot-user: {{ user }}
         azure_arm_parameters:
             vmSize: {{instance_type}}
             # List images https://docs.microsoft.com/en-us/azure/virtual-machines/linux/cli-ps-findimage

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -69,6 +69,8 @@ available_node_types:
     max_workers: {{num_nodes - 1}}
     resources: {}
     node_config:
+      labels:
+        skypilot-user: {{ user }}
   {%- if tpu_vm %}
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -29,6 +29,8 @@ available_node_types:
   ray_head_default:
     resources: {}
     node_config:
+      labels:
+        skypilot-user: {{ user }}
 {%- if tpu_vm %}
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

For better accountability.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

**Tested (run the relevant ones):**

GCP head + worker (note: they have "labels" and "tags"; former is used):

<img width="196" alt="Screen Shot 2023-01-14 at 07 48 25" src="https://user-images.githubusercontent.com/592670/212480729-757c9919-1376-4e60-8d4c-a0550f26ccd0.png">

Azure head + worker:

<img width="354" alt="Screen Shot 2023-01-14 at 07 52 49" src="https://user-images.githubusercontent.com/592670/212480893-9ac4035e-b254-4b90-93a0-2f05ecda9977.png">
<img width="428" alt="Screen Shot 2023-01-14 at 07 52 57" src="https://user-images.githubusercontent.com/592670/212480905-f83e3cf4-40d1-41f7-9f48-1f8b5be9585e.png">


Also tested (previously was throwing an error from within optimizer, `No resource satisfying None on Azure`):
```
» sky launch --use-spot -i10 --down --cloud azure
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: SkyPilot currently has not implemented support for spot instances on Azure. Please file an issue if you need this feature.
```