### PR TITLE
[Autostop/UX] Better UX when the cluster is partially stopped due to autostopping

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1960,21 +1960,23 @@ def _update_cluster_status_no_lock(
         # autostop field in the local cache will be reset, even though the
         # cluster will still be correctly stopped.
         backend = get_backend_from_handle(handle)
-        if isinstance(backend, backends.CloudVmRayBackend) and record['autostop'] >= 0:
+        if isinstance(backend,
+                      backends.CloudVmRayBackend) and record['autostop'] >= 0:
             if not backend.is_autostopping(handle, stream_logs=False):
                 try:
                     backend.set_autostop(handle, -1, stream_logs=False)
                 except (Exception, SystemExit) as e:  # pylint: disable=broad-except
                     logger.debug(f'Failed to reset autostop. Due to '
-                                f'{common_utils.format_exception(e)}')
-                global_user_state.set_cluster_autostop_value(handle.cluster_name,
-                                                            -1,
-                                                            to_down=False)
+                                 f'{common_utils.format_exception(e)}')
+                global_user_state.set_cluster_autostop_value(
+                    handle.cluster_name, -1, to_down=False)
             else:
                 ux_utils.console_newline()
-                operation_str = 'autodowning' if record['down'] else 'autostopping'
-                logger.info(f'Cluster {cluster_name!r} is {operation_str}, it will remain '
-                            'in INIT state until the autostop is finished.')
+                operation_str = 'autodowning' if record[
+                    'down'] else 'autostopping'
+                logger.info(
+                    f'Cluster {cluster_name!r} is {operation_str}, it will remain '
+                    'in INIT state until the autostop is finished.')
 
         # If the user starts part of a STOPPED cluster, we still need a status
         # to represent the abnormal status. For spot cluster, it can also

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1950,19 +1950,21 @@ def _update_cluster_status_no_lock(
     #     abnormal.
     #
     # An abnormal cluster will transition to INIT and have any autostop setting
-    # reset.
+    # reset (unless it's autostopping/autodowning.).
     is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or
                    any(status != global_user_state.ClusterStatus.STOPPED
                        for status in node_statuses))
     if is_abnormal:
-        # Reset the autostop to avoid false information with best effort.
-        # Side effect: if the status is refreshed during autostopping, the
-        # autostop field in the local cache will be reset, even though the
-        # cluster will still be correctly stopped.
         backend = get_backend_from_handle(handle)
         if isinstance(backend,
                       backends.CloudVmRayBackend) and record['autostop'] >= 0:
-            if not backend.is_autostopping(handle, stream_logs=False):
+            if not backend.is_definitely_autostopping(handle,
+                                                      stream_logs=False):
+                # Reset the autostopping as the cluster is abnormal, and may
+                # not correctly autostop. Resetting the autostop will let
+                # the user know that the autostop is not going to happen to
+                # avoid leakages from the assumption that the cluster will
+                # autostop.
                 try:
                     backend.set_autostop(handle, -1, stream_logs=False)
                 except (Exception, SystemExit) as e:  # pylint: disable=broad-except
@@ -1975,8 +1977,8 @@ def _update_cluster_status_no_lock(
                 operation_str = 'autodowning' if record[
                     'to_down'] else 'autostopping'
                 logger.info(
-                    f'Cluster {cluster_name!r} is {operation_str}, it will remain '
-                    'in INIT state until the autostop is finished.')
+                    f'Cluster {cluster_name!r} is {operation_str}. Setting to '
+                    'INIT status; try refresh again in a while.')
 
         # If the user starts part of a STOPPED cluster, we still need a status
         # to represent the abnormal status. For spot cluster, it can also

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1339,17 +1339,17 @@ def get_node_ips(cluster_yaml: str,
                     break
         if len(worker_ips) != expected_num_nodes - 1:
             n = expected_num_nodes - 1
-            # This could be triggered if e.g., some logging is added in
-            # skypilot_config, a module that has some code executed whenever
-            # `sky` is imported.
-            logger.warning(
-                f'Expected {n} worker IP(s); found '
-                f'{len(worker_ips)}: {worker_ips}'
-                '\nThis could happen if there is extra output from '
-                '`ray get-worker-ips`, which should be inspected below.'
-                f'\n== Output ==\n{out}'
-                f'\n== Output ends ==')
             if len(worker_ips) > n:
+                # This could be triggered if e.g., some logging is added in
+                # skypilot_config, a module that has some code executed whenever
+                # `sky` is imported.
+                logger.warning(
+                    f'Expected {n} worker IP(s); found '
+                    f'{len(worker_ips)}: {worker_ips}'
+                    '\nThis could happen if there is extra output from '
+                    '`ray get-worker-ips`, which should be inspected below.'
+                    f'\n== Output ==\n{out}'
+                    f'\n== Output ends ==')
                 logger.warning(f'\nProceeding with the last {n} '
                                f'detected IP(s): {worker_ips[-n:]}.')
                 worker_ips = worker_ips[-n:]

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1973,7 +1973,7 @@ def _update_cluster_status_no_lock(
             else:
                 ux_utils.console_newline()
                 operation_str = 'autodowning' if record[
-                    'down'] else 'autostopping'
+                    'to_down'] else 'autostopping'
                 logger.info(
                     f'Cluster {cluster_name!r} is {operation_str}, it will remain '
                     'in INIT state until the autostop is finished.')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1962,9 +1962,8 @@ def _update_cluster_status_no_lock(
                                                       stream_logs=False):
                 # Reset the autostopping as the cluster is abnormal, and may
                 # not correctly autostop. Resetting the autostop will let
-                # the user know that the autostop is not going to happen to
-                # avoid leakages from the assumption that the cluster will
-                # autostop.
+                # the user know that the autostop may not happen to avoid
+                # leakages from the assumption that the cluster will autostop.
                 try:
                     backend.set_autostop(handle, -1, stream_logs=False)
                 except (Exception, SystemExit) as e:  # pylint: disable=broad-except

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1972,7 +1972,8 @@ def _update_cluster_status_no_lock(
                                                             to_down=False)
             else:
                 ux_utils.console_newline()
-                logger.info(f'Cluster {cluster_name!r} is autostopping, it will remain '
+                operation_str = 'autodowning' if record['down'] else 'autostopping'
+                logger.info(f'Cluster {cluster_name!r} is {operation_str}, it will remain '
                             'in INIT state until the autostop is finished.')
 
         # If the user starts part of a STOPPED cluster, we still need a status

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1970,6 +1970,10 @@ def _update_cluster_status_no_lock(
                 global_user_state.set_cluster_autostop_value(handle.cluster_name,
                                                             -1,
                                                             to_down=False)
+            else:
+                ux_utils.console_newline()
+                logger.info(f'Cluster {cluster_name!r} is autostopping, it will remain '
+                            'in INIT state until the autostop is finished.')
 
         # If the user starts part of a STOPPED cluster, we still need a status
         # to represent the abnormal status. For spot cluster, it can also

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3063,6 +3063,19 @@ class CloudVmRayBackend(backends.Backend):
             global_user_state.set_cluster_autostop_value(
                 handle.cluster_name, idle_minutes_to_autostop, down)
 
+    def is_autostopping(self, handle: ResourceHandle, stream_logs: bool = True) -> bool:
+        code = autostop_lib.AutostopCodeGen.is_autostopping()
+        returncode, stdout, stderr = self.run_on_head(handle,
+                                                      code,
+                                                      require_outputs=True,
+                                                      stream_logs=stream_logs)
+        subprocess_utils.handle_returncode(returncode,
+                                           code,
+                                           'Failed to check autostop',
+                                           stderr=stderr,
+                                           stream_logs=stream_logs)
+        return common_utils.decode_payload(stdout)
+
     # TODO(zhwu): Refactor this to a CommandRunner class, so different backends
     # can support its own command runner.
     @timeline.event

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3063,7 +3063,9 @@ class CloudVmRayBackend(backends.Backend):
             global_user_state.set_cluster_autostop_value(
                 handle.cluster_name, idle_minutes_to_autostop, down)
 
-    def is_autostopping(self, handle: ResourceHandle, stream_logs: bool = True) -> bool:
+    def is_autostopping(self,
+                        handle: ResourceHandle,
+                        stream_logs: bool = True) -> bool:
         code = autostop_lib.AutostopCodeGen.is_autostopping()
         returncode, stdout, stderr = self.run_on_head(handle,
                                                       code,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3071,7 +3071,7 @@ class CloudVmRayBackend(backends.Backend):
                                                       code,
                                                       require_outputs=True,
                                                       stream_logs=stream_logs)
-        
+
         if returncode == 0:
             return common_utils.decode_payload(stdout)
         logger.debug(f'Failed to check if cluster is autostopping: {stderr}')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3071,12 +3071,11 @@ class CloudVmRayBackend(backends.Backend):
                                                       code,
                                                       require_outputs=True,
                                                       stream_logs=stream_logs)
-        subprocess_utils.handle_returncode(returncode,
-                                           code,
-                                           'Failed to check autostop',
-                                           stderr=stderr,
-                                           stream_logs=stream_logs)
-        return common_utils.decode_payload(stdout)
+        
+        if returncode == 0:
+            return common_utils.decode_payload(stdout)
+        logger.debug(f'Failed to check if cluster is autostopping: {stderr}')
+        return False
 
     # TODO(zhwu): Refactor this to a CommandRunner class, so different backends
     # can support its own command runner.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3071,7 +3071,7 @@ class CloudVmRayBackend(backends.Backend):
         Returns:
             True if the cluster is definitely autostopping. It is possible
             that the cluster is still autostopping when False is returned,
-            due to errors like network transiant issues.
+            due to errors like transient network issues.
         """
         code = autostop_lib.AutostopCodeGen.is_autostopping()
         returncode, stdout, stderr = self.run_on_head(handle,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3063,9 +3063,16 @@ class CloudVmRayBackend(backends.Backend):
             global_user_state.set_cluster_autostop_value(
                 handle.cluster_name, idle_minutes_to_autostop, down)
 
-    def is_autostopping(self,
-                        handle: ResourceHandle,
-                        stream_logs: bool = True) -> bool:
+    def is_definitely_autostopping(self,
+                                   handle: ResourceHandle,
+                                   stream_logs: bool = True) -> bool:
+        """Check if the cluster is autostopping.
+
+        Returns:
+            True if the cluster is definitely autostopping. It is possible
+            that the cluster is still autostopping when False is returned,
+            due to errors like network transiant issues.
+        """
         code = autostop_lib.AutostopCodeGen.is_autostopping()
         returncode, stdout, stderr = self.run_on_head(handle,
                                                       code,

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -105,7 +105,7 @@ class AutostopCodeGen:
 
     @classmethod
     def is_autostopping(cls) -> str:
-        code = ['autostop_lib.get_is_autostopping_payload()']
+        code = ['print(autostop_lib.get_is_autostopping_payload())']
         return cls._build(code)
 
     @classmethod

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -17,6 +17,9 @@ _AUTOSTOP_CONFIG_KEY = 'autostop_config'
 # user-issued commands (this module) and the Skylet process running the
 # AutostopEvent need to access that state.
 _AUTOSTOP_LAST_ACTIVE_TIME = 'autostop_last_active_time'
+# AutostopEvent sets this to the boot time when the autostop of the cluster
+# starts. This is used for checking whether the cluster is in the process
+# of autostopping for the current machine.
 _AUTOSTOP_INDICATOR = 'autostop_indicator'
 
 
@@ -59,14 +62,22 @@ def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
         set_last_active_time_to_now()
 
 
-def set_is_autostopping() -> None:
-    """Sets the is_autostopping flag to True."""
+def set_autostopping_indicator() -> None:
+    """Sets the boot time of the machine when autostop starts.
+
+    This function should be called when the cluster is started to autostop,
+    and the boot time of the machine will be stored in the configs database
+    as an autostop indicator.
+    It is used for checking whether the cluster is in the process of
+    autostopping. The indicator is valid only when the machine has the same
+    boot time as the one stored in the indicator.
+    """
     logger.debug('Setting is_autostopping.')
     configs.set_config(_AUTOSTOP_INDICATOR, str(psutil.boot_time()))
 
 
 def get_is_autostopping_payload() -> str:
-    """Returns True if the is_autostopping flag is set."""
+    """Returns whether the cluster is in the process of autostopping."""
     result = configs.get_config(_AUTOSTOP_INDICATOR)
     is_autostopping = (result == str(psutil.boot_time()))
     return common_utils.encode_payload(is_autostopping)

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -58,6 +58,7 @@ def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
         # Either autostop never set, or has been canceled. Reset timer.
         set_last_active_time_to_now()
 
+
 def set_is_autostopping() -> None:
     """Sets the is_autostopping flag to True."""
     logger.debug('Setting is_autostopping.')

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -62,15 +62,14 @@ def set_autostop(idle_minutes: int, backend: Optional[str], down: bool) -> None:
         set_last_active_time_to_now()
 
 
-def set_autostopping_indicator() -> None:
+def set_autostopping_started() -> None:
     """Sets the boot time of the machine when autostop starts.
 
     This function should be called when the cluster is started to autostop,
     and the boot time of the machine will be stored in the configs database
-    as an autostop indicator.
-    It is used for checking whether the cluster is in the process of
-    autostopping. The indicator is valid only when the machine has the same
-    boot time as the one stored in the indicator.
+    as an autostop indicator, which is used for checking whether the cluster
+    is in the process of autostopping. The indicator is valid only when the
+    machine has the same boot time as the one stored in the indicator.
     """
     logger.debug('Setting is_autostopping.')
     configs.set_config(_AUTOSTOP_INDICATOR, str(psutil.boot_time()))

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -60,6 +60,7 @@ def get_config(key: str) -> Optional[str]:
         rows = cursor.execute('SELECT value FROM config WHERE key = ?', (key,))
         for (value,) in rows:
             return value
+        return None
 
 
 @ensure_table

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -128,6 +128,7 @@ class AutostopEvent(SkyletEvent):
     def _stop_cluster(self, autostop_config):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
+            autostop_lib.set_is_autostopping()
             self._replace_yaml_for_stopping(self._ray_yaml_path,
                                             autostop_config.down)
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -128,7 +128,7 @@ class AutostopEvent(SkyletEvent):
     def _stop_cluster(self, autostop_config):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
-            autostop_lib.set_autostopping_indicator()
+            autostop_lib.set_autostopping_started()
             self._replace_yaml_for_stopping(self._ray_yaml_path,
                                             autostop_config.down)
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -128,7 +128,7 @@ class AutostopEvent(SkyletEvent):
     def _stop_cluster(self, autostop_config):
         if (autostop_config.backend ==
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
-            autostop_lib.set_is_autostopping()
+            autostop_lib.set_autostopping_indicator()
             self._replace_yaml_for_stopping(self._ray_yaml_path,
                                             autostop_config.down)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1633 
Fixes the confusion of cluster being in `INIT` status, when it is being autostopped and is partially stopped.

Changes:
1. keep the autostop column in the cluster table, when the cluster is partially stopped
2. Print a hint that the cluster is being autostopped when it is in INIT status

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Snippets from #1633
```
# launch multinode gcp cluster
sky launch -y -d -c test --num-nodes 2 --cloud gcp tests/test_yamls/minimal.yaml

# Try sky status --refresh. This works fine.
sky status test --refresh

# Schedule autostop
sky autostop -y test -i 0

sleep 60

# Try refreshing status - It should print out INIT status / hint for autostopping and autostop column.
sky status test --refresh
```
<img width="817" alt="image" src="https://user-images.githubusercontent.com/6753189/214964420-aa288ab3-2d51-4054-bb6a-502cc78f5f3c.png">


- [x] The following test
```
# launch multinode gcp cluster
sky launch -y -d -c test --num-nodes 2 --cloud gcp tests/test_yamls/minimal.yaml

# Try sky status --refresh. This works fine.
sky status test --refresh

# Schedule autostop
sky autostop -y test -i 5

# Manually stop the head node, no autostop output, no autostop column.
sky status -r
```
<img width="546" alt="image" src="https://user-images.githubusercontent.com/6753189/214966981-184e49e1-bc95-44d7-8ab2-b20065f4c54d.png">
