### PR TITLE
[Logging] Fix logging handling

### DIFF
--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -33,9 +33,10 @@ def init_logger(name: str):
     h.setFormatter(fmt)
 
     logger = logging.getLogger(name)
-    logger.addHandler(h)
     if env_options.Options.SHOW_DEBUG_INFO.get():
-        logger.setLevel(logging.DEBUG)
+        h.setLevel(logging.DEBUG)
     else:
-        logger.setLevel(logging.INFO)
+        h.setLevel(logging.INFO)
+    logger.addHandler(h)
+    logger.setLevel(logging.DEBUG)
     return logger


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We should change the logging level of the handler, instead of the logging level of the logger. The logging level of logger should be set to `DEBUG`, so that other (new) handlers could dump debug info to a logging file. Setting the logging level of the logger to `INFO` would prevent streaming any lower level messages via logging handlers.

This PR does not affect the behavior of Skypilot. No smoke tests required.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
