### PR TITLE
Make `sky gpunode` reuse existing cluster if possible

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -818,23 +818,22 @@ def _create_and_ssh_into_node(
         cluster_name)
     if maybe_status is not None:
         if user_requested_resources:
-            # Reuse existing interactive node if resources = launched resources
-            same_resources = (
-                resources.less_demanding_than(handle.launched_resources) and
-                handle.launched_resources.less_demanding_than(resources))
-            if not same_resources:
+            if not resources.less_demanding_than(handle.launched_resources):
                 name_arg = ''
                 if cluster_name != _default_interactive_node_name(node_type):
                     name_arg = f' -c {cluster_name}'
                 raise click.UsageError(
-                    f'Relaunching existing interactive node {cluster_name!r} '
-                    'with different resource specification. To login to '
-                    f'existing cluster, use {colorama.Style.BRIGHT}'
-                    f'sky {node_type}{name_arg}{colorama.Style.RESET_ALL}. '
-                    f'To launch a new cluster, use {colorama.Style.BRIGHT}'
-                    f'sky {node_type} -c NEW_NAME {colorama.Style.RESET_ALL}')
+                    f'Relaunching interactive node {cluster_name!r} with '
+                    'mismatched resources.\n    '
+                    f'Requested resources: {resources}\n    '
+                    f'Launched resources: {handle.launched_resources}\n'
+                    'To login to existing cluster, use '
+                    f'{colorama.Style.BRIGHT}sky {node_type}{name_arg}'
+                    f'{colorama.Style.RESET_ALL}. To launch a new cluster, '
+                    f'use {colorama.Style.BRIGHT}sky {node_type} -c NEW_NAME '
+                    f'{colorama.Style.RESET_ALL}')
         else:
-            # Use existing interactive node if it already exists and no user
+            # Use existing interactive node if it exists and no user
             # resources were specified.
             resources = handle.launched_resources
 


### PR DESCRIPTION
Partially fixes #1331 by making `sky gpunode` reuse existing cluster if possible.

Before:
```
$ sky gpunode --gpus V100
$ sky gpunode --gpus V100 # fails
```

After
```
$ sky gpunode --gpus V100
$ sky gpunode --gpus V100 # reuses gpunode
```

Tested
- [x] `sky gpunode --gpus V100` followed by `sky gpunode`
- [x] `sky gpunode --gpus V100` followed by `sky gpunode --gpus V100`
- [x] `sky gpunode` followed by `sky gpunode --gpus V100` (should error)
- [x] The above tests, with `-c name`

Notes:
- I wanted to add a smoke test, but I couldn't because `sky gpunode` automatically ssh's into the cluster and there is no detach option.
- It is not possible to check if `sky gpunode` was launched with the exact same resource specification (since some resources are decided during execution), so we reuse the cluster if the required resources are a subset of the launched resources.