### PR TITLE
[Cost Report] Add basic time filtering

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1467,8 +1467,13 @@ def status(all: bool, refresh: bool, clusters: List[str]):  # pylint: disable=re
               is_flag=True,
               required=False,
               help='Show all information in full.')
+@click.option('--timeframe',
+              '-t',
+              required=False,
+              type=str,
+              help=('Timeframe for cost reports'))
 @usage_lib.entrypoint
-def cost_report(all: bool):  # pylint: disable=redefined-builtin
+def cost_report(all: bool, timeframe: str):  # pylint: disable=redefined-builtin
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show cost reports for each cluster.
 
@@ -1485,7 +1490,16 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     on the cloud console.
     """
 
-    cluster_records = core.cost_report()
+    # hour, week, month, year
+
+    if timeframe and timeframe not in ['h', 'd', 'w', 'm', 'y']:
+        click.echo(
+            f'{colorama.Fore.YELLOW}'
+            f'Timeframe {timeframe} not valid. Select from [h, d, w, m, y].'
+            f'{colorama.Style.RESET_ALL}')
+        return
+
+    cluster_records = core.cost_report(timeframe)
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:

--- a/sky/core.py
+++ b/sky/core.py
@@ -186,8 +186,7 @@ def cost_report(timeframe: str) -> List[Dict[str, Any]]:
 
     visible_cluster_reports = []
     for cluster_report in cluster_reports:
-        if cluster_report[
-                'total_cost'] > 0:
+        if cluster_report['total_cost'] > 0:
             visible_cluster_reports.append(cluster_report)
 
     return visible_cluster_reports

--- a/sky/core.py
+++ b/sky/core.py
@@ -186,8 +186,7 @@ def cost_report(timeframe: str) -> List[Dict[str, Any]]:
 
     visible_cluster_reports = []
     for cluster_report in cluster_reports:
-        launch_time = cluster_report['launched_at']
-        if timeframe_start and timeframe_start < launch_time and cluster_report[
+        if cluster_report[
                 'total_cost'] > 0:
             visible_cluster_reports.append(cluster_report)
 


### PR DESCRIPTION
Using `sky cost-report -t h` for example, users can filter all clusters that were used in the last hour. This can be done for hour, day, week, month and year.

Addresses #1646.


Tested:

```
(base) sumanth@MacBook-Pro-5 skypilot % sky cost-report -t y                                                    
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  1 week ago    6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $0.311       
cluster  1 week ago    22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $1.108       
cluster  1 month ago   3m 41s    1x GCP(n1-highmem-8)               $ 0.473       $0.029       
cluster  1 month ago   10m 13s   1x GCP(n1-highmem-8)               $ 0.473       $0.081       
min      2 months ago  6m 25s    1x AWS(m6i.2xlarge)                $ 0.384       $0.041       
min      2 months ago  24m 40s   1x AWS(m6i.2xlarge)                $ 0.384       $0.158       
mount    2 months ago  7m 26s    1x GCP(n1-highmem-8)               $ 0.473       $0.059       
mount2   2 months ago  12m 28s   1x GCP(n1-highmem-8)               $ 0.473       $0.098       
mount    2 months ago  16m 26s   1x GCP(n1-highmem-8)               $ 0.473       $0.130       

(base) sumanth@MacBook-Pro-5 skypilot % sky cost-report -t m
Clusters
NAME     LAUNCHED    DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  1 week ago  6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $0.311       
cluster  1 week ago  22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $1.108   
```