### PR TITLE
[catalog] Fix aws_fetcher by avoiding deprecated df.append

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -178,8 +178,9 @@ def _patch_p4de(region: str, df: pd.DataFrame,
     # Columns:
     # InstanceType,AcceleratorName,AcceleratorCount,vCPUs,MemoryGiB,GpuInfo,
     # Price,SpotPrice,Region,AvailabilityZone
+    records = []
     for zone in df[df['Region'] == region]['AvailabilityZone'].unique():
-        df = df.append(pd.Series({
+        records.append({
             'InstanceType': 'p4de.24xlarge',
             'AcceleratorName': 'A100-80GB',
             'AcceleratorCount': 8,
@@ -194,8 +195,8 @@ def _patch_p4de(region: str, df: pd.DataFrame,
             'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']
                      ['Price'].values[0],
             'SpotPrice': np.nan,
-        }),
-                       ignore_index=True)
+        })
+    df = pd.concat([df, pd.DataFrame.from_records(records)])
     return df
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This fixes the auto catalog fetcher error: https://github.com/skypilot-org/skypilot-catalog/actions/runs/4601334620/jobs/8129070712

To reproduce:
`python -m sky.clouds.service_catalog.data_fetchers.fetch_aws --no-az-mappings --check-all-regions-enabled-for-account` locally with `pandas==2.0`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_aws --no-az-mappings --check-all-regions-enabled-for-account` locally with `pandas==2.0`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
