### PR TITLE
Fix a typo in storage.rst

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -293,5 +293,5 @@ Storage YAML reference
         mounting the remote storage object. With MOUNT mode, files are streamed
         from the remote object store and writes are replicated to the object
         store (and consequently, to other workers mounting the same Storage).
-        With mount mode, files are copied at VM initialization and any writes to
+        With COPY mode, files are copied at VM initialization and any writes to
         the mount path will not be replicated on the object store.


### PR DESCRIPTION
Fix a typo in storage.rst

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
