### PR TITLE
[Catalog] Fix the `fetch_azure --all-regions` to exclude the unsupported region

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -26,6 +26,12 @@ US_REGIONS = [
     # 'WestUS3',   # WestUS3 pricing table is broken as of 2021/11.
 ]
 
+# Exclude the following regions as they do not have ProductName in the
+# pricing table.
+EXCLUDED_REGIONS = {
+    'eastus2euap',
+    'centraluseuap',
+}
 
 def get_regions() -> List[str]:
     """Get all available regions."""
@@ -242,7 +248,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     region_filter = get_regions() if args.all_regions else US_REGIONS
-    region_filter = set(region_filter)
+    region_filter = set(region_filter) - EXCLUDED_REGIONS
 
     instance_df = get_all_regions_instance_types_df(region_filter)
     os.makedirs('azure', exist_ok=True)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -33,6 +33,7 @@ EXCLUDED_REGIONS = {
     'centraluseuap',
 }
 
+
 def get_regions() -> List[str]:
     """Get all available regions."""
     proc = subprocess.run(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -27,7 +27,7 @@ US_REGIONS = [
 ]
 
 # Exclude the following regions as they do not have ProductName in the
-# pricing table.
+# pricing table. Reference: #1768
 EXCLUDED_REGIONS = {
     'eastus2euap',
     'centraluseuap',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1768

Thanks to @carloscdias for pointing this out! There are two regions, `'eastus2euap'` and `'centraluseuap'`, not having `'ProductName'` in the table.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - `python -m sky.clouds.service_catalog.data_fetchers.fetch_azure --all-regions`