### PR TITLE
[Cost Report] Add status for cost report

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -264,7 +264,7 @@ def add_or_update_cluster(cluster_name: str,
     _DB.cursor.execute(
         'INSERT or REPLACE INTO cluster_history'
         '(cluster_hash, name, num_nodes, requested_resources, '
-        'launched_resources, usage_intervals, status) '
+        'launched_resources, usage_intervals) '
         'VALUES ('
         # hash
         '?, '
@@ -277,8 +277,6 @@ def add_or_update_cluster(cluster_name: str,
         # number of nodes
         '?, '
         # usage intervals
-        '?, '
-        # status
         '?)',
         (
             # hash
@@ -293,8 +291,6 @@ def add_or_update_cluster(cluster_name: str,
             pickle.dumps(cluster_handle.launched_resources),
             # usage intervals
             pickle.dumps(usage_intervals),
-            # status,
-            status.value,
         ))
 
     _DB.conn.commit()

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -139,7 +139,7 @@ _STATUS_TO_COLOR = {
     ClusterStatus.INIT: colorama.Fore.BLUE,
     ClusterStatus.UP: colorama.Fore.GREEN,
     ClusterStatus.STOPPED: colorama.Fore.YELLOW,
-    ClusterStatus.TERMINATED: colorama.Fore.BLACK,
+    ClusterStatus.TERMINATED: colorama.Style.DIM,
 }
 
 
@@ -550,8 +550,6 @@ def get_clusters() -> List[Dict[str, Any]]:
 
 
 def get_clusters_from_history() -> List[Dict[str, Any]]:
-    rows = _DB.cursor.execute('SELECT * from cluster_history')
-
     rows = _DB.cursor.execute(
         'SELECT ch.cluster_hash, ch.name, ch.num_nodes, '
         'ch.launched_resources, ch.usage_intervals, clusters.status  '
@@ -575,8 +573,8 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
             status,
         ) = row[:6]
 
-        if status is None:
-            status = 'TERMINATED'
+        if status is not None:
+            status = ClusterStatus[status]
 
         record = {
             'name': name,
@@ -586,7 +584,7 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
             'resources': pickle.loads(launched_resources),
             'cluster_hash': cluster_hash,
             'usage_intervals': pickle.loads(usage_intervals),
-            'status': ClusterStatus[status],
+            'status': status,
         }
 
         records.append(record)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -126,10 +126,6 @@ class ClusterStatus(enum.Enum):
     # Stopped.  This means a `sky stop` call has previously succeeded.
     STOPPED = 'STOPPED'
 
-    # Not used in cluster table, only cluster_history table
-    # This means a `sky down` call has previously succeeded.
-    TERMINATED = 'TERMINATED'
-
     def colored_str(self):
         color = _STATUS_TO_COLOR[self]
         return f'{color}{self.value}{colorama.Style.RESET_ALL}'
@@ -139,7 +135,6 @@ _STATUS_TO_COLOR = {
     ClusterStatus.INIT: colorama.Fore.BLUE,
     ClusterStatus.UP: colorama.Fore.GREEN,
     ClusterStatus.STOPPED: colorama.Fore.YELLOW,
-    ClusterStatus.TERMINATED: colorama.Style.DIM,
 }
 
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,6 +5,7 @@ import colorama
 
 from sky import backends
 from sky import spot
+from sky import global_user_state
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
@@ -277,6 +278,8 @@ def _get_status(cluster_status):
 
 def _get_status_for_cost_report(cluster_status):
     status = cluster_status['status']
+    if status is None:
+        status = global_user_state.ClusterStatus.TERMINATED
     return status.colored_str()
 
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,11 +5,17 @@ import colorama
 
 from sky import backends
 from sky import spot
+from sky import global_user_state
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
 
 _COMMAND_TRUNC_LENGTH = 25
+
+
+def colored_str(status):
+    color = global_user_state.STATUS_TO_COLOR[status]
+    return f'{color}{status}{colorama.Style.RESET_ALL}'
 
 
 def _truncate_long_string(s: str, max_length: int = 35) -> str:
@@ -272,12 +278,12 @@ _get_duration = (lambda cluster_status: log_utils.readable_time_duration(
 
 def _get_status(cluster_status):
     status = cluster_status['status']
-    return status.colored_str()
+    return colored_str(status)
 
 
 def _get_status_for_cost_report(cluster_status):
     status = cluster_status['status']
-    return status.colored_str()
+    return colored_str(status)
 
 
 def _get_resources(cluster_status):

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,7 +5,6 @@ import colorama
 
 from sky import backends
 from sky import spot
-from sky import global_user_state
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
@@ -279,7 +278,7 @@ def _get_status(cluster_status):
 def _get_status_for_cost_report(cluster_status):
     status = cluster_status['status']
     if status is None:
-        status = global_user_state.ClusterStatus.TERMINATED
+        return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
     return status.colored_str()
 
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,17 +5,11 @@ import colorama
 
 from sky import backends
 from sky import spot
-from sky import global_user_state
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
 
 _COMMAND_TRUNC_LENGTH = 25
-
-
-def colored_str(status):
-    color = global_user_state.STATUS_TO_COLOR[status]
-    return f'{color}{status}{colorama.Style.RESET_ALL}'
 
 
 def _truncate_long_string(s: str, max_length: int = 35) -> str:
@@ -278,12 +272,12 @@ _get_duration = (lambda cluster_status: log_utils.readable_time_duration(
 
 def _get_status(cluster_status):
     status = cluster_status['status']
-    return colored_str(status)
+    return status.colored_str()
 
 
 def _get_status_for_cost_report(cluster_status):
     status = cluster_status['status']
-    return colored_str(status)
+    return status.colored_str()
 
 
 def _get_resources(cluster_status):

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -129,6 +129,9 @@ def show_cost_report_table(cluster_records: List[Dict[str, Any]],
         StatusColumn('RESOURCES',
                      _get_resources_for_cost_report,
                      trunc_length=70 if not show_all else 0),
+        StatusColumn('STATUS',
+                     _get_status_for_cost_report,
+                     show_by_default=True),
         StatusColumn('HOURLY_PRICE', _get_price, show_by_default=True),
         StatusColumn('COST (est.)', get_cost_report, show_by_default=True),
     ]
@@ -268,6 +271,11 @@ _get_duration = (lambda cluster_status: log_utils.readable_time_duration(
 
 
 def _get_status(cluster_status):
+    status = cluster_status['status']
+    return status.colored_str()
+
+
+def _get_status_for_cost_report(cluster_status):
     status = cluster_status['status']
     return status.colored_str()
 


### PR DESCRIPTION
Added a status column, which includes a new ClusterStatus type TERMINATED, to the cost report. 


Tested (each the same cluster, just when calling `sky cost-report` at different times:
'''
cluster  1 min ago    1m 8s     1x GCP(n1-highmem-8, {'V100': 1})  INIT        $ 2.953       $0.056       
cluster  4 mins ago   4m 31s    1x GCP(n1-highmem-8, {'V100': 1})  UP          $ 2.953       $0.222       
cluster  21 mins ago  15m 9s    1x GCP(n1-highmem-8, {'V100': 1})  STOPPED     $ 2.953       $0.746   
cluster  34 mins ago  22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  TERMINATED  $ 2.953       $1.108       
'''