### PR TITLE
[UX] Minor UX fixes.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2149,11 +2149,13 @@ def check_cluster_available(
         record = global_user_state.get_cluster_from_name(cluster_name)
         cluster_status, handle = record['status'], record['handle']
 
+    bright = colorama.Style.BRIGHT
+    reset = colorama.Style.RESET_ALL
     if handle is None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(
                 f'{colorama.Fore.YELLOW}Cluster {cluster_name!r} does not '
-                f'exist.{colorama.Style.RESET_ALL}')
+                f'exist.{reset}')
     backend = get_backend_from_handle(handle)
     if check_cloud_vm_ray_backend and not isinstance(
             backend, backends.CloudVmRayBackend):
@@ -2162,7 +2164,7 @@ def check_cluster_available(
                 f'{colorama.Fore.YELLOW}{operation.capitalize()}: skipped for '
                 f'cluster {cluster_name!r}. It is only supported by backend: '
                 f'{backends.CloudVmRayBackend.NAME}.'
-                f'{colorama.Style.RESET_ALL}')
+                f'{reset}')
     if cluster_status != global_user_state.ClusterStatus.UP:
         if onprem_utils.check_if_local_cloud(cluster_name):
             raise exceptions.ClusterNotUpError(
@@ -2170,12 +2172,19 @@ def check_cluster_available(
                     cluster_name),
                 cluster_status=cluster_status)
         with ux_utils.print_exception_no_traceback():
+            hint_for_init = ''
+            if cluster_status == global_user_state.ClusterStatus.INIT:
+                hint_for_init = (
+                    f'{reset} Wait for a launch to finish, or use this command '
+                    f'to try to transition the cluster to UP: {bright}sky '
+                    f'start {cluster_name}{reset}')
             raise exceptions.ClusterNotUpError(
                 f'{colorama.Fore.YELLOW}{operation.capitalize()}: skipped for '
                 f'cluster {cluster_name!r} (status: {cluster_status.value}). '
                 'It is only allowed for '
                 f'{global_user_state.ClusterStatus.UP.value} clusters.'
-                f'{colorama.Style.RESET_ALL}',
+                f'{hint_for_init}'
+                f'{reset}',
                 cluster_status=cluster_status)
 
     if handle.head_ip is None:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2397,7 +2397,9 @@ def _hint_or_raise_for_down_spot_controller(controller_name: str):
         with ux_utils.print_exception_no_traceback():
             raise exceptions.NotSupportedError(
                 f'{colorama.Fore.RED}Tearing down the spot controller while '
-                'it is in INIT state is not supported, as we cannot '
+                'it is in INIT state is not supported (this means a spot '
+                'launch is in progress or the previous launch failed), as we '
+                'cannot '
                 'guarantee that all the spot jobs are finished. Please wait '
                 'until the spot controller is UP or fix it with '
                 f'{colorama.Style.BRIGHT}sky start '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2955,6 +2955,8 @@ def show_gpus(
     if region is not None and cloud is None:
         raise click.UsageError(
             'The --region flag is only valid when the --cloud flag is set.')
+    # This will validate 'cloud' and raise if not found.
+    clouds.CLOUD_REGISTRY.from_str(cloud)
     service_catalog.validate_region_zone(region, None, clouds=cloud)
     show_all = all
     if show_all and gpu_name is not None:

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -54,7 +54,7 @@ class _CloudRegistry(dict):
             return None
         if name.lower() not in self:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Cloud {name} is not a valid cloud among '
+                raise ValueError(f'Cloud {name!r} is not a valid cloud among '
                                  f'{list(self.keys())}')
         return self.get(name.lower())
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -270,9 +270,11 @@ class Optimizer:
                                 f' ({specified_resources} '
                                 f'in {specified_resources.region})')
                     error_msg = (
-                        'Optimizer: No launchable resource found for task '
-                        f'{node}{specified_resources_str}. '
-                        'To fix: relax its resource requirements.\n'
+                        'No launchable resource found for task '
+                        f'{node}{specified_resources_str}. This means the '
+                        'catalog does not contain any instance types to satisfy'
+                        ' the request. '
+                        'To fix: relax/change its resource requirements.\n'
                         'Hint: \'sky show-gpus --all\' '
                         'to list available accelerators.\n'
                         '      \'sky check\' to check the enabled clouds.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes
- some more friendly messages adding "to fix"
- fix `sky show-gpus --cloud xxx` which previously throws a long stacktrace
```
..
ValueError: Cannot find module "sky.clouds.service_catalog.xxx_catalog" for cloud "xxx".
```
currently
```
ValueError: Cloud 'xxx' is not a valid cloud among ['aws', 'azure', 'gcp', 'lambda', 'local']
```
consistent with `sky launch --cloud xxx`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - above
  - `sky exec cluster-in-init echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
