### PR TITLE
Show DEVICE_MEMORY in `show-gpus` for AWS & Lambda.

### DIFF
--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -19,8 +19,8 @@ def import_package(func):
                 googleapiclient = _googleapiclient
                 google = _google
             except ImportError:
-                raise ImportError('Fail to import dependencies for GCP.'
-                                  'Try pip install "skypilot[gcp]"') from None
+                raise ImportError('Failed to import dependencies for GCP. '
+                                  'Try: pip install "skypilot[gcp]"') from None
         return func(*args, **kwargs)
 
     return wrapper

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3033,8 +3033,8 @@ def show_gpus(
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
-                device_memory_str = f'{item.device_memory:.0f}GB' if not pd.isna(
-                    item.device_memory) else '-'
+                device_memory_str = (f'{item.device_memory:.0f}GB' if
+                                     not pd.isna(item.device_memory) else '-')
                 host_memory_str = f'{item.memory:.0f}GB' if not pd.isna(
                     item.memory) else '-'
                 price_str = f'$ {item.price:.3f}' if not pd.isna(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2938,8 +2938,16 @@ def show_gpus(
     To show all accelerators, including less common ones and their detailed
     information, use ``sky show-gpus --all``.
 
-    NOTE: If region is not specified, the price displayed for each instance type
-    is the lowest across all regions for both on-demand and spot instances.
+    Definitions of certain fields:
+
+    * ``DEVICE_MEM``: Memory of a single device; does not depend on the device
+      count of the instance (VM).
+
+    * ``HOST_MEM``: Memory of the host instance (VM).
+
+    If ``--region`` is not specified, the price displayed for each instance
+    type is the lowest across all regions for both on-demand and spot
+    instances. There may be multiple regions with the same lowest price.
     """
     # validation for the --region flag
     if region is not None and cloud is None:
@@ -3012,9 +3020,9 @@ def show_gpus(
                 'QTY',
                 'CLOUD',
                 'INSTANCE_TYPE',
+                'DEVICE_MEM',
                 'vCPUs',
-                'DEVICE_MEMORY',
-                'HOST_MEMORY',
+                'HOST_MEM',
                 'HOURLY_PRICE',
                 'HOURLY_SPOT_PRICE',
             ]
@@ -3047,8 +3055,8 @@ def show_gpus(
                     item.accelerator_count,
                     item.cloud,
                     instance_type_str,
-                    cpu_str,
                     device_memory_str,
+                    cpu_str,
                     host_memory_str,
                     price_str,
                     spot_price_str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3013,6 +3013,7 @@ def show_gpus(
                 'CLOUD',
                 'INSTANCE_TYPE',
                 'vCPUs',
+                'DEVICE_MEMORY',
                 'HOST_MEMORY',
                 'HOURLY_PRICE',
                 'HOURLY_SPOT_PRICE',
@@ -3032,7 +3033,9 @@ def show_gpus(
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
-                mem_str = f'{item.memory:.0f}GB' if not pd.isna(
+                device_memory_str = f'{item.device_memory:.0f}GB' if not pd.isna(
+                    item.device_memory) else '-'
+                host_memory_str = f'{item.memory:.0f}GB' if not pd.isna(
                     item.memory) else '-'
                 price_str = f'$ {item.price:.3f}' if not pd.isna(
                     item.price) else '-'
@@ -3045,7 +3048,8 @@ def show_gpus(
                     item.cloud,
                     instance_type_str,
                     cpu_str,
-                    mem_str,
+                    device_memory_str,
+                    host_memory_str,
                     price_str,
                     spot_price_str,
                 ]

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -181,8 +181,8 @@ def validate_region_zone_impl(
 
     def _get_all_supported_regions_str() -> str:
         all_regions: List[str] = sorted(df['Region'].unique().tolist())
-        return \
-        f'\nList of supported {cloud_name} regions: {", ".join(all_regions)!r}'
+        return (f'\nList of supported {cloud_name} regions: '
+                f'{", ".join(all_regions)!r}')
 
     validated_region, validated_zone = region, zone
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -1,4 +1,5 @@
 """Common utilities for service catalog."""
+import ast
 import hashlib
 import os
 import time
@@ -31,6 +32,7 @@ class InstanceTypeInfo(NamedTuple):
     - accelerator_name: Canonical name of the accelerator. E.g. `V100`.
     - accelerator_count: Number of accelerators offered by this instance type.
     - cpu_count: Number of vCPUs offered by this instance type.
+    - device_memory: Device memory in GiB.
     - memory: Instance memory in GiB.
     - price: Regular instance price per hour (cheapest across all regions).
     - spot_price: Spot instance price per hour (cheapest across all regions).
@@ -41,6 +43,7 @@ class InstanceTypeInfo(NamedTuple):
     accelerator_name: str
     accelerator_count: int
     cpu_count: Optional[float]
+    device_memory: Optional[float]
     memory: Optional[float]
     price: float
     spot_price: float
@@ -435,12 +438,26 @@ def list_accelerators_impl(
     """
     if gpus_only:
         df = df[~df['GpuInfo'].isna()]
+    df = df.copy()  # avoid column assignment warning
+
+    try:
+        gpu_info_df = df['GpuInfo'].apply(ast.literal_eval)
+        df['DeviceMemoryGiB'] = gpu_info_df.apply(
+            lambda row: row['Gpus'][0]['MemoryInfo']['SizeInMiB']) / 1024.0
+    except ValueError:
+        # TODO(zongheng,woosuk): GCP/Azure catalogs do not have well-formed
+        # GpuInfo fields. So the above will throw:
+        #  ValueError: malformed node or string: <_ast.Name object at ..>
+        df['DeviceMemoryGiB'] = None
+
+    # import ipdb; ipdb.set_trace()
     df = df[[
         'InstanceType',
         'AcceleratorName',
         'AcceleratorCount',
         'vCPUs',
-        'MemoryGiB',
+        'DeviceMemoryGiB',  # device memory
+        'MemoryGiB',  # host memory
         'Price',
         'SpotPrice',
         'Region',
@@ -470,6 +487,7 @@ def list_accelerators_impl(
                 row['AcceleratorName'],
                 row['AcceleratorCount'],
                 row['vCPUs'],
+                row['DeviceMemoryGiB'],
                 row['MemoryGiB'],
                 row['Price'],
                 row['SpotPrice'],

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -450,7 +450,6 @@ def list_accelerators_impl(
         #  ValueError: malformed node or string: <_ast.Name object at ..>
         df['DeviceMemoryGiB'] = None
 
-    # import ipdb; ipdb.set_trace()
     df = df[[
         'InstanceType',
         'AcceleratorName',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Partially address #1764: only AWS & Lambda catalogs have the relevant info for now.

Azure / GCP's offerings will show a `-` under the `DEVICE_MEM` column.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - `sky show-gpus -a`
- [x] AWS smoke tests: `pytest tests/test_smoke.py --aws` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
