### PR TITLE
[Spot] Disallow spot autostop

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -190,10 +190,9 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
                      'Please check your network connection.')
         raise
 
-    project_oslogin: str = next(
+    project_oslogin: str = next(  # type: ignore
         (item for item in project['commonInstanceMetadata'].get('items', [])
-         if item['key'] == 'enable-oslogin'), {}).get('value',
-                                                      'False')  # type: ignore
+         if item['key'] == 'enable-oslogin'), {}).get('value', 'False')
 
     if project_oslogin.lower() == 'true':
         # project.
@@ -253,9 +252,9 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     # TODO(zhwu): Use cloud init to add ssh public key, to avoid the permission
     # issue. A blocker is that the cloud init is not installed in the debian
     # image by default.
-    project_keys: str = next(
+    project_keys: str = next(  # type: ignore
         (item for item in project['commonInstanceMetadata'].get('items', [])
-         if item['key'] == 'ssh-keys'), {}).get('value', '')  # type: ignore
+         if item['key'] == 'ssh-keys'), {}).get('value', '')
     ssh_keys = project_keys.split('\n') if project_keys else []
 
     # Get public key from file.

--- a/sky/core.py
+++ b/sky/core.py
@@ -429,8 +429,9 @@ def autostop(
         raise exceptions.NotSupportedError(
             f'{operation} cluster {cluster_name!r} with backend '
             f'{backend.__class__.__name__!r} is not supported.')
-    elif handle.launched_resources.use_spot and not down:
+    elif handle.launched_resources.use_spot and not down and not is_cancel:
         # Disable spot instances to be stopped.
+        # TODO(suquark): enable GCP+spot to be stopped in the future.
         raise exceptions.NotSupportedError(
             f'{colorama.Fore.YELLOW}Scheduling autostop on cluster '
             f'{cluster_name!r}...skipped.{colorama.Style.RESET_ALL}\n'

--- a/sky/core.py
+++ b/sky/core.py
@@ -430,8 +430,8 @@ def autostop(
             f'{operation} cluster {cluster_name!r} with backend '
             f'{backend.__class__.__name__!r} is not supported.')
     elif handle.launched_resources.use_spot and not down and not is_cancel:
-        # Disable spot instances to be stopped.
-        # TODO(suquark): enable GCP+spot to be stopped in the future.
+        # Disable spot instances to be autostopped.
+        # TODO(ewzeng): allow autostop for spot when stopping is supported.
         raise exceptions.NotSupportedError(
             f'{colorama.Fore.YELLOW}Scheduling autostop on cluster '
             f'{cluster_name!r}...skipped.{colorama.Style.RESET_ALL}\n'

--- a/sky/core.py
+++ b/sky/core.py
@@ -321,7 +321,7 @@ def stop(cluster_name: str, purge: bool = False) -> None:
         # TODO(suquark): enable GCP+spot to be stopped in the future.
         raise exceptions.NotSupportedError(
             f'{colorama.Fore.YELLOW}Stopping cluster '
-            f'{cluster_name!r}... skipped.{colorama.Style.RESET_ALL}\n'
+            f'{cluster_name!r}...skipped.{colorama.Style.RESET_ALL}\n'
             '  Stopping spot instances is not supported as the attached '
             'disks will be lost.\n'
             '  To terminate the cluster instead, run: '
@@ -429,6 +429,13 @@ def autostop(
         raise exceptions.NotSupportedError(
             f'{operation} cluster {cluster_name!r} with backend '
             f'{backend.__class__.__name__!r} is not supported.')
+    elif handle.launched_resources.use_spot and not down:
+        # Disable spot instances to be stopped.
+        raise exceptions.NotSupportedError(
+            f'{colorama.Fore.YELLOW}Scheduling autostop on cluster '
+            f'{cluster_name!r}...skipped.{colorama.Style.RESET_ALL}\n'
+            '  Stopping spot instances is not supported as the attached '
+            'disks will be lost.')
 
     if tpu_utils.is_tpu_vm_pod(handle.launched_resources):
         # Reference:
@@ -443,7 +450,6 @@ def autostop(
         cloud.check_features_are_supported(
             {clouds.CloudImplementationFeatures.AUTOSTOP})
 
-    backend = backend_utils.get_backend_from_handle(handle)
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
     backend.set_autostop(handle, idle_minutes, down)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -210,7 +210,8 @@ def _execute(
             if not down:
                 requested_features.add(
                     clouds.CloudImplementationFeatures.AUTOSTOP)
-                # TODO(suquark): enable GCP+spot to be stopped in the future.
+                # TODO(ewzeng): allow autostop for spot when stopping is
+                # supported.
                 if task.use_spot:
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -210,6 +210,11 @@ def _execute(
             if not down:
                 requested_features.add(
                     clouds.CloudImplementationFeatures.AUTOSTOP)
+                # TODO(suquark): enable GCP+spot to be stopped in the future.
+                if task.use_spot:
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            'Autostop is not supported for spot instances.')
 
     elif idle_minutes_to_autostop is not None:
         # TODO(zhwu): Autostop is not supported for non-CloudVmRayBackend.


### PR DESCRIPTION
This PR fixes #1472 by disallowing spot autostop.

Tested:

- [x] `sky launch --cloud gcp --use-spot -i 5` (disallow)
- [x] `sky launch --cloud gcp --use-spot --down -i 5`
- [x] `sky autostop [spot cluster]` (disallow)
- [x] `sky autostop [spot cluster] -i 5` (disallow)
- [x] `sky autostop [spot cluster] --cancel` 
- [x] `sky autostop [spot cluster] --down`
