### PR TITLE
UX: fix Resources/Task repr.

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -995,8 +995,10 @@ def _fill_in_launchable_resources(
                 else:
                     all_fuzzy_candidates.update(fuzzy_candidate_list)
             if len(launchable[resources]) == 0:
+                clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
+                    clouds_list[0])
                 logger.info(f'No resource satisfying {resources} '
-                            f'on {clouds_list}.')
+                            f'on {clouds_str}.')
                 if len(all_fuzzy_candidates) > 0:
                     logger.info('Did you mean: '
                                 f'{colorama.Fore.CYAN}'

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -260,16 +260,17 @@ class Optimizer:
             num_resources = len(node.get_resources())
             for orig_resources, launchable_list in launchable_resources.items():
                 if not launchable_list:
-                    # Region str.
-                    region_str = ''
+                    location_hint = ''
                     if node.get_resources():
                         specified_resources = list(node.get_resources())[0]
-                        if specified_resources.region:
-                            region_str = f' Region: {specified_resources.region}.'
+                        if specified_resources.zone is not None:
+                            location_hint = f' Zone: {specified_resources.zone}.'
+                        elif specified_resources.region:
+                            location_hint = f' Region: {specified_resources.region}.'
 
                     error_msg = (
                         'No launchable resource found for task '
-                        f'{node}.{region_str}\nThis means the '
+                        f'{node}.{location_hint}\nThis means the '
                         'catalog does not contain any instance types that '
                         'satisfy this request.\n'
                         'To fix: relax or change the resource requirements.\n'

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -264,9 +264,11 @@ class Optimizer:
                     if node.get_resources():
                         specified_resources = list(node.get_resources())[0]
                         if specified_resources.zone is not None:
-                            location_hint = f' Zone: {specified_resources.zone}.'
+                            location_hint = (
+                                f' Zone: {specified_resources.zone}.')
                         elif specified_resources.region:
-                            location_hint = f' Region: {specified_resources.region}.'
+                            location_hint = (
+                                f' Region: {specified_resources.region}.')
 
                     error_msg = (
                         'No launchable resource found for task '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -260,9 +260,16 @@ class Optimizer:
             num_resources = len(node.get_resources())
             for orig_resources, launchable_list in launchable_resources.items():
                 if not launchable_list:
+                    # Region str.
+                    region_str = ''
+                    if node.get_resources():
+                        specified_resources = list(node.get_resources())[0]
+                        if specified_resources.region:
+                            region_str = f' Region: {specified_resources.region}.'
+
                     error_msg = (
                         'No launchable resource found for task '
-                        f'{node}.\nThis means the '
+                        f'{node}.{region_str}\nThis means the '
                         'catalog does not contain any instance types that '
                         'satisfy this request.\n'
                         'To fix: relax or change the resource requirements.\n'

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -170,17 +170,13 @@ class Resources:
         else:
             instance_type = ''
 
-        region = ''
-        if self.region is not None:
-            region = f', region={self.region!r}'
-        zone = ''
-        if self.zone is not None:
-            zone = f', zone={self.zone!r}'
-
+        # Do not show region/zone here as `sky status -a` would show them as
+        # separate columns. Also, Resources repr will be printed during
+        # failover, and the region may be dynamically determined.
         hardware_str = (
             f'{instance_type}{use_spot}'
             f'{cpus}{memory}{accelerators}{accelerator_args}{image_id}'
-            f'{disk_size}{region}{zone}')
+            f'{disk_size}')
         # It may have leading ',' (for example, instance_type not set) or empty
         # spaces.  Remove them.
         while hardware_str and hardware_str[0] in (',', ' '):

--- a/sky/task.py
+++ b/sky/task.py
@@ -842,7 +842,7 @@ class Task:
         sky.dag.get_current_dag().add_edge(self, b)
 
     def __repr__(self):
-        if self.name:
+        if self.name and self.name != 'sky-cmd':  # CLI launch with a command
             return self.name
         if isinstance(self.run, str):
             run_msg = self.run.replace('\n', '\\n')
@@ -851,7 +851,7 @@ class Task:
             else:
                 run_msg = f'run=\'{run_msg}\''
         elif self.run is None:
-            run_msg = 'run=None'
+            run_msg = 'run=<empty>'
         else:
             run_msg = 'run=<fn>'
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

<!-- Describe the changes in this PR -->

#1848 accidentally added region/zone info in Resources, which is undesirable:
```
# When launching, even if region is not specified:
  I 04-16 12:11:12 cloud_vm_ray_backend.py:3350] Creating a new cluster: "dbg-private" [1x AWS(m6i.large, region='us-east-1')].

# In `status`: duplicates with `-a`
Clusters
NAME                          LAUNCHED    RESOURCES                                                                  STATUS   AUTOSTOP  COMMAND             
sky-65b4-zongheng             4 days ago  1x Azure(Standard_ND40rs_v2, {'V100-32GB': 8}, region='eastus')            STOPPED  -         sky exec sky-65b4-zongheng...
```

This PR 
- reverted that part of the change
- brought back the location hint in "no instance types found" Optimizer outputs
- fixed `Task.__repr__()` for `sky-cmd` tasks

With
```yaml
# repro.yaml
resources:
  cloud: aws
  accelerators: A100-80GB:8
  use_spot: true
```
This PR will show:
```
» sky launch repro.yaml                                                          1 ↵
Task from YAML spec: repro.yaml
I 04-16 13:47:55 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}).
This means the catalog does not contain any instance types that satisfy this request.
...

» sky launch repro.yaml --region us-east-1                                       1 ↵
Task from YAML spec: repro.yaml
I 04-16 13:48:42 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}). Region: us-east-1.
This means the catalog does not contain any instance types that satisfy this request.
...

» sky launch repro.yaml --zone us-east-1c                                        1 ↵
Task from YAML spec: repro.yaml
I 04-16 13:49:41 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}). Zone: us-east-1c.
This means the catalog does not contain any instance types that satisfy this request.
...

» sky launch --gpus A100-80GB:8 --use-spot --cloud aws                           1 ↵
I 04-16 13:46:39 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}).
This means the catalog does not contain any instance types that satisfy this request.
...

» sky launch --gpus A100-80GB:8 --use-spot --cloud aws --region us-east-1        1 ↵
I 04-16 13:46:23 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}). Region: us-east-1.
This means the catalog does not contain any instance types that satisfy this request.
...

» sky launch --gpus A100-80GB:8 --use-spot --cloud aws --zone us-east-1c                      1 ↵
I 04-16 13:46:03 optimizer.py:998] No resource satisfying AWS([Spot], {'A100-80GB': 8}) on [AWS].
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task Task(run=<empty>)
  resources: AWS([Spot], {'A100-80GB': 8}). Zone: us-east-1c.
This means the catalog does not contain any instance types that satisfy this request.
...
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
