### PR TITLE
.ssh/config overwriting bug

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -434,7 +434,7 @@ class SSHConfigHelper(object):
             # If an existing config with `cluster_name` exists, raise a warning.
             for i, line in enumerate(config):
                 if line.strip() == f'Host {cluster_name}':
-                    prev_line = config[i - 1] if i - 1 > 0 else ''
+                    prev_line = config[i - 1] if i - 1 >= 0 else ''
                     if prev_line.strip().startswith(sky_autogen_comment):
                         overwrite = True
                         overwrite_begin_idx = i - 1
@@ -445,7 +445,7 @@ class SSHConfigHelper(object):
                         logger.warning(f'Using {ip} to identify host instead.')
 
                 if line.strip() == f'Host {ip}':
-                    prev_line = config[i - 1] if i - 1 > 0 else ''
+                    prev_line = config[i - 1] if i - 1 >= 0 else ''
                     if prev_line.strip().startswith(sky_autogen_comment):
                         overwrite = True
                         overwrite_begin_idx = i - 1


### PR DESCRIPTION
SkyPilot occasionally adds duplicate entries into my .ssh/config for the same cluster, which creates issues when I down the cluster or create a new one with the same name (but new IP). I found the bug, where it's not scanning for existing clusters in the config file all the way to the start of the file, only the second line. This fixes that.

Not sure which tests to run here? Running the full suite seems like overkill?

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
