### PR TITLE
[Cost Report] Add some UI fixes

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1695,8 +1695,6 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     """
     cluster_records = core.cost_report()
 
-    total_cost = sum(record['total_cost'] for record in cluster_records)
-
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:
@@ -1708,23 +1706,26 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         else:
             nonreserved_cluster_records.append(cluster_record)
 
+    total_cost = status_utils.get_total_cost_of_displayed_records(nonreserved_cluster_records)
+
     status_utils.show_cost_report_table(nonreserved_cluster_records, all)
     for cluster_group_name, cluster_record in reserved_clusters.items():
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
+        total_cost += status_utils.get_total_cost_of_displayed_records([cluster_record])
 
     click.echo(f'\n{colorama.Style.BRIGHT}'
-               f'Total Cost: ${total_cost:.3f}{colorama.Style.RESET_ALL}')
+               f'Total Cost: ${total_cost:.2f}{colorama.Style.RESET_ALL}')
 
     if not all:
         click.secho(
-            'NOTE: Since --all is not set, '
-            'not all cost report records '
-            'may be displayed above.',
+            'Showing the N most recent clusters. '
+            'To see all clusters in history, '
+            'pass the --all flag.',
             fg='yellow')
 
     click.secho(
-        'NOTE: This feature is experimental. '
+        'This feature is experimental. '
         'Costs for clusters with auto{stop,down} '
         'scheduled may not be accurate.',
         fg='yellow')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1702,12 +1702,14 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
-            reserved_clusters[cluster_group_name] = cluster_record
+            # to display most recent entry for each reserved cluster 
+            if cluster_group_name not in reserved_clusters:
+                reserved_clusters[cluster_group_name] = cluster_record
         else:
             nonreserved_cluster_records.append(cluster_record)
 
     total_cost = status_utils.get_total_cost_of_displayed_records(
-        nonreserved_cluster_records)
+        nonreserved_cluster_records, all)
 
     status_utils.show_cost_report_table(nonreserved_cluster_records, all)
     for cluster_group_name, cluster_record in reserved_clusters.items():

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1694,8 +1694,9 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
       - clusters that were terminated/stopped on the cloud console.
     """
     cluster_records = core.cost_report()
-    total_cost = status_utils.get_estimated_total_cost_for_all_records(
-        cluster_records)
+
+    total_cost = sum(record['total_cost'] for record in cluster_records)
+
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:
@@ -1712,8 +1713,15 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
 
-    click.echo(f'\n{colorama.Fore.WHITE}{colorama.Style.BRIGHT}'
-               f'{total_cost}')
+    click.echo(f'\n{colorama.Style.BRIGHT}'
+               f'Total Cost: ${total_cost:.3f}{colorama.Style.RESET_ALL}')
+
+    if not all:
+        click.secho(
+            'NOTE: Since --all is not set, '
+            'not all cost report records '
+            'may be displayed above.',
+            fg='yellow')
 
     click.secho(
         'NOTE: This feature is experimental. '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1703,6 +1703,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
             # to display most recent entry for each reserved cluster
+            # TODO(sgurram): fix assumption of sorted order of clusters
             if cluster_group_name not in reserved_clusters:
                 reserved_clusters[cluster_group_name] = cluster_record
         else:
@@ -1722,7 +1723,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
 
     if not all:
         click.secho(
-            f'Showing the {status_utils.NUM_COST_REPORT_LINES} '
+            f'Showing up to {status_utils.NUM_COST_REPORT_LINES} '
             'most recent clusters. '
             'To see all clusters in history, '
             'pass the --all flag.',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1713,15 +1713,15 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     for cluster_group_name, cluster_record in reserved_clusters.items():
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
-        total_cost += status_utils.get_total_cost_of_displayed_records(
-            [cluster_record])
+        total_cost += cluster_record['total_cost']
 
     click.echo(f'\n{colorama.Style.BRIGHT}'
                f'Total Cost: ${total_cost:.2f}{colorama.Style.RESET_ALL}')
 
     if not all:
         click.secho(
-            'Showing the N most recent clusters. '
+            f'Showing the {status_utils.NUM_COST_REPORT_LINES} '
+            'most recent clusters. '
             'To see all clusters in history, '
             'pass the --all flag.',
             fg='yellow')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1694,6 +1694,8 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
       - clusters that were terminated/stopped on the cloud console.
     """
     cluster_records = core.cost_report()
+    total_cost = status_utils.get_estimated_total_cost_for_all_records(
+        cluster_records)
     nonreserved_cluster_records = []
     reserved_clusters = dict()
     for cluster_record in cluster_records:
@@ -1706,10 +1708,13 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
             nonreserved_cluster_records.append(cluster_record)
 
     status_utils.show_cost_report_table(nonreserved_cluster_records, all)
-
     for cluster_group_name, cluster_record in reserved_clusters.items():
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
+
+    click.echo(f'\n{colorama.Fore.WHITE}{colorama.Style.BRIGHT}'
+               f'{total_cost}')
+
     click.secho(
         'NOTE: This feature is experimental. '
         'Costs for clusters with auto{stop,down} '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1706,13 +1706,15 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         else:
             nonreserved_cluster_records.append(cluster_record)
 
-    total_cost = status_utils.get_total_cost_of_displayed_records(nonreserved_cluster_records)
+    total_cost = status_utils.get_total_cost_of_displayed_records(
+        nonreserved_cluster_records)
 
     status_utils.show_cost_report_table(nonreserved_cluster_records, all)
     for cluster_group_name, cluster_record in reserved_clusters.items():
         status_utils.show_cost_report_table(
             [cluster_record], all, reserved_group_name=cluster_group_name)
-        total_cost += status_utils.get_total_cost_of_displayed_records([cluster_record])
+        total_cost += status_utils.get_total_cost_of_displayed_records(
+            [cluster_record])
 
     click.echo(f'\n{colorama.Style.BRIGHT}'
                f'Total Cost: ${total_cost:.2f}{colorama.Style.RESET_ALL}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1702,7 +1702,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         if cluster_name in backend_utils.SKY_RESERVED_CLUSTER_NAMES:
             cluster_group_name = backend_utils.SKY_RESERVED_CLUSTER_NAMES[
                 cluster_name]
-            # to display most recent entry for each reserved cluster 
+            # to display most recent entry for each reserved cluster
             if cluster_group_name not in reserved_clusters:
                 reserved_clusters[cluster_group_name] = cluster_record
         else:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -459,6 +459,8 @@ def _get_cluster_duration(cluster_hash: str) -> int:
 
     for i, (start_time, end_time) in enumerate(usage_intervals):
         # duration from latest start time to time of query
+        if start_time is None:
+            continue
         if end_time is None:
             assert i == len(usage_intervals) - 1, i
             end_time = int(time.time())

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -104,6 +104,15 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         click.echo('No existing clusters.')
     return num_pending_autostop
 
+def get_total_cost_of_displayed_records(cluster_records: List[_ClusterCostReportRecord]):
+    """Compute total cost of records to be displayed in cost report.
+    """    
+    num_lines_to_display = _NUM_COST_REPORT_LINES
+    displayed_records = cluster_records[:num_lines_to_display]
+
+    total_cost = sum(record['total_cost'] for record in displayed_records)
+    return total_cost
+
 
 def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
                            show_all: bool,
@@ -159,7 +168,7 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
         num_lines_to_display = len(cluster_records)
 
     cluster_records.sort(
-        key=lambda report: -_get_status__value_for_cost_report(report))
+        key=lambda report: -_get_status_value_for_cost_report(report))
 
     for record in cluster_records[:num_lines_to_display]:
         row = []
@@ -348,7 +357,7 @@ def _is_pending_autostop(cluster_record: _ClusterRecord) -> bool:
 # ---- 'sky cost-report' helper functions below ----
 
 
-def _get_status__value_for_cost_report(
+def _get_status_value_for_cost_report(
         cluster_cost_report_record: _ClusterCostReportRecord) -> int:
     status = cluster_cost_report_record['status']
     if status is None:
@@ -394,16 +403,3 @@ def _get_estimated_cost_for_cost_report(
         return '-'
 
     return f'${cost:.3f}'
-
-
-def get_estimated_total_cost_for_all_records(
-        cluster_cost_report_records: List[_ClusterCostReportRecord]) -> str:
-    cost = 0
-
-    for cluster_cost_report_record in cluster_cost_report_records:
-        cost += cluster_cost_report_record['total_cost']
-
-    if not cost:
-        return '-'
-
-    return f'TOTAL COST: ${cost:.3f}'

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,7 +11,7 @@ from sky.utils import common_utils
 from sky.utils import log_utils
 
 _COMMAND_TRUNC_LENGTH = 25
-_NUM_COST_REPORT_LINES = 5
+_NUM_COST_REPORT_LINES = 10
 
 # A record in global_user_state's 'clusters' table.
 _ClusterRecord = Dict[str, Any]
@@ -157,6 +157,9 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
     num_lines_to_display = _NUM_COST_REPORT_LINES
     if show_all:
         num_lines_to_display = len(cluster_records)
+
+    cluster_records.sort(
+        key=lambda report: -_get_status__value_for_cost_report(report))
 
     for record in cluster_records[:num_lines_to_display]:
         row = []
@@ -343,6 +346,14 @@ def _is_pending_autostop(cluster_record: _ClusterRecord) -> bool:
 
 
 # ---- 'sky cost-report' helper functions below ----
+
+
+def _get_status__value_for_cost_report(
+        cluster_cost_report_record: _ClusterCostReportRecord) -> int:
+    status = cluster_cost_report_record['status']
+    if status is None:
+        return -1
+    return 1
 
 
 def _get_status_for_cost_report(

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,6 +11,7 @@ from sky.utils import common_utils
 from sky.utils import log_utils
 
 _COMMAND_TRUNC_LENGTH = 25
+_NUM_COST_REPORT_LINES = 5
 
 # A record in global_user_state's 'clusters' table.
 _ClusterRecord = Dict[str, Any]
@@ -153,7 +154,11 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
             columns.append(status_column.name)
     cluster_table = log_utils.create_table(columns)
 
-    for record in cluster_records:
+    num_lines_to_display = _NUM_COST_REPORT_LINES
+    if show_all:
+        num_lines_to_display = len(cluster_records)
+
+    for record in cluster_records[:num_lines_to_display]:
         row = []
         for status_column in status_columns:
             if status_column.show_by_default or show_all:
@@ -378,3 +383,16 @@ def _get_estimated_cost_for_cost_report(
         return '-'
 
     return f'${cost:.3f}'
+
+
+def get_estimated_total_cost_for_all_records(
+        cluster_cost_report_records: List[_ClusterCostReportRecord]) -> str:
+    cost = 0
+
+    for cluster_cost_report_record in cluster_cost_report_records:
+        cost += cluster_cost_report_record['total_cost']
+
+    if not cost:
+        return '-'
+
+    return f'TOTAL COST: ${cost:.3f}'

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -11,7 +11,7 @@ from sky.utils import common_utils
 from sky.utils import log_utils
 
 _COMMAND_TRUNC_LENGTH = 25
-_NUM_COST_REPORT_LINES = 10
+NUM_COST_REPORT_LINES = 5
 
 # A record in global_user_state's 'clusters' table.
 _ClusterRecord = Dict[str, Any]
@@ -107,10 +107,11 @@ def show_status_table(cluster_records: List[_ClusterRecord],
 
 def get_total_cost_of_displayed_records(
         cluster_records: List[_ClusterCostReportRecord]):
-    """Compute total cost of records to be displayed in cost report.
-    """
-    num_lines_to_display = _NUM_COST_REPORT_LINES
-    displayed_records = cluster_records[:num_lines_to_display]
+    """Compute total cost of records to be displayed in cost report."""
+    cluster_records.sort(
+        key=lambda report: -_get_status_value_for_cost_report(report))
+
+    displayed_records = cluster_records[:NUM_COST_REPORT_LINES]
 
     total_cost = sum(record['total_cost'] for record in displayed_records)
     return total_cost
@@ -165,10 +166,11 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
             columns.append(status_column.name)
     cluster_table = log_utils.create_table(columns)
 
-    num_lines_to_display = _NUM_COST_REPORT_LINES
+    num_lines_to_display = NUM_COST_REPORT_LINES
     if show_all:
         num_lines_to_display = len(cluster_records)
 
+    # prioritize showing non-terminated clusters in table
     cluster_records.sort(
         key=lambda report: -_get_status_value_for_cost_report(report))
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -104,9 +104,11 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         click.echo('No existing clusters.')
     return num_pending_autostop
 
-def get_total_cost_of_displayed_records(cluster_records: List[_ClusterCostReportRecord]):
+
+def get_total_cost_of_displayed_records(
+        cluster_records: List[_ClusterCostReportRecord]):
     """Compute total cost of records to be displayed in cost report.
-    """    
+    """
     num_lines_to_display = _NUM_COST_REPORT_LINES
     displayed_records = cluster_records[:num_lines_to_display]
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -106,12 +106,14 @@ def show_status_table(cluster_records: List[_ClusterRecord],
 
 
 def get_total_cost_of_displayed_records(
-        cluster_records: List[_ClusterCostReportRecord]):
+        cluster_records: List[_ClusterCostReportRecord], display_all: bool):
     """Compute total cost of records to be displayed in cost report."""
     cluster_records.sort(
         key=lambda report: -_get_status_value_for_cost_report(report))
 
     displayed_records = cluster_records[:NUM_COST_REPORT_LINES]
+    if display_all:
+        displayed_records = cluster_records
 
     total_cost = sum(record['total_cost'] for record in displayed_records)
     return total_cost


### PR DESCRIPTION
Limit lines in each table to 5 lines (this number is up for debate).
Display total cost across all reports in cost-report (even costs that are not displayed due to the above limit).


```
(sky) sumanth@MacBook-Pro-5 skypilot % sky cost-report   
Clusters
NAME     LAUNCHED      DURATION  RESOURCES                          STATUS      HOURLY_PRICE  COST (est.)  
cluster  1 month ago   6m 19s    1x GCP(n1-highmem-8, {'V100': 1})  TERMINATED  $ 2.953       $0.311       
cluster  1 month ago   22m 31s   1x GCP(n1-highmem-8, {'V100': 1})  TERMINATED  $ 2.953       $1.108       
cluster  2 months ago  3m 41s    1x GCP(n1-highmem-8)               TERMINATED  $ 0.473       $0.029       
cluster  2 months ago  10m 13s   1x GCP(n1-highmem-8)               TERMINATED  $ 0.473       $0.081       

Managed spot controller (will be autostopped if idle for 10min)
NAME                          LAUNCHED     DURATION  RESOURCES                          STATUS      HOURLY_PRICE  COST (est.)  
sky-spot-controller-d16122f1  1 month ago  10m 25s   1x AWS(m6i.2xlarge, disk_size=50)  TERMINATED  $ 0.384       $0.067       

TOTAL COST: $189.105
NOTE: This feature is experimental. Costs for clusters with auto{stop,down} scheduled may not be accurate.
```