### PR TITLE
Lambda recursive v2

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -317,12 +317,11 @@ def setup_lambda_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
 
     # Ensure ssh key is registered with Lambda Cloud
     lambda_client = lambda_utils.LambdaCloudClient()
-    if lambda_client.ssh_key_name is None:
-        public_key_path = os.path.expanduser(PUBLIC_SSH_KEY_PATH)
-        with open(public_key_path, 'r') as f:
-            public_key = f.read()
-        name = f'sky-key-{common_utils.get_user_hash()}'
-        lambda_client.set_ssh_key(name, public_key)
+    public_key_path = os.path.expanduser(PUBLIC_SSH_KEY_PATH)
+    with open(public_key_path, 'r') as f:
+        public_key = f.read()
+    name = f'sky-key-{common_utils.get_user_hash()}'
+    lambda_client.register_ssh_key(name, public_key)
 
     # Need to use ~ relative path because Ray uses the same
     # path for finding the public key path on both local and head node.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -69,7 +69,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = {
     clouds.AWS: 90,
     clouds.Azure: 90,
     clouds.GCP: 120,
-    clouds.Lambda: 120,
+    clouds.Lambda: 150,
     clouds.Local: 90,
 }
 

--- a/sky/skylet/providers/lambda_cloud/lambda_utils.py
+++ b/sky/skylet/providers/lambda_cloud/lambda_utils.py
@@ -78,8 +78,8 @@ def raise_lambda_error(response: requests.Response) -> None:
         raise LambdaCloudError('Your API requests are being rate limited.')
     try:
         resp_json = response.json()
-        code = resp_json['error']['code']
-        message = resp_json['error']['message']
+        code = resp_json.get('error', {}).get('code')
+        message = resp_json.get('error', {}).get('message')
     except (KeyError, json.decoder.JSONDecodeError):
         raise LambdaCloudError(f'Unexpected error. Status code: {status_code}')
     raise LambdaCloudError(f'{code}: {message}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This pr fixes #1836 and #1837 by improving how we handle the ssh key name. We no longer store the ssh key in `lambda_keys` and query Lambda Cloud instead (they have a new API for this). We also improve some error handling code in the Lambda Cloud node provider.

Tested:

- [x] `pytest tests/test_smoke.py --lambda` 
