### PR TITLE
GCP Ports Prototype

### DIFF
--- a/examples/ports.yaml
+++ b/examples/ports.yaml
@@ -1,0 +1,10 @@
+resources:
+  cloud: gcp
+
+setup: |
+  echo "running setup"
+
+run: |
+  conda env list
+
+ports: tcp:9091

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2319,6 +2319,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             self._update_after_cluster_provisioned(handle, task,
                                                    prev_cluster_status, ip_list,
                                                    lock_path)
+            print("HEREHREREHERHE", handle.launched_resources.ports)
+            resources = handle.launched_resources
+            if resources.ports and resources.cloud == clouds.GCP:
+                print("ADDING PORTS")
+
+            #if not resources.ports and resources.cloud:
             return handle
 
     def _update_after_cluster_provisioned(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -688,3 +688,21 @@ class GCP(clouds.Cloud):
             zone: Optional[str] = None) -> None:
         service_catalog.check_accelerator_attachable_to_host(
             instance_type, accelerators, zone, 'gcp')
+
+    @staticmethod
+    def add_ports(cluster_name: str, port: int) -> None:
+        from sky.backends import backend_utils
+        handle = backend_utils.check_cluster_available(
+            cluster_name,
+            operation='adding ports'
+        )
+        backend = backend_utils.get_backend_From_handle(handle)
+        ray_config = common_utils.read_yaml(handle.cluster_yaml)
+
+        returncode, full_name, _ = backend.run_on_head(handle,
+        "hostname", require_outputs=True, separate_stderr=True)
+
+        external_ip = handle.head_ip
+
+        full_name = full_name.strip()
+        region = ray_config['provider']['availability_zone'].strip()

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -6,6 +6,7 @@ import datetime
 import itertools
 from multiprocessing import pool as mp_pool
 import os
+import sys
 import subprocess
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -59,6 +60,10 @@ USEFUL_COLUMNS = [
 # only available in this region, but it serves pricing information for all
 # regions.
 PRICING_TABLE_URL_FMT = 'https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/{region}/index.csv'  # pylint: disable=line-too-long
+# Hardcode the regions that offer p4de.24xlarge as our credential does not have
+# the permission to query the offerings of the instance.
+# Ref: https://aws.amazon.com/ec2/instance-types/p4/
+P4DE_REGIONS = ['us-east-1', 'us-west-2']
 
 regions_enabled: Optional[Set[str]] = None
 
@@ -166,6 +171,34 @@ def _get_spot_pricing_table(region: str) -> pd.DataFrame:
     return df
 
 
+def _patch_p4de(region: str, df: pd.DataFrame,
+                pricing_df: pd.DataFrame) -> pd.DataFrame:
+    # Hardcoded patch for p4de.24xlarge, as our credentials doesn't have access
+    # to the instance type.
+    # Columns:
+    # InstanceType,AcceleratorName,AcceleratorCount,vCPUs,MemoryGiB,GpuInfo,
+    # Price,SpotPrice,Region,AvailabilityZone
+    for zone in df[df['Region'] == region]['AvailabilityZone'].unique():
+        df = df.append(pd.Series({
+            'InstanceType': 'p4de.24xlarge',
+            'AcceleratorName': 'A100-80GB',
+            'AcceleratorCount': 8,
+            'vCPUs': 96,
+            'MemoryGiB': 1152,
+            'GpuInfo':
+                ('{\'Gpus\': [{\'Name\': \'A100-80GB\', \'Manufacturer\': '
+                 '\'NVIDIA\', \'Count\': 8, \'MemoryInfo\': {\'SizeInMiB\': '
+                 '81920}}], \'TotalGpuMemoryInMiB\': 655360}'),
+            'AvailabilityZone': zone,
+            'Region': region,
+            'Price': pricing_df[pricing_df['InstanceType'] == 'p4de.24xlarge']
+                     ['Price'].values[0],
+            'SpotPrice': np.nan,
+        }),
+                       ignore_index=True)
+    return df
+
+
 def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
     try:
         # Fetch the zone info first to make sure the account has access to the
@@ -247,11 +280,14 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = pd.concat(
             [df, df.apply(get_additional_columns, axis='columns')],
             axis='columns')
-        # patch the GpuInfo for p4de.24xlarge
-        df.loc[df['InstanceType'] == 'p4de.24xlarge', 'GpuInfo'] = 'A100-80GB'
+        # patch the df for p4de.24xlarge
+        if region in P4DE_REGIONS:
+            df = _patch_p4de(region, df, pricing_df)
+        if 'GpuInfo' not in df.columns:
+            df['GpuInfo'] = np.nan
         df = df[USEFUL_COLUMNS]
     except Exception as e:  # pylint: disable=broad-except
-        print(f'{region} failed with {e}')
+        print(f'{region} failed with {e}', file=sys.stderr)
         return region
     return df
 
@@ -267,7 +303,7 @@ def get_all_regions_instance_types_df(regions: Set[str]) -> pd.DataFrame:
             new_dfs.append(df_or_region)
 
     df = pd.concat(new_dfs)
-    df.sort_values(['InstanceType', 'Region'], inplace=True)
+    df.sort_values(['InstanceType', 'Region', 'AvailabilityZone'], inplace=True)
     return df
 
 
@@ -402,9 +438,10 @@ if __name__ == '__main__':
             # requested are the same as the ones we fetched.
             # The mismatch could happen for network issues or glitches
             # in the AWS API.
+            diff = user_regions - fetched_regions
             raise RuntimeError(
                 f'{name}: Fetched regions {fetched_regions} does not match '
-                f'requested regions {user_regions}.')
+                f'requested regions {user_regions}; Diff: {diff}')
 
     instance_df = get_all_regions_instance_types_df(user_regions)
     _check_regions_integrity(instance_df, 'instance types')

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -269,6 +269,11 @@ def _execute(
                                            stream_logs=stream_logs,
                                            cluster_name=cluster_name,
                                            retry_until_up=retry_until_up)
+            if task.ports is not None:
+                if isinstance(handle.launched_resources.cloud, clouds.GCP):
+                    backend_utils.add_ports(cluster_name, task.ports)
+                else:
+                    logger.warning('Ports only supported for GCP')
 
         if dryrun:
             logger.info('Dry run finished.')

--- a/sky/task.py
+++ b/sky/task.py
@@ -288,6 +288,10 @@ class Task:
                         raise ValueError(f'Unable to parse file_mount '
                                          f'{dst_path}:{src}')
             task.set_file_mounts(copy_mounts)
+        
+        #Ports
+        ports = config.pop('ports', None)
+        task.set_ports(ports)
 
         task_storage_mounts = {}  # type: Dict[str, Storage]
         all_storages = fm_storages
@@ -542,6 +546,9 @@ class Task:
 
         self.file_mounts = file_mounts
         return self
+
+    def set_ports(self, ports) -> 'Task':
+        self.ports = ports
 
     def update_file_mounts(self, file_mounts: Dict[str, str]) -> 'Task':
         """Updates the file mounts for this task.

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -186,6 +186,9 @@ def get_task_schema():
                     'type': 'number'
                 }
             },
+            'ports': {
+                'type': 'string',
+            },
         }
     }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -86,6 +86,9 @@ def get_resources_schema():
                     'type': 'object',
                     'required': [],
                 }]
+            },
+            'ports': {
+                'type': 'string',
             }
         }
     }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Allows you to open ports by using the `ports` feature in the YAML.

Works by creating a network tag for each cluster that matches the cluster name then an ingress firewall rule for that tag to allow connections from any source for the specified set of ports.
