### PR TITLE
Fix backward compatibility for cost tracking

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -185,7 +185,6 @@ def add_or_update_cluster(cluster_name: str,
 
     # first time a cluster is being launched
     if not usage_intervals:
-        assert requested_resources is not None
         usage_intervals = []
 
     # if this is the cluster init or we are starting after a stop


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce the problem:
1. `sky launch -c min` with the commit before #1301 
2. `ssh min; ray stop`
3. switch to the latest master. `sky status -r`

Since we will call the `global_user_state.add_or_update_cluster` with the `requested_resources=None` in the following line, the status refresh will fail. 
https://github.com/skypilot-org/skypilot/blob/6fd21d7fadb65e2f889e47f9616ef4e54a22f72e/sky/backends/backend_utils.py#L1965

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] The reproducible snippet above.