### PR TITLE
Make rsync more resilient

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1186,7 +1186,8 @@ def parallel_data_transfer_to_nodes(
             subprocess_utils.handle_returncode(
                 rc,
                 cmd, ('Failed to run command before rsync '
-                      f'{origin_source} -> {target}.'),
+                      f'{origin_source} -> {target}.'
+                      'Ensure that the network is stable, then retry.'),
                 stderr=stdout + stderr)
 
         if run_rsync:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1186,7 +1186,7 @@ def parallel_data_transfer_to_nodes(
             subprocess_utils.handle_returncode(
                 rc,
                 cmd, ('Failed to run command before rsync '
-                      f'{origin_source} -> {target}.'
+                      f'{origin_source} -> {target}. '
                       'Ensure that the network is stable, then retry.'),
                 stderr=stdout + stderr)
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -305,6 +305,7 @@ class SSHCommandRunner:
             log_path: Redirect stdout/stderr to the log_path.
             stream_logs: Stream logs to the stdout/stderr.
             max_retry: The maximum number of retries for the rsync command.
+              This value should be non-negative.
 
         Raises:
             exceptions.CommandError: rsync command failed.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -367,11 +367,10 @@ class SSHCommandRunner:
             retry_cnt -= 1
 
         direction = 'up' if up else 'down'
-        error_msg = (f"Failed to rsync {direction}: {source} -> {target}."
-                     "Ensure that the network is stable, then retry.")
-        subprocess_utils.handle_returncode(
-            returncode,
-            command,
-            error_msg,
-            stderr=stderr,
-            stream_logs=stream_logs)
+        error_msg = (f'Failed to rsync {direction}: {source} -> {target}.'
+                     'Ensure that the network is stable, then retry.')
+        subprocess_utils.handle_returncode(returncode,
+                                           command,
+                                           error_msg,
+                                           stderr=stderr,
+                                           stream_logs=stream_logs)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Closes #1538.
- `rsync` related errors are normally related to transient network issues, so this adds "to fix" information for the user in error messages
- This also adds retrying to the `rsync` command to reduce the frequency of failures due to transient network issues

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
