### PR TITLE
Nullify cost for autostop clusters in cost report

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1649,13 +1649,13 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:
+        cluster_record = status_utils.nullify_cost_for_autostop(cluster_record)
         cluster_name = cluster_record['name']
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
-            reserved_clusters[
-                cluster_group_name] = status_utils.nullify_cost_for_autostop(
-                    cluster_record)
+            if cluster_group_name not in reserved_clusters:
+                reserved_clusters[cluster_group_name] = cluster_record
         else:
             nonreserved_cluster_records.append(cluster_record)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1653,7 +1653,9 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
-            reserved_clusters[cluster_group_name] = cluster_record
+            reserved_clusters[
+                cluster_group_name] = status_utils.nullify_cost_for_autostop(
+                    cluster_record)
         else:
             nonreserved_cluster_records.append(cluster_record)
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -109,7 +109,7 @@ def nullify_cost_for_autostop(cluster_record: Dict[str, Any]):
     return cluster_record
 
 
-def show_cost_report_table(cluster_records: List[Dict[str, Any]],
+def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                            show_all: bool,
                            reserved_group_name: Optional[str] = None):
     """Compute cluster table values and display for cost report.

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -104,7 +104,12 @@ def show_status_table(cluster_records: List[_ClusterRecord],
     return num_pending_autostop
 
 
-def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
+def nullify_cost_for_autostop(cluster_record: Dict[str, Any]):
+    cluster_record['total_cost'] = 0
+    return cluster_record
+
+
+def show_cost_report_table(cluster_records: List[Dict[str, Any]],
                            show_all: bool,
                            reserved_group_name: Optional[str] = None):
     """Compute cluster table values and display for cost report.

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -105,7 +105,9 @@ def show_status_table(cluster_records: List[_ClusterRecord],
 
 
 def nullify_cost_for_autostop(cluster_record: Dict[str, Any]):
-    cluster_record['total_cost'] = 0
+    # check that cluster has autostop
+    if cluster_record['autostop'] >= 0:
+        cluster_record['total_cost'] = 0
     return cluster_record
 
 


### PR DESCRIPTION
Addreses #1645.

Tested (run the relevant ones):

```
(sky) sumanth@MacBook-Pro-5 skypilot % sky cost-report
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  2 weeks ago   6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $0.311       
cluster  2 weeks ago   22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       $1.108       
cluster  1 month ago   3m 41s    1x GCP(n1-highmem-8)               $ 0.473       $0.029       
cluster  1 month ago   10m 13s   1x GCP(n1-highmem-8)               $ 0.473       $0.081       
min      2 months ago  6m 25s    1x AWS(m6i.2xlarge)                $ 0.384       $0.041       
min      2 months ago  24m 40s   1x AWS(m6i.2xlarge)                $ 0.384       $0.158       
mount    2 months ago  7m 26s    1x GCP(n1-highmem-8)               $ 0.473       $0.059       
mount2   2 months ago  12m 28s   1x GCP(n1-highmem-8)               $ 0.473       $0.098       
mount    2 months ago  16m 26s   1x GCP(n1-highmem-8)               $ 0.473       $0.130       

Managed spot controller (will be autostopped if idle for 10min)
NAME                          LAUNCHED    DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
sky-spot-controller-d16122f1  3 days ago  10m 25s   1x AWS(m6i.2xlarge, disk_size=50)  $ 0.384       -     
```