### PR TITLE
Make sky status -r updates the owner of the cluster

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1770,6 +1770,7 @@ def check_owner_identity(cluster_name: str) -> None:
                         'allow the operation as the two identities are likely to have '
                         'the same access to the cluster, but please be aware that '
                         'this is not guaranteed.')
+                if i != 0 or len(owner_identity) != len(current_user_identity):
                     # Update the user identity to avoid showing the warning above
                     # again.
                     global_user_state.set_owner_identity_for_cluster(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now allow `sky status -r` update the owner of the cluster, so that the user can be easier to migrate the existing cluster to the new identity setting.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
