### PR TITLE
[AWS] Enable p4de in the catalog

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -300,7 +300,7 @@ def get_all_regions_instance_types_df(regions: Set[str]) -> pd.DataFrame:
             new_dfs.append(df_or_region)
 
     df = pd.concat(new_dfs)
-    df.sort_values(['InstanceType', 'Region'], inplace=True)
+    df.sort_values(['InstanceType', 'Region', 'AvailabilityZone'], inplace=True)
     return df
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -183,9 +183,9 @@ def _patch_p4de(region: str, df: pd.DataFrame,
             'vCPUs': 96,
             'MemoryGiB': 1152,
             'GpuInfo': (
-                '{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': \'NVIDIA\', '
-                '\'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': 40960}}], '
-                '\'TotalGpuMemoryInMiB\': 327680}'),
+                '{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': '
+                '\'NVIDIA\', \'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': '
+                '40960}}], \'TotalGpuMemoryInMiB\': 327680}'),
             'AvailabilityZone': zone,
             'Region': region,
             'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -182,10 +182,10 @@ def _patch_p4de(region: str, df: pd.DataFrame,
             'AcceleratorCount': 8,
             'vCPUs': 96,
             'MemoryGiB': 1152,
-            'GpuInfo': (
-                '{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': '
-                '\'NVIDIA\', \'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': '
-                '40960}}], \'TotalGpuMemoryInMiB\': 327680}'),
+            'GpuInfo':
+                ('{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': '
+                 '\'NVIDIA\', \'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': '
+                 '40960}}], \'TotalGpuMemoryInMiB\': 327680}'),
             'AvailabilityZone': zone,
             'Region': region,
             'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -60,6 +60,9 @@ USEFUL_COLUMNS = [
 # only available in this region, but it serves pricing information for all
 # regions.
 PRICING_TABLE_URL_FMT = 'https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/{region}/index.csv'  # pylint: disable=line-too-long
+# Hardcode the regions that offer p4de.24xlarge as our credential does not have
+# the permission to query the offerings of the instance.
+# Ref: https://aws.amazon.com/ec2/instance-types/p4/
 P4DE_REGIONS = ['us-east-1', 'us-west-2']
 
 regions_enabled: Optional[Set[str]] = None
@@ -185,7 +188,7 @@ def _patch_p4de(region: str, df: pd.DataFrame,
             'GpuInfo':
                 ('{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': '
                  '\'NVIDIA\', \'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': '
-                 '40960}}], \'TotalGpuMemoryInMiB\': 327680}'),
+                 '81920}}], \'TotalGpuMemoryInMiB\': 655360}'),
             'AvailabilityZone': zone,
             'Region': region,
             'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -6,6 +6,7 @@ import datetime
 import itertools
 from multiprocessing import pool as mp_pool
 import os
+import sys
 import subprocess
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -59,6 +60,7 @@ USEFUL_COLUMNS = [
 # only available in this region, but it serves pricing information for all
 # regions.
 PRICING_TABLE_URL_FMT = 'https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/{region}/index.csv'  # pylint: disable=line-too-long
+P4DE_REGIONS = ['us-east-1', 'us-west-2']
 
 regions_enabled: Optional[Set[str]] = None
 
@@ -166,6 +168,34 @@ def _get_spot_pricing_table(region: str) -> pd.DataFrame:
     return df
 
 
+def _patch_p4de(region: str, df: pd.DataFrame,
+                pricing_df: pd.DataFrame) -> pd.DataFrame:
+    # Hardcoded patch for p4de.24xlarge, as our credentials doesn't have access
+    # to the instance type.
+    # Columns:
+    # InstanceType,AcceleratorName,AcceleratorCount,vCPUs,MemoryGiB,GpuInfo,
+    # Price,SpotPrice,Region,AvailabilityZone
+    for zone in df[df['Region'] == region]['AvailabilityZone'].unique():
+        df = df.append(pd.Series({
+            'InstanceType': 'p4de.24xlarge',
+            'AcceleratorName': 'A100-80GB',
+            'AcceleratorCount': 8,
+            'vCPUs': 96,
+            'MemoryGiB': 1152,
+            'GpuInfo': (
+                '{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': \'NVIDIA\', '
+                '\'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': 40960}}], '
+                '\'TotalGpuMemoryInMiB\': 327680}'),
+            'AvailabilityZone': zone,
+            'Region': region,
+            'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']
+                     ['Price'].values[0],
+            'SpotPrice': np.nan,
+        }),
+                       ignore_index=True)
+    return df
+
+
 def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
     try:
         # Fetch the zone info first to make sure the account has access to the
@@ -247,11 +277,14 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = pd.concat(
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
-        # patch the GpuInfo for p4de.24xlarge
-        df.loc[df['InstanceType'] == 'p4de.24xlarge', 'GpuInfo'] = 'A100-80GB'
+        # patch the df for p4de.24xlarge
+        if region in P4DE_REGIONS:
+            df = _patch_p4de(region, df, pricing_df)
+        if 'GpuInfo' not in df.columns:
+            df['GpuInfo'] = np.nan
         df = df[USEFUL_COLUMNS]
     except Exception as e:  # pylint: disable=broad-except
-        print(f'{region} failed with {e}')
+        print(f'{region} failed with {e}', file=sys.stderr)
         return region
     return df
 
@@ -402,9 +435,10 @@ if __name__ == '__main__':
             # requested are the same as the ones we fetched.
             # The mismatch could happen for network issues or glitches
             # in the AWS API.
+            diff = user_regions - fetched_regions
             raise RuntimeError(
                 f'{name}: Fetched regions {fetched_regions} does not match '
-                f'requested regions {user_regions}.')
+                f'requested regions {user_regions}; Diff: {diff}')
 
     instance_df = get_all_regions_instance_types_df(user_regions)
     _check_regions_integrity(instance_df, 'instance types')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Since our AWS credential does not have permission to query the offerings for A100-80GB instances, we now hardcoded it in our `fetch_aws` to unblock the uses of that instance for users.

Fixes #1201

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_aws`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
