### PR TITLE
Support managing on-demand TPU

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -538,6 +538,11 @@ def spot_launch(
     change_default_value = dict()
     if not resources.use_spot_specified:
         change_default_value['use_spot'] = True
+    elif not resources.use_spot:
+        print(f'{colorama.Fore.RED}'
+              'User specify --no-use-spot. '
+              'This task will be run by on-demand instances.'
+              f'{colorama.Style.RESET_ALL}')
     if resources.spot_recovery is None:
         change_default_value['spot_recovery'] = spot.SPOT_DEFAULT_STRATEGY
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -500,11 +500,6 @@ class Resources:
     def _try_validate_spot(self) -> None:
         if self._spot_recovery is None:
             return
-        if not self._use_spot:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cannot specify spot_recovery without use_spot set to True.'
-                )
         if self._spot_recovery not in spot.SPOT_STRATEGIES:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1372,7 +1372,6 @@ def test_on_demand_tpu_recovery_gcp():
             f'{_SPOT_QUEUE_WAIT}| grep {name} | head -n1 | grep "RUNNING"',
             # Check if the recovered TPU is on-demand.
             check_on_demand_cmd,
-            f'RUN_ID=$(cat /tmp/{name}-run-id); echo $RUN_ID; sky spot logs -n {name} --no-follow | grep SKYPILOT_JOB_ID | grep "$RUN_ID"',
         ],
         f'sky spot cancel -y -n {name}',
         timeout=25 * 60,

--- a/tests/test_yamls/test_tpu_recovery.yaml
+++ b/tests/test_yamls/test_tpu_recovery.yaml
@@ -1,0 +1,8 @@
+resources:
+  accelerators: tpu-v2-8
+  accelerator_args:
+    runtime_version: tpu-vm-base
+    tpu_vm: True
+
+run: |
+  sleep 1800


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR implements a possible solution to https://github.com/skypilot-org/skypilot/issues/909.
Recently users report their on-demand TPUs have been taken back quite frequently.
This PR does some small modification to make controller manage on-demand VMs.
User needs to add `--no-use-spot` to `spot launch` explicitly.
```
sky spot launch --no-use-spot tpuvm.yaml
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Tested `sky spot launch --no-use-spot` a TPU VM and recovered successfully from preemption
- [x] Add a new smoke test `pytest tests/test_smoke.py::test_on_demand_tpu_recovery_gcp`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
