### PR TITLE
[Spot] [Cost Report] Add CLI support for getting VM cost for spot jobs

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3650,14 +3650,12 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
 @spot.command('cost-report', cls=_DocumentedCodeCommand)
-@click.option(
-    '--all',
-    '-a',
-    default=False,
-    is_flag=True,
-    required=False,
-    help='Display all rows of spot cost report table.'
-)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Display all rows of spot cost report table.')
 @click.option(
     '--refresh',
     '-r',
@@ -3671,7 +3669,7 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
               default=False,
               is_flag=True,
               required=False,
-              help='If true,  breakdown of spot job preemptions.')
+              help='If true, do not show breakdown of spot job preemptions.')
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def spot_cost_report(all: bool, refresh: bool, condensed: bool):

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3648,21 +3648,20 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
-@click.option(
-    '--verbose',
-    '-s',
-    default=True,
-    is_flag=True,
-    required=False,
-    help='Query the latest statuses, restarting the spot controller if stopped.'
-)
+@click.option('--condensed',
+              '-c',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='If true, do not show verbose breakdown of spot job costs.')
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def spot_cost_report(refresh: bool, verbose: bool):
+def spot_cost_report(refresh: bool, condensed: bool):
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job costs...', fg='yellow')
     no_costs_found_str = '  No job costs found.'
+    verbose = not condensed
     try:
         cost_table = core.spot_cost_report(refresh, verbose)
     except exceptions.ClusterNotUpError:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3628,6 +3628,42 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
 _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
+@spot.command('cost', cls=_DocumentedCodeCommand)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Show all information in full.')
+@click.option(
+    '--refresh',
+    '-r',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Query the latest statuses, restarting the spot controller if stopped.'
+)
+@usage_lib.entrypoint
+# pylint: disable=redefined-builtin
+def spot_cost_report(refresh: bool):
+    """Show cost report of managed spot jobs.
+    """
+    click.secho('Fetching managed spot job statuses...', fg='yellow')
+    no_jobs_found_str = '  No jobs found.'
+    try:
+        cost_table = core.spot_cost_report(refresh=refresh)
+    except exceptions.ClusterNotUpError:
+        return
+
+    if not cost_table:
+        cost_table = no_jobs_found_str
+    else:
+        cost_table = spot_lib.format_cost_table(cost_table)
+
+    in_progress_only_hint = ' (showing in-progress jobs only)'
+    click.echo(f'Managed spot jobs{in_progress_only_hint}:\n{cost_table}')
+
+
 @spot.command('cancel', cls=_DocumentedCodeCommand)
 @click.option('--name',
               '-n',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3640,6 +3640,12 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
 @spot.command('cost', cls=_DocumentedCodeCommand)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Show all information in full.')
 @click.option(
     '--refresh',
     '-r',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3689,6 +3689,7 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
+<<<<<<< HEAD
 @click.option('--condensed',
               '-c',
               default=False,
@@ -3698,12 +3699,29 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def spot_cost_report(refresh: bool, condensed: bool):
+=======
+@click.option(
+    '--verbose',
+    '-s',
+    default=True,
+    is_flag=True,
+    required=False,
+    help='Query the latest statuses, restarting the spot controller if stopped.'
+)
+@usage_lib.entrypoint
+# pylint: disable=redefined-builtin
+def spot_cost_report(refresh: bool, verbose: bool):
+>>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job costs...', fg='yellow')
     no_costs_found_str = '  No job costs found.'
     try:
+<<<<<<< HEAD
         cost_table = core.spot_cost_report(refresh, condensed)
+=======
+        cost_table = core.spot_cost_report(refresh, verbose)
+>>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     except exceptions.ClusterNotUpError:
         with log_utils.safe_rich_status('[cyan]Checking spot jobs[/]'):
             _, msg = _get_spot_jobs(refresh=refresh,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3649,7 +3649,6 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
 _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
-
 @spot.command('cost-report', cls=_DocumentedCodeCommand)
 @click.option(
     '--refresh',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3649,22 +3649,22 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
 @click.option(
-    '--split',
+    '--verbose',
     '-s',
-    default=False,
+    default=True,
     is_flag=True,
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def spot_cost_report(refresh: bool, split: bool):
+def spot_cost_report(refresh: bool, verbose: bool):
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job costs...', fg='yellow')
     no_costs_found_str = '  No job costs found.'
     try:
-        cost_table = core.spot_cost_report(refresh, split)
+        cost_table = core.spot_cost_report(refresh, verbose)
     except exceptions.ClusterNotUpError:
 
         return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1810,7 +1810,7 @@ def cost_report(all: bool, condensed: bool, clusters: List[str]):  # pylint: dis
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
-                
+
             # to display most recent entry for each reserved cluster
             # TODO(sgurram): fix assumption of sorted order of clusters
             if cluster_group_name not in reserved_clusters:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1762,6 +1762,7 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
               is_flag=True,
               required=False,
               help='Show all information in full.')
+<<<<<<< HEAD
 @click.option('--condensed',
               '-c',
               default=False,
@@ -1775,6 +1776,16 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                 **_get_shell_complete_args(_complete_cluster_name))
 @usage_lib.entrypoint
 def cost_report(all: bool, condensed: bool, clusters: List[str]):  # pylint: disable=redefined-builtin
+=======
+@click.option('--cluster',
+              '-c',
+              default=None,
+              type=str,
+              required=False,
+              help='Specify a cluster name to report cost for.')
+@usage_lib.entrypoint
+def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
+>>>>>>> 21bad003 (address almost all PR comments)
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show estimated costs for launched clusters.
 
@@ -1793,6 +1804,7 @@ def cost_report(all: bool, condensed: bool, clusters: List[str]):  # pylint: dis
 
     - Clusters that were terminated/stopped on the cloud console.
     """
+<<<<<<< HEAD
     if all and len(clusters) > 0:
         click.secho('Either specify --all or --cluster, not both', fg='yellow')
         return
@@ -1803,6 +1815,20 @@ def cost_report(all: bool, condensed: bool, clusters: List[str]):  # pylint: dis
         return
     cluster_records = core.cost_report(clusters, condensed)
 
+=======
+<<<<<<< HEAD
+    cluster_records = core.cost_report()
+=======
+
+    if all and cluster is not None:
+            click.secho(
+                'Either specify --all or --cluster, not both',
+                fg='yellow')
+            return
+    cluster_records = core.cost_report(cluster)
+    
+>>>>>>> 2bad0924 (address almost all PR comments)
+>>>>>>> 21bad003 (address almost all PR comments)
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1789,12 +1789,10 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
     - Clusters that were terminated/stopped on the cloud console.
     """
     if all and cluster is not None:
-            click.secho(
-                'Either specify --all or --cluster, not both',
-                fg='yellow')
-            return
+        click.secho('Either specify --all or --cluster, not both', fg='yellow')
+        return
     cluster_records = core.cost_report(cluster)
-    
+
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3680,7 +3680,17 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
 _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
+<<<<<<< HEAD
 @spot.command('cost-report', cls=_DocumentedCodeCommand)
+=======
+@spot.command('cost', cls=_DocumentedCodeCommand)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Show all information in full.')
+>>>>>>> 8fa31ba9 (add spot cost report)
 @click.option(
     '--refresh',
     '-r',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1805,6 +1805,7 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
     - Clusters that were terminated/stopped on the cloud console.
     """
 <<<<<<< HEAD
+<<<<<<< HEAD
     if all and len(clusters) > 0:
         click.secho('Either specify --all or --cluster, not both', fg='yellow')
         return
@@ -1819,16 +1820,20 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
 <<<<<<< HEAD
     cluster_records = core.cost_report()
 =======
+=======
+>>>>>>> 97a20536 (lint and format)
 
     if all and cluster is not None:
-            click.secho(
-                'Either specify --all or --cluster, not both',
-                fg='yellow')
-            return
+        click.secho('Either specify --all or --cluster, not both', fg='yellow')
+        return
     cluster_records = core.cost_report(cluster)
+<<<<<<< HEAD
     
 >>>>>>> 2bad0924 (address almost all PR comments)
 >>>>>>> 21bad003 (address almost all PR comments)
+=======
+
+>>>>>>> 97a20536 (lint and format)
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1788,6 +1788,7 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
 
     - Clusters that were terminated/stopped on the cloud console.
     """
+
     if all and cluster is not None:
         click.secho('Either specify --all or --cluster, not both', fg='yellow')
         return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1762,14 +1762,13 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
               is_flag=True,
               required=False,
               help='Show all information in full.')
-@click.option('--cluster',
-              '-c',
-              default=None,
-              type=str,
-              required=False,
-              help='Specify a cluster name to report cost for.')
+@click.argument('cluster',
+                required=False,
+                type=str,
+                nargs=-1,
+                **_get_shell_complete_args(_complete_cluster_name))
 @usage_lib.entrypoint
-def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
+def cost_report(all: bool, cluster: Optional[str]):  # pylint: disable=redefined-builtin
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show estimated costs for launched clusters.
 
@@ -1788,7 +1787,7 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
 
     - Clusters that were terminated/stopped on the cloud console.
     """
-
+    cluster = cluster[0]
     if all and cluster is not None:
         click.secho('Either specify --all or --cluster, not both', fg='yellow')
         return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1791,10 +1791,12 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
+                
             # to display most recent entry for each reserved cluster
             # TODO(sgurram): fix assumption of sorted order of clusters
             if cluster_group_name not in reserved_clusters:
-                reserved_clusters[cluster_group_name] = cluster_record
+                for aggregated_record in core.cost_report(cluster_name):
+                    reserved_clusters[cluster_group_name] = aggregated_record
         else:
             nonreserved_cluster_records.append(cluster_record)
 
@@ -3629,12 +3631,6 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
 @spot.command('cost', cls=_DocumentedCodeCommand)
-@click.option('--all',
-              '-a',
-              default=False,
-              is_flag=True,
-              required=False,
-              help='Show all information in full.')
 @click.option(
     '--refresh',
     '-r',
@@ -3649,14 +3645,15 @@ def spot_cost_report(refresh: bool):
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job statuses...', fg='yellow')
-    no_jobs_found_str = '  No jobs found.'
+    no_costs_found_str = '  No job costs found.'
     try:
         cost_table = core.spot_cost_report(refresh=refresh)
     except exceptions.ClusterNotUpError:
+
         return
 
     if not cost_table:
-        cost_table = no_jobs_found_str
+        cost_table = no_costs_found_str
     else:
         cost_table = spot_lib.format_cost_table(cost_table)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3639,15 +3639,23 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
+@click.option(
+    '--split',
+    '-s',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Query the latest statuses, restarting the spot controller if stopped.'
+)
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def spot_cost_report(refresh: bool):
+def spot_cost_report(refresh: bool, split: bool):
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job statuses...', fg='yellow')
     no_costs_found_str = '  No job costs found.'
     try:
-        cost_table = core.spot_cost_report(refresh=refresh)
+        cost_table = core.spot_cost_report(refresh, split)
     except exceptions.ClusterNotUpError:
 
         return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1762,7 +1762,6 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
               is_flag=True,
               required=False,
               help='Show all information in full.')
-<<<<<<< HEAD
 @click.option('--condensed',
               '-c',
               default=False,
@@ -1776,16 +1775,6 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                 **_get_shell_complete_args(_complete_cluster_name))
 @usage_lib.entrypoint
 def cost_report(all: bool, condensed: bool, clusters: List[str]):  # pylint: disable=redefined-builtin
-=======
-@click.option('--cluster',
-              '-c',
-              default=None,
-              type=str,
-              required=False,
-              help='Specify a cluster name to report cost for.')
-@usage_lib.entrypoint
-def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
->>>>>>> 21bad003 (address almost all PR comments)
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Show estimated costs for launched clusters.
 
@@ -1804,8 +1793,6 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
 
     - Clusters that were terminated/stopped on the cloud console.
     """
-<<<<<<< HEAD
-<<<<<<< HEAD
     if all and len(clusters) > 0:
         click.secho('Either specify --all or --cluster, not both', fg='yellow')
         return
@@ -1816,24 +1803,6 @@ def cost_report(all: bool, cluster: str):  # pylint: disable=redefined-builtin
         return
     cluster_records = core.cost_report(clusters, condensed)
 
-=======
-<<<<<<< HEAD
-    cluster_records = core.cost_report()
-=======
-=======
->>>>>>> 97a20536 (lint and format)
-
-    if all and cluster is not None:
-        click.secho('Either specify --all or --cluster, not both', fg='yellow')
-        return
-    cluster_records = core.cost_report(cluster)
-<<<<<<< HEAD
-    
->>>>>>> 2bad0924 (address almost all PR comments)
->>>>>>> 21bad003 (address almost all PR comments)
-=======
-
->>>>>>> 97a20536 (lint and format)
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:
@@ -3680,17 +3649,7 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
 _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 
-<<<<<<< HEAD
 @spot.command('cost-report', cls=_DocumentedCodeCommand)
-=======
-@spot.command('cost', cls=_DocumentedCodeCommand)
-@click.option('--all',
-              '-a',
-              default=False,
-              is_flag=True,
-              required=False,
-              help='Show all information in full.')
->>>>>>> 8fa31ba9 (add spot cost report)
 @click.option(
     '--refresh',
     '-r',
@@ -3699,7 +3658,6 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
     required=False,
     help='Query the latest statuses, restarting the spot controller if stopped.'
 )
-<<<<<<< HEAD
 @click.option('--condensed',
               '-c',
               default=False,
@@ -3709,29 +3667,12 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def spot_cost_report(refresh: bool, condensed: bool):
-=======
-@click.option(
-    '--verbose',
-    '-s',
-    default=True,
-    is_flag=True,
-    required=False,
-    help='Query the latest statuses, restarting the spot controller if stopped.'
-)
-@usage_lib.entrypoint
-# pylint: disable=redefined-builtin
-def spot_cost_report(refresh: bool, verbose: bool):
->>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job costs...', fg='yellow')
     no_costs_found_str = '  No job costs found.'
     try:
-<<<<<<< HEAD
         cost_table = core.spot_cost_report(refresh, condensed)
-=======
-        cost_table = core.spot_cost_report(refresh, verbose)
->>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     except exceptions.ClusterNotUpError:
         with log_utils.safe_rich_status('[cyan]Checking spot jobs[/]'):
             _, msg = _get_spot_jobs(refresh=refresh,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3651,6 +3651,14 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
 
 @spot.command('cost-report', cls=_DocumentedCodeCommand)
 @click.option(
+    '--all',
+    '-a',
+    default=False,
+    is_flag=True,
+    required=False,
+    help='Display all rows of spot cost report table.'
+)
+@click.option(
     '--refresh',
     '-r',
     default=False,
@@ -3666,7 +3674,7 @@ _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)
               help='If true,  breakdown of spot job preemptions.')
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def spot_cost_report(refresh: bool, condensed: bool):
+def spot_cost_report(all: bool, refresh: bool, condensed: bool):
     """Show cost report of managed spot jobs.
     """
     click.secho('Fetching managed spot job costs...', fg='yellow')
@@ -3687,7 +3695,7 @@ def spot_cost_report(refresh: bool, condensed: bool):
     if not cost_table:
         cost_table = no_costs_found_str
     else:
-        cost_table = spot_lib.format_cost_table(cost_table)
+        cost_table = spot_lib.format_cost_table(cost_table, all)
 
     click.echo(f'Managed spot jobs:\n{cost_table}')
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -143,8 +143,15 @@ def cost_report(cluster_names: List[str],
         A list of dicts, with each dict containing the cost information of a
         cluster.
     """
+<<<<<<< HEAD
     if aggregate_by_cluster_name:
         cluster_reports = cost_utils.aggregate_all_records(condensed=True)
+=======
+
+    # aggregate records for spot controller
+    if cluster_name is not None:
+        cluster_reports = cost_utils.aggregate_all_records(verbose=False)
+>>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     else:
         cluster_reports = global_user_state.get_clusters_from_history()
 
@@ -931,7 +938,11 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 
 
 @usage_lib.entrypoint
+<<<<<<< HEAD
 def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
+=======
+def spot_cost_report(refresh: bool, verbose: bool) -> List[Dict[str, Any]]:
+>>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
 
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
@@ -985,7 +996,11 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
 
+<<<<<<< HEAD
     code = spot.SpotCodeGen.get_cost_report(condensed)
+=======
+    code = spot.SpotCodeGen.get_cost_report(verbose)
+>>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
 
     returncode, job_costs_payload, stderr = backend.run_on_head(
         handle,

--- a/sky/core.py
+++ b/sky/core.py
@@ -24,6 +24,7 @@ from sky.utils import tpu_utils
 from sky.utils import ux_utils
 from sky.utils import subprocess_utils
 from sky.utils.cli_utils import cost_utils
+from sky.status_lib import ClusterStatus
 
 logger = sky_logging.init_logger(__name__)
 
@@ -970,8 +971,8 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
         return []
 
     if (refresh and controller_status in [
-            global_user_state.ClusterStatus.STOPPED,
-            global_user_state.ClusterStatus.INIT
+            ClusterStatus.STOPPED,
+            ClusterStatus.INIT
     ]):
         print(f'{colorama.Fore.YELLOW}'
               'Restarting controller for latest status...'
@@ -979,7 +980,7 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
 
         handle = _start(spot.SPOT_CONTROLLER_NAME)
 
-    controller_status = global_user_state.ClusterStatus.UP
+    controller_status = ClusterStatus.UP
 
     if handle is None or handle.head_ip is None:
         raise exceptions.ClusterNotUpError('Spot controller is not up.',

--- a/sky/core.py
+++ b/sky/core.py
@@ -142,7 +142,6 @@ def cost_report(cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
         A list of dicts, with each dict containing the cost information of a
         cluster.
     """
-
     # aggregate records for spot controller
     if cluster_name is not None:
         cluster_reports = cost_utils.aggregate_all_records(verbose=False)

--- a/sky/core.py
+++ b/sky/core.py
@@ -970,10 +970,8 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
     if controller_status is None:
         return []
 
-    if (refresh and controller_status in [
-            ClusterStatus.STOPPED,
-            ClusterStatus.INIT
-    ]):
+    if (refresh and
+            controller_status in [ClusterStatus.STOPPED, ClusterStatus.INIT]):
         print(f'{colorama.Fore.YELLOW}'
               'Restarting controller for latest status...'
               f'{colorama.Style.RESET_ALL}')

--- a/sky/core.py
+++ b/sky/core.py
@@ -144,9 +144,7 @@ def cost_report(cluster_name: str = None) -> List[Dict[str, Any]]:
 
     # aqgregate records for spot controller
     if cluster_name is not None:
-        cluster_reports = [
-            global_user_state.aggregate_records_by_name(cluster_name)
-        ]
+        cluster_reports = global_user_state.aggregate_all_records(split=False)
     else:
         cluster_reports = global_user_state.get_clusters_from_history()
 
@@ -929,7 +927,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 
 
 @usage_lib.entrypoint
-def spot_cost_report(refresh: bool) -> List[Dict[str, Any]]:
+def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
 
@@ -978,7 +976,7 @@ def spot_cost_report(refresh: bool) -> List[Dict[str, Any]]:
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
 
-    code = spot.SpotCodeGen.get_cost_report()
+    code = spot.SpotCodeGen.get_cost_report(split)
     returncode, job_costs_payload, stderr = backend.run_on_head(
         handle,
         code,

--- a/sky/core.py
+++ b/sky/core.py
@@ -961,7 +961,8 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
 
     stop_msg = ''
     if not refresh:
-        stop_msg = 'To view the latest job table: sky spot cost --refresh'
+        command = 'sky spot cost-report --refresh'
+        stop_msg = f'To view the latest job table: {command}'
 
     controller_status, handle = spot.is_spot_controller_up(stop_msg)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -151,8 +151,7 @@ def cost_report(cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
 
     filtered_reports = []
     for cluster_report in cluster_reports:
-        cluster_report['total_cost'] = cost_utils.get_total_cost(
-            cluster_report)
+        cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         if cluster_name is None:
             filtered_reports.append(cluster_report)
         elif cluster_report['name'] == cluster_name:

--- a/sky/core.py
+++ b/sky/core.py
@@ -143,18 +143,8 @@ def cost_report(cluster_names: List[str],
         A list of dicts, with each dict containing the cost information of a
         cluster.
     """
-<<<<<<< HEAD
-<<<<<<< HEAD
     if aggregate_by_cluster_name:
         cluster_reports = cost_utils.aggregate_all_records(condensed=True)
-=======
-
-=======
->>>>>>> 8fa31ba9 (add spot cost report)
-    # aggregate records for spot controller
-    if cluster_name is not None:
-        cluster_reports = cost_utils.aggregate_all_records(verbose=False)
->>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
     else:
         cluster_reports = global_user_state.get_clusters_from_history()
 
@@ -941,11 +931,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 
 
 @usage_lib.entrypoint
-<<<<<<< HEAD
 def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
-=======
-def spot_cost_report(refresh: bool, verbose: bool) -> List[Dict[str, Any]]:
->>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
 
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
@@ -999,11 +985,7 @@ def spot_cost_report(refresh: bool, verbose: bool) -> List[Dict[str, Any]]:
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
 
-<<<<<<< HEAD
     code = spot.SpotCodeGen.get_cost_report(condensed)
-=======
-    code = spot.SpotCodeGen.get_cost_report(verbose)
->>>>>>> f6f00092 (untested changes to address feature reqs in pr comments)
 
     returncode, job_costs_payload, stderr = backend.run_on_head(
         handle,

--- a/sky/core.py
+++ b/sky/core.py
@@ -145,7 +145,7 @@ def cost_report(cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
 
     # aggregate records for spot controller
     if cluster_name is not None:
-        cluster_reports = cost_utils.aggregate_all_records(split=False)
+        cluster_reports = cost_utils.aggregate_all_records(verbose=False)
     else:
         cluster_reports = global_user_state.get_clusters_from_history()
 
@@ -932,7 +932,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 
 
 @usage_lib.entrypoint
-def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
+def spot_cost_report(refresh: bool, verbose: bool) -> List[Dict[str, Any]]:
 
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
@@ -983,7 +983,7 @@ def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
 
-    code = spot.SpotCodeGen.get_cost_report(split)
+    code = spot.SpotCodeGen.get_cost_report(verbose)
 
     returncode, job_costs_payload, stderr = backend.run_on_head(
         handle,

--- a/sky/core.py
+++ b/sky/core.py
@@ -928,6 +928,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
 
 @usage_lib.entrypoint
 def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
+
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get statuses of managed spot jobs.
 
@@ -955,6 +956,7 @@ def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
     stop_msg = ''
     if not refresh:
         stop_msg = 'To view the latest job table: sky spot cost --refresh'
+
     controller_status, handle = spot.is_spot_controller_up(stop_msg)
 
     if controller_status is None:
@@ -977,6 +979,7 @@ def spot_cost_report(refresh: bool, split: bool) -> List[Dict[str, Any]]:
     assert isinstance(backend, backends.CloudVmRayBackend)
 
     code = spot.SpotCodeGen.get_cost_report(split)
+
     returncode, job_costs_payload, stderr = backend.run_on_head(
         handle,
         code,

--- a/sky/core.py
+++ b/sky/core.py
@@ -110,7 +110,7 @@ def status(cluster_names: Optional[Union[str, List[str]]] = None,
 
 
 @usage_lib.entrypoint
-def cost_report() -> List[Dict[str, Any]]:
+def cost_report(cluster_name: str = None) -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get all cluster cost reports, including those that have been downed.
 
@@ -142,9 +142,13 @@ def cost_report() -> List[Dict[str, Any]]:
         cluster.
     """
 
-    cluster_reports = global_user_state.get_clusters_from_history()
-
-    # cluster_reports = global_user_state.aggregate_all_records()
+    # aqgregate records for spot controller
+    if cluster_name is not None:
+        cluster_reports = [
+            global_user_state.aggregate_records_by_name(cluster_name)
+        ]
+    else:
+        cluster_reports = global_user_state.get_clusters_from_history()
 
     for cluster_report in cluster_reports:
         cluster_report['total_cost'] = global_user_state.get_total_cost(
@@ -952,7 +956,7 @@ def spot_cost_report(refresh: bool) -> List[Dict[str, Any]]:
 
     stop_msg = ''
     if not refresh:
-        stop_msg = 'To view the latest job table: sky spot queue --refresh'
+        stop_msg = 'To view the latest job table: sky spot cost --refresh'
     controller_status, handle = spot.is_spot_controller_up(stop_msg)
 
     if controller_status is None:

--- a/sky/core.py
+++ b/sky/core.py
@@ -144,10 +144,13 @@ def cost_report(cluster_names: List[str],
         cluster.
     """
 <<<<<<< HEAD
+<<<<<<< HEAD
     if aggregate_by_cluster_name:
         cluster_reports = cost_utils.aggregate_all_records(condensed=True)
 =======
 
+=======
+>>>>>>> 8fa31ba9 (add spot cost report)
     # aggregate records for spot controller
     if cluster_name is not None:
         cluster_reports = cost_utils.aggregate_all_records(verbose=False)

--- a/sky/core.py
+++ b/sky/core.py
@@ -150,7 +150,8 @@ def cost_report(cluster_names: List[str],
 
     filtered_reports = []
     for cluster_report in cluster_reports:
-        cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
+        cluster_report['total_cost'] = global_user_state.get_total_cost(
+            cluster_report)
         if len(cluster_names) == 0:
             filtered_reports.append(cluster_report)
         elif cluster_report['name'] in cluster_names:

--- a/sky/core.py
+++ b/sky/core.py
@@ -955,6 +955,8 @@ def spot_cost_report(refresh: bool, condensed: bool) -> List[Dict[str, Any]]:
         ]
     Raises:
         sky.exceptions.ClusterNotUpError: the spot controller is not up.
+        RuntimeError: failed to fetch job cost report.
+
     """
 
     stop_msg = ''

--- a/sky/core.py
+++ b/sky/core.py
@@ -977,8 +977,11 @@ def spot_cost_report(refresh: bool, verbose: bool) -> List[Dict[str, Any]]:
 
         handle = _start(spot.SPOT_CONTROLLER_NAME)
 
+    controller_status = global_user_state.ClusterStatus.UP
+
     if handle is None or handle.head_ip is None:
-        raise exceptions.ClusterNotUpError('Spot controller is not up.')
+        raise exceptions.ClusterNotUpError('Spot controller is not up.',
+                                           cluster_status=controller_status)
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)

--- a/sky/core.py
+++ b/sky/core.py
@@ -151,7 +151,7 @@ def cost_report(cluster_name: Optional[str] = None) -> List[Dict[str, Any]]:
 
     filtered_reports = []
     for cluster_report in cluster_reports:
-        cluster_report['total_cost'] = global_user_state.get_total_cost(
+        cluster_report['total_cost'] = cost_utils.get_total_cost(
             cluster_report)
         if cluster_name is None:
             filtered_reports.append(cluster_report)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -741,3 +741,12 @@ def get_storage() -> List[Dict[str, Any]]:
             'status': status_lib.StorageStatus[status],
         })
     return records
+
+
+def get_total_cost(cluster_report: dict) -> float:
+    duration = cluster_report['duration']
+    launched_nodes = cluster_report['num_nodes']
+    launched_resources = cluster_report['resources']
+
+    cost = (launched_resources.get_cost(duration) * launched_nodes)
+    return cost

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -109,7 +109,7 @@ def create_table(cursor, conn):
 
     db_utils.add_column_to_table(cursor, conn, 'clusters', 'cluster_hash',
                                  'TEXT DEFAULT null')
-                                 
+
     conn.commit()
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -752,3 +752,12 @@ def get_storage() -> List[Dict[str, Any]]:
             'status': status_lib.StorageStatus[status],
         })
     return records
+
+
+def get_total_cost(cluster_report: dict) -> float:
+    duration = cluster_report['duration']
+    launched_nodes = cluster_report['num_nodes']
+    launched_resources = cluster_report['resources']
+
+    cost = (launched_resources.get_cost(duration) * launched_nodes)
+    return cost

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,6 +384,14 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
+def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
+    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+    return rows
+
+def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()    
+    return rows
 
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,7 +384,16 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
+def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
+    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+    return rows
 
+def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()    
+    return rows
+
+<<<<<<< HEAD
 <<<<<<< HEAD
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(
@@ -408,6 +417,18 @@ def aggregate_all_records() -> List[Optional[Dict[str, Any]]]:
             records[cluster_name] = record
 
     return list(records.values())
+=======
+def aggregate_all_records(split: bool) -> List[Optional[Dict[str, Any]]]:
+    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+
+    records = []
+
+    for (cluster_name,) in rows:
+        if split:
+            records += get_split_view_records_by_name(cluster_name)
+        else:
+            records.append(aggregate_records_by_name(cluster_name))
+>>>>>>> 21bad003 (address almost all PR comments)
 
 
 def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,17 +384,7 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
-def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
-    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
-    return rows
 
-def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
-    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
-                              (cluster_name,)).fetchall()    
-    return rows
-
-<<<<<<< HEAD
-<<<<<<< HEAD
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(
         'SELECT DISTINCT name from cluster_history').fetchall()
@@ -405,30 +395,18 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
                               (cluster_name,)).fetchall()
     return rows
-=======
-def aggregate_all_records() -> List[Optional[Dict[str, Any]]]:
-    rows = _DB.cursor.execute('SELECT name from cluster_history').fetchall()
 
-    records = {}
 
-    for (cluster_name,) in rows:
-        record = aggregate_records_by_name(cluster_name)
-        if cluster_name not in records:
-            records[cluster_name] = record
+def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
+    rows = _DB.cursor.execute(
+        'SELECT DISTINCT name from cluster_history').fetchall()
+    return rows
 
-    return list(records.values())
-=======
-def aggregate_all_records(split: bool) -> List[Optional[Dict[str, Any]]]:
-    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
 
-    records = []
-
-    for (cluster_name,) in rows:
-        if split:
-            records += get_split_view_records_by_name(cluster_name)
-        else:
-            records.append(aggregate_records_by_name(cluster_name))
->>>>>>> 21bad003 (address almost all PR comments)
+def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()
+    return rows
 
 
 def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
@@ -457,11 +435,17 @@ def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
         else:
             record['duration'] += _get_cluster_duration(cluster_hash)
             record['usage_intervals'] += pickle.loads(usage_intervals)
+<<<<<<< HEAD
+=======
+            record['resources'] = pickle.loads(launched_resources)
+            record['num_nodes'] = num_nodes
+>>>>>>> 97a20536 (lint and format)
 
     return record
 >>>>>>> 61c23eae (add spot cost report)
 
 
+<<<<<<< HEAD
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(
         'SELECT DISTINCT name from cluster_history').fetchall()
@@ -479,6 +463,43 @@ def _get_cluster_usage_intervals(
 ) -> Optional[List[Tuple[int, Optional[int]]]]:
     if cluster_hash is None:
         return None
+=======
+<<<<<<< HEAD
+=======
+def get_split_view_records_by_name(
+        cluster_name: str) -> Optional[Dict[str, Any]]:
+
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()
+
+    records = []
+
+    for row in rows:
+        # TODO: use namedtuple instead of dict
+
+        (cluster_hash, name, num_nodes, _, launched_resources,
+         usage_intervals) = row[:6]
+
+        record = {
+            'name': '',
+            'launched_at': get_cluster_launch_time(cluster_hash),
+            'duration': _get_cluster_duration(cluster_hash),
+            'num_nodes': num_nodes,
+            'resources': pickle.loads(launched_resources),
+            'cluster_hash': cluster_hash,
+            'usage_intervals': pickle.loads(usage_intervals),
+        }
+
+        if len(records) == 0:
+            record['name'] = name
+        records.append(record)
+
+    return records
+
+
+>>>>>>> 97a20536 (lint and format)
+def _get_cluster_usage_intervals(cluster_hash: str) -> Optional[Dict[str, Any]]:
+>>>>>>> 8df22022 (lint and format)
     rows = _DB.cursor.execute(
         'SELECT usage_intervals FROM cluster_history WHERE cluster_hash=(?)',
         (cluster_hash,))

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -109,7 +109,7 @@ def create_table(cursor, conn):
 
     db_utils.add_column_to_table(cursor, conn, 'clusters', 'cluster_hash',
                                  'TEXT DEFAULT null')
-
+                                 
     conn.commit()
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,13 +384,16 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
+
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
-    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+    rows = _DB.cursor.execute(
+        'SELECT DISTINCT name from cluster_history').fetchall()
     return rows
+
 
 def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
-                              (cluster_name,)).fetchall()    
+                              (cluster_name,)).fetchall()
     return rows
 
 def _get_cluster_usage_intervals(

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,6 +384,14 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
+def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
+    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+    return rows
+
+def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()    
+    return rows
 
 def _get_cluster_usage_intervals(
         cluster_hash: Optional[str]

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -385,7 +385,7 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
+def get_distinct_cluster_names_from_history() -> List[Tuple[Any]]:
     rows = _DB.cursor.execute(
         'SELECT DISTINCT name from cluster_history').fetchall()
     return rows
@@ -397,12 +397,12 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     return rows
 
 
-def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
+def aggregate_records_by_name(cluster_name: str) -> Dict[str, Any]:
 
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
                               (cluster_name,)).fetchall()
 
-    record = {}
+    record: Dict[str, Any] = {}
 
     for row in rows:
         # TODO: use namedtuple instead of dict
@@ -441,14 +441,13 @@ def _get_cluster_usage_intervals(
         return pickle.loads(usage_intervals)
     return None
 
-    
-def get_split_view_records_by_name(
-        cluster_name: str) -> Optional[Dict[str, Any]]:
+
+def get_split_view_records_by_name(cluster_name: str) -> List[Dict[str, Any]]:
 
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
                               (cluster_name,)).fetchall()
 
-    records = []
+    records: List[Dict[str, Any]] = []
 
     for row in rows:
         # TODO: use namedtuple instead of dict

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -385,6 +385,7 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
+<<<<<<< HEAD
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(
         'SELECT DISTINCT name from cluster_history').fetchall()
@@ -395,6 +396,49 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
                               (cluster_name,)).fetchall()
     return rows
+=======
+def aggregate_all_records() -> List[Optional[Dict[str, Any]]]:
+    rows = _DB.cursor.execute('SELECT name from cluster_history').fetchall()
+
+    records = {}
+
+    for (cluster_name,) in rows:
+        record = aggregate_records_by_name(cluster_name)
+        if cluster_name not in records:
+            records[cluster_name] = record
+
+    return list(records.values())
+
+
+def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
+
+    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
+                              (cluster_name,)).fetchall()
+
+    record = {}
+
+    for row in rows:
+        # TODO: use namedtuple instead of dict
+
+        (cluster_hash, name, num_nodes, _, launched_resources,
+         usage_intervals) = row[:6]
+
+        if not record:
+            record = {
+                'name': name,
+                'launched_at': _get_cluster_launch_time(cluster_hash),
+                'duration': _get_cluster_duration(cluster_hash),
+                'num_nodes': num_nodes,
+                'resources': pickle.loads(launched_resources),
+                'cluster_hash': cluster_hash,
+                'usage_intervals': pickle.loads(usage_intervals),
+            }
+        else:
+            record['duration'] += _get_cluster_duration(cluster_hash)
+            record['usage_intervals'] += pickle.loads(usage_intervals)
+
+    return record
+>>>>>>> 61c23eae (add spot cost report)
 
 
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -397,18 +397,6 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     return rows
 
 
-def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
-    rows = _DB.cursor.execute(
-        'SELECT DISTINCT name from cluster_history').fetchall()
-    return rows
-
-
-def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
-    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
-                              (cluster_name,)).fetchall()
-    return rows
-
-
 def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
 
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
@@ -435,37 +423,25 @@ def aggregate_records_by_name(cluster_name: str) -> Optional[Dict[str, Any]]:
         else:
             record['duration'] += _get_cluster_duration(cluster_hash)
             record['usage_intervals'] += pickle.loads(usage_intervals)
-<<<<<<< HEAD
-=======
-            record['resources'] = pickle.loads(launched_resources)
-            record['num_nodes'] = num_nodes
->>>>>>> 97a20536 (lint and format)
 
     return record
->>>>>>> 61c23eae (add spot cost report)
 
-
-<<<<<<< HEAD
-def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
-    rows = _DB.cursor.execute(
-        'SELECT DISTINCT name from cluster_history').fetchall()
-    return rows
-
-
-def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
-    rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
-                              (cluster_name,)).fetchall()
-    return rows
-    
 
 def _get_cluster_usage_intervals(
         cluster_hash: Optional[str]
 ) -> Optional[List[Tuple[int, Optional[int]]]]:
     if cluster_hash is None:
         return None
-=======
-<<<<<<< HEAD
-=======
+    rows = _DB.cursor.execute(
+        'SELECT usage_intervals FROM cluster_history WHERE cluster_hash=(?)',
+        (cluster_hash,))
+    for (usage_intervals,) in rows:
+        if usage_intervals is None:
+            return None
+        return pickle.loads(usage_intervals)
+    return None
+
+    
 def get_split_view_records_by_name(
         cluster_name: str) -> Optional[Dict[str, Any]]:
 
@@ -495,19 +471,6 @@ def get_split_view_records_by_name(
         records.append(record)
 
     return records
-
-
->>>>>>> 97a20536 (lint and format)
-def _get_cluster_usage_intervals(cluster_hash: str) -> Optional[Dict[str, Any]]:
->>>>>>> 8df22022 (lint and format)
-    rows = _DB.cursor.execute(
-        'SELECT usage_intervals FROM cluster_history WHERE cluster_hash=(?)',
-        (cluster_hash,))
-    for (usage_intervals,) in rows:
-        if usage_intervals is None:
-            return None
-        return pickle.loads(usage_intervals)
-    return None
 
 
 def _get_cluster_launch_time(cluster_hash: str) -> Optional[int]:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -749,12 +749,3 @@ def get_storage() -> List[Dict[str, Any]]:
             'status': status_lib.StorageStatus[status],
         })
     return records
-
-
-def get_total_cost(cluster_report: dict) -> float:
-    duration = cluster_report['duration']
-    launched_nodes = cluster_report['num_nodes']
-    launched_resources = cluster_report['resources']
-
-    cost = (launched_resources.get_cost(duration) * launched_nodes)
-    return cost

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -396,6 +396,7 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
                               (cluster_name,)).fetchall()
     return rows
 
+
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
     rows = _DB.cursor.execute(
         'SELECT DISTINCT name from cluster_history').fetchall()
@@ -406,6 +407,7 @@ def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
                               (cluster_name,)).fetchall()
     return rows
+    
 
 def _get_cluster_usage_intervals(
         cluster_hash: Optional[str]

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -384,13 +384,16 @@ def set_cluster_metadata(cluster_name: str, metadata: Dict[str, Any]) -> None:
     if count == 0:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
+
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:
-    rows = _DB.cursor.execute('SELECT DISTINCT name from cluster_history').fetchall()
+    rows = _DB.cursor.execute(
+        'SELECT DISTINCT name from cluster_history').fetchall()
     return rows
+
 
 def get_cluster_from_history_by_name(cluster_name: str) -> List[Optional[Any]]:
     rows = _DB.cursor.execute('SELECT * from cluster_history WHERE name=(?)',
-                              (cluster_name,)).fetchall()    
+                              (cluster_name,)).fetchall()
     return rows
 
 def get_distinct_cluster_names_from_history() -> List[Optional[str]]:

--- a/sky/spot/__init__.py
+++ b/sky/spot/__init__.py
@@ -15,8 +15,10 @@ from sky.spot.spot_utils import dump_job_table_cache
 from sky.spot.spot_utils import dump_spot_job_queue
 from sky.spot.spot_utils import load_job_table_cache
 from sky.spot.spot_utils import format_job_table
+from sky.spot.spot_utils import format_cost_table
 from sky.spot.spot_utils import is_spot_controller_up
 from sky.spot.spot_utils import load_spot_job_queue
+from sky.spot.spot_utils import load_spot_cost_report
 
 pathlib.Path(SPOT_TASK_YAML_PREFIX).expanduser().parent.mkdir(parents=True,
                                                               exist_ok=True)
@@ -34,7 +36,9 @@ __all__ = [
     'dump_job_table_cache',
     'load_job_table_cache',
     'format_job_table',
+    'format_cost_table',
     'is_spot_controller_up',
     'dump_spot_job_queue',
     'load_spot_job_queue',
+    'load_spot_cost_report',
 ]

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -505,7 +505,8 @@ def load_spot_job_queue(payload: str) -> List[Dict[str, Any]]:
     return jobs
 
 
-def format_job_table(jobs: List[Dict[str, Any]],
+@typing.overload
+def format_job_table(tasks: List[Dict[str, Any]],
                      show_all: bool,
                      return_rows: Literal[False] = False,
                      max_jobs: Optional[int] = None) -> str:
@@ -537,7 +538,6 @@ def format_job_table(
     Returns: A formatted string of spot jobs, if not `return_rows`; otherwise a
       list of "rows" (each of which is a list of str).
     """
-
     columns = [
         'ID', 'TASK', 'NAME', 'RESOURCES', 'SUBMITTED', 'TOT. DURATION',
         'JOB DURATION', '#RECOVERIES', 'STATUS'
@@ -561,8 +561,6 @@ def format_job_table(
         jobs[task['job_id']].append(task)
 
     for job_id, job_tasks in jobs.items():
-        print(job_id, job_tasks)
-
         if len(job_tasks) > 1:
             # Aggregate the tasks into a new row in the table.
             job_name = job_tasks[0]['job_name']

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -536,7 +536,6 @@ def format_job_table(
       list of "rows" (each of which is a list of str).
     """
 
-
     columns = [
         'ID', 'TASK', 'NAME', 'RESOURCES', 'SUBMITTED', 'TOT. DURATION',
         'JOB DURATION', '#RECOVERIES', 'STATUS'
@@ -677,10 +676,6 @@ def format_job_table(
         return job_table.rows
     return output
 
-def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
-    """Load job costs from json string."""
-    cost_report = common_utils.decode_payload(payload)
-    return cost_report
 
 def dump_spot_cost(condensed: bool) -> str:
     cluster_reports = cost_utils.aggregate_all_records(condensed)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -700,6 +700,9 @@ def dump_spot_cost(condensed: bool) -> str:
 
         else:
             cluster_report['name'] = ''
+            cluster_report['resources'] = '-'
+            cluster_report['num_nodes'] = '-'
+            cluster_report['region'] = '-'
 
     return common_utils.encode_payload(cluster_reports)
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -707,7 +707,8 @@ def dump_spot_cost(condensed: bool) -> str:
             cluster_report['name'] = get_job_name_from_spot_cluster_name(
                 cluster_name)
 
-            if cluster_report['num_recoveries'] > 0:
+            if 'num_recoveries' in cluster_report and cluster_report[
+                    'num_recoveries'] > 0:
                 cluster_report['resources'] = '-'
                 cluster_report['num_nodes'] = '-'
                 cluster_report['zone'] = '-'
@@ -760,6 +761,11 @@ def format_cost_table(reports: List[Dict[str, Any]], all: bool) -> str:
 
         cost = report['total_cost']
 
+        num_recoveries = 0
+
+        if 'num_recoveries' in report:
+            num_recoveries = report['num_recoveries']
+
         cost_str = f'${cost:.3f}'
         duration_str = duration
 
@@ -772,7 +778,7 @@ def format_cost_table(reports: List[Dict[str, Any]], all: bool) -> str:
         values = [
             report['job_id'],
             report['name'],
-            report['num_recoveries'],
+            num_recoveries,
             report['resources'],
             report['num_nodes'],
             report['zone'],

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -698,8 +698,8 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
     return str(cost_table)
 
 
-def spot_cost_report() -> str:
-    cluster_reports = global_user_state.aggregate_all_records()
+def spot_cost_report(split: bool) -> str:
+    cluster_reports = global_user_state.aggregate_all_records(split)
 
     for cluster_report in cluster_reports:
         cluster_report['total_cost'] = global_user_state.get_total_cost(
@@ -789,8 +789,8 @@ class SpotCodeGen:
     @classmethod
     def get_cost_report(cls) -> str:
         code = [
-            'spot_cost_report_table = spot_utils.spot_cost_report()',
-            'print(spot_cost_report_table, flush=True)',
+            f'spot_cost_table = spot_utils.spot_cost_report(split={split})',
+            'print(spot_cost_table, flush=True)',
         ]
         return cls._build(code)
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -542,6 +542,7 @@ def format_job_table(
       list of "rows" (each of which is a list of str).
     """
 
+
     columns = [
         'ID', 'TASK', 'NAME', 'RESOURCES', 'SUBMITTED', 'TOT. DURATION',
         'JOB DURATION', '#RECOVERIES', 'STATUS'
@@ -687,8 +688,8 @@ def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
     cost_report = common_utils.decode_payload(payload)
     return cost_report
 
-def dump_spot_cost(verbose: bool) -> str:
-    cluster_reports = cost_utils.aggregate_all_records(verbose)
+def dump_spot_cost(condensed: bool) -> str:
+    cluster_reports = cost_utils.aggregate_all_records(condensed)
 
     seen_cluster_names = set()
 
@@ -712,12 +713,6 @@ def dump_spot_cost(verbose: bool) -> str:
             cluster_report['name'] = ''
 
     return common_utils.encode_payload(cluster_reports)
-
-
-def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
-    """Load job costs from json string."""
-    cost_report = common_utils.decode_payload(payload)
-    return cost_report
 
 
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
@@ -836,9 +831,9 @@ class SpotCodeGen:
         return cls._build(code)
 
     @classmethod
-    def get_cost_report(cls, verbose: bool) -> str:
+    def get_cost_report(cls, condensed: bool) -> str:
         code = [
-            f'spot_cost_table=spot_utils.dump_spot_cost(verbose={verbose})',
+            f'spot_cost_table=spot_utils.dump_spot_cost({condensed})',
             'print(spot_cost_table, flush=True)',
         ]
         return cls._build(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -502,13 +502,6 @@ def load_spot_job_queue(payload: str) -> List[Dict[str, Any]]:
         job['status'] = spot_state.SpotStatus(job['status'])
     return jobs
 
-
-def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
-    """Load job costs from json string."""
-    cost_report = common_utils.decode_payload(payload)
-    return cost_report
-
-
 def format_job_table(jobs: List[Dict[str, Any]],
                      show_all: bool,
                      return_rows: Literal[False] = False,
@@ -754,7 +747,6 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
         cost_table.add_row(values)
 
     return str(cost_table)
-
 
 class SpotCodeGen:
     """Code generator for managed spot job utility functions.

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -693,6 +693,7 @@ def dump_spot_cost(verbose: bool) -> str:
     seen_cluster_names = set()
 
     for cluster_report in cluster_reports:
+
         cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         launched_resources = cluster_report['resources']
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -485,8 +485,7 @@ def load_spot_job_queue(payload: str) -> List[Dict[str, Any]]:
     return jobs
 
 
-@typing.overload
-def format_job_table(tasks: List[Dict[str, Any]],
+def format_job_table(jobs: List[Dict[str, Any]],
                      show_all: bool,
                      return_rows: Literal[False] = False,
                      max_jobs: Optional[int] = None) -> str:
@@ -668,8 +667,7 @@ def dump_spot_cost_report(split: bool) -> str:
     cluster_reports = cost_utils.aggregate_all_records(split)
 
     for cluster_report in cluster_reports:
-        cluster_report['total_cost'] = cost_utils.get_total_cost(
-            cluster_report)
+        cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         launched_resources = cluster_report['resources']
 
         cluster_report['resources'] = f'{launched_resources}'
@@ -677,10 +675,12 @@ def dump_spot_cost_report(split: bool) -> str:
 
     return common_utils.encode_payload(cluster_reports)
 
+
 def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
     """Load job costs from json string."""
     cost_report = common_utils.decode_payload(payload)
     return cost_report
+
 
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
     """Show all spot costs."""
@@ -714,6 +714,7 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
         cost_table.add_row(values)
 
     return str(cost_table)
+
 
 class SpotCodeGen:
     """Code generator for managed spot job utility functions.
@@ -792,7 +793,7 @@ class SpotCodeGen:
     @classmethod
     def get_cost_report(cls) -> str:
         code = [
-            f'spot_cost_table = spot_utils.dump_spot_cost_report(split={split})',
+            f'spot_cost_table=spot_utils.dump_spot_cost_report(split={split})',
             'print(spot_cost_table, flush=True)',
         ]
         return cls._build(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -687,7 +687,6 @@ def dump_spot_cost(condensed: bool) -> str:
     seen_cluster_names = set()
 
     for cluster_report in cluster_reports:
-
         cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         launched_resources = cluster_report['resources']
 
@@ -706,6 +705,15 @@ def dump_spot_cost(condensed: bool) -> str:
             cluster_report['name'] = ''
 
     return common_utils.encode_payload(cluster_reports)
+
+<<<<<<< HEAD
+=======
+
+def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
+    """Load job costs from json string."""
+    cost_report = common_utils.decode_payload(payload)
+    return cost_report
+>>>>>>> 97a20536 (lint and format)
 
 
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
@@ -747,6 +755,7 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
         cost_table.add_row(values)
 
     return str(cost_table)
+
 
 class SpotCodeGen:
     """Code generator for managed spot job utility functions.
@@ -825,7 +834,11 @@ class SpotCodeGen:
     @classmethod
     def get_cost_report(cls, condensed: bool) -> str:
         code = [
+<<<<<<< HEAD
             f'spot_cost_table=spot_utils.dump_spot_cost({condensed})',
+=======
+            f'spot_cost_table=spot_utils.dump_spot_cost_report(split={split})',
+>>>>>>> 97a20536 (lint and format)
             'print(spot_cost_table, flush=True)',
         ]
         return cls._build(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -502,6 +502,7 @@ def load_spot_job_queue(payload: str) -> List[Dict[str, Any]]:
         job['status'] = spot_state.SpotStatus(job['status'])
     return jobs
 
+
 def format_job_table(jobs: List[Dict[str, Any]],
                      show_all: bool,
                      return_rows: Literal[False] = False,

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -724,7 +724,8 @@ def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
     return cost_report
 
 
-def format_cost_table(reports: List[Dict[str, Any]], all: bool) -> str:
+def format_cost_table(reports: List[Dict[str, Any]],
+                      show_all_rows: bool) -> str:
     """Show all spot costs."""
     columns = [
         'JOB ID',
@@ -745,7 +746,7 @@ def format_cost_table(reports: List[Dict[str, Any]], all: bool) -> str:
     num_main_rows = 0
 
     num_main_rows_to_show = _NUM_SPOT_COST_REPORT_ROWS_TO_SHOW
-    if all:
+    if show_all_rows:
         num_main_rows_to_show = len(reports)
 
     for i, report in enumerate(reports):

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -213,6 +213,18 @@ def get_job_id_from_spot_cluster_name(spot_cluster_name: str) -> str:
     return spot_cluster_name.split('-')[-1]
 
 
+def get_job_name_from_spot_cluster_name(spot_cluster_name: str) -> str:
+    """Parse job name from spot cluster name."""
+
+    if spot_cluster_name == '':
+        return ''
+
+    job_id = get_job_id_from_spot_cluster_name(spot_cluster_name)
+    suffix_length = len(job_id) + 1
+
+    return spot_cluster_name[:-suffix_length]
+
+
 def cancel_jobs_by_id(job_ids: Optional[List[int]]) -> str:
     """Cancel jobs by id.
 
@@ -686,8 +698,10 @@ def dump_spot_cost(verbose: bool) -> str:
         cluster_name = cluster_report['name']
         if cluster_name not in seen_cluster_names:
             cluster_report['job_id'] = get_job_id_from_spot_cluster_name(
-                cluster_report['name'])
+                cluster_name)
             seen_cluster_names.add(cluster_name)
+            cluster_report['name'] = get_job_name_from_spot_cluster_name(
+                cluster_name)
 
         else:
             cluster_report['name'] = ''

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -680,6 +680,13 @@ def format_job_table(
 def dump_spot_cost(condensed: bool) -> str:
     cluster_reports = cost_utils.aggregate_all_records(condensed)
 
+    for cluster_report in cluster_reports:
+        cluster_report['job_id'] = get_job_id_from_spot_cluster_name(
+            cluster_report['name'])
+
+    cluster_reports.sort(
+        key=lambda report: (-int(report['job_id']), int(report['launched_at'])))
+
     seen_cluster_names = set()
 
     for cluster_report in cluster_reports:
@@ -692,8 +699,6 @@ def dump_spot_cost(condensed: bool) -> str:
 
         cluster_name = cluster_report['name']
         if cluster_name not in seen_cluster_names:
-            cluster_report['job_id'] = get_job_id_from_spot_cluster_name(
-                cluster_name)
             seen_cluster_names.add(cluster_name)
             cluster_report['name'] = get_job_name_from_spot_cluster_name(
                 cluster_name)
@@ -702,8 +707,8 @@ def dump_spot_cost(condensed: bool) -> str:
                 cluster_report['resources'] = '-'
                 cluster_report['num_nodes'] = '-'
                 cluster_report['zone'] = '-'
-
         else:
+            cluster_report['job_id'] = ''
             cluster_report['name'] = ''
             cluster_report['num_recoveries'] = ''
 
@@ -719,8 +724,8 @@ def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
     """Show all spot costs."""
     columns = [
-        'JOB NAME',
         'JOB ID',
+        'JOB NAME',
         '# RECOVERIES',
         'RESOURCES',
         'NODES',
@@ -755,8 +760,8 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
             duration_str = f' {duration}'
 
         values = [
-            report['name'],
             report['job_id'],
+            report['name'],
             report['num_recoveries'],
             report['resources'],
             report['num_nodes'],

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -698,9 +698,10 @@ def dump_spot_cost(condensed: bool) -> str:
             cluster_report['name'] = get_job_name_from_spot_cluster_name(
                 cluster_name)
 
-            cluster_report['resources'] = '-'
-            cluster_report['num_nodes'] = '-'
-            cluster_report['zone'] = '-'
+            if cluster_report['num_recoveries'] > 0:
+                cluster_report['resources'] = '-'
+                cluster_report['num_nodes'] = '-'
+                cluster_report['zone'] = '-'
 
         else:
             cluster_report['name'] = ''

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -688,7 +688,7 @@ def dump_spot_cost(condensed: bool) -> str:
         launched_resources = cluster_report['resources']
 
         cluster_report['resources'] = f'{launched_resources}'
-        cluster_report['region'] = launched_resources.region
+        cluster_report['zone'] = launched_resources.zone
 
         cluster_name = cluster_report['name']
         if cluster_name not in seen_cluster_names:
@@ -702,7 +702,7 @@ def dump_spot_cost(condensed: bool) -> str:
             cluster_report['name'] = ''
             cluster_report['resources'] = '-'
             cluster_report['num_nodes'] = '-'
-            cluster_report['region'] = '-'
+            cluster_report['zone'] = '-'
 
     return common_utils.encode_payload(cluster_reports)
 
@@ -720,7 +720,7 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
         'JOB ID',
         'RESOURCES',
         'NODES',
-        'REGION',
+        'ZONE',
         'LAUNCH TIME',
         'TOT. DURATION',
         'TOT. COST',
@@ -743,7 +743,7 @@ def format_cost_table(reports: List[Dict[str, Any]]) -> str:
             report['job_id'],
             report['resources'],
             report['num_nodes'],
-            report['region'],
+            report['zone'],
             launch_time,
             duration,
             f'${cost:.3f}',

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -668,7 +668,7 @@ def dump_spot_cost_report(split: bool) -> str:
     cluster_reports = cost_utils.aggregate_all_records(split)
 
     for cluster_report in cluster_reports:
-        cluster_report['total_cost'] = global_user_state.get_total_cost(
+        cluster_report['total_cost'] = cost_utils.get_total_cost(
             cluster_report)
         launched_resources = cluster_report['resources']
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -714,6 +714,7 @@ def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
     cost_report = common_utils.decode_payload(payload)
     return cost_report
 
+
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
     """Show all spot costs."""
     columns = [

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -709,6 +709,10 @@ def dump_spot_cost(condensed: bool) -> str:
     return common_utils.encode_payload(cluster_reports)
 
 
+def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
+    """Load job costs from json string."""
+    cost_report = common_utils.decode_payload(payload)
+    return cost_report
 
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
     """Show all spot costs."""

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -687,6 +687,7 @@ def dump_spot_cost(condensed: bool) -> str:
     seen_cluster_names = set()
 
     for cluster_report in cluster_reports:
+
         cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         launched_resources = cluster_report['resources']
 
@@ -706,14 +707,6 @@ def dump_spot_cost(condensed: bool) -> str:
 
     return common_utils.encode_payload(cluster_reports)
 
-<<<<<<< HEAD
-=======
-
-def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
-    """Load job costs from json string."""
-    cost_report = common_utils.decode_payload(payload)
-    return cost_report
->>>>>>> 97a20536 (lint and format)
 
 
 def format_cost_table(reports: List[Dict[str, Any]]) -> str:
@@ -834,11 +827,7 @@ class SpotCodeGen:
     @classmethod
     def get_cost_report(cls, condensed: bool) -> str:
         code = [
-<<<<<<< HEAD
             f'spot_cost_table=spot_utils.dump_spot_cost({condensed})',
-=======
-            f'spot_cost_table=spot_utils.dump_spot_cost_report(split={split})',
->>>>>>> 97a20536 (lint and format)
             'print(spot_cost_table, flush=True)',
         ]
         return cls._build(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -503,6 +503,12 @@ def load_spot_job_queue(payload: str) -> List[Dict[str, Any]]:
     return jobs
 
 
+def load_spot_cost_report(payload: str) -> List[Dict[str, Any]]:
+    """Load job costs from json string."""
+    cost_report = common_utils.decode_payload(payload)
+    return cost_report
+
+
 def format_job_table(jobs: List[Dict[str, Any]],
                      show_all: bool,
                      return_rows: Literal[False] = False,

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -693,7 +693,6 @@ def dump_spot_cost(verbose: bool) -> str:
     seen_cluster_names = set()
 
     for cluster_report in cluster_reports:
-
         cluster_report['total_cost'] = cost_utils.get_total_cost(cluster_report)
         launched_resources = cluster_report['resources']
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -215,7 +215,6 @@ def get_job_id_from_spot_cluster_name(spot_cluster_name: str) -> str:
 
 def get_job_name_from_spot_cluster_name(spot_cluster_name: str) -> str:
     """Parse job name from spot cluster name."""
-
     if spot_cluster_name == '':
         return ''
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -83,8 +83,6 @@ def _get_non_condensed_records_by_name(
     agg_records: List[Dict[str, Any]] = []
     total_duration = 0
 
-    total_duration = 0
-
     for record in records:
 
         if record['name'] == cluster_name:

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -52,6 +52,7 @@ def _get_non_condensed_records_by_name(
     agg_records: List[Dict[str, Any]] = []
     total_duration = 0
     num_recoveries = 0
+    min_launch_time = float('inf')
 
     for record in records:
 
@@ -70,6 +71,7 @@ def _get_non_condensed_records_by_name(
 
             total_duration += record['duration']
             num_recoveries += 1
+            min_launch_time = min(min_launch_time, record['launched_at'])
 
             agg_records.append(agg_record)
 
@@ -83,6 +85,7 @@ def _get_non_condensed_records_by_name(
 
     head_record['duration'] = total_duration
     head_record['num_recoveries'] = num_recoveries
+    head_record['launched_at'] = min_launch_time - 1
 
     agg_records = [head_record] + agg_records
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -12,7 +12,6 @@ def get_cost_report(cluster_status):
 
     return f'${cost:.3f}'
 
-
 def get_status_for_cost_report(cluster_status):
     status = None
     if 'status' in cluster_status:
@@ -21,7 +20,6 @@ def get_status_for_cost_report(cluster_status):
     if status is None:
         return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
     return status.colored_str()
-
 
 def get_resources_for_cost_report(cluster_status):
     launched_nodes = cluster_status['num_nodes']

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -79,6 +79,7 @@ def get_split_view_records_by_name(cluster_name: str,
                                    records: List[Any]) -> List[Dict[str, Any]]:
 
     agg_records: List[Dict[str, Any]] = []
+    total_duration = 0
 
     total_duration = 0
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -4,7 +4,7 @@ import colorama
 from sky import global_user_state
 
 
-def get_cost_from_record(record):
+def get_cost_from_record(record: Dict[str, Any]) -> str:
     cost = record['total_cost']
 
     if not cost:
@@ -13,7 +13,7 @@ def get_cost_from_record(record):
     return f'${cost:.3f}'
 
 
-def get_status_for_cost_report(record):
+def get_status_for_cost_report(record: Dict[str, Any]) -> str:
     status = None
     if 'status' in record:
         status = record['status']
@@ -23,7 +23,7 @@ def get_status_for_cost_report(record):
     return status.colored_str()
 
 
-def get_resources_for_cost_report(record):
+def get_resources_for_cost_report(record: Dict[str, Any]) -> str:
     launched_nodes = record['num_nodes']
     launched_resources = record['resources']
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -51,6 +51,7 @@ def _get_non_condensed_records_by_name(
 
     agg_records: List[Dict[str, Any]] = []
     total_duration = 0
+    num_recoveries = 0
 
     for record in records:
 
@@ -64,9 +65,11 @@ def _get_non_condensed_records_by_name(
                 'launched_at': record['launched_at'],
                 'duration': record['duration'],
                 'usage_intervals': record['usage_intervals'],
+                'num_recoveries': 0,
             }
 
             total_duration += record['duration']
+            num_recoveries += 1
 
             agg_records.append(agg_record)
 
@@ -79,6 +82,8 @@ def _get_non_condensed_records_by_name(
         head_record[k] = v
 
     head_record['duration'] = total_duration
+    head_record['num_recoveries'] = num_recoveries
+
     agg_records = [head_record] + agg_records
 
     return agg_records

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -79,16 +79,17 @@ def get_split_view_records_by_name(cluster_name: str,
                                    records: List[Any]) -> List[Dict[str, Any]]:
 
     agg_records: List[Dict[str, Any]] = []
+
     total_duration = 0
 
     for record in records:
 
         if record['name'] == cluster_name:
             agg_record = {
-                'name': '',
+                'name': record['name'],
                 'job_id': '',
-                'num_nodes': '',
-                'resources': '',
+                'num_nodes': record['num_nodes'],
+                'resources': record['resources'],
                 'cluster_hash': record['cluster_hash'],
                 'launched_at': record['launched_at'],
                 'duration': record['duration'],
@@ -99,15 +100,17 @@ def get_split_view_records_by_name(cluster_name: str,
 
             agg_records.append(agg_record)
 
-            if len(agg_records) == 0:
-                agg_record['name'] = record['name']
-                agg_record['num_nodes'] = record['num_nodes']
-                agg_record['resources'] = record['resources']
+    if len(agg_records) == 1:
+        return agg_records
 
-                agg_records.append(agg_record)
-                agg_records[0], agg_records[1] = agg_records[1], agg_records[0]
+    head_record = {}
 
-    agg_records[0]['duration'] = total_duration
+    for k, v in agg_records[0].items():
+        head_record[k] = v
+
+    head_record['duration'] = total_duration
+    agg_records = [head_record] + agg_records
+
     return agg_records
 
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -1,37 +1,6 @@
 """Utilities for sky cost report and sky spot cost."""
 from typing import Any, Dict, List
-import colorama
 from sky import global_user_state
-
-
-def get_cost_from_record(record: Dict[str, Any]) -> str:
-    cost = record['total_cost']
-
-    if not cost:
-        return '-'
-
-    return f'${cost:.3f}'
-
-
-def get_status_for_cost_report(record: Dict[str, Any]) -> str:
-    status = None
-    if 'status' in record:
-        status = record['status']
-
-    if status is None:
-        return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
-    return status.colored_str()
-
-
-def get_resources_for_cost_report(record: Dict[str, Any]) -> str:
-    launched_nodes = record['num_nodes']
-    launched_resources = record['resources']
-
-    launched_resource_str = str(launched_resources)
-    resources_str = (f'{launched_nodes}x '
-                     f'{launched_resource_str}')
-
-    return resources_str
 
 
 def aggregate_all_records(condensed: bool) -> List[Dict[str, Any]]:

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -24,6 +24,9 @@ def _aggregate_records_by_name(cluster_name: str,
                                records: List[Any]) -> Dict[str, Any]:
     agg_record: Dict[str, Any] = {}
 
+    # to have most updated cluster status in aggregated record
+    records.sort(key=lambda record: record['launched_at'])
+
     for record in records:
 
         if record['name'] == cluster_name:
@@ -42,6 +45,7 @@ def _aggregate_records_by_name(cluster_name: str,
                 agg_record['usage_intervals'] += record['usage_intervals']
                 agg_record['resources'] = record['resources']
                 agg_record['num_nodes'] = record['num_nodes']
+                agg_record['status'] = record['status']
 
     return agg_record
 

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -12,6 +12,7 @@ def get_cost_report(cluster_status):
 
     return f'${cost:.3f}'
 
+
 def get_status_for_cost_report(cluster_status):
     status = None
     if 'status' in cluster_status:
@@ -20,6 +21,7 @@ def get_status_for_cost_report(cluster_status):
     if status is None:
         return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
     return status.colored_str()
+
 
 def get_resources_for_cost_report(cluster_status):
     launched_nodes = cluster_status['num_nodes']

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -1,14 +1,8 @@
 """Utilities for sky cost report and sky spot cost."""
-from typing import Any, Callable, Dict, List, Optional
-import click
+from typing import Any, Dict, List
 import colorama
-
-from sky import backends
-from sky import spot
 from sky import global_user_state
-from sky.backends import backend_utils
-from sky.utils import common_utils
-from sky.utils import log_utils
+
 
 def get_cost_report(cluster_status):
     cost = cluster_status['total_cost']
@@ -17,6 +11,7 @@ def get_cost_report(cluster_status):
         return '-'
 
     return f'${cost:.3f}'
+
 
 def get_status_for_cost_report(cluster_status):
     status = None
@@ -27,6 +22,7 @@ def get_status_for_cost_report(cluster_status):
         return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
     return status.colored_str()
 
+
 def get_resources_for_cost_report(cluster_status):
     launched_nodes = cluster_status['num_nodes']
     launched_resources = cluster_status['resources']
@@ -36,13 +32,13 @@ def get_resources_for_cost_report(cluster_status):
                      f'{launched_resource_str}')
 
     return resources_str
-    
 
-def aggregate_all_records(split: bool) -> List[Optional[Dict[str, Any]]]:
+
+def aggregate_all_records(split: bool) -> List[Dict[str, Any]]:
     rows = global_user_state.get_distinct_cluster_names_from_history()
-    records = global_user_state.get_clusters_from_history();
+    records = global_user_state.get_clusters_from_history()
 
-    agg_records = []
+    agg_records: List[Dict[str, Any]] = []
 
     for (cluster_name,) in rows:
         if split:
@@ -52,8 +48,10 @@ def aggregate_all_records(split: bool) -> List[Optional[Dict[str, Any]]]:
 
     return agg_records
 
-def aggregate_records_by_name(cluster_name: str, records: List[Any]) -> Optional[Dict[str, Any]]:
-    agg_record = {}
+
+def aggregate_records_by_name(cluster_name: str,
+                              records: List[Any]) -> Dict[str, Any]:
+    agg_record: Dict[str, Any] = {}
 
     for record in records:
 
@@ -77,10 +75,10 @@ def aggregate_records_by_name(cluster_name: str, records: List[Any]) -> Optional
     return agg_record
 
 
-def get_split_view_records_by_name(
-        cluster_name: str, records: List[Any]) -> Optional[Dict[str, Any]]:
+def get_split_view_records_by_name(cluster_name: str,
+                                   records: List[Any]) -> List[Dict[str, Any]]:
 
-    agg_records = []
+    agg_records: List[Dict[str, Any]] = []
 
     for record in records:
 
@@ -101,7 +99,8 @@ def get_split_view_records_by_name(
 
     return agg_records
 
-def get_total_cost(cluster_report: dict) -> float:
+
+def get_total_cost(cluster_report: Dict[str, Any]) -> float:
     duration = cluster_report['duration']
     launched_nodes = cluster_report['num_nodes']
     launched_resources = cluster_report['resources']

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -100,3 +100,11 @@ def get_split_view_records_by_name(
             agg_records.append(agg_record)
 
     return agg_records
+
+def get_total_cost(cluster_report: dict) -> float:
+    duration = cluster_report['duration']
+    launched_nodes = cluster_report['num_nodes']
+    launched_resources = cluster_report['resources']
+
+    cost = (launched_resources.get_cost(duration) * launched_nodes)
+    return cost

--- a/sky/utils/cli_utils/cost_utils.py
+++ b/sky/utils/cli_utils/cost_utils.py
@@ -1,0 +1,102 @@
+"""Utilities for sky cost report and sky spot cost."""
+from typing import Any, Callable, Dict, List, Optional
+import click
+import colorama
+
+from sky import backends
+from sky import spot
+from sky import global_user_state
+from sky.backends import backend_utils
+from sky.utils import common_utils
+from sky.utils import log_utils
+
+def get_cost_report(cluster_status):
+    cost = cluster_status['total_cost']
+
+    if not cost:
+        return '-'
+
+    return f'${cost:.3f}'
+
+def get_status_for_cost_report(cluster_status):
+    status = None
+    if 'status' in cluster_status:
+        status = cluster_status['status']
+
+    if status is None:
+        return f'{colorama.Style.DIM}{"TERMINATED"}{colorama.Style.RESET_ALL}'
+    return status.colored_str()
+
+def get_resources_for_cost_report(cluster_status):
+    launched_nodes = cluster_status['num_nodes']
+    launched_resources = cluster_status['resources']
+
+    launched_resource_str = str(launched_resources)
+    resources_str = (f'{launched_nodes}x '
+                     f'{launched_resource_str}')
+
+    return resources_str
+    
+
+def aggregate_all_records(split: bool) -> List[Optional[Dict[str, Any]]]:
+    rows = global_user_state.get_distinct_cluster_names_from_history()
+    records = global_user_state.get_clusters_from_history();
+
+    agg_records = []
+
+    for (cluster_name,) in rows:
+        if split:
+            agg_records += get_split_view_records_by_name(cluster_name, records)
+        else:
+            agg_records.append(aggregate_records_by_name(cluster_name, records))
+
+    return agg_records
+
+def aggregate_records_by_name(cluster_name: str, records: List[Any]) -> Optional[Dict[str, Any]]:
+    agg_record = {}
+
+    for record in records:
+
+        if record['name'] == cluster_name:
+            if not agg_record:
+                agg_record = {
+                    'name': record['name'],
+                    'launched_at': record['launched_at'],
+                    'duration': record['duration'],
+                    'num_nodes': record['num_nodes'],
+                    'resources': record['resources'],
+                    'cluster_hash': record['cluster_hash'],
+                    'usage_intervals': record['usage_intervals'],
+                }
+            else:
+                agg_record['duration'] += record['duration']
+                agg_record['usage_intervals'] += record['usage_intervals']
+                agg_record['resources'] = record['resources']
+                agg_record['num_nodes'] = record['num_nodes']
+
+    return agg_record
+
+
+def get_split_view_records_by_name(
+        cluster_name: str, records: List[Any]) -> Optional[Dict[str, Any]]:
+
+    agg_records = []
+
+    for record in records:
+
+        if record['name'] == cluster_name:
+            agg_record = {
+                'name': '',
+                'launched_at': record['launched_at'],
+                'duration': record['duration'],
+                'num_nodes': record['num_nodes'],
+                'resources': record['resources'],
+                'cluster_hash': record['cluster_hash'],
+                'usage_intervals': record['usage_intervals'],
+            }
+
+            if len(agg_records) == 0:
+                agg_record['name'] = record['name']
+            agg_records.append(agg_record)
+
+    return agg_records

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -160,8 +160,7 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
         StatusColumn('COST/hr',
                      _get_price_for_cost_report,
                      show_by_default=True),
-        StatusColumn('COST (est.)',
-                     _get_estimated_cost_for_cost_report),
+        StatusColumn('COST (est.)', _get_estimated_cost_for_cost_report),
     ]
 
     columns = []

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -161,7 +161,7 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                      _get_price_for_cost_report,
                      show_by_default=True),
         StatusColumn('COST (est.)',
-                     _get_estimated_cost_for_cost_report)
+                     _get_estimated_cost_for_cost_report),
     ]
 
     columns = []

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -162,7 +162,6 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                      show_by_default=True),
         StatusColumn('COST (est.)',
                      _get_estimated_cost_for_cost_report,
-                     show_by_default=True),
     ]
 
     columns = []

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -382,7 +382,9 @@ def _get_status_value_for_cost_report(
 
 def _get_status_for_cost_report(
         cluster_cost_report_record: _ClusterCostReportRecord) -> str:
-    status = cluster_cost_report_record['status']
+    status = None
+    if 'status' in cluster_cost_report_record:
+        status = cluster_cost_report_record['status']
     if status is None:
         return f'{colorama.Style.DIM}TERMINATED{colorama.Style.RESET_ALL}'
     return status.colored_str()

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,7 +11,6 @@ from sky import status_lib
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
-from sky.utils.cli_utils import cost_utils
 
 _COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
@@ -152,15 +151,17 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
         StatusColumn('LAUNCHED', _get_launched),
         StatusColumn('DURATION', _get_duration, trunc_length=20),
         StatusColumn('RESOURCES',
-                     cost_utils.get_resources_for_cost_report,
+                     _get_resources_for_cost_report,
                      trunc_length=70 if not show_all else 0),
         StatusColumn('STATUS',
-                     cost_utils.get_status_for_cost_report,
+                     _get_status_for_cost_report,
                      show_by_default=True),
         StatusColumn('COST/hr',
                      _get_price_for_cost_report,
                      show_by_default=True),
-        StatusColumn('COST (est.)', _get_estimated_cost_for_cost_report),
+        StatusColumn('COST (est.)',
+                     _get_estimated_cost_for_cost_report,
+                     show_by_default=True),
     ]
 
     columns = []

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,6 +11,7 @@ from sky import status_lib
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
+from sky.utils.cli_utils import cost_utils
 
 _COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
@@ -151,10 +152,10 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
         StatusColumn('LAUNCHED', _get_launched),
         StatusColumn('DURATION', _get_duration, trunc_length=20),
         StatusColumn('RESOURCES',
-                     _get_resources_for_cost_report,
+                     cost_utils.get_resources_for_cost_report,
                      trunc_length=70 if not show_all else 0),
         StatusColumn('STATUS',
-                     _get_status_for_cost_report,
+                     cost_utils.get_status_for_cost_report,
                      show_by_default=True),
         StatusColumn('COST/hr',
                      _get_price_for_cost_report,

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -161,7 +161,7 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                      _get_price_for_cost_report,
                      show_by_default=True),
         StatusColumn('COST (est.)',
-                     _get_estimated_cost_for_cost_report,
+                     _get_estimated_cost_for_cost_report)
     ]
 
     columns = []


### PR DESCRIPTION
Add `sky spot cost`, which will calculate cluster cost for a spot job. Since a spot job can be preempted and re-launched with new clusters, the job's cost is aggregated over all of its relaunched clusters. The spot controller's cost is included with `sky cost-report` along with the other on-demand clusters. Users can also do `sky cost spot --split` to see a breakdown of each spot job's clusters across its multiple preemptions and recoveries. Addresses #1670.

Tested:

Below is the local CLI results when running `sky spot cost`:

```
(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report
Fetching managed spot job statuses...
Managed spot jobs (showing in-progress jobs only):
NAME            RESOURCES                 NODES  REGION    TOT. DURATION  TOT. COST  
spot-cluster-1  GCP(n2-standard-8[Spot])  1      us-west4  28m 30s        $0.039     

(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report
Fetching managed spot job statuses...
Managed spot jobs (showing in-progress jobs only):
NAME            RESOURCES                 NODES  REGION    TOT. DURATION  TOT. COST  
spot-cluster-1  GCP(n2-standard-8[Spot])  1      us-west4  28m 59s        $0.040     

(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cancel 1
Cancelling managed spot jobs with IDs 1. Proceed? [Y/n]: y
I 02-05 06:21:53 spot_utils.py:155] Cancelling jobs 1.
Job with ID 1 is scheduled to be cancelled.

(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report    
Fetching managed spot job statuses...
Managed spot jobs (showing in-progress jobs only):
NAME            RESOURCES                 NODES  REGION    TOT. DURATION  TOT. COST  
spot-cluster-1  GCP(n2-standard-8[Spot])  1      us-west4  29m 52s        $0.041     

(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report
Fetching managed spot job statuses...
Managed spot jobs (showing in-progress jobs only):
NAME            RESOURCES                 NODES  REGION    TOT. DURATION  TOT. COST  
spot-cluster-1  GCP(n2-standard-8[Spot])  1      us-west4  30m 16s        $0.042     

(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report
Fetching managed spot job statuses...
Managed spot jobs (showing in-progress jobs only):
NAME            RESOURCES                 NODES  REGION    TOT. DURATION  TOT. COST  
spot-cluster-1  GCP(n2-standard-8[Spot])  1      us-west4  30m 16s        $0.042     

(sky) sumanth@MacBook-Pro-5 skypilot % sky cost-report
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  2 weeks ago   6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $0.311       
cluster  2 weeks ago   22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $1.108       
cluster  1 month ago   3m 41s    1x GCP(n1-highmem-8)               $ 0.473       $0.029       
cluster  1 month ago   10m 13s   1x GCP(n1-highmem-8)               $ 0.473       $0.081       
min      2 months ago  6m 25s    1x AWS(m6i.2xlarge)                $ 0.384       $0.041       
min      2 months ago  24m 40s   1x AWS(m6i.2xlarge)                $ 0.384       $0.158       
mount    2 months ago  7m 26s    1x GCP(n1-highmem-8)               $ 0.473       $0.059       
mount2   2 months ago  12m 28s   1x GCP(n1-highmem-8)               $ 0.473       $0.098       
mount    2 months ago  16m 26s   1x GCP(n1-highmem-8)               $ 0.473       $0.130       

Managed spot controller (will be autostopped if idle for 10min)
NAME                          LAUNCHED   DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
sky-spot-controller-d16122f1  1 day ago  10m 25s   1x AWS(m6i.2xlarge, disk_size=50)  $ 0.384       $0.067     
```

The spot job cluster `spot-cluster-1` was manually preempted several times via GCP console. I verified that `sky cost-report` ran correctly on the controller itself:

```
(before preemption)
gcpuser@ray-sky-spot-controller-d16122f1-head-091679ac-compute:~$ sky cost-report
Clusters
NAME            LAUNCHED    DURATION  RESOURCES                    HOURLY_PRICE  COST (est.)  
spot-cluster-1  8 mins ago  8m 48s    1x GCP(n2-standard-8[Spot])  $ 0.083       $0.012     

(during preemption)

gcpuser@ray-sky-spot-controller-d16122f1-head-091679ac-compute:~$ sky cost-report
Clusters
NAME            LAUNCHED    DURATION  RESOURCES                    HOURLY_PRICE  COST (est.)  
spot-cluster-1  9 mins ago  9m 14s    1x GCP(n2-standard-8[Spot])  $ 0.083       $0.013     

(after recovery)

gcpuser@ray-sky-spot-controller-d16122f1-head-091679ac-compute:~$ sky cost-report
Clusters
NAME            LAUNCHED     DURATION  RESOURCES                    HOURLY_PRICE  COST (est.)  
spot-cluster-1  19 secs ago  19s       1x GCP(n2-standard-8[Spot])  $ 0.083       $0.000       
spot-cluster-1  9 mins ago   9m 16s    1x GCP(n2-standard-8[Spot])  $ 0.083       $0.013    
```

After preempting and recovering a spot job, I also tested `sky spot cost-report`, which displays each preemption and associated duration and cost data.

```
...
5       spot-cluster     3             -                         -      -                          4 months ago  18m 35s        $0.031     
                                       GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago   7m 11s         $0.012    
                                       GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago   6m 59s         $0.012    
                                       GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago   4m 25s         $0.007    
                                                                                                                                           
4       spot-cluster     2             -                         -      -                          4 months ago  19m 17s        $0.032     
                                       GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago   11m 25s        $0.019    
                                       GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago   7m 52s         $0.013    
                                                                                                                                           
3       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  8m 31s         $0.014     
                                                                                                                                           
2       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  12m 11s        $0.020     
                                                                                                                                           
1       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  10m 30s        $0.018    

```

We can consolidate this information (duration and cost) into a single row for a given spot task by using `--condensed=True`.

```
...
5       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  18m 35s        $0.031     
                                                                                                                                           
4       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  19m 17s        $0.032     
                                                                                                                                           
3       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  8m 31s         $0.014     
                                                                                                                                           
2       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  12m 11s        $0.020     
                                                                                                                                           
1       spot-cluster     0             GCP(n2-standard-8[Spot])  1      us-west4-a                 4 months ago  10m 30s        $0.018  
```

Here is `sky spot cost-report` working correctly with multi-task spot jobs, in terms of displaying `job_id`, `resources` and `cost` correctly. Note here we are not using `--all`, and thus by default we only display 5 rows (excluding preemption rows when --condensed is False).

```
(sky) sumanth@MacBook-Pro-5 skypilot % sky spot cost-report 
Fetching managed spot job costs...
Managed spot jobs:
JOB ID  JOB NAME         # RECOVERIES  RESOURCES                 NODES  ZONE                       LAUNCH TIME  TOT. DURATION  TOT. COST  
11      spot-sub-task-0  0             GCP(n2-standard-2[Spot])  1      northamerica-northeast2-a  1 hr ago     4m 43s         $0.001     
                                                                                                                                          
11      spot-sub-task-1  0             GCP(n2-standard-2[Spot])  3      northamerica-northeast2-a  1 hr ago     7m 31s         $0.004     
                                                                                                                                          
11      spot-sub-task-2  0             GCP(n2-standard-8[Spot])  1      northamerica-northeast2-a  1 hr ago     20m 32s        $0.015     
                                                                                                                                          
10      spot-sub-task-0  0             GCP(n2-standard-8[Spot])  1      northamerica-northeast2-a  1 hr ago     4m 10s         $0.003     
                                                                                                                                          
10      spot-sub-task-1  0             GCP(n2-standard-2[Spot])  1      us-east4-b                 1 hr ago     4m 25s         $0.002   

```
