### PR TITLE
[GCP Storage] Upgrade GCSFuse version

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -56,7 +56,7 @@ _GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
 GCLOUD_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     gcloud --help > /dev/null 2>&1 || \
     {{ mkdir -p {os.path.dirname(_GCLOUD_INSTALLATION_LOG)} && \
-    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-382.0.0-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
+    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-424.0.0-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
     tar xzf google-cloud-sdk-382.0.0-linux-x86_64.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
     rm -rf ~/google-cloud-sdk >> {_GCLOUD_INSTALLATION_LOG}  && \
     mv google-cloud-sdk ~/ && \

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -50,14 +50,15 @@ _CREDENTIAL_FILES = [
 ]
 
 _GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
+_GCLOUD_VERSION = '424.0.0'
 # Need to be run with /bin/bash
 # We factor out the installation logic to keep it align in both spot
 # controller and cloud stores.
 GCLOUD_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     gcloud --help > /dev/null 2>&1 || \
     {{ mkdir -p {os.path.dirname(_GCLOUD_INSTALLATION_LOG)} && \
-    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-424.0.0-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
-    tar xzf google-cloud-sdk-382.0.0-linux-x86_64.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
+    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
+    tar xzf google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
     rm -rf ~/google-cloud-sdk >> {_GCLOUD_INSTALLATION_LOG}  && \
     mv google-cloud-sdk ~/ && \
     ~/google-cloud-sdk/install.sh -q >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -8,7 +8,7 @@ def get_mounting_command(
     mount_path: str,
     install_cmd: str,
     mount_cmd: str,
-    version: Optional[str] = None,
+    version_check_cmd: Optional[str] = None,
 ) -> str:
     """
     Generates the mounting command for a given bucket. Generated script first
@@ -27,8 +27,8 @@ def get_mounting_command(
     """
     mount_binary = mount_cmd.split()[0]
     installed_check = f'[ -x "$(command -v {mount_binary})" ]'
-    if version is not None:
-        installed_check += f' && {mount_binary} --version | grep -q {version}'
+    if version_check_cmd is not None:
+        installed_check += f' && {version_check_cmd}'
     script = textwrap.dedent(f"""
         #!/usr/bin/env bash
         set -e

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -26,9 +26,9 @@ def get_mounting_command(
         str: Mounting command with the mounting script as a heredoc.
     """
     mount_binary = mount_cmd.split()[0]
-    not_installed_check = f'! [ -x "$(command -v {mount_binary})" ]'
+    installed_check = f'[ -x "$(command -v {mount_binary})" ]'
     if version is not None:
-        not_installed_check += f' || {mount_binary} --version | grep -q {version}'
+        installed_check += f' && {mount_binary} --version | grep -q {version}'
     script = textwrap.dedent(f"""
         #!/usr/bin/env bash
         set -e
@@ -44,11 +44,11 @@ def get_mounting_command(
         fi
 
         # Install MOUNT_BINARY if not already installed
-        if {not_installed_check}; then
+        if {installed_check}; then
+          echo "$MOUNT_BINARY already installed. Proceeding..."
+        else
           echo "Installing $MOUNT_BINARY..."
           {install_cmd}
-        else
-          echo "$MOUNT_BINARY already installed. Proceeding..."
         fi
 
         # Check if mount path exists

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -1,12 +1,14 @@
 """Helper functions for object store mounting in Sky Storage"""
 import random
 import textwrap
+from typing import Optional
 
 
 def get_mounting_command(
     mount_path: str,
     install_cmd: str,
     mount_cmd: str,
+    version: Optional[str] = None,
 ) -> str:
     """
     Generates the mounting command for a given bucket. Generated script first
@@ -24,6 +26,9 @@ def get_mounting_command(
         str: Mounting command with the mounting script as a heredoc.
     """
     mount_binary = mount_cmd.split()[0]
+    not_installed_check = f'! [ -x "$(command -v {mount_binary})" ]'
+    if version is not None:
+        not_installed_check += f' || {mount_binary} --version | grep -q {version}'
     script = textwrap.dedent(f"""
         #!/usr/bin/env bash
         set -e
@@ -39,7 +44,7 @@ def get_mounting_command(
         fi
 
         # Install MOUNT_BINARY if not already installed
-        if ! [ -x "$(command -v $MOUNT_BINARY)" ]; then
+        if {not_installed_check}; then
           echo "Installing $MOUNT_BINARY..."
           {install_cmd}
         else

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1364,7 +1364,8 @@ class GcsStore(AbstractStore):
                      f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
-        version_check_cmd = f'gcsfuse --version | grep -q {self.GCSFUSE_VERSION}'
+        version_check_cmd = (
+            f'gcsfuse --version | grep -q {self.GCSFUSE_VERSION}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1364,10 +1364,11 @@ class GcsStore(AbstractStore):
                      f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
+        version_check_cmd = f'gcsfuse --version | grep -q {self.GCSFUSE_VERSION}'
         return mounting_utils.get_mounting_command(mount_path,
                                                    install_cmd,
                                                    mount_cmd,
-                                                   version=self.GCSFUSE_VERSION)
+                                                   version_check_cmd)
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on GS bucket

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1114,6 +1114,7 @@ class GcsStore(AbstractStore):
     """
 
     ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
+    GCSFUSE_VERSION = '0.42.3'
 
     def __init__(self,
                  name: str,
@@ -1353,7 +1354,8 @@ class GcsStore(AbstractStore):
           mount_path: str; Path to mount the bucket to.
         """
         install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
-                       '/releases/download/v0.41.10/gcsfuse_0.41.10_amd64.deb '
+                       f'/releases/download/v{self.GCSFUSE_VERSION}/'
+                       f'gcsfuse_{self.GCSFUSE_VERSION}_amd64.deb '
                        '-O /tmp/gcsfuse.deb && '
                        'sudo dpkg --install /tmp/gcsfuse.deb')
         mount_cmd = ('gcsfuse -o allow_other '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1364,8 +1364,10 @@ class GcsStore(AbstractStore):
                      f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
-        return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd, version=self.GCSFUSE_VERSION)
+        return mounting_utils.get_mounting_command(mount_path,
+                                                   install_cmd,
+                                                   mount_cmd,
+                                                   version=self.GCSFUSE_VERSION)
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on GS bucket

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1365,10 +1365,8 @@ class GcsStore(AbstractStore):
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
         version_check_cmd = f'gcsfuse --version | grep -q {self.GCSFUSE_VERSION}'
-        return mounting_utils.get_mounting_command(mount_path,
-                                                   install_cmd,
-                                                   mount_cmd,
-                                                   version_check_cmd)
+        return mounting_utils.get_mounting_command(mount_path, install_cmd,
+                                                   mount_cmd, version_check_cmd)
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on GS bucket

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1365,7 +1365,7 @@ class GcsStore(AbstractStore):
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
-                                                   mount_cmd)
+                                                   mount_cmd, version=self.GCSFUSE_VERSION)
 
     def _download_file(self, remote_path: str, local_path: str) -> None:
         """Downloads file from remote to local on GS bucket


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We encountered an issue with the gcsfuse that the saved large model checkpoints on a mounted GCS bucket can be incomplete. It could be a problem with the old gcsfuse we were using:
in the release note of gcsfuse (discovered by @infwinston):
> Fixed a critical bug in write workflow - although it was very rare, but gcsfuse was writing wrong file content while doing append operation on larger file.

https://github.com/GoogleCloudPlatform/gcsfuse/releases/tag/v0.41.11

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] Launch a node and write things to the mounted bucket.
  - [x] `pytest tests/test_smoke.py::test_aws_storage_mounts --aws`; to test the mounting of GCS bucket on AWS VM.
  - [x] `pytest tests/test_smoke.py::test_gcp_storage_mounts`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
