### PR TITLE
Make GCP VPC creation more robust

### DIFF
--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -534,10 +534,12 @@ def _check_firewall_rules(vpc_name, config, compute):
                         else:
                             assert (
                                 len(parse_ports) == 2
-                            ), "Failed to parse the port range: {}".format(port_range)
+                            ), f"Failed to parse the port range: {port_range}"
                             port_set.update(
                                 set(range(int(parse_ports[0]), int(parse_ports[1]) + 1)))
-                source2rules[direction_source][allowed["IPProtocol"]] = port_set
+                if allowed["IPProtocol"] not in source2rules[direction_source]:
+                    source2rules[direction_source][allowed["IPProtocol"]] = set()
+                source2rules[direction_source][allowed["IPProtocol"]].update(port_set)
         return source2rules
 
     effective_rules = _merge_and_refine_rule(effective_rules)

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -602,7 +602,8 @@ def get_usable_vpc(config):
 
         # Create firewall rules
         for rule in FIREWALL_RULES_TEMPLATE:
-            # if the rule already exists, delete it first
+            # Query firewall rule by its name (unique in a project).
+            # If the rule already exists, delete it first.
             rule_name = rule["name"].format(VPC_NAME=SKYPILOT_VPC_NAME)
             rule_list = _list_firewall_rules(
                 config, compute, filter=f"(name={rule_name})")

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -506,7 +506,7 @@ def _check_firewall_rules(vpc_name, config, compute):
     effective_rules = response["firewalls"]
 
     def _merge_and_refine_rule(rules):
-        # Example of source2rules:
+        # Example of source2rules: Dict[(direction, sourceRanges) -> Dict(protocol -> Set[ports])]
         #   {("INGRESS", "0.0.0.0/0"): {"tcp": {80, 443}, "udp": {53}}}
         source2rules : Dict[Tuple[str, str], Dict[str, Set[int]]] = {}
         source2allowed_list : Dict[Tuple[str, str], List[Dict[str, str]]] = {}

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -508,14 +508,14 @@ def _check_firewall_rules(vpc_name, config, compute):
         # Output: dict of (direction, source) -> {protocol -> ports}
         tmp = {}
         for rule in rules:
-            direction = rule.get("direction")
-            sources = rule.get("sourceRanges")
-            allowed = rule.get("allowed")
+            direction = rule.get("direction", "")
+            sources = rule.get("sourceRanges", [])
+            allowed = rule.get("allowed", [])
             for source in sources:
                 tmp[(direction, source)] = tmp.get((direction, source), []) + allowed
-        all = {}
+        source2rules = {}
         for (direction, source), allowed_list in tmp.items():
-            all[(direction, source)] = {}
+            source2rules[(direction, source)] = {}
             for allowed in allowed_list:
                 ports = set()
                 for port in allowed.get('ports', set()):
@@ -525,8 +525,8 @@ def _check_firewall_rules(vpc_name, config, compute):
                     else:
                         ports.update(
                             set(range(int(parse_ports[0]), int(parse_ports[1]) + 1)))
-                all[(direction, source)][allowed["IPProtocol"]] = ports
-        return all
+                source2rules[(direction, source)][allowed["IPProtocol"]] = ports
+        return source2rules
 
     effective_rules = _merge_and_refine_rule(effective_rules)
     required_rules = _merge_and_refine_rule(required_rules)

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -542,7 +542,6 @@ def _check_firewall_rules(vpc_name, config, compute):
         for protocol, ports in allowed_req.items():
             ports_eff = allowed_eff.get(protocol, set())
             if not ports.issubset(ports_eff):
-                print("ports", ports, "ports_eff", ports_eff)
                 return False
     return True
 

--- a/sky/skylet/providers/gcp/constants.py
+++ b/sky/skylet/providers/gcp/constants.py
@@ -11,6 +11,7 @@ VPC_TEMPLATE = {
 }
 # Required firewall rules for SkyPilot to work.
 FIREWALL_RULES_REQUIRED = [
+    # Allow internal connections between GCP VMs for Ray multi-node cluster.
     {
         "direction": "INGRESS",
         "allowed": [
@@ -19,6 +20,7 @@ FIREWALL_RULES_REQUIRED = [
         ],
         "sourceRanges": ["10.128.0.0/9"],
     },
+    # Allow ssh connection from anywhere.
     {
         "direction": "INGRESS",
         "allowed": [{

--- a/sky/skylet/providers/gcp/constants.py
+++ b/sky/skylet/providers/gcp/constants.py
@@ -16,7 +16,6 @@ FIREWALL_RULES_REQUIRED = [
         "allowed": [
             {'IPProtocol': 'tcp', 'ports': ['0-65535']},
             {'IPProtocol': 'udp', 'ports': ['0-65535']},
-            {'IPProtocol': 'icmp'}
         ],
         "sourceRanges": ["10.128.0.0/9"],
     },

--- a/sky/skylet/providers/gcp/constants.py
+++ b/sky/skylet/providers/gcp/constants.py
@@ -10,44 +10,24 @@ VPC_TEMPLATE = {
     "routingConfig": {"routingMode": "GLOBAL"},
 }
 # Required firewall rules for SkyPilot to work.
-# Note: there are more than one acceptable required rules.
 FIREWALL_RULES_REQUIRED = [
-    [
-        {
-            "direction": "INGRESS",
-            "allowed": [
-                {'IPProtocol': 'tcp', 'ports': ['0-65535']},
-                {'IPProtocol': 'udp', 'ports': ['0-65535']},
-                {'IPProtocol': 'icmp'}
-            ],
-            "sourceRanges": ["10.128.0.0/9"],
-        },
-        {
-            "direction": "INGRESS",
-            "allowed": [{
-                "IPProtocol": "tcp",
-                "ports": ["22"],
-            }],
-            "sourceRanges": ["0.0.0.0/0"],
-        }
-    ],
-    [
-        {
-            "direction": "INGRESS",
-            "allowed": [
-                {'IPProtocol': 'all'},
-            ],
-            "sourceRanges": ["10.128.0.0/9"],
-        },
-        {
-            "direction": "INGRESS",
-            "allowed": [{
-                "IPProtocol": "tcp",
-                "ports": ["22"],
-            }],
-            "sourceRanges": ["0.0.0.0/0"],
-        }
-    ]
+    {
+        "direction": "INGRESS",
+        "allowed": [
+            {'IPProtocol': 'tcp', 'ports': ['0-65535']},
+            {'IPProtocol': 'udp', 'ports': ['0-65535']},
+            {'IPProtocol': 'icmp'}
+        ],
+        "sourceRanges": ["10.128.0.0/9"],
+    },
+    {
+        "direction": "INGRESS",
+        "allowed": [{
+            "IPProtocol": "tcp",
+            "ports": ["22"],
+        }],
+        "sourceRanges": ["0.0.0.0/0"],
+    }
 ]
 # Template when creating firewall rules for a new VPC.
 FIREWALL_RULES_TEMPLATE = [

--- a/sky/skylet/providers/gcp/constants.py
+++ b/sky/skylet/providers/gcp/constants.py
@@ -9,6 +9,47 @@ VPC_TEMPLATE = {
     "mtu": 1460,
     "routingConfig": {"routingMode": "GLOBAL"},
 }
+# Required firewall rules for SkyPilot to work.
+# Note: there are more than one acceptable required rules.
+FIREWALL_RULES_REQUIRED = [
+    [
+        {
+            "direction": "INGRESS",
+            "allowed": [
+                {'IPProtocol': 'tcp', 'ports': ['0-65535']},
+                {'IPProtocol': 'udp', 'ports': ['0-65535']},
+                {'IPProtocol': 'icmp'}
+            ],
+            "sourceRanges": ["10.128.0.0/9"],
+        },
+        {
+            "direction": "INGRESS",
+            "allowed": [{
+                "IPProtocol": "tcp",
+                "ports": ["22"],
+            }],
+            "sourceRanges": ["0.0.0.0/0"],
+        }
+    ],
+    [
+        {
+            "direction": "INGRESS",
+            "allowed": [
+                {'IPProtocol': 'all'},
+            ],
+            "sourceRanges": ["10.128.0.0/9"],
+        },
+        {
+            "direction": "INGRESS",
+            "allowed": [{
+                "IPProtocol": "tcp",
+                "ports": ["22"],
+            }],
+            "sourceRanges": ["0.0.0.0/0"],
+        }
+    ]
+]
+# Template when creating firewall rules for a new VPC.
 FIREWALL_RULES_TEMPLATE = [
     {
         "name": "{VPC_NAME}-allow-custom",


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In this PR, we
1. reduce one required firewall rule (ICMP) as SkyPilot doesn't necessary need it to function
2. make the VPC creation idempotent to avoid user accidentally touch the VPC and robust against failure during VPC creation. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky launch` with no VPC
- [x] `sky launch` with an existing skypilot-vpc with no firewall rules
- [x] `sky launch` with an existing "default" VPC that includes two required firewall rules + some additional rules
- [x] All smoke tests: `pytest tests/test_smoke.py --gcp` 
