### PR TITLE
Fix GCP status and region.zones is `None`

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1678,9 +1678,10 @@ def _query_status_gcp(
                      f'--filter="(labels.ray-cluster-name={cluster})" '
                      '--format="value(state)"')
     else:
+        # Ref: https://cloud.google.com/compute/docs/instances/instance-life-cycle
         status_map = {
             'PROVISIONING': global_user_state.ClusterStatus.INIT,
-            'STARTING': global_user_state.ClusterStatus.INIT,
+            'STAGING': global_user_state.ClusterStatus.INIT,
             'RUNNING': global_user_state.ClusterStatus.UP,
             'REPAIRING': global_user_state.ClusterStatus.INIT,
             # 'TERMINATED' in GCP means stopped, with disk preserved.

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -868,7 +868,7 @@ def _make_launchables_for_valid_region_zones(
     launchables = []
     regions = launchable_resources.get_offering_regions_for_launchable()
     for region in regions:
-        if launchable_resources.use_spot:
+        if launchable_resources.use_spot and region.zones is not None:
             # Spot instances.
             # Do not batch the per-zone requests.
             for zone in region.zones:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Bug fixes for GCP status list and `region.zones is None` handling.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
