### PR TITLE
[test] Add option for termination on failure and set spot controller cloud for testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ To run smoke tests (NOTE: Running all smoke tests launches ~20 clusters):
 # Run all tests except for AWS and Lambda Cloud
 pytest tests/test_smoke.py
 
+# Terminate failed clusetrs after test finishes
+pytest tests/test_smoke.py --terminate-on-failure
+
 # Re-run last failed tests
 pytest --lf
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To run smoke tests (NOTE: Running all smoke tests launches ~20 clusters):
 # Run all tests except for AWS and Lambda Cloud
 pytest tests/test_smoke.py
 
-# Terminate failed clusetrs after test finishes
+# Terminate a test's cluster even if the test failed (default is to keep it around for debugging)
 pytest tests/test_smoke.py --terminate-on-failure
 
 # Re-run last failed tests

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -633,6 +633,18 @@ def spot_launch(
         controller_task = task_lib.Task.from_yaml(yaml_path)
         controller_task.spot_task = task
         assert len(controller_task.resources) == 1
+
+        # Override the spot controller cloud if the user has specified it.
+        controller_cloud_str = os.getenv(
+            env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR)
+        if controller_cloud_str is not None:
+            controller_cloud = clouds.CLOUD_REGISTRY.from_str(
+                controller_cloud_str)
+            logger.info(f'Override spot controller cloud to {controller_cloud}')
+            controller_resources = list(controller_task.resources)[0]
+            controller_task.set_resources(
+                {controller_resources.copy(cloud=controller_cloud)})
+
         print(f'{colorama.Fore.YELLOW}'
               f'Launching managed spot job {name} from spot controller...'
               f'{colorama.Style.RESET_ALL}')

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -634,17 +634,6 @@ def spot_launch(
         controller_task.spot_task = task
         assert len(controller_task.resources) == 1
 
-        # Override the spot controller cloud if the user has specified it.
-        controller_cloud_str = os.getenv(
-            env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR)
-        if controller_cloud_str is not None:
-            controller_cloud = clouds.CLOUD_REGISTRY.from_str(
-                controller_cloud_str)
-            logger.info(f'Override spot controller cloud to {controller_cloud}')
-            controller_resources = list(controller_task.resources)[0]
-            controller_task.set_resources(
-                {controller_resources.copy(cloud=controller_cloud)})
-
         print(f'{colorama.Fore.YELLOW}'
               f'Launching managed spot job {name} from spot controller...'
               f'{colorama.Style.RESET_ALL}')

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -2,6 +2,8 @@
 import enum
 import os
 
+SPOT_CONTROLLER_CLOUD_ENV_VAR = 'SKYPILOT_SPOT_CONTROLLER_CLOUD'
+
 
 class Options(enum.Enum):
     """Environment variables for SkyPilot."""

--- a/sky/utils/env_options.py
+++ b/sky/utils/env_options.py
@@ -2,8 +2,6 @@
 import enum
 import os
 
-SPOT_CONTROLLER_CLOUD_ENV_VAR = 'SKYPILOT_SPOT_CONTROLLER_CLOUD'
-
 
 class Options(enum.Enum):
     """Environment variables for SkyPilot."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ import tempfile
 import textwrap
 from typing import List
 
+import sky
+from sky import spot
+from sky.utils import env_options
+
 # Usage: use
 #   @pytest.mark.slow
 # to mark a test as slow and to skip by default.
@@ -11,12 +15,15 @@ from typing import List
 
 # By default, only run generic tests and cloud-specific tests for GCP and Azure,
 # due to the cloud credit limit for the development account.
-# To only run tests for a specific cloud (as well as generic tests), use
-# --aws, --gcp, --azure, or --lambda.
-# To only run tests for managed spot (without generic tests), use --managed-spot.
+#
 # A "generic test" tests a generic functionality (e.g., autostop) that
 # should work on any cloud we support. The cloud used for such a test
 # is controlled by `--generic-cloud` (typically you do not need to set it).
+#
+# To only run tests for a specific cloud (as well as generic tests), use
+# --aws, --gcp, --azure, or --lambda.
+#
+# To only run tests for managed spot (without generic tests), use --managed-spot.
 all_clouds_in_smoke_tests = ['aws', 'gcp', 'azure', 'lambda']
 default_clouds_to_run = ['gcp', 'azure']
 
@@ -69,9 +76,6 @@ def pytest_configure(config):
             'markers', f'{cloud_keyword}: mark test as {cloud} specific')
 
     pytest.terminate_on_failure = config.getoption('--terminate-on-failure')
-    import sky
-    from sky import spot
-    from sky.utils import env_options
     generic_cloud = _generic_cloud(config)
     cluster = sky.status(spot.SPOT_CONTROLLER_NAME)
     if not cluster:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,11 @@ def pytest_addoption(parser):
         'not within the clouds to be run, it will be reset to the first '
         'cloud in the list of the clouds to be run.')
 
+    parser.addoption('--terminate-on-failure',
+                     action='store_true',
+                     default=False,
+                     help='Terminate test VMs on failure.')
+
 
 def pytest_configure(config):
     config.addinivalue_line('markers', 'slow: mark test as slow to run')
@@ -62,6 +67,11 @@ def pytest_configure(config):
         cloud_keyword = cloud_to_pytest_keyword[cloud]
         config.addinivalue_line(
             'markers', f'{cloud_keyword}: mark test as {cloud} specific')
+
+    pytest.terminate_on_failure = config.getoption('--terminate-on-failure')
+    from sky.utils import env_options
+    os.environ[env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR] = str(
+        _generic_cloud(config))
 
 
 def _get_cloud_to_run(config) -> List[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def pytest_configure(config):
     from sky.utils import env_options
     generic_cloud = _generic_cloud(config)
     cluster = sky.status(spot.SPOT_CONTROLLER_NAME)
-    if cluster is None:
+    if not cluster:
         # Set the spot controller cloud to the generic cloud if it does not
         # exist.
         os.environ[env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR] = str(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,6 @@ import tempfile
 import textwrap
 from typing import List
 
-import sky
-from sky import spot
-from sky.utils import env_options
-
 # Usage: use
 #   @pytest.mark.slow
 # to mark a test as slow and to skip by default.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,9 +69,16 @@ def pytest_configure(config):
             'markers', f'{cloud_keyword}: mark test as {cloud} specific')
 
     pytest.terminate_on_failure = config.getoption('--terminate-on-failure')
+    import sky
+    from sky import spot
     from sky.utils import env_options
-    os.environ[env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR] = str(
-        _generic_cloud(config))
+    generic_cloud = _generic_cloud(config)
+    cluster = sky.status(spot.SPOT_CONTROLLER_NAME)
+    if cluster is None:
+        # Set the spot controller cloud to the generic cloud if it does not
+        # exist.
+        os.environ[env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR] = str(
+            generic_cloud)
 
 
 def _get_cloud_to_run(config) -> List[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,13 +76,6 @@ def pytest_configure(config):
             'markers', f'{cloud_keyword}: mark test as {cloud} specific')
 
     pytest.terminate_on_failure = config.getoption('--terminate-on-failure')
-    generic_cloud = _generic_cloud(config)
-    cluster = sky.status(spot.SPOT_CONTROLLER_NAME)
-    if not cluster:
-        # Set the spot controller cloud to the generic cloud if it does not
-        # exist.
-        os.environ[env_options.SPOT_CONTROLLER_CLOUD_ENV_VAR] = str(
-            generic_cloud)
 
 
 def _get_cloud_to_run(config) -> List[str]:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -133,7 +133,8 @@ def run_one_test(test: Test) -> Tuple[int, str, str]:
            f'\nLog: less {log_file.name}\n')
     test.echo(msg)
     log_file.write(msg)
-    if proc.returncode == 0 and test.teardown is not None:
+    if (proc.returncode == 0 or
+            pytest.terminate_on_failure) and test.teardown is not None:
         subprocess_utils.run(
             test.teardown,
             stdout=log_file,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,22 +3,22 @@
 # Example usage:
 # Run all tests except for AWS and Lambda Cloud
 # > pytest tests/test_smoke.py
-
+#
 # Terminate failed clusetrs after test finishes
 # > pytest tests/test_smoke.py --terminate-on-failure
-
+#
 # Re-run last failed tests
 # > pytest --lf
-
+#
 # Run one of the smoke tests
 # > pytest tests/test_smoke.py::test_minimal
-
+#
 # Only run managed spot tests
 # > pytest tests/test_smoke.py --managed-spot
-
+#
 # Only run test for AWS + generic tests
 # > pytest tests/test_smoke.py --aws
-
+#
 # Change cloud for generic tests to aws
 # > pytest tests/test_smoke.py --generic-cloud aws
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,5 +1,26 @@
 # Smoke tests for SkyPilot
 # Default options are set in pyproject.toml
+# Example usage:
+# Run all tests except for AWS and Lambda Cloud
+# > pytest tests/test_smoke.py
+
+# Terminate failed clusetrs after test finishes
+# > pytest tests/test_smoke.py --terminate-on-failure
+
+# Re-run last failed tests
+# > pytest --lf
+
+# Run one of the smoke tests
+# > pytest tests/test_smoke.py::test_minimal
+
+# Only run managed spot tests
+# > pytest tests/test_smoke.py --managed-spot
+
+# Only run test for AWS + generic tests
+# > pytest tests/test_smoke.py --aws
+
+# Change cloud for generic tests to aws
+# > pytest tests/test_smoke.py --generic-cloud aws
 
 import hashlib
 import inspect


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

1. Add option for termination on failure to avoid clusters forgot to be terminated after failure. `--terminate-on-failure`
2. Set the cloud for spot controller to the generic cloud if the controller does not exist.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `pytest tests/test_smoke.py::test_spot` when the controller exists
  - [x] `pytest tests/test_smoke.py::test_spot` when the controller does not exist
  - [x] `pytest tests/test_smoke.py --terminate-on-failure`