### PR TITLE
[SSO/Spot] Fix spot controller failed to launch spot cluster when using SSO

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2467,7 +2467,11 @@ def validate_schema(obj, schema, err_msg_prefix=''):
 
 
 def check_public_cloud_enabled():
-    """Checks if any of the public clouds is enabled."""
+    """Checks if any of the public clouds is enabled.
+
+    Exceptions:
+        exceptions.AllCloudDisabledError: if no public cloud is enabled.
+    """
 
     def _no_public_cloud():
         enabled_clouds = global_user_state.get_enabled_clouds()
@@ -2481,7 +2485,7 @@ def check_public_cloud_enabled():
     sky_check.check(quiet=True)
     if _no_public_cloud():
         with ux_utils.print_exception_no_traceback():
-            raise RuntimeError(
+            raise exceptions.AllCloudDisabledError(
                 'Cloud access is not set up. Run: '
                 f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2470,7 +2470,7 @@ def check_public_cloud_enabled():
     """Checks if any of the public clouds is enabled.
 
     Exceptions:
-        exceptions.AllCloudDisabledError: if no public cloud is enabled.
+        exceptions.NoCloudAccessError: if no public cloud is enabled.
     """
 
     def _no_public_cloud():
@@ -2485,7 +2485,7 @@ def check_public_cloud_enabled():
     sky_check.check(quiet=True)
     if _no_public_cloud():
         with ux_utils.print_exception_no_traceback():
-            raise exceptions.AllCloudDisabledError(
+            raise exceptions.NoCloudAccessError(
                 'Cloud access is not set up. Run: '
                 f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -721,7 +721,7 @@ def _launch_with_confirm(
         # Show the optimize log before the prompt if the cluster does not exist.
         try:
             backend_utils.check_public_cloud_enabled()
-        except exceptions.AllCloudDisabledError as e:
+        except exceptions.NoCloudAccessError as e:
             # Catch the exception where the public cloud is not enabled, and
             # only print the error message without the error type.
             click.secho(e, fg='yellow')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -721,7 +721,7 @@ def _launch_with_confirm(
         # Show the optimize log before the prompt if the cluster does not exist.
         try:
             backend_utils.check_public_cloud_enabled()
-        except RuntimeError as e:
+        except exceptions.AllCloudDisabledError as e:
             # Catch the exception where the public cloud is not enabled, and
             # only print the error message without the error type.
             click.secho(e, fg='yellow')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -419,7 +419,7 @@ class AWS(clouds.Cloud):
             'if you want to use multiple clouds. To set up static credentials, '
             'try: aws configure')
         if identity_type == AWSIdentityType.SSO:
-            hints = 'AWS SSO is set. '
+            hints = 'AWS SSO is set.'
             if static_credential_exists:
                 hints += (
                     ' To ensure multiple clouds work correctly, please use SkyPilot '
@@ -433,7 +433,7 @@ class AWS(clouds.Cloud):
             # file. This will happen when the user is on the VM (or spot-controller)
             # created by SSO account, i.e. the VM will be assigned with the IAM
             # role: skypilot-v1.
-            hints = f'AWS IAM role is set. {single_cloud_hint}'
+            hints = f'AWS IAM role is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on
             # other clouds to access private s3 buckets and resources like EC2.

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -202,3 +202,8 @@ class CloudUserIdentityError(Exception):
 class ClusterOwnerIdentityMismatchError(Exception):
     """The cluster's owner identity does not match the current user identity."""
     pass
+
+
+class AllCloudDisabledError(Exception):
+    """Raised when all clouds are disabled."""
+    pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -204,6 +204,6 @@ class ClusterOwnerIdentityMismatchError(Exception):
     pass
 
 
-class AllCloudDisabledError(Exception):
+class NoCloudAccessError(Exception):
     """Raised when all clouds are disabled."""
     pass

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -415,6 +415,7 @@ def launch(
                 our pre-checks (e.g., cluster name invalid) or a region/zone
                 throwing resource unavailability.
         exceptions.CommandError: any ssh command error.
+        exceptions.NoCloudAccessError: if all clouds are disabled.
     Other exceptions may be raised depending on the backend.
     """
     entrypoint = task

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -105,6 +105,7 @@ class Optimizer:
         Raises:
             exceptions.ResourcesUnavailableError: if no resources are available
                 for a task.
+            exceptions.AllCloudDisabledError: if no public clouds are enabled.
         """
         # This function is effectful: mutates every node in 'dag' by setting
         # node.best_resources if it is None.

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -105,7 +105,7 @@ class Optimizer:
         Raises:
             exceptions.ResourcesUnavailableError: if no resources are available
                 for a task.
-            exceptions.AllCloudDisabledError: if no public clouds are enabled.
+            exceptions.NoCloudAccessError: if no public clouds are enabled.
         """
         # This function is effectful: mutates every node in 'dag' by setting
         # node.best_resources if it is None.

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -253,7 +253,7 @@ class StrategyExecutor:
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
             except (exceptions.InvalidClusterNameError,
-                    exceptions.AllCloudDisabledError) as e:
+                    exceptions.NoCloudAccessError) as e:
                 logger.error('Failure happened before provisioning. '
                              f'{common_utils.format_exception(e)}')
                 if raise_on_failure:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -252,7 +252,8 @@ class StrategyExecutor:
                            detach_run=True,
                            _is_launched_by_spot_controller=True)
                 logger.info('Spot cluster launched.')
-            except exceptions.InvalidClusterNameError as e:
+            except (exceptions.InvalidClusterNameError,
+                    exceptions.AllCloudDisabledError) as e:
                 logger.error('Failure happened before provisioning. '
                              f'{common_utils.format_exception(e)}')
                 if raise_on_failure:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that when using AWS SSO account, the `sky spot launch` will fail due to the controller does not have any cloud access enabled. That is a bug with our current SSO implementation, as the controller is assigned with an assumed IAM-role, which has the access to create the spot cluster and will not have static credential files, but our cloud access checking will fail when it finds there is no credential files.
Another problem with the spot controller is: the controller will keep retrying even if the all cloud disabled exception is raised, causing the spot job in STARTING status forever.

To reproduce:
1. Run in a new docker container
2. log in with SSO account
3. `sky spot launch -n test echo hi --retry-until-up`

This PR fixes:
1. The spot controller will now be able to launch the spot cluster when the user is using AWS SSO
2. Spot controller will be able to catch the all cloud disabled exception and fail early. (This is for any potential future identity problem with that exception)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] The reproducible script process.
