### PR TITLE
[Azure] Fix azure launch

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1103,9 +1103,10 @@ class RetryingVmProvisioner(object):
             if zones is not None:
                 for zone in zones:
                     for blocked_resources in self._blocked_resources:
-                        if to_provision.copy(region=region.name,
-                                            zone=zone.name).should_be_blocked_by(
-                                                blocked_resources):
+                        if to_provision.copy(
+                                region=region.name,
+                                zone=zone.name).should_be_blocked_by(
+                                    blocked_resources):
                             remaining_unblocked_zones.remove(zone)
                             break
             if zones and not remaining_unblocked_zones:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1100,13 +1100,14 @@ class RetryingVmProvisioner(object):
             # but the optimizer that does the filtering will not be involved
             # until the next region.
             remaining_unblocked_zones = copy.deepcopy(zones)
-            for zone in zones:
-                for blocked_resources in self._blocked_resources:
-                    if to_provision.copy(region=region.name,
-                                         zone=zone.name).should_be_blocked_by(
-                                             blocked_resources):
-                        remaining_unblocked_zones.remove(zone)
-                        break
+            if zones is not None:
+                for zone in zones:
+                    for blocked_resources in self._blocked_resources:
+                        if to_provision.copy(region=region.name,
+                                            zone=zone.name).should_be_blocked_by(
+                                                blocked_resources):
+                            remaining_unblocked_zones.remove(zone)
+                            break
             if zones and not remaining_unblocked_zones:
                 # Skip the region if all zones are blocked.
                 continue


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a problem introduced by #1585, which assume the `zones` to be a list while it can be NoneType, causing the following error during `pytest tests/test_smoke.py::test_azure_start_stop`. This is another evidence for the importance of #1564 ; )

```
  File "/home/gcpuser/skypilot/sky/utils/common_utils.py", line 239, in _record
    return f(*args, **kwargs)
  File "/home/gcpuser/skypilot/sky/backends/cloud_vm_ray_backend.py", line 1637, in provision_with_retries
    config_dict = self._retry_region_zones(
  File "/home/gcpuser/skypilot/sky/backends/cloud_vm_ray_backend.py", line 1103, in _retry_region_zones
    for zone in zones:
TypeError: 'NoneType' object is not iterable
^[[31mFailed^[[0m.
Reason: sky start -y t-azure-start-stop-c884-b5
Log: less /tmp/azure-start-stop-3h69lw1t.log
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_azure_start_stop` 
