### PR TITLE
Add disk tier to vicuna example for better performance

### DIFF
--- a/llm/vicuna/serve.yaml
+++ b/llm/vicuna/serve.yaml
@@ -1,6 +1,8 @@
 resources:
   accelerators: A100:1
   disk_size: 1024
+  # Note: The disk_tier option is not offered in skypilot<=0.2.5, we need
+  # to install SkyPilot from source.
   disk_tier: high
 
 setup: |

--- a/llm/vicuna/serve.yaml
+++ b/llm/vicuna/serve.yaml
@@ -1,6 +1,7 @@
 resources:
   accelerators: A100:1
   disk_size: 1024
+  disk_tier: high
 
 setup: |
   conda activate chatbot

--- a/llm/vicuna/train.yaml
+++ b/llm/vicuna/train.yaml
@@ -2,6 +2,7 @@ resources:
   accelerators: A100-80GB:8
   disk_size: 1000
   use_spot: true
+  disk_tier: high
 
 num_nodes: 1
 

--- a/llm/vicuna/train.yaml
+++ b/llm/vicuna/train.yaml
@@ -2,6 +2,8 @@ resources:
   accelerators: A100-80GB:8
   disk_size: 1000
   use_spot: true
+  # Note: The disk_tier option is not offered in skypilot<=0.2.5, we need
+  # to install SkyPilot from source.
   disk_tier: high
 
 num_nodes: 1


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now use the high-performance disk for the vicuna example, so as to get much better checkpointing efficiency and align with the configuration we used in the actual training.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch ./train.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
