### PR TITLE
[UX] Fix the output of `sky spot queue`

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1087,9 +1087,8 @@ class RetryingVmProvisioner(object):
         assert 'tpu-create-script' in config_dict, \
             'Expect TPU provisioning with gcloud.'
         try:
-            with backend_utils.safe_console_status(
-                    '[bold cyan]Provisioning TPU '
-                    f'[green]{tpu_name}[/]'):
+            with log_utils.safe_rich_status('[bold cyan]Provisioning TPU '
+                                            f'[green]{tpu_name}[/]'):
                 subprocess_utils.run(f'bash {config_dict["tpu-create-script"]}',
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE)
@@ -2334,8 +2333,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # know the actual previous status of the cluster.
             job_owner = onprem_utils.get_job_owner(handle.cluster_yaml)
             cmd = job_lib.JobLibCodeGen.update_status(job_owner)
-            with backend_utils.safe_console_status(
-                    '[bold cyan]Preparing Job Queue'):
+            with log_utils.safe_rich_status('[bold cyan]Preparing Job Queue'):
                 returncode, _, stderr = self.run_on_head(handle,
                                                          cmd,
                                                          require_outputs=True)
@@ -2431,7 +2429,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         tail_cmd = f'tail -n100 -f {log_path}'
         logger.info('To view detailed progress: '
                     f'{style.BRIGHT}{tail_cmd}{style.RESET_ALL}')
-        with backend_utils.safe_console_status('[bold cyan]Syncing[/]'):
+        with log_utils.safe_rich_status('[bold cyan]Syncing[/]'):
             subprocess_utils.run_in_parallel(_sync_workdir_node, runners)
 
     def _sync_file_mounts(
@@ -3010,8 +3008,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # autoscaler.
             resource_group = config['provider']['resource_group']
             terminate_cmd = f'az group delete -y --name {resource_group}'
-            with backend_utils.safe_console_status(f'[bold cyan]Terminating '
-                                                   f'[green]{cluster_name}'):
+            with log_utils.safe_rich_status(f'[bold cyan]Terminating '
+                                            f'[green]{cluster_name}'):
                 returncode, stdout, stderr = log_lib.run_with_log(
                     terminate_cmd,
                     log_abs_path,
@@ -3054,8 +3052,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(f'Unsupported cloud {cloud} for stopped '
                                      f'cluster {cluster_name!r}.')
-            with backend_utils.safe_console_status(f'[bold cyan]Terminating '
-                                                   f'[green]{cluster_name}'):
+            with log_utils.safe_rich_status(f'[bold cyan]Terminating '
+                                            f'[green]{cluster_name}'):
                 returncode, stdout, stderr = log_lib.run_with_log(
                     terminate_cmd,
                     log_abs_path,
@@ -3072,9 +3070,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 f.flush()
 
                 teardown_verb = 'Terminating' if terminate else 'Stopping'
-                with backend_utils.safe_console_status(
-                        f'[bold cyan]{teardown_verb} '
-                        f'[green]{cluster_name}'):
+                with log_utils.safe_rich_status(f'[bold cyan]{teardown_verb} '
+                                                f'[green]{cluster_name}'):
                     # FIXME(zongheng): support retries. This call can fail for
                     # example due to GCP returning list requests per limit
                     # exceeded.
@@ -3144,8 +3141,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         if (handle.tpu_delete_script is not None and
                 os.path.exists(handle.tpu_delete_script)):
-            with backend_utils.safe_console_status(
-                    '[bold cyan]Terminating TPU...'):
+            with log_utils.safe_rich_status('[bold cyan]Terminating TPU...'):
                 tpu_rc, tpu_stdout, tpu_stderr = log_lib.run_with_log(
                     ['bash', handle.tpu_delete_script],
                     log_abs_path,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1404,7 +1404,7 @@ def _get_spot_jobs(
     Args:
         refresh: Query the latest statuses, restarting the spot controller if
             stopped.
-        skip_finished: Show only pending/running jobs\' information.
+        skip_finished: Show only in-progress jobs.
         show_all: Show all information in full.
         limit_num_jobs_to_show: If True, limit the number of jobs to show to
             _NUM_SPOT_JOBS_TO_SHOW_IN_STATUS, which is mainly used by

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1400,6 +1400,15 @@ def _get_spot_jobs(
         show_all: bool,
         limit_num_jobs_to_show: bool = False) -> Tuple[Optional[int], str]:
     """Get the in-progress spot jobs.
+    
+    Args:
+        refresh: Query the latest statuses, restarting the spot controller if
+            stopped.
+        skip_finished: Show only pending/running jobs\' information.
+        show_all: Show all information in full.
+        limit_num_jobs_to_show: If True, limit the number of jobs to show to
+            _NUM_SPOT_JOBS_TO_SHOW_IN_STATUS, which is mainly used by
+            `sky status`
 
     Returns:
         A tuple of (num_in_progress_jobs, msg). If num_in_progress_jobs is None,
@@ -1436,6 +1445,7 @@ def _get_spot_jobs(
         msg = spot_lib.format_job_table(spot_jobs,
                                         show_all=show_all,
                                         max_jobs=max_jobs_to_show)
+    print('hi')
     return num_in_progress_jobs, msg
 
 
@@ -1527,7 +1537,7 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                                                     refresh=False,
                                                     skip_finished=True,
                                                     show_all=False,
-                                                    limit_num_jobs_to_show=all))
+                                                    limit_num_jobs_to_show=not all))
         click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
                    f'{colorama.Style.RESET_ALL}')
         query_clusters: Optional[List[str]] = None

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3353,7 +3353,8 @@ def spot_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool):
     _, handle = spot_lib.is_spot_controller_up(
         'All managed spot jobs should have finished.')
     if handle is None:
-        return
+        # Hint messages already printed by the call above.
+        sys.exit(1)
 
     job_id_str = ','.join(map(str, job_ids))
     if sum([len(job_ids) > 0, name is not None, all]) != 1:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1405,7 +1405,7 @@ def _get_spot_jobs(
         refresh: Query the latest statuses, restarting the spot controller if
             stopped.
         skip_finished: Show only in-progress jobs.
-        show_all: Show all information in full.
+        show_all: Show all information of each spot job (e.g., region, price).
         limit_num_jobs_to_show: If True, limit the number of jobs to show to
             _NUM_SPOT_JOBS_TO_SHOW_IN_STATUS, which is mainly used by
             `sky status`

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1409,7 +1409,7 @@ def _get_spot_jobs(
     """
     num_in_progress_jobs = None
     try:
-        with core.silent():
+        with sky_logging.silent():
             # Make the call silent
             spot_jobs = core.spot_queue(refresh=refresh,
                                         skip_finished=skip_finished)
@@ -1551,8 +1551,7 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
         if show_spot_jobs:
             click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                        f'Managed spot jobs{colorama.Style.RESET_ALL}')
-            with backend_utils.safe_console_status(
-                    '[cyan]Checking spot jobs[/]'):
+            with log_utils.safe_rich_status('[cyan]Checking spot jobs[/]'):
                 num_in_progress_jobs, msg = spot_jobs_future.get()
 
                 try:
@@ -2335,7 +2334,7 @@ def _hint_or_raise_for_down_spot_controller(controller_name: str):
            'jobs (output of `sky spot queue`) will be lost.')
     click.echo(msg)
     if cluster_status == global_user_state.ClusterStatus.UP:
-        with backend_utils.safe_console_status(
+        with log_utils.safe_rich_status(
                 '[bold cyan]Checking for in-progress spot jobs[/]'):
             try:
                 spot_jobs = core.spot_queue(refresh=False)
@@ -3296,18 +3295,18 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
 
       watch -n60 sky spot queue
     """
+    click.secho('Fetching managed spot job statuses...', fg='yellow')
+    with log_utils.safe_rich_status('[cyan]Checking spot jobs[/]'):
+        _, msg = _get_spot_jobs(refresh=refresh,
+                                skip_finished=skip_finished,
+                                show_all=all)
     if not skip_finished:
         in_progress_only_hint = ''
     else:
         in_progress_only_hint = ' (showing in-progress jobs only)'
     click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                f'Managed spot jobs{colorama.Style.RESET_ALL}'
-               f'{in_progress_only_hint}')
-    with backend_utils.safe_console_status('[cyan]Checking spot jobs[/]'):
-        _, msg = _get_spot_jobs(refresh=refresh,
-                                skip_finished=skip_finished,
-                                show_all=all)
-    click.echo(msg)
+               f'{in_progress_only_hint}\n{msg}')
 
 
 _add_command_alias_to_group(spot, spot_queue, 'status', hidden=True)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1400,7 +1400,7 @@ def _get_spot_jobs(
         show_all: bool,
         limit_num_jobs_to_show: bool = False) -> Tuple[Optional[int], str]:
     """Get the in-progress spot jobs.
-    
+
     Args:
         refresh: Query the latest statuses, restarting the spot controller if
             stopped.
@@ -1532,12 +1532,12 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
         show_spot_jobs = show_spot_jobs and not clusters
         if show_spot_jobs:
             # Run the spot job query in parallel to speed up the status query.
-            spot_jobs_future = pool.apply_async(_get_spot_jobs,
-                                                kwds=dict(
-                                                    refresh=False,
-                                                    skip_finished=True,
-                                                    show_all=False,
-                                                    limit_num_jobs_to_show=not all))
+            spot_jobs_future = pool.apply_async(
+                _get_spot_jobs,
+                kwds=dict(refresh=False,
+                          skip_finished=True,
+                          show_all=False,
+                          limit_num_jobs_to_show=not all))
         click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
                    f'{colorama.Style.RESET_ALL}')
         query_clusters: Optional[List[str]] = None

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1408,7 +1408,7 @@ def _get_spot_jobs(
         show_all: Show all information of each spot job (e.g., region, price).
         limit_num_jobs_to_show: If True, limit the number of jobs to show to
             _NUM_SPOT_JOBS_TO_SHOW_IN_STATUS, which is mainly used by
-            `sky status`
+            `sky status`.
 
     Returns:
         A tuple of (num_in_progress_jobs, msg). If num_in_progress_jobs is None,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1424,6 +1424,9 @@ def _get_spot_jobs(
                 None, global_user_state.ClusterStatus.STOPPED
             ]
             msg = 'No in progress jobs.'
+            if controller_status is None:
+                msg += (f' (See: {colorama.Style.BRIGHT}sky spot -h'
+                        f'{colorama.Style.RESET_ALL})')
     except RuntimeError:
         msg = ('Failed to query spot jobs due to connection '
                'issues. Try again later.')
@@ -1525,7 +1528,8 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                                                     skip_finished=True,
                                                     show_all=False,
                                                     limit_num_jobs_to_show=all))
-
+        click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
+                   f'{colorama.Style.RESET_ALL}')
         query_clusters: Optional[List[str]] = None
         if clusters:
             query_clusters = _get_glob_clusters(clusters)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1445,7 +1445,6 @@ def _get_spot_jobs(
         msg = spot_lib.format_job_table(spot_jobs,
                                         show_all=show_all,
                                         max_jobs=max_jobs_to_show)
-    print('hi')
     return num_in_progress_jobs, msg
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1428,8 +1428,8 @@ def _get_spot_jobs(
         msg = ('Failed to query spot jobs due to connection '
                'issues. Try again later.')
     else:
-        max_jobs_to_show = (None if limit_num_jobs_to_show else
-                            _NUM_SPOT_JOBS_TO_SHOW_IN_STATUS)
+        max_jobs_to_show = (_NUM_SPOT_JOBS_TO_SHOW_IN_STATUS
+                            if limit_num_jobs_to_show else None)
         msg = spot_lib.format_job_table(spot_jobs,
                                         show_all=show_all,
                                         max_jobs=max_jobs_to_show)

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -10,9 +10,9 @@ import requests
 import pandas as pd
 
 from sky import sky_logging
-from sky.backends import backend_utils
 from sky.clouds import cloud as cloud_lib
 from sky.clouds.service_catalog import constants
+from sky.utils import log_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -100,7 +100,7 @@ def read_catalog(filename: str,
             update_frequency_str = ''
             if pull_frequency_hours is not None:
                 update_frequency_str = f' (every {pull_frequency_hours} hours)'
-            with backend_utils.safe_console_status(
+            with log_utils.safe_rich_status(
                 (f'Updating {cloud} catalog: '
                  f'{filename}'
                  f'{update_frequency_str}')) as status:

--- a/sky/core.py
+++ b/sky/core.py
@@ -169,7 +169,7 @@ def _start(
     if handle is None:
         raise ValueError(f'Cluster {cluster_name!r} does not exist.')
     if not force and cluster_status == global_user_state.ClusterStatus.UP:
-        sky_logging.echo(f'Cluster {cluster_name!r} is already up.')
+        sky_logging.print(f'Cluster {cluster_name!r} is already up.')
         return handle
     assert force or cluster_status in (
         global_user_state.ClusterStatus.INIT,
@@ -549,14 +549,14 @@ def cancel(cluster_name: str,
     backend = backend_utils.get_backend_from_handle(handle)
 
     if all:
-        sky_logging.echo(f'{colorama.Fore.YELLOW}'
-                         f'Cancelling all jobs on cluster {cluster_name!r}...'
-                         f'{colorama.Style.RESET_ALL}')
+        sky_logging.print(f'{colorama.Fore.YELLOW}'
+                          f'Cancelling all jobs on cluster {cluster_name!r}...'
+                          f'{colorama.Style.RESET_ALL}')
         job_ids = None
     else:
         assert job_ids is not None, 'job_ids should not be None'
         jobs_str = ', '.join(map(str, job_ids))
-        sky_logging.echo(
+        sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Cancelling jobs ({jobs_str}) on cluster {cluster_name!r}...'
             f'{colorama.Style.RESET_ALL}')
@@ -594,9 +594,10 @@ def tail_logs(cluster_name: str,
     job_str = f'job {job_id}'
     if job_id is None:
         job_str = 'the last job'
-    sky_logging.echo(f'{colorama.Fore.YELLOW}'
-                     f'Tailing logs of {job_str} on cluster {cluster_name!r}...'
-                     f'{colorama.Style.RESET_ALL}')
+    sky_logging.print(
+        f'{colorama.Fore.YELLOW}'
+        f'Tailing logs of {job_str} on cluster {cluster_name!r}...'
+        f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     backend.tail_logs(handle, job_id, follow=follow)
@@ -637,9 +638,9 @@ def download_logs(
         return {}
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    sky_logging.echo(f'{colorama.Fore.YELLOW}'
-                     'Syncing down logs to local...'
-                     f'{colorama.Style.RESET_ALL}')
+    sky_logging.print(f'{colorama.Fore.YELLOW}'
+                      'Syncing down logs to local...'
+                      f'{colorama.Style.RESET_ALL}')
     local_log_dirs = backend.sync_down_logs(handle, job_ids, local_dir)
     return local_log_dirs
 
@@ -685,9 +686,9 @@ def job_status(cluster_name: str,
     if job_ids is not None and len(job_ids) == 0:
         return {}
 
-    sky_logging.echo(f'{colorama.Fore.YELLOW}'
-                     'Getting job status...'
-                     f'{colorama.Style.RESET_ALL}')
+    sky_logging.print(f'{colorama.Fore.YELLOW}'
+                      'Getting job status...'
+                      f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     statuses = backend.get_job_status(handle, job_ids, stream_logs=stream_logs)
@@ -702,7 +703,7 @@ def job_status(cluster_name: str,
 @usage_lib.entrypoint
 def spot_status(refresh: bool) -> List[Dict[str, Any]]:
     """[Deprecated] (alias of spot_queue) Get statuses of managed spot jobs."""
-    sky_logging.echo(
+    sky_logging.print(
         f'{colorama.Fore.YELLOW}WARNING: `spot_status()` is deprecated. '
         f'Instead, use: spot_queue(){colorama.Style.RESET_ALL}',
         file=sys.stderr)
@@ -733,7 +734,8 @@ def spot_queue(refresh: bool,
             }
         ]
     Raises:
-        sky.exceptions.ClusterNotUpError: the spot controller is not up.
+        sky.exceptions.ClusterNotUpError: the spot controller is not up or
+            does not exist.
         RuntimeError: if failed to get the spot jobs with ssh.
     """
 
@@ -746,9 +748,9 @@ def spot_queue(refresh: bool,
             global_user_state.ClusterStatus.STOPPED,
             global_user_state.ClusterStatus.INIT
     ]):
-        sky_logging.echo(f'{colorama.Fore.YELLOW}'
-                         'Restarting controller for latest status...'
-                         f'{colorama.Style.RESET_ALL}')
+        sky_logging.print(f'{colorama.Fore.YELLOW}'
+                          'Restarting controller for latest status...'
+                          f'{colorama.Style.RESET_ALL}')
 
         log_utils.force_update_rich_status(
             '[cyan] Checking spot jobs - restarting '
@@ -845,7 +847,7 @@ def spot_cancel(name: Optional[str] = None,
     except exceptions.CommandError as e:
         raise RuntimeError(e.error_msg) from e
 
-    sky_logging.echo(stdout)
+    sky_logging.print(stdout)
     if 'Multiple jobs found with name' in stdout:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(

--- a/sky/data/data_transfer.py
+++ b/sky/data/data_transfer.py
@@ -24,7 +24,7 @@ import colorama
 from sky import clouds
 from sky import sky_logging
 from sky.adaptors import aws, gcp
-from sky.backends import backend_utils
+from sky.utils import log_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -93,7 +93,7 @@ def s3_to_gcs(s3_bucket_name: str, gs_bucket_name: str) -> None:
     logger.debug(json.dumps(operation, indent=4))
     logger.info('Waiting for the transfer to finish')
     start = time.time()
-    with backend_utils.safe_console_status('Transferring'):
+    with log_utils.safe_rich_status('Transferring'):
         for _ in range(MAX_POLLS):
             result = (storagetransfer.transferOperations().get(
                 name=operation['name']).execute())

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -20,6 +20,7 @@ from sky.data import mounting_utils
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky.utils import log_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
@@ -932,7 +933,7 @@ class S3Store(AbstractStore):
         else:
             source_message = source_path_list[0]
 
-        with backend_utils.safe_console_status(
+        with log_utils.safe_rich_status(
                 f'[bold cyan]Syncing '
                 f'[green]{source_message}[/] to [green]s3://{self.name}/[/]'):
             data_utils.parallel_upload(
@@ -1065,7 +1066,7 @@ class S3Store(AbstractStore):
         # which removes the bucket by force.
         remove_command = f'aws s3 rb s3://{bucket_name} --force'
         try:
-            with backend_utils.safe_console_status(
+            with log_utils.safe_rich_status(
                     f'[bold cyan]Deleting S3 bucket {bucket_name}[/]'):
                 subprocess.check_output(remove_command.split(' '))
         except subprocess.CalledProcessError as e:
@@ -1200,7 +1201,7 @@ class GcsStore(AbstractStore):
         sync_command = (f'echo "{copy_list}" | '
                         f'gsutil -m cp -e -n -r -I gs://{self.name}')
 
-        with backend_utils.safe_console_status(
+        with log_utils.safe_rich_status(
                 f'[bold cyan]Syncing '
                 f'[green]{source_message}[/] to [green]gs://{self.name}/[/]'):
             data_utils.run_upload_cli(sync_command,
@@ -1246,7 +1247,7 @@ class GcsStore(AbstractStore):
         else:
             source_message = source_path_list[0]
 
-        with backend_utils.safe_console_status(
+        with log_utils.safe_rich_status(
                 f'[bold cyan]Syncing '
                 f'[green]{source_message}[/] to [green]gs://{self.name}/[/]'):
             data_utils.parallel_upload(
@@ -1374,7 +1375,7 @@ class GcsStore(AbstractStore):
                     'external bucket.') from e
 
         try:
-            with backend_utils.safe_console_status(
+            with log_utils.safe_rich_status(
                     f'[bold cyan]Deleting GCS bucket {bucket_name}[/]'):
                 remove_obj_command = ('gsutil -m rm -r'
                                       f' gs://{bucket_name}')

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -1,5 +1,4 @@
 """Logging utilities."""
-import builtins
 import contextlib
 import logging
 import sys
@@ -35,6 +34,7 @@ _logging_config = threading.local()
 _logging_config.is_silent = False
 
 echo = print
+
 
 def _setup_logger(
     logging_level: int = logging.DEBUG,

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -3,15 +3,14 @@ import contextlib
 import logging
 import sys
 import threading
-from typing import Optional
 
 from sky.utils import env_options
 
 # If the SKYPILOT_MINIMIZE_LOGGING environment variable is set to True,
 # remove logging prefixes and unnecessary information in optimizer
-FORMAT = (None if env_options.Options.MINIMIZE_LOGGING.get() else
-          '%(levelname).1s %(asctime)s %(filename)s:%(lineno)d] %(message)s')
-DATE_FORMAT = '%m-%d %H:%M:%S'
+_FORMAT = (None if env_options.Options.MINIMIZE_LOGGING.get() else
+           '%(levelname).1s %(asctime)s %(filename)s:%(lineno)d] %(message)s')
+_DATE_FORMAT = '%m-%d %H:%M:%S'
 
 
 class NewLineFormatter(logging.Formatter):
@@ -36,11 +35,8 @@ _logging_config.is_silent = False
 echo = print
 
 
-def _setup_logger(
-    logging_level: int = logging.DEBUG,
-    logging_format: Optional[str] = FORMAT,
-):
-    _root_logger.setLevel(logging_level)
+def _setup_logger():
+    _root_logger.setLevel(logging.DEBUG)
     global _default_handler
     if _default_handler is None:
         _default_handler = logging.StreamHandler(sys.stdout)
@@ -50,13 +46,16 @@ def _setup_logger(
         else:
             _default_handler.setLevel(logging.INFO)
         _root_logger.addHandler(_default_handler)
-    fmt = NewLineFormatter(logging_format, datefmt=DATE_FORMAT)
+    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
     _default_handler.setFormatter(fmt)
     # Setting this will avoid the message
     # being propagated to the parent logger.
     _root_logger.propagate = False
 
 
+# The logger is initialized when the module is imported.
+# This is thread-safe as the module is only imported once,
+# guaranteed by the Python GIL.
 _setup_logger()
 
 
@@ -66,7 +65,11 @@ def init_logger(name: str):
 
 @contextlib.contextmanager
 def silent():
-    """Turn off logging."""
+    """Make all sky_logging.echo() and logger.{info, warning...} silent.
+
+    We preserve the ERROR level logging, so that errors are
+    still printed.
+    """
     global echo
     global _logging_config
     previous_level = _root_logger.level
@@ -74,7 +77,7 @@ def silent():
     previous_echo = echo
 
     # Turn off logger
-    _root_logger.setLevel(logging.CRITICAL)
+    _root_logger.setLevel(logging.ERROR)
     _logging_config.is_silent = True
     echo = lambda *args, **kwargs: None
     yield

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -38,7 +38,7 @@ _logging_config.is_silent = False
 # This is to make controlled logging via is_silent() possible:
 # in some situation we would like to disable any
 # printing/logging.
-print = builtins.print # pylint: disable=redefined-builtin
+print = builtins.print  # pylint: disable=redefined-builtin
 
 
 def _setup_logger():

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -559,6 +559,7 @@ def load_job_table_cache() -> Optional[Tuple[float, str]]:
 
 def is_spot_controller_up(
     stopped_message: str,
+    silent: bool = False,
 ) -> Tuple[Optional[global_user_state.ClusterStatus],
            Optional['backends.CloudVmRayResourceHandle']]:
     """Check if the spot controller is up.
@@ -580,6 +581,7 @@ def is_spot_controller_up(
         exceptions.CloudUserIdentityError: if we fail to get the current user
           identity.
     """
+    echo = lambda *args, **kwargs: None if silent else print
     try:
         # Set force_refresh=False to make sure the refresh only happens when the
         # controller is INIT/UP. This optimization avoids unnecessary costly
@@ -603,7 +605,7 @@ def is_spot_controller_up(
             controller_status, handle = record['status'], record['handle']
 
     if controller_status is None:
-        print('No managed spot jobs are found.')
+        echo('No managed spot jobs are found.')
     elif controller_status != global_user_state.ClusterStatus.UP:
         msg = (f'Spot controller {SPOT_CONTROLLER_NAME} '
                f'is {controller_status.value}.')
@@ -611,6 +613,6 @@ def is_spot_controller_up(
             msg += f'\n{stopped_message}'
         if controller_status == global_user_state.ClusterStatus.INIT:
             msg += '\nPlease wait for the controller to be ready.'
-        print(msg)
+        echo(msg)
         handle = None
     return controller_status, handle

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -217,7 +217,8 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
     controller_status = job_lib.get_status(job_id)
     status_msg = ('[bold cyan]Waiting for controller process to be RUNNING '
                   '{status_str}[/]. It may take a few minutes.')
-    status_display = log_utils.safe_rich_status(status_msg.format(status_str=''))
+    status_display = log_utils.safe_rich_status(
+        status_msg.format(status_str=''))
     with status_display:
         prev_msg = None
         while (controller_status != job_lib.JobStatus.RUNNING and

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import colorama
 import filelock
-import rich
 
 from sky import backends
 from sky import exceptions
@@ -218,7 +217,7 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
     controller_status = job_lib.get_status(job_id)
     status_msg = ('[bold cyan]Waiting for controller process to be RUNNING '
                   '{status_str}[/]. It may take a few minutes.')
-    status_display = rich.status.Status(status_msg.format(status_str=''))
+    status_display = log_utils.safe_rich_status(status_msg.format(status_str=''))
     with status_display:
         prev_msg = None
         while (controller_status != job_lib.JobStatus.RUNNING and

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -559,7 +559,6 @@ def load_job_table_cache() -> Optional[Tuple[float, str]]:
 
 def is_spot_controller_up(
     stopped_message: str,
-    silent: bool = False,
 ) -> Tuple[Optional[global_user_state.ClusterStatus],
            Optional['backends.CloudVmRayResourceHandle']]:
     """Check if the spot controller is up.
@@ -581,7 +580,6 @@ def is_spot_controller_up(
         exceptions.CloudUserIdentityError: if we fail to get the current user
           identity.
     """
-    echo = lambda *args, **kwargs: None if silent else print
     try:
         # Set force_refresh=False to make sure the refresh only happens when the
         # controller is INIT/UP. This optimization avoids unnecessary costly
@@ -605,7 +603,7 @@ def is_spot_controller_up(
             controller_status, handle = record['status'], record['handle']
 
     if controller_status is None:
-        echo('No managed spot jobs are found.')
+        sky_logging.echo('No managed spot jobs are found.')
     elif controller_status != global_user_state.ClusterStatus.UP:
         msg = (f'Spot controller {SPOT_CONTROLLER_NAME} '
                f'is {controller_status.value}.')
@@ -613,6 +611,6 @@ def is_spot_controller_up(
             msg += f'\n{stopped_message}'
         if controller_status == global_user_state.ClusterStatus.INIT:
             msg += '\nPlease wait for the controller to be ready.'
-        echo(msg)
+        sky_logging.echo(msg)
         handle = None
     return controller_status, handle

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -603,7 +603,7 @@ def is_spot_controller_up(
             controller_status, handle = record['status'], record['handle']
 
     if controller_status is None:
-        sky_logging.echo('No managed spot jobs are found.')
+        sky_logging.print('No managed spot jobs are found.')
     elif controller_status != global_user_state.ClusterStatus.UP:
         msg = (f'Spot controller {SPOT_CONTROLLER_NAME} '
                f'is {controller_status.value}.')
@@ -611,6 +611,6 @@ def is_spot_controller_up(
             msg += f'\n{stopped_message}'
         if controller_status == global_user_state.ClusterStatus.INIT:
             msg += '\nPlease wait for the controller to be ready.'
-        sky_logging.echo(msg)
+        sky_logging.print(msg)
         handle = None
     return controller_status, handle

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -98,8 +98,6 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         num_pending_autostop += _is_pending_autostop(record)
 
     if cluster_records:
-        click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
-                   f'{colorama.Style.RESET_ALL}')
         click.echo(cluster_table)
     else:
         click.echo('No existing clusters.')

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -1,15 +1,59 @@
 """Logging utils."""
 import enum
+import threading
 from typing import List, Optional
+
+import rich.console as rich_console
 
 import colorama
 import pendulum
 import prettytable
-import rich.status
 
 from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
+
+console = rich_console.Console()
+_status = None
+
+
+class NoOpConsoleStatus:
+    """An empty class for multi-threaded console.status."""
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def update(self, text):
+        pass
+
+    def stop(self):
+        pass
+
+    def start(self):
+        pass
+
+
+def safe_rich_status(msg: str):
+    """A wrapper for multi-threaded console.status."""
+    if (threading.current_thread() is threading.main_thread() and
+            not sky_logging.is_silent()):
+        global _status
+        if _status is None:
+            _status = console.status(msg)
+        _status.update(msg)
+        return _status
+    return NoOpConsoleStatus()
+
+
+def force_update_rich_status(msg: str):
+    """A wrapper for multi-threaded console.status."""
+    if threading.current_thread() is threading.main_thread():
+        global _status
+        if _status is not None:
+            _status.update(msg)
 
 
 class LineProcessor(object):
@@ -35,7 +79,7 @@ class RayUpLineProcessor(LineProcessor):
 
     def __enter__(self):
         self.state = self.ProvisionStatus.LAUNCH
-        self.status_display = rich.status.Status('[bold cyan]Launching')
+        self.status_display = safe_rich_status('[bold cyan]Launching')
         self.status_display.start()
 
     def process_line(self, log_line):

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -49,7 +49,7 @@ def safe_rich_status(msg: str):
 
 
 def force_update_rich_status(msg: str):
-    """Update the status message even if it is set to be silent."""
+    """Update the status message even if sky_logging.is_silent() is true."""
     if threading.current_thread() is threading.main_thread():
         global _status
         if _status is not None:

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -17,7 +17,7 @@ console = rich_console.Console()
 _status = None
 
 
-class NoOpConsoleStatus:
+class _NoOpConsoleStatus:
     """An empty class for multi-threaded console.status."""
 
     def __enter__(self):
@@ -45,11 +45,11 @@ def safe_rich_status(msg: str):
             _status = console.status(msg)
         _status.update(msg)
         return _status
-    return NoOpConsoleStatus()
+    return _NoOpConsoleStatus()
 
 
 def force_update_rich_status(msg: str):
-    """A wrapper for multi-threaded console.status."""
+    """Update the status message even if it is set to be silent."""
     if threading.current_thread() is threading.main_thread():
         global _status
         if _status is not None:

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -1,6 +1,5 @@
 """Utility functions for UX."""
 import contextlib
-import os
 import sys
 
 import rich.console as rich_console
@@ -33,12 +32,3 @@ def print_exception_no_traceback():
     sys.tracebacklimit = 0
     yield
     sys.tracebacklimit = original_tracelimit
-
-
-@contextlib.contextmanager
-def suppress_output():
-    """Suppress stdout and stderr."""
-    with open(os.devnull, 'w') as devnull:
-        with contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(
-                devnull):
-            yield

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -72,7 +72,7 @@ storage_setup_commands = [
 # the spot queue command will return staled table.
 _SPOT_QUEUE_WAIT = ('s=$(sky spot queue); '
                     'until [ `echo "$s" '
-                    '| grep "Please wait for the controller to be ready" '
+                    '| grep "jobs will not be shown until it becomes UP." '
                     '| wc -l` -eq 0 ]; '
                     'do echo "Waiting for spot queue to be ready..."; '
                     'sleep 5; s=$(sky spot queue); done; echo "$s"; '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes in this PR:
1. We refactored the code to show a similar message for the spot queue in `sky spot queue` and `sky status`.
2. Make `core` able to be silent with `with core.silent():` context manager
3. Remove the cache for the spot queue as it causes much confusion while providing not many benefits.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky spot queue` during `for i in `seq 10`;  do sky spot launch -n test-large-$i --cloud gcp -y -d --cpus 2 sleep 10000; done`
  - [x] when controller is INIT
  - [x] when controller is UP
  - [x] `sky spot queue -r`
  - [x] `sky spot queue -s`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
