### PR TITLE
[core] Filter out regions not in proxy command earlier

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -824,22 +824,12 @@ def write_cluster_config(
     if (isinstance(ssh_proxy_command_config, str) or
             ssh_proxy_command_config is None):
         ssh_proxy_command = ssh_proxy_command_config
-    elif isinstance(ssh_proxy_command_config, dict):
-        ssh_proxy_command = ssh_proxy_command_config.get(region_name, None)
-        if ssh_proxy_command is None:
-            # Skip this region. The upper layer will handle the failover to
-            # other regions.
-            raise exceptions.ResourcesUnavailableError(
-                f'No ssh_proxy_command provided for region {region_name}. Skipped.'
-            )
-        elif not isinstance(ssh_proxy_command, str):
-            raise ValueError(
-                'Invalid ssh_proxy_command config (expected a str): '
-                f'{ssh_proxy_command_config!r}')
     else:
-        raise ValueError(
-            'Invalid ssh_proxy_command config (expected a str or a dict with '
-            f'region names as keys): {ssh_proxy_command_config!r}')
+        # The existence of the region_name should be guaranteed by the
+        # Resources.get_valid_regions_for_launchable()
+        assert (isinstance(ssh_proxy_command_config, dict) and region_name
+                in ssh_proxy_command_config), ssh_proxy_command_config
+        ssh_proxy_command = ssh_proxy_command_config[region_name]
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -825,10 +825,14 @@ def write_cluster_config(
             ssh_proxy_command_config is None):
         ssh_proxy_command = ssh_proxy_command_config
     else:
-        # The existence of the region_name should be guaranteed by the
-        # Resources.get_valid_regions_for_launchable()
-        assert (isinstance(ssh_proxy_command_config, dict) and region_name
-                in ssh_proxy_command_config), ssh_proxy_command_config
+        # ssh_proxy_command_config: Dict[str, str], region_name -> command
+        # It is guaranteed by the skypilot_config.
+        if region_name not in ssh_proxy_command_config:
+            # Skip this region. The upper layer will handle the failover to
+            # other regions.
+            raise exceptions.ResourcesUnavailableError(
+                f'No ssh_proxy_command provided for region {region_name}. Skipped.'
+            )
         ssh_proxy_command = ssh_proxy_command_config[region_name]
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -826,7 +826,7 @@ def write_cluster_config(
         ssh_proxy_command = ssh_proxy_command_config
     else:
         # ssh_proxy_command_config: Dict[str, str], region_name -> command
-        # It is guaranteed by the skypilot_config.
+        # This type check is done by skypilot_config at config load time.
         if region_name not in ssh_proxy_command_config:
             # Skip this region. The upper layer will handle the failover to
             # other regions.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -695,6 +695,7 @@ class RetryingVmProvisioner(object):
             self, launchable_resources: 'resources_lib.Resources',
             region: 'clouds.Region', zones: Optional[List['clouds.Zone']],
             stdout: str, stderr: str):
+        assert launchable_resources.is_launchable()
         assert zones is not None, 'AWS should always have zones.'
 
         style = colorama.Style
@@ -942,9 +943,10 @@ class RetryingVmProvisioner(object):
                 resources.
         """
         assert (to_provision.cloud is not None and
-                to_provision.region is not None), (
-                    to_provision,
-                    'cloud and region must have been set by optimizer')
+                to_provision.region is not None and to_provision.instance_type
+                is not None), (to_provision,
+                               'cloud, region and instance_type must have been '
+                               'set by optimizer')
         cloud = to_provision.cloud
         region = clouds.Region(to_provision.region)
         zones = None

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -90,12 +90,11 @@ class AWS(clouds.Cloud):
     #### Regions/Zones ####
 
     @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
-        assert instance_type is not None
         regions = service_catalog.get_region_zones_for_instance_type(
             instance_type, use_spot, 'aws')
 
@@ -114,7 +113,7 @@ class AWS(clouds.Cloud):
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[List[clouds.Zone]]:
@@ -291,14 +290,8 @@ class AWS(clouds.Cloud):
                                                             clouds='aws')
 
     def make_deploy_resources_variables(
-            self, resources: 'resources_lib.Resources',
-            region: Optional['clouds.Region'],
+            self, resources: 'resources_lib.Resources', region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']]) -> Dict[str, Optional[str]]:
-        if region is None:
-            assert zones is None, (
-                'Set either both or neither for: region, zones.')
-            region = self._get_default_region()
-            zones = region.zones
         assert zones is not None, (region, zones)
 
         region_name = region.name

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -90,53 +90,20 @@ class AWS(clouds.Cloud):
     #### Regions/Zones ####
 
     @classmethod
-    def regions(cls):
-        if not cls._regions:
-            # https://aws.amazon.com/premiumsupport/knowledge-center/vpc-find-availability-zone-options/
-            cls._regions = [
-                clouds.Region('us-west-1').set_zones([
-                    clouds.Zone('us-west-1a'),
-                    clouds.Zone('us-west-1b'),
-                ]),
-                clouds.Region('us-west-2').set_zones([
-                    clouds.Zone('us-west-2a'),
-                    clouds.Zone('us-west-2b'),
-                    clouds.Zone('us-west-2c'),
-                    clouds.Zone('us-west-2d'),
-                ]),
-                clouds.Region('us-east-2').set_zones([
-                    clouds.Zone('us-east-2a'),
-                    clouds.Zone('us-east-2b'),
-                    clouds.Zone('us-east-2c'),
-                ]),
-                clouds.Region('us-east-1').set_zones([
-                    clouds.Zone('us-east-1a'),
-                    clouds.Zone('us-east-1b'),
-                    clouds.Zone('us-east-1c'),
-                    clouds.Zone('us-east-1d'),
-                    clouds.Zone('us-east-1e'),
-                    clouds.Zone('us-east-1f'),
-                ]),
-            ]
-        return cls._regions
-
-    @classmethod
     def regions_with_offering(cls, instance_type: Optional[str],
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
-        if instance_type is None:
-            # Fall back to default regions
-            regions = cls.regions()
-        else:
-            regions = service_catalog.get_region_zones_for_instance_type(
-                instance_type, use_spot, 'aws')
+        assert instance_type is not None
+        regions = service_catalog.get_region_zones_for_instance_type(
+            instance_type, use_spot, 'aws')
 
         if region is not None:
             regions = [r for r in regions if r.name == region]
         if zone is not None:
             for r in regions:
+                assert r.zones is not None, r
                 r.set_zones([z for z in r.zones if z.name == zone])
             regions = [r for r in regions if r.zones]
         return regions

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -51,8 +51,6 @@ class Azure(clouds.Cloud):
     # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 42
 
-    _regions: List[clouds.Region] = []
-
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
@@ -151,13 +149,12 @@ class Azure(clouds.Cloud):
         return image_config
 
     @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
         assert zone is None, 'Azure does not support zones'
-        assert instance_type is not None
         regions = service_catalog.get_region_zones_for_instance_type(
             instance_type, use_spot, 'azure')
 
@@ -171,7 +168,7 @@ class Azure(clouds.Cloud):
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[None]:
@@ -209,13 +206,9 @@ class Azure(clouds.Cloud):
         return None
 
     def make_deploy_resources_variables(
-            self, resources: 'resources.Resources',
-            region: Optional['clouds.Region'],
+            self, resources: 'resources.Resources', region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']]) -> Dict[str, Optional[str]]:
-        if region is None:
-            assert zones is None, (
-                'Set either both or neither for: region, zones.')
-            region = self._get_default_region()
+        assert zones is None, ('Azure does not support zones', zones)
 
         region_name = region.name
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -151,36 +151,15 @@ class Azure(clouds.Cloud):
         return image_config
 
     @classmethod
-    def regions(cls) -> List[clouds.Region]:
-        # NOTE on zones: Ray Autoscaler does not support specifying
-        # availability zones, and Azure CLI will try launching VMs in all
-        # zones. Hence for our purposes we do not keep track of zones.
-        if not cls._regions:
-            cls._regions = [
-                clouds.Region('centralus'),
-                clouds.Region('eastus'),
-                clouds.Region('eastus2'),
-                clouds.Region('northcentralus'),
-                clouds.Region('southcentralus'),
-                clouds.Region('westcentralus'),
-                clouds.Region('westus'),
-                clouds.Region('westus2'),
-            ]
-        return cls._regions
-
-    @classmethod
     def regions_with_offering(cls, instance_type: Optional[str],
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
         assert zone is None, 'Azure does not support zones'
-        if instance_type is None:
-            # Fall back to default regions
-            regions = cls.regions()
-        else:
-            regions = service_catalog.get_region_zones_for_instance_type(
-                instance_type, use_spot, 'azure')
+        assert instance_type is not None
+        regions = service_catalog.get_region_zones_for_instance_type(
+            instance_type, use_spot, 'azure')
 
         if region is not None:
             regions = [r for r in regions if r.name == region]

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -101,11 +101,7 @@ class Cloud:
     #### Regions/Zones ####
 
     @classmethod
-    def regions(cls) -> List[Region]:
-        raise NotImplementedError
-
-    @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[Region]:
@@ -131,7 +127,7 @@ class Cloud:
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[Optional[List[Zone]]]:
@@ -221,7 +217,7 @@ class Cloud:
     def make_deploy_resources_variables(
         self,
         resources: 'resources.Resources',
-        region: Optional['Region'],
+        region: 'Region',
         zones: Optional[List['Zone']],
     ) -> Dict[str, Optional[str]]:
         """Converts planned sky.Resources to cloud-specific resource variables.
@@ -264,10 +260,6 @@ class Cloud:
         This method may return None if the cloud's default instance family
         does not have a VM with the given number of vCPUs (e.g., when cpus='7').
         """
-        raise NotImplementedError
-
-    @classmethod
-    def _get_default_region(cls) -> Region:
         raise NotImplementedError
 
     @classmethod

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -97,9 +97,6 @@ class GCP(clouds.Cloud):
     # lower limit.
     _MAX_CLUSTER_NAME_LEN_LIMIT = 35
 
-    _regions: List[clouds.Region] = []
-    _zones: List[clouds.Zone] = []
-
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
@@ -111,11 +108,10 @@ class GCP(clouds.Cloud):
 
     #### Regions/Zones ####
     @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
-        assert instance_type is not None
         if accelerators is None:
             regions = service_catalog.get_region_zones_for_instance_type(
                 instance_type, use_spot, clouds='gcp')
@@ -164,7 +160,7 @@ class GCP(clouds.Cloud):
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[List[clouds.Zone]]:
@@ -267,19 +263,9 @@ class GCP(clouds.Cloud):
         return service_catalog.get_default_instance_type(cpus=cpus,
                                                          clouds='gcp')
 
-    @classmethod
-    def _get_default_region(cls) -> clouds.Region:
-        return cls.regions()[-1]
-
     def make_deploy_resources_variables(
-            self, resources: 'resources.Resources',
-            region: Optional['clouds.Region'],
+            self, resources: 'resources.Resources', region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']]) -> Dict[str, Optional[str]]:
-        if region is None:
-            assert zones is None, (
-                'Set either both or neither for: region, zones.')
-            region = self._get_default_region()
-            zones = region.zones
         assert zones is not None, (region, zones)
 
         region_name = region.name

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -110,60 +110,15 @@ class GCP(clouds.Cloud):
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     #### Regions/Zones ####
-
-    @classmethod
-    def regions(cls) -> List[clouds.Region]:
-        if not cls._regions:
-            # https://cloud.google.com/compute/docs/regions-zones
-            cls._regions = [
-                clouds.Region('us-west1').set_zones([
-                    clouds.Zone('us-west1-a'),
-                    clouds.Zone('us-west1-b'),
-                    # clouds.Zone('us-west1-c'),  # No GPUs.
-                ]),
-                clouds.Region('us-central1').set_zones([
-                    clouds.Zone('us-central1-a'),
-                    clouds.Zone('us-central1-b'),
-                    clouds.Zone('us-central1-c'),
-                    clouds.Zone('us-central1-f'),
-                ]),
-                clouds.Region('us-east1').set_zones([
-                    clouds.Zone('us-east1-b'),
-                    clouds.Zone('us-east1-c'),
-                    clouds.Zone('us-east1-d'),
-                ]),
-                clouds.Region('us-east4').set_zones([
-                    clouds.Zone('us-east4-a'),
-                    clouds.Zone('us-east4-b'),
-                    clouds.Zone('us-east4-c'),
-                ]),
-                clouds.Region('us-west2').set_zones([
-                    # clouds.Zone('us-west2-a'),  # No GPUs.
-                    clouds.Zone('us-west2-b'),
-                    clouds.Zone('us-west2-c'),
-                ]),
-                # Ignoring us-west3 as it doesn't have GPUs.
-                clouds.Region('us-west4').set_zones([
-                    clouds.Zone('us-west4-a'),
-                    clouds.Zone('us-west4-b'),
-                    # clouds.Zone('us-west4-c'),  # No GPUs.
-                ]),
-            ]
-        return cls._regions
-
     @classmethod
     def regions_with_offering(cls, instance_type: Optional[str],
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
+        assert instance_type is not None
         if accelerators is None:
-            if instance_type is None:
-                # Fall back to the default regions.
-                # TODO: Get the regions from the service catalog.
-                regions = cls.regions()
-            else:
-                regions = service_catalog.get_region_zones_for_instance_type(
-                    instance_type, use_spot, clouds='gcp')
+            regions = service_catalog.get_region_zones_for_instance_type(
+                instance_type, use_spot, clouds='gcp')
         else:
             assert len(accelerators) == 1, accelerators
             acc = list(accelerators.keys())[0]

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -36,8 +36,6 @@ class Lambda(clouds.Cloud):
         clouds.CloudImplementationFeatures.MULTI_NODE: 'Multi-node is not supported by the Lambda Cloud implementation yet.',
     }
 
-    _regions: List[clouds.Region] = []
-
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
@@ -48,28 +46,7 @@ class Lambda(clouds.Cloud):
         return cls._MAX_CLUSTER_NAME_LEN_LIMIT
 
     @classmethod
-    def regions(cls) -> List[clouds.Region]:
-        if not cls._regions:
-            cls._regions = [
-                # Popular US regions
-                clouds.Region('us-east-1'),
-                clouds.Region('us-west-2'),
-                clouds.Region('us-west-1'),
-                clouds.Region('us-south-1'),
-
-                # Everyone else
-                clouds.Region('asia-northeast-1'),
-                clouds.Region('asia-northeast-2'),
-                clouds.Region('asia-south-1'),
-                clouds.Region('australia-southeast-1'),
-                clouds.Region('europe-central-1'),
-                clouds.Region('europe-south-1'),
-                clouds.Region('me-west-1'),
-            ]
-        return cls._regions
-
-    @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
@@ -77,12 +54,8 @@ class Lambda(clouds.Cloud):
         del accelerators, zone  # unused
         if use_spot:
             return []
-        if instance_type is None:
-            # Fall back to default regions
-            regions = cls.regions()
-        else:
-            regions = service_catalog.get_region_zones_for_instance_type(
-                instance_type, use_spot, 'lambda')
+        regions = service_catalog.get_region_zones_for_instance_type(
+            instance_type, use_spot, 'lambda')
 
         if region is not None:
             regions = [r for r in regions if r.name == region]
@@ -94,7 +67,7 @@ class Lambda(clouds.Cloud):
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[None]:
@@ -165,12 +138,9 @@ class Lambda(clouds.Cloud):
         return None
 
     def make_deploy_resources_variables(
-            self, resources: 'resources_lib.Resources',
-            region: Optional['clouds.Region'],
+            self, resources: 'resources_lib.Resources', region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']]) -> Dict[str, Optional[str]]:
-        del zones
-        if region is None:
-            region = self._get_default_region()
+        assert zones is None, 'Lambda does not support zones.'
 
         r = resources
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
@@ -274,3 +244,7 @@ class Lambda(clouds.Cloud):
                                       zone: Optional[str] = None) -> bool:
         return service_catalog.accelerator_in_region_or_zone(
             accelerator, acc_count, region, zone, 'lambda')
+
+    @classmethod
+    def regions(cls) -> List['clouds.Region']:
+        return service_catalog.regions(clouds='lambda')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -42,7 +42,6 @@ class Local(clouds.Cloud):
         clouds.CloudImplementationFeatures.AUTOSTOP:
             ('Local cloud does not support stopping instances.')
     }
-    _regions: List[clouds.Region] = [LOCAL_REGION]
 
     @classmethod
     def _cloud_unsupported_features(
@@ -54,17 +53,13 @@ class Local(clouds.Cloud):
         return None
 
     @classmethod
-    def regions(cls):
-        return cls._regions
-
-    @classmethod
-    def regions_with_offering(cls, instance_type: Optional[str],
+    def regions_with_offering(cls, instance_type: str,
                               accelerators: Optional[Dict[str, int]],
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         """Local cloud resources are placed in only one region."""
         del instance_type, accelerators, use_spot, region, zone
-        return cls.regions()
+        return [cls.LOCAL_REGION]
 
     @classmethod
     def zones_provision_loop(
@@ -72,7 +67,7 @@ class Local(clouds.Cloud):
         *,
         region: str,
         num_nodes: int,
-        instance_type: Optional[str] = None,
+        instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
     ) -> Iterator[None]:

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -128,6 +128,10 @@ class Local(clouds.Cloud):
         # the ResourceHandle, which calculates the accelerators in the cluster.
         return None
 
+    @classmethod
+    def regions(cls) -> List[clouds.Region]:
+        return [Local.LOCAL_REGION]
+
     def make_deploy_resources_variables(
             self, resources: 'resources_lib.Resources',
             region: Optional['clouds.Region'],

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -129,7 +129,9 @@ def accelerator_in_region_or_zone(
 
 
 def regions(clouds: CloudFilter = None) -> 'List[cloud.Region]':
-    """Returns a list of regions."""
+    """Returns the list of regions in a Cloud's catalog.
+    Each Region object contains a list of Zones, if available.
+    """
     return _map_clouds_catalog(clouds, 'regions')
 
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -128,6 +128,11 @@ def accelerator_in_region_or_zone(
                                acc_name, acc_count, region, zone)
 
 
+def regions(clouds: CloudFilter = None) -> 'List[cloud.Region]':
+    """Returns a list of regions."""
+    return _map_clouds_catalog(clouds, 'regions')
+
+
 def get_region_zones_for_instance_type(
         instance_type: str,
         use_spot: bool,

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -99,6 +99,10 @@ def get_instance_type_for_accelerator(
                                                          zone=zone)
 
 
+def regions() -> List['cloud.Region']:
+    return common.get_region_zones(_df, use_spot=False)
+
+
 def get_region_zones_for_instance_type(instance_type: str,
                                        use_spot: bool) -> List['cloud.Region']:
     df = _df[_df['InstanceType'] == instance_type]

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -866,7 +866,7 @@ def _make_launchables_for_valid_region_zones(
     # TODO(woosuk): A better design is to implement batching at a higher level
     # (e.g., in provisioner or optimizer), not here.
     launchables = []
-    regions = launchable_resources.get_offering_regions_for_launchable()
+    regions = launchable_resources.get_valid_regions_for_launchable()
     for region in regions:
         if launchable_resources.use_spot and region.zones is not None:
             # Spot instances.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -390,7 +390,7 @@ class Resources:
 
         # Filter the regions by the skypilot_config
         ssh_proxy_command_config = skypilot_config.get_nested(
-            ('aws', 'ssh_proxy_command'), None)
+            (str(self._cloud).lower(), 'ssh_proxy_command'), None)
         if (isinstance(ssh_proxy_command_config, str) or
                 ssh_proxy_command_config is None):
             # All regions are valid as the regions are not specified for the
@@ -398,7 +398,7 @@ class Resources:
             return regions
 
         # ssh_proxy_command_config: Dict[str, str], region_name -> command
-        # It is guaranteed by the skypilot_config.
+        # This type check is done by skypilot_config at config load time.
         filtered_regions = []
         for region in regions:
             region_name = region.name

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -400,8 +400,8 @@ class Resources:
                 ssh_proxy_command = ssh_proxy_command_config.get(
                     region_name, None)
                 if ssh_proxy_command is None:
-                    # Skip this region. The upper layer will handle the failover to
-                    # other regions.
+                    # Skip this region. The upper layer will handle the failover
+                    # to other regions.
                     continue
                 # TODO: filter out the zones not available in the vpc_name
                 filtered_regions.append(region)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -403,6 +403,7 @@ class Resources:
                     # Skip this region. The upper layer will handle the failover to
                     # other regions.
                     continue
+                # TODO: filter out the zones not available in the vpc_name
                 filtered_regions.append(region)
             return filtered_regions
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -74,46 +74,6 @@ logger = sky_logging.init_logger(__name__)
 _dict = None
 
 
-def _try_load_config() -> None:
-    global _dict
-    config_path_via_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
-    if config_path_via_env_var is not None:
-        config_path = config_path_via_env_var
-    else:
-        config_path = CONFIG_PATH
-    config_path = os.path.expanduser(config_path)
-    if os.path.exists(config_path):
-        logger.debug(f'Using config path: {config_path}')
-        try:
-            _dict = common_utils.read_yaml(config_path)
-            logger.debug(f'Config loaded: {_dict}')
-        except yaml.YAMLError as e:
-            logger.error(f'Error in loading config file ({config_path}):', e)
-
-        for cloud in clouds.CLOUD_REGISTRY:
-            _syntax_check_for_ssh_proxy_command(cloud)
-        logger.debug('Config syntax check passed.')
-
-
-# Load on import.
-_try_load_config()
-
-
-def _check_loaded_or_die():
-    """Checks loaded() is true; otherwise raises RuntimeError."""
-    global _dict
-    if _dict is None:
-        raise RuntimeError(
-            f'No user configs loaded. Check {CONFIG_PATH} exists and '
-            'can be loaded.')
-
-
-def loaded() -> bool:
-    """Returns if the user configurations are loaded."""
-    global _dict
-    return _dict is not None
-
-
 def get_nested(keys: Sequence[str], default_value: Any) -> Any:
     """Gets a nested key.
 
@@ -174,3 +134,43 @@ def _syntax_check_for_ssh_proxy_command(cloud: str) -> None:
     raise ValueError(
         'Invalid ssh_proxy_command config (expected a str or a dict with '
         f'region names as keys): {ssh_proxy_command_config!r}')
+
+
+def _try_load_config() -> None:
+    global _dict
+    config_path_via_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
+    if config_path_via_env_var is not None:
+        config_path = config_path_via_env_var
+    else:
+        config_path = CONFIG_PATH
+    config_path = os.path.expanduser(config_path)
+    if os.path.exists(config_path):
+        logger.debug(f'Using config path: {config_path}')
+        try:
+            _dict = common_utils.read_yaml(config_path)
+            logger.debug(f'Config loaded: {_dict}')
+        except yaml.YAMLError as e:
+            logger.error(f'Error in loading config file ({config_path}):', e)
+
+        for cloud in clouds.CLOUD_REGISTRY:
+            _syntax_check_for_ssh_proxy_command(cloud)
+        logger.debug('Config syntax check passed.')
+
+
+# Load on import.
+_try_load_config()
+
+
+def _check_loaded_or_die():
+    """Checks loaded() is true; otherwise raises RuntimeError."""
+    global _dict
+    if _dict is None:
+        raise RuntimeError(
+            f'No user configs loaded. Check {CONFIG_PATH} exists and '
+            'can be loaded.')
+
+
+def loaded() -> bool:
+    """Returns if the user configurations are loaded."""
+    global _dict
+    return _dict is not None

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -48,6 +48,7 @@ from typing import Any, Dict, Sequence
 import yaml
 
 from sky import sky_logging
+from sky import clouds
 from sky.utils import common_utils
 
 # The config path is discovered in this order:
@@ -88,6 +89,10 @@ def _try_load_config() -> None:
             logger.debug(f'Config loaded: {_dict}')
         except yaml.YAMLError as e:
             logger.error(f'Error in loading config file ({config_path}):', e)
+
+        for cloud in clouds.CLOUD_REGISTRY:
+            _syntax_check_for_ssh_proxy_command(cloud)
+        logger.debug('Config syntax check passed.')
 
 
 # Load on import.
@@ -150,3 +155,22 @@ def pop_nested(keys: Sequence[str]) -> Dict[str, Any]:
             # If any key not found, simply return.
             return to_return
     return to_return
+
+
+def _syntax_check_for_ssh_proxy_command(cloud: str) -> None:
+    ssh_proxy_command_config = get_nested((cloud.lower(), 'ssh_proxy_command'),
+                                          None)
+    if ssh_proxy_command_config is None or isinstance(ssh_proxy_command_config,
+                                                      str):
+        return
+
+    if isinstance(ssh_proxy_command_config, dict):
+        for region, cmd in ssh_proxy_command_config.items():
+            if not isinstance(cmd, str):
+                raise ValueError(
+                    f'Invalid ssh_proxy_command config for region {region!r} '
+                    f'(expected a str): {cmd!r}')
+        return
+    raise ValueError(
+        'Invalid ssh_proxy_command config (expected a str or a dict with '
+        f'region names as keys): {ssh_proxy_command_config!r}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously we filter the regions not in proxy commands in `skypilot_config` when we failover to that region. This will print messages about the region in the optimizer output, making it confusing.

Now we filter out the regions not included to short-circuit the optimizer and failover for them.

```
# config.yaml
aws:
  ssh_proxy_command:
    us-east-2: ssh -W %h:%p -i ~/.ssh/sky-key  -o StrictHostKeyChecking=no ec2-user@18.188.102.65
```
Previous output
```
> sky launch -c vpc-aws-spot --cloud aws -t t3.micro --use-spot                                                                                                     
I 02-26 14:41:00 optimizer.py:617] == Optimizer ==
I 02-26 14:41:00 optimizer.py:628] Target: minimizing cost
I 02-26 14:41:00 optimizer.py:640] Estimated cost: $0.0 / hour
I 02-26 14:41:00 optimizer.py:640] 
I 02-26 14:41:00 optimizer.py:703] Considered resources (1 node):
I 02-26 14:41:00 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:00 optimizer.py:751]  CLOUD   INSTANCE         vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-26 14:41:00 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:00 optimizer.py:751]  AWS     t3.micro[Spot]   2       -              us-east-1a    0.00          ✔     
I 02-26 14:41:00 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:00 optimizer.py:751] 
Launching a new cluster 'vpc-aws-spot'. Proceed? [Y/n]: 
I 02-26 14:41:02 execution.py:227] Launching an unmanaged spot task, which does not automatically recover from preemptions.
I 02-26 14:41:02 execution.py:227] To get automatic recovery, use managed spot instead: sky spot launch or sky.spot_launch().
I 02-26 14:41:02 cloud_vm_ray_backend.py:3326] Creating a new cluster: "vpc-aws-spot" [1x AWS(t3.micro[Spot])].
I 02-26 14:41:02 cloud_vm_ray_backend.py:3326] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
I 02-26 14:41:09 cloud_vm_ray_backend.py:1151] To view detailed progress: tail -n100 -f /Users/zhwu/sky_logs/sky-2023-02-26-14-40-57-433719/provision.log
I 02-26 14:41:10 cloud_vm_ray_backend.py:1211] Failed to find catalog in region us-east-1: No ssh_proxy_command provided for region us-east-1. Skipped.
W 02-26 14:41:10 cloud_vm_ray_backend.py:1747] sky.exceptions.ResourcesUnavailableError: Failed to acquire resources in us-east-1a. Try changing resource requirements or use another zone.
W 02-26 14:41:10 cloud_vm_ray_backend.py:1756] 
W 02-26 14:41:10 cloud_vm_ray_backend.py:1756] Provision failed for 1x AWS(t3.micro[Spot]) in us-east-1a. Trying other locations (if any).
I 02-26 14:41:13 optimizer.py:617] == Optimizer ==
I 02-26 14:41:13 optimizer.py:628] Target: minimizing cost
I 02-26 14:41:13 optimizer.py:640] Estimated cost: $0.0 / hour
I 02-26 14:41:13 optimizer.py:640] 
I 02-26 14:41:13 optimizer.py:703] Considered resources (1 node):
I 02-26 14:41:13 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:13 optimizer.py:751]  CLOUD   INSTANCE         vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-26 14:41:13 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:13 optimizer.py:751]  AWS     t3.micro[Spot]   2       -              us-east-1b    0.00          ✔     
I 02-26 14:41:13 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:13 optimizer.py:751] 
I 02-26 14:41:13 cloud_vm_ray_backend.py:1151] To view detailed progress: tail -n100 -f /Users/zhwu/sky_logs/sky-2023-02-26-14-40-57-433719/provision.log
I 02-26 14:41:16 cloud_vm_ray_backend.py:1211] Failed to find catalog in region us-east-1: No ssh_proxy_command provided for region us-east-1. Skipped.
W 02-26 14:41:16 cloud_vm_ray_backend.py:1747] sky.exceptions.ResourcesUnavailableError: Failed to acquire resources in us-east-1b. Try changing resource requirements or use another zone.
W 02-26 14:41:16 cloud_vm_ray_backend.py:1756] 
W 02-26 14:41:16 cloud_vm_ray_backend.py:1756] Provision failed for 1x AWS(t3.micro[Spot]) in us-east-1b. Trying other locations (if any).
I 02-26 14:41:19 optimizer.py:617] == Optimizer ==
I 02-26 14:41:19 optimizer.py:628] Target: minimizing cost
I 02-26 14:41:19 optimizer.py:640] Estimated cost: $0.0 / hour
I 02-26 14:41:19 optimizer.py:640] 
I 02-26 14:41:19 optimizer.py:703] Considered resources (1 node):
I 02-26 14:41:19 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:19 optimizer.py:751]  CLOUD   INSTANCE         vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-26 14:41:19 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:19 optimizer.py:751]  AWS     t3.micro[Spot]   2       -              us-east-1c    0.00          ✔     
I 02-26 14:41:19 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:19 optimizer.py:751] 
I 02-26 14:41:19 cloud_vm_ray_backend.py:1151] To view detailed progress: tail -n100 -f /Users/zhwu/sky_logs/sky-2023-02-26-14-40-57-433719/provision.log
I 02-26 14:41:20 cloud_vm_ray_backend.py:1211] Failed to find catalog in region us-east-1: No ssh_proxy_command provided for region us-east-1. Skipped.
W 02-26 14:41:20 cloud_vm_ray_backend.py:1747] sky.exceptions.ResourcesUnavailableError: Failed to acquire resources in us-east-1c. Try changing resource requirements or use another zone.
W 02-26 14:41:20 cloud_vm_ray_backend.py:1756] 
W 02-26 14:41:20 cloud_vm_ray_backend.py:1756] Provision failed for 1x AWS(t3.micro[Spot]) in us-east-1c. Trying other locations (if any).
I 02-26 14:41:23 optimizer.py:617] == Optimizer ==
I 02-26 14:41:23 optimizer.py:628] Target: minimizing cost
I 02-26 14:41:23 optimizer.py:640] Estimated cost: $0.0 / hour
I 02-26 14:41:23 optimizer.py:640] 
I 02-26 14:41:23 optimizer.py:703] Considered resources (1 node):
I 02-26 14:41:23 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:23 optimizer.py:751]  CLOUD   INSTANCE         vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-26 14:41:23 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:23 optimizer.py:751]  AWS     t3.micro[Spot]   2       -              us-east-1d    0.00          ✔     
I 02-26 14:41:23 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:41:23 optimizer.py:751] 
I 02-26 14:41:23 cloud_vm_ray_backend.py:1151] To view detailed progress: tail -n100 -f /Users/zhwu/sky_logs/sky-2023-02-26-14-40-57-433719/provision.log
I 02-26 14:41:24 cloud_vm_ray_backend.py:1211] Failed to find catalog in region us-east-1: No ssh_proxy_command provided for region us-east-1. Skipped.
W 02-26 14:41:24 cloud_vm_ray_backend.py:1747] sky.exceptions.ResourcesUnavailableError: Failed to acquire resources in us-east-1d. Try changing resource requirements or use another zone.
W 02-26 14:41:24 cloud_vm_ray_backend.py:1756] 
W 02-26 14:41:24 cloud_vm_ray_backend.py:1756] Provision failed for 1x AWS(t3.micro[Spot]) in us-east-1d. Trying other locations (if any).
```

New output:
```
> sky launch -c vpc-aws-spot --cloud aws -t t3.micro --use-spot                                                                                
I 02-26 14:42:18 optimizer.py:617] == Optimizer ==
I 02-26 14:42:18 optimizer.py:628] Target: minimizing cost
I 02-26 14:42:18 optimizer.py:640] Estimated cost: $0.0 / hour
I 02-26 14:42:18 optimizer.py:640] 
I 02-26 14:42:18 optimizer.py:703] Considered resources (1 node):
I 02-26 14:42:18 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:42:18 optimizer.py:751]  CLOUD   INSTANCE         vCPUs   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 02-26 14:42:18 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:42:18 optimizer.py:751]  AWS     t3.micro[Spot]   2       -              us-east-2a    0.00          ✔     
I 02-26 14:42:18 optimizer.py:751] -----------------------------------------------------------------------------------
I 02-26 14:42:18 optimizer.py:751] 
Launching a new cluster 'vpc-aws-spot'. Proceed? [Y/n]: 
I 02-26 14:42:20 execution.py:227] Launching an unmanaged spot task, which does not automatically recover from preemptions.
I 02-26 14:42:20 execution.py:227] To get automatic recovery, use managed spot instead: sky spot launch or sky.spot_launch().
I 02-26 14:42:20 cloud_vm_ray_backend.py:3326] Creating a new cluster: "vpc-aws-spot" [1x AWS(t3.micro[Spot])].
I 02-26 14:42:20 cloud_vm_ray_backend.py:3326] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
I 02-26 14:42:26 cloud_vm_ray_backend.py:1151] To view detailed progress: tail -n100 -f /Users/zhwu/sky_logs/sky-2023-02-26-14-42-17-819927/provision.log
I 02-26 14:42:27 cloud_vm_ray_backend.py:1475] Launching on AWS us-east-2 (us-east-2a)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c vpc-aws --cloud aws --use-spot` with the config.yaml
  - [x] `sky launch -c no-vpc --cloud aws --use-spot` without config.yaml
  - [x] `sky launch -c no-vpc-all-cloud`
- [x] `pytest tests/test_smoke.py`
- [x] `pytest tests/test_smoke.py --aws`
- [x] `sky launch --cloud lambda`