### PR TITLE
[Lambda Cloud] Update docs and add `[lambda]` install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 SkyPilot is a framework for easily and cost effectively running ML workloads[^1] on any cloud. 
 
 SkyPilot abstracts away the cloud infra burden:
-- Launch jobs & clusters on any cloud (AWS, Azure, GCP)
+- Launch jobs & clusters on any cloud (AWS, Azure, GCP, Lambda Cloud)
 - Find scarce resources across zones/regions/clouds
 - Queue jobs & use cloud object stores
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -22,7 +22,9 @@ only have access to certain clouds, use any combination of
 :code:`"[aws,azure,gcp]"` (e.g., :code:`"[aws,gcp]"`) to reduce the
 dependencies installed.
 
-You may also install SkyPilot from source.
+SkyPilot also supports a fourth cloud provider, `Lambda <https://lambdalabs.com/>`_, if you install SkyPilot from source.
+
+To install SkyPilot from source:
 
 .. code-block:: console
 
@@ -92,6 +94,20 @@ Note: if you encounter *Authorization Error (Error 400: invalid_request)* with t
 
 Hint: run ``az account subscription list`` to get a list of subscription IDs under your account.
 
+**Lambda**
+
+Create the file :code:`~/.lambda_cloud/lambda_keys`, go to `API Keys <https://cloud.lambdalabs.com/api-keys>`_ to generate a key, and then add the line
+
+.. code-block:: text
+
+  api_key = your_api_key_here
+
+to :code:`~/.lambda_cloud/lambda_keys`.
+
+.. note::
+
+  Currently, SkyPilot does not support multi-node clusters or stopping instances on Lambda Cloud.
+
 **Verifying cloud setup**
 
 After configuring the desired clouds, you can optionally run :code:`sky check` to verify that credentials are correctly set up:
@@ -108,6 +124,7 @@ This will produce a summary like:
     AWS: enabled
     GCP: enabled
     Azure: enabled
+    Lambda: enabled
 
   SkyPilot will use only the enabled clouds to run tasks. To change this, configure cloud credentials, and run sky check.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -97,7 +97,7 @@ Hint: run ``az account subscription list`` to get a list of subscription IDs und
 
 Lambda Labs GPU Cloud is a cloud provider offering low-cost GPUs. You can learn more about them `here <https://lambdalabs.com/>`__.
 
-To configure Lambda Cloud access, go to `API Keys <https://cloud.lambdalabs.com/api-keys>`_ to generate a key and then add it to :code:`~/.lambda_cloud/lambda_keys` by running:
+To configure Lambda Cloud access, go to the `API Keys <https://cloud.lambdalabs.com/api-keys>`_ page on your Lambda console to generate a key and then add it to :code:`~/.lambda_cloud/lambda_keys` by running:
 
 .. code-block:: console
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -14,17 +14,16 @@ Install SkyPilot using pip:
   $ pip install skypilot
   $ # pip install "skypilot[gcp]"
   $ # pip install "skypilot[azure]"
+  $ # pip install "skypilot[lambda]"
   $ # pip install "skypilot[all]"
 
 
-SkyPilot currently supports three major cloud providers: AWS, GCP, and Azure.  If you
-only have access to certain clouds, use any combination of
-:code:`"[aws,azure,gcp]"` (e.g., :code:`"[aws,gcp]"`) to reduce the
+SkyPilot currently supports four cloud providers: AWS, GCP, Azure, and Lambda Cloud.
+If you only have access to certain clouds, use any combination of
+:code:`"[aws,azure,gcp,lambda]"` (e.g., :code:`"[aws,gcp]"`) to reduce the
 dependencies installed.
 
-SkyPilot also supports a fourth cloud provider, `Lambda <https://lambdalabs.com/>`_, if you install SkyPilot from source.
-
-To install SkyPilot from source:
+You may also install SkyPilot from source.
 
 .. code-block:: console
 
@@ -94,19 +93,22 @@ Note: if you encounter *Authorization Error (Error 400: invalid_request)* with t
 
 Hint: run ``az account subscription list`` to get a list of subscription IDs under your account.
 
-**Lambda**
+**Lambda Cloud**
 
-Create the file :code:`~/.lambda_cloud/lambda_keys`, go to `API Keys <https://cloud.lambdalabs.com/api-keys>`_ to generate a key, and then add the line
+Lambda Labs GPU Cloud is a cloud provider offering low-cost GPUs. You can learn more about them `here <https://lambdalabs.com/>`__.
 
-.. code-block:: text
+To configure Lambda Cloud access, go to `API Keys <https://cloud.lambdalabs.com/api-keys>`_ to generate a key and then add it to :code:`~/.lambda_cloud/lambda_keys` by running:
 
-  api_key = your_api_key_here
+.. code-block:: console
 
-to :code:`~/.lambda_cloud/lambda_keys`.
+  $ # Create directory if required
+  $ mkdir -p ~/.lambda_cloud
+  $ # Add the line "api_key = <your_api_key_here>" to lambda_keys file
+  $ echo "api_key = <your_api_key_here>" > ~/.lambda_cloud/lambda_keys
 
 .. note::
 
-  Currently, SkyPilot does not support multi-node clusters or stopping instances on Lambda Cloud.
+  Multi-node clusters and stopping instances are currently not supported on Lambda Cloud.
 
 **Verifying cloud setup**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,7 @@ SkyPilot is a framework for easily and cost effectively running ML workloads on 
 
 SkyPilot abstracts away cloud infra burden:
 
-- Launch jobs & clusters on any cloud (AWS, Azure, GCP, Lambda)
+- Launch jobs & clusters on any cloud (AWS, Azure, GCP, Lambda Cloud)
 - Find scarce resources across zones/regions/clouds
 - Queue jobs & use cloud object stores
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,7 +25,7 @@ SkyPilot is a framework for easily and cost effectively running ML workloads on 
 
 SkyPilot abstracts away cloud infra burden:
 
-- Launch jobs & clusters on any cloud (AWS, Azure, GCP)
+- Launch jobs & clusters on any cloud (AWS, Azure, GCP, Lambda)
 - Find scarce resources across zones/regions/clouds
 - Queue jobs & use cloud object stores
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -113,6 +113,7 @@ extras_require = {
     'azure': ['azure-cli>=2.31.0', 'azure-core', 'azure-identity'],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],
     'docker': ['docker'],
+    'lambda': [],
 }
 
 extras_require['all'] = sum(extras_require.values(), [])

--- a/sky/templates/lambda-ray.yml.j2
+++ b/sky/templates/lambda-ray.yml.j2
@@ -72,7 +72,7 @@ setup_commands:
     which conda > /dev/null 2>&1 || (wget -nc https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b && eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true);
     source ~/.bashrc;
     (pip3 list | grep ray | grep {{ray_version}} 2>&1 > /dev/null || pip3 install -U ray[default]=={{ray_version}}) && mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && touch ~/.sudo_as_admin_successful;
-    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
+    (pip3 list | grep skypilot && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[lambda]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;


### PR DESCRIPTION
Add Lambda Cloud to documentation and add the `[lambda]` option. (The `[lambda]` option does not install anything extra, but is included for uniformity).
