### PR TITLE
Allow longer name for AWS/Azure cluster and refactoring

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2410,9 +2410,7 @@ def check_cluster_name_is_valid(cluster_name: str,
     """
     if cluster_name is None:
         return
-    # GCP errors return this exact regex.  An informal description is at:
-    # https://cloud.google.com/compute/docs/naming-resources#resource-name-format
-    valid_regex = '[a-z]([-a-z0-9]{0,61}[a-z0-9])?'
+    valid_regex = '[a-z]([-a-z0-9]*[a-z0-9])?'
     if re.fullmatch(valid_regex, cluster_name) is None:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.InvalidClusterNameError(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -90,15 +90,6 @@ WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
 _TEST_IP = 'https://8.8.8.8'
 
-# GCP has a 63 char limit; however, Ray autoscaler adds many
-# characters. Through testing, this is the maximum length for the Sky cluster
-# name on GCP.  Ref:
-# https://cloud.google.com/compute/docs/naming-resources#resource-name-format
-# NOTE: actually 37 is maximum for a single-node cluster which gets the suffix
-# '-head', but 35 for a multinode cluster because workers get the suffix
-# '-worker'. Here we do not distinguish these cases and take the lower limit.
-_MAX_CLUSTER_NAME_LEN_FOR_GCP = 35
-
 # Allow each CPU thread take 2 tasks.
 # Note: This value cannot be too small, otherwise OOM issue may occur.
 DEFAULT_TASK_CPU_DEMAND = 0.5
@@ -2420,33 +2411,6 @@ def get_task_resources_str(task: 'task_lib.Task') -> str:
         resources_str = ', '.join(f'{k}:{v}' for k, v in resources_dict.items())
     resources_str = f'{task.num_nodes}x [{resources_str}]'
     return resources_str
-
-
-def check_cluster_name_is_valid(cluster_name: str,
-                                cloud: Optional[clouds.Cloud] = None) -> None:
-    """Errors out on invalid cluster names not supported by cloud providers.
-
-    Bans (including but not limited to) names that:
-    - are digits-only
-    - contain underscore (_)
-    """
-    if cluster_name is None:
-        return
-    valid_regex = '[a-z]([-a-z0-9]*[a-z0-9])?'
-    if re.fullmatch(valid_regex, cluster_name) is None:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.InvalidClusterNameError(
-                f'Cluster name "{cluster_name}" is invalid; '
-                f'ensure it is fully matched by regex: {valid_regex}')
-    if isinstance(cloud, clouds.GCP):
-        # GCP has too restrictive of a length limit. Don't check for other
-        # clouds.
-        if len(cluster_name) > _MAX_CLUSTER_NAME_LEN_FOR_GCP:
-            with ux_utils.print_exception_no_traceback():
-                raise exceptions.InvalidClusterNameError(
-                    f'Cluster name {cluster_name!r} has {len(cluster_name)} '
-                    f'chars; maximum length is {_MAX_CLUSTER_NAME_LEN_FOR_GCP} '
-                    'chars.')
 
 
 def check_cluster_name_not_reserved(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1719,9 +1719,7 @@ class RetryingVmProvisioner(object):
             else:
                 # Provisioning succeeded.
                 break
-            logger.warning(f'\n{style.BRIGHT}Provision failed for {num_nodes}x '
-                           f'{to_provision}. Trying other launchable resources '
-                           f'(if any).{style.RESET_ALL}')
+
             if to_provision.zone is None:
                 region_or_zone_str = str(to_provision.region)
             else:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1699,8 +1699,8 @@ class RetryingVmProvisioner(object):
                 # InvalidClusterNameError: cluster name is invalid,
                 # NotSupportedError: cloud does not support requested features,
                 # CloudUserIdentityError: cloud user identity is invalid.
-                # The exceptions above should not be applicable to the whole cloud,
-                # so we do add the cloud to the blocked resources.
+                # The exceptions above should not be applicable to the whole
+                # cloud, so we do add the cloud to the blocked resources.
                 logger.warning(common_utils.format_exception(e))
                 self._blocked_resources.add(
                     resources_lib.Resources(cloud=to_provision.cloud))

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1673,8 +1673,7 @@ class RetryingVmProvisioner(object):
             try:
                 # Recheck cluster name as the 'except:' block below may
                 # change the cloud assignment.
-                backend_utils.check_cluster_name_is_valid(
-                    cluster_name, to_provision.cloud)
+                to_provision.cloud.check_cluster_name_is_valid(cluster_name)
                 if dryrun:
                     cloud_user = None
                 else:
@@ -3198,11 +3197,12 @@ class CloudVmRayBackend(backends.Backend):
                 cluster_exists=True)
         usage_lib.messages.usage.set_new_cluster()
         assert len(task.resources) == 1, task.resources
-        resources = list(task.resources)[0]
-        task_cloud = resources.cloud
         # Use the task_cloud, because the cloud in `to_provision` can be changed
         # later during the retry.
-        backend_utils.check_cluster_name_is_valid(cluster_name, task_cloud)
+        resources = list(task.resources)[0]
+        task_cloud = (resources.cloud
+                      if resources.cloud is not None else clouds.Cloud)
+        task_cloud.check_cluster_name_is_valid(cluster_name)
 
         cloud = to_provision.cloud
         if isinstance(cloud, clouds.Local):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1277,12 +1277,7 @@ class RetryingVmProvisioner(object):
                 # The stdout/stderr of ray up is not useful here, since
                 # head node is successfully provisioned.
                 definitely_no_nodes_launched = self._update_blocklist_on_error(
-                    to_provision,
-                    region,
-                    # Ignored and block region:
-                    zones=None,
-                    stdout=None,
-                    stderr=None)
+                    to_provision, region, zones=zones, stdout=None, stderr=None)
                 # GANG_FAILED means head is up, workers failed.
                 assert definitely_no_nodes_launched is False, (
                     definitely_no_nodes_launched)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1699,7 +1699,7 @@ class RetryingVmProvisioner(object):
                 # InvalidClusterNameError: cluster name is invalid,
                 # NotSupportedError: cloud does not support requested features,
                 # CloudUserIdentityError: cloud user identity is invalid.
-                # The exceptions above should not be applicable to the whole
+                # The exceptions above should be applicable to the whole
                 # cloud, so we do add the cloud to the blocked resources.
                 logger.warning(common_utils.format_exception(e))
                 self._blocked_resources.add(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3077,7 +3077,7 @@ def spot_launch(
     if name is None:
         name = backend_utils.generate_cluster_name()
     else:
-        backend_utils.check_cluster_name_is_valid(name)
+        clouds.Cloud.check_cluster_name_is_valid(name)
 
     task = _make_task_from_entrypoint_with_overrides(
         entrypoint,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3077,6 +3077,9 @@ def spot_launch(
     if name is None:
         name = backend_utils.generate_cluster_name()
     else:
+        # This does the basic regex check for the cluster name, while the name
+        # length check will be done by the controller when it starts
+        # provisioning the cluster.
         clouds.Cloud.check_cluster_name_is_valid(name)
 
     task = _make_task_from_entrypoint_with_overrides(

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -6,7 +6,7 @@ import json
 import os
 import subprocess
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 from sky import exceptions
@@ -547,9 +547,3 @@ class AWS(clouds.Cloud):
                                       zone: Optional[str] = None) -> bool:
         return service_catalog.accelerator_in_region_or_zone(
             accelerator, acc_count, region, zone, 'aws')
-
-    @classmethod
-    def check_features_are_supported(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
-        # All clouds.CloudImplementationFeatures implemented
-        return

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -49,10 +49,11 @@ class AWS(clouds.Cloud):
     _REPR = 'AWS'
 
     # AWS has a limit of the tag value length to 256 characters.
-    # Since we use the tag value to store the cluster name, we need to
-    # limit the cluster name length to 256 characters.
+    # By testing, the actual limit is 256 - 10 = 246 characters,
+    # due to the maximum length of DescribeInstances API filter
+    # value.
     # Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html # pylint: disable=line-too-long
-    _MAX_CLUSTER_NAME_LEN_LIMIT = 256
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 246
 
     _regions: List[clouds.Region] = []
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -549,9 +549,7 @@ class AWS(clouds.Cloud):
             accelerator, acc_count, region, zone, 'aws')
 
     @classmethod
-    def supports(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]
-    ) -> bool:
+    def check_features_are_supported(
+            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
         # All clouds.CloudImplementationFeatures implemented
-        del requested_features
-        return True
+        return

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -66,6 +66,15 @@ class AWS(clouds.Cloud):
     )
 
     @classmethod
+    def _cloud_unsupported_features(
+            cls) -> Dict[clouds.CloudImplementationFeatures, str]:
+        return dict()
+
+    @classmethod
+    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+        return cls._MAX_CLUSTER_NAME_LEN_LIMIT
+
+    @classmethod
     def _sso_credentials_help_str(cls, expired: bool = False) -> str:
         help_str = 'Run the following commands (must use aws v2 CLI):'
         if not expired:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -47,6 +47,9 @@ class AWS(clouds.Cloud):
     """Amazon Web Services."""
 
     _REPR = 'AWS'
+
+    _MAX_CLUSTER_NAME_LEN_LIMIT = None
+
     _regions: List[clouds.Region] = []
 
     _INDENT_PREFIX = '    '

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -49,11 +49,11 @@ class AWS(clouds.Cloud):
     _REPR = 'AWS'
 
     # AWS has a limit of the tag value length to 256 characters.
-    # By testing, the actual limit is 256 - 10 = 246 characters,
-    # due to the maximum length of DescribeInstances API filter
-    # value.
+    # By testing, the actual limit is 256 - 12 = 244 characters
+    # (ray adds additional `ray-` and `-worker`), due to the
+    # maximum length of DescribeInstances API filter value.
     # Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html # pylint: disable=line-too-long
-    _MAX_CLUSTER_NAME_LEN_LIMIT = 246
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 244
 
     _regions: List[clouds.Region] = []
 
@@ -72,7 +72,7 @@ class AWS(clouds.Cloud):
         return dict()
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+    def _max_cluster_name_length(cls) -> Optional[int]:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     @classmethod

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -48,7 +48,11 @@ class AWS(clouds.Cloud):
 
     _REPR = 'AWS'
 
-    _MAX_CLUSTER_NAME_LEN_LIMIT = None
+    # AWS has a limit of the tag value length to 256 characters.
+    # Since we use the tag value to store the cluster name, we need to
+    # limit the cluster name length to 256 characters.
+    # Reference: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html # pylint: disable=line-too-long
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 256
 
     _regions: List[clouds.Region] = []
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -45,6 +45,7 @@ class Azure(clouds.Cloud):
     _REPR = 'Azure'
     # Azure has a 90 char limit for resource group; however, SkyPilot adds the
     # suffix `-<region name>`.
+    # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/
     _MAX_CLUSTER_NAME_LEN_LIMIT = 70
     _regions: List[clouds.Region] = []
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -411,9 +411,7 @@ class Azure(clouds.Cloud):
         return azure_subscription_id
 
     @classmethod
-    def supports(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]
-    ) -> bool:
+    def check_features_are_supported(
+            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
         # All clouds.CloudImplementationFeatures implemented
-        del requested_features
-        return True
+        return

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -45,7 +45,7 @@ class Azure(clouds.Cloud):
     _REPR = 'Azure'
     # Azure has a 90 char limit for resource group; however, SkyPilot adds the
     # suffix `-<region name>`.
-    # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/
+    # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 70
     _regions: List[clouds.Region] = []
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -3,7 +3,7 @@ import json
 import os
 import subprocess
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 from sky import exceptions
@@ -409,9 +409,3 @@ class Azure(clouds.Cloud):
                     'cli command: "az account set -s <subscription_id>".'
                 ) from e
         return azure_subscription_id
-
-    @classmethod
-    def check_features_are_supported(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
-        # All clouds.CloudImplementationFeatures implemented
-        return

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -43,6 +43,9 @@ class Azure(clouds.Cloud):
     """Azure."""
 
     _REPR = 'Azure'
+    # Azure has a 90 char limit for resource group; however, SkyPilot adds the
+    # suffix `-<region name>`.
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 70
     _regions: List[clouds.Region] = []
 
     def instance_type_to_hourly_cost(self,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -44,9 +44,11 @@ class Azure(clouds.Cloud):
 
     _REPR = 'Azure'
     # Azure has a 90 char limit for resource group; however, SkyPilot adds the
-    # suffix `-<region name>`.
+    # suffix `-<region name>`. Azure also has a 64 char limit for VM names, and
+    # ray adds addtional `ray-`, `-worker`, and `-<9 chars hash>` for the VM
+    # names, so the limit is 64 - 4 - 7 - 10 = 43.
     # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ # pylint: disable=line-too-long
-    _MAX_CLUSTER_NAME_LEN_LIMIT = 70
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 42
 
     _regions: List[clouds.Region] = []
 
@@ -56,7 +58,7 @@ class Azure(clouds.Cloud):
         return dict()
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> int:
+    def _max_cluster_name_length(cls) -> int:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     def instance_type_to_hourly_cost(self,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -47,7 +47,17 @@ class Azure(clouds.Cloud):
     # suffix `-<region name>`.
     # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 70
+
     _regions: List[clouds.Region] = []
+
+    @classmethod
+    def _cloud_unsupported_features(
+            cls) -> Dict[clouds.CloudImplementationFeatures, str]:
+        return dict()
+
+    @classmethod
+    def _max_cluster_name_len_limit(cls) -> int:
+        return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -84,11 +84,11 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+    def _max_cluster_name_length(cls) -> Optional[int]:
         """Returns the maximum length limit of a cluster name.
 
-        This method is used by check_cluster_name() to check if the cluster
-        name is too long.
+        This method is used by check_cluster_name_is_valid() to check if the
+        cluster name is too long.
 
         None means no limit.
         """
@@ -376,7 +376,7 @@ class Cloud:
                     '\n\t' + table.get_string().replace('\n', '\n\t'))
 
     @classmethod
-    def check_cluster_name_is_valid(cls, cluster_name: str):
+    def check_cluster_name_is_valid(cls, cluster_name: str) -> None:
         """Errors out on invalid cluster names not supported by cloud providers.
 
         Bans (including but not limited to) names that:
@@ -388,7 +388,7 @@ class Cloud:
         """
         if cluster_name is None:
             return
-        max_cluster_name_len_limit = cls._max_cluster_name_len_limit()
+        max_cluster_name_len_limit = cls._max_cluster_name_length()
         valid_regex = '[a-z]([-a-z0-9]*[a-z0-9])?'
         if re.fullmatch(valid_regex, cluster_name) is None:
             with ux_utils.print_exception_no_traceback():

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -16,7 +16,7 @@ if typing.TYPE_CHECKING:
 class CloudImplementationFeatures(enum.Enum):
     """Features that might not be implemented for all clouds.
 
-    Used by Cloud.supports()
+    Used by Cloud.check_features_are_supported()
     """
     STOP = 'stop'
     AUTOSTOP = 'autostop'
@@ -324,12 +324,16 @@ class Cloud:
         return False
 
     @classmethod
-    def supports(cls,
-                 requested_features: Set[CloudImplementationFeatures]) -> bool:
-        """Returns whether all of the requested features are supported.
+    def check_features_are_supported(
+            cls, requested_features: Set[CloudImplementationFeatures]):
+        """Raises an exception if the cloud does not support all the requested features.
 
         For instance, Lambda Cloud does not support autostop, so
-        Lambda.support({CloudImplementationFeatures.AUTOSTOP}) returns False.
+        Lambda.support({CloudImplementationFeatures.AUTOSTOP}) raises the exception.
+
+        Raises:
+            exceptions.NotSupportedError: If the cloud does not support all the requested
+            features.
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -18,6 +18,10 @@ class CloudImplementationFeatures(enum.Enum):
     """Features that might not be implemented for all clouds.
 
     Used by Cloud.check_features_are_supported().
+
+    Note: If any new feature is added, please check and update
+    _cloud_unsupported_features in all clouds to make sure the
+    check_features_are_supported() works as expected.
     """
     STOP = 'stop'
     AUTOSTOP = 'autostop'

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -326,14 +326,15 @@ class Cloud:
     @classmethod
     def check_features_are_supported(
             cls, requested_features: Set[CloudImplementationFeatures]):
-        """Raises an exception if the cloud does not support all the requested features.
+        """Errors out if the cloud does not support all requested features.
 
         For instance, Lambda Cloud does not support autostop, so
-        Lambda.support({CloudImplementationFeatures.AUTOSTOP}) raises the exception.
+        Lambda.support({CloudImplementationFeatures.AUTOSTOP}) raises the
+        exception.
 
         Raises:
-            exceptions.NotSupportedError: If the cloud does not support all the requested
-            features.
+            exceptions.NotSupportedError: If the cloud does not support all the
+            requested features.
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -70,6 +70,12 @@ class Cloud:
 
     _MAX_CLUSTER_NAME_LEN_LIMIT: Optional[int] = None
 
+    # All features implemented by this cloud. Used by
+    # Cloud.check_features_are_supported()
+    # None means all features are supported.
+    _CLOUD_IMPLEMENTATION_FEATURES: Optional[
+        Set[CloudImplementationFeatures]] = None
+
     #### Regions/Zones ####
 
     @classmethod
@@ -336,7 +342,15 @@ class Cloud:
             exceptions.NotSupportedError: If the cloud does not support all the
             requested features.
         """
-        raise NotImplementedError
+        if cls._CLOUD_IMPLEMENTATION_FEATURES is None:
+            return
+        unsupported_features = (requested_features -
+                                cls._CLOUD_IMPLEMENTATION_FEATURES)
+        if unsupported_features:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.NotSupportedError(
+                    f'Cloud {cls} does not support the following '
+                    f'features: {unsupported_features}')
 
     @classmethod
     def check_cluster_name_is_valid(cls, cluster_name: str):

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -347,10 +347,12 @@ class Cloud:
         unsupported_features = (requested_features -
                                 cls._CLOUD_IMPLEMENTATION_FEATURES)
         if unsupported_features:
+            unsupported_features_str = ', '.join(
+                [f.name for f in unsupported_features])
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(
-                    f'Cloud {cls} does not support the following '
-                    f'features: {unsupported_features}')
+                    f'Cloud {cls._REPR} does not support the following '
+                    f'features: {unsupported_features_str}')
 
     @classmethod
     def check_cluster_name_is_valid(cls, cluster_name: str):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -677,9 +677,7 @@ class GCP(clouds.Cloud):
             instance_type, accelerators, zone, 'gcp')
 
     @classmethod
-    def supports(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]
-    ) -> bool:
+    def check_features_are_supported(
+            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
         # All clouds.CloudImplementationFeatures implemented
-        del requested_features
-        return True
+        return

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import time
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 from sky import exceptions
@@ -675,9 +675,3 @@ class GCP(clouds.Cloud):
             zone: Optional[str] = None) -> None:
         service_catalog.check_accelerator_attachable_to_host(
             instance_type, accelerators, zone, 'gcp')
-
-    @classmethod
-    def check_features_are_supported(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
-        # All clouds.CloudImplementationFeatures implemented
-        return

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -99,6 +99,15 @@ class GCP(clouds.Cloud):
     _regions: List[clouds.Region] = []
     _zones: List[clouds.Zone] = []
 
+    @classmethod
+    def _cloud_unsupported_features(
+            cls) -> Dict[clouds.CloudImplementationFeatures, str]:
+        return dict()
+
+    @classmethod
+    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+        return cls._MAX_CLUSTER_NAME_LEN_LIMIT
+
     #### Regions/Zones ####
 
     @classmethod

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -105,7 +105,7 @@ class GCP(clouds.Cloud):
         return dict()
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+    def _max_cluster_name_length(cls) -> Optional[int]:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     #### Regions/Zones ####

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -85,6 +85,17 @@ class GCP(clouds.Cloud):
     """Google Cloud Platform."""
 
     _REPR = 'GCP'
+
+    # GCP has a 63 char limit; however, Ray autoscaler adds many
+    # characters. Through testing, this is the maximum length for the Sky
+    # cluster name on GCP.  Ref:
+    # https://cloud.google.com/compute/docs/naming-resources#resource-name-format
+    # NOTE: actually 37 is maximum for a single-node cluster which gets the
+    # suffix '-head', but 35 for a multinode cluster because workers get the
+    # suffix '-worker'. Here we do not distinguish these cases and take the
+    # lower limit.
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 35
+
     _regions: List[clouds.Region] = []
     _zones: List[clouds.Zone] = []
 

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -29,9 +29,22 @@ class Lambda(clouds.Cloud):
     # for Lambda Cloud.
     # STOP/AUTOSTOP: The Lambda cloud provider does not support stopping VMs.
     # MULTI_NODE: Multi-node is not supported by the implementation yet.
-    _CLOUD_IMPLEMENTATION_FEATURES = set()
+    _CLOUD_UNSUPPORTED_FEATURES = {
+        clouds.CloudImplementationFeatures.STOP: 'Lambda cloud does not support stopping VMs.',
+        clouds.CloudImplementationFeatures.AUTOSTOP: 'Lambda cloud does not support stopping VMs.',
+        clouds.CloudImplementationFeatures.MULTI_NODE: 'Multi-node is not supported by the implementation yet.',
+    }
 
     _regions: List[clouds.Region] = []
+
+    @classmethod
+    def _cloud_unsupported_features(
+            cls) -> Dict[clouds.CloudImplementationFeatures, str]:
+        return cls._CLOUD_UNSUPPORTED_FEATURES
+
+    @classmethod
+    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+        return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     @classmethod
     def regions(cls) -> List[clouds.Region]:

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -4,8 +4,10 @@ import typing
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from sky import clouds
+from sky import exceptions
 from sky.clouds import service_catalog
 from sky.skylet.providers.lambda_cloud import lambda_utils
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -253,7 +255,12 @@ class Lambda(clouds.Cloud):
             accelerator, acc_count, region, zone, 'lambda')
 
     @classmethod
-    def supports(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]
-    ) -> bool:
-        return requested_features.issubset(_LAMBDA_IMPLEMENTATION_FEATURES)
+    def check_features_are_supported(
+            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
+        if not requested_features.issubset(_LAMBDA_IMPLEMENTATION_FEATURES):
+            requested_features_str = ', '.join(
+                [f.value for f in requested_features])
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.NotSupportedError(
+                    'does not support all the '
+                    f'features in [{requested_features_str}].')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -23,7 +23,7 @@ class Lambda(clouds.Cloud):
 
     _REPR = 'Lambda'
     # Lamdba has a 64 char limit for cluster name.
-    # Reference: https://cloud.lambdalabs.com/api/v1/docs#operation/launchInstance
+    # Reference: https://cloud.lambdalabs.com/api/v1/docs#operation/launchInstance # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 64
     # Currently, none of clouds.CloudImplementationFeatures are implemented
     # for Lambda Cloud.

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -26,6 +26,9 @@ class Lambda(clouds.Cloud):
     """Lambda Labs GPU Cloud."""
 
     _REPR = 'Lambda'
+    # Lamdba has a 64 char limit for cluster name.
+    _MAX_CLUSTER_NAME_LEN_LIMIT = 64
+
     _regions: List[clouds.Region] = []
 
     @classmethod

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -1,13 +1,11 @@
 """Lambda Cloud."""
 import json
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
-from sky import exceptions
 from sky.clouds import service_catalog
 from sky.skylet.providers.lambda_cloud import lambda_utils
-from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -18,10 +16,6 @@ _CREDENTIAL_FILES = [
     'lambda_keys',
 ]
 
-# Currently, none of clouds.CloudImplementationFeatures are implemented
-# for Lambda Cloud
-_LAMBDA_IMPLEMENTATION_FEATURES: Set[clouds.CloudImplementationFeatures] = set()
-
 
 @clouds.CLOUD_REGISTRY.register
 class Lambda(clouds.Cloud):
@@ -30,6 +24,11 @@ class Lambda(clouds.Cloud):
     _REPR = 'Lambda'
     # Lamdba has a 64 char limit for cluster name.
     _MAX_CLUSTER_NAME_LEN_LIMIT = 64
+    # Currently, none of clouds.CloudImplementationFeatures are implemented
+    # for Lambda Cloud.
+    # STOP/AUTOSTOP: The Lambda cloud provider does not support stopping VMs.
+    # MULTI_NODE: Multi-node is not supported by the implementation yet.
+    _CLOUD_IMPLEMENTATION_FEATURES = set()
 
     _regions: List[clouds.Region] = []
 
@@ -253,14 +252,3 @@ class Lambda(clouds.Cloud):
                                       zone: Optional[str] = None) -> bool:
         return service_catalog.accelerator_in_region_or_zone(
             accelerator, acc_count, region, zone, 'lambda')
-
-    @classmethod
-    def check_features_are_supported(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]):
-        if not requested_features.issubset(_LAMBDA_IMPLEMENTATION_FEATURES):
-            requested_features_str = ', '.join(
-                [f.value for f in requested_features])
-            with ux_utils.print_exception_no_traceback():
-                raise exceptions.NotSupportedError(
-                    'does not support all the '
-                    f'features in [{requested_features_str}].')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -23,6 +23,7 @@ class Lambda(clouds.Cloud):
 
     _REPR = 'Lambda'
     # Lamdba has a 64 char limit for cluster name.
+    # Reference: https://cloud.lambdalabs.com/api/v1/docs#operation/launchInstance
     _MAX_CLUSTER_NAME_LEN_LIMIT = 64
     # Currently, none of clouds.CloudImplementationFeatures are implemented
     # for Lambda Cloud.

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -22,6 +22,7 @@ class Lambda(clouds.Cloud):
     """Lambda Labs GPU Cloud."""
 
     _REPR = 'Lambda'
+
     # Lamdba has a 64 char limit for cluster name.
     # Reference: https://cloud.lambdalabs.com/api/v1/docs#operation/launchInstance # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 64
@@ -32,7 +33,7 @@ class Lambda(clouds.Cloud):
     _CLOUD_UNSUPPORTED_FEATURES = {
         clouds.CloudImplementationFeatures.STOP: 'Lambda cloud does not support stopping VMs.',
         clouds.CloudImplementationFeatures.AUTOSTOP: 'Lambda cloud does not support stopping VMs.',
-        clouds.CloudImplementationFeatures.MULTI_NODE: 'Multi-node is not supported by the implementation yet.',
+        clouds.CloudImplementationFeatures.MULTI_NODE: 'Multi-node is not supported by the Lambda Cloud implementation yet.',
     }
 
     _regions: List[clouds.Region] = []
@@ -43,7 +44,7 @@ class Lambda(clouds.Cloud):
         return cls._CLOUD_UNSUPPORTED_FEATURES
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+    def _max_cluster_name_length(cls) -> Optional[int]:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -174,7 +174,7 @@ class Local(clouds.Cloud):
         return region, zone
 
     @classmethod
-    def supports(
+    def check_features_are_supported(
             cls, requested_features: Set[clouds.CloudImplementationFeatures]
     ) -> bool:
         del requested_features

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -50,7 +50,7 @@ class Local(clouds.Cloud):
         return cls._CLOUD_UNSUPPORTED_FEATURES
 
     @classmethod
-    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+    def _max_cluster_name_length(cls) -> Optional[int]:
         return None
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -36,11 +36,22 @@ class Local(clouds.Cloud):
     """
     _DEFAULT_INSTANCE_TYPE = 'on-prem'
     LOCAL_REGION = clouds.Region('Local')
-    _CLOUD_IMPLEMENTATION_FEATURES = {
-        clouds.CloudImplementationFeatures.STOP,
-        clouds.CloudImplementationFeatures.AUTOSTOP
+    _CLOUD_UNSUPPORTED_FEATURES = {
+        clouds.CloudImplementationFeatures.STOP:
+            ('Local cloud does not support stopping instances.'),
+        clouds.CloudImplementationFeatures.AUTOSTOP:
+            ('Local cloud does not support stopping instances.')
     }
     _regions: List[clouds.Region] = [LOCAL_REGION]
+
+    @classmethod
+    def _cloud_unsupported_features(
+            cls) -> Dict[clouds.CloudImplementationFeatures, str]:
+        return cls._CLOUD_UNSUPPORTED_FEATURES
+
+    @classmethod
+    def _max_cluster_name_len_limit(cls) -> Optional[int]:
+        return None
 
     @classmethod
     def regions(cls):

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -1,7 +1,7 @@
 """Local/On-premise."""
 import subprocess
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 
@@ -36,6 +36,10 @@ class Local(clouds.Cloud):
     """
     _DEFAULT_INSTANCE_TYPE = 'on-prem'
     LOCAL_REGION = clouds.Region('Local')
+    _CLOUD_IMPLEMENTATION_FEATURES = {
+        clouds.CloudImplementationFeatures.STOP,
+        clouds.CloudImplementationFeatures.AUTOSTOP
+    }
     _regions: List[clouds.Region] = [LOCAL_REGION]
 
     @classmethod
@@ -172,10 +176,3 @@ class Local(clouds.Cloud):
             raise ValueError(f'Region {region!r} does not match the Local'
                              ' cloud region {Local.LOCAL_REGION.name!r}.')
         return region, zone
-
-    @classmethod
-    def check_features_are_supported(
-            cls, requested_features: Set[clouds.CloudImplementationFeatures]
-    ) -> bool:
-        del requested_features
-        return True

--- a/sky/core.py
+++ b/sky/core.py
@@ -312,9 +312,8 @@ def stop(cluster_name: str, purge: bool = False) -> None:
 
     # Check cloud supports stopping instances
     cloud = handle.launched_resources.cloud
-    if not cloud.supports({clouds.CloudImplementationFeatures.STOP}):
-        raise exceptions.NotSupportedError(
-            (f'{cloud} does not support stopping instances.'))
+    cloud.check_features_are_supported(
+        {clouds.CloudImplementationFeatures.STOP})
 
     backend = backend_utils.get_backend_from_handle(handle)
     if (isinstance(backend, backends.CloudVmRayBackend) and
@@ -437,9 +436,8 @@ def autostop(
     # Check autostop is implemented for cloud
     cloud = handle.launched_resources.cloud
     if not down and idle_minutes >= 0:
-        if not cloud.supports({clouds.CloudImplementationFeatures.AUTOSTOP}):
-            raise exceptions.NotSupportedError(
-                (f'autostop not implemented for {cloud}.'))
+        cloud.check_features_are_supported(
+            {clouds.CloudImplementationFeatures.AUTOSTOP})
 
     backend = backend_utils.get_backend_from_handle(handle)
     usage_lib.record_cluster_name_for_current_operation(cluster_name)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -327,11 +327,11 @@ def format_exception(e: Exception, use_bracket: bool = False) -> str:
     Returns:
         A string that represents the exception.
     """
-    BRIGHT = colorama.Style.BRIGHT
-    RESET = colorama.Style.RESET_ALL
+    bright = colorama.Style.BRIGHT
+    reset = colorama.Style.RESET_ALL
     if use_bracket:
-        return f'{BRIGHT}[{class_fullname(e.__class__)}]:{RESET} {e}'
-    return f'{BRIGHT}{class_fullname(e.__class__)}:{RESET} {e}'
+        return f'{bright}[{class_fullname(e.__class__)}]:{reset} {e}'
+    return f'{bright}{class_fullname(e.__class__)}:{reset} {e}'
 
 
 def remove_color(s: str):

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Optional
 import uuid
 import yaml
 
+import colorama
+
 from sky import sky_logging
 
 _USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
@@ -325,9 +327,11 @@ def format_exception(e: Exception, use_bracket: bool = False) -> str:
     Returns:
         A string that represents the exception.
     """
+    BRIGHT = colorama.Style.BRIGHT
+    RESET = colorama.Style.RESET_ALL
     if use_bracket:
-        return f'[{class_fullname(e.__class__)}]: {e}'
-    return f'{class_fullname(e.__class__)}: {e}'
+        return f'{BRIGHT}[{class_fullname(e.__class__)}]:{RESET} {e}'
+    return f'{BRIGHT}{class_fullname(e.__class__)}:{RESET} {e}'
 
 
 def remove_color(s: str):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR
1. fixes the first part of the TODOs in #963, to unblock the user from using a long name for spot jobs on AWS. 
2. moves the cluster name checking into each Cloud.
3. refactors the `cloud.supports` to `cloud.check_features_are_supported` and change the boolean return value to exception raising.
4. optimizes the failover for `InvalidClusterNameError` and `ClusterUserIdentityError` to directly move to the next cloud, as those errors apply to the whole cloud.
5. fixes minor UX issues for failover:
  Previously:
    <img width="829" alt="image" src="https://user-images.githubusercontent.com/6753189/215648917-c6fbafba-337a-4047-a56b-0992fcef3b63.png">
  Now:
    <img width="824" alt="image" src="https://user-images.githubusercontent.com/6753189/215648995-7c3bf83e-5833-4145-8d0b-566a8c137972.png">



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky launch -c i-am-using-a-very-long-name-for-the-aws-cluster-it-should-be-more-than-63-characters-and-hopefully-it-works-this-sentence-has-135-chars --cloud aws`
    - [x] AWS 244 characters: `sky launch -c i-am-using-a-very-long-name-for-the-aws-cluster-it-should-be-more-than-63-characters-and-hopefully-it-works-by-checking-the-document-of-aws-we-found-that-the-cluster-name-length-should-be-less-than-250-due-to-the-tag-limit-this-sentence-has-246-c --num-nodes 2 --cloud aws -t t3.micro` (and 247 does not work)
    - [x] GCP (didn't change the original tested limit)
    - [x] Azure 42 characters: `sky launch -c i-am-using-a-very-long-name-for-the-aws-cluste --cloud azure --region southcentralus --num-nodes 2`
    - [x]  Lambda 64 characters: `sky launch -c i-am-using-a-very-long-name-for-the-aws-cluster-it-should-be-mor --cloud lambda` works
    - [x] `sky launch -c i-am-using-a-very-long-name-for-the-azure-cluster-it-should-be-more-than-63-characters-and-hopefully-it-works-this-sentence-has-136-chars --cloud azure`: correctly fails for the Azure
    - [x] `sky launch -c i-am-using-a-very-long-name-for-the-aws-cluster-it-should-be-more-than-63-characters-and-hopefully-it-works-this-sentence-has-135-chars --gpus A100:8`, it successfully and quickly failover through Lambda/GCP/Azure and AWS (skip the first three clouds with a single try and try all the regions on AWS).
