### PR TITLE
Fix ubuntu ami

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -93,6 +93,8 @@ def setup_aws_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     # Use cloud init in UserData to set up the authorized_keys to get
     # around the number of keys limit and permission issues with
     # ec2.describe_key_pairs.
+    # Note that sudo and shell need to be specified to ensure setup works.
+    # Reference: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups  # pylint: disable=line-too-long
     for node_type in config['available_node_types']:
         config['available_node_types'][node_type]['node_config']['UserData'] = (
             textwrap.dedent(f"""\

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -99,6 +99,8 @@ def setup_aws_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
             #cloud-config
             users:
             - name: {config['auth']['ssh_user']}
+              shell: /bin/bash
+              sudo: ALL=(ALL) NOPASSWD:ALL
               ssh-authorized-keys:
                 - {public_key}
             """))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -606,7 +606,7 @@ def test_aws_storage_mounts():
         file_path = f.name
         test_commands = [
             *storage_setup_commands,
-            f'sky launch -y -c {name}-aws --cloud aws {file_path}',
+            f'sky launch -y -c {name} --cloud aws {file_path}',
             f'sky logs {name} 1 --status',  # Ensure job succeeded.
             f'aws s3 ls {storage_name}/hello.txt',
         ]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes https://github.com/skypilot-org/skypilot/issues/1616 in which `sky launch` was stuck forever during `ray up`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
-  Tested with the Ubuntu Server 20.04 LTS (HVM) AMI
```sky launch -c ubuntu2004 --cloud aws --region us-east-1 --image-id ami-0778521d914d23bc1```
- [x] All smoke tests: `pytest tests/test_smoke.py` 
