### PR TITLE
[GCP] Fix sky check for not having application default set

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -502,7 +502,8 @@ class GCP(clouds.Cloud):
             # `auth.default()` does not guarantee these files exist.
             for file in [
                     '~/.config/gcloud/access_tokens.db',
-                    '~/.config/gcloud/credentials.db'
+                    '~/.config/gcloud/credentials.db',
+                    '~/.config/gcloud/application_default_credentials.json'
             ]:
                 if not os.path.isfile(os.path.expanduser(file)):
                     raise FileNotFoundError(file)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, if the user only runs `gcloud init` without `gcloud auth application-default login`, the `sky check` still passed for GCP and `sky launch --cloud gcp` will raise the following issue:
```
cp: cannot stat '/root/.config/gcloud/application_default_credentials.json': No such file or directory
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky check` without `gcloud auth application-default login`
- [x] `sky launch -c test-gcp --cloud gcp` in a new environment without `gcloud auth application-default login`
