### PR TITLE
GCP/provisioner: Handle the RESOURCE_NOT_FOUND error.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -659,13 +659,13 @@ class RetryingVmProvisioner(object):
                         launchable_resources.copy(zone=zone.name))
                 elif code == 'RESOURCE_NOT_FOUND':
                     # https://github.com/skypilot-org/skypilot/issues/1797
-                    # The VM may be alive on console. In the inner provision
-                    # loop we have used retries to recover but failed. The
-                    # provision loop will terminate the potentially live VMs
-                    # and move onto the next zone. Since the VM may have been
-                    # provisioned in this zone, it doesn't seem right to block
-                    # the current zone.
-                    pass
+                    # In the inner provision loop we have used retries to
+                    # recover but failed. This indicates this zone is most
+                    # likely out of capacity. The provision loop will terminate
+                    # any potentially live VMs before moving onto the next
+                    # zone.
+                    self._blocked_resources.add(
+                        launchable_resources.copy(zone=zone.name))
                 else:
                     assert False, error
         elif len(httperror_str) >= 1:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1797.

I've tried a few days and finally got a set_trace inside `need_ray_up()`, tested that the `re.search()` there works. This doesn't test things end-to-end, however.
```
sky launch -y --gpus A100-80GB:8 --cloud gcp --down -c dbg -r 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
