### PR TITLE
Handle null usage intervals in duration computing

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -427,11 +427,16 @@ def _get_cluster_launch_time(cluster_hash: str) -> Optional[Dict[str, Any]]:
 
 
 def _get_cluster_duration(cluster_hash: str) -> Optional[Dict[str, Any]]:
+    total_duration = 0
     usage_intervals = _get_cluster_usage_intervals(cluster_hash)
 
-    total_duration = 0
+    if usage_intervals is None:
+        return total_duration
+
     for i, (start_time, end_time) in enumerate(usage_intervals):
         # duration from latest start time to time of query
+        if start_time is None:
+            continue
         if end_time is None:
             assert i == len(usage_intervals) - 1, i
             end_time = int(time.time())

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -426,7 +426,7 @@ def _get_cluster_launch_time(cluster_hash: str) -> Optional[Dict[str, Any]]:
     return usage_intervals[0][0]
 
 
-def _get_cluster_duration(cluster_hash: str) -> Optional[Dict[str, Any]]:
+def _get_cluster_duration(cluster_hash: str) -> int:
     total_duration = 0
     usage_intervals = _get_cluster_usage_intervals(cluster_hash)
 
@@ -435,8 +435,6 @@ def _get_cluster_duration(cluster_hash: str) -> Optional[Dict[str, Any]]:
 
     for i, (start_time, end_time) in enumerate(usage_intervals):
         # duration from latest start time to time of query
-        if start_time is None:
-            continue
         if end_time is None:
             assert i == len(usage_intervals) - 1, i
             end_time = int(time.time())


### PR DESCRIPTION
For clusters that are very old and have no history due to being present before changes to `cluster_history` tracking for `sky cost-report`, we return zero duration and cost as a form of error-handling.


Tested (run the relevant ones):

Simulated null usage intervals and start times and triggered the error-handling as seen below:

```
(sky) sumanth@MacBook-Pro-5 skypilot % sky cost-report
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
cluster  2 weeks ago   -         1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       -            
cluster  2 weeks ago   -         1x GCP(n1-highmem-8, {'V100': 1})  $ 2.953       -            
cluster  1 month ago   -         1x GCP(n1-highmem-8)               $ 0.473       -            
cluster  1 month ago   -         1x GCP(n1-highmem-8)               $ 0.473       -            
min      2 months ago  -         1x AWS(m6i.2xlarge)                $ 0.384       -            
min      2 months ago  -         1x AWS(m6i.2xlarge)                $ 0.384       -            
mount    2 months ago  -         1x GCP(n1-highmem-8)               $ 0.473       -            
mount2   2 months ago  -         1x GCP(n1-highmem-8)               $ 0.473       -            
mount    2 months ago  -         1x GCP(n1-highmem-8)               $ 0.473       -            

Managed spot controller (will be autostopped if idle for 10min)
NAME                          LAUNCHED    DURATION  RESOURCES                          HOURLY_PRICE  COST (est.)  
sky-spot-controller-d16122f1  3 days ago  -         1x AWS(m6i.2xlarge, disk_size=50)  $ 0.384       -  
```
