### PR TITLE
Fix TPU message

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1409,8 +1409,9 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
             # May be a leaked preempted resource, or terminated by user in the
             # console, or still in the process of being created.
             ux_utils.console_newline()
-            logger.warning(f'TPU VM {tpu_id} is not in READY state. '
-                           'Skipping IP query...')
+            logger.warning(f'TPU VM {tpu_id} is in {tpuvm_json["state"]} '
+                           'state. Skipping IP query... '
+                           'Hint: make sure it is not leaked.')
             continue
 
         if not get_internal_ips:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1409,9 +1409,9 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
             # May be a leaked preempted resource, or terminated by user in the
             # console, or still in the process of being created.
             ux_utils.console_newline()
-            logger.warning(f'TPU VM {tpu_id} is in {tpuvm_json["state"]} '
-                           'state. Skipping IP query... '
-                           'Hint: make sure it is not leaked.')
+            logger.debug(f'TPU VM {tpu_id} is in {tpuvm_json["state"]} '
+                         'state. Skipping IP query... '
+                         'Hint: make sure it is not leaked.')
             continue
 
         if not get_internal_ips:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1407,10 +1407,10 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
         tpuvm_json = json.loads(stdout)
         if tpuvm_json['state'] != 'READY':
             # May be a leaked preempted resource, or terminated by user in the
-            # console.
+            # console, or still in the process of being created.
             ux_utils.console_newline()
             logger.warning(f'TPU VM {tpu_id} is not in READY state. '
-                           'Skipping...')
+                           'Skipping IP query...')
             continue
 
         if not get_internal_ips:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

From @concretevitamin, the output from `sky down` a TPU Pod VM can be confusing.
To reproduce
```
> sky launch TPU-Pod
> Ctrl-C  # after 30 secs
> sky down --all -y
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--
TPU VM ray-sky-a2e9-gcpuser-head-d806ba73-tpu is not in READY state. Skipping...
```
With this PR, it becomes
```
> sky down --all -y
... Skipping IP query...
```