### PR TITLE
[core] Launching existing cluster in the same zone to avoid leakage

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -117,7 +117,9 @@ _REMOTE_RUNTIME_FILES_DIR = '~/.sky/.runtime_files'
 _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
     'cluster_name', 'provider', 'auth', 'node_config'
 }
-_RAY_YAML_KEYS_TO_RESTORE_EXCLUDE_FOR_BACK_COMPATIBILITY = [['provider', 'availability_zone']]
+_RAY_YAML_KEYS_TO_RESTORE_EXCLUDE_FOR_BACK_COMPATIBILITY = [[
+    'provider', 'availability_zone'
+]]
 
 
 def is_ip(s: str) -> bool:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -117,9 +117,7 @@ _REMOTE_RUNTIME_FILES_DIR = '~/.sky/.runtime_files'
 _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
     'cluster_name', 'provider', 'auth', 'node_config'
 }
-_RAY_YAML_KEYS_TO_RESTORE_EXCLUDE_FOR_BACK_COMPATIBILITY = [[
-    'provider', 'region'
-], ['provider', 'availability_zone'], ['provider', 'location']]
+_RAY_YAML_KEYS_TO_RESTORE_EXCLUDE_FOR_BACK_COMPATIBILITY = [['provider', 'availability_zone']]
 
 
 def is_ip(s: str) -> bool:
@@ -698,7 +696,7 @@ class SSHConfigHelper(object):
 
 def _replace_yaml_dicts(new_yaml: str, old_yaml: str,
                         restore_key_names: Set[str],
-                        exclude_restore_key_names: Set[List[str]]) -> str:
+                        exclude_restore_key_names: List[List[str]]) -> str:
     """Replaces 'new' with 'old' for all keys in key_names.
 
     The replacement will be applied recursively and only for the blocks
@@ -719,7 +717,7 @@ def _replace_yaml_dicts(new_yaml: str, old_yaml: str,
 
     new_config = yaml.safe_load(new_yaml)
     old_config = yaml.safe_load(old_yaml)
-    exlucded_results = {}
+    excluded_results = {}
     # Find all key values excluded from restore
     for exclude_restore_key_name_list in exclude_restore_key_names:
         excluded_result = new_config
@@ -731,14 +729,14 @@ def _replace_yaml_dicts(new_yaml: str, old_yaml: str,
                 break
             excluded_result = excluded_result[key]
         if found_excluded_key:
-            exlucded_results[json.dumps(
+            excluded_results[json.dumps(
                 exclude_restore_key_name_list)] = excluded_result
 
     # Restore from old config
     _restore_block(new_config, old_config)
 
     # Revert the changes for the excluded key values
-    for exclude_restore_key_name_list, value in exlucded_results.items():
+    for exclude_restore_key_name_list, value in excluded_results.items():
         exclude_restore_key_name_list = json.loads(
             exclude_restore_key_name_list)
         curr = new_config

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -119,7 +119,7 @@ _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
 }
 _RAY_YAML_KEYS_TO_RESTORE_EXCLUDE_FOR_BACK_COMPATIBILITY = [[
     'provider', 'region'
-], ['provider, availability_zone'], ['provider', 'location']]
+], ['provider', 'availability_zone'], ['provider', 'location']]
 
 
 def is_ip(s: str) -> bool:
@@ -725,8 +725,8 @@ def _replace_yaml_dicts(new_yaml: str, old_yaml: str,
         excluded_result = new_config
         found_excluded_key = True
         for key in exclude_restore_key_name_list:
-            if not isinstance(excluded_result,
-                              dict) or key not in excluded_result:
+            if (not isinstance(excluded_result, dict) or
+                    key not in excluded_result):
                 found_excluded_key = False
                 break
             excluded_result = excluded_result[key]

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2141,7 +2141,6 @@ class CloudVmRayBackend(backends.Backend):
                 to_provision,
                 task.num_nodes,
                 previous_cluster_status=None)
-            prev_cluster_status = None
             if not dryrun:  # dry run doesn't need to check existing cluster.
                 # Try to launch the exiting cluster first
                 to_provision_config = self._check_existing_cluster(
@@ -2149,6 +2148,7 @@ class CloudVmRayBackend(backends.Backend):
             assert to_provision_config.resources is not None, (
                 'to_provision should not be None', to_provision_config)
 
+            prev_cluster_status = to_provision_config.previous_cluster_status
             usage_lib.messages.usage.update_cluster_resources(
                 to_provision_config.num_nodes, to_provision_config.resources)
             usage_lib.messages.usage.update_cluster_status(prev_cluster_status)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -731,14 +731,16 @@ class RetryingVmProvisioner(object):
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError('Errors occurred during provision; '
                                    'check logs above.')
-        if region.zones is None:
-            logger.warning(f'Got error(s) in {region.name}:')
-        if set(zones) == set(region.zones):
+
+        zones_str = ', '.join(z.name for z in zones)
+        if len(zones) > 1:
+            # Multiple zones means the upper-level retry loop is trying the
+            # whole region, so we should print the region name.
             # The underlying AWS NodeProvider will try all specified zones of a
             # region. (Each boto3 request takes one zone.)
-            logger.warning(f'Got error(s) in all zones of {region.name}:')
+            logger.warning(
+                f'Got error(s) in all zones of {region.name} ({zones_str}):')
         else:
-            zones_str = ', '.join(z.name for z in zones)
             logger.warning(f'Got error(s) in {zones_str}:')
         messages = '\n\t'.join(errors)
         logger.warning(f'{style.DIM}\t{messages}{style.RESET_ALL}')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2227,10 +2227,11 @@ class CloudVmRayBackend(backends.Backend):
                         ip_list, **ssh_credentials)
 
                     def _get_zone(runner):
-                        returncode, stdout, stderr = runner.run(get_zone_cmd)
+                        returncode, stdout, stderr = runner.run(
+                            get_zone_cmd, require_outputs=True)
                         subprocess_utils.handle_returncode(
                             returncode,
-                            cmd,
+                            get_zone_cmd,
                             'Failed to get zone for ',
                             stderr=stderr,
                             stream_logs=stream_logs)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -554,18 +554,15 @@ class RetryingVmProvisioner(object):
     class ToProvisionConfig:
         """Resources to be provisioned."""
 
-        def __init__(self,
-                     cluster_name: str,
+        def __init__(self, cluster_name: str,
                      resources: Optional[resources_lib.Resources],
                      num_nodes: int,
-                     cluster_exists: bool = False) -> None:
+                     prev_status: global_user_state.ClusterStatus) -> None:
             assert cluster_name is not None, 'cluster_name must be specified.'
             self.cluster_name = cluster_name
             self.resources = resources
             self.num_nodes = num_nodes
-            # Whether the cluster exists in the clusters table. It may be
-            # actually live or down.
-            self.cluster_exists = cluster_exists
+            self.prev_status = prev_status
 
     class GangSchedulingStatus(enum.Enum):
         """Enum for gang scheduling status."""
@@ -912,59 +909,35 @@ class RetryingVmProvisioner(object):
 
         return definitely_no_nodes_launched
 
-    def _yield_region_zones(self, to_provision: resources_lib.Resources,
-                            cluster_name: str, cluster_exists: bool):
+    def _yield_zones(self, to_provision: resources_lib.Resources,
+                     num_nodes: int, cluster_name: str):
+        assert (to_provision.cloud is not None and
+                to_provision.region is not None), (
+                    to_provision,
+                    'cloud and region must have been set by optimizer')
         cloud = to_provision.cloud
-        region = None
+        region = to_provision.region
         zones = None
         # Try loading previously launched region/zones and try them first,
         # because we may have an existing cluster there.
         # Get the *previous* cluster status and handle.
         cluster_status, handle = backend_utils.refresh_cluster_status_handle(
             cluster_name, acquire_per_cluster_status_lock=False)
-        if handle is not None:
-            try:
-                config = common_utils.read_yaml(handle.cluster_yaml)
-                prev_resources = handle.launched_resources
-                if prev_resources is not None and cloud.is_same_cloud(
-                        prev_resources.cloud):
-                    if cloud.is_same_cloud(clouds.GCP()) or cloud.is_same_cloud(
-                            clouds.AWS()):
-                        region = config['provider']['region']
-                        zones = config['provider']['availability_zone']
-                    elif cloud.is_same_cloud(clouds.Azure()):
-                        region = config['provider']['location']
-                        zones = None
-                    elif cloud.is_same_cloud(clouds.Lambda()):
-                        region = config['provider']['region']
-                        zones = None
-                    elif cloud.is_same_cloud(clouds.Local()):
-                        local_regions = clouds.Local.regions()
-                        region = local_regions[0].name
-                        zones = None
-                    else:
-                        assert False, cloud
-                    assert region == prev_resources.region, (
-                        f'Region mismatch. The region in '
-                        f'{handle.cluster_yaml} '
-                        'has been changed from '
-                        f'{prev_resources.region} to {region}.')
-                    assert (zones is None or prev_resources.zone is None or
-                            prev_resources.zone
-                            in zones), (f'{prev_resources.zone} not found in '
-                                        f'zones of {handle.cluster_yaml}.')
-                    # Note that we don't overwrite the zone field in Ray YAML
-                    # even if prev_resources.zone != zones.
-                    # This is because Ray will consider the YAML hash changed
-                    # and not reuse the existing cluster.
-            except FileNotFoundError:
-                # Happens if no previous cluster.yaml exists.
-                pass
+        if cluster_status is not None:
+            # When the cluster exists, the to_provision should have been set
+            # to the previous cluster's resources.
+            zones = [clouds.Zone(name=to_provision.zone)
+                    ] if to_provision.zone is not None else None
+            # Reuse the zone field in the ray yaml as the prev_resources.zone
+            # field may not be set before the previous cluster is launched.
+            config = common_utils.read_yaml(handle.cluster_yaml)
+            if (cloud.is_same_cloud(clouds.GCP()) or
+                    cloud.is_same_cloud(clouds.AWS()) and zones is None):
+                zones = config['provider']['availability_zone']
+                zones = [clouds.Zone(name=zone) for zone in zones.split(',')]
 
-        if region is not None and cluster_exists:
             region = clouds.Region(name=region)
             if zones is not None:
-                zones = [clouds.Zone(name=zone) for zone in zones.split(',')]
                 region.set_zones(zones)
 
             if cluster_status != global_user_state.ClusterStatus.UP:
@@ -972,16 +945,10 @@ class RetryingVmProvisioner(object):
                     f'Cluster {cluster_name!r} (status: {cluster_status.value})'
                     f' was previously launched in {cloud} '
                     f'({region.name}). Relaunching in that region.')
-            # This should be handled in the check_resources_match function.
-            assert (to_provision.region is None or
-                    region.name == to_provision.region), (
-                        f'Cluster {cluster_name!r} was previously launched in '
-                        f'{cloud} ({region.name}). It does not match the '
-                        f'required region {to_provision.region}.')
             # TODO(zhwu): The cluster being killed by cloud provider should
             # be tested whether re-launching a cluster killed spot instance
             # will recover the data.
-            yield (region, zones)  # Ok to yield again in the next loop.
+            yield zones
 
             # Cluster with status UP can reach here, if it was killed by the
             # cloud provider and no available resources in that region to
@@ -1044,19 +1011,31 @@ class RetryingVmProvisioner(object):
             # cloud/region and with current resources.
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(message)
-
-        for region, zones in cloud.region_zones_provision_loop(
-                instance_type=to_provision.instance_type,
-                accelerators=to_provision.accelerators,
-                use_spot=to_provision.use_spot,
-        ):
-            # Only retry requested region/zones or all if not specified.
-            zone_names = [zone.name for zone in zones]
-            if not to_provision.valid_on_region_zones(region.name, zone_names):
-                continue
-            if to_provision.zone is not None:
-                zones = [clouds.Zone(name=to_provision.zone)]
-            yield (region, zones)
+        else:
+            # When the cluster exists, all possible region/zones based on the
+            # to_provision should have been tried. If it reaches here, it
+            # means the cluster does not exist.
+            for region, zones in cloud.region_zones_provision_loop(
+                    instance_type=to_provision.instance_type,
+                    accelerators=to_provision.accelerators,
+                    use_spot=to_provision.use_spot,
+                    region=to_provision.region,
+            ):
+                # Only retry requested region/zones or all if not specified.
+                zone_names = [zone.name for zone in zones]
+                if not to_provision.valid_on_region_zones(
+                        region.name, zone_names):
+                    continue
+                if to_provision.zone is not None:
+                    zones = [clouds.Zone(name=to_provision.zone)]
+                if num_nodes > 1:
+                    # When num_nodes > 1, we need to try the zones one by one,
+                    # to avoid the nodes of a same cluster being placed in
+                    # different zones. (This is a limitation of ray up)
+                    for zone in zones:
+                        yield [zone]
+                else:
+                    yield zones
 
     def _try_provision_tpu(self, to_provision: resources_lib.Resources,
                            config_dict: Dict[str, str]) -> bool:
@@ -1110,7 +1089,7 @@ class RetryingVmProvisioner(object):
             logger.error(stderr)
             raise e
 
-    def _retry_region_zones(
+    def _retry_zones(
         self,
         to_provision: resources_lib.Resources,
         num_nodes: int,
@@ -1119,7 +1098,7 @@ class RetryingVmProvisioner(object):
         stream_logs: bool,
         cluster_name: str,
         cloud_user_identity: str,
-        cluster_exists: bool = False,
+        prev_cluster_status: Optional[global_user_state.ClusterStatus],
     ):
         """The provision retry loop."""
         style = colorama.Style
@@ -1132,16 +1111,17 @@ class RetryingVmProvisioner(object):
                     f'{style.BRIGHT}{tail_cmd}{style.RESET_ALL}')
 
         # Get previous cluster status
-        prev_cluster_status = backend_utils.refresh_cluster_status_handle(
-            cluster_name, acquire_per_cluster_status_lock=False)[0]
+        cluster_exists = prev_cluster_status is not None
         is_prev_cluster_healthy = prev_cluster_status in [
             global_user_state.ClusterStatus.STOPPED,
             global_user_state.ClusterStatus.UP
         ]
 
-        for region, zones in self._yield_region_zones(to_provision,
-                                                      cluster_name,
-                                                      cluster_exists):
+        assert to_provision.region is not None, (
+            to_provision, 'region should have been set by the optimizer.')
+        region = clouds.Region(to_provision.region)
+
+        for zones in self._yield_zones(to_provision, num_nodes, cluster_name):
             # Filter out zones that are blocked, if any.
             # This optimize the provision loop by skipping zones that are
             # indicated to be unavailable from previous provision attempts.
@@ -1664,7 +1644,7 @@ class RetryingVmProvisioner(object):
         cluster_name = to_provision_config.cluster_name
         to_provision = to_provision_config.resources
         num_nodes = to_provision_config.num_nodes
-        cluster_exists = to_provision_config.cluster_exists
+        prev_cluster_status = to_provision_config.prev_status
         launchable_retries_disabled = (self._dag is None or
                                        self._optimize_target is None)
 
@@ -1685,7 +1665,7 @@ class RetryingVmProvisioner(object):
                 to_provision.cloud.check_features_are_supported(
                     self._requested_features)
 
-                config_dict = self._retry_region_zones(
+                config_dict = self._retry_zones(
                     to_provision,
                     num_nodes,
                     requested_resources=task.resources,
@@ -1693,7 +1673,7 @@ class RetryingVmProvisioner(object):
                     stream_logs=stream_logs,
                     cluster_name=cluster_name,
                     cloud_user_identity=cloud_user,
-                    cluster_exists=cluster_exists)
+                    prev_cluster_status=prev_cluster_status)
                 if dryrun:
                     return
             except (exceptions.InvalidClusterNameError,
@@ -1732,11 +1712,14 @@ class RetryingVmProvisioner(object):
             logger.warning(f'\n{style.BRIGHT}Provision failed for {num_nodes}x '
                            f'{to_provision} in {region_or_zone_str}. '
                            f'Trying other locations (if any).{style.RESET_ALL}')
-            if not cluster_exists:
+            if prev_cluster_status is None:
                 # Add failed resources to the blocklist, only when it
                 # is in fallback mode.
                 self._blocked_resources.add(to_provision)
-            else:
+            elif (global_user_state.get_handle_from_cluster_name(cluster_name)
+                  is None and num_nodes != task.num_nodes):
+                # If reached here, it means that the existing cluster should
+                # have been removed.
                 logger.info('Retrying provisioning with requested resources '
                             f'{task.num_nodes}x {task.resources}')
                 # Retry with the current, potentially "smaller" resources:
@@ -1745,7 +1728,7 @@ class RetryingVmProvisioner(object):
                 # num_nodes is not part of a Resources so must be updated
                 # separately.
                 num_nodes = task.num_nodes
-                cluster_exists = False
+                prev_cluster_status = None
 
             # Set to None so that sky.optimize() will assign a new one
             # (otherwise will skip re-optimizing this task).
@@ -2114,6 +2097,7 @@ class CloudVmRayBackend(backends.Backend):
                 will be set as at least 1 exception from either our pre-checks
                 (e.g., cluster name invalid) or a region/zone throwing
                 resource unavailability.
+            exceptions.CommandError: any ssh command error.
         """
         # FIXME: ray up for Azure with different cluster_names will overwrite
         # each other.
@@ -2124,15 +2108,12 @@ class CloudVmRayBackend(backends.Backend):
             backend_utils.CLUSTER_STATUS_LOCK_PATH.format(cluster_name))
         with timeline.FileLockEvent(lock_path):
             to_provision_config = RetryingVmProvisioner.ToProvisionConfig(
-                cluster_name, to_provision, task.num_nodes)
+                cluster_name, to_provision, task.num_nodes, prev_status=None)
             prev_cluster_status = None
             if not dryrun:  # dry run doesn't need to check existing cluster.
                 # Try to launch the exiting cluster first
                 to_provision_config = self._check_existing_cluster(
                     task, to_provision, cluster_name)
-                prev_cluster_status, _ = (
-                    backend_utils.refresh_cluster_status_handle(
-                        cluster_name, acquire_per_cluster_status_lock=False))
             assert to_provision_config.resources is not None, (
                 'to_provision should not be None', to_provision_config)
 
@@ -2236,26 +2217,31 @@ class CloudVmRayBackend(backends.Backend):
                 # provisioning), then we know the exact zone already.
                 handle.launched_resources = handle.launched_resources.copy(
                     zone=zones[0].name)
-            elif (task.num_nodes == 1 or
-                  handle.launched_resources.zone is not None):
-                # Query zone if the cluster has 1 node, or a zone is
-                # specifically requested for a multinode cluster.  Otherwise
-                # leave the zone field to None because head and worker nodes
-                # can be launched in different zones.
+            else:
                 get_zone_cmd = (
                     handle.launched_resources.cloud.get_zone_shell_cmd())
                 if get_zone_cmd is not None:
-                    returncode, stdout, stderr = self.run_on_head(
-                        handle, get_zone_cmd, require_outputs=True)
-                    subprocess_utils.handle_returncode(returncode,
-                                                       get_zone_cmd,
-                                                       'Failed to get zone',
-                                                       stderr=stderr,
-                                                       stream_logs=stream_logs)
-                    # zone will be checked during Resources cls
-                    # initialization.
-                    handle.launched_resources = handle.launched_resources.copy(
-                        zone=stdout.strip())
+                    ssh_credentials = backend_utils.ssh_credential_from_yaml(
+                        handle.cluster_yaml)
+                    runners = command_runner.SSHCommandRunner.make_runner_list(
+                        ip_list, **ssh_credentials)
+
+                    def _get_zone(runner):
+                        returncode, stdout, stderr = runner.run(get_zone_cmd)
+                        subprocess_utils.handle_returncode(
+                            returncode,
+                            cmd,
+                            'Failed to get zone for ',
+                            stderr=stderr,
+                            stream_logs=stream_logs)
+                        return stdout.strip()
+
+                    zones = subprocess_utils.run_in_parallel(_get_zone, runners)
+                    if len(set(zones)) == 1:
+                        # zone will be checked during Resources cls
+                        # initialization.
+                        handle.launched_resources = (
+                            handle.launched_resources.copy(zone=zones[0]))
 
             usage_lib.messages.usage.update_cluster_resources(
                 handle.launched_nodes, handle.launched_resources)
@@ -3214,8 +3200,11 @@ class CloudVmRayBackend(backends.Backend):
     def _check_existing_cluster(
             self, task: task_lib.Task, to_provision: resources_lib.Resources,
             cluster_name: str) -> RetryingVmProvisioner.ToProvisionConfig:
-        handle = global_user_state.get_handle_from_cluster_name(cluster_name)
-        if handle is not None:
+        prev_cluster_status, handle = (
+            backend_utils.refresh_cluster_status_handle(
+                cluster_name, acquire_per_cluster_status_lock=False))
+        if prev_cluster_status is not None:
+            assert handle is not None
             # Cluster already exists.
             self.check_resources_fit_cluster(handle, task)
             # Use the existing cluster.
@@ -3224,7 +3213,7 @@ class CloudVmRayBackend(backends.Backend):
                 cluster_name,
                 handle.launched_resources,
                 handle.launched_nodes,
-                cluster_exists=True)
+                prev_status=prev_cluster_status)
         usage_lib.messages.usage.set_new_cluster()
         assert len(task.resources) == 1, task.resources
         # Use the task_cloud, because the cloud in `to_provision` can be changed
@@ -3253,7 +3242,8 @@ class CloudVmRayBackend(backends.Backend):
                 'Run `sky status` to see existing clusters.')
         return RetryingVmProvisioner.ToProvisionConfig(cluster_name,
                                                        to_provision,
-                                                       task.num_nodes)
+                                                       task.num_nodes,
+                                                       prev_status=None)
 
     def _set_tpu_name(self, handle: ResourceHandle, tpu_name: str) -> None:
         """Sets TPU_NAME on all nodes."""

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -732,7 +732,7 @@ class RetryingVmProvisioner(object):
                 raise RuntimeError('Errors occurred during provision; '
                                    'check logs above.')
         if region.zones is None:
-            logger.warning(f'Got error(s) in {region.name}:') 
+            logger.warning(f'Got error(s) in {region.name}:')
         if set(zones) == set(region.zones):
             # The underlying AWS NodeProvider will try all specified zones of a
             # region. (Each boto3 request takes one zone.)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -733,7 +733,6 @@ class RetryingVmProvisioner(object):
                 raise RuntimeError('Errors occurred during provision; '
                                    'check logs above.')
 
-        zones_str = ', '.join(z.name for z in zones)
         regions_with_zones = clouds.AWS.regions_with_offering(
             launchable_resources.instance_type,
             launchable_resources.accelerators,
@@ -747,6 +746,7 @@ class RetryingVmProvisioner(object):
             # region. (Each boto3 request takes one zone.)
             logger.warning(f'Got error(s) in all zones of {region.name}:')
         else:
+            zones_str = ', '.join(z.name for z in zones)
             logger.warning(f'Got error(s) in {zones_str}:')
         messages = '\n\t'.join(errors)
         logger.warning(f'{style.DIM}\t{messages}{style.RESET_ALL}')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -733,14 +733,15 @@ class RetryingVmProvisioner(object):
                 raise RuntimeError('Errors occurred during provision; '
                                    'check logs above.')
 
-        regions_with_zones = clouds.AWS.regions_with_offering(
+        # Fill in the zones field in the Region.
+        region_with_zones_list = clouds.AWS.regions_with_offering(
             launchable_resources.instance_type,
             launchable_resources.accelerators,
             launchable_resources.use_spot,
             region.name,
             zone=None)
-        assert len(regions_with_zones) == 1, regions_with_zones
-        region_with_zones = regions_with_zones[0]
+        assert len(region_with_zones_list) == 1, region_with_zones_list
+        region_with_zones = region_with_zones_list[0]
         if set(zones) == set(region_with_zones.zones):
             # The underlying AWS NodeProvider will try all specified zones of a
             # region. (Each boto3 request takes one zone.)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -946,7 +946,7 @@ class RetryingVmProvisioner(object):
                 # cluster is launched.
                 handle = global_user_state.get_handle_from_cluster_name(
                     cluster_name)
-                assert handle is not None, cluster_name
+                assert handle is not None, f'handle should not be None {cluster_name}'
                 config = common_utils.read_yaml(handle.cluster_yaml)
                 # This is for the case when the zone field is not set in the
                 # launched resources in a previous launch (e.g., ctrl-c during
@@ -1756,7 +1756,7 @@ class RetryingVmProvisioner(object):
                 # num_nodes is not part of a Resources so must be updated
                 # separately.
                 num_nodes = task.num_nodes
-                prev_cluster_status = None
+            prev_cluster_status = None
 
             # Set to None so that sky.optimize() will assign a new one
             # (otherwise will skip re-optimizing this task).

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -946,7 +946,8 @@ class RetryingVmProvisioner(object):
                 # cluster is launched.
                 handle = global_user_state.get_handle_from_cluster_name(
                     cluster_name)
-                assert handle is not None, f'handle should not be None {cluster_name}'
+                assert handle is not None, (
+                    f'handle should not be None {cluster_name!r}')
                 config = common_utils.read_yaml(handle.cluster_yaml)
                 # This is for the case when the zone field is not set in the
                 # launched resources in a previous launch (e.g., ctrl-c during

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -154,14 +154,12 @@ class AWS(clouds.Cloud):
     ) -> Iterator[Optional[List[clouds.Zone]]]:
         # AWS provisioner can handle batched requests, so yield all zones under
         # each region.
-        print(instance_type)
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
-            print(r.zones)
             yield r.zones
 
     @classmethod

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -154,12 +154,14 @@ class AWS(clouds.Cloud):
     ) -> Iterator[Optional[List[clouds.Zone]]]:
         # AWS provisioner can handle batched requests, so yield all zones under
         # each region.
+        print(instance_type)
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
+            print(r.zones)
             yield r.zones
 
     @classmethod

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -150,16 +150,17 @@ class AWS(clouds.Cloud):
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
         # AWS provisioner can handle batched requests, so yield all zones under
         # each region.
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
-                                            region=None,
+                                            region=region,
                                             zone=None)
-        for region in regions:
-            yield region, region.zones
+        for r in regions:
+            yield r, r.zones
 
     @classmethod
     def _get_default_ami(cls, region_name: str, instance_type: str) -> str:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -163,9 +163,10 @@ class AWS(clouds.Cloud):
         for r in regions:
             assert r.zones is not None, r
             if num_nodes > 1:
-                # When num_nodes > 1, we need to try the zones one by
-                # one, to avoid the nodes of a same cluster being
-                # placed in different zones.
+                # When num_nodes > 1, we shouldn't pass a list of zones to the
+                # AWS NodeProvider to try, because it may then place the nodes of
+                # the same cluster in different zones. This is an artifact of the
+                # current AWS NodeProvider implementation.
                 for z in r.zones:
                     yield [z]
             else:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -144,14 +144,14 @@ class AWS(clouds.Cloud):
         return regions
 
     @classmethod
-    def region_zones_provision_loop(
+    def zones_provision_loop(
         cls,
         *,
+        region: str,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-        region: Optional[str] = None,
-    ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         # AWS provisioner can handle batched requests, so yield all zones under
         # each region.
         regions = cls.regions_with_offering(instance_type,
@@ -160,7 +160,7 @@ class AWS(clouds.Cloud):
                                             region=region,
                                             zone=None)
         for r in regions:
-            yield r, r.zones
+            yield r.zones
 
     @classmethod
     def _get_default_ami(cls, region_name: str, instance_type: str) -> str:
@@ -324,9 +324,7 @@ class AWS(clouds.Cloud):
                 'Set either both or neither for: region, zones.')
             region = self._get_default_region()
             zones = region.zones
-        else:
-            assert zones is not None, (
-                'Set either both or neither for: region, zones.')
+        assert zones is not None, (region, zones)
 
         region_name = region.name
         zone_names = [zone.name for zone in zones]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -190,16 +190,19 @@ class Azure(clouds.Cloud):
         cls,
         *,
         region: str,
+        num_nodes: int,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-    ) -> Iterator[Optional[List[clouds.Zone]]]:
+    ) -> Iterator[None]:
+        del num_nodes  # unused
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
+            assert r.zones is None, r
             yield r.zones
 
     # TODO: factor the following three methods, as they are the same logic

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -173,6 +173,7 @@ class Azure(clouds.Cloud):
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
+        assert zone is None, 'Azure does not support zones'
         if instance_type is None:
             # Fall back to default regions
             regions = cls.regions()
@@ -182,28 +183,24 @@ class Azure(clouds.Cloud):
 
         if region is not None:
             regions = [r for r in regions if r.name == region]
-        if zone is not None:
-            for r in regions:
-                r.set_zones([z for z in r.zones if z.name == zone])
-            regions = [r for r in regions if r.zones]
         return regions
 
     @classmethod
-    def region_zones_provision_loop(
+    def zones_provision_loop(
         cls,
         *,
+        region: str,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-        region: Optional[str] = None,
-    ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
-            yield r, r.zones
+            yield r.zones
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -195,14 +195,15 @@ class Azure(clouds.Cloud):
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
-                                            region=None,
+                                            region=region,
                                             zone=None)
-        for region in regions:
-            yield region, region.zones
+        for r in regions:
+            yield r, r.zones
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -130,6 +130,7 @@ class Cloud:
         cls,
         *,
         region: str,
+        num_nodes: int,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
@@ -139,13 +140,13 @@ class Cloud:
         Certain clouds' provisioners may handle batched requests, retrying for
         itself a list of zones under a region.  Others may need a specific zone
         per provision request (in that case, yields a one-element list for each
-        zone.
-
+        zone).
         Optionally, caller can filter the yielded region/zones by specifying the
         instance_type, accelerators, and use_spot.
 
         Args:
             region: The region to provision.
+            num_nodes: The number of nodes to provision.
             instance_type: The instance type to provision.
             accelerators: The accelerators to provision.
             use_spot: Whether to use spot instances.
@@ -169,11 +170,15 @@ class Cloud:
                                            instance_type='existing-instance'):
                     assert zone is None
                 ```
+            This means if something is yielded, either it's None (zones are not
+            supported and the region offers the resources) or it's a non-empty
+            list (zones are supported and they offer the resources).
 
         Typical usage:
 
             for zones in cloud.region_zones_provision_loop(
                 region,
+                num_nodes,
                 instance_type,
                 accelerators,
                 use_spot

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -132,6 +132,7 @@ class Cloud:
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[Region, List[Zone]]]:
         """Loops over (region, zones) to retry for provisioning.
 
@@ -146,6 +147,7 @@ class Cloud:
             instance_type: The instance type to provision.
             accelerators: The accelerators to provision.
             use_spot: Whether to use spot instances.
+            region: The region to provision.
 
         Typical usage:
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -138,8 +138,9 @@ class Cloud:
 
         Certain clouds' provisioners may handle batched requests, retrying for
         itself a list of zones under a region.  Others may need a specific zone
-        per provision request (in that case, yields (region, a one-element list
-        for each zone)).
+        per provision request (in that case, yields a one-element list for each
+        zone.
+
         Optionally, caller can filter the yielded region/zones by specifying the
         instance_type, accelerators, and use_spot.
 
@@ -150,14 +151,29 @@ class Cloud:
             use_spot: Whether to use spot instances.
 
         Yields:
-            A list of zones to provision in the given region, in the order of
-            price. If there is no zone that offers the specified resources,
-            nothing is yielded;
-            If the cloud does not support `Zone`s, None will be yielded.
-
+            A list of zones that offer the requested resources in the given
+            region, in the order of price.
+            (1) If there is no zone that offers the specified resources, nothing
+                is yielded. For example, Azure does not support zone, and calling
+                this method with non-existing instance_type in the given region,
+                will yield nothing, i.e. raise StopIteration.
+                ```
+                for zone in Azure.zones_provision_loop(region=region,
+                                           instance_type='non-existing'):
+                    # Will not reach here.
+                ```
+            (2) If the cloud's provisioner does not support `Zone`s, `None` will
+                be yielded.
+                ```
+                for zone in Azure.zones_provision_loop(region=region,
+                                           instance_type='existing-instance'):
+                    assert zone is None
+                ```
+            
         Typical usage:
 
-            for region, zones in cloud.region_zones_provision_loop(
+            for zones in cloud.region_zones_provision_loop(
+                region,
                 instance_type,
                 accelerators,
                 use_spot

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -154,9 +154,9 @@ class Cloud:
             A list of zones that offer the requested resources in the given
             region, in the order of price.
             (1) If there is no zone that offers the specified resources, nothing
-                is yielded. For example, Azure does not support zone, and calling
-                this method with non-existing instance_type in the given region,
-                will yield nothing, i.e. raise StopIteration.
+                is yielded. For example, Azure does not support zone, and
+                calling this method with non-existing instance_type in the given
+                region, will yield nothing, i.e. raise StopIteration.
                 ```
                 for zone in Azure.zones_provision_loop(region=region,
                                            instance_type='non-existing'):
@@ -169,7 +169,7 @@ class Cloud:
                                            instance_type='existing-instance'):
                     assert zone is None
                 ```
-            
+
         Typical usage:
 
             for zones in cloud.region_zones_provision_loop(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -206,16 +206,17 @@ class GCP(clouds.Cloud):
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
-                                            region=None,
+                                            region=region,
                                             zone=None)
         # GCP provisioner currently takes 1 zone per request.
-        for region in regions:
-            for zone in region.zones:
-                yield (region, [zone])
+        for r in regions:
+            for zone in r.zones:
+                yield (r, [zone])
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -207,10 +207,12 @@ class GCP(clouds.Cloud):
         cls,
         *,
         region: str,
+        num_nodes: int,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-    ) -> Iterator[Optional[List[clouds.Zone]]]:
+    ) -> Iterator[List[clouds.Zone]]:
+        del num_nodes  # Unused.
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -182,6 +182,8 @@ class GCP(clouds.Cloud):
                     for r2 in vm_regions:
                         if r1.name != r2.name:
                             continue
+                        assert r1.zones is not None, r1
+                        assert r2.zones is not None, r2
                         zones = []
                         for z1 in r1.zones:
                             for z2 in r2.zones:
@@ -195,19 +197,20 @@ class GCP(clouds.Cloud):
             regions = [r for r in regions if r.name == region]
         if zone is not None:
             for r in regions:
+                assert r.zones is not None, r
                 r.set_zones([z for z in r.zones if z.name == zone])
             regions = [r for r in regions if r.zones]
         return regions
 
     @classmethod
-    def region_zones_provision_loop(
+    def zones_provision_loop(
         cls,
         *,
+        region: str,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-        region: Optional[str] = None,
-    ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
@@ -215,8 +218,9 @@ class GCP(clouds.Cloud):
                                             zone=None)
         # GCP provisioner currently takes 1 zone per request.
         for r in regions:
+            assert r.zones is not None, r
             for zone in r.zones:
-                yield (r, [zone])
+                yield [zone]
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:
@@ -318,9 +322,7 @@ class GCP(clouds.Cloud):
                 'Set either both or neither for: region, zones.')
             region = self._get_default_region()
             zones = region.zones
-        else:
-            assert zones is not None, (
-                'Set either both or neither for: region, zones.')
+        assert zones is not None, (region, zones)
 
         region_name = region.name
         zone_name = zones[0].name

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -94,14 +94,15 @@ class Lambda(clouds.Cloud):
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
-                                            region=None,
+                                            region=region,
                                             zone=None)
-        for region in regions:
-            yield region, region.zones
+        for r in regions:
+            yield r, r.zones
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -93,16 +93,19 @@ class Lambda(clouds.Cloud):
         cls,
         *,
         region: str,
+        num_nodes: int,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-    ) -> Iterator[Optional[List[clouds.Zone]]]:
+    ) -> Iterator[None]:
+        del num_nodes  # unused
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
+            assert r.zones is None, r
             yield r.zones
 
     def instance_type_to_hourly_cost(self,

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -73,6 +73,7 @@ class Lambda(clouds.Cloud):
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
+        assert zone is None, 'Lambda does not support zones.'
         del accelerators, zone  # unused
         if use_spot:
             return []
@@ -88,21 +89,21 @@ class Lambda(clouds.Cloud):
         return regions
 
     @classmethod
-    def region_zones_provision_loop(
+    def zones_provision_loop(
         cls,
         *,
+        region: str,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-        region: Optional[str] = None,
-    ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
-            yield r, r.zones
+            yield r.zones
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -67,21 +67,21 @@ class Local(clouds.Cloud):
         return cls.regions()
 
     @classmethod
-    def region_zones_provision_loop(
+    def zones_provision_loop(
         cls,
         *,
+        region: str,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-        region: Optional[str] = None,
-    ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot=use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
-            yield r, r.zones
+            yield r.zones
 
     #### Normal methods ####
 

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -71,16 +71,19 @@ class Local(clouds.Cloud):
         cls,
         *,
         region: str,
+        num_nodes: int,
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-    ) -> Iterator[Optional[List[clouds.Zone]]]:
+    ) -> Iterator[None]:
+        del num_nodes  # Unused.
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot=use_spot,
                                             region=region,
                                             zone=None)
         for r in regions:
+            assert r.zones is None, r
             yield r.zones
 
     #### Normal methods ####

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -73,14 +73,15 @@ class Local(clouds.Cloud):
         instance_type: Optional[str] = None,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
+        region: Optional[str] = None,
     ) -> Iterator[Tuple[clouds.Region, List[clouds.Zone]]]:
         regions = cls.regions_with_offering(instance_type,
                                             accelerators,
                                             use_spot=use_spot,
-                                            region=None,
+                                            region=region,
                                             zone=None)
-        for region in regions:
-            yield region, region.zones
+        for r in regions:
+            yield r, r.zones
 
     #### Normal methods ####
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -230,10 +230,10 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df['Region'] = region
         # An instance type may not be available in all zones. We need to
         # merge the zone info to the instance type info.
-        df = df.merge(offering_df, on=['InstanceType'], how='outer')
+        df = df.merge(offering_df, on=['InstanceType'], how='inner')
         # Add the mapping from zone name to zone id, as the zone id is
         # the real identifier for a zone across different users.
-        df = df.merge(zone_df, on=['AvailabilityZoneName'], how='outer')
+        df = df.merge(zone_df, on=['AvailabilityZoneName'], how='inner')
 
         # Add spot price column, by joining the spot pricing table.
         df = df.merge(spot_pricing_df,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -85,6 +85,20 @@ def _get_instance_types(region: str) -> pd.DataFrame:
 
 
 @ray.remote
+def _get_instance_type_offerings(region: str) -> pd.DataFrame:
+    client = aws.client('ec2', region_name=region)
+    paginator = client.get_paginator('describe_instance_type_offerings')
+    items = []
+    for i, resp in enumerate(
+            paginator.paginate(LocationType='availability-zone')):
+        print(f'{region} getting instance type offerings page {i}')
+        items += resp['InstanceTypeOfferings']
+
+    return pd.DataFrame(items).rename(
+        columns={'Location': 'AvailabilityZoneName'})
+
+
+@ray.remote
 def _get_availability_zones(region: str) -> Optional[pd.DataFrame]:
     client = aws.client('ec2', region_name=region)
     zones = []
@@ -164,8 +178,9 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         if zone_df is None:
             raise RuntimeError(f'No access to region {region}')
 
-        df, pricing_df, spot_pricing_df = ray.get([
+        df, offering_df, pricing_df, spot_pricing_df = ray.get([
             _get_instance_types.remote(region),
+            _get_instance_type_offerings.remote(region),
             _get_pricing_table.remote(region),
             _get_spot_pricing_table.remote(region),
         ])
@@ -213,9 +228,12 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         # so we need to merge the two dataframes.
         df = df.merge(pricing_df, on=['InstanceType'], how='outer')
         df['Region'] = region
-        # Cartesian product of instance types and availability zones, so that
-        # we can join the spot pricing table per instance type and zone.
-        df = df.merge(pd.DataFrame(zone_df), how='cross')
+        # An instance type may not be available in all zones. We need to
+        # merge the zone info to the instance type info.
+        df = df.merge(offering_df, on=['InstanceType'], how='outer')
+        # Add the mapping from zone name to zone id, as the zone id is
+        # the real identifier for a zone across different users.
+        df = df.merge(zone_df, on=['AvailabilityZoneName'], how='outer')
 
         # Add spot price column, by joining the spot pricing table.
         df = df.merge(spot_pricing_df,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

1. Fixes #1054
2. Refactors the cloud vm ray backend to make it more efficient.
3. Fix the AWS catalog fetching by excluding availability zones that do not contain the instance type: some instance types are not available on all the availability zones within a region even if it is on-demand (e.g., p4d.24xlarge is only supported in `use1-az1`, `use-az2`, `use-az6`, but our previous catalog fetcher assumed that all the zones contain the instance type).

A potential leakage that may not be solved by this PR:
  1. The user Ctrl-C during the launching process of a new cluster `sky launch -c new-cluster --cloud aws` and the actual node was successfully launched on `us-east-1a`.
  2. The user manually stopped the node on the AWS console
  3. After that, the user do `sky launch -c new-cluster` again, the availability zone `us-east-1a` now has no capacity for the instance, but `us-east-1b` does. 
  5. Since the ray yaml has `us-east-1a, us-east-1b,...` in the section `provider.availability_zone` section, it is possible that ray will keep the original node stopped and create a new one on `us-east-1a`. (need to confirm).

Potential solution:
  1. Fetch zone info directly from cloud provider
  2. Do not combine zones (This only happens for AWS single node) -- let the failover go through the zones one by one
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-on-demand --gpus A100:8 --cloud aws` only try zones that contain the instance type `p4d.24xlarge` (For fix 3 above) and try to launch again during the INIT status
  - [x] `sky launch -c test-spot --gpus A100:8 --use-spot --cloud aws` only try zones that contain the instance type `p4d.24xlarge` (For fix 3 above)
  - [x] `sky launch -c test-spot --cloud aws --use-spot`
  - [x] `sky launch -c test-spot --cloud aws --use-spot` INIT cluster
  - [x] `sky launch -c test-on-demand --cloud aws`
  - [x] `sky launch -c test-on-demand --num-nodes 2 --cloud aws`: failover through single zones.
  - [x] `sky launch -c test-on-demand --cloud aws` INIT cluster
  - [x] `sky launch -c test-on-demand --cloud aws` STOPPED cluster
  - [x] `sky launch -c test-spot --cloud gcp --use-spot`
  - [x] `sky launch -c test-spot --cloud gcp --use-spot` INIT cluster
  - [x] `sky launch -c test-on-demand --num-nodes 2 --cloud gcp`: failover through single zones.
  - [x] `sky launch -c test-spot --cloud azure --use-spot`
  - [x] `sky launch -c test-spot --cloud azure --use-spot` INIT cluster
  - [x] `sky launch -c test-spot --cloud azure --use-spot` STOPPED cluster
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` 
- [x] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh` with GCP
- [x] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh` with AWS
- [x] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh` with Azure
