### PR TITLE
Fix autostop/autodown rare bug: drop AWS keys from env vars.

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -166,20 +166,30 @@ class AutostopEvent(SkyletEvent):
                           write_ray_up_script_with_patched_launch_hash_fn(
                               self._ray_yaml_path,
                               ray_up_kwargs={'restart_only': True}))
+                # Passing env inherited from os.environ is technically not
+                # needed, because we call `python <script>` rather than `ray
+                # <cmd>`. We just need the {RAY_USAGE_STATS_ENABLED: 0} part.
                 subprocess.run([sys.executable, script], check=True, env=env)
 
                 logger.info('Running ray down.')
                 # Stop the workers first to avoid orphan workers.
-                subprocess.run([
-                    'ray', 'down', '-y', '--workers-only', self._ray_yaml_path
-                ],
-                               check=True,
-                               env=env)
+                subprocess.run(
+                    [
+                        'ray', 'down', '-y', '--workers-only',
+                        self._ray_yaml_path
+                    ],
+                    check=True,
+                    # We pass env inherited from os.environ due to calling `ray
+                    # <cmd>`.
+                    env=env)
 
             logger.info('Running final ray down.')
-            subprocess.run(['ray', 'down', '-y', self._ray_yaml_path],
-                           check=True,
-                           env=env)
+            subprocess.run(
+                ['ray', 'down', '-y', self._ray_yaml_path],
+                check=True,
+                # We pass env inherited from os.environ due to calling `ray
+                # <cmd>`.
+                env=env)
         else:
             raise NotImplementedError
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -173,14 +173,21 @@ class AutostopEvent(SkyletEvent):
 
                 logger.info('Running ray down.')
                 # Stop the workers first to avoid orphan workers.
-                subprocess.run([
-                    'ray', 'down', '-y', '--workers-only', self._ray_yaml_path
-                ],
-                               check=True)
+                subprocess.run(
+                    [
+                        'ray', 'down', '-y', '--workers-only',
+                        self._ray_yaml_path
+                    ],
+                    check=True,
+                    # See above on why we don't inherit from os.environ.
+                    env={})
 
             logger.info('Running final ray down.')
-            subprocess.run(['ray', 'down', '-y', self._ray_yaml_path],
-                           check=True)
+            subprocess.run(
+                ['ray', 'down', '-y', self._ray_yaml_path],
+                check=True,
+                # See above on why we don't inherit from os.environ.
+                env={})
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

#1880 didn't fix user's issue because the "final ray down" still calls bootstrap in the node provider, which then throws the VPC-not-found error. 

This PR explicitly drops AWS keys from env vars for all `ray` commands during autostop/down. Confirmed with user this fixed things for them.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
```
pytest tests/test_smoke.py::test_autostop --aws
pytest tests/test_smoke.py::test_autodown --aws
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
