### PR TITLE
[usage] Change usage logging URL.

### DIFF
--- a/sky/usage/constants.py
+++ b/sky/usage/constants.py
@@ -1,6 +1,6 @@
 """Constants for usage collection."""
 
-LOG_URL = 'http://54.68.242.202:9090/loki/api/v1/push'  # pylint: disable=line-too-long
+LOG_URL = 'http://usage.skypilot.co:9090/loki/api/v1/push'  # pylint: disable=line-too-long
 
 USAGE_MESSAGE_SCHEMA_VERSION = 1
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to easily swap out the logging server and its IP.

Tested that the new URL works.