### PR TITLE
[Tests] Bump test_autostop sleep

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -942,7 +942,7 @@ def test_autostop(generic_cloud: str):
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep UP',
 
             # Ensure the cluster is STOPPED.
-            'sleep 150',
+            'sleep 250',
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep STOPPED',
 
             # Ensure the cluster is UP and the autostop setting is reset ('-').
@@ -960,7 +960,7 @@ def test_autostop(generic_cloud: str):
             f'sky autostop -y {name} -i 1',  # Should restart the timer.
             'sleep 45',
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s" | grep {name} | grep UP',
-            'sleep 150',
+            'sleep 250',
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep STOPPED',
 
             # Test restarting the idleness timer via exec:
@@ -971,7 +971,7 @@ def test_autostop(generic_cloud: str):
             f'sky exec {name} echo hi',  # Should restart the timer.
             'sleep 45',
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep UP',
-            'sleep 150',
+            'sleep 250',
             f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep STOPPED',
         ],
         f'sky down -y {name}',


### PR DESCRIPTION
Aims to partially mitigate `test_autostop` failing (#1633) due to `sky status --refresh` being called when worker nodes are stopped but head node is not.

Sleep has been bumped from 150->250s. I tried 200s sleep but it failed 2/5 times I ran the test, so sticking with 250s. For reference, this was run on GCP n2-standard-8.

Tested:
- [x] `pytest tests/test_smoke.py::test_autostop` 
