### PR TITLE
[back compat] Fix configuring private VPC causing old clusters to have wrong `sky_ray.yml`

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -922,6 +922,10 @@ def write_cluster_config(
     # special dir, and upload that as the only file_mount instead. Delay
     # calling this optimization until now, when all source files have been
     # written and their contents finalized.
+    #
+    # Note that the ray yaml file will be copied into that special dir (i.e.,
+    # uploaded as part of the file_mounts), so the restore for backward
+    # compatibility should go before this call.
     if not isinstance(cloud, clouds.Local):
         # Only optimize the file mounts for public clouds now, as local has not
         # been fully tested yet.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -918,6 +918,19 @@ def write_cluster_config(
         with open(tmp_yaml_path, 'w') as f:
             f.write(restored_yaml_content)
 
+    # Optimization: copy the contents of source files in file_mounts to a
+    # special dir, and upload that as the only file_mount instead. Delay
+    # calling this optimization until now, when all source files have been
+    # written and their contents finalized.
+    if not isinstance(cloud, clouds.Local):
+        # Only optimize the file mounts for public clouds now, as local has not
+        # been fully tested yet.
+        _optimize_file_mounts(tmp_yaml_path)
+
+    # Rename the tmp file to the final YAML path.
+    os.rename(tmp_yaml_path, yaml_path)
+    usage_lib.messages.usage.update_ray_yaml(yaml_path)
+
     # For TPU nodes. TPU VMs do not need TPU_NAME.
     if (resources_vars.get('tpu_type') is not None and
             resources_vars.get('tpu_vm') is None):
@@ -950,19 +963,6 @@ def write_cluster_config(
         config_dict['tpu-create-script'] = scripts[0]
         config_dict['tpu-delete-script'] = scripts[1]
         config_dict['tpu_name'] = tpu_name
-
-    # Optimization: copy the contents of source files in file_mounts to a
-    # special dir, and upload that as the only file_mount instead. Delay
-    # calling this optimization until now, when all source files have been
-    # written and their contents finalized.
-    if not isinstance(cloud, clouds.Local):
-        # Only optimize the file mounts for public clouds now, as local has not
-        # been fully tested yet.
-        _optimize_file_mounts(tmp_yaml_path)
-
-    # Rename the tmp file to the final YAML path.
-    os.rename(tmp_yaml_path, yaml_path)
-    usage_lib.messages.usage.update_ray_yaml(yaml_path)
     return config_dict
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1288,7 +1288,7 @@ def test_spot_failed_setup(generic_cloud: str):
         'spot-failed-setup',
         [
             f'sky spot launch -n {name} --cloud {generic_cloud} -y -d tests/test_yamls/failed_setup.yaml',
-            'sleep 200',
+            'sleep 300',
             # Make sure the job failed quickly.
             f'{_SPOT_QUEUE_WAIT} | grep {name} | head -n1 | grep "FAILED_SETUP"',
         ],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
To reproduce this bug:
- Clear `~/.sky/config.yaml`, launch a cluster `dbg`, have it autostopped
- Now fill in `~/.sky/config.yaml` with private VPC configured
```yaml
aws:
  vpc_name: nonexisting-vpc
  use_internal_ips: True
  ssh_proxy_command: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@1.2.3.4
```
- `sky launch -c dbg -i0` again
- Observe that it correctly restarted in the old default VPC; however, the autostopping would fail, due to `~/.sky/sky_ray.yml` on the remote containing wrong contents:
```yaml
provider:
  ...  # other fields are correct/preserved
  # BUG: this is added
  vpc_name: nonexisting-vpc
  # BUG: this is not preserved
  use_internal_ips: true

auth:
  ...
  # BUG: this is added
  ssh_proxy_command: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@1.2.3.4
```

This is due to the ordering of when we call `_optimize_file_mounts()`.  This PR changes it so that we optimize file mounts only after finalizing all source files.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - The above repro, which no longer has this problem
- [x] All smoke tests: `pytest tests/test_smoke.py` 
```
pytest tests/test_smoke.py
pytest tests/test_smoke.py --aws
```
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
