### PR TITLE
Update envs instead of replacing

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1030,7 +1030,7 @@ def _make_task_from_entrypoint_with_overrides(
         task.num_nodes = num_nodes
     if name is not None:
         task.name = name
-    task.set_envs(env)
+    task.update_envs(env)
     # TODO(wei-lin): move this validation into Python API.
     if new_resources.accelerators is not None:
         acc, _ = list(new_resources.accelerators.items())[0]

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -44,7 +44,7 @@ class SpotController:
         job_id_env_var = common_utils.get_global_job_id(
             self._backend.run_timestamp, 'spot', str(self._job_id))
         task_envs[constants.JOB_ID_ENV_VAR] = job_id_env_var
-        self._task.set_envs(task_envs)
+        self._task.update_envs(task_envs)
 
         spot_state.set_submitted(
             self._job_id,

--- a/sky/task.py
+++ b/sky/task.py
@@ -340,7 +340,7 @@ class Task:
     def update_envs(
             self, envs: Union[None, Tuple[Tuple[str, str]],
                               Dict[str, str]]) -> 'Task':
-        """Sets the environment variables for use inside the setup/run commands.
+        """Updates the environment variables for use inside the setup/run commands.
 
         Args:
           envs: (optional) either a list of ``(env_name, value)`` or a dict

--- a/sky/task.py
+++ b/sky/task.py
@@ -340,7 +340,7 @@ class Task:
     def update_envs(
             self, envs: Union[None, Tuple[Tuple[str, str]],
                               Dict[str, str]]) -> 'Task':
-        """Updates the environment variables for use inside the setup/run commands.
+        """Updates environment variables for use inside the setup/run commands.
 
         Args:
           envs: (optional) either a list of ``(env_name, value)`` or a dict

--- a/sky/task.py
+++ b/sky/task.py
@@ -337,7 +337,7 @@ class Task:
     def envs(self) -> Dict[str, str]:
         return self._envs
 
-    def set_envs(
+    def update_envs(
             self, envs: Union[None, Tuple[Tuple[str, str]],
                               Dict[str, str]]) -> 'Task':
         """Sets the environment variables for use inside the setup/run commands.
@@ -353,8 +353,7 @@ class Task:
           ValueError: if various invalid inputs errors are detected.
         """
         if envs is None:
-            self._envs = {}
-            return self
+            envs = {}
         if isinstance(envs, (list, tuple)):
             keys = set(env[0] for env in envs)
             if len(keys) != len(envs):
@@ -374,7 +373,7 @@ class Task:
                 raise ValueError(
                     'envs must be List[Tuple[str, str]] or Dict[str, str]: '
                     f'{envs}')
-        self._envs = envs
+        self._envs.update(envs)
         return self
 
     @property

--- a/sky/task.py
+++ b/sky/task.py
@@ -347,7 +347,7 @@ class Task:
             ``{env_name: value}``.
 
         Returns:
-          self: The current task, with envs set.
+          self: The current task, with envs updated.
 
         Raises:
           ValueError: if various invalid inputs errors are detected.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The current behavior of our cli for `sky launch -c test cluster.yaml --env WANDB_API_KEY` will remove all the environments specified in `cluster.yaml` which is not desired.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
