### PR TITLE
Fix KeyError when listing instances

### DIFF
--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -93,7 +93,7 @@ class LambdaNodeProvider(NodeProvider):
     def _list_instances_in_cluster(self) -> Dict[str, Any]:
         """List running instances in cluster."""
         vms = self.lambda_client.list_instances()
-        return [node for node in vms if node['name'] == self.cluster_name]
+        return [node for node in vms if node.get('name') == self.cluster_name]
 
     @synchronized
     def _get_filtered_nodes(self, tag_filters: Dict[str,


### PR DESCRIPTION
This fixes a KeyError which occurs when listing instances that were manually launched on the Lambda Cloud dashboard which do not have a name attribute set.

<!-- Describe the changes in this PR -->
Channged the name key indexing into a call to .get which will return `None` if the key 'name' is not set. The key 'name' is not set when you manually launch an instance in our cloud.

<!-- Describe the tests ran -->
I edited the node_providers.py file manually that was installed by pip install skypilot[lambda]

Running the command line tool now works.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name`
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

Here is the trace from the error:

```
sabalaba@tensorbook:~$ sky launch --gpus A10
SkyPilot collects usage data to improve its services. `setup` and `run` commands are not collected to ensure privacy.
Usage logging can be disabled by setting the environment variable SKYPILOT_DISABLE_USAGE_COLLECTION=1.
I 02-21 17:24:11 optimizer.py:605] == Optimizer ==
I 02-21 17:24:11 optimizer.py:616] Target: minimizing cost
I 02-21 17:24:11 optimizer.py:628] Estimated cost: $0.6 / hour
I 02-21 17:24:11 optimizer.py:628] 
I 02-21 17:24:11 optimizer.py:691] Considered resources (1 node):
I 02-21 17:24:11 optimizer.py:739] --------------------------------------------------------------------------------
I 02-21 17:24:11 optimizer.py:739]  CLOUD    INSTANCE     vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-21 17:24:11 optimizer.py:739] --------------------------------------------------------------------------------
I 02-21 17:24:11 optimizer.py:739]  Lambda   gpu_1x_a10   30      A10:1          us-east-1     0.60          ✔     
I 02-21 17:24:11 optimizer.py:739] --------------------------------------------------------------------------------
I 02-21 17:24:11 optimizer.py:739] 
Launching a new cluster 'sky-25fd-sabalaba'. Proceed? [Y/n]: 
I 02-21 17:24:13 cloud_vm_ray_backend.py:3212] Creating a new cluster: "sky-25fd-sabalaba" [1x Lambda(gpu_1x_a10, {'A10': 1})].
I 02-21 17:24:13 cloud_vm_ray_backend.py:3212] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
I 02-21 17:24:13 cloud_vm_ray_backend.py:1124] To view detailed progress: tail -n100 -f /home/sabalaba/sky_logs/sky-2023-02-21-17-24-08-653878/provision.log
I 02-21 17:24:14 cloud_vm_ray_backend.py:1444] Launching on Lambda us-east-1 (all zones)
I 02-21 17:24:15 cloud_vm_ray_backend.py:794] ====== stdout ======
2023-02-21 17:24:14,507	INFO commands.py:276 -- Cluster: sky-25fd-sabalaba
2023-02-21 17:24:14,570	INFO commands.py:353 -- Checking External environment settings

I 02-21 17:24:15 cloud_vm_ray_backend.py:797] ====== stderr ======
Dropping the empty legacy field head_node. head_nodeis not supported for ray>=2.0.0. It is recommended to removehead_node from the cluster config.
Dropping the empty legacy field worker_nodes. worker_nodesis not supported for ray>=2.0.0. It is recommended to removeworker_nodes from the cluster config.
Traceback (most recent call last):
  File "/tmp/skypilot_ray_up_0kbb97xx.py", line 42, in <module>
    sdk.create_or_update_cluster('/home/sabalaba/.sky/generated/sky-25fd-sabalaba.yml', **{'no_restart': True})
  File "/home/sabalaba/.local/lib/python3.10/site-packages/ray/autoscaler/sdk/sdk.py", line 38, in create_or_update_cluster
    return commands.create_or_update_cluster(
  File "/home/sabalaba/.local/lib/python3.10/site-packages/ray/autoscaler/_private/commands.py", line 282, in create_or_update_cluster
    get_or_create_head_node(
  File "/home/sabalaba/.local/lib/python3.10/site-packages/ray/autoscaler/_private/commands.py", line 639, in get_or_create_head_node
    provider = _provider or _get_node_provider(
  File "/home/sabalaba/.local/lib/python3.10/site-packages/ray/autoscaler/_private/providers.py", line 229, in _get_node_provider
    new_provider = provider_cls(provider_config, cluster_name)
  File "/home/sabalaba/.local/lib/python3.10/site-packages/sky/skylet/providers/lambda_cloud/node_provider.py", line 54, in __init__
    vms = self._list_instances_in_cluster()
  File "/home/sabalaba/.local/lib/python3.10/site-packages/sky/skylet/providers/lambda_cloud/node_provider.py", line 95, in _list_instances_in_cluster
    return [
  File "/home/sabalaba/.local/lib/python3.10/site-packages/sky/skylet/providers/lambda_cloud/node_provider.py", line 97, in <listcomp>
    if node['name'] == self.cluster_name
KeyError: 'name'
```

You can easily replicate this by manually launching an instance in our cloud without a name attribute specified, this breaks the sky client.
