### PR TITLE
Core/CLI: make `down -p` bypass identity mismatch errors.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1849,13 +1849,14 @@ def _update_cluster_status_no_lock(
         if ready_head + ready_workers == handle.launched_nodes:
             ray_cluster_up = True
 
-        # For non-spot clusters:
-        # If ray status shows all nodes are healthy, it is safe to set
-        # the status to UP as starting ray is the final step of sky launch.
-        # For spot clusters, the above can be unsafe because the Ray cluster
-        # may remain healthy for a while before the cloud completely
-        # preempts the VMs.
-        # Additionally, we query the VM state from the cloud provider.
+        # For non-spot clusters: If ray status shows all nodes are healthy, it
+        # is safe to set the status to UP as starting ray is the final step of
+        # sky launch.
+        #
+        # For spot clusters: the above can be unsafe because the Ray cluster
+        # may remain healthy for a while before the cloud completely preempts
+        # the VMs. Thus, we ddditionally query the VM state from the cloud
+        # provider.
         if ray_cluster_up and not use_spot:
             record['status'] = global_user_state.ClusterStatus.UP
             global_user_state.add_or_update_cluster(cluster_name,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2807,7 +2807,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     f'set, ignoring the above error.{reset}\n{yellow}It is the '
                     'user\'s responsibility to ensure that this '
                     f'cluster is actually terminated on the cloud.{reset}')
-                pass
             else:
                 raise
 
@@ -2822,7 +2821,14 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     lock_path,
                     backend_utils.CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS):
                 success = self.teardown_no_lock(
-                    handle, terminate, purge, refresh_cluster_status=not purge)
+                    handle,
+                    terminate,
+                    purge,
+                    # The refresh code path checks current user identity can
+                    # throw ClusterOwnerIdentityMismatchError. However, the
+                    # argument/flag `purge` should bypass such ID mismatch
+                    # errors.
+                    refresh_cluster_status=not purge)
             if success and terminate:
                 common_utils.remove_file_if_exists(lock_path)
         except filelock.Timeout as e:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2841,7 +2841,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         except exceptions.ClusterOwnerIdentityMismatchError as e:
             if purge:
                 logger.error(e)
-                verb = 'terminate' if terminate else 'stop'
                 verbed = 'terminated' if terminate else 'stopped'
                 logger.warning(
                     f'{yellow}Purge (-p/--purge) is set, ignoring the '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2802,11 +2802,14 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         except exceptions.ClusterOwnerIdentityMismatchError as e:
             if purge:
                 logger.error(e)
+                verb = 'terminate' if terminate else 'stop'
+                verbed = 'terminated' if terminate else 'stopped'
                 logger.warning(
                     f'{yellow}Purge (-p/--purge) is '
-                    f'set, ignoring the above error.{reset}\n{yellow}It is the '
+                    f'set, ignoring the above error and proceeding to attempt '
+                    f'to {verb} the cluster.{reset}\n{yellow}It is the '
                     'user\'s responsibility to ensure that this '
-                    f'cluster is actually terminated on the cloud.{reset}')
+                    f'cluster is actually {verbed} on the cloud.{reset}')
             else:
                 raise
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->


Fixes #1761.

Repro:
```
AWS_PROFILE=AdministratorAccess-1234 sky launch -c sso -t t3.large -i0 -y
sky down sso -p -y
```
Now:
```
# When cluster in INIT/UP (goes through `ray down`):
E 04-22 19:31:29 cloud_vm_ray_backend.py:2805] 'sso' (AWS) is owned by account ['A<stuff>:zongheng', '1234'], but the activated account is ['5678', '5678'].
W 04-22 19:31:29 cloud_vm_ray_backend.py:2807] Purge (-p/--purge) is set, ignoring the above error.
W 04-22 19:31:29 cloud_vm_ray_backend.py:2807] It is the user's responsibility to ensure that this cluster is actually terminated on the cloud.

# When cluster in STOPPED (goes through AWS CLI):
E 04-22 19:33:38 cloud_vm_ray_backend.py:2805] 'sso' (AWS) is owned by account ['A<stuff>:zongheng', '1234'], but the activated account is ['5678', '5678'].
W 04-22 19:33:38 cloud_vm_ray_backend.py:2807] Purge (-p/--purge) is set, ignoring the above error.
W 04-22 19:33:38 cloud_vm_ray_backend.py:2807] It is the user's responsibility to ensure that this cluster is actually terminated on the cloud.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--W 04-22 19:33:40 cloud_vm_ray_backend.py:3137] WARNING: Received non-zero exit code from stopping/terminating cluster nodes. Make sure resources are manually deleted.
```
At this point the cluster is removed from the `status` table, the `~/.ssh/config` file, etc.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
