### PR TITLE
[Setup] Pin Jinja2 version to avoid an markupsafe version

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -71,7 +71,10 @@ install_requires = [
     # the latest version.
     'colorama<0.4.5',
     'cryptography',
-    'jinja2',
+    # Jinja has a bug in older versions because of the lack of pinning
+    # the version of the underlying markupsafe package. See:
+    # https://github.com/pallets/jinja/issues/1585
+    'jinja2>=3.0',
     'jsonschema',
     'networkx',
     'oauth2client',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to fix the issue in https://github.com/pallets/jinja/issues/1585, raised by one of our user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `pip install .` in a new environment and `sky launch -c test --cloud gcp`
