### PR TITLE
Use 1.1.1.1 instead of 8.8.8.8 as IP for network check.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -86,7 +86,7 @@ WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 # We use fixed IP address to avoid DNS lookup blocking the check, for machine
 # with no internet connection.
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
-_TEST_IP = 'https://8.8.8.8'
+_TEST_IP = 'https://1.1.1.1'
 
 # Allow each CPU thread take 2 tasks.
 # Note: This value cannot be too small, otherwise OOM issue may occur.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We've seen reports that 8.8.8.8 can be unreachable (#1767).

Changes to Cloudflare's 1.1.1.1 as a mitigation.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
- (US) `sky launch --cloud gcp --down`
- Confirmed with friend in China that 1.1.1.1 is reachable

