### PR TITLE
[docs] CLI help strings: wording, ordering, and formatting.

### DIFF
--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -109,6 +109,21 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                            reserved_group_name: Optional[str] = None):
     """Compute cluster table values and display for cost report.
 
+    For each cluster, we show: cluster name, resources, launched time, duration
+    that cluster was up, and total estimated cost.
+
+    The estimated cost column indicates the price for the cluster based on the
+    type of resources being used and the duration of use up until now. This
+    means if the cluster is UP, successive calls to cost-report will show
+    increasing price.
+
+    The estimated cost is calculated based on the local cache of the cluster
+    status, and may not be accurate for:
+
+      - clusters with autostop/use_spot set; or
+
+      - clusters that were terminated/stopped on the cloud console.
+
     Returns:
         Number of pending auto{stop,down} clusters.
     """


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes
- Changed the ordering of commands shown in `sky / sky -h`
- Wording / correctness fixes
- Formatting fixes

With this PR, `sky` shows
```
Commands:
  check        Check what clouds are available to use.
  launch       Launch a task from a YAML or a command (rerun setup if...
  exec         Execute a task or a command on a cluster (skip setup).
  stop         Stop cluster(s).
  autostop     Schedule an autostop or autodown for cluster(s).
  start        Restart cluster(s).
  down         Tear down cluster(s).
  status       Show clusters.
  queue        Show the job queue for cluster(s).
  logs         Tail the log of a job.
  cancel       Cancel job(s).
  show-gpus    Show supported GPU/TPU/accelerators and their prices.
  cost-report  Show estimated costs for launched clusters.
  spot         Managed Spot commands (spot instances with auto-recovery).
  gpunode      Launch or attach to an interactive GPU node.
  cpunode      Launch or attach to an interactive CPU node.
  tpunode      Launch or attach to an interactive TPU node.
  storage      SkyPilot Storage CLI.
  admin        SkyPilot On-prem administrator CLI.
  bench        SkyPilot Benchmark CLI.
```
which roughly matches https://skypilot.readthedocs.io/en/latest/reference/cli.html.

TODO in future PRs
- [ ] add section titles to these commands
- [ ] fix `launch` & `exec`'s help str displayed above

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - `sky <cmd> -h` for each command
  - rendered docs locally and checked formatting
