### PR TITLE
[Storage] Improve UX for error message when bucket is not accessible

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -45,12 +45,12 @@ STORE_ENABLED_CLOUDS = [clouds.AWS(), clouds.GCP()]
 _MAX_CONCURRENT_UPLOADS = 32
 
 _BUCKET_FAIL_TO_CONNECT_MESSAGE = (
-    'Failed to connect to an existing bucket {name!r}. '
+    'Failed to access existing bucket {name!r}. '
     'This is likely because it is a private bucket you do not have access to.\n'
     'To fix: \n'
-    '  1. If you are trying to create a new bucket - use a different name.\n'
-    '  2. If you are trying to connect to an existing bucket - make sure '
-    'you have access to it.')
+    '  1. If you are trying to create a new bucket: use a different name.\n'
+    '  2. If you are trying to connect to an existing bucket: make sure '
+    'your cloud credentials have access to it.')
 
 
 class StoreType(enum.Enum):

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -45,9 +45,10 @@ STORE_ENABLED_CLOUDS = [clouds.AWS(), clouds.GCP()]
 _MAX_CONCURRENT_UPLOADS = 32
 
 _BUCKET_FAIL_TO_CONNECT_MESSAGE = (
-    'Failed to connect to an existing bucket {name!r}.\n'
-    'Please check if:\n  1. the bucket name is taken and/or '
-    '\n  2. the bucket permissions are not setup correctly.')
+    'Failed to connect to an existing bucket {name!r}. '
+    'This is likely because it is a private bucket you do not have access to.\n'
+    'To fix: \n  1. If you are trying to create a new bucket - use a different name.'
+    '\n  2. If you are trying to connect to an existing bucket - make sure you have access to it.')
 
 
 class StoreType(enum.Enum):
@@ -1008,7 +1009,7 @@ class S3Store(AbstractStore):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +
-                        f' To debug, consider using {command}.') from e
+                        f' To debug, consider running `{command}`.') from e
 
         if isinstance(self.source, str) and self.source.startswith('s3://'):
             with ux_utils.print_exception_no_traceback():
@@ -1342,7 +1343,7 @@ class GcsStore(AbstractStore):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +
-                        f' To debug, consider using {command}.') from e
+                        f' To debug, consider running `{command}`.') from e
 
     def mount_command(self, mount_path: str) -> str:
         """Returns the command to mount the bucket to the mount_path.
@@ -1624,7 +1625,7 @@ class R2Store(AbstractStore):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
                         _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +
-                        f' To debug, consider using {command}.') from e
+                        f' To debug, consider running `{command}`.') from e
 
         if isinstance(self.source, str) and self.source.startswith('r2://'):
             with ux_utils.print_exception_no_traceback():

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -47,8 +47,10 @@ _MAX_CONCURRENT_UPLOADS = 32
 _BUCKET_FAIL_TO_CONNECT_MESSAGE = (
     'Failed to connect to an existing bucket {name!r}. '
     'This is likely because it is a private bucket you do not have access to.\n'
-    'To fix: \n  1. If you are trying to create a new bucket - use a different name.'
-    '\n  2. If you are trying to connect to an existing bucket - make sure you have access to it.')
+    'To fix: \n'
+    '  1. If you are trying to create a new bucket - use a different name.\n'
+    '  2. If you are trying to connect to an existing bucket - make sure '
+    'you have access to it.')
 
 
 class StoreType(enum.Enum):


### PR DESCRIPTION
Changes the error message when a bucket is not accessible to focus on fix rather than the problem. Considered moving the root error (boto3/gcloud) to after our exception or removing it altogether, but decided it's better to let it come first, followed by our exception.

Before:
```
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadBucket operation: Forbidden

The above exception was the direct cause of the following exception:

sky.exceptions.StorageBucketGetError: Failed to connect to an existing bucket 'mybucket'.
Please check if:
  1. the bucket name is taken and/or 
  2. the bucket permissions are not setup correctly. To debug, consider using aws s3 ls checkpoint.
```

After:
```
botocore.exceptions.ClientError: An error occurred (403) when calling the HeadBucket operation: Forbidden

The above exception was the direct cause of the following exception:

sky.exceptions.StorageBucketGetError: Failed to connect to an existing bucket 'mybucket'. This is likely because it is a private bucket you do not have access to.
To fix: 
  1. If you are trying to create a new bucket - use a different name.
  2. If you are trying to connect to an existing bucket - make sure you have access to it. To debug, consider running `aws s3 ls mybucket`.
```
Tested (run the relevant ones):

- [x] Test with a common bucket name like `checkpoint` for s3, gcs and r2.
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials`
