### PR TITLE
Fix bug for GCP auth config

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -20,7 +20,6 @@ from sky import sky_logging
 from sky.adaptors import gcp
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
-from sky.utils import ux_utils
 from sky.skylet.providers.lambda_cloud import lambda_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -199,26 +198,8 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         logger.info(
             f'OS Login is enabled for GCP project {project_id}. Running '
             'additional authentication steps.')
-        # Read the account information from the credential file, since the user
-        # should be set according the account, when the oslogin is enabled.
-        config_path = os.path.expanduser(clouds.gcp.GCP_CONFIG_PATH)
-        sky_backup_config_path = os.path.expanduser(
-            clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH)
-        assert os.path.exists(sky_backup_config_path), (
-            'GCP credential backup file '
-            f'{sky_backup_config_path!r} does not exist.')
-
-        with open(sky_backup_config_path, 'r') as infile:
-            for line in infile:
-                if line.startswith('account'):
-                    account = line.split('=')[1].strip()
-                    break
-            else:
-                with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'GCP authentication failed, as the oslogin is enabled '
-                        f'but the file {config_path} does not contain the '
-                        'account information.')
+        account = clouds.gcp.GCP.get_current_user_identity()
+        account = account.split(' ')[0]
         config['auth']['ssh_user'] = account.replace('@', '_').replace('.', '_')
 
         # Add ssh key to GCP with oslogin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,3 @@ def enable_all_clouds(monkeypatch):
         lambda: enabled_clouds,
     )
     monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
-    config_file_backup = tempfile.NamedTemporaryFile(
-        prefix='tmp_backup_config_default', delete=False)
-    monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
-                        config_file_backup.name)

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -48,11 +48,6 @@ def _make_resources(
     )
     monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
 
-    config_file_backup = tempfile.NamedTemporaryFile(
-        prefix='tmp_backup_config_default', delete=False)
-    monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
-                        config_file_backup.name)
-
     # Should create Resources here, since it uses the enabled clouds.
     return sky.Resources(*resources_args, **resources_kwargs)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes https://github.com/skypilot-org/skypilot/issues/1771.
What happened to the user was the config file `~/.config/gcloud/configurations/config_default` does not exist even if the user already successfully run
```
gcloud init
gcloud auth application-default login
```
which triggered the below error.
https://github.com/skypilot-org/skypilot/blob/704a9dda70a9835ee9a0e1eea7543377dc0db443/sky/clouds/gcp.py#L564-L566

However, it's actually possible that `config_default` doesn't exist and may not be the config in use. Instead, what's specified in`~/.config/gcloud/active_config` is the one in use.
(we briefly discussed this in https://github.com/skypilot-org/skypilot/pull/1539)
So we shouldn't assume the existence of `config_default`.

In addition, our logic for backing up the config file seems unnecessary. I removed them and tested
- [x] `sky launch` and login to the VM. The GCP config is normal.
- [x] `sky launch` and login to the VM. `gsutil ls gs://[a-private-bucket]` works.
- [x] `sky spot launch "echo hi"` with a GCP controller works normally
- [ ] `sky launch` with `os-login` enabled with the account

Looks to me we don't really need to backup the `config_default`? I had a discussion with @Michaelvll and it seems that if the above things work without `config_default`, we may be safe to remove it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
