### PR TITLE
Update `sky show-gpus`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2864,7 +2864,7 @@ def show_gpus(
     To show the detailed information of a GPU/TPU type (which clouds offer it,
     the quantity in each VM type, etc.), use ``sky show-gpus <gpu>``.
 
-    To show detailed pricing information, use ``sky show-gpus --all``.
+    Append ``--all`` to show detailed information for the listed GPUs/TPUs.
 
     NOTE: If region is not specified, the price displayed for each instance type
     is the lowest across all regions for both on-demand and spot instances.
@@ -2926,14 +2926,14 @@ def show_gpus(
                                                    region_filter=region,
                                                    clouds=cloud)
         if len(result) == 0:
-            yield f'Resources \'{gpu_name}\' not found. '
-            yield 'Try \'sky show-gpus --all\' '
-            yield 'to show available accelerators.'
+            yield f'Resources \'{gpu_name}\' not found.'
             return
 
-        yield '*NOTE*: for most GCP accelerators, '
-        yield 'INSTANCE_TYPE == (attachable) means '
-        yield 'the host VM\'s cost is not included.\n\n'
+        if cloud is None or cloud == 'gcp':
+            yield '*NOTE*: for most GCP accelerators, '
+            yield 'INSTANCE_TYPE == (attachable) means '
+            yield 'the host VM\'s cost is not included.\n\n'
+
         import pandas as pd  # pylint: disable=import-outside-toplevel
         for i, (gpu, items) in enumerate(result.items()):
             accelerator_table_headers = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2834,7 +2834,7 @@ def check():
               '-a',
               is_flag=True,
               default=False,
-              help='Show details of all GPU/TPU/accelerator offerings.')
+              help='Show detailed information for the listed GPUs/TPUs.')
 @click.option('--cloud',
               default=None,
               type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2834,7 +2834,7 @@ def check():
               '-a',
               is_flag=True,
               default=False,
-              help='Show detailed information for the listed GPUs/TPUs.')
+              help='Show detailed information.')
 @click.option('--cloud',
               default=None,
               type=str,
@@ -2864,7 +2864,8 @@ def show_gpus(
     To show the detailed information of a GPU/TPU type (which clouds offer it,
     the quantity in each VM type, etc.), use ``sky show-gpus <gpu>``.
 
-    Append ``--all`` to show detailed information for the listed GPUs/TPUs.
+    Append ``--all`` to show detailed information for queried GPUs/TPUs, e.g.
+    ``sky show-gpus --all``.
 
     NOTE: If region is not specified, the price displayed for each instance type
     is the lowest across all regions for both on-demand and spot instances.

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -279,7 +279,16 @@ def check_accelerator_attachable_to_host(instance_type: str,
 def get_common_gpus() -> List[str]:
     """Returns a list of commonly used GPU names."""
     return [
-        'V100', 'V100-32GB', 'A100', 'A100-80GB', 'P100', 'K80', 'T4', 'M60'
+        'V100',
+        'V100-32GB',
+        'A100',
+        'A100-80GB',
+        'P100',
+        'K80',
+        'T4',
+        'M60',
+        'A10',
+        'A10G',
     ]
 
 


### PR DESCRIPTION
This pr updates `sky show-gpus` and fixes #1733.

Changes:

- `sky show-gpus [--cloud CLOUD] [--region REGION]` shows all gpus satisfying the query, but does not show any detailed information (e.g. specs, pricing)
- Using `--all` shows detailed information
- A10, A10G are part of `COMMON_GPU` (@WoosukKwon I forgot which ones you wanted to move out of `COMMON_GPU`, could you remind me?)

Tested:

- [x] `sky show-gpus`
- [x] `sky show-gpus -a`
- [x] `sky show-gpus --cloud lambda`
- [x] `sky show-gpus --cloud lambda --region us-east-1`
- [x] `sky show-gpus --cloud lambda -a`
- [x] `sky show-gpus --cloud gcp`
- [x] `sky show-gpus --cloud gcp -a`
- [x] `sky show-gpus A100`