### PR TITLE
Revert spot job setup failure handling (revert #1579)

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2371,13 +2371,10 @@ class CloudVmRayBackend(backends.Backend):
                             f'{colorama.Style.RESET_ALL}')
                     return err_msg
 
-                try:
-                    subprocess_utils.handle_returncode(returncode=returncode,
-                                                       command=setup_cmd,
-                                                       error_msg=error_message)
-                except exceptions.CommandError as e:
-                    with ux_utils.print_exception_no_traceback():
-                        raise exceptions.ClusterSetUpError(str(e)) from e
+                subprocess_utils.handle_returncode(returncode=returncode,
+                                                    command=setup_cmd,
+                                                    error_msg=error_message)
+
 
             num_nodes = len(ip_list)
             plural = 's' if num_nodes > 1 else ''

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2372,9 +2372,8 @@ class CloudVmRayBackend(backends.Backend):
                     return err_msg
 
                 subprocess_utils.handle_returncode(returncode=returncode,
-                                                    command=setup_cmd,
-                                                    error_msg=error_message)
-
+                                                   command=setup_cmd,
+                                                   error_msg=error_message)
 
             num_nodes = len(ip_list)
             plural = 's' if num_nodes > 1 else ''

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -176,11 +176,6 @@ class SpotController:
             spot_state.set_failed(
                 self._job_id,
                 failure_type=spot_state.SpotStatus.FAILED_NO_RESOURCE)
-        except exceptions.ClusterSetUpError as e:
-            logger.error(f'{common_utils.class_fullname(e.__class__)}: '
-                         f'{colorama.Fore.RED}{e}{colorama.Style.RESET_ALL}')
-            spot_state.set_failed(self._job_id,
-                                  failure_type=spot_state.SpotStatus.FAILED)
         except (Exception, SystemExit) as e:  # pylint: disable=broad-except
             logger.error(traceback.format_exc())
             logger.error('Unexpected error occurred: '

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -160,11 +160,6 @@ class StrategyExecutor:
             except exceptions.InvalidClusterNameError as e:
                 # The cluster name is too long.
                 raise exceptions.ResourcesUnavailableError(str(e)) from e
-            except exceptions.ClusterSetUpError as e:
-                # When setup fails, do not retry, as it will likely fail again.
-                # The exception will be handled by the caller and set the job
-                # state to FAILED.
-                raise
             except Exception as e:  # pylint: disable=broad-except
                 # If the launch fails, it will be recovered by the following
                 # code.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,9 @@ def pytest_addoption(parser):
                          default=False,
                          help=f'Only run {cloud.upper()} tests')
     parser.addoption('--managed-spot',
-                    action='store_true',
-                    default=False,
-                    help='Only run tests for managed spot instances')
+                     action='store_true',
+                     default=False,
+                     help='Only run tests for managed spot instances')
     parser.addoption(
         '--generic-cloud',
         type=str,
@@ -65,7 +65,8 @@ def _get_cloud_to_run(config) -> List[str]:
 def pytest_collection_modifyitems(config, items):
     skip_marks = {}
     skip_marks['slow'] = pytest.mark.skip(reason='need --runslow option to run')
-    skip_marks['managed_spot'] = pytest.mark.skip(reason='skipped, due to --managed-spot option is set')
+    skip_marks['managed_spot'] = pytest.mark.skip(
+        reason='skipped, due to --managed-spot option is set')
     for cloud in all_clouds_in_smoke_tests:
         skip_marks[cloud] = pytest.mark.skip(
             reason=f'tests for {cloud} is skipped, try setting --{cloud}')
@@ -78,8 +79,9 @@ def pytest_collection_modifyitems(config, items):
         for cloud in all_clouds_in_smoke_tests:
             if cloud in item.keywords and cloud not in cloud_to_run:
                 item.add_marker(skip_marks[cloud])
-        
-        if (not 'managed_spot' in item.keywords) and config.getoption('--managed-spot'):
+
+        if (not 'managed_spot'
+                in item.keywords) and config.getoption('--managed-spot'):
             item.add_marker(skip_marks['managed_spot'])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,10 +31,6 @@ def pytest_addoption(parser):
                          action='store_true',
                          default=False,
                          help=f'Only run {cloud.upper()} tests')
-    parser.addoption('--managed-spot',
-                     action='store_true',
-                     default=False,
-                     help='Only run tests for managed spot instances')
     parser.addoption(
         '--generic-cloud',
         type=str,
@@ -63,10 +59,8 @@ def _get_cloud_to_run(config) -> List[str]:
 
 
 def pytest_collection_modifyitems(config, items):
+    skip_slow = pytest.mark.skip(reason='need --runslow option to run')
     skip_marks = {}
-    skip_marks['slow'] = pytest.mark.skip(reason='need --runslow option to run')
-    skip_marks['managed_spot'] = pytest.mark.skip(
-        reason='skipped, due to --managed-spot option is set')
     for cloud in all_clouds_in_smoke_tests:
         skip_marks[cloud] = pytest.mark.skip(
             reason=f'tests for {cloud} is skipped, try setting --{cloud}')
@@ -75,14 +69,10 @@ def pytest_collection_modifyitems(config, items):
 
     for item in items:
         if 'slow' in item.keywords and not config.getoption('--runslow'):
-            item.add_marker(skip_marks['slow'])
+            item.add_marker(skip_slow)
         for cloud in all_clouds_in_smoke_tests:
             if cloud in item.keywords and cloud not in cloud_to_run:
                 item.add_marker(skip_marks[cloud])
-
-        if (not 'managed_spot'
-                in item.keywords) and config.getoption('--managed-spot'):
-            item.add_marker(skip_marks['managed_spot'])
 
 
 @pytest.fixture

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1124,25 +1124,6 @@ def test_spot(generic_cloud: str):
     run_one_test(test)
 
 
-@pytest.mark.managed_spot
-def test_spot_failed_setup(generic_cloud: str):
-    """Test managed spot job with failed setup."""
-    name = _get_cluster_name()
-    test = Test(
-        'spot-failed-setup',
-        [
-            f'sky spot launch -n {name} --cloud {generic_cloud} -y -d tests/test_yamls/failed_setup.yaml',
-            'sleep 200',
-            # Make sure the job failed quickly.
-            f's=$(sky spot queue); echo "$s"; echo; echo; echo "$s" | grep {name} | head -n1 | grep "FAILED"',
-        ],
-        f'sky spot cancel -y -n {name}',
-        # Increase timeout since sky spot queue -r can be blocked by other spot tests.
-        timeout=20 * 60,
-    )
-    run_one_test(test)
-
-
 # ---------- Testing managed spot recovery ----------
 @pytest.mark.aws
 @pytest.mark.managed_spot

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1123,24 +1123,6 @@ def test_spot(generic_cloud: str):
     run_one_test(test)
 
 
-def test_spot_failed_setup(generic_cloud: str):
-    """Test managed spot job with failed setup."""
-    name = _get_cluster_name()
-    test = Test(
-        'spot-failed-setup',
-        [
-            f'sky spot launch -n {name} --cloud {generic_cloud} -y -d tests/test_yamls/failed_setup.yaml',
-            'sleep 200',
-            # Make sure the job failed quickly.
-            f's=$(sky spot queue); echo "$s"; echo; echo; echo "$s" | grep {name} | head -n1 | grep "FAILED"',
-        ],
-        f'sky spot cancel -y -n {name}',
-        # Increase timeout since sky spot queue -r can be blocked by other spot tests.
-        timeout=20 * 60,
-    )
-    run_one_test(test)
-
-
 # ---------- Testing managed spot recovery ----------
 @pytest.mark.aws
 def test_spot_recovery_aws():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1099,7 +1099,6 @@ def test_use_spot(generic_cloud: str):
 
 
 # ---------- Testing managed spot ----------
-@pytest.mark.managed_spot
 def test_spot(generic_cloud: str):
     """Test the spot yaml."""
     name = _get_cluster_name()
@@ -1124,9 +1123,26 @@ def test_spot(generic_cloud: str):
     run_one_test(test)
 
 
+def test_spot_failed_setup(generic_cloud: str):
+    """Test managed spot job with failed setup."""
+    name = _get_cluster_name()
+    test = Test(
+        'spot-failed-setup',
+        [
+            f'sky spot launch -n {name} --cloud {generic_cloud} -y -d tests/test_yamls/failed_setup.yaml',
+            'sleep 200',
+            # Make sure the job failed quickly.
+            f's=$(sky spot queue); echo "$s"; echo; echo; echo "$s" | grep {name} | head -n1 | grep "FAILED"',
+        ],
+        f'sky spot cancel -y -n {name}',
+        # Increase timeout since sky spot queue -r can be blocked by other spot tests.
+        timeout=20 * 60,
+    )
+    run_one_test(test)
+
+
 # ---------- Testing managed spot recovery ----------
 @pytest.mark.aws
-@pytest.mark.managed_spot
 def test_spot_recovery_aws():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1157,7 +1173,6 @@ def test_spot_recovery_aws():
 
 
 @pytest.mark.gcp
-@pytest.mark.managed_spot
 def test_spot_recovery_gcp():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1188,7 +1203,6 @@ def test_spot_recovery_gcp():
     run_one_test(test)
 
 
-@pytest.mark.managed_spot
 def test_spot_recovery_default_resources(generic_cloud: str):
     """Test managed spot recovery for default resources."""
     name = _get_cluster_name()
@@ -1206,7 +1220,6 @@ def test_spot_recovery_default_resources(generic_cloud: str):
 
 
 @pytest.mark.aws
-@pytest.mark.managed_spot
 def test_spot_recovery_multi_node_aws():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1238,7 +1251,6 @@ def test_spot_recovery_multi_node_aws():
 
 
 @pytest.mark.gcp
-@pytest.mark.managed_spot
 def test_spot_recovery_multi_node_gcp():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1272,7 +1284,6 @@ def test_spot_recovery_multi_node_gcp():
 
 
 @pytest.mark.aws
-@pytest.mark.managed_spot
 def test_spot_cancellation_aws():
     name = _get_cluster_name()
     region = 'us-east-2'
@@ -1333,7 +1344,6 @@ def test_spot_cancellation_aws():
 
 
 @pytest.mark.gcp
-@pytest.mark.managed_spot
 def test_spot_cancellation_gcp():
     name = _get_cluster_name()
     zone = 'us-west3-b'
@@ -1389,7 +1399,6 @@ def test_spot_cancellation_gcp():
 
 
 # ---------- Testing storage for managed spot ----------
-@pytest.mark.managed_spot
 def test_spot_storage(generic_cloud: str):
     """Test storage with managed spot"""
     name = _get_cluster_name()
@@ -1417,7 +1426,6 @@ def test_spot_storage(generic_cloud: str):
 
 # ---------- Testing spot TPU ----------
 @pytest.mark.gcp
-@pytest.mark.managed_spot
 def test_spot_tpu():
     """Test managed spot on TPU."""
     name = _get_cluster_name()
@@ -1453,7 +1461,6 @@ def test_inline_env(generic_cloud: str):
 
 
 # ---------- Testing env for spot ----------
-@pytest.mark.managed_spot
 def test_inline_spot_env(generic_cloud: str):
     """Test env"""
     name = _get_cluster_name()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1099,6 +1099,7 @@ def test_use_spot(generic_cloud: str):
 
 
 # ---------- Testing managed spot ----------
+@pytest.mark.managed_spot
 def test_spot(generic_cloud: str):
     """Test the spot yaml."""
     name = _get_cluster_name()
@@ -1123,6 +1124,7 @@ def test_spot(generic_cloud: str):
     run_one_test(test)
 
 
+@pytest.mark.managed_spot
 def test_spot_failed_setup(generic_cloud: str):
     """Test managed spot job with failed setup."""
     name = _get_cluster_name()
@@ -1143,6 +1145,7 @@ def test_spot_failed_setup(generic_cloud: str):
 
 # ---------- Testing managed spot recovery ----------
 @pytest.mark.aws
+@pytest.mark.managed_spot
 def test_spot_recovery_aws():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1173,6 +1176,7 @@ def test_spot_recovery_aws():
 
 
 @pytest.mark.gcp
+@pytest.mark.managed_spot
 def test_spot_recovery_gcp():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1203,6 +1207,7 @@ def test_spot_recovery_gcp():
     run_one_test(test)
 
 
+@pytest.mark.managed_spot
 def test_spot_recovery_default_resources(generic_cloud: str):
     """Test managed spot recovery for default resources."""
     name = _get_cluster_name()
@@ -1220,6 +1225,7 @@ def test_spot_recovery_default_resources(generic_cloud: str):
 
 
 @pytest.mark.aws
+@pytest.mark.managed_spot
 def test_spot_recovery_multi_node_aws():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1251,6 +1257,7 @@ def test_spot_recovery_multi_node_aws():
 
 
 @pytest.mark.gcp
+@pytest.mark.managed_spot
 def test_spot_recovery_multi_node_gcp():
     """Test managed spot recovery."""
     name = _get_cluster_name()
@@ -1284,6 +1291,7 @@ def test_spot_recovery_multi_node_gcp():
 
 
 @pytest.mark.aws
+@pytest.mark.managed_spot
 def test_spot_cancellation_aws():
     name = _get_cluster_name()
     region = 'us-east-2'
@@ -1344,6 +1352,7 @@ def test_spot_cancellation_aws():
 
 
 @pytest.mark.gcp
+@pytest.mark.managed_spot
 def test_spot_cancellation_gcp():
     name = _get_cluster_name()
     zone = 'us-west3-b'
@@ -1399,6 +1408,7 @@ def test_spot_cancellation_gcp():
 
 
 # ---------- Testing storage for managed spot ----------
+@pytest.mark.managed_spot
 def test_spot_storage(generic_cloud: str):
     """Test storage with managed spot"""
     name = _get_cluster_name()
@@ -1426,6 +1436,7 @@ def test_spot_storage(generic_cloud: str):
 
 # ---------- Testing spot TPU ----------
 @pytest.mark.gcp
+@pytest.mark.managed_spot
 def test_spot_tpu():
     """Test managed spot on TPU."""
     name = _get_cluster_name()
@@ -1461,6 +1472,7 @@ def test_inline_env(generic_cloud: str):
 
 
 # ---------- Testing env for spot ----------
+@pytest.mark.managed_spot
 def test_inline_spot_env(generic_cloud: str):
     """Test env"""
     name = _get_cluster_name()

--- a/tests/test_yamls/failed_setup.yaml
+++ b/tests/test_yamls/failed_setup.yaml
@@ -1,6 +1,0 @@
-setup: |
-  echo failed setup
-  exit 1
-
-run: |
-  echo run


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR reverts #1579, because if the cluster is preempted during the setup stage of a recovery, the changes in #1579 will fail the whole job instead of trying again or moving to another region. cc @infwinston 

Reproducible process:
1. `sky spot launch long-setup.yaml`
2. Delete the instance on the console during the setup process
3. The spot job fails directly.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] All managed spot-related smoke tests

Future TODO:
- [ ] Add a test for a spot job being preempted during the setup stage of recovery.
