### PR TITLE
`show-gpus`: make A10/A10G "common" GPUs, and add hints.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2984,7 +2984,7 @@ def show_gpus(
                 clouds=cloud,
                 region_filter=region,
             )
-            # NVIDIA GPUs
+            # "Common" GPUs
             for gpu in service_catalog.get_common_gpus():
                 if gpu in result:
                     gpu_table.add_row([gpu, _list_to_str(result.pop(gpu))])

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2972,7 +2972,7 @@ def show_gpus(
 
     def _output():
         gpu_table = log_utils.create_table(
-            ['NVIDIA_GPU', 'AVAILABLE_QUANTITIES'])
+            ['COMMON_GPU', 'AVAILABLE_QUANTITIES'])
         tpu_table = log_utils.create_table(
             ['GOOGLE_TPU', 'AVAILABLE_QUANTITIES'])
         other_table = log_utils.create_table(
@@ -3006,6 +3006,8 @@ def show_gpus(
                 yield from other_table.get_string()
                 yield '\n\n'
             else:
+                yield ('\n\nHint: use -a/--all to see all accelerators '
+                       '(including non-common ones) and pricing.')
                 return
 
         # Show detailed accelerator information

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -288,7 +288,16 @@ def check_accelerator_attachable_to_host(instance_type: str,
 def get_common_gpus() -> List[str]:
     """Returns a list of commonly used GPU names."""
     return [
-        'V100', 'V100-32GB', 'A100', 'A100-80GB', 'P100', 'K80', 'T4', 'M60'
+        'A10',
+        'A10G',
+        'A100',
+        'A100-80GB',
+        'K80',
+        'M60',
+        'P100',
+        'T4',
+        'V100',
+        'V100-32GB',
     ]
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes
- A10/A10G are popular GPUs and are available/in-demand
- Rename header `NVIDIA_GPU` -> `COMMON_GPU`
- Added some hint

We still need to fix some other logging issues, e.g., removing
```
*NOTE*: for most GCP accelerators, INSTANCE_TYPE == (attachable) means the host VM's cost is not included.
```
if GCP is not queried. cc @ewzeng 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
```
sky show-gpus
sky show-gpus A10
sky show-gpus --cloud aws
sky show-gpus --cloud aws A10
sky show-gpus --cloud aws -a
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
