### PR TITLE
[Spot] Fix spot failure reason when cloud is specified

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2072,6 +2072,10 @@ class CloudVmRayBackend(backends.Backend):
 
         The resources requested by the task should be smaller than the existing
         cluster.
+
+        Raises:
+            exceptions.ResourcesMismatchError: If the resources requested by the
+                task are larger than the existing cluster.
         """
         assert len(task.resources) == 1, task.resources
 
@@ -2141,6 +2145,9 @@ class CloudVmRayBackend(backends.Backend):
         Raises:
             exceptions.ClusterOwnerIdentityMismatchError: if the cluster
                 'cluster_name' exists and is owned by another user.
+            exceptions.InvalidClusterNameError: if the cluster name is invalid.
+            exceptions.ResourcesMismatchError: if the requested resources
+                do not match the existing cluster.
             exceptions.ResourcesUnavailableError: if the requested resources
                 cannot be satisfied. The failover_history of the exception
                 will be set as at least 1 exception from either our pre-checks
@@ -3269,6 +3276,14 @@ class CloudVmRayBackend(backends.Backend):
     def _check_existing_cluster(
             self, task: task_lib.Task, to_provision: resources_lib.Resources,
             cluster_name: str) -> RetryingVmProvisioner.ToProvisionConfig:
+        """Checks if the cluster exists and returns the provision config.
+        
+        Raises:
+            exceptions.ResourcesMismatchError: If the resources in the task
+                does not match the existing cluster.
+            exceptions.InvalidClusterNameError: If the cluster name is invalid.
+            # TODO(zhwu): complete the list of exceptions.
+        """
         prev_cluster_status, handle = (
             backend_utils.refresh_cluster_status_handle(
                 cluster_name, acquire_per_cluster_status_lock=False))

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2154,6 +2154,7 @@ class CloudVmRayBackend(backends.Backend):
                 (e.g., cluster name invalid) or a region/zone throwing
                 resource unavailability.
             exceptions.CommandError: any ssh command error.
+            # TODO(zhwu): complete the list of exceptions.
         """
         # FIXME: ray up for Azure with different cluster_names will overwrite
         # each other.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3277,7 +3277,7 @@ class CloudVmRayBackend(backends.Backend):
             self, task: task_lib.Task, to_provision: resources_lib.Resources,
             cluster_name: str) -> RetryingVmProvisioner.ToProvisionConfig:
         """Checks if the cluster exists and returns the provision config.
-        
+
         Raises:
             exceptions.ResourcesMismatchError: If the resources in the task
                 does not match the existing cluster.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2074,8 +2074,8 @@ class CloudVmRayBackend(backends.Backend):
         cluster.
 
         Raises:
-            exceptions.ResourcesMismatchError: If the resources requested by the
-                task are larger than the existing cluster.
+            exceptions.ResourcesMismatchError: If the resources in the task
+                does not match the existing cluster.
         """
         assert len(task.resources) == 1, task.resources
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -393,6 +393,11 @@ def launch(
     Raises:
         exceptions.ClusterOwnerIdentityMismatchError: if the cluster is
             owned by another user.
+        exceptions.InvalidClusterNameError: if the cluster name is invalid.
+        exceptions.ResourcesMismatchError: if the requested resources
+            do not match the existing cluster.
+        exceptions.NotSupportedError: if required features are not supported
+            by the backend/cloud/cluster.
         exceptions.ResourcesUnavailableError: if the requested resources
             cannot be satisfied. The failover_history of the exception
             will be set as:
@@ -402,7 +407,7 @@ def launch(
                 2. Non-empty: iff at least 1 exception from either
                 our pre-checks (e.g., cluster name invalid) or a region/zone
                 throwing resource unavailability.
-        exceptions.NotSupportedError: if the cluster name is reserved.
+        exceptions.CommandError: any ssh command error.
     Other exceptions may be raised depending on the backend.
     """
     entrypoint = task

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -246,6 +246,13 @@ class StrategyExecutor:
                            detach_run=True,
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
+            except (exceptions.InvalidClusterNameError,
+                    exceptions.NotSupportedError,
+                    exceptions.CloudUserIdentityError) as e:
+                if raise_on_failure:
+                        raise exceptions.ProvisionPrechecksError(
+                            reasons=[e])
+                return None
             except exceptions.ResourcesUnavailableError as e:
                 # This is raised when the launch fails due to prechecks or
                 # after failing over through all the candidates.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -250,8 +250,7 @@ class StrategyExecutor:
                     exceptions.NotSupportedError,
                     exceptions.CloudUserIdentityError) as e:
                 if raise_on_failure:
-                        raise exceptions.ProvisionPrechecksError(
-                            reasons=[e])
+                    raise exceptions.ProvisionPrechecksError(reasons=[e])
                 return None
             except exceptions.ResourcesUnavailableError as e:
                 # This is raised when the launch fails due to prechecks or

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -247,6 +247,9 @@ class StrategyExecutor:
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
             except exceptions.InvalidClusterNameError as e:
+                logger.error(
+                        'Failure happened before provisioning. '
+                        f'{common_utils.format_exception(e)}')
                 if raise_on_failure:
                     raise exceptions.ProvisionPrechecksError(reasons=[e])
                 return None

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -247,9 +247,8 @@ class StrategyExecutor:
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
             except exceptions.InvalidClusterNameError as e:
-                logger.error(
-                        'Failure happened before provisioning. '
-                        f'{common_utils.format_exception(e)}')
+                logger.error('Failure happened before provisioning. '
+                             f'{common_utils.format_exception(e)}')
                 if raise_on_failure:
                     raise exceptions.ProvisionPrechecksError(reasons=[e])
                 return None

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -246,9 +246,7 @@ class StrategyExecutor:
                            detach_run=True,
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
-            except (exceptions.InvalidClusterNameError,
-                    exceptions.NotSupportedError,
-                    exceptions.CloudUserIdentityError) as e:
+            except exceptions.InvalidClusterNameError as e:
                 if raise_on_failure:
                     raise exceptions.ProvisionPrechecksError(reasons=[e])
                 return None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Patches #1655

When the cloud is specified, we don't raise the `ResourcesUnavailableError` but the actual precheck errors. We need to catch those exceptions in the `recovery_strategy`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky spot launch -n spot-maskgit-minerl-maskgit-interp --cloud gcp echo hi`