### PR TITLE
Fix errors from empty 'resources' field in YAML.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2459,7 +2459,9 @@ def validate_schema(obj, schema, err_msg_prefix=''):
                     else:
                         err_msg += f'\nFound unsupported field {field!r}.'
         else:
-            err_msg = err_msg_prefix + e.message
+            # Example e.json_path value: '$.resources'
+            err_msg = (err_msg_prefix + e.message +
+                       f'. Check problematic field(s): {e.json_path}')
 
     if err_msg:
         with ux_utils.print_exception_no_traceback():

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -989,9 +989,6 @@ def _make_task_from_entrypoint_with_overrides(
             click.secho('Task from command: ', fg='yellow', nl=False)
             click.secho(entrypoint, bold=True)
 
-    if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
-        cloud = 'local'
-
     if is_yaml:
         usage_lib.messages.usage.update_user_task_yaml(entrypoint)
         task = sky.Task.from_yaml(entrypoint)
@@ -1002,6 +999,9 @@ def _make_task_from_entrypoint_with_overrides(
     # Override.
     if workdir is not None:
         task.workdir = workdir
+
+    if onprem_utils.check_local_cloud_args(cloud, cluster, yaml_config):
+        cloud = 'local'
 
     override_params = _parse_override_params(cloud=cloud,
                                              region=region,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Repro: create a YAML like this
```yaml
resources:
  # commented out!
```
Previously:
```
» sky launch test.yaml
...
File .. sky/backends/onprem_utils.py", line 492, in check_local_cloud_args
    yaml_cloud = yaml_config['resources'].get('cloud')
AttributeError: 'NoneType' object has no attribute 'get'
```
Now:
```
» sky launch test.yaml
Task from YAML spec: test.yaml
ValueError: Invalid task YAML: None is not of type 'object'. Check problematic field(s): $.resources
```
The fix is we do `check_local_cloud_args()` after `Task` ctor which performs schema validation.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - above