### PR TITLE
[Cost Report] Add cost report auto-stop disclaimer

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1663,8 +1663,9 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
     click.secho(
-        'NOTE: This feature is experimental.'
-        '\nCosts for autostop clusters may not be accurate.',
+        'NOTE: This feature is experimental. '
+        'Costs for clusters with auto{stop,down} '
+        'scheduled may not be accurate.',
         fg='yellow')
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1662,6 +1662,10 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     for cluster_group_name, cluster_record in reserved_clusters.items():
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
+    click.secho(
+        'NOTE: This feature is experimental.'
+        '\nCosts for autostop clusters may not be accurate.',
+        fg='yellow')
 
 
 @cli.command()


### PR DESCRIPTION
Add the following disclaimer to the end of cost-report output:

```
NOTE: This feature is experimental.
Costs for autostop clusters may not be accurate.
```
