### PR TITLE
[Storage] Add validation checks for Store Name

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -862,56 +862,66 @@ class S3Store(AbstractStore):
                     f'Source specified as {self.source}, a R2 bucket. ',
                     'R2 Bucket should exist.')
         # Validate name
-        self._validate_name(self.name)
+        self.name = self.validate_name(self.name)
 
     @classmethod
-    def _validate_name(cls, name):
+    def validate_name(cls, name) -> str:
         """Validates the name of the S3 store.
 
         Source for rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html # pylint: disable=line-too-long
         """
+
         def _raise_no_traceback_name_error(err_str):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageNameError(err_str)
 
         if name is not None and isinstance(name, str):
-            if not (3 <= len(name) <= 63):
+            if not 3 <= len(name) <= 63:
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must be between 3 (min) and 63 (max) characters long.')
+                    f'Invalid store name: name {name} must be between 3 (min) '
+                    'and 63 (max) characters long.')
 
             # Check for valid characters and start/end with a letter or number
             pattern = r'^[a-z0-9][-a-z0-9.]*[a-z0-9]$'
             if not re.match(pattern, name):
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} can consist only of lowercase letters, numbers, dots (.), and hyphens (-). It must begin and end with a letter or number.')
+                    f'Invalid store name: name {name} can consist only of '
+                    'lowercase letters, numbers, dots (.), and hyphens (-). '
+                    'It must begin and end with a letter or number.')
 
             # Check for two adjacent periods
             if '..' in name:
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must not contain two adjacent periods.')
+                    f'Invalid store name: name {name} must not contain '
+                    'two adjacent periods.')
 
             # Check for IP address format
             ip_pattern = r'^(?:\d{1,3}\.){3}\d{1,3}$'
             if re.match(ip_pattern, name):
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must not be formatted as an IP address (for example, 192.168.5.4).')
+                    f'Invalid store name: name {name} must not be formatted as '
+                    'an IP address (for example, 192.168.5.4).')
 
             # Check for 'xn--' prefix
             if name.startswith('xn--'):
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must not start with the prefix "xn--".')
+                    f'Invalid store name: name {name} must not start with the '
+                    'prefix "xn--".')
 
             # Check for '-s3alias' suffix
             if name.endswith('-s3alias'):
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must not end with the suffix "-s3alias".')
+                    f'Invalid store name: name {name} must not end with the '
+                    'suffix "-s3alias".')
 
             # Check for '--ol-s3' suffix
             if name.endswith('--ol-s3'):
                 _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} must not end with the suffix "--ol-s3".')
+                    f'Invalid store name: name {name} must not end with the '
+                    'suffix "--ol-s3".')
         else:
-            raise _raise_no_traceback_name_error('Store name must be specified.')
+            _raise_no_traceback_name_error('Store name must be specified.')
+        return name
 
     def initialize(self):
         """Initializes the S3 store object on the cloud.
@@ -1203,47 +1213,58 @@ class GcsStore(AbstractStore):
                         f'Source specified as {self.source}, a R2 bucket. ',
                         'R2 Bucket should exist.')
         # Validate name
-        self._validate_name(self.name)
+        self.name = self.validate_name(self.name)
 
     @classmethod
-    def _validate_name(cls, name) -> None:
+    def validate_name(cls, name) -> str:
         """Validates the name of the GCS store.
 
         Source for rules: https://cloud.google.com/storage/docs/buckets#naming
         """
+
         def _raise_no_traceback_name_error(err_str):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageNameError(err_str)
 
         if name is not None and isinstance(name, str):
             # Check for overall length
-            if not (3 <= len(name) <= 222):
-                raise _raise_no_traceback_name_error(f'Invalid store name: name {name} must contain 3-222 characters.')
+            if not 3 <= len(name) <= 222:
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must contain 3-222 '
+                    'characters.')
 
             # Check for valid characters and start/end with a number or letter
             pattern = r'^[a-z0-9][-a-z0-9._]*[a-z0-9]$'
             if not re.match(pattern, name):
-                raise _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} can only contain lowercase letters, numeric characters, dashes (-), underscores (_), and dots (.). Spaces are not allowed. Names must start and end with a number or letter.')
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} can only contain '
+                    'lowercase letters, numeric characters, dashes (-), '
+                    'underscores (_), and dots (.). Spaces are not allowed. '
+                    'Names must start and end with a number or letter.')
 
-            # Check for "goog" prefix and "google" in the name
-            if name.startswith("goog") or "google" in name:
-                raise _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} cannot begin with the "goog" prefix and contain "google".')
+            # Check for 'goog' prefix and 'google' in the name
+            if name.startswith('goog') or 'google' in name:
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} cannot begin with the '
+                    '"goog" prefix and contain "google".')
 
             # Check for dot-separated components length
-            components = name.split(".")
+            components = name.split('.')
             if any(len(component) > 63 for component in components):
-                raise _raise_no_traceback_name_error(
-                    f'Invalid store name: Dot-separated components in name {name} can be no longer than 63 characters.')
+                _raise_no_traceback_name_error(
+                    'Invalid store name: Dot-separated components in name '
+                    f'{name} can be no longer than 63 characters.')
 
             # Check for IP address format
             ip_pattern = r'^(?:\d{1,3}\.){3}\d{1,3}$'
             if re.match(ip_pattern, name):
-                raise _raise_no_traceback_name_error(
-                    f'Invalid store name: name {name} cannot be represented as an IP address in dotted-decimal notation (for example, 192.168.5.4).')
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} cannot be represented as '
+                    'an IP address in dotted-decimal notation '
+                    '(for example, 192.168.5.4).')
         else:
             _raise_no_traceback_name_error('Store name must be specified.')
+        return name
 
     def initialize(self):
         """Initializes the GCS store object on the cloud.
@@ -1558,7 +1579,7 @@ class R2Store(AbstractStore):
                 assert self.name == data_utils.split_r2_path(self.source)[0], (
                     'R2 Bucket is specified as path, the name should be '
                     'the same as R2 bucket.')
-        S3Store._validate_name(self.name)
+        self.name = S3Store.validate_name(self.name)
 
     def initialize(self):
         """Initializes the R2 store object on the cloud.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1265,10 +1265,12 @@ class GcsStore(AbstractStore):
                     'Names must start and end with a number or letter.')
 
             # Check for 'goog' prefix and 'google' in the name
-            if name.startswith('goog') or 'google' in name:
+            if name.startswith('goog') or any(
+                    s in name
+                    for s in ['google', 'g00gle', 'go0gle', 'g0ogle']):
                 _raise_no_traceback_name_error(
                     f'Invalid store name: name {name} cannot begin with the '
-                    '"goog" prefix and contain "google".')
+                    '"goog" prefix or contain "google" in various forms.')
 
             # Check for dot-separated components length
             components = name.split('.')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1278,6 +1278,11 @@ class GcsStore(AbstractStore):
                     'Invalid store name: Dot-separated components in name '
                     f'{name} can be no longer than 63 characters.')
 
+            if '..' in name or '.-' in name or '-.' in name:
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not contain two '
+                    'adjacent periods or a dot next to a hyphen.')
+
             # Check for IP address format
             ip_pattern = r'^(?:\d{1,3}\.){3}\d{1,3}$'
             if re.match(ip_pattern, name):

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1,6 +1,7 @@
 """Storage and Store Classes for Sky Data."""
 import enum
 import os
+import re
 import subprocess
 import time
 import typing
@@ -829,7 +830,7 @@ class S3Store(AbstractStore):
     for S3 buckets.
     """
 
-    ACCESS_DENIED_MESSAGE = 'Access Denied'
+    _ACCESS_DENIED_MESSAGE = 'Access Denied'
 
     def __init__(self,
                  name: str,
@@ -860,6 +861,57 @@ class S3Store(AbstractStore):
                 assert data_utils.verify_r2_bucket(self.name), (
                     f'Source specified as {self.source}, a R2 bucket. ',
                     'R2 Bucket should exist.')
+        # Validate name
+        self._validate_name(self.name)
+
+    @classmethod
+    def _validate_name(cls, name):
+        """Validates the name of the S3 store.
+
+        Source for rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html # pylint: disable=line-too-long
+        """
+        def _raise_no_traceback_name_error(err_str):
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageNameError(err_str)
+
+        if name is not None and isinstance(name, str):
+            if not (3 <= len(name) <= 63):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must be between 3 (min) and 63 (max) characters long.')
+
+            # Check for valid characters and start/end with a letter or number
+            pattern = r'^[a-z0-9][-a-z0-9.]*[a-z0-9]$'
+            if not re.match(pattern, name):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} can consist only of lowercase letters, numbers, dots (.), and hyphens (-). It must begin and end with a letter or number.')
+
+            # Check for two adjacent periods
+            if '..' in name:
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not contain two adjacent periods.')
+
+            # Check for IP address format
+            ip_pattern = r'^(?:\d{1,3}\.){3}\d{1,3}$'
+            if re.match(ip_pattern, name):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not be formatted as an IP address (for example, 192.168.5.4).')
+
+            # Check for 'xn--' prefix
+            if name.startswith('xn--'):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not start with the prefix "xn--".')
+
+            # Check for '-s3alias' suffix
+            if name.endswith('-s3alias'):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not end with the suffix "-s3alias".')
+
+            # Check for '--ol-s3' suffix
+            if name.endswith('--ol-s3'):
+                _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} must not end with the suffix "--ol-s3".')
+        else:
+            raise _raise_no_traceback_name_error('Store name must be specified.')
 
     def initialize(self):
         """Initializes the S3 store object on the cloud.
@@ -967,7 +1019,7 @@ class S3Store(AbstractStore):
                 get_file_sync_command,
                 get_dir_sync_command,
                 self.name,
-                self.ACCESS_DENIED_MESSAGE,
+                self._ACCESS_DENIED_MESSAGE,
                 create_dirs=create_dirs,
                 max_concurrent_uploads=_MAX_CONCURRENT_UPLOADS)
 
@@ -1113,7 +1165,7 @@ class GcsStore(AbstractStore):
     for GCS buckets.
     """
 
-    ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
+    _ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
 
     def __init__(self,
                  name: str,
@@ -1150,6 +1202,48 @@ class GcsStore(AbstractStore):
                     assert data_utils.verify_r2_bucket(self.name), (
                         f'Source specified as {self.source}, a R2 bucket. ',
                         'R2 Bucket should exist.')
+        # Validate name
+        self._validate_name(self.name)
+
+    @classmethod
+    def _validate_name(cls, name) -> None:
+        """Validates the name of the GCS store.
+
+        Source for rules: https://cloud.google.com/storage/docs/buckets#naming
+        """
+        def _raise_no_traceback_name_error(err_str):
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageNameError(err_str)
+
+        if name is not None and isinstance(name, str):
+            # Check for overall length
+            if not (3 <= len(name) <= 222):
+                raise _raise_no_traceback_name_error(f'Invalid store name: name {name} must contain 3-222 characters.')
+
+            # Check for valid characters and start/end with a number or letter
+            pattern = r'^[a-z0-9][-a-z0-9._]*[a-z0-9]$'
+            if not re.match(pattern, name):
+                raise _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} can only contain lowercase letters, numeric characters, dashes (-), underscores (_), and dots (.). Spaces are not allowed. Names must start and end with a number or letter.')
+
+            # Check for "goog" prefix and "google" in the name
+            if name.startswith("goog") or "google" in name:
+                raise _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} cannot begin with the "goog" prefix and contain "google".')
+
+            # Check for dot-separated components length
+            components = name.split(".")
+            if any(len(component) > 63 for component in components):
+                raise _raise_no_traceback_name_error(
+                    f'Invalid store name: Dot-separated components in name {name} can be no longer than 63 characters.')
+
+            # Check for IP address format
+            ip_pattern = r'^(?:\d{1,3}\.){3}\d{1,3}$'
+            if re.match(ip_pattern, name):
+                raise _raise_no_traceback_name_error(
+                    f'Invalid store name: name {name} cannot be represented as an IP address in dotted-decimal notation (for example, 192.168.5.4).')
+        else:
+            _raise_no_traceback_name_error('Store name must be specified.')
 
     def initialize(self):
         """Initializes the GCS store object on the cloud.
@@ -1243,7 +1337,7 @@ class GcsStore(AbstractStore):
                 f'[bold cyan]Syncing '
                 f'[green]{source_message}[/] to [green]gs://{self.name}/[/]'):
             data_utils.run_upload_cli(sync_command,
-                                      self.ACCESS_DENIED_MESSAGE,
+                                      self._ACCESS_DENIED_MESSAGE,
                                       bucket_name=self.name)
 
     def batch_gsutil_rsync(self,
@@ -1293,7 +1387,7 @@ class GcsStore(AbstractStore):
                 get_file_sync_command,
                 get_dir_sync_command,
                 self.name,
-                self.ACCESS_DENIED_MESSAGE,
+                self._ACCESS_DENIED_MESSAGE,
                 create_dirs=create_dirs,
                 max_concurrent_uploads=_MAX_CONCURRENT_UPLOADS)
 
@@ -1433,7 +1527,7 @@ class R2Store(AbstractStore):
     for R2 buckets.
     """
 
-    ACCESS_DENIED_MESSAGE = 'Access Denied'
+    _ACCESS_DENIED_MESSAGE = 'Access Denied'
 
     def __init__(self,
                  name: str,
@@ -1464,6 +1558,7 @@ class R2Store(AbstractStore):
                 assert self.name == data_utils.split_r2_path(self.source)[0], (
                     'R2 Bucket is specified as path, the name should be '
                     'the same as R2 bucket.')
+        S3Store._validate_name(self.name)
 
     def initialize(self):
         """Initializes the R2 store object on the cloud.
@@ -1577,7 +1672,7 @@ class R2Store(AbstractStore):
                 get_file_sync_command,
                 get_dir_sync_command,
                 self.name,
-                self.ACCESS_DENIED_MESSAGE,
+                self._ACCESS_DENIED_MESSAGE,
                 create_dirs=create_dirs,
                 max_concurrent_uploads=_MAX_CONCURRENT_UPLOADS)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1671,6 +1671,7 @@ class TestStorageWithCredentials:
         # more than 63 characters
         'Abcdef',  # contains an uppercase letter
         'abc def',  # contains a space
+        'abc..def',  # two adjacent periods
         '192.168.5.4',  # formatted as an IP address
         'xn--bucket',  # starts with 'xn--' prefix
         'bucket-s3alias',  # ends with '-s3alias' suffix
@@ -1688,11 +1689,14 @@ class TestStorageWithCredentials:
         'Abcdef',  # contains an uppercase letter
         'abc def',  # contains a space
         'abc..def',  # two adjacent periods
-        'abc_.def.ghi.jklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz1',
+        'abc_.def.ghi.jklmnopqrstuvwxyzabcdefghijklmnopqfghijklmnopqrstuvw' * 5,
         # more than 222 characters (with dots)
         '192.168.5.4',  # formatted as an IP address
         'googbucket',  # starts with 'goog' prefix
         'googlebucket',  # contains 'google'
+        'g00glebucket',  # variant of 'google'
+        'go0glebucket',  # variant of 'google'
+        'g0oglebucket',  # variant of 'google'
         '.abc',  # starts with a dot
         'abc.',  # ends with a dot
         '_abc',  # starts with an underscore

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1689,6 +1689,8 @@ class TestStorageWithCredentials:
         'Abcdef',  # contains an uppercase letter
         'abc def',  # contains a space
         'abc..def',  # two adjacent periods
+        'abc_.def.ghi.jklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz1'
+        # More than 63 characters between dots
         'abc_.def.ghi.jklmnopqrstuvwxyzabcdefghijklmnopqfghijklmnopqrstuvw' * 5,
         # more than 222 characters (with dots)
         '192.168.5.4',  # formatted as an IP address

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -83,3 +83,20 @@ class TestStorageSpecValidation:
             storage_lib.Storage()
 
         assert 'Storage source or storage name must be specified' in str(e)
+
+    def test_uri_in_name(self):
+        """Tests when name is a URI.
+
+        Other tests for invalid names require store-specific test cases, and
+        are in test_smoke.py::TestStorageWithCredentials"""
+        invalid_names = [
+            's3://mybucket',
+            'gs://mybucket',
+            'r2://mybucket',
+        ]
+
+        for n in invalid_names:
+            with pytest.raises(exceptions.StorageNameError) as e:
+                storage_lib.Storage(name=n)
+
+            assert 'Prefix detected' in str(e)


### PR DESCRIPTION
If the user specifies an invalid `name`, the error is thrown quite deep into the stack after we've sent the bucket request to boto3/gcs. We should catch it early and show it cleanly to the user.

This PR adds name validation for S3, R2 and GCSStores. 

Example:
```
file_mounts:
  /mydata/:
    name: s3://romil-bucket
    store: s3
```

Before:
```
<Long stack trace>

botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid bucket name "s3://romil-bucket": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-.]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
```

After:
```
Task from YAML spec: storage_test.yaml
sky.exceptions.StorageNameError: Prefix detected: `name` cannot start with s3://. If you are trying to use an existing bucket created outside of SkyPilot, please specify it using the `source` field (e.g. `source: s3://mybucket/`). If you are trying to create a new bucket, please use the `store` field to specify the store type (e.g. `store: s3`).
```

TODO:
- [x] Add test cases.

Tested:
- [x] Example YAML
- [x] Add more tests to `test_storage::TestStorageSpecValidation`
- [x] `test_smoke::TestStorageWithCredentials`