### PR TITLE
Allow --cpus for existing clusters

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -400,6 +400,14 @@ _EXTRA_RESOURCES_OPTIONS = [
               '"resources.instance_type" config. Passing "none" resets the '
               'config.'),
     ),
+    click.option(
+        '--cpus',
+        default=None,
+        type=str,
+        required=False,
+        help=('Number of vCPUs each instance must have (e.g., '
+              '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
+              'This is used to automatically select the instance type.')),
 ]
 
 
@@ -1106,13 +1114,6 @@ def cli():
               default=False,
               help='If used, runs locally inside a docker container.')
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
-@click.option('--cpus',
-              default=None,
-              type=str,
-              required=False,
-              help=('Number of vCPUs each instance must have (e.g., '
-                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
-                    'This is used to automatically select the instance type.'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -1284,6 +1285,7 @@ def exec(
     zone: Optional[str],
     workdir: Optional[str],
     gpus: Optional[str],
+    cpus: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1368,7 +1370,7 @@ def exec(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpus=None,
+        cpus=cpus,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -3016,13 +3018,6 @@ def spot():
                 **_get_shell_complete_args(_complete_file_name))
 # TODO(zhwu): Add --dryrun option to test the launch command.
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
-@click.option('--cpus',
-              default=None,
-              type=str,
-              required=False,
-              help=('Number of vCPUs each instance must have (e.g., '
-                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
-                    'This is used to automatically select the instance type.'))
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -400,14 +400,6 @@ _EXTRA_RESOURCES_OPTIONS = [
               '"resources.instance_type" config. Passing "none" resets the '
               'config.'),
     ),
-    click.option(
-        '--cpus',
-        default=None,
-        type=str,
-        required=False,
-        help=('Number of vCPUs each instance must have (e.g., '
-              '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
-              'This is used to automatically select the instance type.')),
 ]
 
 
@@ -1114,6 +1106,13 @@ def cli():
               default=False,
               help='If used, runs locally inside a docker container.')
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
+@click.option('--cpus',
+              default=None,
+              type=str,
+              required=False,
+              help=('Number of vCPUs each instance must have (e.g., '
+                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
+                    'This is used to automatically select the instance type.'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -1285,7 +1284,6 @@ def exec(
     zone: Optional[str],
     workdir: Optional[str],
     gpus: Optional[str],
-    cpus: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1370,7 +1368,7 @@ def exec(
         region=region,
         zone=zone,
         gpus=gpus,
-        cpus=cpus,
+        cpus=None,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -3018,6 +3016,13 @@ def spot():
                 **_get_shell_complete_args(_complete_file_name))
 # TODO(zhwu): Add --dryrun option to test the launch command.
 @_add_click_options(_TASK_OPTIONS + _EXTRA_RESOURCES_OPTIONS)
+@click.option('--cpus',
+              default=None,
+              type=str,
+              required=False,
+              help=('Number of vCPUs each instance must have (e.g., '
+                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
+                    'This is used to automatically select the instance type.'))
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -177,15 +177,8 @@ def _execute(
         existing_handle = global_user_state.get_handle_from_cluster_name(
             cluster_name)
         cluster_exists = existing_handle is not None
-    if cluster_exists:
-        assert len(task.resources) == 1
-        task_resources = list(task.resources)[0]
-        if task_resources.cpus is not None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cannot specify CPU when using an existing cluster. '
-                    'CPU is only used for selecting the instance type when '
-                    'creating a new cluster.')
+        # TODO(woosuk): If the cluster exists, print a warning that
+        # `cpus` is not used as a job scheduling constraint, unlike `gpus`.
 
     stages = stages if stages is not None else list(Stage)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1672 

This PR allows specifying CPU requirements in re-launching (or executing a job on) an existing cluster (i.e., `sky launch -c existing-cluster --cpus x` and `sky exec existing-cluster --cpus x`). Note that in both cases the specified `cpus` will just be silently ignored. That is, 1) we do not check if the CPU requirement is valid, and 2) in `sky exec`, the specified number of CPUs will not work as a scheduling constraint.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

* `sky launch 'echo hi' --cpus 8 -c test-cpus`
* `sky launch 'echo hihi' --cpus 100 -c test-cpus`
* `sky exec test-cpus 'echo hihihi' --cpus 9999`
