### PR TITLE
[Docs] CPU docs update

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -54,7 +54,7 @@ Available fields:
       #
       # E.g., 4+ would first try to find an instance type with 4 vCPUs. If not
       # found, it will use the next cheapest instance with more than 4 vCPUs.
-      cpus: 32+
+      cpus: 32
 
       # Instance type to use (optional). If 'accelerators' is specified,
       # the corresponding instance type is automatically inferred.

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -51,7 +51,10 @@ Available fields:
       #
       # Format: <count> (exactly <count> vCPUs) or <count>+
       # (at least <count> vCPUs).
-      cpus: 32
+      #
+      # E.g., 4+ would first try to find an instance type with 4 vCPUs. If not
+      # found, it will use the next cheapest instance with more than 4 vCPUs.
+      cpus: 32+
 
       # Instance type to use (optional). If 'accelerators' is specified,
       # the corresponding instance type is automatically inferred.


### PR DESCRIPTION
Adds a simple example to explain how the cpu+ field works.

Tested:
- [x] Docs locally rendered
