### PR TITLE
[Storage] Fix `sky storage delete` for externally deleted buckets

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1227,7 +1227,7 @@ class S3Store(AbstractStore):
             if 'NoSuchBucket' in e.output.decode('utf-8'):
                 logger.debug(
                     _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE.format(
-                        bucket_name))
+                        bucket_name=bucket_name))
                 return False
             else:
                 logger.error(e.output)
@@ -1637,7 +1637,7 @@ class GcsStore(AbstractStore):
                 # Do a no-op in that case.
                 logger.debug(
                     _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE.format(
-                        bucket_name))
+                        bucket_name=bucket_name))
                 return False
             try:
                 remove_obj_command = ('gsutil -m rm -r'
@@ -1964,7 +1964,7 @@ class R2Store(AbstractStore):
             if 'NoSuchBucket' in e.output.decode('utf-8'):
                 logger.debug(
                     _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE.format(
-                        bucket_name))
+                        bucket_name=bucket_name))
                 return False
             else:
                 logger.error(e.output)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -151,13 +151,11 @@ class AbstractStore:
                      name: str,
                      source: Optional[SourceType],
                      region: Optional[str] = None,
-                     is_sky_managed: Optional[bool] = None,
-                     sync_on_reconstruction: Optional[bool] = None):
+                     is_sky_managed: Optional[bool] = None):
             self.name = name
             self.source = source
             self.region = region
             self.is_sky_managed = is_sky_managed
-            self.sync_on_reconstruction = sync_on_reconstruction
 
         def __repr__(self):
             return (
@@ -165,8 +163,7 @@ class AbstractStore:
                 f'\n\tname={self.name},'
                 f'\n\tsource={self.source},'
                 f'\n\tregion={self.region},'
-                f'\n\tis_sky_managed={self.is_sky_managed},'
-                f'\n\tsync_on_reconstruction={self.sync_on_reconstruction})')
+                f'\n\tis_sky_managed={self.is_sky_managed})')
 
     def __init__(self,
                  name: str,
@@ -214,8 +211,7 @@ class AbstractStore:
                    is_sky_managed=override_args.get('is_sky_managed',
                                                     metadata.is_sky_managed),
                    sync_on_reconstruction=override_args.get(
-                       'sync_on_reconstruction',
-                       metadata.sync_on_reconstruction))
+                       'sync_on_reconstruction', True))
 
     def get_metadata(self) -> StoreMetadata:
         return self.StoreMetadata(name=self.name,
@@ -439,10 +435,12 @@ class Storage(object):
                         sync_on_reconstruction=self.sync_on_reconstruction)
                 elif s_type == StoreType.GCS:
                     store = GcsStore.from_metadata(s_metadata,
-                                                   source=self.source)
+                                                   source=self.source,
+                                                   sync_on_reconstruction=self.sync_on_reconstruction)
                 elif s_type == StoreType.R2:
                     store = R2Store.from_metadata(s_metadata,
-                                                  source=self.source)
+                                                  source=self.source,
+                                                  sync_on_reconstruction=self.sync_on_reconstruction)
                 else:
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(f'Unknown store type: {s_type}')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1100,8 +1100,8 @@ class S3Store(AbstractStore):
         If the bucket does not exist, there are three cases:
           1) Raise an error if the bucket source starts with s3://
           2) Return None if bucket has been externally deleted and
-             sync_on_reconstruction if False
-          2) Create and return a new bucket otherwise
+             sync_on_reconstruction is False
+          3) Create and return a new bucket otherwise
 
         Raises:
             StorageBucketCreateError: If creating the bucket fails
@@ -1136,7 +1136,7 @@ class S3Store(AbstractStore):
                     f'{self.source}` to debug.')
 
         # If bucket cannot be found in both private and public settings,
-        # the bucket is to be created by Sky. However, skip creation if
+        # the bucket is to be created by Sky. However, creation is skipped if
         # Store object is being reconstructed for deletion.
         if self.sync_on_reconstruction:
             bucket = self._create_s3_bucket(self.name)
@@ -1510,8 +1510,8 @@ class GcsStore(AbstractStore):
         If the bucket does not exist, there are three cases:
           1) Raise an error if the bucket source starts with gs://
           2) Return None if bucket has been externally deleted and
-             sync_on_reconstruction if False
-          2) Create and return a new bucket otherwise
+             sync_on_reconstruction is False
+          3) Create and return a new bucket otherwise
 
         Raises:
             StorageBucketCreateError: If creating the bucket fails
@@ -1529,8 +1529,8 @@ class GcsStore(AbstractStore):
             else:
 
                 # If bucket cannot be found (i.e., does not exist), it is to be
-                # created by Sky. However, skip creation if Store object is
-                # being reconstructed for deletion.
+                # created by Sky. However, creation is skipped if Store object
+                # is being reconstructed for deletion.
                 if self.sync_on_reconstruction:
                     bucket = self._create_gcs_bucket(self.name)
                     return bucket, True
@@ -1826,8 +1826,8 @@ class R2Store(AbstractStore):
         If the bucket does not exist, there are three cases:
           1) Raise an error if the bucket source starts with s3://
           2) Return None if bucket has been externally deleted and
-             sync_on_reconstruction if False
-          2) Create and return a new bucket otherwise
+             sync_on_reconstruction is False
+          3) Create and return a new bucket otherwise
 
         Raises:
             StorageBucketCreateError: If creating the bucket fails

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -158,12 +158,11 @@ class AbstractStore:
             self.is_sky_managed = is_sky_managed
 
         def __repr__(self):
-            return (
-                f'StoreMetadata('
-                f'\n\tname={self.name},'
-                f'\n\tsource={self.source},'
-                f'\n\tregion={self.region},'
-                f'\n\tis_sky_managed={self.is_sky_managed})')
+            return (f'StoreMetadata('
+                    f'\n\tname={self.name},'
+                    f'\n\tsource={self.source},'
+                    f'\n\tregion={self.region},'
+                    f'\n\tis_sky_managed={self.is_sky_managed})')
 
     def __init__(self,
                  name: str,
@@ -434,13 +433,15 @@ class Storage(object):
                         source=self.source,
                         sync_on_reconstruction=self.sync_on_reconstruction)
                 elif s_type == StoreType.GCS:
-                    store = GcsStore.from_metadata(s_metadata,
-                                                   source=self.source,
-                                                   sync_on_reconstruction=self.sync_on_reconstruction)
+                    store = GcsStore.from_metadata(
+                        s_metadata,
+                        source=self.source,
+                        sync_on_reconstruction=self.sync_on_reconstruction)
                 elif s_type == StoreType.R2:
-                    store = R2Store.from_metadata(s_metadata,
-                                                  source=self.source,
-                                                  sync_on_reconstruction=self.sync_on_reconstruction)
+                    store = R2Store.from_metadata(
+                        s_metadata,
+                        source=self.source,
+                        sync_on_reconstruction=self.sync_on_reconstruction)
                 else:
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(f'Unknown store type: {s_type}')

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1781,6 +1781,48 @@ class TestStorageWithCredentials:
         'abc_',  # ends with an underscore
     ]
 
+
+    @staticmethod
+    def cli_delete_cmd(store_type, bucket_name):
+        if store_type == storage_lib.StoreType.S3:
+            url = f's3://{bucket_name}'
+            return ['aws', 's3', 'rb', url, '--force']
+        if store_type == storage_lib.StoreType.GCS:
+            url = f'gs://{bucket_name}'
+            return ['gsutil', '-m', 'rm', '-r', url]
+        if store_type == storage_lib.StoreType.R2:
+            endpoint_url = cloudflare.create_endpoint()
+            url = f's3://{bucket_name}'
+            return [
+                'aws', 's3', 'rb', url, '--force', '--endpoint', endpoint_url,
+                '--profile=r2'
+            ]
+
+    @staticmethod
+    def cli_ls_cmd(store_type, bucket_name, suffix=''):
+        if store_type == storage_lib.StoreType.S3:
+            if suffix:
+                url = f's3://{bucket_name}/{suffix}'
+            else:
+                url = f's3://{bucket_name}'
+            return ['aws', 's3', 'ls', url]
+        if store_type == storage_lib.StoreType.GCS:
+            if suffix:
+                url = f'gs://{bucket_name}/{suffix}'
+            else:
+                url = f'gs://{bucket_name}'
+            return ['gsutil', 'ls', url]
+        if store_type == storage_lib.StoreType.R2:
+            endpoint_url = cloudflare.create_endpoint()
+            if suffix:
+                url = f's3://{bucket_name}/{suffix}'
+            else:
+                url = f's3://{bucket_name}'
+            return [
+                'aws', 's3', 'ls', url, '--endpoint', endpoint_url,
+                '--profile=r2'
+            ]
+
     @pytest.fixture
     def tmp_source(self, tmp_path):
         # Creates a temporary directory with a file in it
@@ -1916,6 +1958,36 @@ class TestStorageWithCredentials:
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_local_storage_obj.name not in out.decode('utf-8')
 
+
+    @pytest.mark.parametrize('store_type', [
+        storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
+        pytest.param(storage_lib.StoreType.R2, marks=pytest.mark.cloudflare)
+    ])
+    def test_bucket_external_deletion(self, tmp_scratch_storage_obj,
+                                              store_type):
+        # Creates a bucket, deletes it externally using cloud cli commands
+        # and then tries to delete it using sky storage delete.
+        tmp_scratch_storage_obj.add_store(store_type)
+
+        # Run sky storage ls to check if storage object exists in the output
+        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        assert tmp_scratch_storage_obj.name in out.decode('utf-8')
+
+        # Delete bucket externally
+        cmd = self.cli_delete_cmd(store_type, tmp_scratch_storage_obj.name)
+        subprocess.check_output(cmd)
+
+        # Run sky storage delete to delete the storage object
+        out = subprocess.check_output(
+            ['sky', 'storage', 'delete', tmp_scratch_storage_obj.name])
+        # Make sure bucket was not created during deletion (see issue #1322)
+        assert 'created' not in out.decode('utf-8').lower()
+
+        # Run sky storage ls to check if storage object is deleted
+        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        assert tmp_scratch_storage_obj.name not in out.decode('utf-8')
+
+
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.R2, marks=pytest.mark.cloudflare)
@@ -2023,31 +2095,6 @@ class TestStorageWithCredentials:
                 match=storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
                     name=private_bucket_name)):
             storage_obj = storage_lib.Storage(source=private_bucket)
-
-    @staticmethod
-    def cli_ls_cmd(store_type, bucket_name, suffix=''):
-        if store_type == storage_lib.StoreType.S3:
-            if suffix:
-                url = f's3://{bucket_name}/{suffix}'
-            else:
-                url = f's3://{bucket_name}'
-            return ['aws', 's3', 'ls', url]
-        if store_type == storage_lib.StoreType.GCS:
-            if suffix:
-                url = f'gs://{bucket_name}/{suffix}'
-            else:
-                url = f'gs://{bucket_name}'
-            return ['gsutil', 'ls', url]
-        if store_type == storage_lib.StoreType.R2:
-            endpoint_url = cloudflare.create_endpoint()
-            if suffix:
-                url = f's3://{bucket_name}/{suffix}'
-            else:
-                url = f's3://{bucket_name}'
-            return [
-                'aws', 's3', 'ls', url, '--endpoint', endpoint_url,
-                '--profile=r2'
-            ]
 
     @pytest.mark.parametrize('ext_bucket_fixture, store_type',
                              [('tmp_awscli_bucket', storage_lib.StoreType.S3),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1781,7 +1781,6 @@ class TestStorageWithCredentials:
         'abc_',  # ends with an underscore
     ]
 
-
     @staticmethod
     def cli_delete_cmd(store_type, bucket_name):
         if store_type == storage_lib.StoreType.S3:
@@ -1958,13 +1957,12 @@ class TestStorageWithCredentials:
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_local_storage_obj.name not in out.decode('utf-8')
 
-
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.R2, marks=pytest.mark.cloudflare)
     ])
     def test_bucket_external_deletion(self, tmp_scratch_storage_obj,
-                                              store_type):
+                                      store_type):
         # Creates a bucket, deletes it externally using cloud cli commands
         # and then tries to delete it using sky storage delete.
         tmp_scratch_storage_obj.add_store(store_type)
@@ -1986,7 +1984,6 @@ class TestStorageWithCredentials:
         # Run sky storage ls to check if storage object is deleted
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_scratch_storage_obj.name not in out.decode('utf-8')
-
 
     @pytest.mark.parametrize('store_type', [
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,


### PR DESCRIPTION
Closes #1322.

If a bucket is deleted externally, then store.delete() now does a no-op (instead of creating and deleting like before). The logging has been updated. 

Now:
```
(base) ➜  repro git:(storage_deletionfix) ✗ SKYPILOT_DEBUG=0 sky storage delete -a
Deleting all storage objects.
# Shows spinner Deleting S3 bucket romilmybucket.
I 04-16 22:47:19 storage.py:1029] S3 bucket romilmybucket may have been deleted externally. Removing from local state.
```

Tested (run the relevant ones):

- [x] [Snippet](https://github.com/skypilot-org/skypilot/issues/1322#issuecomment-1510541254) from #1322
- [x] Storage smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` and with `--cloudflare`.
- [x] Backward compatibility testing by creating buckets in master, upgrading, then trying deletion and launching with existing buckets.
