### PR TITLE
[UX] Fix azure import error handling

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -6,6 +6,8 @@ import subprocess
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
+import colorama
+
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
@@ -354,16 +356,18 @@ class Azure(clouds.Cloud):
             retry_cnt += 1
             try:
                 import knack  # pylint: disable=import-outside-toplevel
-            except FileNotFoundError as e:
+            except ModuleNotFoundError as e:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.CloudUserIdentityError(
                         'Failed to import knack. To install the dependencies for Azure, '
-                        'Please install SkyPilot with: pip install skypilot[azure]'
+                        'Please install SkyPilot with: '
+                        f'{colorama.Style.BRIGHT}pip install skypilot[azure]'
+                        f'{colorama.Style.RESET_ALL}'
                     ) from e
             try:
                 account_email = azure.get_current_account_user()
                 break
-            except knack.util.CLIError as e:
+            except (FileNotFoundError, knack.util.CLIError) as e:
                 error = exceptions.CloudUserIdentityError(
                     'Failed to get activated Azure account.\n'
                     '  Reason: '

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -362,8 +362,7 @@ class Azure(clouds.Cloud):
                         'Failed to import knack. To install the dependencies for Azure, '
                         'Please install SkyPilot with: '
                         f'{colorama.Style.BRIGHT}pip install skypilot[azure]'
-                        f'{colorama.Style.RESET_ALL}'
-                    ) from e
+                        f'{colorama.Style.RESET_ALL}') from e
             try:
                 account_email = azure.get_current_account_user()
                 break

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -354,9 +354,16 @@ class Azure(clouds.Cloud):
             retry_cnt += 1
             try:
                 import knack  # pylint: disable=import-outside-toplevel
+            except FileNotFoundError as e:
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.CloudUserIdentityError(
+                        'Failed to import knack. To install the dependencies for Azure, '
+                        'Please install SkyPilot with: pip install skypilot[azure]'
+                    ) from e
+            try:
                 account_email = azure.get_current_account_user()
                 break
-            except (FileNotFoundError, knack.util.CLIError) as e:
+            except knack.util.CLIError as e:
                 error = exceptions.CloudUserIdentityError(
                     'Failed to get activated Azure account.\n'
                     '  Reason: '

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -359,7 +359,7 @@ class Azure(clouds.Cloud):
             except ModuleNotFoundError as e:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.CloudUserIdentityError(
-                        'Failed to import knack. To install the dependencies for Azure, '
+                        'Failed to import \'knack\'. To install the dependencies for Azure, '
                         'Please install SkyPilot with: '
                         f'{colorama.Style.BRIGHT}pip install skypilot[azure]'
                         f'{colorama.Style.RESET_ALL}') from e


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is a fix for the user without `knack` installed. To reproduce:
```
pip uninstall knack
sky launch --cloud azure
```

The following error is raised:
```
Traceback (most recent call last):
  File "/home/eli/src/my/skypilot/sky/clouds/azure.py", line 356, in get_current_user_identity
    import knack  # pylint: disable=import-outside-toplevel
ModuleNotFoundError: No module named 'knack'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/eli/src/my/skypilot/sky/usage/usage_lib.py", line 416, in entrypoint_context
    yield
  File "/home/eli/src/my/skypilot/sky/utils/common_utils.py", line 241, in _record
    return f(*args, **kwargs)
  File "/home/eli/src/my/skypilot/sky/cli.py", line 2872, in check
    sky_check.check()
  File "/home/eli/src/my/skypilot/sky/check.py", line 18, in check
    ok, reason = cloud.check_credentials()
  File "/home/eli/src/my/skypilot/sky/clouds/azure.py", line 323, in check_credentials
    cls.get_current_user_identity()
  File "/home/eli/src/my/skypilot/sky/clouds/azure.py", line 359, in get_current_user_identity
    except (FileNotFoundError, knack.util.CLIError) as e:
UnboundLocalError: local variable 'knack' referenced before assignment
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - The snippets above
