### PR TITLE
[Resources] Add `cpus` in resource specification

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -47,6 +47,12 @@ Available fields:
       # Format: <name>:<count> (or simply <name>, short for a count of 1).
       accelerators: V100:4
 
+      # Number of vCPUs per node (optional).
+      #
+      # Format: <count> (exactly <count> vCPUs) or <count>+
+      # (at least <count> vCPUs).
+      cpus: 32
+
       # Instance type to use (optional). If 'accelerators' is specified,
       # the corresponding instance type is automatically inferred.
       instance_type: p3.8xlarge

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -43,7 +43,7 @@ def make_application():
             sky.Resources(sky.AWS(), 'p3.2xlarge'),  # 1 V100, EC2.
             sky.Resources(sky.AWS(), 'p3.8xlarge'),  # 4 V100s, EC2.
             # Tuples mean all resources are required.
-            sky.Resources(sky.GCP(), 'n1-standard-8', 'tpu-v3-8'),
+            sky.Resources(sky.GCP(), 'n1-standard-8', accelerators='tpu-v3-8'),
         })
 
         train_op.set_time_estimator(time_estimators.resnet50_estimate_runtime)
@@ -60,8 +60,8 @@ def make_application():
         infer_op.set_resources({
             sky.Resources(sky.AWS(), 'inf1.2xlarge'),
             sky.Resources(sky.AWS(), 'p3.2xlarge'),
-            sky.Resources(sky.GCP(), 'n1-standard-4', 'T4'),
-            sky.Resources(sky.GCP(), 'n1-standard-8', 'T4'),
+            sky.Resources(sky.GCP(), 'n1-standard-4', accelerators='T4'),
+            sky.Resources(sky.GCP(), 'n1-standard-8', accelerators='T4'),
         })
 
         infer_op.set_time_estimator(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -175,10 +175,10 @@ def _interactive_node_cli_command(cli_func):
                                         type=str,
                                         help='Instance type to use.')
     cpu = click.option('--cpu',
-                        default=None,
-                        type=str,
-                        help='Number of CPUs to use. '
-                        '(e.g., ``--cpu=4`` or ``--cpu=4+``).')
+                       default=None,
+                       type=str,
+                       help='Number of CPUs to use. '
+                       '(e.g., ``--cpu=4`` or ``--cpu=4+``).')
     gpus = click.option('--gpus',
                         default=None,
                         type=str,
@@ -2438,11 +2438,11 @@ def _down_or_stop_clusters(
 # pylint: disable=redefined-outer-name
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str], gpus: Optional[str],
-            use_spot: Optional[bool], screen: Optional[bool],
-            tmux: Optional[bool], disk_size: Optional[int],
-            idle_minutes_to_autostop: Optional[int], down: bool,
-            retry_until_up: bool):
+            instance_type: Optional[str], cpu: Optional[str],
+            gpus: Optional[str], use_spot: Optional[bool],
+            screen: Optional[bool], tmux: Optional[bool],
+            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
+            down: bool, retry_until_up: bool):
     """Launch or attach to an interactive GPU node.
 
     Examples:
@@ -2481,8 +2481,8 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpu is None and
-                                    gpus is None and use_spot is None)
+                                    cpu is None and gpus is None and
+                                    use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['gpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
     if gpus is None and instance_type is None:
@@ -2519,10 +2519,11 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str], use_spot: Optional[bool],
-            screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
-            down: bool, retry_until_up: bool):
+            instance_type: Optional[str], cpu: Optional[str],
+            use_spot: Optional[bool], screen: Optional[bool],
+            tmux: Optional[bool], disk_size: Optional[int],
+            idle_minutes_to_autostop: Optional[int], down: bool,
+            retry_until_up: bool):
     """Launch or attach to an interactive CPU node.
 
     Examples:
@@ -2594,11 +2595,12 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str], tpus: Optional[str],
-            use_spot: Optional[bool], tpu_vm: Optional[bool],
-            screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
-            down: bool, retry_until_up: bool):
+            instance_type: Optional[str], cpu: Optional[str],
+            tpus: Optional[str], use_spot: Optional[bool],
+            tpu_vm: Optional[bool], screen: Optional[bool],
+            tmux: Optional[bool], disk_size: Optional[int],
+            idle_minutes_to_autostop: Optional[int], down: bool,
+            retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
 
     Examples:
@@ -2635,8 +2637,8 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         name = _default_interactive_node_name('tpunode')
 
     user_requested_resources = not (region is None and zone is None and
-                                    instance_type is None and cpu is None and tpus is None and
-                                    use_spot is None)
+                                    instance_type is None and cpu is None and
+                                    tpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['tpunode']
     accelerator_args = default_resources.accelerator_args
     if tpu_vm:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -174,6 +174,11 @@ def _interactive_node_cli_command(cli_func):
                                         default=None,
                                         type=str,
                                         help='Instance type to use.')
+    cpu = click.option('--cpu',
+                        default=None,
+                        type=str,
+                        help='Number of CPUs to use. '
+                        '(e.g., ``--cpu=4`` or ``--cpu=4+``).')
     gpus = click.option('--gpus',
                         default=None,
                         type=str,
@@ -268,6 +273,7 @@ def _interactive_node_cli_command(cli_func):
         region_option,
         zone_option,
         instance_type_option,
+        cpu,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
         spot_option,
@@ -2432,7 +2438,7 @@ def _down_or_stop_clusters(
 # pylint: disable=redefined-outer-name
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], gpus: Optional[str],
+            instance_type: Optional[str], cpu: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
             idle_minutes_to_autostop: Optional[int], down: bool,
@@ -2475,6 +2481,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
+                                    cpu is None and
                                     gpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['gpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2488,6 +2495,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
+                              cpu=cpu,
                               accelerators=gpus,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2511,7 +2519,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], use_spot: Optional[bool],
+            instance_type: Optional[str], cpu: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
             down: bool, retry_until_up: bool):
@@ -2552,7 +2560,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    use_spot is None)
+                                    cpu is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['cpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
     if instance_type is None:
@@ -2563,6 +2571,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
+                              cpu=cpu,
                               use_spot=use_spot,
                               disk_size=disk_size)
 
@@ -2585,7 +2594,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], tpus: Optional[str],
+            instance_type: Optional[str], cpu: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
@@ -2626,7 +2635,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         name = _default_interactive_node_name('tpunode')
 
     user_requested_resources = not (region is None and zone is None and
-                                    instance_type is None and tpus is None and
+                                    instance_type is None and cpu is None and tpus is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['tpunode']
     accelerator_args = default_resources.accelerator_args
@@ -2643,6 +2652,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
+                              cpu=cpu,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -398,12 +398,6 @@ _EXTRA_RESOURCES_OPTIONS = [
               '"resources.instance_type" config. Passing "none" resets the '
               'config.'),
     ),
-    click.option(
-        '--cpu',
-        default=None,
-        type=str,
-        required=False,
-        help=('The number of vCPUs to use. Either <number> or <number>+.')),
 ]
 
 
@@ -1110,6 +1104,11 @@ def cli():
               default=False,
               help='If used, runs locally inside a docker container.')
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
+@click.option('--cpu',
+              default=None,
+              type=str,
+              required=False,
+              help='The number of vCPUs to use. Either <number> or <number>+.')
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -1281,7 +1280,6 @@ def exec(
     zone: Optional[str],
     workdir: Optional[str],
     gpus: Optional[str],
-    cpu: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1366,7 +1364,7 @@ def exec(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpu=cpu,
+        cpu=None,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -2997,6 +2995,11 @@ def spot():
                 **_get_shell_complete_args(_complete_file_name))
 # TODO(zhwu): Add --dryrun option to test the launch command.
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
+@click.option('--cpu',
+              default=None,
+              type=str,
+              required=False,
+              help='The number of vCPUs to use. Either <number> or <number>+.')
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -392,6 +392,12 @@ _EXTRA_RESOURCES_OPTIONS = [
               '"resources.instance_type" config. Passing "none" resets the '
               'config.'),
     ),
+    click.option(
+        '--cpu',
+        default=None,
+        type=str,
+        required=False,
+        help=('The number of vCPUs to use. Either <number> or <number>+.')),
 ]
 
 
@@ -556,6 +562,7 @@ def _parse_override_params(cloud: Optional[str] = None,
                            region: Optional[str] = None,
                            zone: Optional[str] = None,
                            gpus: Optional[str] = None,
+                           cpu: Optional[str] = None,
                            instance_type: Optional[str] = None,
                            use_spot: Optional[bool] = None,
                            image_id: Optional[str] = None,
@@ -582,6 +589,11 @@ def _parse_override_params(cloud: Optional[str] = None,
             override_params['accelerators'] = None
         else:
             override_params['accelerators'] = gpus
+    if cpu is not None:
+        if cpu.lower() == 'none':
+            override_params['cpu'] = None
+        else:
+            override_params['cpu'] = cpu
     if instance_type is not None:
         if instance_type.lower() == 'none':
             override_params['instance_type'] = None
@@ -908,6 +920,7 @@ def _make_task_from_entrypoint_with_overrides(
     region: Optional[str] = None,
     zone: Optional[str] = None,
     gpus: Optional[str] = None,
+    cpu: Optional[str] = None,
     instance_type: Optional[str] = None,
     num_nodes: Optional[int] = None,
     use_spot: Optional[bool] = None,
@@ -949,6 +962,7 @@ def _make_task_from_entrypoint_with_overrides(
                                              region=region,
                                              zone=zone,
                                              gpus=gpus,
+                                             cpu=cpu,
                                              instance_type=instance_type,
                                              use_spot=use_spot,
                                              image_id=image_id,
@@ -1154,6 +1168,7 @@ def launch(
     region: Optional[str],
     zone: Optional[str],
     gpus: Optional[str],
+    cpu: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1198,6 +1213,7 @@ def launch(
         region=region,
         zone=zone,
         gpus=gpus,
+        cpu=cpu,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,
@@ -1259,6 +1275,7 @@ def exec(
     zone: Optional[str],
     workdir: Optional[str],
     gpus: Optional[str],
+    cpu: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1343,6 +1360,7 @@ def exec(
         region=region,
         zone=zone,
         gpus=gpus,
+        cpu=cpu,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -2975,6 +2993,7 @@ def spot_launch(
     region: Optional[str],
     zone: Optional[str],
     gpus: Optional[str],
+    cpu: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -3013,6 +3032,7 @@ def spot_launch(
         region=region,
         zone=zone,
         gpus=gpus,
+        cpu=cpu,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -177,7 +177,7 @@ def _interactive_node_cli_command(cli_func):
     cpu = click.option('--cpu',
                        default=None,
                        type=str,
-                       help='Number of CPUs to use. '
+                       help='Number of vCPUs to use. '
                        '(e.g., ``--cpu=4`` or ``--cpu=4+``).')
     gpus = click.option('--gpus',
                         default=None,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -174,12 +174,12 @@ def _interactive_node_cli_command(cli_func):
                                         default=None,
                                         type=str,
                                         help='Instance type to use.')
-    cpu = click.option(
-        '--cpu',
+    cpus = click.option(
+        '--cpus',
         default=None,
         type=str,
         help=('Number of vCPUs each instance must have '
-              '(e.g., ``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+              '(e.g., ``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
               'This is used to automatically select the instance type.'))
     gpus = click.option('--gpus',
                         default=None,
@@ -275,7 +275,7 @@ def _interactive_node_cli_command(cli_func):
         region_option,
         zone_option,
         instance_type_option,
-        cpu,
+        cpus,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
         spot_option,
@@ -564,7 +564,7 @@ def _parse_override_params(cloud: Optional[str] = None,
                            region: Optional[str] = None,
                            zone: Optional[str] = None,
                            gpus: Optional[str] = None,
-                           cpu: Optional[str] = None,
+                           cpus: Optional[str] = None,
                            instance_type: Optional[str] = None,
                            use_spot: Optional[bool] = None,
                            image_id: Optional[str] = None,
@@ -591,11 +591,11 @@ def _parse_override_params(cloud: Optional[str] = None,
             override_params['accelerators'] = None
         else:
             override_params['accelerators'] = gpus
-    if cpu is not None:
-        if cpu.lower() == 'none':
-            override_params['cpu'] = None
+    if cpus is not None:
+        if cpus.lower() == 'none':
+            override_params['cpus'] = None
         else:
-            override_params['cpu'] = cpu
+            override_params['cpus'] = cpus
     if instance_type is not None:
         if instance_type.lower() == 'none':
             override_params['instance_type'] = None
@@ -922,7 +922,7 @@ def _make_task_from_entrypoint_with_overrides(
     region: Optional[str] = None,
     zone: Optional[str] = None,
     gpus: Optional[str] = None,
-    cpu: Optional[str] = None,
+    cpus: Optional[str] = None,
     instance_type: Optional[str] = None,
     num_nodes: Optional[int] = None,
     use_spot: Optional[bool] = None,
@@ -964,7 +964,7 @@ def _make_task_from_entrypoint_with_overrides(
                                              region=region,
                                              zone=zone,
                                              gpus=gpus,
-                                             cpu=cpu,
+                                             cpus=cpus,
                                              instance_type=instance_type,
                                              use_spot=use_spot,
                                              image_id=image_id,
@@ -1106,12 +1106,12 @@ def cli():
               default=False,
               help='If used, runs locally inside a docker container.')
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
-@click.option('--cpu',
+@click.option('--cpus',
               default=None,
               type=str,
               required=False,
               help=('Number of vCPUs each instance must have (e.g., '
-                    '``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option('--disk-size',
               default=None,
@@ -1177,7 +1177,7 @@ def launch(
     region: Optional[str],
     zone: Optional[str],
     gpus: Optional[str],
-    cpu: Optional[str],
+    cpus: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1222,7 +1222,7 @@ def launch(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpu=cpu,
+        cpus=cpus,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,
@@ -1368,7 +1368,7 @@ def exec(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpu=None,
+        cpus=None,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -2440,7 +2440,7 @@ def _down_or_stop_clusters(
 # pylint: disable=redefined-outer-name
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str],
+            instance_type: Optional[str], cpus: Optional[str],
             gpus: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
@@ -2483,7 +2483,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpu is None and gpus is None and
+                                    cpus is None and gpus is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['gpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2497,7 +2497,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
-                              cpu=cpu,
+                              cpus=cpus,
                               accelerators=gpus,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2521,7 +2521,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str],
+            instance_type: Optional[str], cpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
             idle_minutes_to_autostop: Optional[int], down: bool,
@@ -2563,7 +2563,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpu is None and use_spot is None)
+                                    cpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['cpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
     if instance_type is None:
@@ -2574,7 +2574,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
-                              cpu=cpu,
+                              cpus=cpus,
                               use_spot=use_spot,
                               disk_size=disk_size)
 
@@ -2597,7 +2597,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 # pylint: disable=redefined-outer-name
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             region: Optional[str], zone: Optional[str],
-            instance_type: Optional[str], cpu: Optional[str],
+            instance_type: Optional[str], cpus: Optional[str],
             tpus: Optional[str], use_spot: Optional[bool],
             tpu_vm: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
@@ -2639,7 +2639,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
         name = _default_interactive_node_name('tpunode')
 
     user_requested_resources = not (region is None and zone is None and
-                                    instance_type is None and cpu is None and
+                                    instance_type is None and cpus is None and
                                     tpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['tpunode']
     accelerator_args = default_resources.accelerator_args
@@ -2656,7 +2656,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               region=region,
                               zone=zone,
                               instance_type=instance_type,
-                              cpu=cpu,
+                              cpus=cpus,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,
@@ -2999,12 +2999,12 @@ def spot():
                 **_get_shell_complete_args(_complete_file_name))
 # TODO(zhwu): Add --dryrun option to test the launch command.
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
-@click.option('--cpu',
+@click.option('--cpus',
               default=None,
               type=str,
               required=False,
               help=('Number of vCPUs each instance must have (e.g., '
-                    '``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option('--spot-recovery',
               default=None,
@@ -3048,7 +3048,7 @@ def spot_launch(
     region: Optional[str],
     zone: Optional[str],
     gpus: Optional[str],
-    cpu: Optional[str],
+    cpus: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -3087,7 +3087,7 @@ def spot_launch(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpu=cpu,
+        cpus=cpus,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -174,11 +174,13 @@ def _interactive_node_cli_command(cli_func):
                                         default=None,
                                         type=str,
                                         help='Instance type to use.')
-    cpu = click.option('--cpu',
-                       default=None,
-                       type=str,
-                       help='Number of vCPUs to use. '
-                       '(e.g., ``--cpu=4`` or ``--cpu=4+``).')
+    cpu = click.option(
+        '--cpu',
+        default=None,
+        type=str,
+        help=('Number of vCPUs each instance must have '
+              '(e.g., ``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+              'This is used to automatically select the instance type.'))
     gpus = click.option('--gpus',
                         default=None,
                         type=str,
@@ -1108,7 +1110,9 @@ def cli():
               default=None,
               type=str,
               required=False,
-              help='The number of vCPUs to use. Either <number> or <number>+.')
+              help=('Number of vCPUs each instance must have (e.g., '
+                    '``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+                    'This is used to automatically select the instance type.'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -2999,7 +3003,9 @@ def spot():
               default=None,
               type=str,
               required=False,
-              help='The number of vCPUs to use. Either <number> or <number>+.')
+              help=('Number of vCPUs each instance must have (e.g., '
+                    '``--cpu=4`` (exactly 4) or ``--cpu=4+`` (at least 4)). '
+                    'This is used to automatically select the instance type.'))
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -333,12 +333,11 @@ class AWS(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        fuzzy_candidate_list: List[str] = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).
             resources = resources.copy(accelerators=None)
-            return ([resources], fuzzy_candidate_list)
+            return ([resources], [])
 
         def _make(instance_list):
             resource_list = []
@@ -361,9 +360,9 @@ class AWS(clouds.Cloud):
             default_instance_type = AWS.get_default_instance_type(
                 cpu=resources.cpu)
             if default_instance_type is None:
-                return ([], fuzzy_candidate_list)
+                return ([], [])
             else:
-                return (_make([default_instance_type]), fuzzy_candidate_list)
+                return (_make([default_instance_type]), [])
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -274,10 +274,8 @@ class AWS(clouds.Cloud):
         return isinstance(other, AWS)
 
     @classmethod
-    def get_default_instance_type(cls) -> str:
-        # General-purpose instance with 8 vCPUs and 32 GB RAM.
-        # Intel Ice Lake 8375C
-        return 'm6i.2xlarge'
+    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+        return service_catalog.get_default_instance_type(cpu=cpu, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -350,6 +348,7 @@ class AWS(clouds.Cloud):
                     # Setting this to None as AWS doesn't separately bill /
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
+                    cpu=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -357,8 +356,8 @@ class AWS(clouds.Cloud):
         # Currently, handle a filter on accelerators only.
         accelerators = resources.accelerators
         if accelerators is None:
-            # No requirements to filter, so just return a default VM type.
-            return (_make([AWS.get_default_instance_type()]),
+            # Return a default VM type for the given CPU.
+            return (_make([AWS.get_default_instance_type(cpu=resources.cpu)]),
                     fuzzy_candidate_list)
 
         assert len(accelerators) == 1, resources
@@ -368,6 +367,7 @@ class AWS(clouds.Cloud):
             acc,
             acc_count,
             use_spot=resources.use_spot,
+            cpu=resources.cpu,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -275,8 +275,8 @@ class AWS(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(cls,
-                                  cpu: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpu=cpu, clouds='aws')
+                                  cpus: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(cpus=cpus, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -348,7 +348,7 @@ class AWS(clouds.Cloud):
                     # Setting this to None as AWS doesn't separately bill /
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
-                    cpu=None,
+                    cpus=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -358,7 +358,7 @@ class AWS(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
-                cpu=resources.cpu)
+                cpus=resources.cpus)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -371,7 +371,7 @@ class AWS(clouds.Cloud):
             acc,
             acc_count,
             use_spot=resources.use_spot,
-            cpu=resources.cpu,
+            cpus=resources.cpus,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -276,7 +276,8 @@ class AWS(clouds.Cloud):
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpus=cpus, clouds='aws')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -274,7 +274,8 @@ class AWS(clouds.Cloud):
         return isinstance(other, AWS)
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+    def get_default_instance_type(cls,
+                                  cpu: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpu=cpu, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
@@ -356,9 +357,13 @@ class AWS(clouds.Cloud):
         # Currently, handle a filter on accelerators only.
         accelerators = resources.accelerators
         if accelerators is None:
-            # Return a default VM type for the given CPU.
-            return (_make([AWS.get_default_instance_type(cpu=resources.cpu)]),
-                    fuzzy_candidate_list)
+            # Return a default instance type.
+            default_instance_type = AWS.get_default_instance_type(
+                cpu=resources.cpu)
+            if default_instance_type is None:
+                return ([], fuzzy_candidate_list)
+            else:
+                return (_make([default_instance_type]), fuzzy_candidate_list)
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -357,7 +357,7 @@ class AWS(clouds.Cloud):
         # Currently, handle a filter on accelerators only.
         accelerators = resources.accelerators
         if accelerators is None:
-            # Return a default instance type.
+            # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
                 cpu=resources.cpu)
             if default_instance_type is None:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -274,7 +274,7 @@ class Azure(clouds.Cloud):
         # Currently, handle a filter on accelerators only.
         accelerators = resources.accelerators
         if accelerators is None:
-            # Return a default VM type with the given number of vCPUs.
+            # Return a default instance type with the given number of vCPUs.
             default_instance_type = Azure.get_default_instance_type(
                 cpu=resources.cpu)
             if default_instance_type is None:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -250,12 +250,11 @@ class Azure(clouds.Cloud):
             # TODO(zhwu): our azure subscription offer ID does not support spot.
             # Need to support it.
             return ([], [])
-        fuzzy_candidate_list = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).
             resources = resources.copy(accelerators=None)
-            return ([resources], fuzzy_candidate_list)
+            return ([resources], [])
 
         def _make(instance_list):
             resource_list = []
@@ -278,9 +277,9 @@ class Azure(clouds.Cloud):
             default_instance_type = Azure.get_default_instance_type(
                 cpu=resources.cpu)
             if default_instance_type is None:
-                return ([], fuzzy_candidate_list)
+                return ([], [])
             else:
-                return (_make([default_instance_type]), fuzzy_candidate_list)
+                return (_make([default_instance_type]), [])
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -95,8 +95,8 @@ class Azure(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(cls,
-                                  cpu: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpu=cpu,
+                                  cpus: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(cpus=cpus,
                                                          clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
@@ -265,7 +265,7 @@ class Azure(clouds.Cloud):
                     # Setting this to None as Azure doesn't separately bill /
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
-                    cpu=None,
+                    cpus=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -275,7 +275,7 @@ class Azure(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Azure.get_default_instance_type(
-                cpu=resources.cpu)
+                cpus=resources.cpus)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -287,7 +287,7 @@ class Azure(clouds.Cloud):
         ) = service_catalog.get_instance_type_for_accelerator(
             acc,
             acc_count,
-            cpu=resources.cpu,
+            cpus=resources.cpus,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -94,7 +94,8 @@ class Azure(clouds.Cloud):
         return isinstance(other, Azure)
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+    def get_default_instance_type(cls,
+                                  cpu: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpu=cpu,
                                                          clouds='azure')
 
@@ -273,9 +274,13 @@ class Azure(clouds.Cloud):
         # Currently, handle a filter on accelerators only.
         accelerators = resources.accelerators
         if accelerators is None:
-            # Return a default VM type for the given CPU.
-            return (_make([Azure.get_default_instance_type(cpu=resources.cpu)]),
-                    fuzzy_candidate_list)
+            # Return a default VM type with the given number of vCPUs.
+            default_instance_type = Azure.get_default_instance_type(
+                cpu=resources.cpu)
+            if default_instance_type is None:
+                return ([], fuzzy_candidate_list)
+            else:
+                return (_make([default_instance_type]), fuzzy_candidate_list)
 
         assert len(accelerators) == 1, resources
         acc, acc_count = list(accelerators.items())[0]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -95,7 +95,8 @@ class Azure(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
-        return service_catalog.get_default_instance_type(cpu=cpu, clouds='azure')
+        return service_catalog.get_default_instance_type(cpu=cpu,
+                                                         clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
         # az vm image list \

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -180,7 +180,7 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+    def get_default_instance_type(cls, cpu: Optional[str] = None) -> Optional[str]:
         raise NotImplementedError
 
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -180,7 +180,7 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(cls) -> str:
+    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
         raise NotImplementedError
 
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -181,12 +181,12 @@ class Cloud:
 
     @classmethod
     def get_default_instance_type(cls,
-                                  cpu: Optional[str] = None) -> Optional[str]:
+                                  cpus: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type with the given number of CPUs.
 
-        When cpu is None, this method will never return None.
+        When cpus is None, this method will never return None.
         This method may return None if the cloud's default instance family
-        does not have a VM with the given number of CPUs (e.g., when cpu='123').
+        does not have a VM with the given number of CPUs (e.g., when cpus='13').
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -182,11 +182,15 @@ class Cloud:
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None) -> Optional[str]:
-        """Returns the default instance type with the given number of CPUs.
+        """Returns the default instance type with the given number of vCPUs.
+
+        For example, if cpus='4', this method returns the default instance type
+        with 4 vCPUs.  If cpus='4+', this method returns the default instance
+        type with 4 or more vCPUs.
 
         When cpus is None, this method will never return None.
         This method may return None if the cloud's default instance family
-        does not have a VM with the given number of CPUs (e.g., when cpus='13').
+        does not have a VM with the given number of vCPUs (e.g., when cpus='7').
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -180,7 +180,8 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpu: Optional[str] = None) -> Optional[str]:
         raise NotImplementedError
 
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -182,6 +182,12 @@ class Cloud:
     @classmethod
     def get_default_instance_type(cls,
                                   cpu: Optional[str] = None) -> Optional[str]:
+        """Returns the default instance type with the given number of CPUs.
+
+        When cpu is None, this method will never return None.
+        This method may return None if the cloud's default instance family
+        does not have a VM with the given number of CPUs (e.g., when cpu='123').
+        """
         raise NotImplementedError
 
     @classmethod

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -376,16 +376,15 @@ class GCP(clouds.Cloud):
         return resources_vars
 
     def get_feasible_launchable_resources(self, resources):
-        fuzzy_candidate_list = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
-            return ([resources], fuzzy_candidate_list)
+            return ([resources], [])
 
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             host_vm_type = GCP.get_default_instance_type(cpu=resources.cpu)
             if host_vm_type is None:
-                return ([], fuzzy_candidate_list)
+                return ([], [])
             else:
                 r = resources.copy(
                     cloud=GCP(),
@@ -393,7 +392,7 @@ class GCP(clouds.Cloud):
                     accelerators=None,
                     cpu=None,
                 )
-                return ([r], fuzzy_candidate_list)
+                return ([r], [])
 
         use_tpu_vm = False
         if resources.accelerator_args is not None:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -281,7 +281,8 @@ class GCP(clouds.Cloud):
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpus=cpus, clouds='gcp')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         clouds='gcp')
 
     @classmethod
     def _get_default_region(cls) -> clouds.Region:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -382,7 +382,7 @@ class GCP(clouds.Cloud):
             return ([resources], fuzzy_candidate_list)
 
         if resources.accelerators is None:
-            # Return a default instance type.
+            # Return a default instance type with the given number of vCPUs.
             host_vm_type = GCP.get_default_instance_type(cpu=resources.cpu)
             if host_vm_type is None:
                 return ([], fuzzy_candidate_list)

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -279,10 +279,8 @@ class GCP(clouds.Cloud):
             raise
 
     @classmethod
-    def get_default_instance_type(cls) -> str:
-        # General-purpose instance with 8 vCPUs and 32 GB RAM.
-        # Intel Ice Lake 8373C or Cascade Lake 6268CL
-        return 'n2-standard-8'
+    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+        return service_catalog.get_default_instance_type(cpu=cpu, clouds='gcp')
 
     @classmethod
     def _get_default_region(cls) -> clouds.Region:
@@ -382,40 +380,48 @@ class GCP(clouds.Cloud):
             assert resources.is_launchable(), resources
             return ([resources], fuzzy_candidate_list)
 
-        # No other resources (cpu/mem) to filter for now, so just return a
-        # default VM type.
-        host_vm_type = GCP.get_default_instance_type()
-        acc_dict = None
+        if resources.accelerators is None:
+            # Return a default VM type for the given CPU.
+            host_vm_type = GCP.get_default_instance_type(cpu=resources.cpu)
+            r = resources.copy(
+                cloud=GCP(),
+                instance_type=host_vm_type,
+                accelerators=None,
+                cpu=None
+            )
+            return ([r], fuzzy_candidate_list)
+
         # Find instance candidates to meet user's requirements
-        if resources.accelerators is not None:
-            assert len(resources.accelerators.items(
-            )) == 1, 'cannot handle more than one accelerator candidates.'
-            acc, acc_count = list(resources.accelerators.items())[0]
-            (instance_list, fuzzy_candidate_list
-            ) = service_catalog.get_instance_type_for_accelerator(
-                acc,
-                acc_count,
-                use_spot=resources.use_spot,
-                region=resources.region,
-                zone=resources.zone,
-                clouds='gcp')
+        assert len(resources.accelerators.items(
+        )) == 1, 'cannot handle more than one accelerator candidates.'
+        acc, acc_count = list(resources.accelerators.items())[0]
+        (instance_list, fuzzy_candidate_list
+        ) = service_catalog.get_instance_type_for_accelerator(
+            acc,
+            acc_count,
+            cpu=resources.cpu,
+            use_spot=resources.use_spot,
+            region=resources.region,
+            zone=resources.zone,
+            clouds='gcp')
 
-            if instance_list is None:
-                return ([], fuzzy_candidate_list)
-            assert len(
-                instance_list
-            ) == 1, f'More than one instance type matched, {instance_list}'
+        if instance_list is None:
+            return ([], fuzzy_candidate_list)
+        assert len(
+            instance_list
+        ) == 1, f'More than one instance type matched, {instance_list}'
 
-            host_vm_type = instance_list[0]
-            acc_dict = {acc: acc_count}
-            if resources.accelerator_args is not None:
-                use_tpu_vm = resources.accelerator_args.get('tpu_vm', False)
-                if use_tpu_vm:
-                    host_vm_type = 'TPU-VM'
+        host_vm_type = instance_list[0]
+        acc_dict = {acc: acc_count}
+        if resources.accelerator_args is not None:
+            use_tpu_vm = resources.accelerator_args.get('tpu_vm', False)
+            if use_tpu_vm:
+                host_vm_type = 'TPU-VM'
         r = resources.copy(
             cloud=GCP(),
             instance_type=host_vm_type,
             accelerators=acc_dict,
+            cpu=None,
         )
         return ([r], fuzzy_candidate_list)
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -280,8 +280,8 @@ class GCP(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(cls,
-                                  cpu: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpu=cpu, clouds='gcp')
+                                  cpus: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(cpus=cpus, clouds='gcp')
 
     @classmethod
     def _get_default_region(cls) -> clouds.Region:
@@ -382,7 +382,7 @@ class GCP(clouds.Cloud):
 
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.
-            host_vm_type = GCP.get_default_instance_type(cpu=resources.cpu)
+            host_vm_type = GCP.get_default_instance_type(cpus=resources.cpus)
             if host_vm_type is None:
                 return ([], [])
             else:
@@ -390,7 +390,7 @@ class GCP(clouds.Cloud):
                     cloud=GCP(),
                     instance_type=host_vm_type,
                     accelerators=None,
-                    cpu=None,
+                    cpus=None,
                 )
                 return ([r], [])
 
@@ -409,7 +409,7 @@ class GCP(clouds.Cloud):
         ) = service_catalog.get_instance_type_for_accelerator(
             acc,
             acc_count,
-            cpu=resources.cpu if not use_tpu_vm else None,
+            cpus=resources.cpus if not use_tpu_vm else None,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,
@@ -425,14 +425,14 @@ class GCP(clouds.Cloud):
             host_vm_type = 'TPU-VM'
             # FIXME(woosuk): This leverages the fact that TPU VMs have 96 vCPUs.
             num_cpus_in_tpu_vm = 96
-            if resources.cpu is not None:
-                if resources.cpu.endswith('+'):
-                    cpu = float(resources.cpu[:-1])
-                    if cpu > num_cpus_in_tpu_vm:
+            if resources.cpus is not None:
+                if resources.cpus.endswith('+'):
+                    cpus = float(resources.cpus[:-1])
+                    if cpus > num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
                 else:
-                    cpu = float(resources.cpu)
-                    if cpu != num_cpus_in_tpu_vm:
+                    cpus = float(resources.cpus)
+                    if cpus != num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
         else:
             host_vm_type = instance_list[0]
@@ -442,7 +442,7 @@ class GCP(clouds.Cloud):
             cloud=GCP(),
             instance_type=host_vm_type,
             accelerators=acc_dict,
-            cpu=None,
+            cpus=None,
         )
         return ([r], fuzzy_candidate_list)
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -387,13 +387,13 @@ class GCP(clouds.Cloud):
                 cloud=GCP(),
                 instance_type=host_vm_type,
                 accelerators=None,
-                cpu=None
+                cpu=None,
             )
             return ([r], fuzzy_candidate_list)
 
         # Find instance candidates to meet user's requirements
-        assert len(resources.accelerators.items(
-        )) == 1, 'cannot handle more than one accelerator candidates.'
+        assert len(resources.accelerators.items()
+                  ) == 1, 'cannot handle more than one accelerator candidates.'
         acc, acc_count = list(resources.accelerators.items())[0]
         (instance_list, fuzzy_candidate_list
         ) = service_catalog.get_instance_type_for_accelerator(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -279,7 +279,8 @@ class GCP(clouds.Cloud):
             raise
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+    def get_default_instance_type(cls,
+                                  cpu: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpu=cpu, clouds='gcp')
 
     @classmethod
@@ -381,15 +382,18 @@ class GCP(clouds.Cloud):
             return ([resources], fuzzy_candidate_list)
 
         if resources.accelerators is None:
-            # Return a default VM type for the given CPU.
+            # Return a default instance type.
             host_vm_type = GCP.get_default_instance_type(cpu=resources.cpu)
-            r = resources.copy(
-                cloud=GCP(),
-                instance_type=host_vm_type,
-                accelerators=None,
-                cpu=None,
-            )
-            return ([r], fuzzy_candidate_list)
+            if host_vm_type is None:
+                return ([], fuzzy_candidate_list)
+            else:
+                r = resources.copy(
+                    cloud=GCP(),
+                    instance_type=host_vm_type,
+                    accelerators=None,
+                    cpu=None,
+                )
+                return ([r], fuzzy_candidate_list)
 
         use_tpu_vm = False
         if resources.accelerator_args is not None:

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -94,9 +94,9 @@ class Local(clouds.Cloud):
         return isinstance(other, Local)
 
     @classmethod
-    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
+    def get_default_instance_type(cls, cpus: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
-        del cpu  # Unused.
+        del cpus  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -94,8 +94,9 @@ class Local(clouds.Cloud):
         return isinstance(other, Local)
 
     @classmethod
-    def get_default_instance_type(cls) -> str:
+    def get_default_instance_type(cls, cpu: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
+        del cpu  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -157,6 +157,11 @@ def get_vcpus_from_instance_type(instance_type: str,
                                instance_type)
 
 
+def get_default_instance_type(cpu: Optional[str] = None, clouds: CloudFilter = None) -> Optional[str]:
+    """Returns the default instance type for the given number of CPU."""
+    return _map_clouds_catalog(clouds, 'get_default_instance_type', cpu)
+
+
 def get_accelerators_from_instance_type(
         instance_type: str,
         clouds: CloudFilter = None) -> Optional[Dict[str, int]]:
@@ -168,6 +173,7 @@ def get_accelerators_from_instance_type(
 def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
+    cpu: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -178,7 +184,7 @@ def get_instance_type_for_accelerator(
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
     return _map_clouds_catalog(clouds, 'get_instance_type_for_accelerator',
-                               acc_name, acc_count, use_spot, region, zone)
+                               acc_name, acc_count, cpu, use_spot, region, zone)
 
 
 def get_accelerator_hourly_cost(

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -157,7 +157,8 @@ def get_vcpus_from_instance_type(instance_type: str,
                                instance_type)
 
 
-def get_default_instance_type(cpu: Optional[str] = None, clouds: CloudFilter = None) -> Optional[str]:
+def get_default_instance_type(cpu: Optional[str] = None,
+                              clouds: CloudFilter = None) -> str:
     """Returns the default instance type for the given number of CPU."""
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpu)
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -159,10 +159,10 @@ def get_vcpus_from_instance_type(instance_type: str,
                                instance_type)
 
 
-def get_default_instance_type(cpu: Optional[str] = None,
+def get_default_instance_type(cpus: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
     """Returns the default instance type for the given number of CPU."""
-    return _map_clouds_catalog(clouds, 'get_default_instance_type', cpu)
+    return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus)
 
 
 def get_accelerators_from_instance_type(
@@ -176,7 +176,7 @@ def get_accelerators_from_instance_type(
 def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
-    cpu: Optional[str] = None,
+    cpus: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -187,7 +187,7 @@ def get_instance_type_for_accelerator(
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
     return _map_clouds_catalog(clouds, 'get_instance_type_for_accelerator',
-                               acc_name, acc_count, cpu, use_spot, region, zone)
+                               acc_name, acc_count, cpus, use_spot, region, zone)
 
 
 def get_accelerator_hourly_cost(

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -158,7 +158,7 @@ def get_vcpus_from_instance_type(instance_type: str,
 
 
 def get_default_instance_type(cpu: Optional[str] = None,
-                              clouds: CloudFilter = None) -> str:
+                              clouds: CloudFilter = None) -> Optional[str]:
     """Returns the default instance type for the given number of CPU."""
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpu)
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -161,7 +161,12 @@ def get_vcpus_from_instance_type(instance_type: str,
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
-    """Returns the default instance type for the given number of CPU."""
+    """Returns the cloud's default instance type for the given number of vCPUs.
+
+    For example, if cpus='4', this method returns the default instance type
+    with 4 vCPUs.  If cpus='4+', this method returns the default instance
+    type with 4 or more vCPUs.
+    """
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus)
 
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -187,7 +187,8 @@ def get_instance_type_for_accelerator(
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
     return _map_clouds_catalog(clouds, 'get_instance_type_for_accelerator',
-                               acc_name, acc_count, cpus, use_spot, region, zone)
+                               acc_name, acc_count, cpus, use_spot, region,
+                               zone)
 
 
 def get_accelerator_hourly_cost(

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -105,7 +105,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
         cpu = str(_DEFAULT_NUM_VCPUS)
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
     df = _df[_df['InstanceType'].str.startswith(instance_type_prefix)]
-    return common.get_default_instance_type_impl(df, cpu)
+    return common.get_instance_type_for_cpu_impl(df, cpu)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -19,8 +19,9 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-# General-purpose instance with Intel Ice Lake 8375C
-# 4 GB RAM per 1 vCPU
+# This is the latest general-purpose instance family as of Jan 2023.
+# CPU: Intel Ice Lake 8375C.
+# Memory: 4 GiB RAM per 1 vCPU.
 _DEFAULT_INSTANCE_FAMILY = 'm6i'
 _DEFAULT_NUM_VCPUS = 8
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -104,7 +104,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
         cpu = str(_DEFAULT_NUM_VCPUS)
     # The metal instance is not included in the default instance family.
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
-    instance_type_suffix = 'xlarge'
+    instance_type_suffix = 'large'
     df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) &
              _df['InstanceType'].str.endswith(instance_type_suffix)]
     return common.get_default_instance_type_impl(df, cpu)

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -100,12 +100,12 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
-    if cpu is None:
-        cpu = str(_DEFAULT_NUM_VCPUS)
+def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
+    if cpus is None:
+        cpus = str(_DEFAULT_NUM_VCPUS)
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
     df = _df[_df['InstanceType'].str.startswith(instance_type_prefix)]
-    return common.get_instance_type_for_cpu_impl(df, cpu)
+    return common.get_instance_type_for_cpus_impl(df, cpus)
 
 
 def get_accelerators_from_instance_type(
@@ -116,7 +116,7 @@ def get_accelerators_from_instance_type(
 def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
-    cpu: Optional[str] = None,
+    cpus: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -128,7 +128,7 @@ def get_instance_type_for_accelerator(
     return common.get_instance_type_for_accelerator_impl(df=_df,
                                                          acc_name=acc_name,
                                                          acc_count=acc_count,
-                                                         cpu=cpu,
+                                                         cpus=cpus,
                                                          use_spot=use_spot,
                                                          region=region,
                                                          zone=zone)

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -102,11 +102,8 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
 def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
         cpu = str(_DEFAULT_NUM_VCPUS)
-    # The metal instance is not included in the default instance family.
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
-    instance_type_suffix = 'large'
-    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) &
-             _df['InstanceType'].str.endswith(instance_type_suffix)]
+    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix)]
     return common.get_default_instance_type_impl(df, cpu)
 
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -22,6 +22,7 @@ logger = sky_logging.init_logger(__name__)
 # General-purpose instance with Intel Ice Lake 8375C
 # 4 GB RAM per 1 vCPU
 _DEFAULT_INSTANCE_FAMILY = 'm6i'
+_DEFAULT_NUM_VCPUS = 8
 
 # Keep it synced with the frequency in
 # skypilot-catalog/.github/workflows/update-aws-catalog.yml
@@ -100,7 +101,7 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
 
 def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
-        cpu = '8'
+        cpu = str(_DEFAULT_NUM_VCPUS)
     # The metal instance is not included in the default instance family.
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
     instance_type_suffix = 'xlarge'

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -104,7 +104,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> str:
     # The metal instance is not included in the default instance family.
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
     instance_type_suffix = 'xlarge'
-    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) & 
+    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) &
              _df['InstanceType'].str.endswith(instance_type_suffix)]
     return common.get_default_instance_type(df, cpu)
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -98,7 +98,7 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(cpu: Optional[str] = None) -> str:
+def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
         cpu = '8'
     # The metal instance is not included in the default instance family.

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -106,7 +106,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     instance_type_suffix = 'xlarge'
     df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) &
              _df['InstanceType'].str.endswith(instance_type_suffix)]
-    return common.get_default_instance_type(df, cpu)
+    return common.get_default_instance_type_impl(df, cpu)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -19,6 +19,10 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
+# General-purpose instance with Intel Ice Lake 8375C
+# 4 GB RAM per 1 vCPU
+_DEFAULT_INSTANCE_FAMILY = 'm6i'
+
 # Keep it synced with the frequency in
 # skypilot-catalog/.github/workflows/update-aws-catalog.yml
 _PULL_FREQUENCY_HOURS = 7
@@ -94,6 +98,17 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 
 
+def get_default_instance_type(cpu: Optional[str] = None) -> str:
+    if cpu is None:
+        cpu = '8'
+    # The metal instance is not included in the default instance family.
+    instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}.'
+    instance_type_suffix = 'xlarge'
+    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix) & 
+             _df['InstanceType'].str.endswith(instance_type_suffix)]
+    return common.get_default_instance_type(df, cpu)
+
+
 def get_accelerators_from_instance_type(
         instance_type: str) -> Optional[Dict[str, int]]:
     return common.get_accelerators_from_instance_type_impl(_df, instance_type)
@@ -102,6 +117,7 @@ def get_accelerators_from_instance_type(
 def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
+    cpu: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -113,6 +129,7 @@ def get_instance_type_for_accelerator(
     return common.get_instance_type_for_accelerator_impl(df=_df,
                                                          acc_name=acc_name,
                                                          acc_count=acc_count,
+                                                         cpu=cpu,
                                                          use_spot=use_spot,
                                                          region=region,
                                                          zone=zone)

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -72,9 +72,11 @@ def _get_instance_family(instance_type: str) -> str:
     # TODO(woosuk): Use better regex.
     if '-' in instance_type:
         x = re.match(r'([A-Za-z]+)([0-9]+)(-)([0-9]+)(.*)', instance_type)
+        assert x is not None, x
         instance_family = x.group(1) + '_' + x.group(5)
     else:
         x = re.match(r'([A-Za-z]+)([0-9]+)(.*)', instance_type)
+        assert x is not None, x
         instance_family = x.group(1) + x.group(3)
     return instance_family
 
@@ -82,7 +84,8 @@ def _get_instance_family(instance_type: str) -> str:
 def get_default_instance_type(cpu: Optional[str] = None) -> str:
     if cpu is None:
         cpu = '8'
-    df = _df[_df['InstanceType'].apply(_get_instance_family) == _DEFAULT_INSTANCE_FAMILY]
+    df = _df[_df['InstanceType'].apply(_get_instance_family) ==
+             _DEFAULT_INSTANCE_FAMILY]
     return common.get_default_instance_type(df, cpu)
 
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -83,12 +83,12 @@ def _get_instance_family(instance_type: str) -> str:
     return instance_family
 
 
-def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
-    if cpu is None:
-        cpu = str(_DEFAULT_NUM_VCPUS)
+def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
+    if cpus is None:
+        cpus = str(_DEFAULT_NUM_VCPUS)
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==
              _DEFAULT_INSTANCE_FAMILY]
-    return common.get_instance_type_for_cpu_impl(df, cpu)
+    return common.get_instance_type_for_cpus_impl(df, cpus)
 
 
 def get_accelerators_from_instance_type(
@@ -99,7 +99,7 @@ def get_accelerators_from_instance_type(
 def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
-        cpu: Optional[str] = None,
+        cpus: Optional[str] = None,
         use_spot: bool = False,
         region: Optional[str] = None,
         zone: Optional[str] = None) -> Tuple[Optional[List[str]], List[str]]:
@@ -113,7 +113,7 @@ def get_instance_type_for_accelerator(
     return common.get_instance_type_for_accelerator_impl(df=_df,
                                                          acc_name=acc_name,
                                                          acc_count=acc_count,
-                                                         cpu=cpu,
+                                                         cpus=cpus,
                                                          use_spot=use_spot,
                                                          region=region,
                                                          zone=zone)

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -81,7 +81,7 @@ def _get_instance_family(instance_type: str) -> str:
     return instance_family
 
 
-def get_default_instance_type(cpu: Optional[str] = None) -> str:
+def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
         cpu = '8'
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -15,6 +15,7 @@ _df = common.read_catalog('azure/vms.csv')
 # General-purpose instance with Intel Ice Lake 8370C
 # 4 GB RAM per 1 vCPU
 _DEFAULT_INSTANCE_FAMILY = 'D_v5'
+_DEFAULT_NUM_VCPUS = 8
 
 
 def instance_type_exists(instance_type: str) -> bool:
@@ -83,7 +84,7 @@ def _get_instance_family(instance_type: str) -> str:
 
 def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
-        cpu = '8'
+        cpu = str(_DEFAULT_NUM_VCPUS)
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==
              _DEFAULT_INSTANCE_FAMILY]
     return common.get_default_instance_type_impl(df, cpu)

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -88,7 +88,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
         cpu = str(_DEFAULT_NUM_VCPUS)
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==
              _DEFAULT_INSTANCE_FAMILY]
-    return common.get_default_instance_type_impl(df, cpu)
+    return common.get_instance_type_for_cpu_impl(df, cpu)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -86,7 +86,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
         cpu = '8'
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==
              _DEFAULT_INSTANCE_FAMILY]
-    return common.get_default_instance_type(df, cpu)
+    return common.get_default_instance_type_impl(df, cpu)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -12,8 +12,9 @@ from sky.utils import ux_utils
 
 _df = common.read_catalog('azure/vms.csv')
 
-# General-purpose instance with Intel Ice Lake 8370C
-# 4 GB RAM per 1 vCPU
+# This is the latest general-purpose instance family as of Jan 2023.
+# CPU: Intel Ice Lake 8370C.
+# Memory: 4 GiB RAM per 1 vCPU.
 _DEFAULT_INSTANCE_FAMILY = 'D_v5'
 _DEFAULT_NUM_VCPUS = 8
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -279,7 +279,7 @@ def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == float(cpu)]
 
 
-def get_default_instance_type(df: pd.DataFrame,
+def get_default_instance_type_impl(df: pd.DataFrame,
                               cpu: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpu(df, cpu)
     if df.empty:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -267,7 +267,8 @@ def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == float(cpu)]
 
 
-def get_default_instance_type(df: pd.DataFrame, cpu: Optional[str] = None) -> str:
+def get_default_instance_type(df: pd.DataFrame,
+                              cpu: Optional[str] = None) -> str:
     df = _filter_with_cpu(df, cpu)
     if df.empty:
         with ux_utils.print_exception_no_traceback():
@@ -276,7 +277,7 @@ def get_default_instance_type(df: pd.DataFrame, cpu: Optional[str] = None) -> st
                              'the cpu value to allow larger vCPUs.')
     # Sort by the number of vCPUs and then by the price.
     df = df.sort_values(by=['vCPUs', 'Price'], ascending=True)
-    return df['InstanceType'].iloc[0]    
+    return df['InstanceType'].iloc[0]
 
 
 def get_accelerators_from_instance_type_impl(

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -284,9 +284,8 @@ def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
         num_cpus = float(num_cpus_str)
     except ValueError:
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                f'The "cpus" field should be either a number or '
-                f'a string "<number>+". Found: {cpus!r}') from None
+            raise ValueError(f'The "cpus" field should be either a number or '
+                             f'a string "<number>+". Found: {cpus!r}') from None
 
     if cpus.endswith('+'):
         return df[df['vCPUs'] >= num_cpus]

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -270,18 +270,18 @@ def get_vcpus_from_instance_type_impl(
     return float(vcpus)
 
 
-def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
-    if cpu is None:
+def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
+    if cpus is None:
         return df
-    if cpu.endswith('+'):
-        return df[df['vCPUs'] >= float(cpu[:-1])]
+    if cpus.endswith('+'):
+        return df[df['vCPUs'] >= float(cpus[:-1])]
     else:
-        return df[df['vCPUs'] == float(cpu)]
+        return df[df['vCPUs'] == float(cpus)]
 
 
-def get_instance_type_for_cpu_impl(df: pd.DataFrame,
-                                   cpu: Optional[str] = None) -> Optional[str]:
-    df = _filter_with_cpu(df, cpu)
+def get_instance_type_for_cpus_impl(df: pd.DataFrame,
+                                   cpus: Optional[str] = None) -> Optional[str]:
+    df = _filter_with_cpus(df, cpus)
     if df.empty:
         return None
     # Sort by the number of vCPUs and then by the price.
@@ -308,7 +308,7 @@ def get_instance_type_for_accelerator_impl(
     df: pd.DataFrame,
     acc_name: str,
     acc_count: int,
-    cpu: Optional[str] = None,
+    cpus: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -333,7 +333,7 @@ def get_instance_type_for_accelerator_impl(
                                             f'{int(row["AcceleratorCount"])}')
         return (None, fuzzy_candidate_list)
 
-    result = _filter_with_cpu(result, cpu)
+    result = _filter_with_cpus(result, cpus)
     if region is not None:
         result = result[result['Region'] == region]
     if zone is not None:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -334,9 +334,6 @@ def get_instance_type_for_accelerator_impl(
         return (None, fuzzy_candidate_list)
 
     result = _filter_with_cpu(result, cpu)
-    if len(result) == 0:
-        return ([], [])
-
     if region is not None:
         result = result[result['Region'] == region]
     if zone is not None:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -280,7 +280,7 @@ def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
 
 
 def get_default_instance_type_impl(df: pd.DataFrame,
-                              cpu: Optional[str] = None) -> Optional[str]:
+                                   cpu: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpu(df, cpu)
     if df.empty:
         return None

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -279,8 +279,8 @@ def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == float(cpus)]
 
 
-def get_instance_type_for_cpus_impl(df: pd.DataFrame,
-                                   cpus: Optional[str] = None) -> Optional[str]:
+def get_instance_type_for_cpus_impl(
+        df: pd.DataFrame, cpus: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpus(df, cpus)
     if df.empty:
         return None

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -273,10 +273,25 @@ def get_vcpus_from_instance_type_impl(
 def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
     if cpus is None:
         return df
+
+    # The following code is redundant with the code in resources.py::_set_cpus()
+    # but we add it here for safety.
     if cpus.endswith('+'):
-        return df[df['vCPUs'] >= float(cpus[:-1])]
+        num_cpus_str = cpus[:-1]
     else:
-        return df[df['vCPUs'] == float(cpus)]
+        num_cpus_str = cpus
+    try:
+        num_cpus = float(num_cpus_str)
+    except ValueError:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'The "cpus" field should be either a number or '
+                f'a string "<number>+". Found: {cpus!r}') from None
+
+    if cpus.endswith('+'):
+        return df[df['vCPUs'] >= num_cpus]
+    else:
+        return df[df['vCPUs'] == num_cpus]
 
 
 def get_instance_type_for_cpus_impl(

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -279,7 +279,7 @@ def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == float(cpu)]
 
 
-def get_default_instance_type_impl(df: pd.DataFrame,
+def get_instance_type_for_cpu_impl(df: pd.DataFrame,
                                    cpu: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpu(df, cpu)
     if df.empty:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -268,13 +268,10 @@ def _filter_with_cpu(df: pd.DataFrame, cpu: Optional[str]) -> pd.DataFrame:
 
 
 def get_default_instance_type(df: pd.DataFrame,
-                              cpu: Optional[str] = None) -> str:
+                              cpu: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpu(df, cpu)
     if df.empty:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'No default instance type found for cpu={cpu}. '
-                             'Try other cpu values or add "+" to the end of '
-                             'the cpu value to allow larger vCPUs.')
+        return None
     # Sort by the number of vCPUs and then by the price.
     df = df.sort_values(by=['vCPUs', 'Price'], ascending=True)
     return df['InstanceType'].iloc[0]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -177,7 +177,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-standard-'
     df = _df[~_df['InstanceType'].isna()]
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
-    return common.get_default_instance_type_impl(df, cpu)
+    return common.get_instance_type_for_cpu_impl(df, cpu)
 
 
 def get_instance_type_for_accelerator(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -29,7 +29,7 @@ _TPU_REGIONS = [
 # This is the latest general-purpose instance family as of Jan 2023.
 # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
 # Memory: 4 GiB RAM per 1 vCPU.
-_DEFAULT_INSTANCE_FAMILY = 'n2'
+_DEFAULT_INSTANCE_FAMILY = 'n2-standard'
 _DEFAULT_NUM_VCPUS = 8
 
 # This can be switched between n1 and n2.
@@ -174,8 +174,8 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
 def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
     if cpus is None:
         cpus = str(_DEFAULT_NUM_VCPUS)
-    instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-standard-'
-    df = _df[~_df['InstanceType'].isna()]
+    instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-'
+    df = _df[_df['InstanceType'].notna()]
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
     return common.get_instance_type_for_cpus_impl(df, cpus)
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -448,7 +448,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
     acc_name, acc_count = acc[0]
 
     if acc_name.startswith('tpu-'):
-        # TODO(woosuk): Check max vcpus and memory for each TPU type.
+        # TODO(woosuk): Check max vCPUs and memory for each TPU type.
         assert instance_type == 'TPU-VM' or instance_type.startswith('n1-')
         return
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -175,7 +175,7 @@ def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-standard-'
     df = _df[~_df['InstanceType'].isna()]
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
-    return common.get_default_instance_type(df, cpu)
+    return common.get_default_instance_type_impl(df, cpu)
 
 
 def get_instance_type_for_accelerator(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -26,8 +26,9 @@ _TPU_REGIONS = [
 ]
 
 # Default instance family for CPU-only VMs.
-# General-purpose instance with Intel Ice Lake 8373C or Cascade Lake 6268CL
-# 4 GB RAM per 1 vCPU
+# This is the latest general-purpose instance family as of Jan 2023.
+# CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
+# Memory: 4 GiB RAM per 1 vCPU.
 _DEFAULT_INSTANCE_FAMILY = 'n2'
 _DEFAULT_NUM_VCPUS = 8
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -29,6 +29,7 @@ _TPU_REGIONS = [
 # General-purpose instance with Intel Ice Lake 8373C or Cascade Lake 6268CL
 # 4 GB RAM per 1 vCPU
 _DEFAULT_INSTANCE_FAMILY = 'n2'
+_DEFAULT_NUM_VCPUS = 8
 
 # This can be switched between n1 and n2.
 # n2 is not allowed for launching GPUs.
@@ -171,7 +172,7 @@ def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
 
 def get_default_instance_type(cpu: Optional[str] = None) -> Optional[str]:
     if cpu is None:
-        cpu = '8'
+        cpu = str(_DEFAULT_NUM_VCPUS)
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-standard-'
     df = _df[~_df['InstanceType'].isna()]
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,12 +176,15 @@ def _execute(
         existing_handle = global_user_state.get_handle_from_cluster_name(
             cluster_name)
         cluster_exists = existing_handle is not None
-    if cluster_exists and task.resources.cpu is not None:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                'Cannot specify CPU when using an existing cluster. '
-                'CPU is only used for selecting the instance type when '
-                'creating a new cluster.')
+    if cluster_exists:
+        assert len(task.resources) == 1
+        task_resources = list(task.resources)[0]
+        if task_resources.cpu is not None:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'Cannot specify CPU when using an existing cluster. '
+                    'CPU is only used for selecting the instance type when '
+                    'creating a new cluster.')
 
     stages = stages if stages is not None else list(Stage)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -179,7 +179,7 @@ def _execute(
     if cluster_exists:
         assert len(task.resources) == 1
         task_resources = list(task.resources)[0]
-        if task_resources.cpu is not None:
+        if task_resources.cpus is not None:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Cannot specify CPU when using an existing cluster. '

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -460,6 +460,20 @@ def exec(  # pylint: disable=redefined-builtin
     backend_utils.check_cluster_name_not_reserved(cluster_name,
                                                   operation_str='sky.exec')
 
+    if isinstance(entrypoint, sky.Dag):
+        task = entrypoint.tasks[0]
+    else:
+        task = entrypoint
+    task_resources = task.get_resources()
+    if task_resources:
+        assert len(task_resources) == 1
+        task_resources = list(task_resources)[0]
+        if task_resources.cpu is not None:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'Cannot specify CPU resources for sky exec. '
+                    f'CPU resources: {task_resources.cpu}')
+
     handle = backend_utils.check_cluster_available(
         cluster_name,
         operation='executing tasks',

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -460,18 +460,18 @@ def exec(  # pylint: disable=redefined-builtin
     backend_utils.check_cluster_name_not_reserved(cluster_name,
                                                   operation_str='sky.exec')
 
+    # Currently, we do not allow using CPU resources for sky exec.
     if isinstance(entrypoint, sky.Dag):
         task = entrypoint.tasks[0]
     else:
         task = entrypoint
     task_resources = task.get_resources()
-    if task_resources:
-        assert len(task_resources) == 1
-        task_resources = list(task_resources)[0]
-        if task_resources.cpu is not None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Cannot specify CPU resources for sky exec. '
-                                 f'CPU resources: {task_resources.cpu}')
+    assert len(task_resources) == 1
+    task_resources = list(task_resources)[0]
+    if task_resources.cpu is not None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'Cannot specify CPU resources for sky exec. '
+                                f'CPU resources: {task_resources.cpu}')
 
     handle = backend_utils.check_cluster_available(
         cluster_name,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -471,7 +471,7 @@ def exec(  # pylint: disable=redefined-builtin
     if task_resources.cpu is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(f'Cannot specify CPU resources for sky exec. '
-                                f'CPU resources: {task_resources.cpu}')
+                             f'CPU resources: {task_resources.cpu}')
 
     handle = backend_utils.check_cluster_available(
         cluster_name,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -470,9 +470,8 @@ def exec(  # pylint: disable=redefined-builtin
         task_resources = list(task_resources)[0]
         if task_resources.cpu is not None:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    f'Cannot specify CPU resources for sky exec. '
-                    f'CPU resources: {task_resources.cpu}')
+                raise ValueError(f'Cannot specify CPU resources for sky exec. '
+                                 f'CPU resources: {task_resources.cpu}')
 
     handle = backend_utils.check_cluster_available(
         cluster_name,

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -960,6 +960,10 @@ def _fill_in_launchable_resources(
                                 f'{colorama.Fore.CYAN}'
                                 f'{sorted(all_fuzzy_candidates)}'
                                 f'{colorama.Style.RESET_ALL}')
+                elif resources.cpu is not None:
+                    logger.info('Try specifying a different CPU count, '
+                                'or add "+" to the end of the CPU count '
+                                'to allow for larger instances.')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_resources)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -960,7 +960,7 @@ def _fill_in_launchable_resources(
                                 f'{colorama.Fore.CYAN}'
                                 f'{sorted(all_fuzzy_candidates)}'
                                 f'{colorama.Style.RESET_ALL}')
-                elif resources.cpu is not None:
+                elif resources.cpus is not None:
                     logger.info('Try specifying a different CPU count, '
                                 'or add "+" to the end of the CPU count '
                                 'to allow for larger instances.')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -429,7 +429,7 @@ class Resources:
                             f'{self.instance_type} does not have enough vCPUs. '
                             f'{self.instance_type} has {cpu} vCPUs, '
                             f'but {self.cpu} is requested.')
-            elif cpu != self.cpu:
+            elif cpu != float(self.cpu):
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'{self.instance_type} does not have the requested '

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -427,6 +427,10 @@ class Resources:
         if self.cpus is None:
             return
         if self.instance_type is not None:
+            # The assertion should be true because we have already executed
+            # _try_validate_instance_type() before this method.
+            # The _try_validate_instance_type() method infers and sets
+            # self.cloud if self.instance_type is not None.
             assert self.cloud is not None
             cpus = self.cloud.get_vcpus_from_instance_type(self.instance_type)
             if self.cpus.endswith('+'):

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -138,6 +138,10 @@ class Resources:
             if self.accelerator_args is not None:
                 accelerator_args = f', accelerator_args={self.accelerator_args}'
 
+        cpu = ''
+        if self.cpu is not None:
+            cpu = f', cpu={self.cpu}'
+
         if isinstance(self.cloud, clouds.Local):
             return f'{self.cloud}({self.accelerators})'
 
@@ -163,7 +167,7 @@ class Resources:
 
         hardware_str = (
             f'{instance_type}{use_spot}'
-            f'{accelerators}{accelerator_args}{image_id}{disk_size}')
+            f'{cpu}{accelerators}{accelerator_args}{image_id}{disk_size}')
         # It may have leading ',' (for example, instance_type not set) or empty
         # spaces.  Remove them.
         while hardware_str and hardware_str[0] in (',', ' '):

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -700,9 +700,6 @@ class Resources:
             return False
         # self._instance_type <= other.instance_type
 
-        # We do not allow comparing the clusters in terms of vCPUs.
-        assert self.cpus is None and other.cpus is None
-
         other_accelerators = other.accelerators
         if self.accelerators is not None:
             if other_accelerators is None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -598,62 +598,6 @@ class Resources:
                 self.accelerators, self.use_spot, self._region, self._zone)
         return hourly_cost * hours
 
-    def is_same_resources(self, other: 'Resources') -> bool:
-        """Returns whether two resources are the same.
-
-        Returns True if they are the same, False if not.
-        """
-        if (self.cloud is None) != (other.cloud is None):
-            # self and other's cloud should be both None or both not None
-            return False
-
-        if self.cloud is not None and not self.cloud.is_same_cloud(other.cloud):
-            return False
-        # self.cloud == other.cloud
-
-        if (self.region is None) != (other.region is None):
-            # self and other's region should be both None or both not None
-            return False
-
-        if self.region is not None and self.region != other.region:
-            return False
-        # self.region <= other.region
-
-        if (self.zone is None) != (other.zone is None):
-            # self and other's zone should be both None or both not None
-            return False
-
-        if self.zone is not None and self.zone != other.zone:
-            return False
-
-        if (self.image_id is None) != (other.image_id is None):
-            # self and other's image id should be both None or both not None
-            return False
-
-        if (self.image_id is not None and self.image_id != other.image_id):
-            return False
-
-        if (self._instance_type is not None and
-                self._instance_type != other.instance_type):
-            return False
-        # self._instance_type == other.instance_type
-
-        other_accelerators = other.accelerators
-        accelerators = self.accelerators
-        if accelerators != other_accelerators:
-            return False
-        # self.accelerators == other.accelerators
-
-        if self.accelerator_args != other.accelerator_args:
-            return False
-        # self.accelerator_args == other.accelerator_args
-
-        if self.use_spot != other.use_spot:
-            return False
-
-        # self == other
-        return True
-
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],
                             requested_num_nodes: int = 1) -> bool:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -255,7 +255,7 @@ class Resources:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'The "cpu" field should be either a number or '
-                        f'a string "<number>+". Found: {cpu!r}')
+                        f'a string "<number>+". Found: {cpu!r}') from None
         else:
             num_cpu = float(cpu)
 
@@ -431,7 +431,7 @@ class Resources:
                         f'{self.instance_type} does not have the requested '
                         f'number of vCPUs. {self.instance_type} has {cpu} '
                         f'vCPUs, but {self.cpu} is requested.')
-            
+
     def _try_validate_accelerators(self) -> None:
         """Validate accelerators against the instance type and region/zone."""
         acc_requested = self.accelerators

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -195,10 +195,10 @@ class Resources:
 
     @property
     def cpus(self) -> Optional[str]:
-        """Returns the number of vcpus that each instance must have.
+        """Returns the number of vCPUs that each instance must have.
 
-        For example, cpus='4' means each instance must have exactly 4 vcpus,
-        and cpus='4+' means each instance must have at least 4 vcpus.
+        For example, cpus='4' means each instance must have exactly 4 vCPUs,
+        and cpus='4+' means each instance must have at least 4 vCPUs.
         The cpus field is only used to select the instance type at launch time.
         Thus, Resources in ResourceHandle will have cpus field set to None.
         """

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -199,8 +199,10 @@ class Resources:
 
         For example, cpus='4' means each instance must have exactly 4 vCPUs,
         and cpus='4+' means each instance must have at least 4 vCPUs.
-        The cpus field is only used to select the instance type at launch time.
-        Thus, Resources in ResourceHandle will have cpus field set to None.
+
+        (Developer note: The cpus field is only used to select the instance type
+        at launch time. Thus, Resources in the backend's ResourceHandle will
+        always have the cpus field set to None.)
         """
         return self._cpus
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -195,6 +195,13 @@ class Resources:
 
     @property
     def cpu(self) -> Optional[str]:
+        """Returns the number of vcpus that each instance must have.
+
+        For example, cpu='4' means each instance must have exactly 4 vcpus,
+        and cpu='4+' means each instance must have at least 4 vcpus.
+        The cpu field is only used to select the instance type at launch time.
+        Thus, Resources in ResourceHandle will have cpu field set to None.
+        """
         return self._cpu
 
     @property

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -41,10 +41,8 @@ class Resources:
         # TODO:
         sky.Resources(requests={'mem': '16g', 'cpu': 8})
     """
-    # If any fields changed:
-    # 1. Increment the version. For backward compatibility.
-    # 2. Change the __setstate__ method to handle the new fields.
-    # 3. Modify the to_config method to handle the new fields.
+    # If any fields changed, increment the version. For backward compatibility,
+    # modify the __setstate__ method to handle the old version.
     _VERSION = 7
 
     def __init__(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -700,6 +700,9 @@ class Resources:
             return False
         # self._instance_type <= other.instance_type
 
+        # We do not allow comparing the clusters in terms of vCPUs.
+        assert self.cpus is None and other.cpus is None
+
         other_accelerators = other.accelerators
         if self.accelerators is not None:
             if other_accelerators is None:

--- a/sky/task.py
+++ b/sky/task.py
@@ -448,6 +448,7 @@ class Task:
         """
         if isinstance(resources, sky.Resources):
             resources = {resources}
+        # TODO(woosuk): Check if the resources are None.
         self.resources = resources
         return self
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -25,7 +25,7 @@ def get_resources_schema():
             'zone': {
                 'type': 'string',
             },
-            'cpu': {
+            'cpus': {
                 'anyOf': [{
                     'type': 'string',
                 }, {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -25,6 +25,13 @@ def get_resources_schema():
             'zone': {
                 'type': 'string',
             },
+            'cpu': {
+                'anyOf': [{
+                    'type': 'string',
+                }, {
+                    'type': 'number',
+                }],
+            },
             'accelerators': {
                 'anyOf': [{
                     'type': 'string',

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -176,7 +176,7 @@ def test_instance_type_mismatches_cpus(monkeypatch):
                                    sky.AWS(),
                                    instance_type=instance,
                                    cpus=cpus)
-        assert 'Infeasible resource demands found' in str(e.value)
+        assert 'does not have the requested number of vCPUs' in str(e.value)
 
 
 def test_instance_type_matches_cpus(monkeypatch):

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -348,12 +348,12 @@ def test_parse_cpus_from_yaml():
     spec = textwrap.dedent("""\
         resources:
             cpus: 1""")
-    _test_parse_cpus(spec, 1)
+    _test_parse_cpus(spec, '1')
 
     spec = textwrap.dedent("""\
         resources:
             cpus: 1.5""")
-    _test_parse_cpus(spec, 1.5)
+    _test_parse_cpus(spec, '1.5')
 
     spec = textwrap.dedent("""\
         resources:

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -168,7 +168,7 @@ def test_instance_type_mismatches_cpus(monkeypatch):
         # Actual: 8
         ('m6i.2xlarge', 4),
         # Actual: 2
-        ('c6i.xlarge', 4),
+        ('c6i.large', 4),
     ]
     for instance, cpus in bad_instance_and_cpus:
         with pytest.raises(ValueError) as e:

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -187,7 +187,7 @@ def test_instance_type_matches_cpus(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.Azure(),
                            instance_type='Standard_E8s_v5',
-                           cpus=8)
+                           cpus='8')
     _test_resources_launch(monkeypatch,
                            sky.GCP(),
                            instance_type='n1-standard-8',
@@ -195,7 +195,7 @@ def test_instance_type_matches_cpus(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.AWS(),
                            instance_type='g4dn.2xlarge',
-                           cpus=8)
+                           cpus=8.0)
 
 
 def test_instance_type_mistmatches_accelerators(monkeypatch):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Closes #387

This PR introduces the ability for users to specify resource requirements in terms of the number of vCPUs in the `Resources` class and the `resources` section in the SkyPilot yaml.

**Semantics**
1. If the instance type and accelerators are not specified, SkyPilot will use the `cpus` parameter to select an appropriate VM size from the cloud's **default** VM family (i.e., m6i for AWS, Dv5 for Azure, and n2-standard for GCP).

For example,
* `sky launch --cpus 8` or `Resources(cpus=8)`: SkyPilot will find the VMs that have exactly 8 vCPUs. Namely,
  * AWS: m6i.2xlarge
  * Azure: Standard_D8_v5
  * GCP: n2-standard-8

* `sky launch --cpus 12+` or `Resources(cpus='12+')`: SkyPilot will consider the VMs that have 12 or more vCPUs. Namely,
  * AWS: m6i.4xlarge
  * Azure: Standard_D16_v5
  * GCP: n2-standard-16

(Note: The selected three instance types have 16 vCPUs instead of 12 vCPUs, because the default instance families of the clouds do not include any VM with 12-15 vCPUs.)

2. If the accelerators are specified, the instance family can be inferred for each cloud, and SkyPilot will use the `cpus` parameter to choose the VM of the right size in the instance family. For example,
* `sky launch --gpus T4 --cpus 8+` or `Resources(accelerators='T4', cpus='8+')`: SkyPilot will choose VMs that have 1 T4 GPU along with 8 or more vCPUs. Namely,
  * AWS: g4dn.2xlarge'
  * Azure: Standard_NC8as_T4_v3
  * GCP: n1-highmem-8 (+ T4)

The same semantics applies to `cpunode`, `gpunode`, `tpunode`, and `spot launch`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
