### PR TITLE
[Provisioner] Support multi level performance disk

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -74,10 +74,10 @@ Available fields:
       disk_size: 256
 
       # Disk tier to use for OS (optional).
-      # Could be one of 'low', 'medium', 'high'. Rough performance estimate:
-      #   low: 500 IOPS
-      #   medium: 3000 IOPS
-      #   high: 6000 IOPS
+      # Could be one of 'low', 'medium', or 'high' (default: 'medium'). Rough performance estimate:
+      #   low: 500 IOPS; read 20MB/s; write 40 MB/s
+      #   medium: 3000 IOPS; read 220 MB/s; write 200 MB/s
+      #   high: 6000 IOPS; 340 MB/s; write 250 MB/s
       disk_tier: 'medium'
 
       # Additional accelerator metadata (optional); only used for TPU node

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -73,6 +73,13 @@ Available fields:
       # have a large working directory or tasks that write out large outputs.
       disk_size: 256
 
+      # Disk type to use for OS (optional).
+      # Could be one of 'low', 'medium', 'high'. Rough performance estimate:
+      #   low: 500 IOPS
+      #   medium: 3000 IOPS
+      #   high: 6000 IOPS
+      disk_type: 'medium'
+
       # Additional accelerator metadata (optional); only used for TPU node
       # and TPU VM.
       # Example usage:

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -73,12 +73,12 @@ Available fields:
       # have a large working directory or tasks that write out large outputs.
       disk_size: 256
 
-      # Disk type to use for OS (optional).
+      # Disk tier to use for OS (optional).
       # Could be one of 'low', 'medium', 'high'. Rough performance estimate:
       #   low: 500 IOPS
       #   medium: 3000 IOPS
       #   high: 6000 IOPS
-      disk_type: 'medium'
+      disk_tier: 'medium'
 
       # Additional accelerator metadata (optional); only used for TPU node
       # and TPU VM.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -842,7 +842,7 @@ def write_cluster_config(
     disk_configure = {
         'disk_type': to_provision.get_cloud_disk_type_str(),
     }
-    # AWS need to specify iops and throughput manually.
+    # AWS need to specify iops manually.
     if isinstance(cloud, clouds.AWS):
         disk_configure['disk_iops'] = to_provision.get_disk_iops()
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -839,13 +839,6 @@ def write_cluster_config(
 
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
-    disk_configure = {
-        'disk_type': to_provision.get_cloud_disk_type_str(),
-    }
-    # AWS need to specify iops manually.
-    if isinstance(cloud, clouds.AWS):
-        disk_configure['disk_iops'] = to_provision.get_disk_iops()
-
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -857,6 +850,7 @@ def write_cluster_config(
                 'cluster_name': cluster_name,
                 'num_nodes': num_nodes,
                 'disk_size': to_provision.disk_size,
+                'disk_type': to_provision.get_cloud_disk_type(),
                 # If the current code is run by controller, propagate the real
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).
@@ -905,8 +899,6 @@ def write_cluster_config(
                 'worker_ips': None if ip_list is None else ip_list[1:],
                 # Authentication (optional).
                 **auth_config,
-                # Disk configuration.
-                **disk_configure,
             }),
         output_path=tmp_yaml_path)
     config_dict['cluster_name'] = cluster_name

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -839,6 +839,13 @@ def write_cluster_config(
 
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
+    disk_configure = {
+        'disk_type': to_provision.get_cloud_disk_type_str(),
+    }
+    # AWS need to specify iops and throughput manually.
+    if isinstance(cloud, clouds.AWS):
+        disk_configure['disk_iops'] = to_provision.get_disk_iops()
+
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -898,6 +905,8 @@ def write_cluster_config(
                 'worker_ips': None if ip_list is None else ip_list[1:],
                 # Authentication (optional).
                 **auth_config,
+                # Disk configuration.
+                **disk_configure,
             }),
         output_path=tmp_yaml_path)
     config_dict['cluster_name'] = cluster_name

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -850,7 +850,6 @@ def write_cluster_config(
                 'cluster_name': cluster_name,
                 'num_nodes': num_nodes,
                 'disk_size': to_provision.disk_size,
-                'disk_type': to_provision.get_cloud_disk_type(),
                 # If the current code is run by controller, propagate the real
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -221,6 +221,12 @@ def _interactive_node_cli_command(cli_func):
                              type=int,
                              required=False,
                              help=('OS disk size in GBs.'))
+    disk_type = click.option('--disk-type',
+                             default=None,
+                             type=str,
+                             required=False,
+                             help=('OS disk type. Could be one of "low", '
+                                   '"medium", "high".'))
     no_confirm = click.option('--yes',
                               '-y',
                               is_flag=True,
@@ -299,6 +305,7 @@ def _interactive_node_cli_command(cli_func):
         screen_option,
         tmux_option,
         disk_size,
+        disk_type,
     ]
     decorator = functools.reduce(lambda res, f: f(res),
                                  reversed(click_decorators), cli_func)
@@ -2684,8 +2691,8 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             memory: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
-            idle_minutes_to_autostop: Optional[int], down: bool,
-            retry_until_up: bool):
+            disk_type: Optional[str], idle_minutes_to_autostop: Optional[int],
+            down: bool, retry_until_up: bool):
     """Launch or attach to an interactive GPU node.
 
     Examples:
@@ -2742,7 +2749,8 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               memory=memory,
                               accelerators=gpus,
                               use_spot=use_spot,
-                              disk_size=disk_size)
+                              disk_size=disk_size,
+                              disk_type=disk_type)
 
     _create_and_ssh_into_node(
         'gpunode',
@@ -2766,8 +2774,9 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             instance_type: Optional[str], cpus: Optional[str],
             memory: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
-            down: bool, retry_until_up: bool):
+            disk_size: Optional[int], disk_type: Optional[str],
+            idle_minutes_to_autostop: Optional[int], down: bool,
+            retry_until_up: bool):
     """Launch or attach to an interactive CPU node.
 
     Examples:
@@ -2820,7 +2829,8 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               cpus=cpus,
                               memory=memory,
                               use_spot=use_spot,
-                              disk_size=disk_size)
+                              disk_size=disk_size,
+                              disk_type=disk_type)
 
     _create_and_ssh_into_node(
         'cpunode',
@@ -2845,8 +2855,9 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             memory: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], idle_minutes_to_autostop: Optional[int],
-            down: bool, retry_until_up: bool):
+            disk_size: Optional[int], disk_type: Optional[str],
+            idle_minutes_to_autostop: Optional[int], down: bool,
+            retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
 
     Examples:
@@ -2906,7 +2917,8 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               accelerators=tpus,
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,
-                              disk_size=disk_size)
+                              disk_size=disk_size,
+                              disk_type=disk_type)
 
     _create_and_ssh_into_node(
         'tpunode',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1186,11 +1186,14 @@ def cli():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-tier',
-              default=None,
-              type=str,
-              required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
+@click.option(
+    '--disk-tier',
+    default=None,
+    type=str,
+    required=False,
+    help=(
+        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+    ))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',
@@ -3301,11 +3304,14 @@ def spot():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-tier',
-              default=None,
-              type=str,
-              required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
+@click.option(
+    '--disk-tier',
+    default=None,
+    type=str,
+    required=False,
+    help=(
+        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+    ))
 @click.option(
     '--detach-run',
     '-d',
@@ -3684,11 +3690,14 @@ def bench():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-tier',
-              default=None,
-              type=str,
-              required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
+@click.option(
+    '--disk-tier',
+    default=None,
+    type=str,
+    required=False,
+    help=(
+        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+    ))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3305,7 +3305,7 @@ def spot():
               default=None,
               type=str,
               required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high".'))
+              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
 @click.option(
     '--detach-run',
     '-d',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3688,7 +3688,7 @@ def bench():
               default=None,
               type=str,
               required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high".'))
+              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1192,7 +1192,7 @@ def cli():
     type=str,
     required=False,
     help=(
-        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
     ))
 @click.option(
     '--idle-minutes-to-autostop',
@@ -3310,7 +3310,7 @@ def spot():
     type=str,
     required=False,
     help=(
-        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
     ))
 @click.option(
     '--detach-run',
@@ -3696,7 +3696,7 @@ def bench():
     type=str,
     required=False,
     help=(
-        'OS disk type. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
     ))
 @click.option(
     '--idle-minutes-to-autostop',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -221,11 +221,11 @@ def _interactive_node_cli_command(cli_func):
                              type=int,
                              required=False,
                              help=('OS disk size in GBs.'))
-    disk_type = click.option('--disk-type',
+    disk_tier = click.option('--disk-tier',
                              default=None,
                              type=str,
                              required=False,
-                             help=('OS disk type. Could be one of "low", '
+                             help=('OS disk tier. Could be one of "low", '
                                    '"medium", "high".'))
     no_confirm = click.option('--yes',
                               '-y',
@@ -305,7 +305,7 @@ def _interactive_node_cli_command(cli_func):
         screen_option,
         tmux_option,
         disk_size,
-        disk_type,
+        disk_tier,
     ]
     decorator = functools.reduce(lambda res, f: f(res),
                                  reversed(click_decorators), cli_func)
@@ -596,7 +596,7 @@ def _parse_override_params(cloud: Optional[str] = None,
                            use_spot: Optional[bool] = None,
                            image_id: Optional[str] = None,
                            disk_size: Optional[int] = None,
-                           disk_type: Optional[str] = None) -> Dict[str, Any]:
+                           disk_tier: Optional[str] = None) -> Dict[str, Any]:
     """Parses the override parameters into a dictionary."""
     override_params: Dict[str, Any] = {}
     if cloud is not None:
@@ -643,8 +643,8 @@ def _parse_override_params(cloud: Optional[str] = None,
             override_params['image_id'] = image_id
     if disk_size is not None:
         override_params['disk_size'] = disk_size
-    if disk_type is not None:
-        override_params['disk_type'] = disk_type
+    if disk_tier is not None:
+        override_params['disk_tier'] = disk_tier
     return override_params
 
 
@@ -984,7 +984,7 @@ def _make_task_from_entrypoint_with_overrides(
     use_spot: Optional[bool] = None,
     image_id: Optional[str] = None,
     disk_size: Optional[int] = None,
-    disk_type: Optional[str] = None,
+    disk_tier: Optional[str] = None,
     env: Optional[List[Tuple[str, str]]] = None,
     # spot launch specific
     spot_recovery: Optional[str] = None,
@@ -1029,7 +1029,7 @@ def _make_task_from_entrypoint_with_overrides(
                                              use_spot=use_spot,
                                              image_id=image_id,
                                              disk_size=disk_size,
-                                             disk_type=disk_type)
+                                             disk_tier=disk_tier)
     # Spot launch specific.
     if spot_recovery is not None:
         if spot_recovery.lower() == 'none':
@@ -1186,7 +1186,7 @@ def cli():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-type',
+@click.option('--disk-tier',
               default=None,
               type=str,
               required=False,
@@ -1258,7 +1258,7 @@ def launch(
     image_id: Optional[str],
     env: List[Tuple[str, str]],
     disk_size: Optional[int],
-    disk_type: Optional[str],
+    disk_tier: Optional[str],
     idle_minutes_to_autostop: Optional[int],
     down: bool,  # pylint: disable=redefined-outer-name
     retry_until_up: bool,
@@ -1305,7 +1305,7 @@ def launch(
         image_id=image_id,
         env=env,
         disk_size=disk_size,
-        disk_type=disk_type,
+        disk_tier=disk_tier,
     )
 
     backend: backends.Backend
@@ -2691,7 +2691,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             memory: Optional[str], gpus: Optional[str],
             use_spot: Optional[bool], screen: Optional[bool],
             tmux: Optional[bool], disk_size: Optional[int],
-            disk_type: Optional[str], idle_minutes_to_autostop: Optional[int],
+            disk_tier: Optional[str], idle_minutes_to_autostop: Optional[int],
             down: bool, retry_until_up: bool):
     """Launch or attach to an interactive GPU node.
 
@@ -2750,7 +2750,7 @@ def gpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               accelerators=gpus,
                               use_spot=use_spot,
                               disk_size=disk_size,
-                              disk_type=disk_type)
+                              disk_tier=disk_tier)
 
     _create_and_ssh_into_node(
         'gpunode',
@@ -2774,7 +2774,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             instance_type: Optional[str], cpus: Optional[str],
             memory: Optional[str], use_spot: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], disk_type: Optional[str],
+            disk_size: Optional[int], disk_tier: Optional[str],
             idle_minutes_to_autostop: Optional[int], down: bool,
             retry_until_up: bool):
     """Launch or attach to an interactive CPU node.
@@ -2830,7 +2830,7 @@ def cpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               memory=memory,
                               use_spot=use_spot,
                               disk_size=disk_size,
-                              disk_type=disk_type)
+                              disk_tier=disk_tier)
 
     _create_and_ssh_into_node(
         'cpunode',
@@ -2855,7 +2855,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
             memory: Optional[str], tpus: Optional[str],
             use_spot: Optional[bool], tpu_vm: Optional[bool],
             screen: Optional[bool], tmux: Optional[bool],
-            disk_size: Optional[int], disk_type: Optional[str],
+            disk_size: Optional[int], disk_tier: Optional[str],
             idle_minutes_to_autostop: Optional[int], down: bool,
             retry_until_up: bool):
     """Launch or attach to an interactive TPU node.
@@ -2918,7 +2918,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
                               accelerator_args=accelerator_args,
                               use_spot=use_spot,
                               disk_size=disk_size,
-                              disk_type=disk_type)
+                              disk_tier=disk_tier)
 
     _create_and_ssh_into_node(
         'tpunode',
@@ -3301,7 +3301,7 @@ def spot():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-type',
+@click.option('--disk-tier',
               default=None,
               type=str,
               required=False,
@@ -3349,7 +3349,7 @@ def spot_launch(
     spot_recovery: Optional[str],
     env: List[Tuple[str, str]],
     disk_size: Optional[int],
-    disk_type: Optional[str],
+    disk_tier: Optional[str],
     detach_run: bool,
     retry_until_up: bool,
     yes: bool,
@@ -3387,7 +3387,7 @@ def spot_launch(
         image_id=image_id,
         env=env,
         disk_size=disk_size,
-        disk_type=disk_type,
+        disk_tier=disk_tier,
         spot_recovery=spot_recovery,
     )
 
@@ -3684,7 +3684,7 @@ def bench():
               type=int,
               required=False,
               help=('OS disk size in GBs.'))
-@click.option('--disk-type',
+@click.option('--disk-tier',
               default=None,
               type=str,
               required=False,
@@ -3720,7 +3720,7 @@ def benchmark_launch(
     image_id: Optional[str],
     env: List[Tuple[str, str]],
     disk_size: Optional[int],
-    disk_type: Optional[str],
+    disk_tier: Optional[str],
     idle_minutes_to_autostop: Optional[int],
     yes: bool,
 ) -> None:
@@ -3777,9 +3777,9 @@ def benchmark_launch(
         if disk_size is not None:
             if any('disk_size' in candidate for candidate in candidates):
                 raise click.BadParameter(f'disk_size {message}')
-        if disk_type is not None:
-            if any('disk_type' in candidate for candidate in candidates):
-                raise click.BadParameter(f'disk_type {message}')
+        if disk_tier is not None:
+            if any('disk_tier' in candidate for candidate in candidates):
+                raise click.BadParameter(f'disk_tier {message}')
 
     # The user can specify the benchmark candidates in either of the two ways:
     # 1. By specifying resources.candidates in the YAML.
@@ -3823,7 +3823,7 @@ def benchmark_launch(
                                              use_spot=use_spot,
                                              image_id=image_id,
                                              disk_size=disk_size,
-                                             disk_type=disk_type)
+                                             disk_tier=disk_tier)
     resources_config.update(override_params)
     if 'cloud' in resources_config:
         cloud = resources_config.pop('cloud')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1190,7 +1190,7 @@ def cli():
               default=None,
               type=str,
               required=False,
-              help=('OS disk type. Could be one of "low", "medium", "high".'))
+              help=('OS disk type. Could be one of "low", "medium", "high". Default: medium'))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -226,7 +226,7 @@ def _interactive_node_cli_command(cli_func):
                              type=str,
                              required=False,
                              help=('OS disk tier. Could be one of "low", '
-                                   '"medium", "high".'))
+                                   '"medium", "high". Default: medium'))
     no_confirm = click.option('--yes',
                               '-y',
                               is_flag=True,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -331,7 +331,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            'disk_iops': r.cloud.get_disk_iops()
+            'disk_iops': r.cloud.get_disk_iops(r.disk_type)
         }
 
     def get_feasible_launchable_resources(self,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -331,7 +331,8 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            'disk_iops': r.cloud.get_disk_iops(r.disk_type)
+            'disk_iops': r.cloud.get_disk_iops(r.disk_type),
+            'disk_throughput': r.cloud.get_disk_throughput(r.disk_type),
         }
 
     def get_feasible_launchable_resources(self,
@@ -626,19 +627,18 @@ class AWS(clouds.Cloud):
 
     @classmethod
     def get_disk_type(cls, disk_type: str) -> str:
-        # medium & low will be configured to different IOPS
-        type2name = {
-            'high': 'io2',
-            'medium': 'gp3',
-            'low': 'gp3',
-        }
-        return type2name[disk_type]
+        # aws disk will be configured to different IOPS and throughput
+        return 'gp3'
 
     @classmethod
     def get_disk_iops(cls, disk_type: str) -> int:
         type2iops = {
-            'high': 27000,
-            'medium': 9000,
-            'low': 3000,
+            'high': 15000,
+            'medium': 4500,
+            'low': 3500,
         }
         return type2iops[disk_type]
+
+    @classmethod
+    def get_disk_throughput(cls, disk_type: str) -> int:
+        return cls.get_disk_iops(disk_type) // 16

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -333,7 +333,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            **AWS.get_disk_specs(r.disk_tier)
+            **AWS._get_disk_specs(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self,
@@ -621,28 +621,25 @@ class AWS(clouds.Cloud):
             accelerator, acc_count, region, zone, 'aws')
 
     @classmethod
-    def check_disk_tier_enabled(
-        cls,
-        instance_type: Optional[str],  # pylint: disable=unused-argument
-        disk_tier: str  # pylint: disable=unused-argument
-    ) -> None:
-        return
+    def check_disk_tier_enabled(cls, instance_type: str,
+                                disk_tier: str) -> None:
+        del instance_type, disk_tier  # unused
 
     @classmethod
     def _get_disk_type(cls, disk_tier: str) -> str:
         return 'standard' if disk_tier == 'low' else 'gp3'
 
     @classmethod
-    def get_disk_specs(cls, opt_disk_tier: Optional[str]) -> Dict[str, Any]:
-        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
+    def _get_disk_specs(cls, disk_tier: Optional[str]) -> Dict[str, Any]:
+        tier = disk_tier or cls._DEFAULT_DISK_TIER
         tier2iops = {
             'high': 7000,
             'medium': 3500,
             'low': 0,  # only gp3 is required to set iops
         }
         return {
-            'disk_tier': cls._get_disk_type(disk_tier),
-            'disk_iops': tier2iops[disk_tier],
-            'disk_throughput': tier2iops[disk_tier] // 16,
-            'custom_disk_perf': disk_tier != 'low',
+            'disk_tier': cls._get_disk_type(tier),
+            'disk_iops': tier2iops[tier],
+            'disk_throughput': tier2iops[tier] // 16,
+            'custom_disk_perf': tier != 'low',
         }

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -623,7 +623,7 @@ class AWS(clouds.Cloud):
     @classmethod
     def check_disk_tier_enabled(
         cls,
-        instance_type: str,  # pylint: disable=unused-argument
+        instance_type: Optional[str],  # pylint: disable=unused-argument
         disk_tier: str  # pylint: disable=unused-argument
     ) -> None:
         return

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -636,7 +636,7 @@ class AWS(clouds.Cloud):
         type2iops = {
             'high': 7000,
             'medium': 3500,
-            'low': 0, # only gp3 is required to set iops
+            'low': 0,  # only gp3 is required to set iops
         }
         return type2iops[disk_type]
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -333,7 +333,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            **AWS._get_disk_specs(r.disk_tier)
+            **AWS.get_disk_specs(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self,
@@ -633,7 +633,7 @@ class AWS(clouds.Cloud):
         return 'standard' if disk_tier == 'low' else 'gp3'
 
     @classmethod
-    def _get_disk_specs(cls, opt_disk_tier: Optional[str]) -> Dict[str, Any]:
+    def get_disk_specs(cls, opt_disk_tier: Optional[str]) -> Dict[str, Any]:
         disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         tier2iops = {
             'high': 7000,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -283,9 +283,11 @@ class AWS(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None,
+            disk_tier: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpus=cpus,
                                                          memory=memory,
+                                                         disk_tier=disk_tier,
                                                          clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
@@ -362,7 +364,9 @@ class AWS(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = AWS.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus,
+                memory=resources.memory,
+                disk_tier=resources.disk_tier)
             if default_instance_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -324,6 +324,8 @@ class AWS(clouds.Cloud):
 
         image_id = self._get_image_id(r.image_id, region_name, r.instance_type)
 
+        disk_type = r.disk_type if r.disk_type is not None else 'low'
+
         return {
             'instance_type': r.instance_type,
             'custom_resources': custom_resources,
@@ -331,9 +333,9 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            'disk_iops': AWS.get_disk_iops(r.disk_type),
-            'disk_throughput': AWS.get_disk_throughput(r.disk_type),
-            'custom_disk_perf': AWS.enable_custom_disk_perf(r.disk_type),
+            'disk_iops': AWS.get_disk_iops(disk_type),
+            'disk_throughput': AWS.get_disk_throughput(disk_type),
+            'custom_disk_perf': AWS.enable_custom_disk_perf(disk_type),
         }
 
     def get_feasible_launchable_resources(self,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -331,7 +331,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            **AWS._get_disk_specs(r.disk_type or 'low')
+            **AWS._get_disk_specs(r.disk_tier or 'low')
         }
 
     def get_feasible_launchable_resources(self,
@@ -617,27 +617,27 @@ class AWS(clouds.Cloud):
             accelerator, acc_count, region, zone, 'aws')
 
     @classmethod
-    def check_disk_type_enabled(
+    def check_disk_tier_enabled(
         cls,
         instance_type: str,  # pylint: disable=unused-argument
-        disk_type: str  # pylint: disable=unused-argument
+        disk_tier: str  # pylint: disable=unused-argument
     ) -> None:
         return
 
     @classmethod
-    def _get_disk_type(cls, disk_type: str) -> str:
-        return 'standard' if disk_type == 'low' else 'gp3'
+    def _get_disk_type(cls, disk_tier: str) -> str:
+        return 'standard' if disk_tier == 'low' else 'gp3'
 
     @classmethod
-    def _get_disk_specs(cls, disk_type: str) -> Dict[str, Any]:
-        type2iops = {
+    def _get_disk_specs(cls, disk_tier: str) -> Dict[str, Any]:
+        tier2iops = {
             'high': 7000,
             'medium': 3500,
             'low': 0,  # only gp3 is required to set iops
         }
         return {
-            'disk_type': cls._get_disk_type(disk_type),
-            'disk_iops': type2iops[disk_type],
-            'disk_throughput': type2iops[disk_type] // 16,
-            'custom_disk_perf': disk_type != 'low',
+            'disk_tier': cls._get_disk_type(disk_tier),
+            'disk_iops': tier2iops[disk_tier],
+            'disk_throughput': tier2iops[disk_tier] // 16,
+            'custom_disk_perf': disk_tier != 'low',
         }

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -617,16 +617,12 @@ class AWS(clouds.Cloud):
             accelerator, acc_count, region, zone, 'aws')
 
     @classmethod
-    def check_disk_type_enabled(cls, instance_type: str,
-                                disk_type: str) -> None:
-        # Only S-series supported premium ssd
-        # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
-        series = instance_type.split('_')[1].lower()
-        if disk_type == 'high' and not 's' in series:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Azure premium SSD is only supported for S-series '
-                    'instances. Please use disk_type=medium or low.')
+    def check_disk_type_enabled(
+        cls,
+        instance_type: str,  # pylint: disable=unused-argument
+        disk_type: str  # pylint: disable=unused-argument
+    ) -> None:
+        return
 
     @classmethod
     def get_disk_type(cls, disk_type: str) -> str:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -331,7 +331,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            **AWS._get_disk_specs(r.disk_tier or 'low')
+            **AWS._get_disk_specs(r.disk_tier or 'medium')
         }
 
     def get_feasible_launchable_resources(self,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -331,7 +331,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            **AWS._get_disk_specs(r.disk_tier or 'medium')
+            **AWS._get_disk_specs(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self,
@@ -629,7 +629,8 @@ class AWS(clouds.Cloud):
         return 'standard' if disk_tier == 'low' else 'gp3'
 
     @classmethod
-    def _get_disk_specs(cls, disk_tier: str) -> Dict[str, Any]:
+    def _get_disk_specs(cls, opt_disk_tier: Optional[str]) -> Dict[str, Any]:
+        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         tier2iops = {
             'high': 7000,
             'medium': 3500,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -417,12 +417,14 @@ class Azure(clouds.Cloud):
         return azure_subscription_id
 
     @classmethod
-    def check_disk_type_enabled(cls, instance_type: str,
+    def check_disk_type_enabled(cls, instance_type: Optional[str],
                                 disk_type: str) -> None:
         if disk_type == 'high':
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('Azure disk_type=high is not supported now. '
                                  'Please use disk_type={low, medium} instead.')
+        if instance_type is None:
+            return
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
         series = instance_type.split('_')[1].lower()

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -241,7 +241,7 @@ class Azure(clouds.Cloud):
             # Azure does not support specific zones.
             'zones': None,
             **image_config,
-            'disk_tier': Azure._get_disk_type(r.disk_tier)
+            'disk_tier': Azure.get_disk_type(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self, resources):
@@ -461,7 +461,7 @@ class Azure(clouds.Cloud):
                            'Please use disk_tier={low, medium} instead.')
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
-        if cls._get_disk_type(
+        if cls.get_disk_type(
                 disk_tier
         ) == 'Premium_LRS' and not Azure._is_s_series(instance_type):
             return False, (
@@ -479,7 +479,7 @@ class Azure(clouds.Cloud):
                 raise ValueError(msg)
 
     @classmethod
-    def _get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
+    def get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
         disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
         # cannot be used as OS disks so we might need data disk support

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -451,7 +451,9 @@ class Azure(clouds.Cloud):
 
     @classmethod
     def check_disk_tier(cls, instance_type: str,
-                        disk_tier: str) -> Tuple[bool, str]:
+                        disk_tier: Optional[str]) -> Tuple[bool, str]:
+        if disk_tier is None:
+            return True, ''
         if disk_tier == 'high':
             return False, ('Azure disk_tier=high is not supported now. '
                            'Please use disk_tier={low, medium} instead.')
@@ -467,10 +469,8 @@ class Azure(clouds.Cloud):
         return True, ''
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+    def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
-        if instance_type is None:
-            return
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:
             with ux_utils.print_exception_no_traceback():

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -241,7 +241,7 @@ class Azure(clouds.Cloud):
             # Azure does not support specific zones.
             'zones': None,
             **image_config,
-            'disk_tier': Azure.get_disk_type(r.disk_tier)
+            'disk_tier': Azure._get_disk_type(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self, resources):
@@ -461,7 +461,7 @@ class Azure(clouds.Cloud):
                            'Please use disk_tier={low, medium} instead.')
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
-        if cls.get_disk_type(
+        if cls._get_disk_type(
                 disk_tier
         ) == 'Premium_LRS' and not Azure._is_s_series(instance_type):
             return False, (
@@ -471,7 +471,7 @@ class Azure(clouds.Cloud):
         return True, ''
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+    def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:
@@ -479,8 +479,8 @@ class Azure(clouds.Cloud):
                 raise ValueError(msg)
 
     @classmethod
-    def get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
-        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
+    def _get_disk_type(cls, disk_tier: Optional[str]) -> str:
+        tier = disk_tier or cls._DEFAULT_DISK_TIER
         # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
         # cannot be used as OS disks so we might need data disk support
         tier2name = {
@@ -488,4 +488,4 @@ class Azure(clouds.Cloud):
             'medium': 'Premium_LRS',
             'low': 'Standard_LRS',
         }
-        return tier2name[disk_tier]
+        return tier2name[tier]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -446,11 +446,13 @@ class Azure(clouds.Cloud):
         return instance_family
 
     @classmethod
-    def _is_s_series(cls, instance_type: str) -> bool:
+    def _is_s_series(cls, instance_type: Optional[str]) -> bool:
+        if instance_type is None:
+            return True
         return 's' in cls.get_instance_family(instance_type).lower()
 
     @classmethod
-    def check_disk_tier(cls, instance_type: str,
+    def check_disk_tier(cls, instance_type: Optional[str],
                         disk_tier: Optional[str]) -> Tuple[bool, str]:
         if disk_tier is None:
             return True, ''
@@ -469,7 +471,7 @@ class Azure(clouds.Cloud):
         return True, ''
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: str,
+    def check_disk_tier_enabled(cls, instance_type: Optional[str],
                                 disk_tier: str) -> None:
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -416,6 +416,19 @@ class Azure(clouds.Cloud):
         return azure_subscription_id
 
     @classmethod
+    def check_disk_type_enabled(cls, instance_type: str,
+                                disk_type: str) -> None:
+        # Only S-series supported premium ssd
+        # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
+        series = instance_type.split('_')[1].lower()
+        if disk_type == 'high' and not 's' in series:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'Azure premium SSDs are only supported for S-series '
+                    'instances. To use disk_type=high, please make sure '
+                    'instance_type is specified to an S-series instance.')
+
+    @classmethod
     def get_disk_type(cls, disk_type: str) -> str:
         # TODO(tian): maybe use UltraSSD_LRS?
         type2name = {

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -238,7 +238,7 @@ class Azure(clouds.Cloud):
             # Azure does not support specific zones.
             'zones': None,
             **image_config,
-            'disk_tier': Azure._get_disk_type(r.disk_tier or 'medium')
+            'disk_tier': Azure._get_disk_type(r.disk_tier)
         }
 
     def get_feasible_launchable_resources(self, resources):
@@ -439,7 +439,8 @@ class Azure(clouds.Cloud):
                     'instance_type is specified to an S-series instance.')
 
     @classmethod
-    def _get_disk_type(cls, disk_tier: str) -> str:
+    def _get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
+        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
         # cannot be used as OS disks so we might need data disk support
         tier2name = {

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -420,9 +420,8 @@ class Azure(clouds.Cloud):
                                 disk_type: str) -> None:
         if disk_type == 'high':
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Azure disk_type=high is not supported now. '
-                    'Please use disk_type={low, medium} instead.')
+                raise ValueError('Azure disk_type=high is not supported now. '
+                                 'Please use disk_type={low, medium} instead.')
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
         series = instance_type.split('_')[1].lower()

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -449,7 +449,10 @@ class Azure(clouds.Cloud):
     def _is_s_series(cls, instance_type: Optional[str]) -> bool:
         if instance_type is None:
             return True
-        return 's' in cls.get_instance_family(instance_type).lower()
+        instance_family = cls.get_instance_family(instance_type).lower()
+        if instance_family == 'basic_a':
+            return False
+        return 's' in instance_family
 
     @classmethod
     def check_disk_tier(cls, instance_type: Optional[str],

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -237,7 +237,8 @@ class Azure(clouds.Cloud):
             'region': region_name,
             # Azure does not support specific zones.
             'zones': None,
-            **image_config
+            **image_config,
+            'disk_type': Azure._get_disk_type(r.disk_type or 'low')
         }
 
     def get_feasible_launchable_resources(self, resources):
@@ -425,7 +426,7 @@ class Azure(clouds.Cloud):
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
         series = instance_type.split('_')[1].lower()
-        if cls.get_disk_type(disk_type) == 'Premium_LRS' and not 's' in series:
+        if cls._get_disk_type(disk_type) == 'Premium_LRS' and not 's' in series:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Azure premium SSDs are only supported for S-series '
@@ -433,7 +434,7 @@ class Azure(clouds.Cloud):
                     'instance_type is specified to an S-series instance.')
 
     @classmethod
-    def get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_type: str) -> str:
         # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
         # cannot be used as OS disks so we might need data disk support
         type2name = {

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -418,6 +418,11 @@ class Azure(clouds.Cloud):
     @classmethod
     def check_disk_type_enabled(cls, instance_type: str,
                                 disk_type: str) -> None:
+        if disk_type == 'high':
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'Azure disk_type=high is not supported now. '
+                    'Please use disk_type={low, medium} instead.')
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
         series = instance_type.split('_')[1].lower()
@@ -425,7 +430,7 @@ class Azure(clouds.Cloud):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Azure premium SSDs are only supported for S-series '
-                    'instances. To use disk_type=high, please make sure '
+                    'instances. To use disk_type=medium, please make sure '
                     'instance_type is specified to an S-series instance.')
 
     @classmethod
@@ -433,8 +438,8 @@ class Azure(clouds.Cloud):
         # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
         # cannot be used as OS disks so we might need data disk support
         type2name = {
-            'high': 'Premium_LRS',
-            'medium': 'StandardSSD_LRS',
+            'high': 'Disabled',
+            'medium': 'Premium_LRS',
             'low': 'Standard_LRS',
         }
         return type2name[disk_type]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -246,6 +246,9 @@ class Azure(clouds.Cloud):
             # TODO(zhwu): our azure subscription offer ID does not support spot.
             # Need to support it.
             return ([], [])
+        if resources.disk_type == 'high':
+            # Azure does not support high disk type.
+            return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -421,7 +421,7 @@ class Azure(clouds.Cloud):
         # Only S-series supported premium ssd
         # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
         series = instance_type.split('_')[1].lower()
-        if disk_type == 'high' and not 's' in series:
+        if cls.get_disk_type(disk_type) == 'Premium_LRS' and not 's' in series:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Azure premium SSDs are only supported for S-series '
@@ -430,7 +430,8 @@ class Azure(clouds.Cloud):
 
     @classmethod
     def get_disk_type(cls, disk_type: str) -> str:
-        # TODO(tian): maybe use UltraSSD_LRS?
+        # TODO(tian): Maybe use PremiumV2_LRS/UltraSSD_LRS? Notice these two
+        # cannot be used as OS disks so we might need data disk support
         type2name = {
             'high': 'Premium_LRS',
             'medium': 'StandardSSD_LRS',

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -414,3 +414,13 @@ class Azure(clouds.Cloud):
                     'cli command: "az account set -s <subscription_id>".'
                 ) from e
         return azure_subscription_id
+
+    @classmethod
+    def get_disk_type(cls, disk_type: str) -> str:
+        # TODO(tian): maybe use UltraSSD_LRS?
+        type2name = {
+            'high': 'Premium_LRS',
+            'medium': 'StandardSSD_LRS',
+            'low': 'Standard_LRS',
+        }
+        return type2name[disk_type]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -238,7 +238,7 @@ class Azure(clouds.Cloud):
             # Azure does not support specific zones.
             'zones': None,
             **image_config,
-            'disk_tier': Azure._get_disk_type(r.disk_tier or 'low')
+            'disk_tier': Azure._get_disk_type(r.disk_tier or 'medium')
         }
 
     def get_feasible_launchable_resources(self, resources):

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -459,10 +459,5 @@ class Cloud:
         """
         raise NotImplementedError
 
-    @classmethod
-    def _get_disk_type(cls, disk_tier: str) -> str:
-        """Returns the disk type name for each cloud."""
-        raise NotImplementedError
-
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -458,7 +458,7 @@ class Cloud:
                     f'{max_cluster_name_len_limit} chars{cloud_name}.')
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: str,
+    def check_disk_tier_enabled(cls, instance_type: Optional[str],
                                 disk_tier: str) -> None:
         """Errors out if the disk tier is not supported by the cloud provider.
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -460,10 +460,10 @@ class Cloud:
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
-        """Errors out if the disk type is not supported by the cloud provider.
+        """Errors out if the disk tier is not supported by the cloud provider.
 
         Raises:
-            exceptions.NotSupportedError: If the disk type is not supported.
+            exceptions.NotSupportedError: If the disk tier is not supported.
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -460,19 +460,9 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_type: str) -> str:
         """Returns the disk type name for each cloud."""
         raise NotImplementedError
-
-    @classmethod
-    def get_disk_desc(cls, disk_type: str) -> str:
-        """Returns a string to describe the disk type for each cloud.
-
-        Default format: {disk_type}:{cloud_disk_type}
-
-        AWS format: {disk_type}:{cloud_disk_type}[{iops}]
-        """
-        return f'{disk_type}:{cls.get_disk_type(disk_type)}'
 
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -475,5 +475,16 @@ class Cloud:
         """
         return 0
 
+    @classmethod
+    def get_disk_throughput(
+            cls,
+            disk_type: str  # pylint: disable=unused-argument
+    ) -> int:
+        """Returns the disk throughput correspond to disk type for each cloud.
+
+        Only AWS will return a non-zero value for cunfiguration.
+        """
+        return 0
+
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -252,8 +252,10 @@ class Cloud:
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
-        """Returns the default instance type with the given #vCPUs and memory.
+            memory: Optional[str] = None,
+            disk_tier: Optional[str] = None) -> Optional[str]:
+        """Returns the default instance type with the given #vCPUs, memory and
+        disk tier.
 
         For example, if cpus='4', this method returns the default instance type
         with 4 vCPUs.  If cpus='4+', this method returns the default instance
@@ -263,9 +265,14 @@ class Cloud:
         memory.  If 'memory=4+', this method returns the default instance
         type with 4GB or more memory.
 
-        When cpus is None or memory is None, this method will never return None.
-        This method may return None if the cloud's default instance family
-        does not have a VM with the given number of vCPUs (e.g., when cpus='7').
+        If disk_rier='medium', this method returns the default instance type
+        that support medium disk tier.
+
+        When cpus is None, memory is None or disk tier is None, this method will
+        never return None. This method may return None if the cloud's default
+        instance family does not have a VM with the given number of vCPUs
+        (e.g., when cpus='7') or does not have a VM with the give disk tier
+        (e.g. Azure, disk_tier='high').
         """
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -465,26 +465,14 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_disk_iops(
-            cls,
-            disk_type: str  # pylint: disable=unused-argument
-    ) -> int:
-        """Returns the disk iops correspond to disk type for each cloud.
+    def get_disk_desc(cls, disk_type: str) -> str:
+        """Returns a string to describe the disk type for each cloud.
 
-        Only AWS will return a non-zero value for cunfiguration.
+        Default format: {disk_type}:{cloud_disk_type}
+
+        AWS format: {disk_type}:{cloud_disk_type}[{iops}]
         """
-        return 0
-
-    @classmethod
-    def get_disk_throughput(
-            cls,
-            disk_type: str  # pylint: disable=unused-argument
-    ) -> int:
-        """Returns the disk throughput correspond to disk type for each cloud.
-
-        Only AWS will return a non-zero value for cunfiguration.
-        """
-        return 0
+        return f'{disk_type}:{cls.get_disk_type(disk_type)}'
 
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -458,7 +458,7 @@ class Cloud:
                     f'{max_cluster_name_len_limit} chars{cloud_name}.')
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+    def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         """Errors out if the disk tier is not supported by the cloud provider.
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -72,6 +72,7 @@ class Cloud:
     """A cloud provider."""
 
     _REPR = '<Cloud>'
+    _DEFAULT_DISK_TIER = 'medium'
 
     @classmethod
     def _cloud_unsupported_features(

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -450,8 +450,8 @@ class Cloud:
                     f'{max_cluster_name_len_limit} chars{cloud_name}.')
 
     @classmethod
-    def check_disk_type_enabled(cls, instance_type: str,
-                                disk_type: str) -> None:
+    def check_disk_tier_enabled(cls, instance_type: str,
+                                disk_tier: str) -> None:
         """Errors out if the disk type is not supported by the cloud provider.
 
         Raises:
@@ -460,7 +460,7 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def _get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_tier: str) -> str:
         """Returns the disk type name for each cloud."""
         raise NotImplementedError
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -449,5 +449,31 @@ class Cloud:
                     'chars; maximum length is '
                     f'{max_cluster_name_len_limit} chars{cloud_name}.')
 
+    @classmethod
+    def check_disk_type_enabled(cls, instance_type: str,
+                                disk_type: str) -> None:
+        """Errors out if the disk type is not supported by the cloud provider.
+
+        Raises:
+            exceptions.NotSupportedError: If the disk type is not supported.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_disk_type(cls, disk_type: str) -> str:
+        """Returns the disk type name for each cloud."""
+        raise NotImplementedError
+
+    @classmethod
+    def get_disk_iops(
+            cls,
+            disk_type: str  # pylint: disable=unused-argument
+    ) -> int:
+        """Returns the disk iops correspond to disk type for each cloud.
+
+        Only AWS will return a non-zero value for cunfiguration.
+        """
+        return 0
+
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -699,7 +699,7 @@ class GCP(clouds.Cloud):
     @classmethod
     def check_disk_tier_enabled(
         cls,
-        instance_type: str,  # pylint: disable=unused-argument
+        instance_type: Optional[str],  # pylint: disable=unused-argument
         disk_tier: str  # pylint: disable=unused-argument
     ) -> None:
         return

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -353,7 +353,8 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or 'medium')
+        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or
+                                                         'medium')
 
         return resources_vars
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -353,8 +353,7 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or
-                                                         'medium')
+        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier)
 
         return resources_vars
 
@@ -702,7 +701,8 @@ class GCP(clouds.Cloud):
         return
 
     @classmethod
-    def _get_disk_type(cls, disk_tier: str) -> str:
+    def _get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
+        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         tier2name = {
             'high': 'pd-ssd',
             'medium': 'pd-balanced',

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -691,6 +691,14 @@ class GCP(clouds.Cloud):
             instance_type, accelerators, zone, 'gcp')
 
     @classmethod
+    def check_disk_type_enabled(
+        cls,
+        instance_type: str,  # pylint: disable=unused-argument
+        disk_type: str  # pylint: disable=unused-argument
+    ) -> None:
+        return
+
+    @classmethod
     def get_disk_type(cls, disk_type: str) -> str:
         type2name = {
             'high': 'pd-ssd',

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -689,3 +689,12 @@ class GCP(clouds.Cloud):
             zone: Optional[str] = None) -> None:
         service_catalog.check_accelerator_attachable_to_host(
             instance_type, accelerators, zone, 'gcp')
+
+    @classmethod
+    def get_disk_type(cls, disk_type: str) -> str:
+        type2name = {
+            'high': 'pd-ssd',
+            'medium': 'pd-balanced',
+            'low': 'pd-standard',
+        }
+        return type2name[disk_type]

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -353,6 +353,8 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
+        resources_vars['disk_type'] = GCP._get_disk_type(r.disk_type or 'low')
+
         return resources_vars
 
     def get_feasible_launchable_resources(self, resources):
@@ -699,7 +701,7 @@ class GCP(clouds.Cloud):
         return
 
     @classmethod
-    def get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_type: str) -> str:
         type2name = {
             'high': 'pd-ssd',
             'medium': 'pd-balanced',

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -355,7 +355,7 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_tier'] = GCP.get_disk_type(r.disk_tier)
+        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier)
 
         return resources_vars
 
@@ -697,19 +697,16 @@ class GCP(clouds.Cloud):
             instance_type, accelerators, zone, 'gcp')
 
     @classmethod
-    def check_disk_tier_enabled(
-        cls,
-        instance_type: Optional[str],  # pylint: disable=unused-argument
-        disk_tier: str  # pylint: disable=unused-argument
-    ) -> None:
-        return
+    def check_disk_tier_enabled(cls, instance_type: str,
+                                disk_tier: str) -> None:
+        del instance_type, disk_tier  # unused
 
     @classmethod
-    def get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
-        disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
+    def _get_disk_type(cls, disk_tier: Optional[str]) -> str:
+        tier = disk_tier or cls._DEFAULT_DISK_TIER
         tier2name = {
             'high': 'pd-ssd',
             'medium': 'pd-balanced',
             'low': 'pd-standard',
         }
-        return tier2name[disk_tier]
+        return tier2name[tier]

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -353,7 +353,7 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_type'] = GCP._get_disk_type(r.disk_type or 'low')
+        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or 'low')
 
         return resources_vars
 
@@ -693,18 +693,18 @@ class GCP(clouds.Cloud):
             instance_type, accelerators, zone, 'gcp')
 
     @classmethod
-    def check_disk_type_enabled(
+    def check_disk_tier_enabled(
         cls,
         instance_type: str,  # pylint: disable=unused-argument
-        disk_type: str  # pylint: disable=unused-argument
+        disk_tier: str  # pylint: disable=unused-argument
     ) -> None:
         return
 
     @classmethod
-    def _get_disk_type(cls, disk_type: str) -> str:
-        type2name = {
+    def _get_disk_type(cls, disk_tier: str) -> str:
+        tier2name = {
             'high': 'pd-ssd',
             'medium': 'pd-balanced',
             'low': 'pd-standard',
         }
-        return type2name[disk_type]
+        return tier2name[disk_tier]

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -270,9 +270,11 @@ class GCP(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None,
+            disk_tier: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpus=cpus,
                                                          memory=memory,
+                                                         disk_tier=disk_tier,
                                                          clouds='gcp')
 
     def make_deploy_resources_variables(
@@ -365,7 +367,9 @@ class GCP(clouds.Cloud):
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             host_vm_type = GCP.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus,
+                memory=resources.memory,
+                disk_tier=resources.disk_tier)
             if host_vm_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -353,7 +353,7 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or 'low')
+        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier or 'medium')
 
         return resources_vars
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -355,7 +355,7 @@ class GCP(clouds.Cloud):
         assert image_id is not None, (image_id, r)
         resources_vars['image_id'] = image_id
 
-        resources_vars['disk_tier'] = GCP._get_disk_type(r.disk_tier)
+        resources_vars['disk_tier'] = GCP.get_disk_type(r.disk_tier)
 
         return resources_vars
 
@@ -705,7 +705,7 @@ class GCP(clouds.Cloud):
         return
 
     @classmethod
-    def _get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
+    def get_disk_type(cls, opt_disk_tier: Optional[str]) -> str:
         disk_tier = opt_disk_tier or cls._DEFAULT_DISK_TIER
         tier2name = {
             'high': 'pd-ssd',

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -115,9 +115,11 @@ class Lambda(clouds.Cloud):
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
-            memory: Optional[str] = None) -> Optional[str]:
+            memory: Optional[str] = None,
+            disk_tier: Optional[str] = None) -> Optional[str]:
         return service_catalog.get_default_instance_type(cpus=cpus,
                                                          memory=memory,
+                                                         disk_tier=disk_tier,
                                                          clouds='lambda')
 
     @classmethod
@@ -188,7 +190,9 @@ class Lambda(clouds.Cloud):
         if accelerators is None:
             # Return a default instance type with the given number of vCPUs.
             default_instance_type = Lambda.get_default_instance_type(
-                cpus=resources.cpus, memory=resources.memory)
+                cpus=resources.cpus,
+                memory=resources.memory,
+                disk_tier=resources.disk_tier)
             if default_instance_type is None:
                 return ([], [])
             else:

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -259,7 +259,7 @@ class Lambda(clouds.Cloud):
         return service_catalog.regions(clouds='lambda')
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+    def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk tiers.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -160,7 +160,7 @@ class Lambda(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        if resources.use_spot:
+        if resources.use_spot or resources.disk_type is not None:
             return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -160,7 +160,7 @@ class Lambda(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        if resources.use_spot or resources.disk_type is not None:
+        if resources.use_spot or resources.disk_tier is not None:
             return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
@@ -255,12 +255,12 @@ class Lambda(clouds.Cloud):
         return service_catalog.regions(clouds='lambda')
 
     @classmethod
-    def check_disk_type_enabled(cls, instance_type: str,
-                                disk_type: str) -> None:
+    def check_disk_tier_enabled(cls, instance_type: str,
+                                disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk types.')
 
     @classmethod
-    def _get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_tier: str) -> str:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk types.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -259,8 +259,3 @@ class Lambda(clouds.Cloud):
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk tiers.')
-
-    @classmethod
-    def _get_disk_type(cls, disk_tier: str) -> str:
-        raise exceptions.NotSupportedError(
-            'Lambda does not support disk tiers.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -4,6 +4,7 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
+from sky import exceptions
 from sky.clouds import service_catalog
 from sky.skylet.providers.lambda_cloud import lambda_utils
 
@@ -252,3 +253,9 @@ class Lambda(clouds.Cloud):
     @classmethod
     def regions(cls) -> List['clouds.Region']:
         return service_catalog.regions(clouds='lambda')
+
+    @classmethod
+    def check_disk_type_enabled(cls, instance_type: str,
+                                disk_type: str) -> None:
+        raise exceptions.NotSupportedError(
+            'Lambda does not support disk types.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -160,7 +160,7 @@ class Lambda(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        if resources.use_spot or resourceier is not None:
+        if resources.use_spot or resources.disk_tier is not None:
             return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -259,3 +259,8 @@ class Lambda(clouds.Cloud):
                                 disk_type: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk types.')
+
+    @classmethod
+    def _get_disk_type(cls, disk_type: str) -> str:
+        raise exceptions.NotSupportedError(
+            'Lambda does not support disk types.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -160,7 +160,7 @@ class Lambda(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        if resources.use_spot or resources.disk_tier is not None:
+        if resources.use_spot or resourceier is not None:
             return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
@@ -258,9 +258,9 @@ class Lambda(clouds.Cloud):
     def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
-            'Lambda does not support disk types.')
+            'Lambda does not support disk tiers.')
 
     @classmethod
     def _get_disk_type(cls, disk_tier: str) -> str:
         raise exceptions.NotSupportedError(
-            'Lambda does not support disk types.')
+            'Lambda does not support disk tiers.')

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -259,7 +259,7 @@ class Lambda(clouds.Cloud):
         return service_catalog.regions(clouds='lambda')
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: str,
+    def check_disk_tier_enabled(cls, instance_type: Optional[str],
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk tiers.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -111,9 +111,10 @@ class Local(clouds.Cloud):
     @classmethod
     def get_default_instance_type(cls,
                                   cpus: Optional[str] = None,
-                                  memory: Optional[str] = None) -> str:
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[str] = None) -> str:
         # There is only "1" instance type for local cloud: on-prem
-        del cpus, memory  # Unused.
+        del cpus, memory, disk_tier  # Unused.
         return Local._DEFAULT_INSTANCE_TYPE
 
     @classmethod

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -200,3 +200,8 @@ class Local(clouds.Cloud):
                                 disk_type: str) -> None:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk types.')
+
+    @classmethod
+    def _get_disk_type(cls, disk_type: str) -> str:
+        raise exceptions.NotSupportedError(
+            'Local cloud does not support disk types.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -199,7 +199,7 @@ class Local(clouds.Cloud):
         return region, zone
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: str,
+    def check_disk_tier_enabled(cls, instance_type: Optional[str],
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk tiers.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -4,6 +4,7 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
+from sky import exceptions
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -193,3 +194,9 @@ class Local(clouds.Cloud):
             raise ValueError(f'Region {region!r} does not match the Local'
                              ' cloud region {Local.LOCAL_REGION.name!r}.')
         return region, zone
+
+    @classmethod
+    def check_disk_type_enabled(cls, instance_type: str,
+                                disk_type: str) -> None:
+        raise exceptions.NotSupportedError(
+            'Local cloud does not support disk types.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -201,9 +201,9 @@ class Local(clouds.Cloud):
     def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
-            'Local cloud does not support disk types.')
+            'Local cloud does not support disk tiers.')
 
     @classmethod
     def _get_disk_type(cls, disk_tier: str) -> str:
         raise exceptions.NotSupportedError(
-            'Local cloud does not support disk types.')
+            'Local cloud does not support disk tiers.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -202,8 +202,3 @@ class Local(clouds.Cloud):
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk tiers.')
-
-    @classmethod
-    def _get_disk_type(cls, disk_tier: str) -> str:
-        raise exceptions.NotSupportedError(
-            'Local cloud does not support disk tiers.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -143,7 +143,7 @@ class Local(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
-        if resources.disk_type is not None:
+        if resources.disk_tier is not None:
             return ([], [])
         # The entire local cluster's resources is considered launchable, as the
         # check for task resources is deferred later.
@@ -198,12 +198,12 @@ class Local(clouds.Cloud):
         return region, zone
 
     @classmethod
-    def check_disk_type_enabled(cls, instance_type: str,
-                                disk_type: str) -> None:
+    def check_disk_tier_enabled(cls, instance_type: str,
+                                disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk types.')
 
     @classmethod
-    def _get_disk_type(cls, disk_type: str) -> str:
+    def _get_disk_type(cls, disk_tier: str) -> str:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk types.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -143,6 +143,8 @@ class Local(clouds.Cloud):
 
     def get_feasible_launchable_resources(self,
                                           resources: 'resources_lib.Resources'):
+        if resources.disk_type is not None:
+            return ([], [])
         # The entire local cluster's resources is considered launchable, as the
         # check for task resources is deferred later.
         # The check for task resources meeting cluster resources is run in

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -199,7 +199,7 @@ class Local(clouds.Cloud):
         return region, zone
 
     @classmethod
-    def check_disk_tier_enabled(cls, instance_type: Optional[str],
+    def check_disk_tier_enabled(cls, instance_type: str,
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Local cloud does not support disk tiers.')

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -174,6 +174,7 @@ def get_vcpus_mem_from_instance_type(
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
+                              disk_tier: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
     """Returns the cloud's default instance type for given #vCPUs and memory.
 
@@ -187,7 +188,7 @@ def get_default_instance_type(cpus: Optional[str] = None,
     the given CPU and memory requirement.
     """
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus,
-                               memory)
+                               memory, disk_tier)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -180,8 +180,11 @@ def get_vcpus_mem_from_instance_type(
                                                         instance_type)
 
 
-def get_default_instance_type(cpus: Optional[str] = None,
-                              memory: Optional[str] = None) -> Optional[str]:
+def get_default_instance_type(
+        cpus: Optional[str] = None,
+        memory: Optional[str] = None,
+        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
+) -> Optional[str]:
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -180,11 +180,10 @@ def get_vcpus_mem_from_instance_type(
                                                         instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
-) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[str] = None) -> Optional[str]:
+    del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -86,8 +86,6 @@ def get_default_instance_type(cpus: Optional[str] = None,
         Azure.get_instance_family).isin(_DEFAULT_INSTANCE_FAMILY)]
 
     def _filter_disk_type(instance_type: str) -> bool:
-        if disk_tier is None:
-            return True
         return Azure.check_disk_tier(instance_type, disk_tier)[0]
 
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -21,7 +21,7 @@ _DEFAULT_INSTANCE_FAMILY = [
     # The latest memory-optimized instance family as of Mar. 2023.
     # CPU: Intel Ice Lake 8370C.
     # Memory: 8 GiB RAM per 1 vCPU.
-    'E_v5',
+    'Es_v5',
     # The latest compute-optimized instance family as of Mar 2023.
     # CPU: Intel Ice Lake 8370C, Cascade Lake 8272CL, or Skylake 8168.
     # Memory: 2 GiB RAM per 1 vCPU.

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -185,11 +185,10 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
-) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[str] = None) -> Optional[str]:
+    del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -185,8 +185,11 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(cpus: Optional[str] = None,
-                              memory: Optional[str] = None) -> Optional[str]:
+def get_default_instance_type(
+        cpus: Optional[str] = None,
+        memory: Optional[str] = None,
+        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
+) -> Optional[str]:
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -61,8 +61,11 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(cpus: Optional[str] = None,
-                              memory: Optional[str] = None) -> Optional[str]:
+def get_default_instance_type(
+        cpus: Optional[str] = None,
+        memory: Optional[str] = None,
+        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
+) -> Optional[str]:
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -61,11 +61,10 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[str] = None,  # pylint: disable=unused-argument
-) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[str] = None) -> Optional[str]:
+    del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -169,7 +169,7 @@ class Resources:
         disk_type = ''
         if self.disk_type is not None:
             cloud_disk_type = self.cloud.get_disk_type(self.disk_type)
-            disk_type = f', disk_type={cloud_disk_type}'
+            disk_type = f', disk_type={self.disk_type}:{cloud_disk_type}'
 
         disk_size = ''
         if self.disk_size != _DEFAULT_DISK_SIZE_GB:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -168,8 +168,8 @@ class Resources:
 
         disk_type = ''
         if self.disk_type is not None:
-            cloud_disk_type = self.cloud.get_disk_type(self.disk_type)
-            disk_type = f', disk_type={self.disk_type}:{cloud_disk_type}'
+            disk_desc = self.cloud.get_disk_desc(self.disk_type)
+            disk_type = f', disk_type={disk_desc}'
 
         disk_size = ''
         if self.disk_size != _DEFAULT_DISK_SIZE_GB:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -705,6 +705,8 @@ class Resources:
                 raise ValueError(
                     f'Invalid disk_tier {self.disk_tier}. '
                     'Please use one of "high", "medium", or "low".')
+        if self.instance_type is None:
+            return
         if self.cloud is not None:
             self.cloud.check_disk_tier_enabled(self.instance_type,
                                                self.disk_tier)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -99,9 +99,15 @@ class Resources:
                     k.strip(): v.strip() for k, v in image_id.items()
                 }
 
-        # default to basic disk type
         assert disk_type in ['high', 'medium', 'low', None], f'Unsupported disk type: {disk_type}'
+        # default to basic disk type
         self._disk_type = disk_type if disk_type is not None else 'low'
+        if isinstance(self.cloud, clouds.Azure):
+            # Only S-series supported premium ssd
+            # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre
+            series = self.instance_type.split('_')[1].lower()
+            if self._disk_type == 'high' and not 's' in series:
+                self._disk_type = 'medium'
 
         self._set_cpus(cpus)
         self._set_memory(memory)
@@ -300,6 +306,15 @@ class Resources:
                 else "gp3"
                 if self.disk_type == "medium"
                 else "gp3"
+            )
+        if isinstance(self.cloud, clouds.Azure):
+            return (
+                # TODO(tian): maybe use UltraSSD_LRS?
+                "Premium_LRS"
+                if self.disk_type == "high"
+                else "StandardSSD_LRS"
+                if self.disk_type == "medium"
+                else "Standard_LRS"
             )
         raise NotImplementedError(f'Disk type of cloud {self.cloud} is not implemented yet.')
     

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,5 +1,6 @@
 """Resources: compute requirements of Tasks."""
 from typing import Dict, List, Optional, Union
+from typing_extensions import Literal
 
 from sky import clouds
 from sky import global_user_state
@@ -60,6 +61,7 @@ class Resources:
         region: Optional[str] = None,
         zone: Optional[str] = None,
         image_id: Union[Dict[str, str], str, None] = None,
+        disk_type: Optional[Literal['high', 'medium', 'low']] = None,
     ):
         self._version = self._VERSION
         self._cloud = cloud
@@ -96,6 +98,10 @@ class Resources:
                 self._image_id = {
                     k.strip(): v.strip() for k, v in image_id.items()
                 }
+
+        # default to basic disk type
+        assert disk_type in ['high', 'medium', 'low', None], f'Unsupported disk type: {disk_type}'
+        self._disk_type = disk_type if disk_type is not None else 'low'
 
         self._set_cpus(cpus)
         self._set_memory(memory)
@@ -273,6 +279,41 @@ class Resources:
     @property
     def image_id(self) -> Optional[Dict[str, str]]:
         return self._image_id
+
+    @property
+    def disk_type(self) -> str:
+        return self._disk_type
+    
+    def get_cloud_disk_type_str(self) -> str:
+        if isinstance(self.cloud, clouds.GCP):
+            return (
+                "pd-ssd"
+                if self.disk_type == "high"
+                else "pd-balanced"
+                if self.disk_type == "medium"
+                else "pd-standard"
+            )
+        if isinstance(self.cloud, clouds.AWS):
+            return (
+                "io2"
+                if self.disk_type == "high"
+                else "gp3"
+                if self.disk_type == "medium"
+                else "gp3"
+            )
+        raise NotImplementedError(f'Disk type of cloud {self.cloud} is not implemented yet.')
+    
+    def get_disk_iops(self) -> int:
+        if isinstance(self.cloud, clouds.AWS):
+            # TODO(tian): benchmark on each cloud to make sure performance is similar
+            return (
+                27000
+                if self.disk_type == "high"
+                else 9000
+                if self.disk_type == "medium"
+                else 3000
+            )
+        raise NotImplementedError(f'Disk type of cloud {self.cloud} is not implemented yet.')
 
     def _set_cpus(
         self,
@@ -815,6 +856,7 @@ class Resources:
             region=override.pop('region', self.region),
             zone=override.pop('zone', self.zone),
             image_id=override.pop('image_id', self.image_id),
+            disk_type=override.pop('disk_type', self.disk_type),
         )
         assert len(override) == 0
         return resources
@@ -867,6 +909,8 @@ class Resources:
             logger.warning('image_id in resources is experimental. It only '
                            'supports AWS/GCP.')
             resources_fields['image_id'] = config.pop('image_id')
+        if config.get('disk_type') is not None:
+            resources_fields['disk_type'] = config.pop('disk_type')
 
         assert not config, f'Invalid resource args: {config.keys()}'
         return Resources(**resources_fields)
@@ -893,6 +937,7 @@ class Resources:
         add_if_not_none('region', self.region)
         add_if_not_none('zone', self.zone)
         add_if_not_none('image_id', self.image_id)
+        add_if_not_none('disk_type', self.disk_type)
         return config
 
     def __setstate__(self, state):
@@ -951,5 +996,9 @@ class Resources:
         image_id = state.get('_image_id', None)
         if isinstance(image_id, str):
             state['_image_id'] = {state.get('_region', None): image_id}
+        
+        disk_type = state.get('_disk_type', None)
+        if isinstance(disk_type, str):
+            state['_disk_type'] = disk_type
 
         self.__dict__.update(state)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -168,8 +168,7 @@ class Resources:
 
         disk_type = ''
         if self.disk_type is not None:
-            disk_desc = self.cloud.get_disk_desc(self.disk_type)
-            disk_type = f', disk_type={disk_desc}'
+            disk_type = f', disk_type={self.disk_type}'
 
         disk_size = ''
         if self.disk_size != _DEFAULT_DISK_SIZE_GB:
@@ -287,11 +286,6 @@ class Resources:
     @property
     def disk_type(self) -> str:
         return self._disk_type
-
-    def get_cloud_disk_type(self) -> str:
-        # default to low if not specified
-        disk_type = 'low' if self.disk_type is None else self.disk_type
-        return self.cloud.get_disk_type(disk_type)
 
     def _set_cpus(
         self,
@@ -795,6 +789,14 @@ class Resources:
 
         if self.use_spot_specified and self.use_spot != other.use_spot:
             return False
+
+        if self.disk_type is not None:
+            if other.disk_type is None:
+                return False
+            if self.disk_type != other.disk_type:
+                types = ['low', 'medium', 'high']
+                return types.index(self.disk_type) < types.index(
+                    other.disk_type)
 
         # self <= other
         return True

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -700,16 +700,12 @@ class Resources:
     def _try_validate_disk_type(self) -> None:
         if self.disk_type is None:
             return
-        if self.cloud is None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cloud must be specified when disk_type is provided.')
         if self.disk_type not in ['high', 'medium', 'low']:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'Invalid disk_type {self.disk_type}. '
                     'Please use one of "high", "medium", or "low".')
-        if self.instance_type is not None:
+        if self.cloud is not None:
             self.cloud.check_disk_type_enabled(self.instance_type,
                                                self.disk_type)
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -99,12 +99,13 @@ class Resources:
                     k.strip(): v.strip() for k, v in image_id.items()
                 }
 
-        assert disk_type in ['high', 'medium', 'low', None], f'Unsupported disk type: {disk_type}'
+        assert disk_type in ['high', 'medium', 'low',
+                             None], f'Unsupported disk type: {disk_type}'
         # default to basic disk type
         self._disk_type = disk_type if disk_type is not None else 'low'
         if isinstance(self.cloud, clouds.Azure):
             # Only S-series supported premium ssd
-            # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre
+            # see https://stackoverflow.com/questions/48590520/azure-requested-operation-cannot-be-performed-because-storage-account-type-pre  # pylint: disable=line-too-long
             series = self.instance_type.split('_')[1].lower()
             if self._disk_type == 'high' and not 's' in series:
                 self._disk_type = 'medium'
@@ -289,46 +290,30 @@ class Resources:
     @property
     def disk_type(self) -> str:
         return self._disk_type
-    
+
     def get_cloud_disk_type_str(self) -> str:
         if isinstance(self.cloud, clouds.GCP):
-            return (
-                "pd-ssd"
-                if self.disk_type == "high"
-                else "pd-balanced"
-                if self.disk_type == "medium"
-                else "pd-standard"
-            )
+            return ('pd-ssd' if self.disk_type == 'high' else 'pd-balanced'
+                    if self.disk_type == 'medium' else 'pd-standard')
         if isinstance(self.cloud, clouds.AWS):
-            return (
-                "io2"
-                if self.disk_type == "high"
-                else "gp3"
-                if self.disk_type == "medium"
-                else "gp3"
-            )
+            return ('io2' if self.disk_type == 'high' else
+                    'gp3' if self.disk_type == 'medium' else 'gp3')
         if isinstance(self.cloud, clouds.Azure):
             return (
                 # TODO(tian): maybe use UltraSSD_LRS?
-                "Premium_LRS"
-                if self.disk_type == "high"
-                else "StandardSSD_LRS"
-                if self.disk_type == "medium"
-                else "Standard_LRS"
-            )
-        raise NotImplementedError(f'Disk type of cloud {self.cloud} is not implemented yet.')
-    
+                'Premium_LRS' if self.disk_type == 'high' else 'StandardSSD_LRS'
+                if self.disk_type == 'medium' else 'Standard_LRS')
+        raise NotImplementedError(
+            f'Disk type of cloud {self.cloud} is not implemented yet.')
+
     def get_disk_iops(self) -> int:
         if isinstance(self.cloud, clouds.AWS):
-            # TODO(tian): benchmark on each cloud to make sure performance is similar
-            return (
-                27000
-                if self.disk_type == "high"
-                else 9000
-                if self.disk_type == "medium"
-                else 3000
-            )
-        raise NotImplementedError(f'Disk type of cloud {self.cloud} is not implemented yet.')
+            # TODO(tian): benchmark on each cloud to make sure performance
+            # is similar
+            return (27000 if self.disk_type == 'high' else
+                    9000 if self.disk_type == 'medium' else 3000)
+        raise NotImplementedError(
+            f'Disk type of cloud {self.cloud} is not implemented yet.')
 
     def _set_cpus(
         self,
@@ -1011,7 +996,7 @@ class Resources:
         image_id = state.get('_image_id', None)
         if isinstance(image_id, str):
             state['_image_id'] = {state.get('_region', None): image_id}
-        
+
         disk_type = state.get('_disk_type', None)
         if isinstance(disk_type, str):
             state['_disk_type'] = disk_type

--- a/sky/skylet/providers/azure/azure-vm-template.json
+++ b/sky/skylet/providers/azure/azure-vm-template.json
@@ -88,6 +88,12 @@
             "metadata": {
                 "description": "OS disk size in GBs."
             }
+        },
+        "osDiskType": {
+            "type": "string",
+            "metadata": {
+                "description": "OS disk type."
+            }
         }
     },
     "variables": {
@@ -96,7 +102,6 @@
         "networkInterfaceNamePublic": "[concat(parameters('vmName'),'-nic-public')]",
         "networkInterfaceName": "[if(parameters('provisionPublicIp'), variables('networkInterfaceNamePublic'), variables('networkInterfaceNamePrivate'))]",
         "networkIpConfig": "[guid(resourceGroup().id, parameters('vmName'))]",
-        "osDiskType": "Standard_LRS",
         "publicIpAddressName": "[concat(parameters('vmName'), '-ip' )]",
         "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'ray-vnet', 'ray-subnet')]"
     },
@@ -201,7 +206,7 @@
                     "osDisk": {
                         "createOption": "fromImage",
                         "managedDisk": {
-                            "storageAccountType": "[variables('osDiskType')]"
+                            "storageAccountType": "[parameters('osDiskType')]"
                         },
                         "diskSizeGB": "[parameters('osDiskSizeGB')]"
                     },

--- a/sky/skylet/providers/azure/azure-vm-template.json
+++ b/sky/skylet/providers/azure/azure-vm-template.json
@@ -89,7 +89,7 @@
                 "description": "OS disk size in GBs."
             }
         },
-        "osDiskType": {
+        "osDiskTier": {
             "type": "string",
             "allowedValues": [
                 "Premium_LRS",
@@ -211,7 +211,7 @@
                     "osDisk": {
                         "createOption": "fromImage",
                         "managedDisk": {
-                            "storageAccountType": "[parameters('osDiskType')]"
+                            "storageAccountType": "[parameters('osDiskTier')]"
                         },
                         "diskSizeGB": "[parameters('osDiskSizeGB')]"
                     },

--- a/sky/skylet/providers/azure/azure-vm-template.json
+++ b/sky/skylet/providers/azure/azure-vm-template.json
@@ -97,7 +97,7 @@
                 "Standard_LRS"
             ],
             "metadata": {
-                "description": "OS disk type."
+                "description": "OS disk tier."
             }
         }
     },

--- a/sky/skylet/providers/azure/azure-vm-template.json
+++ b/sky/skylet/providers/azure/azure-vm-template.json
@@ -91,6 +91,11 @@
         },
         "osDiskType": {
             "type": "string",
+            "allowedValues": [
+                "Premium_LRS",
+                "StandardSSD_LRS",
+                "Standard_LRS"
+            ],
             "metadata": {
                 "description": "OS disk type."
             }

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -48,8 +48,10 @@ available_node_types:
           Ebs:
             VolumeSize: {{disk_size}}
             VolumeType: {{disk_type}}
+            {% if custom_disk_perf %}
             Iops: {{disk_iops}}
             Throughput: {{disk_throughput}}
+            {% endif %}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -75,8 +77,10 @@ available_node_types:
           Ebs:
             VolumeSize: {{disk_size}}
             VolumeType: {{disk_type}}
+            {% if custom_disk_perf %}
             Iops: {{disk_iops}}
             Throughput: {{disk_throughput}}
+            {% endif %}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -49,6 +49,7 @@ available_node_types:
             VolumeSize: {{disk_size}}
             VolumeType: {{disk_type}}
             Iops: {{disk_iops}}
+            Throughput: {{disk_throughput}}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -75,6 +76,7 @@ available_node_types:
             VolumeSize: {{disk_size}}
             VolumeType: {{disk_type}}
             Iops: {{disk_iops}}
+            Throughput: {{disk_throughput}}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -47,10 +47,8 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            # use default Iops for gp3
-            VolumeType: gp3
-            Iops: 3000
-            Throughput: 125 
+            VolumeType: {{disk_type}}
+            Iops: {{disk_iops}}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot
@@ -75,9 +73,8 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            VolumeType: gp3
-            Iops: 3000
-            Throughput: 125 
+            VolumeType: {{disk_type}}
+            Iops: {{disk_iops}}
       {% if use_spot %}
       InstanceMarketOptions:
           MarketType: spot

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -47,7 +47,7 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            VolumeType: {{disk_type}}
+            VolumeType: {{disk_tier}}
             {% if custom_disk_perf %}
             Iops: {{disk_iops}}
             Throughput: {{disk_throughput}}
@@ -76,7 +76,7 @@ available_node_types:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: {{disk_size}}
-            VolumeType: {{disk_type}}
+            VolumeType: {{disk_tier}}
             {% if custom_disk_perf %}
             Iops: {{disk_iops}}
             Throughput: {{disk_throughput}}

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -45,6 +45,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
+            osDiskType: {{disk_type}}
             # optionally set priority to use Spot instances
             {%- if use_spot %}
             priority: Spot
@@ -52,7 +53,6 @@ available_node_types:
             # billingProfile:
             #     maxPrice: -1
             {%- endif %}
-            osDiskType: {{disk_type}}
         # TODO: attach disk
 {% if num_nodes > 1 %}
     ray.worker.default:
@@ -70,6 +70,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
+            osDiskType: {{disk_type}}
           {%- if use_spot %}
             priority: Spot
             # set a maximum price for spot instances if desired

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -45,7 +45,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
-            osDiskType: {{disk_type}}
+            osDiskType: {{disk_tier}}
             # optionally set priority to use Spot instances
             {%- if use_spot %}
             priority: Spot
@@ -70,7 +70,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
-            osDiskType: {{disk_type}}
+            osDiskType: {{disk_tier}}
           {%- if use_spot %}
             priority: Spot
             # set a maximum price for spot instances if desired

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -45,7 +45,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
-            osDiskType: {{disk_tier}}
+            osDiskTier: {{disk_tier}}
             # optionally set priority to use Spot instances
             {%- if use_spot %}
             priority: Spot
@@ -70,7 +70,7 @@ available_node_types:
             imageSku: "{{image_sku}}"
             imageVersion: {{image_version}}
             osDiskSizeGB: {{disk_size}}
-            osDiskType: {{disk_tier}}
+            osDiskTier: {{disk_tier}}
           {%- if use_spot %}
             priority: Spot
             # set a maximum price for spot instances if desired

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -52,6 +52,7 @@ available_node_types:
             # billingProfile:
             #     maxPrice: -1
             {%- endif %}
+            osDiskType: {{disk_type}}
         # TODO: attach disk
 {% if num_nodes > 1 %}
     ray.worker.default:

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -54,6 +54,7 @@ available_node_types:
             diskSizeGb: {{disk_size}}
             # See https://cloud.google.com/deep-learning-vm/docs/images
             sourceImage: {{image_id}}
+            diskType: zones/{{zones}}/diskTypes/{{disk_type}}
   {%- if gpu is not none %}
       guestAccelerators:
         - acceleratorType: projects/{{gcp_project_id}}/zones/{{zones}}/acceleratorTypes/{{gpu}}
@@ -96,6 +97,7 @@ available_node_types:
             diskSizeGb: {{disk_size}}
             # See https://cloud.google.com/deep-learning-vm/docs/images
             sourceImage: {{image_id}}
+            diskType: zones/{{zones}}/diskTypes/{{disk_type}}
     {%- if gpu is not none %}
       guestAccelerators:
         - acceleratorType: projects/{{gcp_project_id}}/zones/{{zones}}/acceleratorTypes/{{gpu}}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -54,7 +54,7 @@ available_node_types:
             diskSizeGb: {{disk_size}}
             # See https://cloud.google.com/deep-learning-vm/docs/images
             sourceImage: {{image_id}}
-            diskType: zones/{{zones}}/diskTypes/{{disk_type}}
+            diskType: zones/{{zones}}/diskTypes/{{disk_tier}}
   {%- if gpu is not none %}
       guestAccelerators:
         - acceleratorType: projects/{{gcp_project_id}}/zones/{{zones}}/acceleratorTypes/{{gpu}}
@@ -97,7 +97,7 @@ available_node_types:
             diskSizeGb: {{disk_size}}
             # See https://cloud.google.com/deep-learning-vm/docs/images
             sourceImage: {{image_id}}
-            diskType: zones/{{zones}}/diskTypes/{{disk_type}}
+            diskType: zones/{{zones}}/diskTypes/{{disk_tier}}
     {%- if gpu is not none %}
       guestAccelerators:
         - acceleratorType: projects/{{gcp_project_id}}/zones/{{zones}}/acceleratorTypes/{{gpu}}

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -5,7 +5,7 @@ name: {{task_name}}
 resources:
   disk_size: 50
 # It is now using default CPU instance type hard-coded in code for spot controller,
-# i.e. m6i.2xlarge (8vCPUs, 32 GB) for AWS, Standard_D8_v4 (8vCPUs, 32 GB) for Azure, and n1-highmem-8 (8 vCPUs, 52 GB) for GCP.
+# i.e. m6i.2xlarge (8vCPUs, 32 GB) for AWS, Standard_D8s_v4 (8vCPUs, 32 GB) for Azure, and n1-highmem-8 (8 vCPUs, 52 GB) for GCP.
 # This allows users without the credits for some of the clouds available to use managed spot instances.
 # TODO(zhwu): Fix this to be able to failvoer across clouds with cheaper instance.
 #  instance_type: t3.xlarge

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -63,6 +63,9 @@ def get_resources_schema():
             'disk_size': {
                 'type': 'integer',
             },
+            'disk_tier': {
+                'type': 'string',
+            },
             'accelerator_args': {
                 'type': 'object',
                 'required': [],

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -253,7 +253,7 @@ def test_instance_type_from_cpu_memory(monkeypatch, capfd):
     stdout, _ = capfd.readouterr()
     # Choose General Purpose instance types
     assert 'm6i.2xlarge' in stdout  # AWS, 8 vCPUs, 32 GB memory
-    assert 'Standard_D8_v5' in stdout  # Azure, 8 vCPUs, 32 GB memory
+    assert 'Standard_D8s_v5' in stdout  # Azure, 8 vCPUs, 32 GB memory
     assert 'n2-standard-8' in stdout  # GCP, 8 vCPUs, 32 GB memory
 
     _test_resources_launch(monkeypatch, memory=32)
@@ -261,14 +261,14 @@ def test_instance_type_from_cpu_memory(monkeypatch, capfd):
     # Choose memory-optimized instance types, when the memory
     # is specified
     assert 'r6i.xlarge' in stdout  # AWS, 4 vCPUs, 32 GB memory
-    assert 'Standard_E4_v5' in stdout  # Azure, 4 vCPUs, 32 GB memory
+    assert 'Standard_E4s_v5' in stdout  # Azure, 4 vCPUs, 32 GB memory
     assert 'n2-highmem-4' in stdout  # GCP, 4 vCPUs, 32 GB memory
 
     _test_resources_launch(monkeypatch, memory='64+')
     stdout, _ = capfd.readouterr()
     # Choose memory-optimized instance types
     assert 'r6i.2xlarge' in stdout  # AWS, 8 vCPUs, 64 GB memory
-    assert 'Standard_E8_v5' in stdout  # Azure, 8 vCPUs, 64 GB memory
+    assert 'Standard_E8s_v5' in stdout  # Azure, 8 vCPUs, 64 GB memory
     assert 'n2-highmem-8' in stdout  # GCP, 8 vCPUs, 64 GB memory
     assert 'gpu_1x_a6000' in stdout  # Lambda, 14 vCPUs, 100 GB memory
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1662,7 +1662,7 @@ def test_aws_disk_tier():
                 f'--query Volumes[*].{field} | grep {expected} ; ')
 
     for disk_tier in ['low', 'medium', 'high']:
-        specs = AWS.get_disk_specs(disk_tier)
+        specs = AWS._get_disk_specs(disk_tier)
         name = _get_cluster_name() + '-' + disk_tier
         region = 'us-west-2'
         test = Test(
@@ -1689,7 +1689,7 @@ def test_aws_disk_tier():
 
 def test_gcp_disk_tier():
     for disk_tier in ['low', 'medium', 'high']:
-        type = GCP.get_disk_type(disk_tier)
+        type = GCP._get_disk_type(disk_tier)
         name = _get_cluster_name() + '-' + disk_tier
         region = 'us-west2'
         test = Test(
@@ -1710,7 +1710,7 @@ def test_gcp_disk_tier():
 
 def test_azure_disk_tier():
     for disk_tier in ['low', 'medium']:
-        type = Azure.get_disk_type(disk_tier)
+        type = Azure._get_disk_type(disk_tier)
         name = _get_cluster_name() + '-' + disk_tier
         region = 'westus2'
         test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1708,6 +1708,26 @@ def test_gcp_disk_tier():
         run_one_test(test)
 
 
+def test_azure_disk_tier():
+    for disk_tier in ['low', 'medium']:
+        type = Azure.get_disk_type(disk_tier)
+        name = _get_cluster_name() + '-' + disk_tier
+        region = 'westus2'
+        test = Test(
+            'azure-disk-tier',
+            [
+                f'sky launch -y -c {name} --cloud azure --region {region} '
+                f'--disk-tier {disk_tier} echo "hello sky"',
+                f'az resource list --tag ray-cluster-name={name} --query '
+                f'"[?type==\'Microsoft.Compute/disks\'].sku.name" '
+                f'--output tsv | grep {type}'
+            ],
+            f'sky down -y {name}',
+            timeout=20 * 60,  # 20 mins  (it takes around ~12 mins)
+        )
+        run_one_test(test)
+
+
 # ------- Testing the core API --------
 # Most of the core APIs have been tested in the CLI tests.
 # These tests are for testing the return value of the APIs not fully used in CLI.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1666,7 +1666,7 @@ def test_aws_disk_tier():
         name = _get_cluster_name() + '-' + disk_tier
         region = 'us-west-2'
         test = Test(
-            'azure-disk-tier',
+            'aws-disk-tier',
             [
                 f'sky launch -y -c {name} --cloud aws --region {region} '
                 f'--disk-tier {disk_tier} echo "hello sky"',
@@ -1683,6 +1683,27 @@ def test_aws_disk_tier():
             ],
             f'sky down -y {name}',
             timeout=10 * 60,  # 10 mins  (it takes around ~6 mins)
+        )
+        run_one_test(test)
+
+
+def test_gcp_disk_tier():
+    for disk_tier in ['low', 'medium', 'high']:
+        type = GCP.get_disk_type(disk_tier)
+        name = _get_cluster_name() + '-' + disk_tier
+        region = 'us-west2'
+        test = Test(
+            'gcp-disk-tier',
+            [
+                f'sky launch -y -c {name} --cloud gcp --region {region} '
+                f'--disk-tier {disk_tier} echo "hello sky"',
+                f'name=`gcloud compute instances list --filter='
+                f'"labels.ray-cluster-name:{name}" --format="value(name)"`; '
+                f'gcloud compute disks list --filter="name=$name" '
+                f'--format="value(type)" | grep {type} '
+            ],
+            f'sky down -y {name}',
+            timeout=6 * 60,  # 6 mins  (it takes around ~3 mins)
         )
         run_one_test(test)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduces multi-level performance disks in all clouds. By specifying `disk_tier` in `sky.Resources` to one of `high`, `medium`, and `low`, a user could use a disk with custom performance. All clouds' current decisions and prices (256 GB for example) are shown below.

`disk_tier=low`
|Cloud|Disk Type|Benchmarked Read Throughput|Benchmarked Read IOPS|Benchmarked Write Throughput|Benchmarked Write IOPS|Price (GiB/mo)|Price (IOPS/mo)|Total Price Each Month|
|-|-|-|-|-|-|-|-|-|
|GCP|pd-standard|13.87 MB/s|211.63|37.17 MB/s|567.13|0.048|-|12.288|
|Azure|Standard_LRS|861.92 MB/s|13151.92|36.67 MB/s|559.54|-|-|11.328|
|AWS|standard|20.33 MB/s|310.14|282.19 MB/s|4305.91|0.066|-|16.896|

`disk_tier=medium`
|Cloud|Disk Type|Benchmarked Read Throughput|Benchmarked Read IOPS|Benchmarked Write Throughput|Benchmarked Write IOPS|Price (GiB/mo)|Price (IOPS/mo)|Total Price Each Month|
|-|-|-|-|-|-|-|-|-|
|GCP|pd-balanced|222.86 MB/s|3400.58|222.25 MB/s|3391.25|0.12|-|30.72|
|Azure|Premium_LRS|211.80 MB/s|3231.88|176.12 MB/s|2687.44|-|-|36.29|
|AWS|gp3 with IOPS=3500|241.43 MB/s|3683.87|199.15 MB/s|3038.86|0.09|0.005|25.54|

`disk_tier=high`
|Cloud|Disk Type|Benchmarked Read Throughput|Benchmarked Read IOPS|Benchmarked Write Throughput|Benchmarked Write IOPS|Price (GiB/mo)|Price (IOPS/mo)|Total Price Each Month|
|-|-|-|-|-|-|-|-|-|
|GCP|pd-ssd|342.91 MB/s|5232.42|268.17 MB/s|4091.91|0.203|-|51.968|
|Azure|-|-|-|-|-|-|-|-|
|AWS|gp3 with IOPS=7000|323.54 MB/s|4936.80|254.82 MB/s|3888.22|0.09|0.005|43.04|

Azure `disk_tier=high` is disabled now since a high-performance disk in Azure cannot be launched as an OS disk.

Benchmark command:

```shell
fio --name=sync_rand_64k_{read, write}s  --rw=rand{read, write}  --direct=1 --ioengine=sync --bs=64k --numjobs=4 --iodepth=128 --size=1G --group_reporting --directory=/tmp/
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
