### PR TITLE
Add missing azure dependency `azure-mgmt-network`

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -118,7 +118,10 @@ extras_require: Dict[str, List[str]] = {
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
     # azure-identity is needed in node_provider.
-    'azure': ['azure-cli>=2.31.0', 'azure-core', 'azure-identity', 'azure-mgmt-network'],
+    'azure': [
+        'azure-cli>=2.31.0', 'azure-core', 'azure-identity',
+        'azure-mgmt-network'
+    ],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],
     'docker': ['docker'],
     'lambda': [],

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -118,7 +118,7 @@ extras_require: Dict[str, List[str]] = {
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
     # azure-identity is needed in node_provider.
-    'azure': ['azure-cli>=2.31.0', 'azure-core', 'azure-identity'],
+    'azure': ['azure-cli>=2.31.0', 'azure-core', 'azure-identity', 'azure-mgmt-network'],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],
     'docker': ['docker'],
     'lambda': [],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The latest Azure cli does not install the `azure-mgmt-network` by default, which will be used by our `node_provider` for Azure. Adding this to our `setup.py`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
