### PR TITLE
[Spot] Add cancelling state for the spot job

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3355,6 +3355,8 @@ def spot_queue(all: bool, refresh: bool, skip_finished: bool):
         after a maximum number of retry attempts.
     - FAILED_CONTROLLER: The job failed due to an unexpected error in the spot
         controller.
+    - CANCELLING: The job was requested to be cancelled by the user, and the
+        cancellation is in progress.
     - CANCELLED: The job was cancelled by the user.
 
     If the job failed, either due to user code or spot unavailability, the error

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -297,6 +297,7 @@ def start(job_id, task_yaml, retry_until_up):
             time.sleep(1)
     except exceptions.SpotUserCancelledError:
         logger.info(f'Cancelling spot job {job_id}...')
+        spot_state.set_cancelling(job_id)
         cancelling = True
     finally:
         if controller_process is not None:
@@ -321,9 +322,6 @@ def start(job_id, task_yaml, retry_until_up):
         _cleanup(job_id, task_yaml=task_yaml)
         logger.info(f'Spot clusters of job {job_id} has been taken down.')
 
-        # TODO(suquark): It could take a long time cleaning up the cluster.
-        #  In the future, we may add a "cancelling" state for the spot
-        #  controller.
         if cancelling:
             spot_state.set_cancelled(job_id)
 

--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -106,7 +106,8 @@ class SpotStatus(enum.Enum):
     # CANCELLING: The job is requested to be cancelled by the user, and the
     # controller is cleaning up the spot cluster.
     CANCELLING = 'CANCELLING'
-    # CANCELLED: The job is cancelled by the user.
+    # CANCELLED: The job is cancelled by the user. When the spot job is in
+    # CANCELLED status, the spot cluster has been cleaned up.
     CANCELLED = 'CANCELLED'
     # FAILED: The job is finished with failure from the user's program.
     FAILED = 'FAILED'

--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -162,7 +162,7 @@ _SPOT_STATUS_TO_COLOR = {
     SpotStatus.PENDING: colorama.Fore.BLUE,
     SpotStatus.SUBMITTED: colorama.Fore.BLUE,
     SpotStatus.STARTING: colorama.Fore.BLUE,
-    SpotStatus.RUNNING: colorama.Fore.BLACK,
+    SpotStatus.RUNNING: colorama.Fore.GREEN,
     SpotStatus.RECOVERING: colorama.Fore.CYAN,
     SpotStatus.SUCCEEDED: colorama.Fore.GREEN,
     SpotStatus.FAILED: colorama.Fore.RED,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1282,7 +1282,7 @@ def test_spot(generic_cloud: str):
         # TODO(zhwu): Change to _SPOT_CANCEL_WAIT.format(job_name=f'{name}-1 -n {name}-2') when
         # canceling multiple job names is supported.
         (_SPOT_CANCEL_WAIT.format(job_name=f'{name}-1') + '; ' +
-        _SPOT_CANCEL_WAIT.format(job_name=f'{name}-2')),
+         _SPOT_CANCEL_WAIT.format(job_name=f'{name}-2')),
         # Increase timeout since sky spot queue -r can be blocked by other spot tests.
         timeout=20 * 60,
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -77,11 +77,12 @@ _SPOT_QUEUE_WAIT = ('s=$(sky spot queue); '
                     'do echo "Waiting for spot queue to be ready..."; '
                     'sleep 5; s=$(sky spot queue); done; echo "$s"; '
                     'echo; echo; echo "$s"')
-_SPOT_CANCEL_WAIT = ('s=$(sky spot cancel -y -n {job_name}); until [ `echo "$s" '
-                    '| grep "Please wait for the controller to be ready." '
-                    '| wc -l` -eq 0 ]; do echo "Waiting for the spot controller '
-                    'to be ready"; sleep 5; s=$(sky spot cancel -y -n {job_name}); '
-                    'done; echo "$s"; echo; echo; echo "$s"')
+_SPOT_CANCEL_WAIT = (
+    's=$(sky spot cancel -y -n {job_name}); until [ `echo "$s" '
+    '| grep "Please wait for the controller to be ready." '
+    '| wc -l` -eq 0 ]; do echo "Waiting for the spot controller '
+    'to be ready"; sleep 5; s=$(sky spot cancel -y -n {job_name}); '
+    'done; echo "$s"; echo; echo; echo "$s"')
 # TODO(zhwu): make the spot controller on GCP.
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1281,7 +1281,8 @@ def test_spot(generic_cloud: str):
         ],
         # TODO(zhwu): Change to _SPOT_CANCEL_WAIT.format(job_name=f'{name}-1 -n {name}-2') when
         # canceling multiple job names is supported.
-        _SPOT_CANCEL_WAIT.format(job_name=f'{name}-1') + ';' + _SPOT_CANCEL_WAIT.format(job_name=f'{name}-2'),
+        (_SPOT_CANCEL_WAIT.format(job_name=f'{name}-1') + '; ' +
+        _SPOT_CANCEL_WAIT.format(job_name=f'{name}-2')),
         # Increase timeout since sky spot queue -r can be blocked by other spot tests.
         timeout=20 * 60,
     )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -69,7 +69,7 @@ storage_setup_commands = [
 # Wait until the spot controller is not in INIT state.
 # This is a workaround for the issue that when multiple spot tests
 # are running in parallel, the spot controller may be in INIT and
-# the spot queue command will return staled table.
+# the spot queue/cancel command will return staled table.
 _SPOT_QUEUE_WAIT = ('s=$(sky spot queue); '
                     'until [ `echo "$s" '
                     '| grep "jobs will not be shown until it becomes UP." '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

According to the #1745, we now set the CANCELLED state after the spot cluster is fully clean up. That will keep the spot job in the previous job for a while, which can feels unresponsive.
Thanks to @suquark 's [great idea](https://github.com/skypilot-org/skypilot/pull/1745#discussion_r1137558903), we are now adding a CANCELLING state for the spot job to improve the UX.

This will also solve the issue https://github.com/skypilot-org/skypilot/pull/1745#issuecomment-1472176053
Because, previously, our spot job is not set to terminal state immediately, the log streaming will misclassified it as preempted.

TODOs:
- [x] Check and fix the smoke tests for cancellation


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch sleep 600 --cloud gcp` and `sky spot cancel -a` cancel it during the starting period
  - [x] `sky spot launch sleep 600 --cloud gcp` and `sky spot cancel -a` cancel it during the log is streaming 
- [x] All smoke tests: `pytest tests/test_smoke.py --managed-spot` 
