### PR TITLE
[Cost Report] Add cluster name filtering

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -106,7 +106,7 @@ def status(cluster_names: Optional[Union[str, Sequence[str]]] = None,
 
 
 @usage_lib.entrypoint
-def cost_report() -> List[Dict[str, Any]]:
+def cost_report(cluster_names: List[str]) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -139,7 +139,16 @@ def cost_report() -> List[Dict[str, Any]]:
         A list of dicts, with each dict containing the cost information of a
         cluster.
     """
-    cluster_reports = global_user_state.get_clusters_from_history()
+    all_cluster_reports = global_user_state.get_clusters_from_history()
+
+    cluster_reports = []
+    if cluster_names is not None:
+        for cluster_name in cluster_names:
+            for report in all_cluster_reports:
+                if report['name'] == cluster_name:
+                    cluster_reports.append(report)
+    else:
+        cluster_reports = all_cluster_reports
 
     def get_total_cost(cluster_report: dict) -> float:
         duration = cluster_report['duration']

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -353,6 +353,13 @@ def get_glob_cluster_names(cluster_name: str) -> List[str]:
     return [row[0] for row in rows]
 
 
+def get_glob_cluster_history_names(cluster_name: str) -> List[str]:
+    assert cluster_name is not None, 'cluster_name cannot be None'
+    rows = _DB.cursor.execute(
+        'SELECT name FROM cluster_history WHERE name GLOB (?)', (cluster_name,))
+    return [row[0] for row in rows]
+
+
 def set_cluster_status(cluster_name: str, status: ClusterStatus) -> None:
     _DB.cursor.execute('UPDATE clusters SET status=(?) WHERE name=(?)', (
         status.value,


### PR DESCRIPTION
For example, use 'sky cost-report cluster_name` to filter cost report to match clusters with name "cluster_name." 

Addresses #1643.

'''
(base) sumanth@MacBook-Pro-5 skypilot % sky cost-report
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  1 week ago    6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $0.311       
cluster  1 week ago    22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $1.108       
cluster  1 month ago   3m 41s    1x GCP(n1-highmem-8)               $ 0.473       $0.029       
cluster  1 month ago   10m 13s   1x GCP(n1-highmem-8)               $ 0.473       $0.081       
min      2 months ago  6m 25s    1x AWS(m6i.2xlarge)                $ 0.384       $0.041       
min      2 months ago  24m 40s   1x AWS(m6i.2xlarge)                $ 0.384       $0.158       
mount    2 months ago  7m 26s    1x GCP(n1-highmem-8)               $ 0.473       $0.059       
mount2   2 months ago  12m 28s   1x GCP(n1-highmem-8)               $ 0.473       $0.098       
mount    2 months ago  16m 26s   1x GCP(n1-highmem-8)               $ 0.473       $0.130

(base) sumanth@MacBook-Pro-5 skypilot % sky cost-report min
Clusters
NAME  LAUNCHED      DURATION  RESOURCES            HOURLY_PRICE  COST (est.)  
min   2 months ago  6m 25s    1x AWS(m6i.2xlarge)  $ 0.384       $0.041       
min   2 months ago  24m 40s   1x AWS(m6i.2xlarge)  $ 0.384       $0.158       
'''