### PR TITLE
[Spot] Avoid spot jobs files being overwritten on spot controller

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -17,6 +17,7 @@ import enum
 import getpass
 import tempfile
 import os
+import uuid
 from typing import Any, Dict, List, Optional, Union
 
 import colorama
@@ -572,6 +573,7 @@ def spot_launch(
 
     with tempfile.NamedTemporaryFile(prefix=f'spot-task-{name}-',
                                      mode='w') as f:
+        task.name = name
         task_config = task.to_yaml_config()
         common_utils.dump_yaml(f.name, task_config)
 
@@ -581,7 +583,8 @@ def spot_launch(
             'user_yaml_path': f.name,
             'user_config_path': None,
             'spot_controller': controller_name,
-            'cluster_name': name,
+            'task_name': name,
+            'uuid': str(uuid.uuid4().hex[:4]),
             'gcloud_installation_commands': gcp.GCLOUD_INSTALLATION_COMMAND,
             'is_dev': env_options.Options.IS_DEVELOPER.get(),
             'disable_logging': env_options.Options.DISABLE_LOGGING.get(),

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -573,7 +573,8 @@ def spot_launch(
     if name is None:
         if task.name is not None:
             name = task.name
-        name = backend_utils.generate_cluster_name()
+        else:
+            name = backend_utils.generate_cluster_name()
     # Override the task name with the specified name or generated name, so that
     # the controller process can retrieve the task name from the task config.
     task.name = name
@@ -589,6 +590,7 @@ def spot_launch(
             'user_yaml_path': f.name,
             'user_config_path': None,
             'spot_controller': controller_name,
+            # Note: actual spot cluster name will be <task_name>-<spot job ID>
             'task_name': name,
             'uuid': task_uuid,
             'gcloud_installation_commands': gcp.GCLOUD_INSTALLATION_COMMAND,
@@ -639,9 +641,8 @@ def spot_launch(
                         skypilot_config.ENV_VAR_SKYPILOT_CONFIG,
                 })
 
-        yaml_path = os.path.expanduser(
-            os.path.join(spot.SPOT_CONTROLLER_YAML_PREFIX,
-                         f'{name}-{task_uuid}.yaml'))
+        yaml_path = os.path.join(spot.SPOT_CONTROLLER_YAML_PREFIX,
+                                 f'{name}-{task_uuid}.yaml')
         backend_utils.fill_template(spot.SPOT_CONTROLLER_TEMPLATE,
                                     vars_to_fill,
                                     output_path=yaml_path)

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -31,8 +31,8 @@ class SpotController:
     def __init__(self, job_id: int, task_yaml: str,
                  retry_until_up: bool) -> None:
         self._job_id = job_id
-        self._task_name = pathlib.Path(task_yaml).stem
         self._task = sky.Task.from_yaml(task_yaml)
+        self._task_name = self._task.name
 
         self._retry_until_up = retry_until_up
         # TODO(zhwu): this assumes the specific backend.
@@ -330,7 +330,6 @@ if __name__ == '__main__':
                         help='Retry until the spot cluster is up.')
     parser.add_argument('task_yaml',
                         type=str,
-                        help='The path to the user spot task yaml file. '
-                        'The file name is the spot task name.')
+                        help='The path to the user spot task yaml file.')
     args = parser.parse_args()
     start(args.job_id, args.task_yaml, args.retry_until_up)

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -1,6 +1,6 @@
 # The template for the spot controller
 
-name: {{cluster_name}}
+name: {{task_name}}
 
 resources:
   disk_size: 50
@@ -11,9 +11,9 @@ resources:
 #  instance_type: t3.xlarge
 
 file_mounts:
-  {{remote_user_yaml_prefix}}/{{cluster_name}}.yaml: {{user_yaml_path}}
+  {{remote_user_yaml_prefix}}/{{task_name}}-{{uuid}}.yaml: {{user_yaml_path}}
 {% if user_config_path is not none %}
-  {{remote_user_yaml_prefix}}/{{cluster_name}}.config_yaml: {{user_config_path}}
+  {{remote_user_yaml_prefix}}/{{task_name}}-{{uuid}}.config_yaml: {{user_config_path}}
 {% endif %}
 
 setup: |
@@ -37,7 +37,7 @@ setup: |
 
 run: |
   python -u -m sky.spot.controller \
-    {{remote_user_yaml_prefix}}/{{cluster_name}}.yaml \
+    {{remote_user_yaml_prefix}}/{{task_name}}-{{uuid}}.yaml \
     --job-id $SKYPILOT_INTERNAL_JOB_ID {% if retry_until_up %}--retry-until-up{% endif %}
 
 envs:
@@ -46,7 +46,7 @@ envs:
   SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK: 1
   SKYPILOT_USER: {{user}}
 {% if user_config_path is not none %}
-  {{env_var_skypilot_config}}: {{remote_user_yaml_prefix}}/{{cluster_name}}.config_yaml
+  {{env_var_skypilot_config}}: {{remote_user_yaml_prefix}}/{{task_name}}-{{uuid}}.config_yaml
 {% endif %}
 {% if is_dev %}
   SKYPILOT_DEV: 1


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce the overwriting problem:
1. `sky spot launch -n test 'echo hi'` 
2. `sky spot launch -n test 'echo hi2'` in parallel with the first one.
One of the job will overwrite the test.yaml and test.config_yaml of the other one on the spot controller, which may cause an issue that the two tasks have the same run commands, if we add a `sleep 40` before the controller process starts in `spot-controller.yaml.j2`, i.e. both task will show `hi2`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - the snippets above
  - [x] `sky launch --cloud gcp --gpus tpu-v2-8`
  - [x] `sky launch --cloud gcp --cpus 2+`
- [x] All smoke tests: `pytest tests/test_smoke.py --managed-spot` 
