### PR TITLE
[Tests] Fix `f'no_{cloud_keyword}'` pytest mark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We use GitHub to track issues and features. For new contributors, we recommend l
 ```bash
 # SkyPilot requires python >= 3.6.
 # You can just install the dependencies for
-# certain clouds, e.g., ".[aws,azure,gcp]"
+# certain clouds, e.g., ".[aws,azure,gcp,lambda]"
 pip install -e ".[all]"
 pip install -r requirements-dev.txt
 ```
@@ -26,7 +26,7 @@ pip install -r requirements-dev.txt
 ### Testing
 To run smoke tests (NOTE: Running all smoke tests launches ~20 clusters):
 ```
-# Run all tests except for AWS
+# Run all tests except for AWS and Lambda Cloud
 pytest tests/test_smoke.py
 
 # Re-run last failed tests


### PR DESCRIPTION
This fixes #1674 

I tested this pr by creating a fake smoke test file:
```
...
def test_generic_one(generic_cloud: str):
    name = _get_cluster_name()
    test = Test(
        f'generic_one_{generic_cloud}',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)


def test_generic_two(generic_cloud: str):
    name = _get_cluster_name()
    test = Test(
        f'generic_two_{generic_cloud}',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)


@pytest.mark.no_gcp
def test_generic_three(generic_cloud: str):
    name = _get_cluster_name()
    test = Test(
        f'generic_three_{generic_cloud}',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)


@pytest.mark.no_lambda_cloud
def test_generic_four(generic_cloud: str):
    name = _get_cluster_name()
    test = Test(
        f'generic_four_{generic_cloud}',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)

@pytest.mark.gcp
def test_gcp():
    name = _get_cluster_name()
    test = Test(
        'gcp',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)

@pytest.mark.aws
def test_aws():
    name = _get_cluster_name()
    test = Test(
        'aws',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)

@pytest.mark.lambda_cloud
def test_lambda():
    name = _get_cluster_name()
    test = Test(
        'lambda',
        [
            f'sleep 2',
        ],
    )
    run_one_test(test)
```
and running
```
pytest tests/test_smoke_fake.py
pytest tests/test_smoke_fake.py --lambda
pytest tests/test_smoke_fake.py --generic-cloud gcp --gcp --lambda
pytest tests/test_smoke_fake.py --generic-cloud lambda --lamdba --gcp
pytest tests/test_smoke_fake.py --aws
```