### PR TITLE
[UX] Avoid known hosts check

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -371,6 +371,10 @@ class SSHConfigHelper(object):
             proxy = f'ProxyCommand {proxy_command}'
         else:
             proxy = ''
+        # StrictHostKeyChecking=no skips the host key check for the first
+        # time. UserKnownHostsFile=/dev/null prevents the host key from being
+        # added to the known_hosts file, so that the host key check is skipped
+        # for all subsequent connections.
         codegen = textwrap.dedent(f"""\
             {autogen_comment}
             Host {host_name}
@@ -380,6 +384,7 @@ class SSHConfigHelper(object):
               IdentitiesOnly yes
               ForwardAgent yes
               StrictHostKeyChecking no
+              UserKnownHostsFile=/dev/null
               Port 22
               {proxy}
             """.rstrip())

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -372,9 +372,11 @@ class SSHConfigHelper(object):
         else:
             proxy = ''
         # StrictHostKeyChecking=no skips the host key check for the first
-        # time. UserKnownHostsFile=/dev/null prevents the host key from being
-        # added to the known_hosts file, so that the host key check is skipped
-        # for all subsequent connections.
+        # time. UserKnownHostsFile=/dev/null and GlobalKnownHostsFile/dev/null
+        # prevent the host key from being added to the known_hosts file and
+        # always return an empty file for known hosts, making the ssh think
+        # this is a first-time connection, and thus skipping the host key
+        # check.
         codegen = textwrap.dedent(f"""\
             {autogen_comment}
             Host {host_name}
@@ -385,6 +387,7 @@ class SSHConfigHelper(object):
               ForwardAgent yes
               StrictHostKeyChecking no
               UserKnownHostsFile=/dev/null
+              GlobalKnownHostsFile=/dev/null
               Port 22
               {proxy}
             """.rstrip())

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2371,13 +2371,10 @@ class CloudVmRayBackend(backends.Backend):
                             f'{colorama.Style.RESET_ALL}')
                     return err_msg
 
-                try:
-                    subprocess_utils.handle_returncode(returncode=returncode,
-                                                       command=setup_cmd,
-                                                       error_msg=error_message)
-                except exceptions.CommandError as e:
-                    with ux_utils.print_exception_no_traceback():
-                        raise exceptions.ClusterSetUpError(str(e)) from e
+                subprocess_utils.handle_returncode(returncode=returncode,
+                                                    command=setup_cmd,
+                                                    error_msg=error_message)
+
 
             num_nodes = len(ip_list)
             plural = 's' if num_nodes > 1 else ''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reports that sometimes `ssh cluster-name` will complain about `REMOTE HOST IDENTIFICATION HAS CHANGED` error.
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/6753189/213643997-96ddd85e-bf2e-438b-b175-d6547bdae6c4.png">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c min --cloud gcp; ssh min`

