### PR TITLE
Logging UX: update Resources repr & make an optimizer logging nicer.

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -260,19 +260,11 @@ class Optimizer:
             num_resources = len(node.get_resources())
             for orig_resources, launchable_list in launchable_resources.items():
                 if not launchable_list:
-                    specified_resources_str = ''
-                    if node.get_resources():
-                        specified_resources = list(node.get_resources())[0]
-                        specified_resources_str = f' ({specified_resources})'
-                        if specified_resources.region:
-                            specified_resources_str = (
-                                f' ({specified_resources} '
-                                f'in {specified_resources.region})')
                     error_msg = (
                         'No launchable resource found for task '
-                        f'{node}{specified_resources_str}. This means the '
-                        'catalog does not contain any instance types to satisfy'
-                        ' the request. '
+                        f'{node}.\nThis means the '
+                        'catalog does not contain any instance types that '
+                        'satisfy this request.\n'
                         'To fix: relax/change its resource requirements.\n'
                         'Hint: \'sky show-gpus --all\' '
                         'to list available accelerators.\n'

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -265,7 +265,7 @@ class Optimizer:
                         f'{node}.\nThis means the '
                         'catalog does not contain any instance types that '
                         'satisfy this request.\n'
-                        'To fix: relax/change its resource requirements.\n'
+                        'To fix: relax or change the resource requirements.\n'
                         'Hint: \'sky show-gpus --all\' '
                         'to list available accelerators.\n'
                         '      \'sky check\' to check the enabled clouds.')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -170,10 +170,17 @@ class Resources:
         else:
             instance_type = ''
 
+        region = ''
+        if self.region is not None:
+            region = f', region={self.region!r}'
+        zone = ''
+        if self.zone is not None:
+            zone = f', zone={self.zone!r}'
+
         hardware_str = (
             f'{instance_type}{use_spot}'
             f'{cpus}{memory}{accelerators}{accelerator_args}{image_id}'
-            f'{disk_size}')
+            f'{disk_size}{region}{zone}')
         # It may have leading ',' (for example, instance_type not set) or empty
         # spaces.  Remove them.
         while hardware_str and hardware_str[0] in (',', ' '):

--- a/sky/task.py
+++ b/sky/task.py
@@ -862,8 +862,11 @@ class Task:
             s += f'\n  outputs: {self.outputs}'
         if self.num_nodes > 1:
             s += f'\n  nodes: {self.num_nodes}'
-        if len(self.resources) > 1 or not list(self.resources)[0].is_empty():
+        if len(self.resources) > 1:
             s += f'\n  resources: {self.resources}'
+        elif len(
+                self.resources) == 1 and not list(self.resources)[0].is_empty():
+            s += f'\n  resources: {list(self.resources)[0]}'
         else:
             s += '\n  resources: default instances'
         return s


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Repro
```
resources:
  cloud: aws
  accelerators: A100-80GB:8
  use_spot: true
```

Previously
```
I 04-10 18:34:24 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=None)
  resources: {AWS([Spot], {'A100-80GB': 8})} (AWS([Spot], {'A100-80GB': 8})). This means the catalog does not contain any instance types to satisfy the request. To fix: relax/change its resource requirements.
Hint: 'sky show-gpus --all' to list available accelerators.
      'sky check' to check the enabled clouds.
```

Now
```
I 04-10 18:34:05 optimizer.py:990] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=None)
  resources: AWS([Spot], {'A100-80GB': 8}).
This means the catalog does not contain any instance types that satisfy this request.
To fix: relax or change the resource requirements.
Hint: 'sky show-gpus --all' to list available accelerators.
      'sky check' to check the enabled clouds.
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
