### PR TITLE
Remove unsafe colorama.init 

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -583,8 +583,6 @@ class RetryingVmProvisioner(object):
         self._local_wheel_path = local_wheel_path
         self._wheel_hash = wheel_hash
 
-        colorama.init()
-
     def _update_blocklist_on_gcp_error(
             self, launchable_resources: 'resources_lib.Resources',
             region: 'clouds.Region', zones: Optional[List['clouds.Zone']],
@@ -2547,7 +2545,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         detach_run: bool = False,
     ) -> None:
         """Executes generated code on the head node."""
-        colorama.init()
         style = colorama.Style
         fore = colorama.Fore
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
@@ -2732,7 +2729,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def _post_execute(self, handle: CloudVmRayResourceHandle,
                       down: bool) -> None:
-        colorama.init()
         fore = colorama.Fore
         style = colorama.Style
         name = handle.cluster_name

--- a/sky/backends/docker_utils.py
+++ b/sky/backends/docker_utils.py
@@ -131,7 +131,6 @@ def _execute_build(tag, context_path):
         unused_image, unused_build_logs = docker_client.images.build(
             path=context_path, tag=tag, rm=True, quiet=False)
     except docker.build_error() as e:
-        colorama.init()
         style = colorama.Style
         fore = colorama.Fore
         logger.error(f'{fore.RED}Image build for {tag} failed - are your setup '

--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -215,7 +215,6 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
         to it to handle sky exec commands.
         """
         del task, detach_setup  # unused
-        colorama.init()
         style = colorama.Style
         assert handle in self.images, \
             f'No image found for {handle}, have you run Backend.provision()?'
@@ -289,7 +288,6 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
     def _post_execute(self, handle: LocalDockerResourceHandle,
                       down: bool) -> None:
         del down  # unused
-        colorama.init()
         style = colorama.Style
         container = self.containers[handle]
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes https://github.com/skypilot-org/skypilot/issues/1694.
After removing the `init()`, I was trying to add
```
from colorama import just_fix_windows_console
just_fix_windows_console()
```
as suggested by https://github.com/tartley/colorama#initialisation

But this function only introduced after `0.4.5` and we pin `colorama<0.4.5` because it conflicts with `aws-cli` for some reason.
https://github.com/skypilot-org/skypilot/blob/e4b99e08fc585ffde28ef84229cc7d83f4664d4c/sky/setup_files/setup.py#L73
Related issue: https://github.com/skypilot-org/skypilot/pull/1323
Is this still the case after we upgrade ray version? @Michaelvll 

or is it safe to add `colorama.init()` in `sky/__init__.py`?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
