### PR TITLE
[Spot] Add termination and cancellation for spot jobs into the usage collection

### DIFF
--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -101,11 +101,11 @@ class StrategyExecutor:
         retry_cnt = 0
         while True:
             try:
-                handle = global_user_state.get_handle_from_cluster_name(
-                    self.cluster_name)
-                if handle is None:
-                    return
-                self.backend.teardown(handle, terminate=True)
+                usage_lib.messages.usage.set_internal()
+                sky.down(self.cluster_name)
+                return
+            except ValueError:
+                # The cluster is already down.
                 return
             except Exception as e:  # pylint: disable=broad-except
                 retry_cnt += 1
@@ -121,7 +121,8 @@ class StrategyExecutor:
         if handle is None:
             return
         try:
-            self.backend.cancel_jobs(handle, jobs=None)
+            usage_lib.messages.usage.set_internal()
+            sky.cancel(cluster_name=self.cluster_name, all=True)
         except Exception as e:  # pylint: disable=broad-except
             # Ignore the failure as the cluster can be totally stopped, and the
             # job canceling can get connection error.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR is to make sure the usage collection for the spot jobs contain the cancellation and termination action.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky spot launch -n test-termination echo hi` and check the dashboard
- [x] `sky spot launch -n test-cancel sleep 10000` and terminate on the console