### PR TITLE
[UX] Clarify fix for GCP disabled API error

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -171,12 +171,13 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
             logger.error(
                 f'{yellow}Certain GCP APIs are disabled for the GCP project '
                 f'{project_id}.{reset}')
-            logger.error(f'{yellow}Enable them by running:{reset} '
-                         f'{bright}sky check{reset}')
             logger.error('Details:')
             logger.error(f'{dim}{match.group(1)}{reset}\n'
                          f'{dim}    {match.group(2)}{reset}\n'
                          f'{dim}{match.group(3)}{reset}')
+            logger.error(
+                f'{yellow}To fix, enable these APIs by running:{reset} '
+                f'{bright}sky check{reset}')
             sys.exit(1)
         else:
             raise


### PR DESCRIPTION
Closes #1626 by 1) moving the sky check suggestion to the end and 2) explicitly stating that sky check is the fix.

Tested (run the relevant ones):
- [x] `sky launch --cloud gcp` on a new GCP project