### PR TITLE
[Resources] Add memory in resources

### DIFF
--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -136,7 +136,7 @@ def _print_candidate_resources(
             accelerator, count = list(resources.accelerators.items())[0]
             accelerators = f'{accelerator}:{count}'
         cloud = resources.cloud
-        vcpus = cloud.get_vcpus_from_instance_type(resources.instance_type)
+        vcpus = cloud.get_vcpus_mem_from_instance_type(resources.instance_type)
         if vcpus is None:
             vcpus = '-'
         elif vcpus.is_integer():

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -119,6 +119,7 @@ def _print_candidate_resources(
         '# NODES',
         'INSTANCE',
         'vCPUs',
+        'Mem(GB)',
         'ACCELERATORS',
         'PRICE ($/hr)',
     ]
@@ -136,18 +137,24 @@ def _print_candidate_resources(
             accelerator, count = list(resources.accelerators.items())[0]
             accelerators = f'{accelerator}:{count}'
         cloud = resources.cloud
-        vcpus = cloud.get_vcpus_mem_from_instance_type(resources.instance_type)
-        if vcpus is None:
-            vcpus = '-'
-        elif vcpus.is_integer():
-            vcpus = str(int(vcpus))
-        else:
-            vcpus = f'{vcpus:.1f}'
+        vcpus, mem = cloud.get_vcpus_mem_from_instance_type(
+            resources.instance_type)
+
+        def format_number(x):
+            if x is None:
+                return '-'
+            elif x.is_integer():
+                return str(int(x))
+            else:
+                return f'{x:.1f}'
+
+        vcpus = format_number(vcpus)
+        mem = format_number(mem)
         cost = num_nodes * resources.get_cost(3600)
         spot = '[Spot]' if resources.use_spot else ''
         row = [
             cluster, cloud, num_nodes, resources.instance_type + spot, vcpus,
-            accelerators, f'{cost:.2f}'
+            mem, accelerators, f'{cost:.2f}'
         ]
         candidate_table.add_row(row)
     logger.info(f'{candidate_table}\n')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -186,16 +186,16 @@ def _interactive_node_cli_command(cli_func):
         help=('Number of vCPUs each instance must have '
               '(e.g., ``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
               'This is used to automatically select the instance type.'))
-    memory_gb = click.option(
-        '--memory-gb',
+    memory = click.option(
+        '--memory',
         default=None,
         type=str,
         required=False,
-        help=
-        ('Amount of memory each instance must have in GB (e.g., '
-         '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least '
-         '16GB)) or ``--memory-gb=4x`` (at least 4 times the amount of memory '
-         'in GB than #CPUs)'))
+        help=(
+            'Amount of memory each instance must have in GB (e.g., '
+            '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least '
+            '16GB)) or ``--memory=4x`` (at least 4 times the amount of memory '
+            'in GB than #CPUs)'))
     gpus = click.option('--gpus',
                         default=None,
                         type=str,
@@ -291,7 +291,7 @@ def _interactive_node_cli_command(cli_func):
         zone_option,
         instance_type_option,
         cpus,
-        memory_gb,
+        memory,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
         spot_option,
@@ -586,7 +586,7 @@ def _parse_override_params(cloud: Optional[str] = None,
                            zone: Optional[str] = None,
                            gpus: Optional[str] = None,
                            cpus: Optional[str] = None,
-                           memory_gb: Optional[str] = None,
+                           memory: Optional[str] = None,
                            instance_type: Optional[str] = None,
                            use_spot: Optional[bool] = None,
                            image_id: Optional[str] = None,
@@ -618,11 +618,11 @@ def _parse_override_params(cloud: Optional[str] = None,
             override_params['cpus'] = None
         else:
             override_params['cpus'] = cpus
-    if memory_gb is not None:
-        if memory_gb.lower() == 'none':
-            override_params['memory_gb'] = None
+    if memory is not None:
+        if memory.lower() == 'none':
+            override_params['memory'] = None
         else:
-            override_params['memory_gb'] = memory_gb
+            override_params['memory'] = memory
     if instance_type is not None:
         if instance_type.lower() == 'none':
             override_params['instance_type'] = None
@@ -953,7 +953,7 @@ def _make_task_from_entrypoint_with_overrides(
     zone: Optional[str] = None,
     gpus: Optional[str] = None,
     cpus: Optional[str] = None,
-    memory_gb: Optional[str] = None,
+    memory: Optional[str] = None,
     instance_type: Optional[str] = None,
     num_nodes: Optional[int] = None,
     use_spot: Optional[bool] = None,
@@ -997,7 +997,7 @@ def _make_task_from_entrypoint_with_overrides(
                                              zone=zone,
                                              gpus=gpus,
                                              cpus=cpus,
-                                             memory_gb=memory_gb,
+                                             memory=memory,
                                              instance_type=instance_type,
                                              use_spot=use_spot,
                                              image_id=image_id,
@@ -1147,15 +1147,14 @@ def cli():
                     '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option(
-    '--memory-gb',
+    '--memory',
     default=None,
     type=str,
     required=False,
-    help=
-    ('Amount of memory each instance must have in GB (e.g., '
-     '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-     'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB '
-     'than #CPUs)'))
+    help=('Amount of memory each instance must have in GB (e.g., '
+          '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
+          'or ``--memory=4x`` (at least 4 times the amount of memory in GB '
+          'than #CPUs)'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -1221,7 +1220,7 @@ def launch(
     zone: Optional[str],
     gpus: Optional[str],
     cpus: Optional[str],
-    memory_gb: Optional[str],
+    memory: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1267,7 +1266,7 @@ def launch(
         zone=zone,
         gpus=gpus,
         cpus=cpus,
-        memory_gb=memory_gb,
+        memory=memory,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,
@@ -1414,7 +1413,7 @@ def exec(
         zone=zone,
         gpus=gpus,
         cpus=None,
-        memory_gb=None,
+        memory=None,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -2593,7 +2592,7 @@ def _down_or_stop_clusters(
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory_gb: Optional[str], gpus: Optional[str],
+            memory: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
             idle_minutes_to_autostop: Optional[int], down: bool,
@@ -2636,7 +2635,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpus is None and memory_gb is None and
+                                    cpus is None and memory is None and
                                     gpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['gpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2651,7 +2650,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory_gb=memory_gb,
+                              memory=memory,
                               accelerators=gpus,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2676,7 +2675,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory_gb: Optional[str], use_spot: Optional[bool],
+            memory: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
             down: bool, retry_until_up: bool):
@@ -2717,7 +2716,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpus is None and memory_gb is None and
+                                    cpus is None and memory is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['cpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2730,7 +2729,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory_gb=memory_gb,
+                              memory=memory,
                               use_spot=use_spot,
                               disk_size=disk_size)
 
@@ -2754,7 +2753,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory_gb: Optional[str], tpus: Optional[str],
+            memory: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
@@ -2796,7 +2795,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (region is None and zone is None and
                                     instance_type is None and cpus is None and
-                                    memory_gb is None and tpus is None and
+                                    memory is None and tpus is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['tpunode']
     accelerator_args = default_resources.accelerator_args
@@ -2814,7 +2813,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory_gb=memory_gb,
+                              memory=memory,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,
@@ -2979,8 +2978,8 @@ def show_gpus(
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
-                mem_str = f'{item.memory_gb:.0f}GB' if not pd.isna(
-                    item.memory_gb) else '-'
+                mem_str = f'{item.memory:.0f}GB' if not pd.isna(
+                    item.memory) else '-'
                 price_str = f'$ {item.price:.3f}' if not pd.isna(
                     item.price) else '-'
                 spot_price_str = f'$ {item.spot_price:.3f}' if not pd.isna(
@@ -3167,15 +3166,15 @@ def spot():
                     '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option(
-    '--memory-gb',
+    '--memory',
     default=None,
     type=str,
     required=False,
-    help=
-    ('Amount of memory each instance must have in GB (e.g., '
-     '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-     'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
-     '#CPUs)'))
+    help=(
+        'Amount of memory each instance must have in GB (e.g., '
+        '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
+        'or ``--memory=4x`` (at least 4 times the amount of memory in GB than '
+        '#CPUs)'))
 @click.option('--spot-recovery',
               default=None,
               type=str,
@@ -3219,7 +3218,7 @@ def spot_launch(
     zone: Optional[str],
     gpus: Optional[str],
     cpus: Optional[str],
-    memory_gb: Optional[str],
+    memory: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -3257,7 +3256,7 @@ def spot_launch(
         zone=zone,
         gpus=gpus,
         cpus=cpus,
-        memory_gb=memory_gb,
+        memory=memory,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -193,9 +193,9 @@ def _interactive_node_cli_command(cli_func):
         required=False,
         help=
         ('Amount of memory each instance must have in GB (e.g., '
-         '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-         'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
-         '#CPUs)'))
+         '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least '
+         '16GB)) or ``--memory-gb=4x`` (at least 4 times the amount of memory '
+         'in GB than #CPUs)'))
     gpus = click.option('--gpus',
                         default=None,
                         type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -186,15 +186,15 @@ def _interactive_node_cli_command(cli_func):
         help=('Number of vCPUs each instance must have '
               '(e.g., ``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
               'This is used to automatically select the instance type.'))
-    memory = click.option(
-        '--memory',
+    memory_gb = click.option(
+        '--memory-gb',
         default=None,
         type=str,
         required=False,
         help=
         ('Amount of memory each instance must have in GB (e.g., '
-         '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
-         'or ``--memory=4x`` (at least 4 times the amount of memory in GB than '
+         '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
+         'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
          '#CPUs)'))
     gpus = click.option('--gpus',
                         default=None,
@@ -291,7 +291,7 @@ def _interactive_node_cli_command(cli_func):
         zone_option,
         instance_type_option,
         cpus,
-        memory,
+        memory_gb,
         *([gpus] if cli_func.__name__ == 'gpunode' else []),
         *([tpus] if cli_func.__name__ == 'tpunode' else []),
         spot_option,
@@ -586,7 +586,7 @@ def _parse_override_params(cloud: Optional[str] = None,
                            zone: Optional[str] = None,
                            gpus: Optional[str] = None,
                            cpus: Optional[str] = None,
-                           memory: Optional[str] = None,
+                           memory_gb: Optional[str] = None,
                            instance_type: Optional[str] = None,
                            use_spot: Optional[bool] = None,
                            image_id: Optional[str] = None,
@@ -618,11 +618,11 @@ def _parse_override_params(cloud: Optional[str] = None,
             override_params['cpus'] = None
         else:
             override_params['cpus'] = cpus
-    if memory is not None:
-        if memory.lower() == 'none':
-            override_params['memory'] = None
+    if memory_gb is not None:
+        if memory_gb.lower() == 'none':
+            override_params['memory_gb'] = None
         else:
-            override_params['memory'] = memory
+            override_params['memory_gb'] = memory_gb
     if instance_type is not None:
         if instance_type.lower() == 'none':
             override_params['instance_type'] = None
@@ -953,7 +953,7 @@ def _make_task_from_entrypoint_with_overrides(
     zone: Optional[str] = None,
     gpus: Optional[str] = None,
     cpus: Optional[str] = None,
-    memory: Optional[str] = None,
+    memory_gb: Optional[str] = None,
     instance_type: Optional[str] = None,
     num_nodes: Optional[int] = None,
     use_spot: Optional[bool] = None,
@@ -997,7 +997,7 @@ def _make_task_from_entrypoint_with_overrides(
                                              zone=zone,
                                              gpus=gpus,
                                              cpus=cpus,
-                                             memory=memory,
+                                             memory_gb=memory_gb,
                                              instance_type=instance_type,
                                              use_spot=use_spot,
                                              image_id=image_id,
@@ -1147,14 +1147,14 @@ def cli():
                     '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option(
-    '--memory',
+    '--memory-gb',
     default=None,
     type=str,
     required=False,
     help=(
         'Amount of memory each instance must have in GB (e.g., '
-        '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
-        'or ``--memory=4x`` (at least 4 times the amount of memory in GB than '
+        '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
+        'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB than '
         '#CPUs)'))
 @click.option('--disk-size',
               default=None,
@@ -1221,7 +1221,7 @@ def launch(
     zone: Optional[str],
     gpus: Optional[str],
     cpus: Optional[str],
-    memory: Optional[str],
+    memory_gb: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -1267,7 +1267,7 @@ def launch(
         zone=zone,
         gpus=gpus,
         cpus=cpus,
-        memory=memory,
+        memory_gb=memory_gb,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,
@@ -1414,7 +1414,7 @@ def exec(
         zone=zone,
         gpus=gpus,
         cpus=None,
-        memory=None,
+        memory_gb=None,
         instance_type=instance_type,
         use_spot=use_spot,
         image_id=image_id,
@@ -2593,7 +2593,7 @@ def _down_or_stop_clusters(
 def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory: Optional[str], gpus: Optional[str],
+            memory_gb: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
             idle_minutes_to_autostop: Optional[int], down: bool,
@@ -2636,7 +2636,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpus is None and memory is None and
+                                    cpus is None and memory_gb is None and
                                     gpus is None and use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['gpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2651,7 +2651,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory=memory,
+                              memory_gb=memory_gb,
                               accelerators=gpus,
                               use_spot=use_spot,
                               disk_size=disk_size)
@@ -2676,7 +2676,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             cloud: Optional[str], region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory: Optional[str], use_spot: Optional[bool],
+            memory_gb: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
             down: bool, retry_until_up: bool):
@@ -2717,7 +2717,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (cloud is None and region is None and
                                     zone is None and instance_type is None and
-                                    cpus is None and memory is None and
+                                    cpus is None and memory_gb is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['cpunode']
     cloud_provider = clouds.CLOUD_REGISTRY.from_str(cloud)
@@ -2730,7 +2730,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory=memory,
+                              memory_gb=memory_gb,
                               use_spot=use_spot,
                               disk_size=disk_size)
 
@@ -2754,7 +2754,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             region: Optional[str], zone: Optional[str],
             instance_type: Optional[str], cpus: Optional[str],
-            memory: Optional[str], tpus: Optional[str],
+            memory_gb: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
             disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
@@ -2796,7 +2796,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
     user_requested_resources = not (region is None and zone is None and
                                     instance_type is None and cpus is None and
-                                    memory is None and tpus is None and
+                                    memory_gb is None and tpus is None and
                                     use_spot is None)
     default_resources = _INTERACTIVE_NODE_DEFAULT_RESOURCES['tpunode']
     accelerator_args = default_resources.accelerator_args
@@ -2814,7 +2814,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               zone=zone,
                               instance_type=instance_type,
                               cpus=cpus,
-                              memory=memory,
+                              memory_gb=memory_gb,
                               accelerators=tpus,
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,
@@ -2979,8 +2979,8 @@ def show_gpus(
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
-                mem_str = f'{item.memory:.0f}GB' if not pd.isna(
-                    item.memory) else '-'
+                mem_str = f'{item.memory_gb:.0f}GB' if not pd.isna(
+                    item.memory_gb) else '-'
                 price_str = f'$ {item.price:.3f}' if not pd.isna(
                     item.price) else '-'
                 spot_price_str = f'$ {item.spot_price:.3f}' if not pd.isna(
@@ -3167,14 +3167,14 @@ def spot():
                     '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
                     'This is used to automatically select the instance type.'))
 @click.option(
-    '--memory',
+    '--memory-gb',
     default=None,
     type=str,
     required=False,
     help=(
         'Amount of memory each instance must have in GB (e.g., '
-        '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
-        'or ``--memory=4x`` (at least 4 times the amount of memory in GB than '
+        '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
+        'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
         '#CPUs)'))
 @click.option('--spot-recovery',
               default=None,
@@ -3219,7 +3219,7 @@ def spot_launch(
     zone: Optional[str],
     gpus: Optional[str],
     cpus: Optional[str],
-    memory: Optional[str],
+    memory_gb: Optional[str],
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
@@ -3257,7 +3257,7 @@ def spot_launch(
         zone=zone,
         gpus=gpus,
         cpus=cpus,
-        memory=memory,
+        memory_gb=memory_gb,
         instance_type=instance_type,
         num_nodes=num_nodes,
         use_spot=use_spot,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3641,6 +3641,7 @@ def benchmark_launch(
     # The user can specify the benchmark candidates in either of the two ways:
     # 1. By specifying resources.candidates in the YAML.
     # 2. By specifying gpu types as a command line argument (--gpus).
+    override_gpu = None
     if gpus is not None:
         gpu_list = gpus.split(',')
         gpu_list = [gpu.strip() for gpu in gpu_list]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1154,8 +1154,8 @@ def cli():
     help=
     ('Amount of memory each instance must have in GB (e.g., '
      '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-     'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB than '
-     '#CPUs)'))
+     'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB '
+     'than #CPUs)'))
 @click.option('--disk-size',
               default=None,
               type=int,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1151,11 +1151,11 @@ def cli():
     default=None,
     type=str,
     required=False,
-    help=(
-        'Amount of memory each instance must have in GB (e.g., '
-        '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-        'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB than '
-        '#CPUs)'))
+    help=
+    ('Amount of memory each instance must have in GB (e.g., '
+     '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
+     'or ``--memory-gb=4x`` (at least 4 times the amount of memory_gb in GB than '
+     '#CPUs)'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -3171,11 +3171,11 @@ def spot():
     default=None,
     type=str,
     required=False,
-    help=(
-        'Amount of memory each instance must have in GB (e.g., '
-        '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
-        'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
-        '#CPUs)'))
+    help=
+    ('Amount of memory each instance must have in GB (e.g., '
+     '``--memory-gb=16`` (exactly 16GB), ``--memory-gb=16+`` (at least 16GB)) '
+     'or ``--memory-gb=4x`` (at least 4 times the amount of memory in GB than '
+     '#CPUs)'))
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -191,11 +191,9 @@ def _interactive_node_cli_command(cli_func):
         default=None,
         type=str,
         required=False,
-        help=(
-            'Amount of memory each instance must have in GB (e.g., '
-            '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least '
-            '16GB)) or ``--memory=4x`` (at least 4 times the amount of memory '
-            'in GB than #CPUs)'))
+        help=('Amount of memory each instance must have in GB (e.g., '
+              '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least '
+              '16GB))'))
     gpus = click.option('--gpus',
                         default=None,
                         type=str,
@@ -1152,9 +1150,7 @@ def cli():
     type=str,
     required=False,
     help=('Amount of memory each instance must have in GB (e.g., '
-          '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
-          'or ``--memory=4x`` (at least 4 times the amount of memory in GB '
-          'than #CPUs)'))
+          '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB))'))
 @click.option('--disk-size',
               default=None,
               type=int,
@@ -3170,11 +3166,8 @@ def spot():
     default=None,
     type=str,
     required=False,
-    help=(
-        'Amount of memory each instance must have in GB (e.g., '
-        '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB)) '
-        'or ``--memory=4x`` (at least 4 times the amount of memory in GB than '
-        '#CPUs)'))
+    help=('Amount of memory each instance must have in GB (e.g., '
+          '``--memory=16`` (exactly 16GB), ``--memory=16+`` (at least 16GB))'))
 @click.option('--spot-recovery',
               default=None,
               type=str,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -269,9 +269,9 @@ class AWS(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory_gb: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='aws')
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -336,7 +336,7 @@ class AWS(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory_gb=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -346,7 +346,7 @@ class AWS(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
-                cpus=resources.cpus, memory_gb=resources.memory_gb)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -360,7 +360,7 @@ class AWS(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory_gb,
+            memory_gb_or_ratio=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -269,9 +269,9 @@ class AWS(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory_gb: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='aws')
+            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -336,7 +336,7 @@ class AWS(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory=None,
+                    memory_gb=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -346,7 +346,7 @@ class AWS(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus, memory_gb=resources.memory_gb)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -360,7 +360,7 @@ class AWS(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory_gb_or_ratio=resources.memory_gb,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -270,8 +270,9 @@ class AWS(clouds.Cloud):
             cls,
             cpus: Optional[str] = None,
             memory: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='aws')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         memory=memory,
+                                                         clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -360,7 +361,7 @@ class AWS(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -282,12 +282,12 @@ class AWS(clouds.Cloud):
             instance_type, clouds='aws')
 
     @classmethod
-    def get_vcpus_from_instance_type(
+    def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[float]:
-        return service_catalog.get_vcpus_from_instance_type(instance_type,
-                                                            clouds='aws')
+        return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                                clouds='aws')
 
     def make_deploy_resources_variables(
             self, resources: 'resources_lib.Resources', region: 'clouds.Region',
@@ -357,6 +357,7 @@ class AWS(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
+            memory_gb_or_ratio=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -266,10 +266,12 @@ class AWS(clouds.Cloud):
         return isinstance(other, AWS)
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  cpus: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpus=cpus,
-                                                         clouds='aws')
+    def get_default_instance_type(
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
     # between Azure and AWS.
@@ -285,7 +287,7 @@ class AWS(clouds.Cloud):
     def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
-    ) -> Optional[float]:
+    ) -> Tuple[Optional[float], Optional[float]]:
         return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
                                                                 clouds='aws')
 
@@ -334,6 +336,7 @@ class AWS(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -343,7 +346,7 @@ class AWS(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
-                cpus=resources.cpus)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -112,9 +112,9 @@ class Azure(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory_gb: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='azure')
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
         # az vm image list \
@@ -258,7 +258,7 @@ class Azure(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory_gb=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -268,7 +268,7 @@ class Azure(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Azure.get_default_instance_type(
-                cpus=resources.cpus, memory_gb=resources.memory_gb)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -281,7 +281,7 @@ class Azure(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory_gb,
+            memory_gb_or_ratio=resources.memory,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -194,12 +194,12 @@ class Azure(clouds.Cloud):
             instance_type, clouds='azure')
 
     @classmethod
-    def get_vcpus_from_instance_type(
+    def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[float]:
-        return service_catalog.get_vcpus_from_instance_type(instance_type,
-                                                            clouds='azure')
+        return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                                clouds='azure')
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:
@@ -278,6 +278,7 @@ class Azure(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus,
+            memory_gb_or_ratio=resources.memory,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -113,8 +113,9 @@ class Azure(clouds.Cloud):
             cls,
             cpus: Optional[str] = None,
             memory: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='azure')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         memory=memory,
+                                                         clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
         # az vm image list \
@@ -281,7 +282,7 @@ class Azure(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory=resources.memory,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -109,10 +109,12 @@ class Azure(clouds.Cloud):
         return isinstance(other, Azure)
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  cpus: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpus=cpus,
-                                                         clouds='azure')
+    def get_default_instance_type(
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
         # az vm image list \
@@ -197,7 +199,7 @@ class Azure(clouds.Cloud):
     def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
-    ) -> Optional[float]:
+    ) -> Tuple[Optional[float], Optional[float]]:
         return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
                                                                 clouds='azure')
 
@@ -256,6 +258,7 @@ class Azure(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -265,7 +268,7 @@ class Azure(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Azure.get_default_instance_type(
-                cpus=resources.cpus)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -112,9 +112,9 @@ class Azure(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory_gb: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='azure')
+            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='azure')
 
     def _get_image_config(self, gen_version, instance_type):
         # az vm image list \
@@ -258,7 +258,7 @@ class Azure(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory=None,
+                    memory_gb=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -268,7 +268,7 @@ class Azure(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Azure.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus, memory_gb=resources.memory_gb)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -281,7 +281,7 @@ class Azure(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory_gb_or_ratio=resources.memory_gb,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -234,8 +234,8 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_vcpus_from_instance_type(cls,
-                                     instance_type: str) -> Optional[float]:
+    def get_vcpus_mem_from_instance_type(cls,
+                                         instance_type: str) -> Optional[float]:
         """Returns the number of virtual CPUs that the instance type offers."""
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -251,16 +251,16 @@ class Cloud:
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory_gb: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type with the given #vCPUs and memory.
 
         For example, if cpus='4', this method returns the default instance type
         with 4 vCPUs.  If cpus='4+', this method returns the default instance
         type with 4 or more vCPUs.
 
-        If 'memory_gb=4', this method returns the default instance type with 4GB
-        memory.  If 'memory_gb=4+', this method returns the default instance
-        type with 4GB or more memory.  If 'memory_gb=4x', this method returns
+        If 'memory=4', this method returns the default instance type with 4GB
+        memory.  If 'memory=4+', this method returns the default instance
+        type with 4GB or more memory.  If 'memory=4x', this method returns
         the instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
 
         When cpus is None or memory is None, this method will never return None.

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -234,9 +234,9 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_vcpus_mem_from_instance_type(cls,
-                                         instance_type: str) -> Optional[float]:
-        """Returns the number of virtual CPUs that the instance type offers."""
+    def get_vcpus_mem_from_instance_type(
+            cls, instance_type: str) -> Tuple[Optional[float], Optional[float]]:
+        """Returns the #vCPUs and memory that the instance type offers."""
         raise NotImplementedError
 
     @classmethod
@@ -248,15 +248,22 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  cpus: Optional[str] = None) -> Optional[str]:
-        """Returns the default instance type with the given number of vCPUs.
+    def get_default_instance_type(
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None) -> Optional[str]:
+        """Returns the default instance type with the given #vCPUs and memory.
 
         For example, if cpus='4', this method returns the default instance type
         with 4 vCPUs.  If cpus='4+', this method returns the default instance
         type with 4 or more vCPUs.
 
-        When cpus is None, this method will never return None.
+        If 'memory=4', this method returns the default instance type with 4GB
+        memory.  If 'memory=4+', this method returns the default instance type
+        with 4GB or more memory.  If 'memory=4x', this method returns the
+        instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
+
+        When cpus is None or memory is None, this method will never return None.
         This method may return None if the cloud's default instance family
         does not have a VM with the given number of vCPUs (e.g., when cpus='7').
         """

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -259,9 +259,9 @@ class Cloud:
         type with 4 or more vCPUs.
 
         If 'memory_gb=4', this method returns the default instance type with 4GB
-        memory.  If 'memory_gb=4+', this method returns the default instance type
-        with 4GB or more memory.  If 'memory_gb=4x', this method returns the
-        instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
+        memory.  If 'memory_gb=4+', this method returns the default instance
+        type with 4GB or more memory.  If 'memory_gb=4x', this method returns
+        the instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
 
         When cpus is None or memory is None, this method will never return None.
         This method may return None if the cloud's default instance family

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -251,16 +251,16 @@ class Cloud:
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory_gb: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type with the given #vCPUs and memory.
 
         For example, if cpus='4', this method returns the default instance type
         with 4 vCPUs.  If cpus='4+', this method returns the default instance
         type with 4 or more vCPUs.
 
-        If 'memory=4', this method returns the default instance type with 4GB
-        memory.  If 'memory=4+', this method returns the default instance type
-        with 4GB or more memory.  If 'memory=4x', this method returns the
+        If 'memory_gb=4', this method returns the default instance type with 4GB
+        memory.  If 'memory_gb=4+', this method returns the default instance type
+        with 4GB or more memory.  If 'memory_gb=4x', this method returns the
         instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
 
         When cpus is None or memory is None, this method will never return None.

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -260,8 +260,7 @@ class Cloud:
 
         If 'memory=4', this method returns the default instance type with 4GB
         memory.  If 'memory=4+', this method returns the default instance
-        type with 4GB or more memory.  If 'memory=4x', this method returns
-        the instance type with memory-to-vCPU ratio closest to 4GB/vCPU.
+        type with 4GB or more memory.
 
         When cpus is None or memory is None, this method will never return None.
         This method may return None if the cloud's default instance family

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -262,8 +262,9 @@ class GCP(clouds.Cloud):
             cls,
             cpus: Optional[str] = None,
             memory: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='gcp')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         memory=memory,
+                                                         clouds='gcp')
 
     def make_deploy_resources_variables(
             self, resources: 'resources.Resources', region: 'clouds.Region',
@@ -382,7 +383,7 @@ class GCP(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus if not use_tpu_vm else None,
-            memory_gb_or_ratio=resources.memory if not use_tpu_vm else None,
+            memory=resources.memory if not use_tpu_vm else None,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -397,8 +397,10 @@ class GCP(clouds.Cloud):
 
         if use_tpu_vm:
             host_vm_type = 'TPU-VM'
-            # FIXME(woosuk): This leverages the fact that TPU VMs have 96 vCPUs.
-            num_cpus_in_tpu_vm = 96
+            # FIXME(woosuk): This leverages the fact that TPU VMs have 96 vCPUs,
+            # and 240 vCPUs for tpu-v4.
+            # TODO(wei-lin): Move this to service catalog, instead.
+            num_cpus_in_tpu_vm = 240 if 'v4' in acc else 96
             if resources.cpus is not None:
                 if resources.cpus.endswith('+'):
                     cpus = float(resources.cpus[:-1])
@@ -408,15 +410,14 @@ class GCP(clouds.Cloud):
                     cpus = float(resources.cpus)
                     if cpus != num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
-            memory_in_tpu_vm = 624
+            # TODO(wei-lin): Move this to service catalog, instead.
+            # The number needs to be confirmed for tpu vms earlier than
+            # v4.
+            memory_in_tpu_vm = 400 if 'v4' in acc else 334
             if resources.memory is not None:
                 if resources.memory.endswith('+'):
                     memory = float(resources.memory[:-1])
                     if memory > memory_in_tpu_vm:
-                        return ([], fuzzy_candidate_list)
-                elif resources.memory.endswith(('x', 'X')):
-                    memory = float(resources.memory[:-1])
-                    if memory * num_cpus_in_tpu_vm > memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
                 else:
                     memory = float(resources.memory)

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -261,9 +261,9 @@ class GCP(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory_gb: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='gcp')
+            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='gcp')
 
     def make_deploy_resources_variables(
             self, resources: 'resources.Resources', region: 'clouds.Region',
@@ -353,7 +353,7 @@ class GCP(clouds.Cloud):
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             host_vm_type = GCP.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus, memory_gb=resources.memory_gb)
             if host_vm_type is None:
                 return ([], [])
             else:
@@ -362,7 +362,7 @@ class GCP(clouds.Cloud):
                     instance_type=host_vm_type,
                     accelerators=None,
                     cpus=None,
-                    memory=None,
+                    memory_gb=None,
                 )
                 return ([r], [])
 
@@ -382,7 +382,7 @@ class GCP(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus if not use_tpu_vm else None,
-            memory_gb_or_ratio=resources.memory if not use_tpu_vm else None,
+            memory_gb_or_ratio=resources.memory_gb if not use_tpu_vm else None,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,
@@ -408,18 +408,18 @@ class GCP(clouds.Cloud):
                     if cpus != num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
             memory_in_tpu_vm = 624
-            if resources.memory is not None:
-                if resources.memory.endswith('+'):
-                    memory = float(resources.memory[:-1])
-                    if memory > memory_in_tpu_vm:
+            if resources.memory_gb is not None:
+                if resources.memory_gb.endswith('+'):
+                    memory_gb = float(resources.memory_gb[:-1])
+                    if memory_gb > memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
-                elif resources.memory.endswith(('x', 'X')):
-                    memory = float(resources.memory[:-1])
-                    if memory * num_cpus_in_tpu_vm > memory_in_tpu_vm:
+                elif resources.memory_gb.endswith(('x', 'X')):
+                    memory_gb = float(resources.memory_gb[:-1])
+                    if memory_gb * num_cpus_in_tpu_vm > memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
                 else:
-                    memory = float(resources.memory)
-                    if memory != memory_in_tpu_vm:
+                    memory_gb = float(resources.memory_gb)
+                    if memory_gb != memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
         else:
             host_vm_type = instance_list[0]
@@ -430,7 +430,7 @@ class GCP(clouds.Cloud):
             instance_type=host_vm_type,
             accelerators=acc_dict,
             cpus=None,
-            memory=None,
+            memory_gb=None,
         )
         return ([r], fuzzy_candidate_list)
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -378,6 +378,7 @@ class GCP(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus if not use_tpu_vm else None,
+            memory_gb_or_ratio=resources.memory,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,
@@ -424,12 +425,12 @@ class GCP(clouds.Cloud):
         return None
 
     @classmethod
-    def get_vcpus_from_instance_type(
+    def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[float]:
-        return service_catalog.get_vcpus_from_instance_type(instance_type,
-                                                            clouds='gcp')
+        return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                                clouds='gcp')
 
     @classmethod
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -397,9 +397,9 @@ class GCP(clouds.Cloud):
 
         if use_tpu_vm:
             host_vm_type = 'TPU-VM'
-            # FIXME(woosuk): This leverages the fact that TPU VMs have 96 vCPUs,
-            # and 240 vCPUs for tpu-v4.
-            # TODO(wei-lin): Move this to service catalog, instead.
+            # FIXME(woosuk, wei-lin): This leverages the fact that TPU VMs
+            # have 96 vCPUs, and 240 vCPUs for tpu-v4. We need to move
+            # this to service catalog, instead.
             num_cpus_in_tpu_vm = 240 if 'v4' in acc else 96
             if resources.cpus is not None:
                 if resources.cpus.endswith('+'):
@@ -410,9 +410,9 @@ class GCP(clouds.Cloud):
                     cpus = float(resources.cpus)
                     if cpus != num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
-            # TODO(wei-lin): Move this to service catalog, instead.
-            # The number needs to be confirmed for tpu vms earlier than
-            # v4.
+            # FIXME(woosuk, wei-lin): This leverages the fact that TPU VMs
+            # have 334 GB RAM, and 400 GB RAM for tpu-v4. We need to move
+            # this to service catalog, instead.
             memory_in_tpu_vm = 400 if 'v4' in acc else 334
             if resources.memory is not None:
                 if resources.memory.endswith('+'):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -261,9 +261,9 @@ class GCP(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory_gb: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='gcp')
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='gcp')
 
     def make_deploy_resources_variables(
             self, resources: 'resources.Resources', region: 'clouds.Region',
@@ -353,7 +353,7 @@ class GCP(clouds.Cloud):
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             host_vm_type = GCP.get_default_instance_type(
-                cpus=resources.cpus, memory_gb=resources.memory_gb)
+                cpus=resources.cpus, memory=resources.memory)
             if host_vm_type is None:
                 return ([], [])
             else:
@@ -362,7 +362,7 @@ class GCP(clouds.Cloud):
                     instance_type=host_vm_type,
                     accelerators=None,
                     cpus=None,
-                    memory_gb=None,
+                    memory=None,
                 )
                 return ([r], [])
 
@@ -382,7 +382,7 @@ class GCP(clouds.Cloud):
             acc,
             acc_count,
             cpus=resources.cpus if not use_tpu_vm else None,
-            memory_gb_or_ratio=resources.memory_gb if not use_tpu_vm else None,
+            memory_gb_or_ratio=resources.memory if not use_tpu_vm else None,
             use_spot=resources.use_spot,
             region=resources.region,
             zone=resources.zone,
@@ -408,18 +408,18 @@ class GCP(clouds.Cloud):
                     if cpus != num_cpus_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
             memory_in_tpu_vm = 624
-            if resources.memory_gb is not None:
-                if resources.memory_gb.endswith('+'):
-                    memory_gb = float(resources.memory_gb[:-1])
-                    if memory_gb > memory_in_tpu_vm:
+            if resources.memory is not None:
+                if resources.memory.endswith('+'):
+                    memory = float(resources.memory[:-1])
+                    if memory > memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
-                elif resources.memory_gb.endswith(('x', 'X')):
-                    memory_gb = float(resources.memory_gb[:-1])
-                    if memory_gb * num_cpus_in_tpu_vm > memory_in_tpu_vm:
+                elif resources.memory.endswith(('x', 'X')):
+                    memory = float(resources.memory[:-1])
+                    if memory * num_cpus_in_tpu_vm > memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
                 else:
-                    memory_gb = float(resources.memory_gb)
-                    if memory_gb != memory_in_tpu_vm:
+                    memory = float(resources.memory)
+                    if memory != memory_in_tpu_vm:
                         return ([], fuzzy_candidate_list)
         else:
             host_vm_type = instance_list[0]
@@ -430,7 +430,7 @@ class GCP(clouds.Cloud):
             instance_type=host_vm_type,
             accelerators=acc_dict,
             cpus=None,
-            memory_gb=None,
+            memory=None,
         )
         return ([r], fuzzy_candidate_list)
 

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -112,10 +112,12 @@ class Lambda(clouds.Cloud):
         return isinstance(other, Lambda)
 
     @classmethod
-    def get_default_instance_type(cls,
-                                  cpus: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(cpus=cpus,
-                                                         clouds='lambda')
+    def get_default_instance_type(
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None) -> Optional[str]:
+        return service_catalog.get_default_instance_type(
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='lambda')
 
     @classmethod
     def get_accelerators_from_instance_type(
@@ -129,7 +131,7 @@ class Lambda(clouds.Cloud):
     def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
-    ) -> Optional[float]:
+    ) -> Tuple[Optional[float], Optional[float]]:
         return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
                                                                 clouds='lambda')
 
@@ -175,6 +177,7 @@ class Lambda(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -184,7 +187,7 @@ class Lambda(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Lambda.get_default_instance_type(
-                cpus=resources.cpus)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -115,9 +115,9 @@ class Lambda(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory_gb: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='lambda')
+            cpus=cpus, memory_gb_or_ratio=memory, clouds='lambda')
 
     @classmethod
     def get_accelerators_from_instance_type(
@@ -177,7 +177,7 @@ class Lambda(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory_gb=None,
+                    memory=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -187,7 +187,7 @@ class Lambda(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Lambda.get_default_instance_type(
-                cpus=resources.cpus, memory_gb=resources.memory_gb)
+                cpus=resources.cpus, memory=resources.memory)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -201,7 +201,7 @@ class Lambda(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory_gb,
+            memory_gb_or_ratio=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='lambda')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -116,8 +116,9 @@ class Lambda(clouds.Cloud):
             cls,
             cpus: Optional[str] = None,
             memory: Optional[str] = None) -> Optional[str]:
-        return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='lambda')
+        return service_catalog.get_default_instance_type(cpus=cpus,
+                                                         memory=memory,
+                                                         clouds='lambda')
 
     @classmethod
     def get_accelerators_from_instance_type(
@@ -201,7 +202,7 @@ class Lambda(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='lambda')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -126,12 +126,12 @@ class Lambda(clouds.Cloud):
             instance_type, clouds='lambda')
 
     @classmethod
-    def get_vcpus_from_instance_type(
+    def get_vcpus_mem_from_instance_type(
         cls,
         instance_type: str,
     ) -> Optional[float]:
-        return service_catalog.get_vcpus_from_instance_type(instance_type,
-                                                            clouds='lambda')
+        return service_catalog.get_vcpus_mem_from_instance_type(instance_type,
+                                                                clouds='lambda')
 
     @classmethod
     def get_zone_shell_cmd(cls) -> Optional[str]:
@@ -198,6 +198,7 @@ class Lambda(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
+            memory_gb_or_ratio=resources.memory,
             region=resources.region,
             zone=resources.zone,
             clouds='lambda')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -115,9 +115,9 @@ class Lambda(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory_gb: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(
-            cpus=cpus, memory_gb_or_ratio=memory, clouds='lambda')
+            cpus=cpus, memory_gb_or_ratio=memory_gb, clouds='lambda')
 
     @classmethod
     def get_accelerators_from_instance_type(
@@ -177,7 +177,7 @@ class Lambda(clouds.Cloud):
                     # attach the accelerators.  Billed as part of the VM type.
                     accelerators=None,
                     cpus=None,
-                    memory=None,
+                    memory_gb=None,
                 )
                 resource_list.append(r)
             return resource_list
@@ -187,7 +187,7 @@ class Lambda(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Lambda.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus, memory_gb=resources.memory_gb)
             if default_instance_type is None:
                 return ([], [])
             else:
@@ -201,7 +201,7 @@ class Lambda(clouds.Cloud):
             acc_count,
             use_spot=resources.use_spot,
             cpus=resources.cpus,
-            memory_gb_or_ratio=resources.memory,
+            memory_gb_or_ratio=resources.memory_gb,
             region=resources.region,
             zone=resources.zone,
             clouds='lambda')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -108,15 +108,17 @@ class Local(clouds.Cloud):
         return isinstance(other, Local)
 
     @classmethod
-    def get_default_instance_type(cls, cpus: Optional[str] = None) -> str:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
-        del cpus  # Unused.
+        del cpus, memory  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod
-    def get_vcpus_mem_from_instance_type(cls,
-                                         instance_type: str) -> Optional[float]:
-        return None
+    def get_vcpus_mem_from_instance_type(
+            cls, instance_type: str) -> Tuple[Optional[float], Optional[float]]:
+        return None, None
 
     @classmethod
     def get_accelerators_from_instance_type(

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -114,8 +114,8 @@ class Local(clouds.Cloud):
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod
-    def get_vcpus_from_instance_type(cls,
-                                     instance_type: str) -> Optional[float]:
+    def get_vcpus_mem_from_instance_type(cls,
+                                         instance_type: str) -> Optional[float]:
         return None
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -110,9 +110,9 @@ class Local(clouds.Cloud):
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None,
-                                  memory_gb: Optional[str] = None) -> str:
+                                  memory: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
-        del cpus, memory_gb  # Unused.
+        del cpus, memory  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -110,9 +110,9 @@ class Local(clouds.Cloud):
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None,
-                                  memory: Optional[str] = None) -> str:
+                                  memory_gb: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
-        del cpus, memory  # Unused.
+        del cpus, memory_gb  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -164,10 +164,11 @@ def get_hourly_cost(instance_type: str,
                                use_spot, region, zone)
 
 
-def get_vcpus_from_instance_type(instance_type: str,
-                                 clouds: CloudFilter = None) -> Optional[float]:
+def get_vcpus_mem_from_instance_type(instance_type: str,
+                                     clouds: CloudFilter = None
+                                    ) -> Optional[float]:
     """Returns the number of virtual CPUs from a instance type."""
-    return _map_clouds_catalog(clouds, 'get_vcpus_from_instance_type',
+    return _map_clouds_catalog(clouds, 'get_vcpus_mem_from_instance_type',
                                instance_type)
 
 
@@ -194,6 +195,7 @@ def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
     cpus: Optional[str] = None,
+    memory_gb_or_ratio: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -204,8 +206,8 @@ def get_instance_type_for_accelerator(
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
     return _map_clouds_catalog(clouds, 'get_instance_type_for_accelerator',
-                               acc_name, acc_count, cpus, use_spot, region,
-                               zone)
+                               acc_name, acc_count, cpus, memory_gb_or_ratio,
+                               use_spot, region, zone)
 
 
 def get_accelerator_hourly_cost(

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -164,15 +164,16 @@ def get_hourly_cost(instance_type: str,
                                use_spot, region, zone)
 
 
-def get_vcpus_mem_from_instance_type(instance_type: str,
-                                     clouds: CloudFilter = None
-                                    ) -> Optional[float]:
+def get_vcpus_mem_from_instance_type(
+        instance_type: str,
+        clouds: CloudFilter = None) -> Tuple[Optional[float], Optional[float]]:
     """Returns the number of virtual CPUs from a instance type."""
     return _map_clouds_catalog(clouds, 'get_vcpus_mem_from_instance_type',
                                instance_type)
 
 
 def get_default_instance_type(cpus: Optional[str] = None,
+                              memory_gb_or_ratio: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
     """Returns the cloud's default instance type for the given number of vCPUs.
 
@@ -180,7 +181,8 @@ def get_default_instance_type(cpus: Optional[str] = None,
     with 4 vCPUs.  If cpus='4+', this method returns the default instance
     type with 4 or more vCPUs.
     """
-    return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus)
+    return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus,
+                               memory_gb_or_ratio)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -182,7 +182,7 @@ def get_default_instance_type(cpus: Optional[str] = None,
     type with 4 or more vCPUs.
 
     If memory_gb_or_ratio is not specified, this method returns the General
-    Purpose instance type with the given number of vCPUs.  If memory_gb_or_ratio
+    Purpose instance type with the given number of vCPUs. If memory_gb_or_ratio
     is specified, this method returns the cheapest instance type that meets
     the given CPU and memory requirement.
     """

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -173,16 +173,21 @@ def get_vcpus_mem_from_instance_type(
 
 
 def get_default_instance_type(cpus: Optional[str] = None,
-                              memory_gb_or_ratio: Optional[str] = None,
+                              memory: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
-    """Returns the cloud's default instance type for the given number of vCPUs.
+    """Returns the cloud's default instance type for given #vCPUs and memory.
 
     For example, if cpus='4', this method returns the default instance type
     with 4 vCPUs.  If cpus='4+', this method returns the default instance
     type with 4 or more vCPUs.
+
+    If memory_gb_or_ratio is not specified, this method returns the General
+    Purpose instance type with the given number of vCPUs.  If memory_gb_or_ratio
+    is specified, this method returns the cheapest instance type that meets
+    the given CPU and memory requirement.
     """
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus,
-                               memory_gb_or_ratio)
+                               memory)
 
 
 def get_accelerators_from_instance_type(
@@ -197,7 +202,7 @@ def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
     cpus: Optional[str] = None,
-    memory_gb_or_ratio: Optional[str] = None,
+    memory: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -208,8 +213,8 @@ def get_instance_type_for_accelerator(
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
     return _map_clouds_catalog(clouds, 'get_instance_type_for_accelerator',
-                               acc_name, acc_count, cpus, memory_gb_or_ratio,
-                               use_spot, region, zone)
+                               acc_name, acc_count, cpus, memory, use_spot,
+                               region, zone)
 
 
 def get_accelerator_hourly_cost(

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -32,11 +32,11 @@ _DEFAULT_INSTANCE_FAMILY = [
     # Memory: 4 GiB RAM per 1 vCPU;
     'm6i',
     # This is the latest memory-optimized instance family as of Mar 2023.
-    # CPU: TBD
+    # CPU: Intel Ice Lake 8375C
     # Memory: 8 GiB RAM per 1 vCPU;
     'r6i',
     # This is the latest compute-optimized instance family as of Mar 2023.
-    # CPU: TBD
+    # CPU: Intel Ice Lake 8375C
     # Memory: 2 GiB RAM per 1 vCPU;
     'c6i',
 ]

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -170,14 +170,15 @@ def get_vcpus_mem_from_instance_type(
                                                         instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
-    if cpus is None and memory_gb_or_ratio is None:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None) -> Optional[str]:
+    if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
 
-    if memory_gb_or_ratio is None:
+    if memory is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
+    else:
+        memory_gb_or_ratio = memory
     instance_type_prefix = tuple(
         f'{family}.' for family in _DEFAULT_INSTANCE_FAMILY)
     df = _get_df()
@@ -196,7 +197,7 @@ def get_instance_type_for_accelerator(
     acc_name: str,
     acc_count: int,
     cpus: Optional[str] = None,
-    memory_gb_or_ratio: Optional[str] = None,
+    memory: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -205,15 +206,14 @@ def get_instance_type_for_accelerator(
     Returns a list of instance types satisfying the required count of
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """
-    return common.get_instance_type_for_accelerator_impl(
-        df=_get_df(),
-        acc_name=acc_name,
-        acc_count=acc_count,
-        cpus=cpus,
-        memory_gb_or_ratio=memory_gb_or_ratio,
-        use_spot=use_spot,
-        region=region,
-        zone=zone)
+    return common.get_instance_type_for_accelerator_impl(df=_get_df(),
+                                                         acc_name=acc_name,
+                                                         acc_count=acc_count,
+                                                         cpus=cpus,
+                                                         memory=memory,
+                                                         use_spot=use_spot,
+                                                         region=region,
+                                                         zone=zone)
 
 
 def get_region_zones_for_instance_type(instance_type: str,

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -25,12 +25,21 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-# This is the latest general-purpose instance family as of Jan 2023.
-# CPU: Intel Ice Lake 8375C.
-# Memory: m6i - 4 GiB RAM per 1 vCPU;
-#         r6i - 8 GiB RAM per 1 vCPU;
-#         c6i - 2 GiB RAM per 1 vCPU.
-_DEFAULT_INSTANCE_FAMILY = ['m6i', 'r6i', 'c6i']
+# We will select from the following three instance families:
+_DEFAULT_INSTANCE_FAMILY = [
+    # This is the latest general-purpose instance family as of Mar 2023.
+    # CPU: Intel Ice Lake 8375C.
+    # Memory: 4 GiB RAM per 1 vCPU;
+    'm6i',
+    # This is the latest memory-optimized instance family as of Mar 2023.
+    # CPU: TBD
+    # Memory: 8 GiB RAM per 1 vCPU;
+    'r6i',
+    # This is the latest compute-optimized instance family as of Mar 2023.
+    # CPU: TBD
+    # Memory: 2 GiB RAM per 1 vCPU;
+    'c6i',
+]
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -27,7 +27,9 @@ logger = sky_logging.init_logger(__name__)
 
 # This is the latest general-purpose instance family as of Jan 2023.
 # CPU: Intel Ice Lake 8375C.
-# Memory: 4 GiB RAM per 1 vCPU.
+# Memory: m6i - 4 GiB RAM per 1 vCPU;
+#         r6i - 8 GiB RAM per 1 vCPU;
+#         c6i - 2 GiB RAM per 1 vCPU.
 _DEFAULT_INSTANCE_FAMILY = ['m6i', 'r6i', 'c6i']
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
@@ -168,15 +170,14 @@ def get_vcpus_mem_from_instance_type(
                                                         instance_type)
 
 
-def get_default_instance_type(cpus: Optional[str] = None,
-                              memory_gb: Optional[str] = None) -> Optional[str]:
-    if cpus is None:
-        cpus = str(_DEFAULT_NUM_VCPUS)
+def get_default_instance_type(
+        cpus: Optional[str] = None,
+        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
+    if cpus is None and memory_gb_or_ratio is None:
+        cpus = f'{_DEFAULT_NUM_VCPUS}+'
 
-    if memory_gb is None:
+    if memory_gb_or_ratio is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
-    else:
-        memory_gb_or_ratio = memory_gb
     instance_type_prefix = tuple(
         f'{family}.' for family in _DEFAULT_INSTANCE_FAMILY)
     df = _get_df()

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -14,10 +14,10 @@ _df = common.read_catalog('azure/vms.csv')
 
 # This is the latest general-purpose instance family as of Jan 2023.
 # CPU: Intel Ice Lake 8370C.
-# Memory: D_v5 -- 4 GiB RAM per 1 vCPU;
-#         E_v5 -- 8 GiB RAM per 1 vCPU.
-#         F    -- 2 GiB RAM per 1 vCPU.
-_DEFAULT_INSTANCE_FAMILY = ['D_v5', 'E_v5', 'F']
+# Memory: D_v5  -- 4 GiB RAM per 1 vCPU;
+#         E_v5  -- 8 GiB RAM per 1 vCPU.
+#         Fs_v2 -- 2 GiB RAM per 1 vCPU.
+_DEFAULT_INSTANCE_FAMILY = ['D_v5', 'E_v5', 'Fs_v2']
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -12,12 +12,21 @@ from sky.utils import ux_utils
 
 _df = common.read_catalog('azure/vms.csv')
 
-# This is the latest general-purpose instance family as of Jan 2023.
-# CPU: Intel Ice Lake 8370C.
-# Memory: D_v5  -- 4 GiB RAM per 1 vCPU;
-#         E_v5  -- 8 GiB RAM per 1 vCPU.
-#         Fs_v2 -- 2 GiB RAM per 1 vCPU.
-_DEFAULT_INSTANCE_FAMILY = ['D_v5', 'E_v5', 'Fs_v2']
+# We will select from the following three instance families:
+_DEFAULT_INSTANCE_FAMILY = [
+    # The latest general-purpose instance family as of Mar. 2023.
+    # CPU: Intel Ice Lake 8370C.
+    # Memory: 4 GiB RAM per 1 vCPU;
+    'D_v5',
+    # The latest memory-optimized instance family as of Mar. 2023.
+    # CPU: Intel Ice Lake 8370C.
+    # Memory: 8 GiB RAM per 1 vCPU.
+    'E_v5',
+    # The latest compute-optimized instance family as of Mar 2023.
+    # CPU: Intel Ice Lake 8370C, Cascade Lake 8272CL, or Skylake 8168.
+    # Memory: 2 GiB RAM per 1 vCPU.
+    'Fs_v2'
+]
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -87,13 +87,14 @@ def _get_instance_family(instance_type: str) -> str:
     return instance_family
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
-    if cpus is None and memory_gb_or_ratio is None:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None) -> Optional[str]:
+    if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
-    if memory_gb_or_ratio is None:
+    if memory is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
+    else:
+        memory_gb_or_ratio = memory
     df = _df[_df['InstanceType'].apply(_get_instance_family).isin(
         _DEFAULT_INSTANCE_FAMILY)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
@@ -109,7 +110,7 @@ def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
         cpus: Optional[str] = None,
-        memory_gb_or_ratio: Optional[str] = None,
+        memory: Optional[str] = None,
         use_spot: bool = False,
         region: Optional[str] = None,
         zone: Optional[str] = None) -> Tuple[Optional[List[str]], List[str]]:
@@ -120,15 +121,14 @@ def get_instance_type_for_accelerator(
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')
-    return common.get_instance_type_for_accelerator_impl(
-        df=_df,
-        acc_name=acc_name,
-        acc_count=acc_count,
-        cpus=cpus,
-        memory_gb_or_ratio=memory_gb_or_ratio,
-        use_spot=use_spot,
-        region=region,
-        zone=zone)
+    return common.get_instance_type_for_accelerator_impl(df=_df,
+                                                         acc_name=acc_name,
+                                                         acc_count=acc_count,
+                                                         cpus=cpus,
+                                                         memory=memory,
+                                                         use_spot=use_spot,
+                                                         region=region,
+                                                         zone=zone)
 
 
 def get_region_zones_for_instance_type(

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -56,8 +56,9 @@ def get_hourly_cost(instance_type: str,
                                        zone)
 
 
-def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
-    return common.get_vcpus_from_instance_type_impl(_df, instance_type)
+def get_vcpus_mem_from_instance_type(
+        instance_type: str) -> Tuple[Optional[float], Optional[float]]:
+    return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
 def _get_instance_family(instance_type: str) -> str:
@@ -88,7 +89,7 @@ def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
         cpus = str(_DEFAULT_NUM_VCPUS)
     df = _df[_df['InstanceType'].apply(_get_instance_family) ==
              _DEFAULT_INSTANCE_FAMILY]
-    return common.get_instance_type_for_cpus_impl(df, cpus)
+    return common.get_instance_type_for_cpus_mem_impl(df, cpus)
 
 
 def get_accelerators_from_instance_type(
@@ -100,6 +101,7 @@ def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
         cpus: Optional[str] = None,
+        memory_gb_or_ratio: Optional[str] = None,
         use_spot: bool = False,
         region: Optional[str] = None,
         zone: Optional[str] = None) -> Tuple[Optional[List[str]], List[str]]:
@@ -110,13 +112,15 @@ def get_instance_type_for_accelerator(
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')
-    return common.get_instance_type_for_accelerator_impl(df=_df,
-                                                         acc_name=acc_name,
-                                                         acc_count=acc_count,
-                                                         cpus=cpus,
-                                                         use_spot=use_spot,
-                                                         region=region,
-                                                         zone=zone)
+    return common.get_instance_type_for_accelerator_impl(
+        df=_df,
+        acc_name=acc_name,
+        acc_count=acc_count,
+        cpus=cpus,
+        memory_gb_or_ratio=memory_gb_or_ratio,
+        use_spot=use_spot,
+        region=region,
+        zone=zone)
 
 
 def get_region_zones_for_instance_type(

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -253,10 +253,10 @@ def get_hourly_cost_impl(
     return cheapest[price_str]
 
 
-def get_vcpus_from_instance_type_impl(
+def get_vcpus_mem_from_instance_type_impl(
     df: pd.DataFrame,
     instance_type: str,
-) -> Optional[float]:
+) -> Tuple[Optional[float], Optional[float]]:
     df = _get_instance_type(df, instance_type, None)
     if len(df) == 0:
         with ux_utils.print_exception_no_traceback():
@@ -264,10 +264,20 @@ def get_vcpus_from_instance_type_impl(
     assert len(set(df['vCPUs'])) == 1, ('Cannot determine the number of vCPUs '
                                         f'of the instance type {instance_type}.'
                                         f'\n{df}')
+    assert len(set(
+        df['MemoryGiB'])) == 1, ('Cannot determine the memory size '
+                                 f'of the instance type {instance_type}.'
+                                 f'\n{df}')
+
     vcpus = df['vCPUs'].iloc[0]
-    if pd.isna(vcpus):
-        return None
-    return float(vcpus)
+    mem = df['MemoryGiB'].iloc[0]
+
+    def get_value(value):
+        if pd.isna(value):
+            return None
+        return float(value)
+
+    return get_value(vcpus), get_value(mem)
 
 
 def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
@@ -293,9 +303,39 @@ def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == num_cpus]
 
 
-def get_instance_type_for_cpus_impl(
-        df: pd.DataFrame, cpus: Optional[str] = None) -> Optional[str]:
+def _filter_with_mem(df: pd.DataFrame,
+                     memory_gb_or_ratio: Optional[str]) -> pd.DataFrame:
+    if memory_gb_or_ratio is None:
+        return df
+
+    # The following code is redundant with the code in
+    # resources.py::_set_memory() but we add it here for safety.
+    if memory_gb_or_ratio.endswith(('+', 'x', 'X')):
+        memory_gb_str = memory_gb_or_ratio[:-1]
+    else:
+        memory_gb_str = memory_gb_or_ratio
+    try:
+        memory_gb = float(memory_gb_str)
+    except ValueError:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'The "memory" field should be either a number or '
+                             'a string "<number>+" or "<number>x". Found: '
+                             f'{memory_gb_or_ratio!r}') from None
+
+    if memory_gb_or_ratio.endswith('+'):
+        return df[df['MemoryGiB'] >= memory_gb]
+    elif memory_gb_or_ratio.endswith(('x', 'X')):
+        return df[df['MemoryGiB'] >= df['vCPUs'] * memory_gb]
+    else:
+        return df[df['MemoryGiB'] == memory_gb]
+
+
+def get_instance_type_for_cpus_mem_impl(
+        df: pd.DataFrame,
+        cpus: Optional[str] = None,
+        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
     df = _filter_with_cpus(df, cpus)
+    df = _filter_with_mem(df, memory_gb_or_ratio)
     if df.empty:
         return None
     # Sort by the number of vCPUs and then by the price.
@@ -323,6 +363,7 @@ def get_instance_type_for_accelerator_impl(
     acc_name: str,
     acc_count: int,
     cpus: Optional[str] = None,
+    memory_gb_or_ratio: Optional[str] = None,
     use_spot: bool = False,
     region: Optional[str] = None,
     zone: Optional[str] = None,
@@ -348,6 +389,7 @@ def get_instance_type_for_accelerator_impl(
         return (None, fuzzy_candidate_list)
 
     result = _filter_with_cpus(result, cpus)
+    result = _filter_with_mem(result, memory_gb_or_ratio)
     if region is not None:
         result = result[result['Region'] == region]
     if zone is not None:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -31,7 +31,7 @@ class InstanceTypeInfo(NamedTuple):
     - accelerator_name: Canonical name of the accelerator. E.g. `V100`.
     - accelerator_count: Number of accelerators offered by this instance type.
     - cpu_count: Number of vCPUs offered by this instance type.
-    - memory: Instance memory in GiB.
+    - memory_gb: Instance memory in GiB.
     - price: Regular instance price per hour (cheapest across all regions).
     - spot_price: Spot instance price per hour (cheapest across all regions).
     - region: Region where this instance type belongs to.
@@ -41,7 +41,7 @@ class InstanceTypeInfo(NamedTuple):
     accelerator_name: str
     accelerator_count: int
     cpu_count: Optional[float]
-    memory: Optional[float]
+    memory_gb: Optional[float]
     price: float
     spot_price: float
     region: str

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -253,6 +253,12 @@ def get_hourly_cost_impl(
     return cheapest[price_str]
 
 
+def _get_value(value):
+    if pd.isna(value):
+        return None
+    return float(value)
+
+
 def get_vcpus_mem_from_instance_type_impl(
     df: pd.DataFrame,
     instance_type: str,
@@ -272,12 +278,7 @@ def get_vcpus_mem_from_instance_type_impl(
     vcpus = df['vCPUs'].iloc[0]
     mem = df['MemoryGiB'].iloc[0]
 
-    def get_value(value):
-        if pd.isna(value):
-            return None
-        return float(value)
-
-    return get_value(vcpus), get_value(mem)
+    return _get_value(vcpus), _get_value(mem)
 
 
 def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
@@ -310,7 +311,7 @@ def _filter_with_mem(df: pd.DataFrame,
 
     # The following code is partially redundant with the code in
     # resources.py::_set_memory() but we add it here for safety.
-    if memory_gb_or_ratio.endswith(('+', 'x', 'X')):
+    if memory_gb_or_ratio.endswith(('+', 'x')):
         memory_gb_str = memory_gb_or_ratio[:-1]
     else:
         memory_gb_str = memory_gb_or_ratio
@@ -323,7 +324,7 @@ def _filter_with_mem(df: pd.DataFrame,
                              f'{memory_gb_or_ratio!r}') from None
     if memory_gb_or_ratio.endswith('+'):
         return df[df['MemoryGiB'] >= memory]
-    elif memory_gb_or_ratio.endswith(('x', 'X')):
+    elif memory_gb_or_ratio.endswith('x'):
         return df[df['MemoryGiB'] >= df['vCPUs'] * memory]
     else:
         return df[df['MemoryGiB'] == memory]

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -31,7 +31,7 @@ class InstanceTypeInfo(NamedTuple):
     - accelerator_name: Canonical name of the accelerator. E.g. `V100`.
     - accelerator_count: Number of accelerators offered by this instance type.
     - cpu_count: Number of vCPUs offered by this instance type.
-    - memory_gb: Instance memory in GiB.
+    - memory: Instance memory in GiB.
     - price: Regular instance price per hour (cheapest across all regions).
     - spot_price: Spot instance price per hour (cheapest across all regions).
     - region: Region where this instance type belongs to.
@@ -41,7 +41,7 @@ class InstanceTypeInfo(NamedTuple):
     accelerator_name: str
     accelerator_count: int
     cpu_count: Optional[float]
-    memory_gb: Optional[float]
+    memory: Optional[float]
     price: float
     spot_price: float
     region: str
@@ -315,19 +315,18 @@ def _filter_with_mem(df: pd.DataFrame,
     else:
         memory_gb_str = memory_gb_or_ratio
     try:
-        memory_gb = float(memory_gb_str)
+        memory = float(memory_gb_str)
     except ValueError:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(f'The "memory" field should be either a number or '
                              'a string "<number>+" or "<number>x". Found: '
                              f'{memory_gb_or_ratio!r}') from None
-
     if memory_gb_or_ratio.endswith('+'):
-        return df[df['MemoryGiB'] >= memory_gb]
+        return df[df['MemoryGiB'] >= memory]
     elif memory_gb_or_ratio.endswith(('x', 'X')):
-        return df[df['MemoryGiB'] >= df['vCPUs'] * memory_gb]
+        return df[df['MemoryGiB'] >= df['vCPUs'] * memory]
     else:
-        return df[df['MemoryGiB'] == memory_gb]
+        return df[df['MemoryGiB'] == memory]
 
 
 def get_instance_type_for_cpus_mem_impl(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -189,7 +189,7 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
         gpu_name = None
         gpu_count = np.nan
         vcpus = np.nan
-        memory_gb = np.nan
+        memory = np.nan
         gen_version = None
         caps = row['capabilities']
         for item in caps:
@@ -201,19 +201,18 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
             elif item['name'] == 'vCPUs':
                 vcpus = float(item['value'])
             elif item['name'] == 'MemoryGB':
-                memory_gb = item['value']
+                memory = item['value']
             elif item['name'] == 'HyperVGenerations':
                 gen_version = item['value']
-        return gpu_name, gpu_count, vcpus, memory_gb, gen_version
+        return gpu_name, gpu_count, vcpus, memory, gen_version
 
     def get_additional_columns(row):
-        gpu_name, gpu_count, vcpus, memory_gb, gen_version = get_capabilities(
-            row)
+        gpu_name, gpu_count, vcpus, memory, gen_version = get_capabilities(row)
         return pd.Series({
             'AcceleratorName': gpu_name,
             'AcceleratorCount': gpu_count,
             'vCPUs': vcpus,
-            'MemoryGiB': memory_gb,
+            'MemoryGiB': memory,
             'GpuInfo': gpu_name,
             'Generation': gen_version,
         })

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -330,13 +330,12 @@ def list_accelerators(
     # Thus, we can show their exact cost including the host VM prices.
     new_infos = defaultdict(list)
     for info in a100_infos:
-        assert pd.isna(info.instance_type) and pd.isna(
-            info.memory_gb), a100_infos
+        assert pd.isna(info.instance_type) and pd.isna(info.memory), a100_infos
         a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][
             info.accelerator_count]
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
-        memory_gb = df['MemoryGiB'].iloc[0]
+        memory = df['MemoryGiB'].iloc[0]
         vm_price = common.get_hourly_cost_impl(_df,
                                                a100_host_vm_type,
                                                use_spot=False,
@@ -351,7 +350,7 @@ def list_accelerators(
             info._replace(
                 instance_type=a100_host_vm_type,
                 cpu_count=cpu_count,
-                memory_gb=memory_gb,
+                memory=memory,
                 # total cost = VM instance + GPU.
                 price=info.price + vm_price,
                 spot_price=info.spot_price + vm_spot_price,
@@ -482,7 +481,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
     # vCPU counts and memory sizes of N1 machines.
     df = _df[_df['InstanceType'] == instance_type]
     num_cpus = df['vCPUs'].iloc[0]
-    memory_gb = df['MemoryGiB'].iloc[0]
+    memory = df['MemoryGiB'].iloc[0]
 
     if num_cpus > max_cpus:
         with ux_utils.print_exception_no_traceback():
@@ -490,7 +489,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
                 f'{acc_name}:{acc_count} cannot be attached to '
                 f'{instance_type}. The maximum number of vCPUs is {max_cpus}. '
                 'Please refer to: https://cloud.google.com/compute/docs/gpus')
-    if memory_gb > max_memory:
+    if memory > max_memory:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ResourcesMismatchError(
                 f'{acc_name}:{acc_count} cannot be attached to '

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -27,16 +27,16 @@ _TPU_REGIONS = [
 
 # We will select from the following three CPU instance families:
 _DEFAULT_INSTANCE_FAMILY = [
-    # This is the latest general-purpose instance family as of Jan 2023.
+    # This is the latest general-purpose instance family as of Mar 2023.
     # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
     # Memory: 4 GiB RAM per 1 vCPU;
     'n2-standard',
-    # This is the latest memory-optimized instance family as of Jan 2023.
-    # CPU: TBD
+    # This is the latest memory-optimized instance family as of Mar 2023.
+    # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
     # Memory: 8 GiB RAM per 1 vCPU;
     'n2-highmem',
-    # This is the latest compute-optimized instance family as of Jan 2023.
-    # CPU: TBD
+    # This is the latest compute-optimized instance family as of Mar 2023.
+    # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
     # Memory: 1 GiB RAM per 1 vCPU;
     'n2-highcpu',
 ]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -25,18 +25,26 @@ _TPU_REGIONS = [
     'asia-east1',
 ]
 
-# Default instance family for CPU-only VMs.
-# This is the latest general-purpose instance family as of Jan 2023.
-# CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
-# Memory: n2-standard -- 4 GiB RAM per 1 vCPU;
-#         n2-highmem -- 8 GiB RAM per 1 vCPU;
-#         n2-highcpu -- 1 GiB RAM per 1 vCPU.
-_DEFAULT_INSTANCE_FAMILY = ['n2-standard', 'n2-highmem', 'n2-highcpu']
+# We will select from the following three CPU instance families:
+_DEFAULT_INSTANCE_FAMILY = [
+    # This is the latest general-purpose instance family as of Jan 2023.
+    # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
+    # Memory: 4 GiB RAM per 1 vCPU;
+    'n2-standard',
+    # This is the latest memory-optimized instance family as of Jan 2023.
+    # CPU: TBD
+    # Memory: 8 GiB RAM per 1 vCPU;
+    'n2-highmem',
+    # This is the latest compute-optimized instance family as of Jan 2023.
+    # CPU: TBD
+    # Memory: 1 GiB RAM per 1 vCPU;
+    'n2-highcpu',
+]
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
 
 # This can be switched between n1 and n2.
-# n2 is not allowed for launching GPUs right now.
+# n2 is not allowed for launching GPUs.
 _DEFAULT_HOST_VM_FAMILY = 'n1'
 _DEFAULT_GPU_MEMORY_CPU_RATIO = 4
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -330,12 +330,12 @@ def list_accelerators(
     # Thus, we can show their exact cost including the host VM prices.
     new_infos = defaultdict(list)
     for info in a100_infos:
-        assert pd.isna(info.instance_type) and pd.isna(info.memory), a100_infos
+        assert pd.isna(info.instance_type) and pd.isna(info.memory_gb), a100_infos
         a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][
             info.accelerator_count]
         df = _df[_df['InstanceType'] == a100_host_vm_type]
         cpu_count = df['vCPUs'].iloc[0]
-        memory = df['MemoryGiB'].iloc[0]
+        memory_gb = df['MemoryGiB'].iloc[0]
         vm_price = common.get_hourly_cost_impl(_df,
                                                a100_host_vm_type,
                                                use_spot=False,
@@ -350,7 +350,7 @@ def list_accelerators(
             info._replace(
                 instance_type=a100_host_vm_type,
                 cpu_count=cpu_count,
-                memory=memory,
+                memory_gb=memory_gb,
                 # total cost = VM instance + GPU.
                 price=info.price + vm_price,
                 spot_price=info.spot_price + vm_spot_price,
@@ -481,7 +481,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
     # vCPU counts and memory sizes of N1 machines.
     df = _df[_df['InstanceType'] == instance_type]
     num_cpus = df['vCPUs'].iloc[0]
-    memory = df['MemoryGiB'].iloc[0]
+    memory_gb = df['MemoryGiB'].iloc[0]
 
     if num_cpus > max_cpus:
         with ux_utils.print_exception_no_traceback():
@@ -489,7 +489,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
                 f'{acc_name}:{acc_count} cannot be attached to '
                 f'{instance_type}. The maximum number of vCPUs is {max_cpus}. '
                 'Please refer to: https://cloud.google.com/compute/docs/gpus')
-    if memory > max_memory:
+    if memory_gb > max_memory:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ResourcesMismatchError(
                 f'{acc_name}:{acc_count} cannot be attached to '

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -330,7 +330,8 @@ def list_accelerators(
     # Thus, we can show their exact cost including the host VM prices.
     new_infos = defaultdict(list)
     for info in a100_infos:
-        assert pd.isna(info.instance_type) and pd.isna(info.memory_gb), a100_infos
+        assert pd.isna(info.instance_type) and pd.isna(
+            info.memory_gb), a100_infos
         a100_host_vm_type = _A100_INSTANCE_TYPE_DICTS[info.accelerator_name][
             info.accelerator_count]
         df = _df[_df['InstanceType'] == a100_host_vm_type]

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -61,13 +61,15 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
-    if cpus is None and memory_gb_or_ratio is None:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None) -> Optional[str]:
+    if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
-    if memory_gb_or_ratio is None:
+    if memory is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
+    else:
+        memory_gb_or_ratio = memory
+
     # Set to gpu_1x_a100_sxm4 to be the default instance type if match vCPU
     # requirement.
     df = _df[_df['InstanceType'].eq('gpu_1x_a100_sxm4')]
@@ -88,7 +90,7 @@ def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
         cpus: Optional[str] = None,
-        memory_gb_or_ratio: Optional[str] = None,
+        memory: Optional[str] = None,
         use_spot: bool = False,
         region: Optional[str] = None,
         zone: Optional[str] = None) -> Tuple[Optional[List[str]], List[str]]:
@@ -99,15 +101,14 @@ def get_instance_type_for_accelerator(
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_instance_type_for_accelerator_impl(
-        df=_df,
-        acc_name=acc_name,
-        acc_count=acc_count,
-        cpus=cpus,
-        memory_gb_or_ratio=memory_gb_or_ratio,
-        use_spot=use_spot,
-        region=region,
-        zone=zone)
+    return common.get_instance_type_for_accelerator_impl(df=_df,
+                                                         acc_name=acc_name,
+                                                         acc_count=acc_count,
+                                                         cpus=cpus,
+                                                         memory=memory,
+                                                         use_spot=use_spot,
+                                                         region=region,
+                                                         zone=zone)
 
 
 def regions() -> List['cloud.Region']:

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -16,6 +16,7 @@ _df = common.read_catalog('lambda/vms.csv')
 
 # Number of vCPUS for gpu_1x_a100_sxm4
 _DEFAULT_NUM_VCPUS = 30
+_DEFAULT_MEMORY_CPU_RATIO = 4
 
 
 def instance_type_exists(instance_type: str) -> bool:
@@ -60,15 +61,21 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
-    if cpus is None:
-        cpus = str(_DEFAULT_NUM_VCPUS)
+def get_default_instance_type(
+        cpus: Optional[str] = None,
+        memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
+    if cpus is None and memory_gb_or_ratio is None:
+        cpus = f'{_DEFAULT_NUM_VCPUS}+'
+    if memory_gb_or_ratio is not None:
+        memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
     # Set to gpu_1x_a100_sxm4 to be the default instance type if match vCPU
     # requirement.
     df = _df[_df['InstanceType'].eq('gpu_1x_a100_sxm4')]
-    instance = common.get_instance_type_for_cpus_mem_impl(df, cpus)
+    instance = common.get_instance_type_for_cpus_mem_impl(
+        df, cpus, memory_gb_or_ratio)
     if not instance:
-        instance = common.get_instance_type_for_cpus_mem_impl(_df, cpus)
+        instance = common.get_instance_type_for_cpus_mem_impl(
+            _df, cpus, memory_gb_or_ratio)
     return instance
 
 

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -66,7 +66,7 @@ def get_default_instance_type(
         memory_gb_or_ratio: Optional[str] = None) -> Optional[str]:
     if cpus is None and memory_gb_or_ratio is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
-    if memory_gb_or_ratio is not None:
+    if memory_gb_or_ratio is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
     # Set to gpu_1x_a100_sxm4 to be the default instance type if match vCPU
     # requirement.

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -55,8 +55,9 @@ def get_hourly_cost(instance_type: str,
                                        zone)
 
 
-def get_vcpus_from_instance_type(instance_type: str) -> Optional[float]:
-    return common.get_vcpus_from_instance_type_impl(_df, instance_type)
+def get_vcpus_mem_from_instance_type(
+        instance_type: str) -> Tuple[Optional[float], Optional[float]]:
+    return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
 def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
@@ -65,9 +66,9 @@ def get_default_instance_type(cpus: Optional[str] = None) -> Optional[str]:
     # Set to gpu_1x_a100_sxm4 to be the default instance type if match vCPU
     # requirement.
     df = _df[_df['InstanceType'].eq('gpu_1x_a100_sxm4')]
-    instance = common.get_instance_type_for_cpus_impl(df, cpus)
+    instance = common.get_instance_type_for_cpus_mem_impl(df, cpus)
     if not instance:
-        instance = common.get_instance_type_for_cpus_impl(_df, cpus)
+        instance = common.get_instance_type_for_cpus_mem_impl(_df, cpus)
     return instance
 
 
@@ -80,6 +81,7 @@ def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
         cpus: Optional[str] = None,
+        memory_gb_or_ratio: Optional[str] = None,
         use_spot: bool = False,
         region: Optional[str] = None,
         zone: Optional[str] = None) -> Tuple[Optional[List[str]], List[str]]:
@@ -90,13 +92,15 @@ def get_instance_type_for_accelerator(
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Lambda Cloud does not support zones.')
-    return common.get_instance_type_for_accelerator_impl(df=_df,
-                                                         acc_name=acc_name,
-                                                         acc_count=acc_count,
-                                                         cpus=cpus,
-                                                         use_spot=use_spot,
-                                                         region=region,
-                                                         zone=zone)
+    return common.get_instance_type_for_accelerator_impl(
+        df=_df,
+        acc_name=acc_name,
+        acc_count=acc_count,
+        cpus=cpus,
+        memory_gb_or_ratio=memory_gb_or_ratio,
+        use_spot=use_spot,
+        region=region,
+        zone=zone)
 
 
 def regions() -> List['cloud.Region']:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,8 +176,8 @@ def _execute(
             cluster_name)
         cluster_exists = existing_handle is not None
         # TODO(woosuk): If the cluster exists, print a warning that
-        # `cpus` and `memory_gb` is not used as a job scheduling constraint, unlike
-        # `gpus`.
+        # `cpus` and `memory_gb` is not used as a job scheduling constraint,
+        # unlike `gpus`.
 
     stages = stages if stages is not None else list(Stage)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,7 +176,8 @@ def _execute(
             cluster_name)
         cluster_exists = existing_handle is not None
         # TODO(woosuk): If the cluster exists, print a warning that
-        # `cpus` is not used as a job scheduling constraint, unlike `gpus`.
+        # `cpus` and `memory` is not used as a job scheduling constraint, unlike
+        # `gpus`.
 
     stages = stages if stages is not None else list(Stage)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,7 +176,7 @@ def _execute(
             cluster_name)
         cluster_exists = existing_handle is not None
         # TODO(woosuk): If the cluster exists, print a warning that
-        # `cpus` and `memory` is not used as a job scheduling constraint, unlike
+        # `cpus` and `memory_gb` is not used as a job scheduling constraint, unlike
         # `gpus`.
 
     stages = stages if stages is not None else list(Stage)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,7 +176,7 @@ def _execute(
             cluster_name)
         cluster_exists = existing_handle is not None
         # TODO(woosuk): If the cluster exists, print a warning that
-        # `cpus` and `memory` is not used as a job scheduling constraint,
+        # `cpus` and `memory` are not used as a job scheduling constraint,
         # unlike `gpus`.
 
     stages = stages if stages is not None else list(Stage)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,7 +176,7 @@ def _execute(
             cluster_name)
         cluster_exists = existing_handle is not None
         # TODO(woosuk): If the cluster exists, print a warning that
-        # `cpus` and `memory_gb` is not used as a job scheduling constraint,
+        # `cpus` and `memory` is not used as a job scheduling constraint,
         # unlike `gpus`.
 
     stages = stages if stages is not None else list(Stage)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -986,7 +986,7 @@ def _fill_in_launchable_resources(
                         logger.info('Try specifying a different CPU count, '
                                     'or add "+" to the end of the CPU count '
                                     'to allow for larger instances.')
-                    if resources.memory is not None:
+                    if resources.memory_gb is not None:
                         logger.info(
                             'Try specifying a different memory amount, '
                             'or add "+" to the end of the memory amount '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -981,10 +981,16 @@ def _fill_in_launchable_resources(
                                 f'{colorama.Fore.CYAN}'
                                 f'{sorted(all_fuzzy_candidates)}'
                                 f'{colorama.Style.RESET_ALL}')
-                elif resources.cpus is not None:
-                    logger.info('Try specifying a different CPU count, '
-                                'or add "+" to the end of the CPU count '
-                                'to allow for larger instances.')
+                else:
+                    if resources.cpus is not None:
+                        logger.info('Try specifying a different CPU count, '
+                                    'or add "+" to the end of the CPU count '
+                                    'to allow for larger instances.')
+                    if resources.memory is not None:
+                        logger.info(
+                            'Try specifying a different memory amount, '
+                            'or add "+" to the end of the memory amount '
+                            'to allow for larger instances.')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_resources)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -986,7 +986,7 @@ def _fill_in_launchable_resources(
                         logger.info('Try specifying a different CPU count, '
                                     'or add "+" to the end of the CPU count '
                                     'to allow for larger instances.')
-                    if resources.memory_gb is not None:
+                    if resources.memory is not None:
                         logger.info(
                             'Try specifying a different memory amount, '
                             'or add "+" to the end of the memory amount '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -987,10 +987,9 @@ def _fill_in_launchable_resources(
                                     'or add "+" to the end of the CPU count '
                                     'to allow for larger instances.')
                     if resources.memory is not None:
-                        logger.info(
-                            'Try specifying a different memory amount, '
-                            'or add "+" to the end of the memory amount '
-                            'to allow for larger instances.')
+                        logger.info('Try specifying a different memory size, '
+                                    'or add "+" to the end of the memory size '
+                                    'to allow for larger instances.')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_resources)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -656,13 +656,20 @@ class Optimizer:
                 accelerators = f'{accelerators}:{count}'
             spot = '[Spot]' if resources.use_spot else ''
             cloud = resources.cloud
-            vcpus = cloud.get_vcpus_from_instance_type(resources.instance_type)
-            if vcpus is None:
-                vcpus = '-'
-            elif vcpus.is_integer():
-                vcpus = str(int(vcpus))
-            else:
-                vcpus = f'{vcpus:.1f}'
+            vcpus, mem = cloud.get_vcpus_mem_from_instance_type(
+                resources.instance_type)
+
+            def format_number(x):
+                if x is None:
+                    return '-'
+                elif x.is_integer():
+                    return str(int(x))
+                else:
+                    return f'{x:.1f}'
+
+            vcpus = format_number(vcpus)
+            mem = format_number(mem)
+
             if resources.zone is None:
                 region_or_zone = resources.region
             else:
@@ -671,13 +678,15 @@ class Optimizer:
                 str(cloud),
                 resources.instance_type + spot,
                 vcpus,
+                mem,
                 str(accelerators),
                 str(region_or_zone),
             ]
 
         # Print the list of resouces that the optimizer considered.
         resource_fields = [
-            'CLOUD', 'INSTANCE', 'vCPUs', 'ACCELERATORS', 'REGION/ZONE'
+            'CLOUD', 'INSTANCE', 'vCPUs', 'Mem(GB)', 'ACCELERATORS',
+            'REGION/ZONE'
         ]
         # Do not print Source or Sink.
         best_plan_rows = [[t, t.num_nodes] + _get_resources_element_list(r)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -51,6 +51,7 @@ class Resources:
         cloud: Optional[clouds.Cloud] = None,
         instance_type: Optional[str] = None,
         cpus: Union[None, int, float, str] = None,
+        memory: Union[None, int, float, str] = None,
         accelerators: Union[None, str, Dict[str, int]] = None,
         accelerator_args: Optional[Dict[str, str]] = None,
         use_spot: Optional[bool] = None,
@@ -97,11 +98,12 @@ class Resources:
                 }
 
         self._set_cpus(cpus)
+        self._set_memory(memory)
         self._set_accelerators(accelerators, accelerator_args)
 
         self._try_validate_local()
         self._try_validate_instance_type()
-        self._try_validate_cpus()
+        self._try_validate_cpus_mem()
         self._try_validate_accelerators()
         self._try_validate_spot()
         self._try_validate_image_id()
@@ -141,6 +143,10 @@ class Resources:
         if self.cpus is not None:
             cpus = f', cpus={self.cpus}'
 
+        memory = ''
+        if self.memory is not None:
+            memory = f', mem={self.memory}'
+
         if isinstance(self.cloud, clouds.Local):
             return f'{self.cloud}({self.accelerators})'
 
@@ -166,7 +172,8 @@ class Resources:
 
         hardware_str = (
             f'{instance_type}{use_spot}'
-            f'{cpus}{accelerators}{accelerator_args}{image_id}{disk_size}')
+            f'{cpus}{memory}{accelerators}{accelerator_args}{image_id}'
+            f'{disk_size}')
         # It may have leading ',' (for example, instance_type not set) or empty
         # spaces.  Remove them.
         while hardware_str and hardware_str[0] in (',', ' '):
@@ -206,6 +213,22 @@ class Resources:
         always have the cpus field set to None.)
         """
         return self._cpus
+
+    @property
+    def memory(self) -> Optional[str]:
+        """Returns the memory that each instance must have in GB.
+
+        For example, memory='16' means each instance must have exactly 16GB
+        memory; memory='16+' means each instance must have at least 16GB
+        memory; and memory='4x' means each instance must have 4 times the
+        number of CPUs of memory, e.g. if cpus='4', then memory='4x' means
+        each instance must have at least 16GB memory.
+
+        (Developer note: The memory field is only used to select the instance
+        type at launch time. Thus, Resources in the backend's ResourceHandle
+        will always have the memory field set to None.)
+        """
+        return self._memory
 
     @property
     def accelerators(self) -> Optional[Dict[str, int]]:
@@ -275,6 +298,36 @@ class Resources:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'The "cpus" field should be positive. Found: {cpus!r}')
+
+    def _set_memory(
+        self,
+        memory: Union[None, int, float, str],
+    ) -> None:
+        if memory is None:
+            self._memory = None
+            return
+
+        self._memory = str(memory)
+        if isinstance(memory, str):
+            if memory.endswith(('+', 'x', 'X')):
+                num_memory_gb = memory[:-1]
+            else:
+                num_memory_gb = memory
+
+            try:
+                memory_gb_or_ratio = float(num_memory_gb)
+            except ValueError:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'The "cpus" field should be either a number or '
+                        f'a string "<number>+". Found: {memory!r}') from None
+        else:
+            memory_gb_or_ratio = float(memory)
+
+        if memory_gb_or_ratio <= 0:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'The "cpus" field should be positive. Found: {memory!r}')
 
     def _set_accelerators(
         self,
@@ -447,8 +500,8 @@ class Resources:
                 f'inferred from the instance_type {self.instance_type!r}.')
             self._cloud = valid_clouds[0]
 
-    def _try_validate_cpus(self) -> None:
-        if self.cpus is None:
+    def _try_validate_cpus_mem(self) -> None:
+        if self.cpus is None and self.memory is None:
             return
         if self.instance_type is not None:
             # The assertion should be true because we have already executed
@@ -456,20 +509,45 @@ class Resources:
             # The _try_validate_instance_type() method infers and sets
             # self.cloud if self.instance_type is not None.
             assert self.cloud is not None
-            cpus = self.cloud.get_vcpus_from_instance_type(self.instance_type)
-            if self.cpus.endswith('+'):
-                if cpus < float(self.cpus[:-1]):
+            cpus, mem = self.cloud.get_vcpus_mem_from_instance_type(
+                self.instance_type)
+            if self.cpus is not None:
+                if self.cpus.endswith('+'):
+                    if cpus < float(self.cpus[:-1]):
+                        with ux_utils.print_exception_no_traceback():
+                            raise ValueError(
+                                f'{self.instance_type} does not have enough '
+                                f'vCPUs. {self.instance_type} has {cpus} '
+                                f'vCPUs, but {self.cpus} is requested.')
+                elif cpus != float(self.cpus):
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(
-                            f'{self.instance_type} does not have enough vCPUs. '
-                            f'{self.instance_type} has {cpus} vCPUs, '
-                            f'but {self.cpus} is requested.')
-            elif cpus != float(self.cpus):
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError(
-                        f'{self.instance_type} does not have the requested '
-                        f'number of vCPUs. {self.instance_type} has {cpus} '
-                        f'vCPUs, but {self.cpus} is requested.')
+                            f'{self.instance_type} does not have the requested '
+                            f'number of vCPUs. {self.instance_type} has {cpus} '
+                            f'vCPUs, but {self.cpus} is requested.')
+            if self.memory is not None:
+                if self.memory.endswith('+'):
+                    if mem < float(self.memory[:-1]):
+                        with ux_utils.print_exception_no_traceback():
+                            raise ValueError(
+                                f'{self.instance_type} does not have enough '
+                                f'memory. {self.instance_type} has {mem} GB '
+                                f'memory, but {self.memory} is requested.')
+                elif self.memory.endswith(('x', 'X')):
+                    requested_mem = float(self.memory[:-1] * cpus)
+                    if mem < requested_mem:
+                        with ux_utils.print_exception_no_traceback():
+                            raise ValueError(
+                                f'{self.instance_type} does not have the '
+                                f'requested memory. {self.instance_type} has '
+                                f'{cpus} CPUsand {mem} GB memory, but '
+                                f'{self.memory} is requested.')
+                elif mem != float(self.memory):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            f'{self.instance_type} does not have the requested '
+                            f'memory. {self.instance_type} has {mem} GB '
+                            f'memory, but {self.memory} is requested.')
 
     def _try_validate_accelerators(self) -> None:
         """Validate accelerators against the instance type and region/zone."""
@@ -718,6 +796,7 @@ class Resources:
             self.cloud is None,
             self._instance_type is None,
             self.cpus is None,
+            self.memory is None,
             self.accelerators is None,
             self.accelerator_args is None,
             not self._use_spot_specified,
@@ -730,6 +809,7 @@ class Resources:
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),
             cpus=override.pop('cpus', self.cpus),
+            memory=override.pop('memory', self.memory),
             accelerators=override.pop('accelerators', self.accelerators),
             accelerator_args=override.pop('accelerator_args',
                                           self.accelerator_args),
@@ -770,6 +850,8 @@ class Resources:
             resources_fields['instance_type'] = config.pop('instance_type')
         if config.get('cpus') is not None:
             resources_fields['cpus'] = str(config.pop('cpus'))
+        if config.get('memory') is not None:
+            resources_fields['memory'] = str(config.pop('memory'))
         if config.get('accelerators') is not None:
             resources_fields['accelerators'] = config.pop('accelerators')
         if config.get('accelerator_args') is not None:
@@ -804,6 +886,7 @@ class Resources:
         add_if_not_none('cloud', str(self.cloud))
         add_if_not_none('instance_type', self.instance_type)
         add_if_not_none('cpus', self.cpus)
+        add_if_not_none('memory', self.memory)
         add_if_not_none('accelerators', self.accelerators)
         add_if_not_none('accelerator_args', self.accelerator_args)
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -51,7 +51,7 @@ class Resources:
         cloud: Optional[clouds.Cloud] = None,
         instance_type: Optional[str] = None,
         cpus: Union[None, int, float, str] = None,
-        memory_gb: Union[None, int, float, str] = None,
+        memory: Union[None, int, float, str] = None,
         accelerators: Union[None, str, Dict[str, int]] = None,
         accelerator_args: Optional[Dict[str, str]] = None,
         use_spot: Optional[bool] = None,
@@ -98,7 +98,7 @@ class Resources:
                 }
 
         self._set_cpus(cpus)
-        self._set_memory_gb(memory_gb)
+        self._set_memory_gb(memory)
         self._set_accelerators(accelerators, accelerator_args)
 
         self._try_validate_local()
@@ -143,9 +143,9 @@ class Resources:
         if self.cpus is not None:
             cpus = f', cpus={self.cpus}'
 
-        memory_gb = ''
-        if self.memory_gb is not None:
-            memory_gb = f', mem={self.memory_gb}'
+        memory = ''
+        if self.memory is not None:
+            memory = f', mem={self.memory}'
 
         if isinstance(self.cloud, clouds.Local):
             return f'{self.cloud}({self.accelerators})'
@@ -172,7 +172,7 @@ class Resources:
 
         hardware_str = (
             f'{instance_type}{use_spot}'
-            f'{cpus}{memory_gb}{accelerators}{accelerator_args}{image_id}'
+            f'{cpus}{memory}{accelerators}{accelerator_args}{image_id}'
             f'{disk_size}')
         # It may have leading ',' (for example, instance_type not set) or empty
         # spaces.  Remove them.
@@ -215,18 +215,18 @@ class Resources:
         return self._cpus
 
     @property
-    def memory_gb(self) -> Optional[str]:
+    def memory(self) -> Optional[str]:
         """Returns the memory that each instance must have in GB.
 
-        For example, memory_gb='16' means each instance must have exactly 16GB
-        memory; memory_gb='16+' means each instance must have at least 16GB
-        memory; and memory_gb='4x' means each instance must have 4 times the
-        number of CPUs of memory, e.g. if cpus='4', then memory_gb='4x' means
+        For example, memory='16' means each instance must have exactly 16GB
+        memory; memory='16+' means each instance must have at least 16GB
+        memory; and memory='4x' means each instance must have 4 times the
+        number of CPUs of memory, e.g. if cpus='4', then memory='4x' means
         each instance must have at least 16GB memory.
 
-        (Developer note: The memory_gb field is only used to select the instance
+        (Developer note: The memory field is only used to select the instance
         type at launch time. Thus, Resources in the backend's ResourceHandle
-        will always have the memory_gb field set to None.)
+        will always have the memory field set to None.)
         """
         return self._memory_gb
 
@@ -301,18 +301,18 @@ class Resources:
 
     def _set_memory_gb(
         self,
-        memory_gb: Union[None, int, float, str],
+        memory: Union[None, int, float, str],
     ) -> None:
-        if memory_gb is None:
+        if memory is None:
             self._memory_gb = None
             return
 
-        self._memory_gb = str(memory_gb)
-        if isinstance(memory_gb, str):
-            if memory_gb.endswith(('+', 'x', 'X')):
-                num_memory_gb = memory_gb[:-1]
+        self._memory_gb = str(memory)
+        if isinstance(memory, str):
+            if memory.endswith(('+', 'x', 'X')):
+                num_memory_gb = memory[:-1]
             else:
-                num_memory_gb = memory_gb
+                num_memory_gb = memory
 
             try:
                 memory_gb_or_ratio = float(num_memory_gb)
@@ -320,15 +320,14 @@ class Resources:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'The "cpus" field should be either a number or '
-                        f'a string "<number>+". Found: {memory_gb!r}') from None
+                        f'a string "<number>+". Found: {memory!r}') from None
         else:
-            memory_gb_or_ratio = float(memory_gb)
+            memory_gb_or_ratio = float(memory)
 
         if memory_gb_or_ratio <= 0:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'The "cpus" field should be positive. Found: {memory_gb!r}'
-                )
+                    f'The "cpus" field should be positive. Found: {memory!r}')
 
     def _set_accelerators(
         self,
@@ -502,7 +501,7 @@ class Resources:
             self._cloud = valid_clouds[0]
 
     def _try_validate_cpus_mem(self) -> None:
-        if self.cpus is None and self.memory_gb is None:
+        if self.cpus is None and self.memory is None:
             return
         if self.instance_type is not None:
             # The assertion should be true because we have already executed
@@ -526,29 +525,29 @@ class Resources:
                             f'{self.instance_type} does not have the requested '
                             f'number of vCPUs. {self.instance_type} has {cpus} '
                             f'vCPUs, but {self.cpus} is requested.')
-            if self.memory_gb is not None:
-                if self.memory_gb.endswith('+'):
-                    if mem < float(self.memory_gb[:-1]):
+            if self.memory is not None:
+                if self.memory.endswith('+'):
+                    if mem < float(self.memory[:-1]):
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(
                                 f'{self.instance_type} does not have enough '
                                 f'memory. {self.instance_type} has {mem} GB '
-                                f'memory, but {self.memory_gb} is requested.')
-                elif self.memory_gb.endswith(('x', 'X')):
-                    requested_mem = float(self.memory_gb[:-1] * cpus)
+                                f'memory, but {self.memory} is requested.')
+                elif self.memory.endswith(('x', 'X')):
+                    requested_mem = float(self.memory[:-1] * cpus)
                     if mem < requested_mem:
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(
                                 f'{self.instance_type} does not have the '
                                 f'requested memory. {self.instance_type} has '
                                 f'{cpus} CPUsand {mem} GB memory, but '
-                                f'{self.memory_gb} is requested.')
-                elif mem != float(self.memory_gb):
+                                f'{self.memory} is requested.')
+                elif mem != float(self.memory):
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(
                             f'{self.instance_type} does not have the requested '
                             f'memory. {self.instance_type} has {mem} GB '
-                            f'memory, but {self.memory_gb} is requested.')
+                            f'memory, but {self.memory} is requested.')
 
     def _try_validate_accelerators(self) -> None:
         """Validate accelerators against the instance type and region/zone."""
@@ -797,7 +796,7 @@ class Resources:
             self.cloud is None,
             self._instance_type is None,
             self.cpus is None,
-            self.memory_gb is None,
+            self.memory is None,
             self.accelerators is None,
             self.accelerator_args is None,
             not self._use_spot_specified,
@@ -810,7 +809,7 @@ class Resources:
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),
             cpus=override.pop('cpus', self.cpus),
-            memory_gb=override.pop('memory_gb', self.memory_gb),
+            memory=override.pop('memory', self.memory),
             accelerators=override.pop('accelerators', self.accelerators),
             accelerator_args=override.pop('accelerator_args',
                                           self.accelerator_args),
@@ -851,8 +850,8 @@ class Resources:
             resources_fields['instance_type'] = config.pop('instance_type')
         if config.get('cpus') is not None:
             resources_fields['cpus'] = str(config.pop('cpus'))
-        if config.get('memory_gb') is not None:
-            resources_fields['memory_gb'] = str(config.pop('memory_gb'))
+        if config.get('memory') is not None:
+            resources_fields['memory'] = str(config.pop('memory'))
         if config.get('accelerators') is not None:
             resources_fields['accelerators'] = config.pop('accelerators')
         if config.get('accelerator_args') is not None:
@@ -887,7 +886,7 @@ class Resources:
         add_if_not_none('cloud', str(self.cloud))
         add_if_not_none('instance_type', self.instance_type)
         add_if_not_none('cpus', self.cpus)
-        add_if_not_none('memory_gb', self.memory_gb)
+        add_if_not_none('memory', self.memory)
         add_if_not_none('accelerators', self.accelerators)
         add_if_not_none('accelerator_args', self.accelerator_args)
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -327,7 +327,8 @@ class Resources:
         if memory_gb_or_ratio <= 0:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    f'The "cpus" field should be positive. Found: {memory_gb!r}')
+                    f'The "cpus" field should be positive. Found: {memory_gb!r}'
+                )
 
     def _set_accelerators(
         self,
@@ -948,7 +949,7 @@ class Resources:
 
         if version < 7:
             self._cpus = None
-            
+
         if version < 8:
             self._memory_gb = None
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -98,7 +98,7 @@ class Resources:
                 }
 
         self._set_cpus(cpus)
-        self._set_memory_gb(memory)
+        self._set_memory(memory)
         self._set_accelerators(accelerators, accelerator_args)
 
         self._try_validate_local()
@@ -220,15 +220,17 @@ class Resources:
 
         For example, memory='16' means each instance must have exactly 16GB
         memory; memory='16+' means each instance must have at least 16GB
-        memory; and memory='4x' means each instance must have 4 times the
-        number of CPUs of memory, e.g. if cpus='4', then memory='4x' means
-        each instance must have at least 16GB memory.
+        memory.
 
         (Developer note: The memory field is only used to select the instance
         type at launch time. Thus, Resources in the backend's ResourceHandle
         will always have the memory field set to None.)
+        (Developer note 2: The memory field can also end with 'x' or 'X', e.g.
+        memory='4x' means each instance must have 4 times the number of CPUs
+        of memory, e.g. if cpus='4', then memory='4x' means each instance must
+        have at least 16GB memory)
         """
-        return self._memory_gb
+        return self._memory
 
     @property
     def accelerators(self) -> Optional[Dict[str, int]]:
@@ -299,15 +301,15 @@ class Resources:
                 raise ValueError(
                     f'The "cpus" field should be positive. Found: {cpus!r}')
 
-    def _set_memory_gb(
+    def _set_memory(
         self,
         memory: Union[None, int, float, str],
     ) -> None:
         if memory is None:
-            self._memory_gb = None
+            self._memory = None
             return
 
-        self._memory_gb = str(memory)
+        self._memory = str(memory)
         if isinstance(memory, str):
             if memory.endswith(('+', 'x', 'X')):
                 num_memory_gb = memory[:-1]
@@ -950,7 +952,7 @@ class Resources:
             self._cpus = None
 
         if version < 8:
-            self._memory_gb = None
+            self._memory = None
 
         image_id = state.get('_image_id', None)
         if isinstance(image_id, str):

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -225,10 +225,6 @@ class Resources:
         (Developer note: The memory field is only used to select the instance
         type at launch time. Thus, Resources in the backend's ResourceHandle
         will always have the memory field set to None.)
-        (Developer note 2: The memory field can also end with 'x' or 'X', e.g.
-        memory='4x' means each instance must have 4 times the number of CPUs
-        of memory, e.g. if cpus='4', then memory='4x' means each instance must
-        have at least 16GB memory)
         """
         return self._memory
 
@@ -311,22 +307,22 @@ class Resources:
 
         self._memory = str(memory)
         if isinstance(memory, str):
-            if memory.endswith(('+', 'x', 'X')):
+            if memory.endswith('+'):
                 num_memory_gb = memory[:-1]
             else:
                 num_memory_gb = memory
 
             try:
-                memory_gb_or_ratio = float(num_memory_gb)
+                memory_gb = float(num_memory_gb)
             except ValueError:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'The "memory" field should be either a number or '
                         f'a string "<number>+". Found: {memory!r}') from None
         else:
-            memory_gb_or_ratio = float(memory)
+            memory_gb = float(memory)
 
-        if memory_gb_or_ratio <= 0:
+        if memory_gb <= 0:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'The "cpus" field should be positive. Found: {memory!r}')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -321,7 +321,7 @@ class Resources:
             except ValueError:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        f'The "cpus" field should be either a number or '
+                        f'The "memory" field should be either a number or '
                         f'a string "<number>+". Found: {memory!r}') from None
         else:
             memory_gb_or_ratio = float(memory)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -531,15 +531,6 @@ class Resources:
                                 f'{self.instance_type} does not have enough '
                                 f'memory. {self.instance_type} has {mem} GB '
                                 f'memory, but {self.memory} is requested.')
-                elif self.memory.endswith(('x', 'X')):
-                    requested_mem = float(self.memory[:-1] * cpus)
-                    if mem < requested_mem:
-                        with ux_utils.print_exception_no_traceback():
-                            raise ValueError(
-                                f'{self.instance_type} does not have the '
-                                f'requested memory. {self.instance_type} has '
-                                f'{cpus} CPUsand {mem} GB memory, but '
-                                f'{self.memory} is requested.')
                 elif mem != float(self.memory):
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -32,6 +32,13 @@ def get_resources_schema():
                     'type': 'number',
                 }],
             },
+            'memory': {
+                'anyOf': [{
+                    'type': 'string',
+                }, {
+                    'type': 'number',
+                }],
+            },
             'accelerators': {
                 'anyOf': [{
                     'type': 'string',

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -30,7 +30,7 @@ def print_exception_no_traceback():
                 raise ValueError('...')
     """
     original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
-    sys.tracebacklimit = 0
+    # sys.tracebacklimit = 0
     yield
     sys.tracebacklimit = original_tracelimit
 

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -30,7 +30,7 @@ def print_exception_no_traceback():
                 raise ValueError('...')
     """
     original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
-    # sys.tracebacklimit = 0
+    sys.tracebacklimit = 0
     yield
     sys.tracebacklimit = original_tracelimit
 

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -26,6 +26,7 @@ def _test_parse_memory(spec, expected_memory):
             task = sky.Task.from_yaml(f.name)
             assert list(task.resources)[0].memory == expected_memory
 
+
 def _test_parse_accelerators(spec, expected_accelerators):
     with tempfile.NamedTemporaryFile('w') as f:
         f.write(spec)
@@ -112,10 +113,12 @@ def test_partial_cpus(monkeypatch):
     _test_resources_launch(monkeypatch, cpus='4')
     _test_resources_launch(monkeypatch, cpus='7+')
 
+
 def test_partial_memory(monkeypatch):
     _test_resources_launch(monkeypatch, memory=32)
     _test_resources_launch(monkeypatch, memory='32')
     _test_resources_launch(monkeypatch, memory='32+')
+
 
 def test_partial_k80(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='K80')
@@ -190,6 +193,7 @@ def test_instance_type_mismatches_cpus(monkeypatch):
                                    cpus=cpus)
         assert 'does not have the requested number of vCPUs' in str(e.value)
 
+
 def test_instance_type_mismatches_memory(monkeypatch):
     bad_instance_and_memory = [
         # Actual: 32
@@ -224,6 +228,7 @@ def test_instance_type_matches_cpus(monkeypatch):
                            instance_type='g4dn.2xlarge',
                            cpus=8.0)
 
+
 def test_instance_type_matches_memory(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.AWS(),
@@ -242,62 +247,64 @@ def test_instance_type_matches_memory(monkeypatch):
                            instance_type='g4dn.2xlarge',
                            memory=32)
 
+
 def test_instance_type_from_cpu_memory(monkeypatch, capfd):
     _test_resources_launch(monkeypatch, cpus=8)
     stdout, _ = capfd.readouterr()
     # Choose General Purpose instance types
-    assert 'm6i.2xlarge' in stdout # AWS, 8 vCPUs, 32 GB memory
-    assert 'Standard_D8_v5' in stdout # Azure, 8 vCPUs, 32 GB memory
-    assert 'n2-standard-8' in stdout # GCP, 8 vCPUs, 32 GB memory
-    
-    
+    assert 'm6i.2xlarge' in stdout  # AWS, 8 vCPUs, 32 GB memory
+    assert 'Standard_D8_v5' in stdout  # Azure, 8 vCPUs, 32 GB memory
+    assert 'n2-standard-8' in stdout  # GCP, 8 vCPUs, 32 GB memory
+
     _test_resources_launch(monkeypatch, memory=32)
     stdout, _ = capfd.readouterr()
     # Choose memory-optimized instance types, when the memory
     # is specified
-    assert 'r6i.xlarge' in stdout # AWS, 4 vCPUs, 32 GB memory
-    assert 'Standard_E4_v5' in stdout # Azure, 4 vCPUs, 32 GB memory
-    assert 'n2-highmem-4' in stdout # GCP, 4 vCPUs, 32 GB memory
+    assert 'r6i.xlarge' in stdout  # AWS, 4 vCPUs, 32 GB memory
+    assert 'Standard_E4_v5' in stdout  # Azure, 4 vCPUs, 32 GB memory
+    assert 'n2-highmem-4' in stdout  # GCP, 4 vCPUs, 32 GB memory
 
     _test_resources_launch(monkeypatch, memory='64+')
     stdout, _ = capfd.readouterr()
     # Choose memory-optimized instance types
-    assert 'r6i.2xlarge' in stdout # AWS, 8 vCPUs, 64 GB memory
-    assert 'Standard_E8_v5' in stdout # Azure, 8 vCPUs, 64 GB memory
-    assert 'n2-highmem-8' in stdout # GCP, 8 vCPUs, 64 GB memory
-    assert 'gpu_1x_a100_sxm4' in stdout # Lambda, 30 vCPUs, 200 GB memory
-    
+    assert 'r6i.2xlarge' in stdout  # AWS, 8 vCPUs, 64 GB memory
+    assert 'Standard_E8_v5' in stdout  # Azure, 8 vCPUs, 64 GB memory
+    assert 'n2-highmem-8' in stdout  # GCP, 8 vCPUs, 64 GB memory
+    assert 'gpu_1x_a100_sxm4' in stdout  # Lambda, 30 vCPUs, 200 GB memory
+
     _test_resources_launch(monkeypatch, cpus='4+', memory='4+')
     stdout, _ = capfd.readouterr()
     # Choose compute-optimized instance types, when the memory
     # requirement is less than the memory of General Purpose
     # instance types.
-    assert 'n2-highcpu-4' in stdout # GCP, 4 vCPUs, 4 GB memory
-    assert 'c6i.xlarge' in stdout # AWS, 4 vCPUs, 8 GB memory
-    assert 'Standard_F4s_v2' in stdout # Azure, 4 vCPUs, 8 GB memory
-    assert 'gpu_1x_a100_sxm4' in stdout # Lambda, 30 vCPUs, 200 GB memory
+    assert 'n2-highcpu-4' in stdout  # GCP, 4 vCPUs, 4 GB memory
+    assert 'c6i.xlarge' in stdout  # AWS, 4 vCPUs, 8 GB memory
+    assert 'Standard_F4s_v2' in stdout  # Azure, 4 vCPUs, 8 GB memory
+    assert 'gpu_1x_a100_sxm4' in stdout  # Lambda, 30 vCPUs, 200 GB memory
 
     _test_resources_launch(monkeypatch, accelerators='T4')
     stdout, _ = capfd.readouterr()
     # Choose cheapest T4 instance type
-    assert 'g4dn.xlarge' in stdout # AWS, 4 vCPUs, 16 GB memory, 1 T4 GPU
-    assert 'Standard_NC4as_T4_v3' in stdout # Azure, 4 vCPUs, 28 GB memory, 1 T4 GPU
-    assert 'n1-highmem-4' in stdout # GCP, 4 vCPUs, 26 GB memory, 1 T4 GPU
+    assert 'g4dn.xlarge' in stdout  # AWS, 4 vCPUs, 16 GB memory, 1 T4 GPU
+    assert 'Standard_NC4as_T4_v3' in stdout  # Azure, 4 vCPUs, 28 GB memory, 1 T4 GPU
+    assert 'n1-highmem-4' in stdout  # GCP, 4 vCPUs, 26 GB memory, 1 T4 GPU
 
-    _test_resources_launch(monkeypatch, cpus='16+', memory='32+', accelerators='T4')
+    _test_resources_launch(monkeypatch,
+                           cpus='16+',
+                           memory='32+',
+                           accelerators='T4')
     stdout, _ = capfd.readouterr()
     # Choose cheapest T4 instance type that satisfies the requirement
-    assert 'n1-standard-16' in stdout # GCP, 16 vCPUs, 60 GB memory, 1 T4 GPU
-    assert 'g4dn.4xlarge' in stdout # AWS, 16 vCPUs, 64 GB memory, 1 T4 GPU
-    assert 'Standard_NC16as_T4_v3' in stdout # Azure, 16 vCPUs, 110 GB memory, 1 T4 GPU
-    
+    assert 'n1-standard-16' in stdout  # GCP, 16 vCPUs, 60 GB memory, 1 T4 GPU
+    assert 'g4dn.4xlarge' in stdout  # AWS, 16 vCPUs, 64 GB memory, 1 T4 GPU
+    assert 'Standard_NC16as_T4_v3' in stdout  # Azure, 16 vCPUs, 110 GB memory, 1 T4 GPU
+
     _test_resources_launch(monkeypatch, memory='200+', accelerators='T4')
     stdout, _ = capfd.readouterr()
     # Choose cheapest T4 instance type that satisfies the requirement
-    assert 'n1-highmem-32' in stdout # GCP, 32 vCPUs, 208 GB memory, 1 T4 GPU
-    assert 'g4dn.16xlarge' in stdout # AWS, 64 vCPUs, 256 GB memory, 1 T4 GPU
-    assert 'Azure' not in stdout # Azure does not have a 1 T4 GPU instance type with 200+ GB memory
-
+    assert 'n1-highmem-32' in stdout  # GCP, 32 vCPUs, 208 GB memory, 1 T4 GPU
+    assert 'g4dn.16xlarge' in stdout  # AWS, 64 vCPUs, 256 GB memory, 1 T4 GPU
+    assert 'Azure' not in stdout  # Azure does not have a 1 T4 GPU instance type with 200+ GB memory
 
 
 def test_instance_type_mistmatches_accelerators(monkeypatch):
@@ -367,11 +374,13 @@ def test_invalid_cpus(monkeypatch):
             _test_resources(monkeypatch, cloud, cpus='invalid')
         assert '"cpus" field should be' in str(e.value)
 
+
 def test_invalid_memory(monkeypatch):
     for cloud in [sky.AWS(), sky.Azure(), sky.GCP(), None]:
         with pytest.raises(ValueError) as e:
             _test_resources(monkeypatch, cloud, memory='invalid')
         assert '"memory" field should be' in str(e.value)
+
 
 def test_invalid_region(monkeypatch):
     for cloud in [sky.AWS(), sky.Azure(), sky.GCP()]:
@@ -473,7 +482,6 @@ def test_parse_cpus_from_yaml():
     _test_parse_cpus(spec, '3+')
 
 
-
 def test_parse_memory_from_yaml():
     spec = textwrap.dedent("""\
         resources:
@@ -489,7 +497,7 @@ def test_parse_memory_from_yaml():
         resources:
             memory: '3+' """)
     _test_parse_memory(spec, '3+')
-    
+
     spec = textwrap.dedent("""\
         resources:
             memory: 3+ """)

--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -116,7 +116,7 @@ def compare_optimization_results(dag: sky.Dag, minimize_cost: bool):
                                                       dag.tasks, optimizer_plan)
 
     min_objective = find_min_objective(copy_dag, minimize_cost)
-    assert abs(objective - min_objective) < 1e-6
+    assert abs(objective - min_objective) < 1e-3
 
 
 def test_optimizer(enable_all_clouds):

--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -116,7 +116,7 @@ def compare_optimization_results(dag: sky.Dag, minimize_cost: bool):
                                                       dag.tasks, optimizer_plan)
 
     min_objective = find_min_objective(copy_dag, minimize_cost)
-    assert objective == min_objective
+    assert abs(objective - min_objective) < 1e-6
 
 
 def test_optimizer(enable_all_clouds):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1673, this simulates the behavior of `cpus` in resources, thanks to the great effort from @WoosukKwon in #1622 

Added a memory filtering field for the resources:
1. `memory: 16` the memory should be 16GB
2. `memory: 16+` the memory should be more than 16GB
3. ~~`memory: 4x` the memory to core ratio should be larger than 4 times.~~ (Not expose this API as it might be confusing)

Logics for choosing the CPU instance to use:
1. Use the general-purpose CPU instance by default, when the `--memory` is not specified
2. Use the cheapest CPU instance that satisfies the requirement, when the `--memory` is specified.

1. `sky launch -c normal`
```
I 03-07 21:32:21 optimizer.py:712] Considered resources (1 node):
I 03-07 21:32:21 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:32:21 optimizer.py:760]  CLOUD    INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 03-07 21:32:21 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:32:21 optimizer.py:760]  AWS      m6i.2xlarge        8       32        -              us-east-2     0.38          ✔     
I 03-07 21:32:21 optimizer.py:760]  Azure    Standard_D8_v5     8       32        -              eastus        0.38                
I 03-07 21:32:21 optimizer.py:760]  GCP      n2-standard-8      8       32        -              us-central1   0.39                
I 03-07 21:32:21 optimizer.py:760]  Lambda   gpu_1x_a100_sxm4   30      200       A100:1         us-east-1     1.10                
I 03-07 21:32:21 optimizer.py:760] ------------------------------------------------------------------------------------------------
```
2. `sky launch -c cpus --cpus 32+`: general purpose
```
I 03-07 21:33:55 optimizer.py:760] -----------------------------------------------------------------------------------------------
I 03-07 21:33:55 optimizer.py:760]  CLOUD    INSTANCE          vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 03-07 21:33:55 optimizer.py:760] -----------------------------------------------------------------------------------------------
I 03-07 21:33:55 optimizer.py:760]  AWS      m6i.8xlarge       32      128       -              us-east-2     1.54          ✔     
I 03-07 21:33:55 optimizer.py:760]  Azure    Standard_D32_v5   32      128       -              eastus        1.54                
I 03-07 21:33:55 optimizer.py:760]  GCP      n2-standard-32    32      128       -              us-central1   1.55                
I 03-07 21:33:55 optimizer.py:760]  Lambda   gpu_4x_a6000      56      400       A6000:4        us-east-1     3.20                
I 03-07 21:33:55 optimizer.py:760] -----------------------------------------------------------------------------------------------
```
3. `sky launch -c compute-optimized --cpus 32+ --memory 32+`
```
I 03-07 21:43:40 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:43:40 optimizer.py:760]  CLOUD    INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 03-07 21:43:40 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:43:40 optimizer.py:760]  GCP      n2-highcpu-32      32      32        -              us-central1   1.15          ✔     
I 03-07 21:43:40 optimizer.py:760]  Azure    Standard_F32s_v2   32      64        -              eastus        1.35                
I 03-07 21:43:40 optimizer.py:760]  AWS      c6i.8xlarge        32      64        -              us-east-2     1.36                
I 03-07 21:43:40 optimizer.py:760]  Lambda   gpu_4x_a6000       56      400       A6000:4        us-east-1     3.20                
I 03-07 21:43:40 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:43:40 optimizer.py:760] 
```
4. `sky launch -c memory-optimized --memory 32+`
```
I 03-07 21:44:13 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:44:13 optimizer.py:760]  CLOUD    INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 03-07 21:44:13 optimizer.py:760] ------------------------------------------------------------------------------------------------
I 03-07 21:44:13 optimizer.py:760]  AWS      r6i.xlarge         4       32        -              us-east-2     0.25          ✔     
I 03-07 21:44:13 optimizer.py:760]  Azure    Standard_E4_v5     4       32        -              eastus        0.25                
I 03-07 21:44:13 optimizer.py:760]  GCP      n2-highmem-4       4       32        -              us-central1   0.26                
I 03-07 21:44:13 optimizer.py:760]  Lambda   gpu_1x_a100_sxm4   30      200       A100:1         us-east-1     1.10                
I 03-07 21:44:13 optimizer.py:760] ------------------------------------------------------------------------------------------------
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `pytest tests/test_optimizer_dryruns.py` with added memory related unit tests.
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
