### PR TITLE
[Optimizer] Add GCP disk price to the optimizer

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -253,6 +253,17 @@ class AWS(clouds.Cloud):
                                                zone=zone,
                                                clouds='aws')
 
+    def instance_type_to_hourly_disk_cost(self,
+                                          instance_type: str,
+                                          use_spot: bool,
+                                          region: Optional[str] = None,
+                                          zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_disk_cost(instance_type,
+                                                    use_spot=use_spot,
+                                                    region=region,
+                                                    zone=zone,
+                                                    clouds='aws')
+
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],
                                     use_spot: bool,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -242,18 +242,20 @@ class AWS(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self,
-                                     instance_type: str,
-                                     disk_size: int,
-                                     use_spot: bool,
-                                     region: Optional[str] = None,
-                                     zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_cost(instance_type,
-                                               disk_size=disk_size,
-                                               use_spot=use_spot,
-                                               region=region,
-                                               zone=zone,
-                                               clouds='aws')
+    def instance_type_to_cost(self,
+                              time_in_hour: float,
+                              instance_type: str,
+                              disk_size: int,
+                              use_spot: bool,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> float:
+        return service_catalog.get_cost(time_in_hour,
+                                        instance_type,
+                                        disk_size=disk_size,
+                                        use_spot=use_spot,
+                                        region=region,
+                                        zone=zone,
+                                        clouds='aws')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -242,20 +242,18 @@ class AWS(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_cost(self,
-                              time_in_hour: float,
-                              instance_type: str,
-                              disk_size: int,
-                              use_spot: bool,
-                              region: Optional[str] = None,
-                              zone: Optional[str] = None) -> float:
-        return service_catalog.get_cost(time_in_hour,
-                                        instance_type,
-                                        disk_size=disk_size,
-                                        use_spot=use_spot,
-                                        region=region,
-                                        zone=zone,
-                                        clouds='aws')
+    def instance_type_to_hourly_cost(self,
+                                     instance_type: str,
+                                     disk_size: int,
+                                     use_spot: bool,
+                                     region: Optional[str] = None,
+                                     zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
+                                               use_spot=use_spot,
+                                               region=region,
+                                               zone=zone,
+                                               clouds='aws')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -244,25 +244,16 @@ class AWS(clouds.Cloud):
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,
+                                     disk_size: int,
                                      use_spot: bool,
                                      region: Optional[str] = None,
                                      zone: Optional[str] = None) -> float:
         return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
                                                use_spot=use_spot,
                                                region=region,
                                                zone=zone,
                                                clouds='aws')
-
-    def instance_type_to_hourly_disk_cost(self,
-                                          instance_type: str,
-                                          use_spot: bool,
-                                          region: Optional[str] = None,
-                                          zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_disk_cost(instance_type,
-                                                    use_spot=use_spot,
-                                                    region=region,
-                                                    zone=zone,
-                                                    clouds='aws')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -61,18 +61,20 @@ class Azure(clouds.Cloud):
     def _max_cluster_name_length(cls) -> int:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
-    def instance_type_to_hourly_cost(self,
-                                     instance_type: str,
-                                     disk_size: int,
-                                     use_spot: bool,
-                                     region: Optional[str] = None,
-                                     zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_cost(instance_type,
-                                               disk_size=disk_size,
-                                               use_spot=use_spot,
-                                               region=region,
-                                               zone=zone,
-                                               clouds='azure')
+    def instance_type_to_cost(self,
+                              time_in_hour: float,
+                              instance_type: str,
+                              disk_size: int,
+                              use_spot: bool,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> float:
+        return service_catalog.get_cost(time_in_hour,
+                                        instance_type,
+                                        disk_size=disk_size,
+                                        use_spot=use_spot,
+                                        region=region,
+                                        zone=zone,
+                                        clouds='azure')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -72,6 +72,17 @@ class Azure(clouds.Cloud):
                                                zone=zone,
                                                clouds='azure')
 
+    def instance_type_to_hourly_disk_cost(self,
+                                          instance_type: str,
+                                          use_spot: bool,
+                                          region: Optional[str] = None,
+                                          zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_disk_cost(instance_type,
+                                                    use_spot=use_spot,
+                                                    region=region,
+                                                    zone=zone,
+                                                    clouds='azure')
+
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],
                                     use_spot: bool,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -63,25 +63,16 @@ class Azure(clouds.Cloud):
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,
+                                     disk_size: int,
                                      use_spot: bool,
                                      region: Optional[str] = None,
                                      zone: Optional[str] = None) -> float:
         return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
                                                use_spot=use_spot,
                                                region=region,
                                                zone=zone,
                                                clouds='azure')
-
-    def instance_type_to_hourly_disk_cost(self,
-                                          instance_type: str,
-                                          use_spot: bool,
-                                          region: Optional[str] = None,
-                                          zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_disk_cost(instance_type,
-                                                    use_spot=use_spot,
-                                                    region=region,
-                                                    zone=zone,
-                                                    clouds='azure')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -61,20 +61,18 @@ class Azure(clouds.Cloud):
     def _max_cluster_name_length(cls) -> int:
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
-    def instance_type_to_cost(self,
-                              time_in_hour: float,
-                              instance_type: str,
-                              disk_size: int,
-                              use_spot: bool,
-                              region: Optional[str] = None,
-                              zone: Optional[str] = None) -> float:
-        return service_catalog.get_cost(time_in_hour,
-                                        instance_type,
-                                        disk_size=disk_size,
-                                        use_spot=use_spot,
-                                        region=region,
-                                        zone=zone,
-                                        clouds='azure')
+    def instance_type_to_hourly_cost(self,
+                                     instance_type: str,
+                                     disk_size: int,
+                                     use_spot: bool,
+                                     region: Optional[str] = None,
+                                     zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
+                                               use_spot=use_spot,
+                                               region=region,
+                                               zone=zone,
+                                               clouds='azure')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -167,9 +167,10 @@ class Cloud:
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
-                                     use_spot: bool, region: Optional[str],
-                                     zone: Optional[str]) -> float:
+    def instance_type_to_cost(self, time_in_hour: float, instance_type: str,
+                              disk_size: int, use_spot: bool,
+                              region: Optional[str],
+                              zone: Optional[str]) -> float:
         """Returns the hourly on-demand/spot price for an instance type."""
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -167,8 +167,8 @@ class Cloud:
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self, instance_type: str, use_spot: bool,
-                                     region: Optional[str],
+    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
+                                     use_spot: bool, region: Optional[str],
                                      zone: Optional[str]) -> float:
         """Returns the hourly on-demand/spot price for an instance type."""
         raise NotImplementedError

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -167,10 +167,9 @@ class Cloud:
 
     #### Normal methods ####
 
-    def instance_type_to_cost(self, time_in_hour: float, instance_type: str,
-                              disk_size: int, use_spot: bool,
-                              region: Optional[str],
-                              zone: Optional[str]) -> float:
+    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
+                                     use_spot: bool, region: Optional[str],
+                                     zone: Optional[str]) -> float:
         """Returns the hourly on-demand/spot price for an instance type."""
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -179,12 +179,6 @@ class Cloud:
         """Returns the hourly on-demand price for accelerators."""
         raise NotImplementedError
 
-    def instance_type_to_hourly_disk_cost(self, instance_type: str,
-                                          use_spot: bool, region: Optional[str],
-                                          zone: Optional[str]) -> float:
-        """Returns the hourly on-demand/spot disk price for an instance type."""
-        raise NotImplementedError
-
     def get_egress_cost(self, num_gigabytes):
         """Returns the egress cost.
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -179,6 +179,12 @@ class Cloud:
         """Returns the hourly on-demand price for accelerators."""
         raise NotImplementedError
 
+    def instance_type_to_hourly_disk_cost(self, instance_type: str,
+                                          use_spot: bool, region: Optional[str],
+                                          zone: Optional[str]) -> float:
+        """Returns the hourly on-demand/spot disk price for an instance type."""
+        raise NotImplementedError
+
     def get_egress_cost(self, num_gigabytes):
         """Returns the egress cost.
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -239,6 +239,17 @@ class GCP(clouds.Cloud):
                                                zone=zone,
                                                clouds='gcp')
 
+    def instance_type_to_hourly_disk_cost(self,
+                                          instance_type: str,
+                                          use_spot: bool,
+                                          region: Optional[str] = None,
+                                          zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_disk_cost(instance_type,
+                                                    use_spot=use_spot,
+                                                    region=region,
+                                                    zone=zone,
+                                                    clouds='gcp')
+
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],
                                     use_spot: bool,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -228,20 +228,18 @@ class GCP(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_cost(self,
-                              time_in_hour: float,
-                              instance_type: str,
-                              disk_size: int,
-                              use_spot: bool,
-                              region: Optional[str] = None,
-                              zone: Optional[str] = None) -> float:
-        return service_catalog.get_cost(time_in_hour,
-                                        instance_type,
-                                        disk_size=disk_size,
-                                        use_spot=use_spot,
-                                        region=region,
-                                        zone=zone,
-                                        clouds='gcp')
+    def instance_type_to_hourly_cost(self,
+                                     instance_type: str,
+                                     disk_size: int,
+                                     use_spot: bool,
+                                     region: Optional[str] = None,
+                                     zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
+                                               use_spot=use_spot,
+                                               region=region,
+                                               zone=zone,
+                                               clouds='gcp')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -241,17 +241,6 @@ class GCP(clouds.Cloud):
                                                zone=zone,
                                                clouds='gcp')
 
-    def instance_type_to_hourly_disk_cost(self,
-                                          instance_type: str,
-                                          use_spot: bool,
-                                          region: Optional[str] = None,
-                                          zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_disk_cost(instance_type,
-                                                    use_spot=use_spot,
-                                                    region=region,
-                                                    zone=zone,
-                                                    clouds='gcp')
-
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],
                                     use_spot: bool,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -230,10 +230,12 @@ class GCP(clouds.Cloud):
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,
+                                     disk_size: int,
                                      use_spot: bool,
                                      region: Optional[str] = None,
                                      zone: Optional[str] = None) -> float:
         return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
                                                use_spot=use_spot,
                                                region=region,
                                                zone=zone,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -228,18 +228,20 @@ class GCP(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self,
-                                     instance_type: str,
-                                     disk_size: int,
-                                     use_spot: bool,
-                                     region: Optional[str] = None,
-                                     zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_cost(instance_type,
-                                               disk_size=disk_size,
-                                               use_spot=use_spot,
-                                               region=region,
-                                               zone=zone,
-                                               clouds='gcp')
+    def instance_type_to_cost(self,
+                              time_in_hour: float,
+                              instance_type: str,
+                              disk_size: int,
+                              use_spot: bool,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> float:
+        return service_catalog.get_cost(time_in_hour,
+                                        instance_type,
+                                        disk_size=disk_size,
+                                        use_spot=use_spot,
+                                        region=region,
+                                        zone=zone,
+                                        clouds='gcp')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -103,20 +103,18 @@ class Lambda(clouds.Cloud):
         for region in regions:
             yield region, region.zones
 
-    def instance_type_to_cost(self,
-                              time_in_hour: float,
-                              instance_type: str,
-                              disk_size: int,
-                              use_spot: bool,
-                              region: Optional[str] = None,
-                              zone: Optional[str] = None) -> float:
-        return service_catalog.get_cost(time_in_hour,
-                                        instance_type,
-                                        disk_size=disk_size,
-                                        use_spot=use_spot,
-                                        region=region,
-                                        zone=zone,
-                                        clouds='lambda')
+    def instance_type_to_hourly_cost(self,
+                                     instance_type: str,
+                                     disk_size: int,
+                                     use_spot: bool,
+                                     region: Optional[str] = None,
+                                     zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
+                                               use_spot=use_spot,
+                                               region=region,
+                                               zone=zone,
+                                               clouds='lambda')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -105,25 +105,16 @@ class Lambda(clouds.Cloud):
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,
+                                     disk_size: int,
                                      use_spot: bool,
                                      region: Optional[str] = None,
                                      zone: Optional[str] = None) -> float:
         return service_catalog.get_hourly_cost(instance_type,
+                                               disk_size=disk_size,
                                                use_spot=use_spot,
                                                region=region,
                                                zone=zone,
                                                clouds='lambda')
-
-    def instance_type_to_hourly_disk_cost(self,
-                                          instance_type: str,
-                                          use_spot: bool,
-                                          region: Optional[str] = None,
-                                          zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_disk_cost(instance_type,
-                                                    use_spot=use_spot,
-                                                    region=region,
-                                                    zone=zone,
-                                                    clouds='lambda')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -103,18 +103,20 @@ class Lambda(clouds.Cloud):
         for region in regions:
             yield region, region.zones
 
-    def instance_type_to_hourly_cost(self,
-                                     instance_type: str,
-                                     disk_size: int,
-                                     use_spot: bool,
-                                     region: Optional[str] = None,
-                                     zone: Optional[str] = None) -> float:
-        return service_catalog.get_hourly_cost(instance_type,
-                                               disk_size=disk_size,
-                                               use_spot=use_spot,
-                                               region=region,
-                                               zone=zone,
-                                               clouds='lambda')
+    def instance_type_to_cost(self,
+                              time_in_hour: float,
+                              instance_type: str,
+                              disk_size: int,
+                              use_spot: bool,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> float:
+        return service_catalog.get_cost(time_in_hour,
+                                        instance_type,
+                                        disk_size=disk_size,
+                                        use_spot=use_spot,
+                                        region=region,
+                                        zone=zone,
+                                        clouds='lambda')
 
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -114,6 +114,17 @@ class Lambda(clouds.Cloud):
                                                zone=zone,
                                                clouds='lambda')
 
+    def instance_type_to_hourly_disk_cost(self,
+                                          instance_type: str,
+                                          use_spot: bool,
+                                          region: Optional[str] = None,
+                                          zone: Optional[str] = None) -> float:
+        return service_catalog.get_hourly_disk_cost(instance_type,
+                                                    use_spot=use_spot,
+                                                    region=region,
+                                                    zone=zone,
+                                                    clouds='lambda')
+
     def accelerators_to_hourly_cost(self,
                                     accelerators: Dict[str, int],
                                     use_spot: bool,

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -84,9 +84,10 @@ class Local(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
-                                     use_spot: bool, region: Optional[str],
-                                     zone: Optional[str]) -> float:
+    def instance_type_to_cost(self, time_in_hour: float, instance_type: str,
+                              disk_size: int, use_spot: bool,
+                              region: Optional[str],
+                              zone: Optional[str]) -> float:
         # On-prem machines on Sky are assumed free
         # (minus electricity/utility bills).
         return 0.0

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -84,10 +84,9 @@ class Local(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_cost(self, time_in_hour: float, instance_type: str,
-                              disk_size: int, use_spot: bool,
-                              region: Optional[str],
-                              zone: Optional[str]) -> float:
+    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
+                                     use_spot: bool, region: Optional[str],
+                                     zone: Optional[str]) -> float:
         # On-prem machines on Sky are assumed free
         # (minus electricity/utility bills).
         return 0.0

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -97,6 +97,12 @@ class Local(clouds.Cloud):
         # Hourly cost of accelerators is 0 for local cloud.
         return 0.0
 
+    def instance_type_to_hourly_disk_cost(self, instance_type: str,
+                                          use_spot: bool, region: Optional[str],
+                                          zone: Optional[str]) -> float:
+        # Disk cost is 0 for local cloud
+        return 0.0
+
     def get_egress_cost(self, num_gigabytes: float) -> float:
         # Egress cost from a local cluster is assumed to be 0.
         return 0.0

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -84,8 +84,8 @@ class Local(clouds.Cloud):
 
     #### Normal methods ####
 
-    def instance_type_to_hourly_cost(self, instance_type: str, use_spot: bool,
-                                     region: Optional[str],
+    def instance_type_to_hourly_cost(self, instance_type: str, disk_size: int,
+                                     use_spot: bool, region: Optional[str],
                                      zone: Optional[str]) -> float:
         # On-prem machines on Sky are assumed free
         # (minus electricity/utility bills).
@@ -95,12 +95,6 @@ class Local(clouds.Cloud):
                                     region: Optional[str],
                                     zone: Optional[str]) -> float:
         # Hourly cost of accelerators is 0 for local cloud.
-        return 0.0
-
-    def instance_type_to_hourly_disk_cost(self, instance_type: str,
-                                          use_spot: bool, region: Optional[str],
-                                          zone: Optional[str]) -> float:
-        # Disk cost is 0 for local cloud
         return 0.0
 
     def get_egress_cost(self, num_gigabytes: float) -> float:

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -152,6 +152,19 @@ def get_hourly_cost(instance_type: str,
                                use_spot, region, zone)
 
 
+def get_hourly_disk_cost(instance_type: str,
+                         use_spot: bool,
+                         region: Optional[str],
+                         zone: Optional[str],
+                         clouds: CloudFilter = None) -> float:
+    """
+    Returns the hourly disk price of a VM instance in the given region and zone.
+    * (region, zone) is same with get_hourly_cost.
+    """
+    return _map_clouds_catalog(clouds, 'get_hourly_disk_cost', instance_type,
+                               use_spot, region, zone)
+
+
 def get_vcpus_from_instance_type(instance_type: str,
                                  clouds: CloudFilter = None) -> Optional[float]:
     """Returns the number of virtual CPUs from a instance type."""
@@ -300,6 +313,7 @@ __all__ = [
     'list_accelerator_counts',
     'get_region_zones_for_instance_type',
     'get_hourly_cost',
+    'get_hourly_disk_cost',
     'get_accelerators_from_instance_type',
     'get_instance_type_for_accelerator',
     'get_accelerator_hourly_cost',

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -153,19 +153,6 @@ def get_hourly_cost(instance_type: str,
                                disk_size, use_spot, region, zone)
 
 
-def get_hourly_disk_cost(instance_type: str,
-                         use_spot: bool,
-                         region: Optional[str],
-                         zone: Optional[str],
-                         clouds: CloudFilter = None) -> float:
-    """
-    Returns the hourly disk price of a VM instance in the given region and zone.
-    * (region, zone) is same with get_hourly_cost.
-    """
-    return _map_clouds_catalog(clouds, 'get_hourly_disk_cost', instance_type,
-                               use_spot, region, zone)
-
-
 def get_vcpus_from_instance_type(instance_type: str,
                                  clouds: CloudFilter = None) -> Optional[float]:
     """Returns the number of virtual CPUs from a instance type."""
@@ -314,7 +301,6 @@ __all__ = [
     'list_accelerator_counts',
     'get_region_zones_for_instance_type',
     'get_hourly_cost',
-    'get_hourly_disk_cost',
     'get_accelerators_from_instance_type',
     'get_instance_type_for_accelerator',
     'get_accelerator_hourly_cost',

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -133,6 +133,7 @@ def get_region_zones_for_instance_type(
 
 
 def get_hourly_cost(instance_type: str,
+                    disk_size: int,
                     use_spot: bool,
                     region: Optional[str],
                     zone: Optional[str],
@@ -149,7 +150,7 @@ def get_hourly_cost(instance_type: str,
         function returns the hourly price of the instance type in the zone.
     """
     return _map_clouds_catalog(clouds, 'get_hourly_cost', instance_type,
-                               use_spot, region, zone)
+                               disk_size, use_spot, region, zone)
 
 
 def get_hourly_disk_cost(instance_type: str,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -132,24 +132,25 @@ def get_region_zones_for_instance_type(
                                instance_type, use_spot)
 
 
-def get_hourly_cost(instance_type: str,
-                    disk_size: int,
-                    use_spot: bool,
-                    region: Optional[str],
-                    zone: Optional[str],
-                    clouds: CloudFilter = None) -> float:
-    """Returns the hourly price of a VM instance in the given region and zone.
+def get_cost(time_in_hour: float,
+             instance_type: str,
+             disk_size: int,
+             use_spot: bool,
+             region: Optional[str],
+             zone: Optional[str],
+             clouds: CloudFilter = None) -> float:
+    """Returns the price of a VM instance in the given region and zone.
 
-    * If (region, zone) == (None, None), return the cheapest hourly price among
+    * If (region, zone) == (None, None), return the cheapest price among
         all regions and zones.
-    * If (region, zone) == (str, None), return the cheapest hourly price among
+    * If (region, zone) == (str, None), return the cheapest price among
         all the zones in the given region.
-    * If (region, zone) == (None, str), return the hourly price of the instance
+    * If (region, zone) == (None, str), return the price of the instance
         type in the zone.
     * If (region, zone) == (str, str), zone must be in the region, and the
-        function returns the hourly price of the instance type in the zone.
+        function returns the price of the instance type in the zone.
     """
-    return _map_clouds_catalog(clouds, 'get_hourly_cost', instance_type,
+    return _map_clouds_catalog(clouds, 'get_cost', time_in_hour, instance_type,
                                disk_size, use_spot, region, zone)
 
 
@@ -300,7 +301,7 @@ __all__ = [
     'list_accelerators',
     'list_accelerator_counts',
     'get_region_zones_for_instance_type',
-    'get_hourly_cost',
+    'get_cost',
     'get_accelerators_from_instance_type',
     'get_instance_type_for_accelerator',
     'get_accelerator_hourly_cost',

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -132,25 +132,24 @@ def get_region_zones_for_instance_type(
                                instance_type, use_spot)
 
 
-def get_cost(time_in_hour: float,
-             instance_type: str,
-             disk_size: int,
-             use_spot: bool,
-             region: Optional[str],
-             zone: Optional[str],
-             clouds: CloudFilter = None) -> float:
-    """Returns the price of a VM instance in the given region and zone.
+def get_hourly_cost(instance_type: str,
+                    disk_size: int,
+                    use_spot: bool,
+                    region: Optional[str],
+                    zone: Optional[str],
+                    clouds: CloudFilter = None) -> float:
+    """Returns the hourly price of a VM instance in the given region and zone.
 
-    * If (region, zone) == (None, None), return the cheapest price among
+    * If (region, zone) == (None, None), return the cheapest hourly price among
         all regions and zones.
-    * If (region, zone) == (str, None), return the cheapest price among
+    * If (region, zone) == (str, None), return the cheapest hourly price among
         all the zones in the given region.
-    * If (region, zone) == (None, str), return the price of the instance
+    * If (region, zone) == (None, str), return the hourly price of the instance
         type in the zone.
     * If (region, zone) == (str, str), zone must be in the region, and the
-        function returns the price of the instance type in the zone.
+        function returns the hourly price of the instance type in the zone.
     """
-    return _map_clouds_catalog(clouds, 'get_cost', time_in_hour, instance_type,
+    return _map_clouds_catalog(clouds, 'get_hourly_cost', instance_type,
                                disk_size, use_spot, region, zone)
 
 
@@ -301,7 +300,7 @@ __all__ = [
     'list_accelerators',
     'list_accelerator_counts',
     'get_region_zones_for_instance_type',
-    'get_cost',
+    'get_hourly_cost',
     'get_accelerators_from_instance_type',
     'get_instance_type_for_accelerator',
     'get_accelerator_hourly_cost',

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -31,6 +31,8 @@ _PULL_FREQUENCY_HOURS = 7
 
 _df = common.read_catalog('aws/vms.csv',
                           pull_frequency_hours=_PULL_FREQUENCY_HOURS)
+_storage_df = common.read_catalog('aws/storage.csv',
+                                  pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 _image_df = common.read_catalog('aws/images.csv',
                                 pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 
@@ -89,19 +91,12 @@ def accelerator_in_region_or_zone(acc_name: str,
 
 
 def get_hourly_cost(instance_type: str,
+                    disk_size: int,
                     use_spot: bool = False,
                     region: Optional[str] = None,
                     zone: Optional[str] = None) -> float:
-    return common.get_hourly_cost_impl(_df, instance_type, use_spot, region,
-                                       zone)
-
-
-def get_hourly_disk_cost(instance_type: str,
-                         use_spot: bool = False,
-                         region: Optional[str] = None,
-                         zone: Optional[str] = None) -> float:
-    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
-                                            region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -90,14 +90,13 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_cost(time_in_hour: float,
-             instance_type: str,
-             disk_size: int,
-             use_spot: bool = False,
-             region: Optional[str] = None,
-             zone: Optional[str] = None) -> float:
-    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
-                                disk_size, use_spot, region, zone)
+def get_hourly_cost(instance_type: str,
+                    disk_size: int,
+                    use_spot: bool = False,
+                    region: Optional[str] = None,
+                    zone: Optional[str] = None) -> float:
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -96,6 +96,14 @@ def get_hourly_cost(instance_type: str,
                                        zone)
 
 
+def get_hourly_disk_cost(instance_type: str,
+                         use_spot: bool = False,
+                         region: Optional[str] = None,
+                         zone: Optional[str] = None) -> float:
+    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
+                                            region, zone)
+
+
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -90,13 +90,14 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_hourly_cost(instance_type: str,
-                    disk_size: int,
-                    use_spot: bool = False,
-                    region: Optional[str] = None,
-                    zone: Optional[str] = None) -> float:
-    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
-                                       disk_size, use_spot, region, zone)
+def get_cost(time_in_hour: float,
+             instance_type: str,
+             disk_size: int,
+             use_spot: bool = False,
+             region: Optional[str] = None,
+             zone: Optional[str] = None) -> float:
+    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
+                                disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -11,6 +11,7 @@ from sky.clouds.service_catalog import common
 from sky.utils import ux_utils
 
 _df = common.read_catalog('azure/vms.csv')
+_storage_df = common.read_catalog('azure/storage.csv')
 
 # This is the latest general-purpose instance family as of Jan 2023.
 # CPU: Intel Ice Lake 8370C.
@@ -44,6 +45,7 @@ def accelerator_in_region_or_zone(acc_name: str,
 
 
 def get_hourly_cost(instance_type: str,
+                    disk_size: int,
                     use_spot: bool = False,
                     region: Optional[str] = None,
                     zone: Optional[str] = None) -> float:
@@ -52,21 +54,8 @@ def get_hourly_cost(instance_type: str,
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')
-    return common.get_hourly_cost_impl(_df, instance_type, use_spot, region,
-                                       zone)
-
-
-def get_hourly_disk_cost(instance_type: str,
-                         use_spot: bool = False,
-                         region: Optional[str] = None,
-                         zone: Optional[str] = None) -> float:
-    # Ref: https://azure.microsoft.com/en-us/support/legal/offer-details/
-    assert not use_spot, 'Current Azure subscription does not support spot.'
-    if zone is not None:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError('Azure does not support zones.')
-    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
-                                            region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -44,18 +44,19 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_hourly_cost(instance_type: str,
-                    disk_size: int,
-                    use_spot: bool = False,
-                    region: Optional[str] = None,
-                    zone: Optional[str] = None) -> float:
+def get_cost(time_in_hour: float,
+             instance_type: str,
+             disk_size: int,
+             use_spot: bool = False,
+             region: Optional[str] = None,
+             zone: Optional[str] = None) -> float:
     # Ref: https://azure.microsoft.com/en-us/support/legal/offer-details/
     assert not use_spot, 'Current Azure subscription does not support spot.'
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')
-    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
-                                       disk_size, use_spot, region, zone)
+    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
+                                disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -56,6 +56,19 @@ def get_hourly_cost(instance_type: str,
                                        zone)
 
 
+def get_hourly_disk_cost(instance_type: str,
+                         use_spot: bool = False,
+                         region: Optional[str] = None,
+                         zone: Optional[str] = None) -> float:
+    # Ref: https://azure.microsoft.com/en-us/support/legal/offer-details/
+    assert not use_spot, 'Current Azure subscription does not support spot.'
+    if zone is not None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('Azure does not support zones.')
+    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
+                                            region, zone)
+
+
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -44,19 +44,18 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_cost(time_in_hour: float,
-             instance_type: str,
-             disk_size: int,
-             use_spot: bool = False,
-             region: Optional[str] = None,
-             zone: Optional[str] = None) -> float:
+def get_hourly_cost(instance_type: str,
+                    disk_size: int,
+                    use_spot: bool = False,
+                    region: Optional[str] = None,
+                    zone: Optional[str] = None) -> float:
     # Ref: https://azure.microsoft.com/en-us/support/legal/offer-details/
     assert not use_spot, 'Current Azure subscription does not support spot.'
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')
-    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
-                                disk_size, use_spot, region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -1,6 +1,5 @@
 """Common utilities for service catalog."""
 import hashlib
-import json
 import os
 import time
 from typing import Dict, List, NamedTuple, Optional, Tuple
@@ -215,8 +214,7 @@ def validate_region_zone_impl(
     return validated_region, validated_zone
 
 
-def get_region_cheapest_storage_cost(
-    time_in_hour: float,
+def get_region_cheapest_hourly_storage_cost(
     storage_df: pd.DataFrame,
     region: str,
     disk_size: int,
@@ -228,29 +226,12 @@ def get_region_cheapest_storage_cost(
     if 'Region' not in storage_df.columns:
         return 0.0
     df = storage_df[storage_df['Region'] == region]
-    cheapest_price = None
-    for _, row in df.iterrows():
-        price_str = row['Price']
-        price = json.loads(price_str)
-        assert isinstance(price, dict)
-        # assume one month have 30 days here
-        units = time_in_hour * disk_size / 30 / 24
-        tot_price = 0.0
-        # for tier_min_unit in reversed order
-        for tier_min_unit in sorted(price.keys(), key=lambda x: -float(x)):
-            if units >= float(tier_min_unit):
-                tot_price += price[tier_min_unit] * (units -
-                                                     float(tier_min_unit))
-                units = float(tier_min_unit)
-        assert abs(units) < 1e-2, units
-        if cheapest_price is None or tot_price < cheapest_price:
-            cheapest_price = tot_price
-    assert cheapest_price is not None
-    return cheapest_price
+    cheapest_idx = df['Price'].idxmin()  # GB per month
+    # Suppose one month have 30 days here.
+    return df.loc[cheapest_idx]['Price'] * disk_size / (30 * 24)
 
 
-def get_cost_impl(
-    time_in_hour: float,
+def get_hourly_cost_impl(
     df: pd.DataFrame,
     storage_df: pd.DataFrame,
     instance_type: str,
@@ -259,13 +240,10 @@ def get_cost_impl(
     region: Optional[str],
     zone: Optional[str],
 ) -> float:
-    """Returns the price of a VM instance in the given region and zone.
-
-    if `time_in_hour` < 0, this function returns hourly price.
-    @see gcp_catalog.py
+    """Returns the hourly price of a VM instance in the given region and zone.
 
     This implenemtation considered both vm price and storage price.
-    Refer to get_cost in service_catalog/__init__.py for the docstring.
+    Refer to get_hourly_cost in service_catalog/__init__.py for the docstring.
     """
     # total_hourly_cost = instance_price + disk_size * storage_price
     df = _get_instance_type(df, instance_type, region, zone)
@@ -295,10 +273,9 @@ def get_cost_impl(
     cheapest_price = None
     for _, row in df[['Region', price_str]].iterrows():
         instance_region, price = row['Region'], row[price_str]
-        storage_price = get_region_cheapest_storage_cost(
-            time_in_hour, storage_df, instance_region, disk_size)
-        cur_price = price * time_in_hour + storage_price \
-            if time_in_hour >= 0 else price
+        storage_price = get_region_cheapest_hourly_storage_cost(
+            storage_df, instance_region, disk_size)
+        cur_price = price + storage_price
         if cheapest_price is None or cur_price < cheapest_price:
             cheapest_price = cur_price
     assert cheapest_price is not None

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -6,8 +6,9 @@ import argparse
 import json
 import os
 import subprocess
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Dict
 import urllib
+import collections
 
 import numpy as np
 import pandas as pd
@@ -54,9 +55,9 @@ USEFUL_COLUMNS = [
 ]
 
 
-def get_pricing_url(region: Optional[str] = None) -> str:
+def get_pricing_url(service_name: str, region: Optional[str] = None) -> str:
     filters = [
-        'serviceName eq \'Virtual Machines\'',
+        f'serviceName eq \'{service_name}\'',
         'priceType eq \'Consumption\'',
     ]
     if region is not None:
@@ -66,15 +67,18 @@ def get_pricing_url(region: Optional[str] = None) -> str:
 
 
 @ray.remote
-def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
+def get_pricing_df(service_name: str,
+                   region: Optional[str] = None) -> pd.DataFrame:
     all_items = []
-    url = get_pricing_url(region)
-    print(f'Getting pricing for {region}')
+    url = get_pricing_url(service_name, region)
+    print(f'Getting pricing for {region} with service name {service_name}')
     page = 0
     while url is not None:
         page += 1
         if page % 10 == 0:
-            print(f'Fetched pricing pages {page}')
+            print(
+                f'Fetched pricing pages {page} with service name {service_name}'
+            )
         r = requests.get(url)
         r.raise_for_status()
         content_str = r.content.decode('ascii')
@@ -84,7 +88,7 @@ def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
             break
         all_items += items
         url = content.get('NextPageLink')
-    print(f'Done fetching pricing {region}')
+    print(f'Done fetching pricing {region} with service name {service_name}')
     df = pd.DataFrame(all_items)
     assert 'productName' in df.columns, (region, df.columns)
     return df[(~df['productName'].str.contains(' Windows')) &
@@ -92,8 +96,10 @@ def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
 
 
 @ray.remote
-def get_all_regions_pricing_df(regions: Set[str]) -> pd.DataFrame:
-    dfs = ray.get([get_pricing_df.remote(region) for region in regions])
+def get_all_regions_pricing_df(service_name: str,
+                               regions: Set[str]) -> pd.DataFrame:
+    dfs = ray.get(
+        [get_pricing_df.remote(service_name, region) for region in regions])
     return pd.concat(dfs)
 
 
@@ -151,7 +157,7 @@ def get_gpu_name(family: str) -> Optional[str]:
 
 def get_all_regions_instance_types_df(region_set: Set[str]):
     df, df_sku = ray.get([
-        get_all_regions_pricing_df.remote(region_set),
+        get_all_regions_pricing_df.remote('Virtual Machines', region_set),
         get_sku_df.remote(region_set),
     ])
     print('Processing dataframes')
@@ -239,6 +245,43 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
     return df_ret
 
 
+def get_all_regions_storage_df(region_set: Set[str]):
+    df_storage = ray.get(
+        [get_all_regions_pricing_df.remote('Storage', region_set)])[0]
+    df_storage.drop_duplicates(inplace=True)
+    df_storage = df_storage[df_storage['unitPrice'] > 0]
+    # only default storage is used by sky
+    df_storage = df_storage[df_storage['skuName'] == 'Standard LRS']
+    df_storage = df_storage[df_storage['unitOfMeasure'] == '1 GB/Month']
+
+    print('Getting storage df')
+
+    class DiskInfo:
+
+        def __init__(self) -> None:
+            self.region: str = ''
+            # tierMinimumUnits -> unitPrice
+            self.price: Dict[str, float] = dict()
+
+    # name -> (region, tiered_price_dict)
+    storage_dict: Dict[str, DiskInfo] = collections.defaultdict(DiskInfo)
+    for _, row in df_storage.iterrows():
+        name = row['skuId']
+        region = row['armRegionName']
+        price = row['unitPrice']
+        tier_minimum = str(row['tierMinimumUnits'])
+        if storage_dict[name].region == '':
+            storage_dict[name].region = region
+        else:
+            assert storage_dict[name].region == region
+        storage_dict[name].price[tier_minimum] = price
+    df = pd.DataFrame(columns=['Name', 'Region', 'Price'])
+    for name, info in storage_dict.items():
+        df.loc[len(df)] = [name, info.region, json.dumps(info.price)]
+
+    return df
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -255,3 +298,7 @@ if __name__ == '__main__':
     os.makedirs('azure', exist_ok=True)
     instance_df.to_csv('azure/vms.csv', index=False)
     print('Azure Service Catalog saved to azure/vms.csv')
+
+    storage_df = get_all_regions_storage_df(region_filter)
+    storage_df.to_csv('azure/storage.csv', index=False)
+    print('Azure Storage Catalog saved to azure/storage.csv')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -1,579 +1,284 @@
-"""A script that generates Google Cloud GPU catalog.
+"""A script that generates GCP catalog.
 
-Google Cloud does not have an API for querying TPU/GPU offerings, so we crawl
-the information from GCP websites.
+This script gathers the metadata of GCP from the SkyPilot catalog repository
+and queries the GCP API to get the real-time prices of the VMs, GPUs, and TPUs.
 """
+
 import argparse
 import os
-import re
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
-from lxml import html
+from googleapiclient import discovery
 import pandas as pd
-import requests
 
-# pylint: disable=line-too-long
-GCP_VM_PRICING_URL = 'https://cloud.google.com/compute/vm-instance-pricing'
-GCP_VM_ZONES_URL = 'https://cloud.google.com/compute/docs/regions-zones'
-GCP_GPU_PRICING_URL = 'https://cloud.google.com/compute/gpus-pricing'
-GCP_GPU_ZONES_URL = 'https://cloud.google.com/compute/docs/gpus/gpu-regions-zones'
+# Useful links:
+# GCP SKUs: https://cloud.google.com/skus
+# VM pricing: https://cloud.google.com/compute/vm-instance-pricing
+# GPU pricing: https://cloud.google.com/compute/gpus-pricing
+# TPU pricing: https://cloud.google.com/tpu/pricing
 
-NOT_AVAILABLE_STR = 'Not available in this region'
+# FIXME: fix-gcp -> master
+GCP_METADATA_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/fix-gcp/metadata/gcp/'  # pylint: disable=line-too-long
 
-ALL_REGION_PREFIX = ''
-US_REGION_PREFIX = 'us-'
+GCE_SERVICE_ID = '6F81-5844-456A'
+TPU_SERVICE_ID = 'E000-3F24-B8AA'
+
+# The number of digits to round the price to.
+PRICE_ROUNDING = 5
 
 # Refer to: https://github.com/skypilot-org/skypilot/issues/1006
-UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
+UNSUPPORTED_SERIES = ['f1', 'm2']
 
-# Supported GPU types and counts.
-# NOTE: GCP officially uses 'A100 40GB' and 'A100 80GB' as the names of the
-# two A100 GPU types. However, in the catalog, we rename them as
-# 'A100' and 'A100-80GB' respectively, for consistency with other clouds.
-GPU_TYPES_TO_COUNTS = {
-    'A100 40GB': [1, 2, 4, 8, 16],
-    'A100 80GB': [1, 2, 4, 8],
-    'T4': [1, 2, 4],
-    'P4': [1, 2, 4],
-    'V100': [1, 2, 4, 8],
-    'P100': [1, 2, 4],
-    'K80': [1, 2, 4, 8],
+# TODO(woosuk): Make this more robust.
+SERIES_TO_DISCRIPTION = {
+    'a2': 'A2 Instance',
+    'c2': 'Compute optimized',
+    'c2d': 'C2D AMD Instance',
+    'e2': 'E2 Instance',
+    'f1': 'Micro Instance with burstable CPU',
+    'g1': 'Small Instance with 1 VCPU',
+    'm1': 'Memory-optimized Instance',
+    # FIXME(woosuk): Support M2 series.
+    'm3': 'M3 Memory-optimized Instance',
+    'n1': 'N1 Predefined Instance',
+    'n2': 'N2 Instance',
+    'n2d': 'N2D AMD Instance',
+    't2a': 'T2A Arm Instance',
+    't2d': 'T2D AMD Instance',
 }
 
-# A2 VMs that support 16 A100 GPUs only appear in the following zones.
-# Source: https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
-A2_MEGAGPU_16G_ZONES = [
-    'us-central1-a', 'us-central1-b', 'us-central1-c', 'us-central1-f',
-    'europe-west4-a', 'europe-west4-b', 'asia-southeast1-c'
-]
 
-# For the TPU catalog, we maintain our own location/pricing table.
-# NOTE: The CSV files do not completely align with the data in the websites.
-# The differences are:
-# 1. We added us-east1-d (a hidden zone) for TPU-v3 pods.
-# 2. We deleted TPU v3 pods in us-central1, because we found that GCP is not
-#    actually supporting them in the region.
-# 3. We used estimated prices for on-demand tpu-v3-{64,...,2048} as their
-#    prices are not publicly available.
-# 4. For preemptible TPUs whose prices are not publicly available, we applied
-#    70% off discount on the on-demand prices because every known preemptible
-#    TPU price follows this pricing rule.
-# Source: https://cloud.google.com/tpu/docs/regions-zones
-GCP_TPU_ZONES_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/metadata/tpu/zones.csv'  # pylint: disable=line-too-long
-# Source: https://cloud.google.com/tpu/pricing
-GCP_TPU_PRICING_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/metadata/tpu/pricing.csv'  # pylint: disable=line-too-long
+def get_skus(service_id: str) -> List[Dict[str, Any]]:
+    # Get the SKUs from the GCP API.
+    cb = discovery.build('cloudbilling', 'v1')
+    service_name = 'services/' + service_id
 
-COLUMNS = [
-    'InstanceType',  # None for accelerators
-    'AcceleratorName',
-    'AcceleratorCount',
-    'vCPUs',  # None for accelerators
-    'MemoryGiB',  # None for accelerators
-    'GpuInfo',  # Same as AcceleratorName
-    'Price',
-    'SpotPrice',
-    'Region',
-    'AvailabilityZone',
-]
+    skus = []
+    page_token = ''
+    while True:
+        if page_token == '':
+            response = cb.services().skus().list(parent=service_name).execute()
+        else:
+            response = cb.services().skus().list(parent=service_name,
+                                                 pageToken=page_token).execute()
+        skus += response['skus']
+        page_token = response['nextPageToken']
+        if not page_token:
+            break
 
-
-def get_iframe_sources(url: str) -> List[str]:
-    page = requests.get(url)
-    tree = html.fromstring(page.content)
-    return tree.xpath('//iframe/@src')
-
-
-def get_regions(doc: 'html.HtmlElement') -> Dict[str, str]:
-    # Get the dictionary of regions.
-    # E.g., 'kr': 'asia-northeast3'
-    region_info = doc.xpath('//md-option')
-    regions = dict()
-    for region in region_info:
-        region_fullname = re.search(r'\((.*?)\)', region.text)
-        if region_fullname is None:
-            raise ValueError(f'Invalid region name: {region.text}')
-        regions[region.attrib['value']] = region_fullname.group(1)
-    return regions
+    # Prune unnecessary SKUs.
+    new_skus = []
+    for sku in skus:
+        # Prune SKUs that are not Compute (i.e., Storage, Network, and License).
+        if sku['category']['resourceFamily'] != 'Compute':
+            continue
+        # Prune PD snapshot egress and Vm state.
+        if sku['category']['resourceGroup'] in ['PdSnapshotEgress', 'VmState']:
+            continue
+        # Prune commitment SKUs.
+        if sku['category']['usageType'] not in ['OnDemand', 'Preemptible']:
+            continue
+        # Prune custom SKUs.
+        if 'custom' in sku['description'].lower():
+            continue
+        # Prune premium SKUs.
+        if 'premium' in sku['description'].lower():
+            continue
+        # Prune reserved SKUs.
+        if 'reserved' in sku['description'].lower():
+            continue
+        # Prune sole-tenant SKUs.
+        # See https://cloud.google.com/compute/docs/nodes/sole-tenant-nodes
+        if 'sole tenancy' in sku['description'].lower():
+            continue
+        new_skus.append(sku)
+    return new_skus
 
 
-# TODO(woosuk): parallelize this function using Ray.
-# Currently, 'HTML parser error : Tag md-option invalid' is raised
-# when the function is parallelized by Ray.
-def get_vm_price_table(url: str) -> pd.DataFrame:
-    page = requests.get(url)
-    doc = html.fromstring(page.content)
-    regions = get_regions(doc)
+def _get_unit_price(sku: Dict[str, Any]) -> float:
+    pricing_info = sku['pricingInfo'][0]['pricingExpression']
+    unit_price = pricing_info['tieredRates'][0]['unitPrice']
+    units = int(unit_price['units'])
+    nanos = unit_price['nanos'] / 1e9
+    return units + nanos
 
-    # Get the table.
-    rows = doc.xpath('//tr')
-    headers = rows.pop(0).getchildren()
-    headers = [header.text_content() for header in headers]
 
-    # Create the dataframe.
-    table = []
-    for region, full_name in regions.items():
-        for row in rows:
-            new_row = [full_name]
-            cells = row.getchildren()
-            if not cells:
+def get_vm_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
+    df = pd.read_csv(GCP_METADATA_URL + 'instances.csv')
+    # Drop the unsupported series.
+    df = df[~df['InstanceType'].str.startswith(tuple(UNSUPPORTED_SERIES))]
+
+    # TODO(woosuk): Make this more efficient.
+    def get_vm_price(row: pd.Series, spot: bool) -> float:
+        series = row['InstanceType'].split('-')[0].lower()
+
+        ondemand_or_spot = 'OnDemand' if not spot else 'Preemptible'
+        cpu_price = None
+        memory_price = None
+        for sku in skus:
+            if sku['category']['usageType'] != ondemand_or_spot:
+                continue
+            if row['Region'] not in sku['serviceRegions']:
                 continue
 
-            for cell in cells:
-                # Remove duplicated header (in "M1 machine types").
-                if 'Machine type' in cell.text_content():
-                    break
-                # Remove footer.
-                if 'Custom machine type' in cell.text_content():
-                    break
+            # Check if the SKU is for the correct series.
+            description = sku['description']
+            if SERIES_TO_DISCRIPTION[series] not in description:
+                continue
+            # Special check for M1 instances.
+            if series == 'm1' and 'M3' in description:
+                continue
 
-                if 'cloud-pricer' not in cell.attrib:
-                    # This cell only contains a plain text.
-                    text = cell.text_content()
-                    # Remove Skylake related text.
-                    if 'Skylake Platform only' in text:
-                        text = text.replace('Skylake Platform only', '')
-                    new_row.append(text.strip())
-                elif 'default' in cell.attrib:
-                    # This cell only contains a plain text.
-                    new_row.append(cell.attrib['default'])
-                else:
-                    # This cell contains the region-wise price information.
-                    key = region + '-hourly'
-                    if key in cell.attrib:
-                        new_row.append(cell.attrib[key])
-                    else:
-                        new_row.append(NOT_AVAILABLE_STR)
+            resource_group = sku['category']['resourceGroup']
+            # Skip GPU SKUs.
+            if resource_group == 'GPU':
+                continue
+
+            # Is it CPU or memory?
+            is_cpu = False
+            is_memory = False
+            if resource_group in ['CPU', 'F1Micro', 'G1Small']:
+                is_cpu = True
+            elif resource_group == 'RAM':
+                is_memory = True
             else:
-                table.append(new_row)
-    df = pd.DataFrame(table, columns=['Region'] + headers)
+                assert resource_group == 'N1Standard'
+                if 'Core' in description:
+                    is_cpu = True
+                elif 'Ram' in description:
+                    is_memory = True
 
-    # Standardize the column names.
-    column_remapping = {
-        # InstanceType
-        'Machine type': 'InstanceType',
-        # vCPUs
-        'Virtual CPUs': 'vCPUs',
-        'vCPU': 'vCPUs',
-        # MemoryGiB
-        'Memory': 'MemoryGiB',
-        'Memory(GB)': 'MemoryGiB',
-        # Price
-        'On-demand price': 'Price',
-        'On-demand price (USD)': 'Price',
-        'Price (USD)': 'Price',
-        'On Demand List Price': 'Price',
-        'Evaluative price (USD)': 'Price',
-        # SpotPrice
-        'Spot price*': 'SpotPrice',
-        'Spot price* (USD)': 'SpotPrice',
-        'Spot price*(USD)': 'SpotPrice',
-        'Spot price (USD)': 'SpotPrice',
-        ' Spot price* (USD)': 'SpotPrice',
-    }
-    df.rename(columns=column_remapping, inplace=True)
+            # Calculate the price.
+            unit_price = _get_unit_price(sku)
+            if is_cpu:
+                cpu_price = unit_price * row['vCPUs']
+            elif is_memory:
+                memory_price = unit_price * row['MemoryGiB']
 
-    def parse_memory(memory_str: str) -> float:
-        if 'GB' in memory_str:
-            return float(memory_str.replace('GB', ''))
-        else:
-            return float(memory_str)
+        # Special case for F1 and G1 instances.
+        # Memory is not charged for these instances.
+        if series in ['f1', 'g1']:
+            memory_price = 0.0
 
-    pattern = re.compile(r'\$?(.*?)\s?/')
+        assert cpu_price is not None, row
+        assert memory_price is not None, row
+        return cpu_price + memory_price
 
-    def parse_price(price_str: str) -> float:
-        if NOT_AVAILABLE_STR in price_str:
-            return float('nan')
-        try:
-            price = float(price_str[1:])
-        except ValueError:
-            price_match = re.search(pattern, price_str)
-            if price_match is None:
-                raise ValueError(f'Cannot parse price: {price_str}') from None
-            price = float(price_match.group(1))
-        return price
-
-    # Parse the prices.
-    df['Price'] = df['Price'].apply(parse_price)
-    df['SpotPrice'] = df['SpotPrice'].apply(parse_price)
-
-    # Remove unsupported regions.
-    df = df[~df['Price'].isna()]
-    df = df[~df['SpotPrice'].isna()]
-
-    # E.g., m2-ultramem instances will be skipped because their spot prices
-    # are not available.
-    if df.empty:
-        return None
-
-    if 'InstanceType' in df.columns:
-        # Price table for pre-defined instance types.
-        # NOTE: The price of A2 machines includes the price of A100 GPUs,
-        # and thus is modified later by post_process_a2_price().
-
-        df = df[[
-            'InstanceType',
-            'vCPUs',
-            'MemoryGiB',
-            'Region',
-            'Price',
-            'SpotPrice',
-        ]]
-        # vCPUs
-        df['vCPUs'] = df['vCPUs'].astype(float)
-        # MemoryGiB
-        df['MemoryGiB'] = df['MemoryGiB'].apply(parse_memory)
-
-        df['AcceleratorName'] = None
-        df['AcceleratorCount'] = None
-        df['GpuInfo'] = None
-    else:
-        # Others (e.g., per vCPU hour or per GB hour pricing rule table).
-        df = df[['Item', 'Region', 'Price', 'SpotPrice']]
+    df['Price'] = df.apply(lambda row: get_vm_price(row, spot=False), axis=1)
+    df['SpotPrice'] = df.apply(lambda row: get_vm_price(row, spot=True), axis=1)
+    df = df.reset_index(drop=True)
     return df
 
 
-def get_vm_zones(url: str) -> pd.DataFrame:
-    df = pd.read_html(url)[0]
-    column_remapping = {
-        'Zones': 'AvailabilityZone',
-        'Machine types': 'MachineType',  # Different from InstanceType
-    }
-    df.rename(columns=column_remapping, inplace=True)
+def get_gpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
+    gpu_skus = [
+        sku for sku in skus if sku['category']['resourceGroup'] == 'GPU']
+    df = pd.read_csv(GCP_METADATA_URL + 'gpus.csv')
 
-    # Remove unnecessary columns.
-    df = df[['AvailabilityZone', 'MachineType']]
+    def get_gpu_price(row: pd.Series, spot: bool) -> float:
+        ondemand_or_spot = 'OnDemand' if not spot else 'Preemptible'
+        gpu_price = None
+        for sku in gpu_skus:
+            if sku['category']['usageType'] != ondemand_or_spot:
+                continue
 
-    def parse_machine_type_list(list_str: str) -> List[str]:
-        machine_types = list_str.split(', ')
-        returns = []
-        # Handle the typos in the GCP web page.
-        for m in machine_types:
-            if ' ' in m:
-                # us-central1-b: no comma between T2A and N1
-                returns += m.split(' ')
-            elif ',' in m:
-                # us-central1-c: no space between C2 and C2D
-                returns += m.split(',')
+            gpu_name = row['AcceleratorName']
+            if gpu_name == 'A100-80GB':
+                gpu_name = 'A100 80GB'
+            if f'{gpu_name} GPU' not in sku['description']:
+                continue
+
+            unit_price = _get_unit_price(sku)
+            gpu_price = unit_price * row['AcceleratorCount']
+            break
+
+        assert gpu_price is not None, row
+        return gpu_price
+
+    df['Price'] = df.apply(lambda row: get_gpu_price(row, spot=False), axis=1)
+    df['SpotPrice'] = df.apply(
+        lambda row: get_gpu_price(row, spot=True), axis=1)
+    df = df.reset_index(drop=True)
+    return df
+
+
+def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
+    df = pd.read_csv(GCP_METADATA_URL + 'tpus.csv')
+
+    def get_tpu_price(row: pd.Series, spot: bool) -> float:
+        tpu_price = None
+        for sku in skus:
+            description = sku['description']
+            # NOTE: 'usageType' of preemptible TPUs are 'OnDemand'.
+            if spot:
+                if 'Preemptible' not in description:
+                    continue
             else:
-                returns.append(m)
-        return returns
+                if 'Preemptible' in description:
+                    continue
 
-    # Explode the 'MachineType' column.
-    df['MachineType'] = df['MachineType'].apply(parse_machine_type_list)
-    df = df.explode('MachineType', ignore_index=True)
+            tpu_name = row['AcceleratorName']
+            tpu_version = tpu_name.split('-')[1]
+            num_cores = int(tpu_name.split('-')[2])
+            is_pod = num_cores > 8
 
-    # Check duplicates.
-    assert not df.duplicated().any()
+            if f'Tpu-{tpu_version}' not in description:
+                continue
+            if is_pod:
+                if 'Pod' not in description:
+                    continue
+            else:
+                if 'Pod' in description:
+                    continue
+
+            unit_price = _get_unit_price(sku)
+            tpu_price = unit_price * row['AcceleratorCount']
+            break
+
+        assert tpu_price is not None, row
+        return tpu_price
+
+    df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)
+    df['SpotPrice'] = df.apply(
+        lambda row: get_tpu_price(row, spot=True), axis=1)
+    df = df.reset_index(drop=True)
     return df
-
-
-def get_vm_df(region_prefix: str, a100_zones: List[str]) -> pd.DataFrame:
-    """Generates the GCP service catalog for host VMs."""
-    vm_price_table_urls = get_iframe_sources(GCP_VM_PRICING_URL)
-    # Skip the table for "Suspended VM instances".
-    vm_price_table_urls = vm_price_table_urls[:-1]
-
-    vm_dfs = [get_vm_price_table(url) for url in vm_price_table_urls]
-    vm_dfs = [
-        df for df in vm_dfs if df is not None and 'InstanceType' in df.columns
-    ]
-    vm_df = pd.concat(vm_dfs)
-
-    vm_zones = get_vm_zones(GCP_VM_ZONES_URL)
-    # Manually add A2 machines to the zones with A100 GPUs.
-    # This is necessary because GCP_VM_ZONES_URL may not be up to date.
-    df = pd.DataFrame.from_dict({
-        'AvailabilityZone': a100_zones,
-        'MachineType': 'A2',
-    })
-    vm_zones = pd.concat([vm_zones, df], ignore_index=True)
-    # vm_zones alreay includes some zones with A100 GPUs.
-    # When we merge it with a100_zones, we need to remove the duplicates.
-    vm_zones = vm_zones.drop_duplicates()
-
-    # Remove regions not in the pricing data.
-    regions = vm_df['Region'].unique()
-    zone_to_region = lambda x: x[:-2]
-    vm_zones['Region'] = vm_zones['AvailabilityZone'].apply(zone_to_region)
-    vm_zones = vm_zones[vm_zones['Region'].isin(regions)]
-
-    # Define the MachineType column.
-    vm_df['MachineType'] = vm_df['InstanceType'].apply(
-        lambda x: x.split('-')[0].upper())
-    # The f1-micro and g1-small instances belong to the N1 machine family.
-    vm_df.loc[vm_df['InstanceType'].isin(['f1-micro', 'g1-small']),
-              'MachineType'] = 'N1'
-
-    # Merge the dataframes.
-    vm_df = pd.merge(vm_df, vm_zones, on=['Region', 'MachineType'])
-    # Check duplicates.
-    assert not vm_df[['InstanceType', 'AvailabilityZone']].duplicated().any()
-
-    # Remove the MachineType column.
-    vm_df.drop(columns=['MachineType'], inplace=True)
-
-    # Drop regions without the given prefix.
-    vm_df = vm_df[vm_df['Region'].str.startswith(region_prefix)]
-    return vm_df
-
-
-def get_gpu_price_table(url) -> pd.DataFrame:
-    page = requests.get(url)
-    doc = html.fromstring(page.content)
-    regions = get_regions(doc)
-
-    # Get the table.
-    rows = doc.xpath('//tr')
-    headers = rows.pop(0).getchildren()
-    headers = [header.text_content() for header in headers]
-
-    # Create the dataframe.
-    table = []
-    for region, full_name in regions.items():
-        i = 0
-        while i < len(rows):
-            row = rows[i]
-            new_row = [full_name]
-            cells = row.getchildren()
-
-            first_cell = cells[0]
-            # Do not include NVIDIA workstations.
-            if 'virtual workstation' in first_cell.text_content().lower():
-                break
-
-            row_span = int(first_cell.attrib['rowspan'])
-            i += row_span
-
-            for cell in cells:
-                if 'cloud-pricer' not in cell.attrib:
-                    # This cell only contains a plain text.
-                    text = cell.text_content()
-                    new_row.append(text.strip())
-                else:
-                    # This cell contains the region-wise price information.
-                    key = region + '-hourly'
-                    if key in cell.attrib:
-                        new_row.append(cell.attrib[key])
-                    else:
-                        new_row.append(NOT_AVAILABLE_STR)
-            table.append(new_row)
-    df = pd.DataFrame(table, columns=['Region'] + headers)
-
-    # Standardize the column names.
-    column_remapping = {
-        'Model': 'AcceleratorName',
-        'GPU price (USD)': 'Price',
-        'Spot price* (USD)': 'SpotPrice',
-    }
-    df.rename(columns=column_remapping, inplace=True)
-
-    df = df[['AcceleratorName', 'Region', 'Price', 'SpotPrice']]
-    # Fix GPU names (i.e., remove NVIDIA prefix).
-    df['AcceleratorName'] = df['AcceleratorName'].apply(
-        lambda x: x.replace('NVIDIA ', ''))
-    # Add GPU counts.
-    df['AcceleratorCount'] = df['AcceleratorName'].apply(
-        lambda x: GPU_TYPES_TO_COUNTS[x])
-
-    # Parse the prices.
-    pattern = re.compile(r'\$?(.*?)\s?per GPU')
-
-    def parse_price(price_str: str) -> float:
-        if NOT_AVAILABLE_STR in price_str:
-            return float('nan')
-        try:
-            price = float(price_str[1:])
-        except ValueError:
-            price_match = re.search(pattern, price_str)
-            if price_match is None:
-                raise ValueError(f'Cannot parse price: {price_str}') from None
-            price = float(price_match.group(1))
-        return price
-
-    df['Price'] = df['Price'].apply(parse_price)
-    df['SpotPrice'] = df['SpotPrice'].apply(parse_price)
-
-    # Remove unsupported regions.
-    df = df[~df['Price'].isna()]
-    df = df[~df['SpotPrice'].isna()]
-    return df
-
-
-def get_gpu_zones(url) -> pd.DataFrame:
-    page = requests.get(url)
-    df = pd.read_html(page.text.replace('<br>', '\n'))[0]
-    column_remapping = {
-        'GPU platforms': 'AcceleratorName',
-        'Zones': 'AvailabilityZone',
-    }
-    df.rename(columns=column_remapping, inplace=True)
-    df = df[['AvailabilityZone', 'AcceleratorName']]
-
-    # Remove zones that do not support any GPU.
-    df = df[~df['AcceleratorName'].isna()]
-
-    # Explode Availability Zone.
-    df['AvailabilityZone'] = df['AvailabilityZone'].str.split(' ')
-    df = df.explode('AvailabilityZone', ignore_index=True)
-    return df
-
-
-def get_gpu_df(region_prefix: str) -> pd.DataFrame:
-    """Generates the GCP service catalog for GPUs."""
-    gpu_price_table_url = get_iframe_sources(GCP_GPU_PRICING_URL)
-    assert len(gpu_price_table_url) == 1
-    gpu_pricing = get_gpu_price_table(gpu_price_table_url[0])
-    gpu_zones = get_gpu_zones(GCP_GPU_ZONES_URL)
-
-    # Remove zones not in the pricing data.
-    zone_to_region = lambda x: x[:-2]
-    gpu_zones['Region'] = gpu_zones['AvailabilityZone'].apply(zone_to_region)
-    supported_regions = gpu_pricing['Region'].unique()
-    gpu_zones = gpu_zones[gpu_zones['Region'].isin(supported_regions)]
-
-    # Explode GPU types.
-    gpu_zones['AcceleratorName'] = gpu_zones['AcceleratorName'].apply(
-        lambda x: x.split(', '))
-    gpu_zones = gpu_zones.explode(column='AcceleratorName', ignore_index=True)
-
-    # Merge the two dataframes.
-    gpu_df = pd.merge(gpu_zones, gpu_pricing, on=['AcceleratorName', 'Region'])
-
-    # Rename A100 GPUs.
-    gpu_df['AcceleratorName'] = gpu_df['AcceleratorName'].apply(lambda x: {
-        'A100 40GB': 'A100',
-        'A100 80GB': 'A100-80GB',
-    }.get(x, x))
-
-    # Explode GPU counts.
-    gpu_df = gpu_df.explode(column='AcceleratorCount', ignore_index=True)
-    gpu_df['AcceleratorCount'] = gpu_df['AcceleratorCount'].astype(int)
-
-    # Calculate the on-demand and spot prices.
-    gpu_df['Price'] = gpu_df['AcceleratorCount'] * gpu_df['Price']
-    gpu_df['SpotPrice'] = gpu_df['AcceleratorCount'] * gpu_df['SpotPrice']
-
-    # 16xA100 is only supported in certain zones.
-    gpu_df = gpu_df[(gpu_df['AcceleratorName'] != 'A100') |
-                    (gpu_df['AcceleratorCount'] != 16) |
-                    (gpu_df['AvailabilityZone'].isin(A2_MEGAGPU_16G_ZONES))]
-
-    # Add columns for the service catalog.
-    gpu_df['InstanceType'] = None
-    gpu_df['GpuInfo'] = gpu_df['AcceleratorName']
-    gpu_df['vCPUs'] = None
-    gpu_df['MemoryGiB'] = None
-
-    # Drop regions without the given prefix.
-    gpu_df = gpu_df[gpu_df['Region'].str.startswith(region_prefix)]
-    return gpu_df
-
-
-def get_tpu_df() -> pd.DataFrame:
-    """Generates the GCP service catalog for TPUs."""
-    tpu_zones = pd.read_csv(GCP_TPU_ZONES_URL)
-    tpu_pricing = pd.read_csv(GCP_TPU_PRICING_URL)
-
-    # Rename the columns.
-    tpu_zones = tpu_zones.rename(columns={
-        'TPU type': 'AcceleratorName',
-        'Zones': 'AvailabilityZone',
-    })
-    tpu_pricing = tpu_pricing.rename(columns={
-        'TPU type': 'AcceleratorName',
-        'Spot price': 'SpotPrice',
-    })
-
-    # Explode Zones.
-    tpu_zones['AvailabilityZone'] = tpu_zones['AvailabilityZone'].apply(
-        lambda x: x.split(', '))
-    tpu_zones = tpu_zones.explode(column='AvailabilityZone', ignore_index=True)
-    zone_to_region = lambda x: x[:-2]
-    tpu_zones['Region'] = tpu_zones['AvailabilityZone'].apply(zone_to_region)
-
-    # Merge the two dataframes.
-    tpu_df = pd.merge(tpu_zones, tpu_pricing, on=['AcceleratorName', 'Region'])
-    tpu_df['AcceleratorCount'] = 1
-
-    # Add columns for the service catalog.
-    tpu_df['InstanceType'] = None
-    tpu_df['GpuInfo'] = tpu_df['AcceleratorName']
-    tpu_df['vCPUs'] = None
-    tpu_df['MemoryGiB'] = None
-    return tpu_df
-
-
-def post_process_a2_price(catalog_df: pd.DataFrame) -> pd.DataFrame:
-    a100_df = catalog_df[catalog_df['AcceleratorName'].isin(
-        ['A100', 'A100-80GB'])]
-
-    def _deduct_a100_price(
-            row: pd.Series) -> Tuple[Optional[float], Optional[float]]:
-        instance_type = row['InstanceType']
-        if pd.isna(instance_type) or not instance_type.startswith('a2'):
-            return row['Price'], row['SpotPrice']
-
-        zone = row['AvailabilityZone']
-        a100_type = 'A100-80GB' if 'ultragpu' in instance_type else 'A100'
-        a100_count = int(instance_type.split('-')[-1][:-1])
-        a100 = a100_df[(a100_df['AcceleratorName'] == a100_type) &
-                       (a100_df['AcceleratorCount'] == a100_count) &
-                       (a100_df['AvailabilityZone'] == zone)]
-        if a100.empty:
-            # Invalid.
-            # The A2 VM is not acctually supported in this zone.
-            # The row is dropped out later.
-
-            # This happens because GCP_VM_PRICING_URL shows region-wise price,
-            # and GCP_VM_ZONES_URL only tells whether the zone has any A2 VM.
-            # Thus, for example, if zone X in a region only supports A100-40GB
-            # while another zone Y in the same region supports A100-80GB,
-            # it will appear in GCP_VM_PRICING_URL that the region supports
-            # both A100-40GB and A100-80GB. And in GCP_VM_ZONES_URL zone X
-            # will be said to support A2 VMs. In such a case, we do not know
-            # whether zone X supports both A100 GPUs or only one of them.
-            # We need to refer to GCP_GPU_ZONES_URL to know that zone X only
-            # supports A100-40GB. Thus, in get_vm_df(), we add both a2-highgpu
-            # (for A100-40GB) and a2-ultragpu (for A100-80GB) to zone X.
-            # Then in this post-processing step, we nullifies the A2 VMs
-            # that are not supported in zone X.
-
-            # This also filters out a2-megagpu-16g VMs in zones that do not
-            # support 16xA100.
-            return None, None
-
-        price = row['Price'] - a100['Price'].iloc[0]
-        spot_price = row['SpotPrice'] - a100['SpotPrice'].iloc[0]
-        return price, spot_price
-
-    catalog_df[['Price', 'SpotPrice']] = catalog_df.apply(_deduct_a100_price,
-                                                          axis=1,
-                                                          result_type='expand')
-    # Remove invalid A2 instances.
-    catalog_df = catalog_df[catalog_df['InstanceType'].str.startswith('a2').
-                            ne(True) | (catalog_df['Price'].notna())]
-    return catalog_df
 
 
 def get_catalog_df(region_prefix: str) -> pd.DataFrame:
-    """Generates the GCP catalog by combining CPU, GPU, and TPU catalogs."""
-    gpu_df = get_gpu_df(region_prefix)
-    df = gpu_df[gpu_df['AcceleratorName'].isin(['A100', 'A100-80GB'])]
-    a100_zones = df['AvailabilityZone'].unique().tolist()
-    vm_df = get_vm_df(region_prefix, a100_zones)
-    tpu_df = get_tpu_df()
-    catalog_df = pd.concat([vm_df, gpu_df, tpu_df])
-    catalog_df = post_process_a2_price(catalog_df)
+    gcp_skus = get_skus(GCE_SERVICE_ID)
+    vm_df = get_vm_df(gcp_skus)
+    gpu_df = get_gpu_df(gcp_skus)
 
-    # Filter out unsupported VMs from the catalog.
-    for vm in UNSUPPORTED_VMS:
-        # NOTE: The `InstanceType` column can be NaN.
-        catalog_df = catalog_df[catalog_df['InstanceType'].str.startswith(
-            vm).ne(True)]
+    # Drop regions without the given prefix.
+    # NOTE: We intentionally do not drop any TPU regions.
+    vm_df = vm_df[vm_df['Region'].str.startswith(region_prefix)]
+    gpu_df = gpu_df[gpu_df['Region'].str.startswith(region_prefix)]
+
+    gcp_tpu_skus = get_skus(TPU_SERVICE_ID)
+    tpu_df = get_tpu_df(gcp_tpu_skus)
+
+    # Merge the dataframes.
+    df = pd.concat([vm_df, gpu_df, tpu_df])
 
     # Reorder the columns.
-    catalog_df = catalog_df[COLUMNS]
-    return catalog_df
+    df = df[[
+        'InstanceType',
+        'vCPUs',
+        'MemoryGiB',
+        'AcceleratorName',
+        'AcceleratorCount',
+        'GpuInfo',
+        'Region',
+        'AvailabilityZone',
+        'Price',
+        'SpotPrice',
+    ]]
+
+    # Round the prices.
+    df['Price'] = df['Price'].round(PRICE_ROUNDING)
+    df['SpotPrice'] = df['SpotPrice'].round(PRICE_ROUNDING)
+    return df
 
 
 if __name__ == '__main__':
@@ -584,9 +289,9 @@ if __name__ == '__main__':
         help='Fetch all global regions, not just the U.S. ones.')
     args = parser.parse_args()
 
-    region_prefix_filter = ALL_REGION_PREFIX if args.all_regions else US_REGION_PREFIX
-    gcp_catalog_df = get_catalog_df(region_prefix_filter)
+    region_prefix_filter = '' if args.all_regions else 'us-'
+    catalog_df = get_catalog_df(region_prefix_filter)
 
     os.makedirs('gcp', exist_ok=True)
-    gcp_catalog_df.to_csv('gcp/vms.csv', index=False)
+    catalog_df.to_csv('gcp/vms.csv', index=False)
     print('GCP Service Catalog saved to gcp/vms.csv')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -59,8 +59,8 @@ def get_skus(service_id: str) -> List[Dict[str, Any]]:
         if page_token == '':
             response = cb.services().skus().list(parent=service_name).execute()
         else:
-            response = cb.services().skus().list(parent=service_name,
-                                                 pageToken=page_token).execute()
+            response = cb.services().skus().list(
+                parent=service_name, pageToken=page_token).execute()
         skus += response['skus']
         page_token = response['nextPageToken']
         if not page_token:
@@ -172,7 +172,8 @@ def get_vm_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
 
 def get_gpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
     gpu_skus = [
-        sku for sku in skus if sku['category']['resourceGroup'] == 'GPU']
+        sku for sku in skus if sku['category']['resourceGroup'] == 'GPU'
+    ]
     df = pd.read_csv(GCP_METADATA_URL + 'gpus.csv')
 
     def get_gpu_price(row: pd.Series, spot: bool) -> float:
@@ -196,8 +197,8 @@ def get_gpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
         return gpu_price
 
     df['Price'] = df.apply(lambda row: get_gpu_price(row, spot=False), axis=1)
-    df['SpotPrice'] = df.apply(
-        lambda row: get_gpu_price(row, spot=True), axis=1)
+    df['SpotPrice'] = df.apply(lambda row: get_gpu_price(row, spot=True),
+                               axis=1)
     df = df.reset_index(drop=True)
     return df
 
@@ -239,8 +240,8 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
         return tpu_price
 
     df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)
-    df['SpotPrice'] = df.apply(
-        lambda row: get_tpu_price(row, spot=True), axis=1)
+    df['SpotPrice'] = df.apply(lambda row: get_tpu_price(row, spot=True),
+                               axis=1)
     df = df.reset_index(drop=True)
     return df
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -17,8 +17,7 @@ import pandas as pd
 # GPU pricing: https://cloud.google.com/compute/gpus-pricing
 # TPU pricing: https://cloud.google.com/tpu/pricing
 
-# FIXME: fix-gcp -> master
-GCP_METADATA_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/fix-gcp/metadata/gcp/'  # pylint: disable=line-too-long
+GCP_METADATA_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/metadata/gcp/'  # pylint: disable=line-too-long
 
 GCE_SERVICE_ID = '6F81-5844-456A'
 TPU_SERVICE_ID = 'E000-3F24-B8AA'

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -5,6 +5,7 @@ and queries the GCP API to get the real-time prices of the VMs, GPUs, and TPUs.
 """
 
 import argparse
+import json
 import os
 from typing import Any, Dict, List, Optional
 
@@ -132,19 +133,22 @@ def _get_unit_price(sku: Dict[str, Any]) -> float:
     return units + nanos
 
 
-def _get_tired_unit_price(sku: Dict[str, Any]) -> float:
+def _get_tired_unit_price(sku: Dict[str, Any]) -> str:
     pricing_info = sku['pricingInfo'][0]['pricingExpression']
 
-    def _get_tired_price(tier: int) -> float:
-        unit_price = pricing_info['tieredRates'][tier]['unitPrice']
+    def _get_tired_price(unit_price: Dict[str, Any]) -> float:
+        assert unit_price['currencyCode'] == 'USD'
         units = int(unit_price['units'])
         nanos = unit_price['nanos'] / 1e9
         return units + nanos
 
-    # TODO(tian): Ignore first tier for now since it only applies to
-    # first 30 GiBy.mo.
-    return _get_tired_price(0) if len(
-        pricing_info['tieredRates']) == 1 else _get_tired_price(1)
+    # tierMinimumUnits -> unitPrice
+    # use str as type to support json.loads()
+    price: Dict[str, float] = dict()
+    for tier in pricing_info['tieredRates']:
+        tier_min_unit = str(tier['startUsageAmount'])
+        price[tier_min_unit] = _get_tired_price(tier['unitPrice'])
+    return json.dumps(price)
 
 
 def get_vm_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -6,7 +6,7 @@ and queries the GCP API to get the real-time prices of the VMs, GPUs, and TPUs.
 
 import argparse
 import os
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, Dict, List, Optional
 
 from googleapiclient import discovery
 import pandas as pd
@@ -351,22 +351,15 @@ def get_catalog_df(region_prefix: str) -> pd.DataFrame:
 
 
 def get_storage_df() -> pd.DataFrame:
-    # TODO(tian): is TPU machine use same storage SKUs as GCE?
     storage_skus = get_storage_skus(GCE_SERVICE_ID)
-    storage_df = pd.DataFrame(columns=['Name', 'Region', 'Price'])
+    df = pd.DataFrame(columns=['Name', 'Region', 'Price'])
     for sku in storage_skus:
         name = sku['name']
         regions = sku['serviceRegions']
         price = _get_tired_unit_price(sku)
         for region in regions:
-            storage_df = storage_df.append(
-                {
-                    'Name': name,
-                    'Region': region,
-                    'Price': price
-                },
-                ignore_index=True)
-    return storage_df
+            df.loc[len(df.index)] = [name, region, price]
+    return df
 
 
 if __name__ == '__main__':

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -99,8 +99,14 @@ def get_vm_df() -> Tuple[pd.DataFrame, List[str]]:
     # Double-check that all the regions and zones are valid.
     assert_zones_are_valid(vm_df['AvailabilityZone'].unique())
 
-    vm_df = vm_df[
-        ['InstanceType', 'vCPUs', 'MemoryGiB', 'Region', 'AvailabilityZone']]
+    # Reorder the columns.
+    vm_df = vm_df[[
+        'InstanceType',
+        'vCPUs',
+        'MemoryGiB',
+        'Region',
+        'AvailabilityZone',
+    ]]
     vm_df = vm_df.reset_index(drop=True)
 
     # Get the list of zones that support 16xA100.
@@ -142,8 +148,16 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     # Double-check that all the regions and zones are valid.
     assert_zones_are_valid(gpu_df['AvailabilityZone'].unique())
 
-    gpu_df = gpu_df[
-        ['AcceleratorName', 'AcceleratorCount', 'Region', 'AvailabilityZone']]
+    # Add GPUInfo column.
+    gpu_df['GPUInfo'] = ''
+    # Reorder the columns.
+    gpu_df = gpu_df[[
+        'AcceleratorName', 
+        'AcceleratorCount',
+        'GPUInfo',
+        'Region',
+        'AvailabilityZone',
+    ]]
     gpu_df = gpu_df.reset_index(drop=True)
     return gpu_df
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -76,12 +76,13 @@ def get_vm_df() -> Tuple[pd.DataFrame, List[str]]:
     # Drop unused columns.
     vm_df = vm_df[['NAME', 'CPUS', 'MEMORY_GB', 'ZONE']]
     # Rename the columns.
-    vm_df = vm_df.rename(columns={
-        'NAME': 'InstanceType',
-        'CPUS': 'vCPUs',
-        'MEMORY_GB': 'MemoryGiB',
-        'ZONE': 'AvailabilityZone',
-    })
+    vm_df = vm_df.rename(
+        columns={
+            'NAME': 'InstanceType',
+            'CPUS': 'vCPUs',
+            'MEMORY_GB': 'MemoryGiB',
+            'ZONE': 'AvailabilityZone',
+        })
     # Add the Region column.
     vm_df['Region'] = vm_df['AvailabilityZone'].apply(lambda zone: zone[:-2])
 
@@ -106,8 +107,8 @@ def get_vm_df() -> Tuple[pd.DataFrame, List[str]]:
     vm_df = vm_df.reset_index(drop=True)
 
     # Get the list of zones that support 16xA100.
-    a2_megagpu_16g_zones = vm_df[
-        vm_df['InstanceType'] == 'a2-megagpu-16g']['AvailabilityZone'].unique()
+    a2_megagpu_16g_df = vm_df[vm_df['InstanceType'] == 'a2-megagpu-16g']
+    a2_megagpu_16g_zones = a2_megagpu_16g_df['AvailabilityZone'].unique()
     return vm_df, a2_megagpu_16g_zones
 
 
@@ -138,8 +139,8 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
 
     # Remove 16xA100 machines from zones that do not support them.
     gpu_df = gpu_df[~((gpu_df['AcceleratorName'] == 'A100') &
-                    (gpu_df['AcceleratorCount'] == 16) &
-                    (~gpu_df['AvailabilityZone'].isin(a2_megagpu_16g_zones)))]
+                      (gpu_df['AcceleratorCount'] == 16) &
+                      (~gpu_df['AvailabilityZone'].isin(a2_megagpu_16g_zones)))]
 
     # Double-check that all the regions and zones are valid.
     assert_zones_are_valid(gpu_df['AvailabilityZone'].unique())
@@ -148,7 +149,7 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     gpu_df['GpuInfo'] = ''
     # Reorder the columns.
     gpu_df = gpu_df[[
-        'AcceleratorName', 
+        'AcceleratorName',
         'AcceleratorCount',
         'GPUInfo',
         'Region',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -1,11 +1,7 @@
-import argparse
 import os
 from typing import List, Tuple
 
 import pandas as pd
-
-ALL_REGION_PREFIX = ''
-US_REGION_PREFIX = 'us-'
 
 # We rely on the data from https://github.com/Cyclenerd/google-cloud-pricing-cost-calculator  # pylint: disable=line-too-long
 # TODO(woosuk): use the official GCP APIs to fetch the data.
@@ -162,30 +158,13 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     return gpu_df
 
 
-def filter_with_region_prefix(
-    df: pd.DataFrame,
-    region_prefix: str,
-) -> pd.DataFrame:
-    return df[df['Region'].str.startswith(region_prefix)]
-
-
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--all-regions',
-        action='store_true',
-        help='Fetch all global regions, not just the U.S. ones.')
-    args = parser.parse_args()
-    region_prefix_filter = ALL_REGION_PREFIX if args.all_regions else US_REGION_PREFIX
-
     os.makedirs('metadata/gcp/', exist_ok=True)
 
     gcp_vm_df, gcp_megagpu_zones = get_vm_df()
-    gcp_vm_df = filter_with_region_prefix(gcp_vm_df, region_prefix_filter)
     gcp_vm_df.to_csv('metadata/gcp/instances.csv', index=False)
     print('GCP VM metadata saved to metadata/gcp/instances.csv')
 
     gcp_gpu_df = get_gpu_df(gcp_megagpu_zones)
-    gcp_gpu_df = filter_with_region_prefix(gcp_gpu_df, region_prefix_filter)
     gcp_gpu_df.to_csv('metadata/gcp/gpus.csv', index=False)
     print('GCP GPU metadata saved to metadata/gcp/gpus.csv')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -42,7 +42,7 @@ GPU_NAMES = {
 # Refer to: https://cloud.google.com/compute/docs/gpus
 # NOTE: 16xA100 machines are only supported in certain zones.
 # See https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
-GPU_COUNTS = {
+GPU_TYPES_TO_COUNTS = {
     'A100-80GB': [1, 2, 4, 8],
     'A100': [1, 2, 4, 8, 16],
     'K80': [1, 2, 4, 8],
@@ -133,7 +133,7 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
 
     # Add the AcceleratorCount column.
     gpu_df['AcceleratorCount'] = gpu_df['AcceleratorName'].apply(
-        lambda acc_name: GPU_COUNTS[acc_name])
+        lambda acc_name: GPU_TYPES_TO_COUNTS[acc_name])
     gpu_df = gpu_df.explode('AcceleratorCount', ignore_index=True)
     gpu_df['AcceleratorCount'] = gpu_df['AcceleratorCount'].astype(int)
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -145,7 +145,7 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     assert_zones_are_valid(gpu_df['AvailabilityZone'].unique())
 
     # Add GPUInfo column.
-    gpu_df['GPUInfo'] = ''
+    gpu_df['GpuInfo'] = ''
     # Reorder the columns.
     gpu_df = gpu_df[[
         'AcceleratorName', 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -1,3 +1,9 @@
+"""Fetches the metadata of GCP instances and accelerators.
+
+This script fetches the metadata of GCP from a public GitHub repository
+and saves them as CSV files. The metadata include all the information
+except the (on-demand and spot) prices.
+"""
 import os
 from typing import List, Tuple
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -15,7 +15,7 @@ GCP_VM_ZONES_URL = 'https://cloud.google.com/compute/docs/regions-zones'
 INVALID_REGIONS = [
     'us-east2',
     'us-east7',
-    'us-central2',
+    'us-central2',  # NOTE: us-central2-b has TPU v4.
     'europe-west5',
 ]
 
@@ -24,9 +24,6 @@ INVALID_ZONES = [
     'us-east1-a',
     'us-central1-d',
 ]
-
-# Refer to: https://github.com/skypilot-org/skypilot/issues/1006
-UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
 
 # GPU names in GCP -> GPU names in SkyPilot.
 GPU_NAMES = {

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -151,7 +151,7 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     gpu_df = gpu_df[[
         'AcceleratorName',
         'AcceleratorCount',
-        'GPUInfo',
+        'GpuInfo',
         'Region',
         'AvailabilityZone',
     ]]

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -162,10 +162,10 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
 if __name__ == '__main__':
     os.makedirs('metadata/gcp/', exist_ok=True)
 
-    gcp_vm_df, gcp_megagpu_zones = get_vm_df()
+    gcp_vm_df, gcp_a2_megagpu_16g_zones = get_vm_df()
     gcp_vm_df.to_csv('metadata/gcp/instances.csv', index=False)
     print('GCP VM metadata saved to metadata/gcp/instances.csv')
 
-    gcp_gpu_df = get_gpu_df(gcp_megagpu_zones)
+    gcp_gpu_df = get_gpu_df(gcp_a2_megagpu_16g_zones)
     gcp_gpu_df.to_csv('metadata/gcp/gpus.csv', index=False)
     print('GCP GPU metadata saved to metadata/gcp/gpus.csv')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -1,0 +1,177 @@
+import argparse
+import os
+from typing import List, Tuple
+
+import pandas as pd
+
+ALL_REGION_PREFIX = ''
+US_REGION_PREFIX = 'us-'
+
+# We rely on the data from https://github.com/Cyclenerd/google-cloud-pricing-cost-calculator  # pylint: disable=line-too-long
+# TODO(woosuk): use the official GCP APIs to fetch the data.
+VM_CSV_URL = 'https://raw.githubusercontent.com/Cyclenerd/google-cloud-pricing-cost-calculator/master/tools/machinetypezone.csv'  # pylint: disable=line-too-long
+GPU_CSV_URL = 'https://raw.githubusercontent.com/Cyclenerd/google-cloud-pricing-cost-calculator/master/tools/acceleratortypezone.csv'  # pylint: disable=line-too-long
+
+# Official list of the zones in GCP.
+GCP_VM_ZONES_URL = 'https://cloud.google.com/compute/docs/regions-zones'
+
+# Regions that do not exist in https://cloud.google.com/compute/docs/regions-zones
+INVALID_REGIONS = [
+    'us-east2',
+    'us-east7',
+    'us-central2',
+    'europe-west5',
+]
+
+# Zones that do not exist in https://cloud.google.com/compute/docs/regions-zones
+INVALID_ZONES = [
+    'us-east1-a',
+    'us-central1-d',
+]
+
+# Refer to: https://github.com/skypilot-org/skypilot/issues/1006
+UNSUPPORTED_VMS = ['t2a-standard', 'f1-micro']
+
+# GPU names in GCP -> GPU names in SkyPilot.
+GPU_NAMES = {
+    'nvidia-a100-80gb': 'A100-80GB',
+    'nvidia-tesla-a100': 'A100',
+    'nvidia-tesla-k80': 'K80',
+    'nvidia-tesla-p100': 'P100',
+    'nvidia-tesla-p4': 'P4',
+    'nvidia-tesla-t4': 'T4',
+    'nvidia-tesla-v100': 'V100',
+}
+
+# Refer to: https://cloud.google.com/compute/docs/gpus
+# NOTE: 16xA100 machines are only supported in certain zones.
+# See https://cloud.google.com/compute/docs/gpus/gpu-regions-zones#limitations
+GPU_COUNTS = {
+    'A100-80GB': [1, 2, 4, 8],
+    'A100': [1, 2, 4, 8, 16],
+    'K80': [1, 2, 4, 8],
+    'P100': [1, 2, 4],
+    'P4': [1, 2, 4],
+    'T4': [1, 2, 4],
+    'V100': [1, 2, 4, 8],
+}
+
+
+def drop_invalid_zones(df: pd.DataFrame) -> pd.DataFrame:
+    # Remove invalid regions.
+    df = df[~df['Region'].isin(INVALID_REGIONS)]
+    # Remove invalid zones.
+    df = df[~df['AvailabilityZone'].isin(INVALID_ZONES)]
+    return df
+
+
+def assert_zones_are_valid(zones: List[str]) -> None:
+    # Double-check that all the regions and zones are valid.
+    gcp_vm_zones_df = pd.read_html(GCP_VM_ZONES_URL)[0]
+    gcp_zones = gcp_vm_zones_df['Zones'].unique()
+    for zone in zones:
+        assert zone in gcp_zones
+
+
+def get_vm_df() -> Tuple[pd.DataFrame, List[str]]:
+    vm_df = pd.read_csv(VM_CSV_URL, delimiter=';')
+    # Drop deprecated VMs.
+    vm_df = vm_df[vm_df['DEPRECATED'].isna()]
+    # Drop unused columns.
+    vm_df = vm_df[['NAME', 'CPUS', 'MEMORY_GB', 'ZONE']]
+    # Rename the columns.
+    vm_df = vm_df.rename(columns={
+        'NAME': 'InstanceType',
+        'CPUS': 'vCPUs',
+        'MEMORY_GB': 'MemoryGiB',
+        'ZONE': 'AvailabilityZone',
+    })
+    # Add the Region column.
+    vm_df['Region'] = vm_df['AvailabilityZone'].apply(lambda zone: zone[:-2])
+
+    # Drop invalid zones.
+    vm_df = drop_invalid_zones(vm_df)
+
+    # Convert vCPUs and MemoryGiB to float.
+    vm_df['vCPUs'] = vm_df['vCPUs'].astype(float)
+    vm_df['MemoryGiB'] = vm_df['MemoryGiB'].astype(float)
+
+    # Double-check that all the regions and zones are valid.
+    assert_zones_are_valid(vm_df['AvailabilityZone'].unique())
+
+    vm_df = vm_df[
+        ['InstanceType', 'vCPUs', 'MemoryGiB', 'Region', 'AvailabilityZone']]
+    vm_df = vm_df.reset_index(drop=True)
+
+    # Get the list of zones that support 16xA100.
+    a2_megagpu_16g_zones = vm_df[
+        vm_df['InstanceType'] == 'a2-megagpu-16g']['AvailabilityZone'].unique()
+    return vm_df, a2_megagpu_16g_zones
+
+
+def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
+    gpu_df = pd.read_csv(GPU_CSV_URL, delimiter=';')
+    # Rename the columns.
+    gpu_df = gpu_df.rename(columns={
+        'NAME': 'AcceleratorName',
+        'ZONE': 'AvailabilityZone',
+    })
+    # Add the Region column.
+    gpu_df['Region'] = gpu_df['AvailabilityZone'].apply(lambda zone: zone[:-2])
+
+    # Drop VWS GPUs.
+    gpu_df = gpu_df[~gpu_df['AcceleratorName'].str.contains('vws')]
+    # Rename the GPUs.
+    gpu_df['AcceleratorName'] = gpu_df['AcceleratorName'].apply(
+        lambda name: GPU_NAMES[name])
+
+    # Drop invalid zones.
+    gpu_df = drop_invalid_zones(gpu_df)
+
+    # Add the AcceleratorCount column.
+    gpu_df['AcceleratorCount'] = gpu_df['AcceleratorName'].apply(
+        lambda acc_name: GPU_COUNTS[acc_name])
+    gpu_df = gpu_df.explode('AcceleratorCount', ignore_index=True)
+    gpu_df['AcceleratorCount'] = gpu_df['AcceleratorCount'].astype(int)
+
+    # Remove 16xA100 machines from zones that don't support them.
+    gpu_df = gpu_df[~((gpu_df['AcceleratorName'] == 'A100') &
+                    (gpu_df['AcceleratorCount'] == 16) &
+                    (~gpu_df['AvailabilityZone'].isin(a2_megagpu_16g_zones)))]
+
+    # Double-check that all the regions and zones are valid.
+    assert_zones_are_valid(gpu_df['AvailabilityZone'].unique())
+
+    gpu_df = gpu_df[
+        ['AcceleratorName', 'AcceleratorCount', 'Region', 'AvailabilityZone']]
+    gpu_df = gpu_df.reset_index(drop=True)
+    return gpu_df
+
+
+def filter_with_region_prefix(
+    df: pd.DataFrame,
+    region_prefix: str,
+) -> pd.DataFrame:
+    return df[df['Region'].str.startswith(region_prefix)]
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--all-regions',
+        action='store_true',
+        help='Fetch all global regions, not just the U.S. ones.')
+    args = parser.parse_args()
+    region_prefix_filter = ALL_REGION_PREFIX if args.all_regions else US_REGION_PREFIX
+
+    os.makedirs('metadata/gcp/', exist_ok=True)
+
+    gcp_vm_df, gcp_megagpu_zones = get_vm_df()
+    gcp_vm_df = filter_with_region_prefix(gcp_vm_df, region_prefix_filter)
+    gcp_vm_df.to_csv('metadata/gcp/instances.csv', index=False)
+    print('GCP VM metadata saved to metadata/gcp/instances.csv')
+
+    gcp_gpu_df = get_gpu_df(gcp_megagpu_zones)
+    gcp_gpu_df = filter_with_region_prefix(gcp_gpu_df, region_prefix_filter)
+    gcp_gpu_df.to_csv('metadata/gcp/gpus.csv', index=False)
+    print('GCP GPU metadata saved to metadata/gcp/gpus.csv')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -3,6 +3,9 @@
 This script fetches the metadata of GCP from a public GitHub repository
 and saves them as CSV files. The metadata include all the information
 except the (on-demand and spot) prices.
+
+NOTE: The TPU metadata is not fetched by this script. It is manually
+maintained by the SkyPilot developers.
 """
 import os
 from typing import List, Tuple

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp_metadata.py
@@ -140,7 +140,7 @@ def get_gpu_df(a2_megagpu_16g_zones: List[str]) -> pd.DataFrame:
     gpu_df = gpu_df.explode('AcceleratorCount', ignore_index=True)
     gpu_df['AcceleratorCount'] = gpu_df['AcceleratorCount'].astype(int)
 
-    # Remove 16xA100 machines from zones that don't support them.
+    # Remove 16xA100 machines from zones that do not support them.
     gpu_df = gpu_df[~((gpu_df['AcceleratorName'] == 'A100') &
                     (gpu_df['AcceleratorCount'] == 16) &
                     (~gpu_df['AvailabilityZone'].isin(a2_megagpu_16g_zones)))]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -164,6 +164,16 @@ def get_hourly_cost(
                                        zone)
 
 
+def get_hourly_disk_cost(
+    instance_type: str,
+    use_spot: bool = False,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
+) -> float:
+    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
+                                            region, zone)
+
+
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     # The number of vCPUs provided with a TPU VM is not officially documented.
     if instance_type == 'TPU-VM':

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -17,6 +17,7 @@ if typing.TYPE_CHECKING:
     from sky.clouds import cloud
 
 _df = common.read_catalog('gcp/vms.csv')
+_storage_df = common.read_catalog('gcp/storage.csv')
 _image_df = common.read_catalog('gcp/images.csv')
 
 _TPU_REGIONS = [
@@ -153,6 +154,7 @@ def instance_type_exists(instance_type: str) -> bool:
 
 def get_hourly_cost(
     instance_type: str,
+    disk_size: int,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -160,8 +162,8 @@ def get_hourly_cost(
     if instance_type == 'TPU-VM':
         # Currently the host VM of TPU does not cost extra.
         return 0
-    return common.get_hourly_cost_impl(_df, instance_type, use_spot, region,
-                                       zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_hourly_disk_cost(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -152,8 +152,7 @@ def instance_type_exists(instance_type: str) -> bool:
     return common.instance_type_exists_impl(_df, instance_type)
 
 
-def get_cost(
-    time_in_hour: float,
+def get_hourly_cost(
     instance_type: str,
     disk_size: int,
     use_spot: bool = False,
@@ -163,8 +162,8 @@ def get_cost(
     if instance_type == 'TPU-VM':
         # Currently the host VM of TPU does not cost extra.
         return 0
-    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
-                                disk_size, use_spot, region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
@@ -343,23 +342,20 @@ def list_accelerators(
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
         memory = df['MemoryGiB'].iloc[0]
-        # -1 for get hourly price
-        vm_price = common.get_cost_impl(-1,
-                                        _df,
-                                        _storage_df,
-                                        a100_host_vm_type,
-                                        disk_size=0,
-                                        use_spot=False,
-                                        region=None,
-                                        zone=None)
-        vm_spot_price = common.get_cost_impl(-1,
-                                             _df,
-                                             _storage_df,
-                                             a100_host_vm_type,
-                                             disk_size=0,
-                                             use_spot=True,
-                                             region=None,
-                                             zone=None)
+        vm_price = common.get_hourly_cost_impl(_df,
+                                               _storage_df,
+                                               a100_host_vm_type,
+                                               disk_size=0,
+                                               use_spot=False,
+                                               region=None,
+                                               zone=None)
+        vm_spot_price = common.get_hourly_cost_impl(_df,
+                                                    _storage_df,
+                                                    a100_host_vm_type,
+                                                    disk_size=0,
+                                                    use_spot=True,
+                                                    region=None,
+                                                    zone=None)
         new_infos[info.accelerator_name].append(
             info._replace(
                 instance_type=a100_host_vm_type,

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -166,16 +166,6 @@ def get_hourly_cost(
                                        disk_size, use_spot, region, zone)
 
 
-def get_hourly_disk_cost(
-    instance_type: str,
-    use_spot: bool = False,
-    region: Optional[str] = None,
-    zone: Optional[str] = None,
-) -> float:
-    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
-                                            region, zone)
-
-
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     # The number of vCPUs provided with a TPU VM is not officially documented.
     if instance_type == 'TPU-VM':
@@ -353,12 +343,16 @@ def list_accelerators(
         cpu_count = df['vCPUs'].iloc[0]
         memory = df['MemoryGiB'].iloc[0]
         vm_price = common.get_hourly_cost_impl(_df,
+                                               _storage_df,
                                                a100_host_vm_type,
+                                               disk_size=0,
                                                use_spot=False,
                                                region=None,
                                                zone=None)
         vm_spot_price = common.get_hourly_cost_impl(_df,
+                                                    _storage_df,
                                                     a100_host_vm_type,
+                                                    disk_size=0,
                                                     use_spot=True,
                                                     region=None,
                                                     zone=None)

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -152,7 +152,8 @@ def instance_type_exists(instance_type: str) -> bool:
     return common.instance_type_exists_impl(_df, instance_type)
 
 
-def get_hourly_cost(
+def get_cost(
+    time_in_hour: float,
     instance_type: str,
     disk_size: int,
     use_spot: bool = False,
@@ -162,8 +163,8 @@ def get_hourly_cost(
     if instance_type == 'TPU-VM':
         # Currently the host VM of TPU does not cost extra.
         return 0
-    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
-                                       disk_size, use_spot, region, zone)
+    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
+                                disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
@@ -342,20 +343,23 @@ def list_accelerators(
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
         memory = df['MemoryGiB'].iloc[0]
-        vm_price = common.get_hourly_cost_impl(_df,
-                                               _storage_df,
-                                               a100_host_vm_type,
-                                               disk_size=0,
-                                               use_spot=False,
-                                               region=None,
-                                               zone=None)
-        vm_spot_price = common.get_hourly_cost_impl(_df,
-                                                    _storage_df,
-                                                    a100_host_vm_type,
-                                                    disk_size=0,
-                                                    use_spot=True,
-                                                    region=None,
-                                                    zone=None)
+        # -1 for get hourly price
+        vm_price = common.get_cost_impl(-1,
+                                        _df,
+                                        _storage_df,
+                                        a100_host_vm_type,
+                                        disk_size=0,
+                                        use_spot=False,
+                                        region=None,
+                                        zone=None)
+        vm_spot_price = common.get_cost_impl(-1,
+                                             _df,
+                                             _storage_df,
+                                             a100_host_vm_type,
+                                             disk_size=0,
+                                             use_spot=True,
+                                             region=None,
+                                             zone=None)
         new_infos[info.accelerator_name].append(
             info._replace(
                 instance_type=a100_host_vm_type,

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -55,6 +55,19 @@ def get_hourly_cost(instance_type: str,
                                        zone)
 
 
+def get_hourly_disk_cost(instance_type: str,
+                         use_spot: bool = False,
+                         region: Optional[str] = None,
+                         zone: Optional[str] = None) -> float:
+    """Returns the disk cost, or the cheapest cost among all zones for spot."""
+    assert not use_spot, 'Lambda Cloud does not support spot.'
+    if zone is not None:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError('Lambda Cloud does not support zones.')
+    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
+                                            region, zone)
+
+
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
     return common.get_vcpus_from_instance_type_impl(_df, instance_type)
 

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -43,18 +43,19 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_hourly_cost(instance_type: str,
-                    disk_size: int,
-                    use_spot: bool = False,
-                    region: Optional[str] = None,
-                    zone: Optional[str] = None) -> float:
+def get_cost(time_in_hour: float,
+             instance_type: str,
+             disk_size: int,
+             use_spot: bool = False,
+             region: Optional[str] = None,
+             zone: Optional[str] = None) -> float:
     """Returns the cost, or the cheapest cost among all zones for spot."""
     assert not use_spot, 'Lambda Cloud does not support spot.'
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
-                                       disk_size, use_spot, region, zone)
+    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
+                                disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -43,19 +43,18 @@ def accelerator_in_region_or_zone(acc_name: str,
                                                      region, zone)
 
 
-def get_cost(time_in_hour: float,
-             instance_type: str,
-             disk_size: int,
-             use_spot: bool = False,
-             region: Optional[str] = None,
-             zone: Optional[str] = None) -> float:
+def get_hourly_cost(instance_type: str,
+                    disk_size: int,
+                    use_spot: bool = False,
+                    region: Optional[str] = None,
+                    zone: Optional[str] = None) -> float:
     """Returns the cost, or the cheapest cost among all zones for spot."""
     assert not use_spot, 'Lambda Cloud does not support spot.'
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_cost_impl(time_in_hour, _df, _storage_df, instance_type,
-                                disk_size, use_spot, region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -13,6 +13,7 @@ if typing.TYPE_CHECKING:
     from sky.clouds import cloud
 
 _df = common.read_catalog('lambda/vms.csv')
+_storage_df = common.read_catalog('lambda/storage.csv')
 
 # Number of vCPUS for gpu_1x_a100_sxm4
 _DEFAULT_NUM_VCPUS = 30
@@ -43,6 +44,7 @@ def accelerator_in_region_or_zone(acc_name: str,
 
 
 def get_hourly_cost(instance_type: str,
+                    disk_size: int,
                     use_spot: bool = False,
                     region: Optional[str] = None,
                     zone: Optional[str] = None) -> float:
@@ -51,21 +53,8 @@ def get_hourly_cost(instance_type: str,
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_hourly_cost_impl(_df, instance_type, use_spot, region,
-                                       zone)
-
-
-def get_hourly_disk_cost(instance_type: str,
-                         use_spot: bool = False,
-                         region: Optional[str] = None,
-                         zone: Optional[str] = None) -> float:
-    """Returns the disk cost, or the cheapest cost among all zones for spot."""
-    assert not use_spot, 'Lambda Cloud does not support spot.'
-    if zone is not None:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_hourly_disk_cost_impl(_df, instance_type, use_spot,
-                                            region, zone)
+    return common.get_hourly_cost_impl(_df, _storage_df, instance_type,
+                                       disk_size, use_spot, region, zone)
 
 
 def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -598,18 +598,17 @@ class Resources:
                 self.accelerators, self.use_spot, self._region, self._zone)
         return hourly_cost * hours
 
-    def get_disk_cost(self, seconds: float, num_bytes: float) -> float:
+    def get_disk_cost(self, seconds: float, num_gbs: float) -> float:
         """
         Returns cost in USD for the disk usage in bytes and rumtime
         in seconds.
         """
-        gbs = num_bytes / (1024**3)
         hours = seconds / 3600
         # Instance.
         hourly_cost = self.cloud.instance_type_to_hourly_disk_cost(
             self._instance_type, self.use_spot, self._region, self._zone)
         # Accelerators won't change disk cost.
-        return hourly_cost * gbs * hours
+        return hourly_cost * num_gbs * hours
 
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -591,24 +591,13 @@ class Resources:
         hours = seconds / 3600
         # Instance.
         hourly_cost = self.cloud.instance_type_to_hourly_cost(
-            self._instance_type, self.use_spot, self._region, self._zone)
+            self._instance_type, self.disk_size, self.use_spot, self._region,
+            self._zone)
         # Accelerators (if any).
         if self.accelerators is not None:
             hourly_cost += self.cloud.accelerators_to_hourly_cost(
                 self.accelerators, self.use_spot, self._region, self._zone)
         return hourly_cost * hours
-
-    def get_disk_cost(self, seconds: float, num_gbs: float) -> float:
-        """
-        Returns cost in USD for the disk usage in bytes and rumtime
-        in seconds.
-        """
-        hours = seconds / 3600
-        # Instance.
-        hourly_cost = self.cloud.instance_type_to_hourly_disk_cost(
-            self._instance_type, self.use_spot, self._region, self._zone)
-        # Accelerators won't change disk cost.
-        return hourly_cost * num_gbs * hours
 
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -598,6 +598,19 @@ class Resources:
                 self.accelerators, self.use_spot, self._region, self._zone)
         return hourly_cost * hours
 
+    def get_disk_cost(self, seconds: float, num_bytes: float) -> float:
+        """
+        Returns cost in USD for the disk usage in bytes and rumtime
+        in seconds.
+        """
+        gbs = num_bytes / (1024**3)
+        hours = seconds / 3600
+        # Instance.
+        hourly_cost = self.cloud.instance_type_to_hourly_disk_cost(
+            self._instance_type, self.use_spot, self._region, self._zone)
+        # Accelerators won't change disk cost.
+        return hourly_cost * gbs * hours
+
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],
                             requested_num_nodes: int = 1) -> bool:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -590,15 +590,14 @@ class Resources:
         """Returns cost in USD for the runtime in seconds."""
         hours = seconds / 3600
         # Instance.
-        cost = self.cloud.instance_type_to_cost(hours, self._instance_type,
-                                                self.disk_size, self.use_spot,
-                                                self._region, self._zone)
+        hourly_cost = self.cloud.instance_type_to_hourly_cost(
+            self._instance_type, self.disk_size, self.use_spot, self._region,
+            self._zone)
         # Accelerators (if any).
         if self.accelerators is not None:
-            hourly_cost = self.cloud.accelerators_to_hourly_cost(
+            hourly_cost += self.cloud.accelerators_to_hourly_cost(
                 self.accelerators, self.use_spot, self._region, self._zone)
-            cost += hourly_cost * hours
-        return cost
+        return hourly_cost * hours
 
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -590,14 +590,15 @@ class Resources:
         """Returns cost in USD for the runtime in seconds."""
         hours = seconds / 3600
         # Instance.
-        hourly_cost = self.cloud.instance_type_to_hourly_cost(
-            self._instance_type, self.disk_size, self.use_spot, self._region,
-            self._zone)
+        cost = self.cloud.instance_type_to_cost(hours, self._instance_type,
+                                                self.disk_size, self.use_spot,
+                                                self._region, self._zone)
         # Accelerators (if any).
         if self.accelerators is not None:
-            hourly_cost += self.cloud.accelerators_to_hourly_cost(
+            hourly_cost = self.cloud.accelerators_to_hourly_cost(
                 self.accelerators, self.use_spot, self._region, self._zone)
-        return hourly_cost * hours
+            cost += hourly_cost * hours
+        return cost
 
     def less_demanding_than(self,
                             other: Union[List['Resources'], 'Resources'],

--- a/sky/task.py
+++ b/sky/task.py
@@ -155,6 +155,7 @@ class Task:
         # Default to CPUNode
         self.resources = {sky.Resources()}
         self.time_estimator_func = None
+        self.disk_estimator_func = None
         self.file_mounts = None
 
         # Only set when 'self' is a spot controller task: 'self.spot_task' is
@@ -471,9 +472,29 @@ class Task:
         """
         if self.time_estimator_func is None:
             raise NotImplementedError(
-                'Node [{}] does not have a cost model set; '
+                'Node [{}] does not have a time cost model set; '
                 'call set_time_estimator() first'.format(self))
         return self.time_estimator_func(resources)
+
+    def set_disk_estimator(self, func: Callable[['sky.Resources'],
+                                                int]) -> 'Task':
+        """Sets a func mapping resources to estimated disk usage (bytes).
+
+        This is EXPERIMENTAL.
+        """
+        self.disk_estimator_func = func
+        return self
+
+    def estimate_disk_usage(self, resources):
+        """Returns a func mapping resources to estimated disk usage (bytes).
+
+        This is EXPERIMENTAL.
+        """
+        if self.disk_estimator_func is None:
+            raise NotImplementedError(
+                'Node [{}] does not have a disk cost model set; '
+                'call set_disk_estimator() first'.format(self))
+        return self.disk_estimator_func(resources)
 
     def set_file_mounts(self, file_mounts: Optional[Dict[str, str]]) -> 'Task':
         """Sets the file mounts for this task.

--- a/sky/task.py
+++ b/sky/task.py
@@ -155,7 +155,6 @@ class Task:
         # Default to CPUNode
         self.resources = {sky.Resources()}
         self.time_estimator_func = None
-        self.disk_estimator_func = None
         self.file_mounts = None
 
         # Only set when 'self' is a spot controller task: 'self.spot_task' is
@@ -475,26 +474,6 @@ class Task:
                 'Node [{}] does not have a time cost model set; '
                 'call set_time_estimator() first'.format(self))
         return self.time_estimator_func(resources)
-
-    def set_disk_estimator(self, func: Callable[['sky.Resources'],
-                                                int]) -> 'Task':
-        """Sets a func mapping resources to estimated disk usage (bytes).
-
-        This is EXPERIMENTAL.
-        """
-        self.disk_estimator_func = func
-        return self
-
-    def estimate_disk_usage(self, resources):
-        """Returns a func mapping resources to estimated disk usage (bytes).
-
-        This is EXPERIMENTAL.
-        """
-        if self.disk_estimator_func is None:
-            raise NotImplementedError(
-                'Node [{}] does not have a disk cost model set; '
-                'call set_disk_estimator() first'.format(self))
-        return self.disk_estimator_func(resources)
 
     def set_file_mounts(self, file_mounts: Optional[Dict[str, str]]) -> 'Task':
         """Sets the file mounts for this task.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add GCP disk price to the optimizer. This PR is blocking on skypilot-org/skypilot#1642 and resolves #1228 on GCP.

Need to change skypilot-org/skypilot-catalog by adding storage.csv to gcp/storage.csv for fetching.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
