### PR TITLE
[Debug] Enable traceback when `SKYPILOT_DEBUG=1` is set

### DIFF
--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -4,6 +4,8 @@ import sys
 
 import rich.console as rich_console
 
+from sky.utils import env_options
+
 console = rich_console.Console()
 
 
@@ -28,7 +30,11 @@ def print_exception_no_traceback():
             if error():
                 raise ValueError('...')
     """
-    original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
-    sys.tracebacklimit = 0
-    yield
-    sys.tracebacklimit = original_tracelimit
+    if env_options.Options.SHOW_DEBUG_INFO.get():
+        # When SKYPILOT_DEBUG is set, show the full traceback
+        yield
+    else:
+        original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
+        sys.tracebacklimit = 0
+        yield
+        sys.tracebacklimit = original_tracelimit


### PR DESCRIPTION
This PR disables the stack trace suppression in `print_exception_no_traceback` when `SKYPILOT_DEBUG=1` is set. 

I often find myself trying to find the traceback for exceptions raised under our `print_exception_no_traceback` ctx. As a result, for debugging, I edit `print_exception_no_traceback` to yield immediately and run my code to get the stack trace.  With this change, `SKYPILOT_DEBUG=1` becomes more true to its name, actually printing out all stack traces.

Similarly for users, we hide the stack trace for UX. However, we often need the stack traces for debugging, and there's no easy way for users to disable the stack trace suppression so we can debug easily. E.g., https://github.com/skypilot-org/skypilot/issues/1921#issuecomment-1530328009

## Before
```
(base) ➜  examples git:(debug_enable_traceback) ✗  SKYPILOT_DEBUG=1 sky launch -c sto test.yaml
Task from YAML spec: test.yaml
E 05-01 15:41:40 storage.py:683] Could not create StoreType.S3 store with name romil-bucket-s3.
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in CreateBucketConfiguration: "LocationConstraisnt", must be one of: LocationConstraint

The above exception was the direct cause of the following exception:

sky.exceptions.StorageBucketCreateError: Attempted to create a bucket romil-bucket-s3 but failed.

During handling of the above exception, another exception occurred:
```

## After
```
(base) ➜  examples git:(debug_enable_traceback) ✗ SKYPILOT_DEBUG=1 sky launch -c sto test.yaml
Task from YAML spec: test.yaml
E 05-01 15:40:07 storage.py:683] Could not create StoreType.S3 store with name romil-bucket-s3.
Traceback (most recent call last):
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 1159, in _create_s3_bucket
    s3_client.create_bucket(Bucket=bucket_name,
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/botocore/client.py", line 919, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/botocore/client.py", line 990, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/botocore/validate.py", line 381, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Unknown parameter in CreateBucketConfiguration: "LocationConstraisnt", must be one of: LocationConstraint

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 679, in add_store
    store = store_cls(name=self.name, source=self.source)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 867, in __init__
    super().__init__(name, source, region, is_sky_managed)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 188, in __init__
    self.initialize()
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 963, in initialize
    self.bucket, is_new_bucket = self._get_bucket()
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 1110, in _get_bucket
    bucket = self._create_s3_bucket(self.name)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 1164, in _create_s3_bucket
    raise exceptions.StorageBucketCreateError(
sky.exceptions.StorageBucketCreateError: Attempted to create a bucket romil-bucket-s3 but failed.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/romilb/tools/anaconda3/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/common_utils.py", line 220, in _record
    return f(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 1071, in invoke
    return super().invoke(ctx)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/common_utils.py", line 241, in _record
    return f(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 1294, in launch
    task = _make_task_from_entrypoint_with_overrides(
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 1010, in _make_task_from_entrypoint_with_overrides
    task = sky.Task.from_yaml(entrypoint)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/task.py", line 303, in from_yaml
    storage_obj = storage_lib.Storage.from_yaml_config(storage[1])
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 821, in from_yaml_config
    storage_obj.add_store(StoreType(store.upper()))
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/data/storage.py", line 685, in add_store
    global_user_state.set_storage_status(self.name,
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/global_user_state.py", line 706, in set_storage_status
    raise ValueError(f'Storage {storage_name} not found.')
ValueError: Storage romil-bucket-s3 not found.

```

Tested (run the relevant ones):

- [x] Manually injected errors into a fn and tested with `SKYPILOT_DEBUG=0` and `SKYPILOT_DEBUG=1`. See example above.
