### PR TITLE
[Setup] Upgrade support for local ray version to 2.3.0

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -86,7 +86,7 @@ install_requires = [
     'PrettyTable>=2.0.0',
     # Lower local ray version is not fully supported, due to the
     # autoscaler issues (also tracked in #537).
-    'ray[default]>=1.9.0,<=2.2.0',
+    'ray[default]>=1.9.0,<=2.3.0',
     'rich',
     'tabulate',
     'typing-extensions',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add support for ray 2.3.0 local version.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] All smoke tests: `pytest tests/test_smoke.py` 
