### PR TITLE
[UX] Catch any exception for the spot queue fetching failure

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1576,7 +1576,7 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                     # down, and the hint for showing sky spot queue
                     # will still be shown.
                     num_in_progress_jobs = -1
-                    msg = f'KeyboardInterrupt'
+                    msg = 'KeyboardInterrupt'
 
                 try:
                     pool.close()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1439,6 +1439,9 @@ def _get_spot_jobs(
     except RuntimeError:
         msg = ('Failed to query spot jobs due to connection '
                'issues. Try again later.')
+    except Exception as e:  # pylint: disable=broad-except
+        msg = ('Failed to query spot jobs: '
+               f'{common_utils.format_exception(e, use_bracket=True)}')
     else:
         max_jobs_to_show = (_NUM_SPOT_JOBS_TO_SHOW_IN_STATUS
                             if limit_num_jobs_to_show else None)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1568,7 +1568,15 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
             click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                        f'Managed spot jobs{colorama.Style.RESET_ALL}')
             with log_utils.safe_rich_status('[cyan]Checking spot jobs[/]'):
-                num_in_progress_jobs, msg = spot_jobs_future.get()
+                try:
+                    num_in_progress_jobs, msg = spot_jobs_future.get()
+                except KeyboardInterrupt:
+                    pool.terminate()
+                    # Set to -1, so that the controller is not considered
+                    # down, and the hint for showing sky spot queue
+                    # will still be shown.
+                    num_in_progress_jobs = -1
+                    msg = f'KeyboardInterrupt'
 
                 try:
                     pool.close()
@@ -1598,7 +1606,7 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
                             'shown)')
                     job_info += '. '
                 hints.append(
-                    f'* {job_info}To see all jobs: {colorama.Style.BRIGHT}'
+                    f'* {job_info}To see all spot jobs: {colorama.Style.BRIGHT}'
                     f'sky spot queue{colorama.Style.RESET_ALL}')
 
         if num_pending_autostop > 0:

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -5,18 +5,11 @@ import functools
 import threading
 
 _thread_local_config = threading.local()
-# Whether the caller requires the catalog to be narrowed down
-# to the account-specific catalog (e.g., removing regions not
-# enabled for the current account) or just the raw catalog
-# fetched from SkyPilot catalog service. The former is used
-# for launching clusters, while the latter for commands like
-# `show-gpus`.
-_thread_local_config.use_default_catalog = False
 
 
 @contextlib.contextmanager
 def _set_use_default_catalog(value: bool):
-    old_value = _thread_local_config.use_default_catalog
+    old_value = get_use_default_catalog()
     _thread_local_config.use_default_catalog = value
     try:
         yield
@@ -24,7 +17,15 @@ def _set_use_default_catalog(value: bool):
         _thread_local_config.use_default_catalog = old_value
 
 
+# Whether the caller requires the catalog to be narrowed down
+# to the account-specific catalog (e.g., removing regions not
+# enabled for the current account) or just the raw catalog
+# fetched from SkyPilot catalog service. The former is used
+# for launching clusters, while the latter for commands like
+# `show-gpus`.
 def get_use_default_catalog() -> bool:
+    if not hasattr(_thread_local_config, 'use_default_catalog'):
+        _thread_local_config.use_default_catalog = False
     return _thread_local_config.use_default_catalog
 
 

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -25,6 +25,10 @@ def _set_use_default_catalog(value: bool):
 # `show-gpus`.
 def get_use_default_catalog() -> bool:
     if not hasattr(_thread_local_config, 'use_default_catalog'):
+        # Should not set it globally, as the global assignment
+        # will be executed only once if the module is imported
+        # in the main thread, and will not be executed in other
+        # threads.
         _thread_local_config.use_default_catalog = False
     return _thread_local_config.use_default_catalog
 

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -31,7 +31,6 @@ class NewLineFormatter(logging.Formatter):
 _root_logger = logging.getLogger('sky')
 _default_handler = None
 _logging_config = threading.local()
-_logging_config.is_silent = False
 
 # All code inside the library should use sky_logging.print()
 # rather than print().
@@ -79,7 +78,7 @@ def silent():
     global print
     global _logging_config
     previous_level = _root_logger.level
-    previous_is_silent = _logging_config.is_silent
+    previous_is_silent = is_silent()
     previous_print = print
 
     # Turn off logger
@@ -95,4 +94,10 @@ def silent():
 
 
 def is_silent():
+    if not hasattr(_logging_config, 'is_silent'):
+        # Should not set it globally, as the global assignment
+        # will be executed only once if the module is imported
+        # in the main thread, and will not be executed in other
+        # threads.
+        _logging_config.is_silent = False
     return _logging_config.is_silent

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -331,7 +331,7 @@ def format_exception(e: Union[Exception, SystemExit],
     bright = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
     if use_bracket:
-        return f'{bright}[{class_fullname(e.__class__)}]:{reset} {e}'
+        return f'{bright}[{class_fullname(e.__class__)}]{reset} {e}'
     return f'{bright}{class_fullname(e.__class__)}:{reset} {e}'
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,5 @@
-import os
-import pathlib
 import pytest
 import tempfile
-import textwrap
 from typing import List
 
 # Usage: use


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to fix the issue when the `sky status` meet other exceptions during the spot job query. It could happen when the current active account is different from the one used for the spot controller.

Previous:
```
Managed spot jobs
multiprocessing.pool.RemoteTraceback: 
"""
sky.exceptions.ClusterOwnerIdentityMismatchError: 'sky-spot-controller-9ce1ce58' (GCP) is owned by account 'zhwu@berkeley.edu\n [project_id=skypilot-375900]', but the activated account is 'zhwu@berkeley.edu\n [project_id=skypilot-managed-spot]'.
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zhwu/miniconda3/envs/sky-dev/bin/sky", line 33, in <module>
    sys.exit(load_entry_point('skypilot', 'console_scripts', 'sky')())
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/zhwu/Library/CloudStorage/OneDrive-Personal/AResource/PhD/Research/sky-computing/code/sky-experiment-dev/sky/utils/common_utils.py", line 220, in _record
    return f(*args, **kwargs)
  File "/Users/zhwu/Library/CloudStorage/OneDrive-Personal/AResource/PhD/Research/sky-computing/code/sky-experiment-dev/sky/cli.py", line 1041, in invoke
    return super().invoke(ctx)
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/zhwu/Library/CloudStorage/OneDrive-Personal/AResource/PhD/Research/sky-computing/code/sky-experiment-dev/sky/utils/common_utils.py", line 241, in _record
    return f(*args, **kwargs)
  File "/Users/zhwu/Library/CloudStorage/OneDrive-Personal/AResource/PhD/Research/sky-computing/code/sky-experiment-dev/sky/cli.py", line 1595, in status
    num_in_progress_jobs, msg = spot_jobs_future.get()
  File "/Users/zhwu/miniconda3/envs/sky-dev/lib/python3.8/multiprocessing/pool.py", line 771, in get
    raise self._value
sky.exceptions.ClusterOwnerIdentityMismatchError: 'sky-spot-controller-9ce1ce58' (GCP) is owned by account 'zhwu@berkeley.edu\n [project_id=skypilot-375900]', but the activated account is 'zhwu@berkeley.edu\n [project_id=skypilot-managed-spot]'.
```

Now:
```

Managed spot jobs
Failed to query spot jobs: [sky.exceptions.ClusterOwnerIdentityMismatchError]: 'sky-spot-controller-9ce1ce58' (GCP) is owned by account 'zhwu@berkeley.edu\n [project_id=skypilot-375900]', but the activated account is 'zhwu@berkeley.edu\n [project_id=skypilot-managed-spot]'.

* 1 cluster has auto{stop,down} scheduled. Refresh statuses with: sky status --refresh
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
