### PR TITLE
Updated conda environment creation instructions for Apple Silicon devices

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -17,6 +17,9 @@ Install SkyPilot using pip:
   $ # pip install "skypilot[lambda]"
   $ # pip install "skypilot[all]"
 
+.. note::
+
+    There is no native build for python version <3.8 on Apple Silicon. Apple Silicon-based devices should create the conda environment with python version >=3.8.
 
 SkyPilot currently supports five cloud providers: AWS, GCP, Azure, Lambda Cloud and Cloudflare (R2).
 If you only have access to certain clouds, use any combination of


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Added new instructions specific to apple silicon devices that allows for the creation of a conda environment without fail. There is no native build for python version <3.8 on apple silicon.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested:
- Didn't run any tests since I only changed a .rst file and didn't touch the code
