### PR TITLE
Add lock for aws session creation

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -7,21 +7,7 @@ import threading
 
 boto3 = None
 botocore = None
-func_lock = threading.RLock()
-
-
-def _synchronized(func):
-    """Decorator to synchronize a function.
-
-    This decorator is used to synchronize a function across threads.
-    """
-
-    @functools.wraps(func)
-    def synced_func(*args, **kwargs):
-        with func_lock:
-            return func(*args, **kwargs)
-
-    return synced_func
+_session_creation_lock = threading.RLock()
 
 
 def import_package(func):
@@ -43,17 +29,20 @@ def import_package(func):
     return wrapper
 
 
-# Creating the session object is not thread-safe for boto3,
-# so we add a reentrant lock to synchronize the session creation.
-# Reference: https://github.com/boto/boto3/issues/1592
+# lru_cache() is thread-safe and it will return the same session object
+# for different threads.
+# Reference: https://docs.python.org/3/library/functools.html#functools.lru_cache # pylint: disable=line-too-long
 @functools.lru_cache()
-@_synchronized
 @import_package
 def session():
     """Create an AWS session."""
-    # functools.lru_cache() is used to cache the session object
-    # for each thread.
-    return boto3.session.Session()
+    # Creating the session object is not thread-safe for boto3,
+    # so we add a reentrant lock to synchronize the session creation.
+    # Reference: https://github.com/boto/boto3/issues/1592
+    # However, the session object itself is thread-safe, so we are
+    # able to use lru_cache() to cache the session object.
+    with _session_creation_lock:
+        return boto3.session.Session()
 
 
 @functools.lru_cache()

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -9,17 +9,20 @@ boto3 = None
 botocore = None
 func_lock = threading.RLock()
 
+
 def _synchronized(func):
     """Decorator to synchronize a function.
 
     This decorator is used to synchronize a function across threads.
     """
+
     @functools.wraps(func)
     def synced_func(*args, **kwargs):
         with func_lock:
             return func(*args, **kwargs)
 
     return synced_func
+
 
 def import_package(func):
 

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -43,8 +43,8 @@ def import_package(func):
 # Creating the session object is not thread-safe for boto3,
 # so we add a reentrant lock to synchronize the session creation.
 # Reference: https://github.com/boto/boto3/issues/1592
-@_synchronized
 @functools.lru_cache()
+@_synchronized
 @import_package
 def session():
     """Create an AWS session."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported a transient error when running the `sky status -r` 

```
[2023-02-02 22:04:47.820926 HKT] Failed to connect to cluster; refreshing cluster status...
W 02-02 22:05:14 backend_utils.py:2324] Failed to refresh status for 6 clusters:
W 02-02 22:05:14 backend_utils.py:2327]   cluster1: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'credential_provider'.
W 02-02 22:05:14 backend_utils.py:2327]   cluster2: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'endpoint_resolver'.
W 02-02 22:05:14 backend_utils.py:2327]   cluster3: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'credential_provider'.
W 02-02 22:05:14 backend_utils.py:2327]   cluster4: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'endpoint_resolver'.
W 02-02 22:05:14 backend_utils.py:2327]   cluster5: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'endpoint_resolver'.
W 02-02 22:05:14 backend_utils.py:2327]   cluster6: Failed to get AWS user.
W 02-02 22:05:14 backend_utils.py:2327]   Reason: [builtins.KeyError]: 'credential_provider'.
```

This is because the AWS boto API is not threadsafe for creating the session: https://github.com/boto/boto3/issues/1592. We now add the lock to avoid the problem.


### Overhead
Average `time sky status -r` among 10 times (on GCP n1-standard-4)
#### 11 clusters with autostop set up
42.1712s (current PR); 40.3s (original master), i.e. the current PR adds 5% overheads for `sky status -r` 

#### 6 clusters with autostop set up
36.6466 (current PR), 35.2495s (original master), i.e. the current PR adds 4% overheads for `sky status -r`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] `pytest tests/test_smoke.py --aws` 
