### PR TITLE
[Spot] Fix spot launch failure introduced by #1648

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -96,7 +96,7 @@ class Cloud:
 
         None means no limit.
         """
-        raise NotImplementedError
+        return None
 
     #### Regions/Zones ####
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This patches #1648 that breaks the `sky spot launch`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky spot launch -n test echo hi`
