### PR TITLE
Added functionality to support specifying quantity of a resource in call to show-gpus

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -17,6 +17,9 @@ Install SkyPilot using pip:
   $ # pip install "skypilot[lambda]"
   $ # pip install "skypilot[all]"
 
+.. note::
+
+    There is no native build for python version <3.8 on Apple Silicon. Apple Silicon-based devices should create the conda environment with python version >=3.8.
 
 SkyPilot currently supports five cloud providers: AWS, GCP, Azure, Lambda Cloud and Cloudflare (R2).
 If you only have access to certain clouds, use any combination of

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -5,9 +5,9 @@ Install SkyPilot using pip:
 
 .. code-block:: console
 
-  $ # SkyPilot requires python >= 3.6.
+  $ # SkyPilot requires python >= 3.6. For Apple Silicon, use >= 3.8.
   $ # Recommended: use a new conda env to avoid package conflicts.
-  $ conda create -y -n sky python=3.7
+  $ conda create -y -n sky python=3.8
   $ conda activate sky
 
   $ # Choose an extra (default: [aws])
@@ -16,10 +16,6 @@ Install SkyPilot using pip:
   $ # pip install "skypilot[azure]"
   $ # pip install "skypilot[lambda]"
   $ # pip install "skypilot[all]"
-
-.. note::
-
-    There is no native build for python version <3.8 on Apple Silicon. Apple Silicon-based devices should create the conda environment with python version >=3.8.
 
 SkyPilot currently supports five cloud providers: AWS, GCP, Azure, Lambda Cloud and Cloudflare (R2).
 If you only have access to certain clouds, use any combination of

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3063,11 +3063,11 @@ def show_gpus(
                        '(including non-common ones) and pricing.')
                 return
             
-        new_gpu_name = gpu_name 
-        gpu_name_and_count = new_gpu_name.count(":") > 0
+        new_gpu_name = gpu_name
+        gpu_name_and_count = new_gpu_name.count(':') > 0
 
         if (gpu_name_and_count):
-            split_gpu_name = re.split(":", new_gpu_name)
+            split_gpu_name = re.split(':', new_gpu_name)
             new_gpu_name = split_gpu_name[0]
 
         # Show detailed accelerator information
@@ -3122,9 +3122,10 @@ def show_gpus(
                     item.spot_price) else '-'
                 region_str = item.region if not pd.isna(item.region) else '-'
 
-                requested_accelerator_count = item.accelerator_count if not gpu_name_and_count else int(split_gpu_name[1])
+                requested_accelerator_count = item.accelerator_count if not gpu_name_and_count else int(
+                    split_gpu_name[1])
 
-                if (requested_accelerator_count == item.accelerator_count):
+                if requested_accelerator_count == item.accelerator_count:
                     accelerator_table_vals = [
                         item.accelerator_name,
                         item.accelerator_count,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3062,7 +3062,7 @@ def show_gpus(
                 yield ('\n\nHint: use -a/--all to see all accelerators '
                        '(including non-common ones) and pricing.')
                 return
-            
+
         new_gpu_name = gpu_name
         gpu_name_and_count = new_gpu_name.count(':') > 0
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3070,7 +3070,7 @@ def show_gpus(
             quantity = int(accelerator_str.split(":")[1])
         result = service_catalog.list_accelerators(gpus_only=True,
                                                    name_filter=name,
-                                                   quantity = quantity,
+                                                   quantity=quantity,
                                                    region_filter=region,
                                                    clouds=cloud)
         if len(result) == 0:
@@ -3081,7 +3081,8 @@ def show_gpus(
 
         num_accelerators_found = 0
         num_unique_accelerators = len([1 for i in result if len(result[i]) > 0])
-        for i in result: num_accelerators_found += len(result[i])
+        for i in result:
+            num_accelerators_found += len(result[i])
         if num_accelerators_found == 0:
             yield f'Resource \'{name}\', with '
             yield f'requested quantity {quantity}, '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3065,6 +3065,7 @@ def show_gpus(
 
         new_gpu_name = gpu_name
         gpu_name_and_count = new_gpu_name.count(':') > 0
+        total_table_len = 0
 
         if gpu_name_and_count:
             split_gpu_name = re.split(':', new_gpu_name)
@@ -3141,13 +3142,16 @@ def show_gpus(
                     if not show_all:
                         accelerator_table_vals.append(region_str)
                     accelerator_table.add_row(accelerator_table_vals)
-            if i != 0 and len(accelerator_table._rows) != 0:
+            cur_table_vals_len = len(accelerator_table.get_string())
+            if i != 0 and cur_table_vals_len != 0:
                 yield '\n\n'
             yield from accelerator_table.get_string()
 
-        if len(accelerator_table._rows) == 0:
-            yield f'Resource \'{new_gpu_name}\' '
-            yield f'with quantity {requested_accelerator_count} '
+            total_table_len += cur_table_vals_len
+
+        if total_table_len == 0:
+            yield f'Quantity {requested_accelerator_count} of '
+            yield f'resource \'{new_gpu_name}\' '
             yield 'not found. '
             yield 'Try \'sky show-gpus --all\' '
             yield 'to show available accelerators '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3073,13 +3073,12 @@ def show_gpus(
             # Check if quantity is valid
             try:
                 quantity = int(accelerator_split[1])
+                if quantity <= 0:
+                    raise ValueError('Quantity cannot be non-positive integer.')
             except ValueError as invalid_quantity:
                 raise click.UsageError(
                     f'Invalid accelerator quantity {accelerator_split[1]}. '
-                    'Expected an integer.') from invalid_quantity
-            if quantity == 0:
-                raise click.UsageError('Invalid accelerator quantity 0. '
-                                       'Expected a non-zero integer.')
+                    'Expected a positive integer.') from invalid_quantity
         else:
             name, quantity = accelerator_str, None
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3077,6 +3077,11 @@ def show_gpus(
                 raise click.UsageError(
                     f'Invalid accelerator quantity {accelerator_split[1]}. '
                     'Expected an integer.') from invalid_quantity
+            if quantity == 0:
+                raise click.UsageError(
+                    f'Invalid accelerator quantity 0. '
+                    'Expected a non-zero integer.'
+                )
         else:
             name, quantity = accelerator_str, None
 
@@ -3086,7 +3091,8 @@ def show_gpus(
                                                    region_filter=region,
                                                    clouds=cloud)
         if len(result) == 0:
-            yield f'Resources \'{name}\', with requested quantity, not found. '
+            quantity_str = f' with requested quantity {quantity}' if quantity else ''
+            yield f'Resources \'{name}\'{quantity_str} not found. '
             yield 'Try \'sky show-gpus --all\' '
             yield 'to show available accelerators.'
             return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3141,7 +3141,7 @@ def show_gpus(
                     if not show_all:
                         accelerator_table_vals.append(region_str)
                     accelerator_table.add_row(accelerator_table_vals)
-            if i != 0:
+            if i != 0 and len(accelerator_table._rows) != 0:
                 yield '\n\n'
             yield from accelerator_table.get_string()
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3078,9 +3078,8 @@ def show_gpus(
                     f'Invalid accelerator quantity {accelerator_split[1]}. '
                     'Expected an integer.') from invalid_quantity
             if quantity == 0:
-                raise click.UsageError(
-                    f'Invalid accelerator quantity 0. '
-                    'Expected a non-zero integer.')
+                raise click.UsageError('Invalid accelerator quantity 0. '
+                                       'Expected a non-zero integer.')
         else:
             name, quantity = accelerator_str, None
 
@@ -3090,7 +3089,8 @@ def show_gpus(
                                                    region_filter=region,
                                                    clouds=cloud)
         if len(result) == 0:
-            quantity_str = f' with requested quantity {quantity}' if quantity else ''
+            quantity_str = (f' with requested quantity {quantity}'
+                            if quantity else '')
             yield f'Resources \'{name}\'{quantity_str} not found. '
             yield 'Try \'sky show-gpus --all\' '
             yield 'to show available accelerators.'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3066,7 +3066,7 @@ def show_gpus(
         new_gpu_name = gpu_name
         gpu_name_and_count = new_gpu_name.count(':') > 0
 
-        if (gpu_name_and_count):
+        if gpu_name_and_count:
             split_gpu_name = re.split(':', new_gpu_name)
             new_gpu_name = split_gpu_name[0]
 
@@ -3122,8 +3122,8 @@ def show_gpus(
                     item.spot_price) else '-'
                 region_str = item.region if not pd.isna(item.region) else '-'
 
-                requested_accelerator_count = item.accelerator_count if not gpu_name_and_count else int(
-                    split_gpu_name[1])
+                requested_accelerator_count = (item.accelerator_count if not 
+                    gpu_name_and_count else int(split_gpu_name[1]))
 
                 if requested_accelerator_count == item.accelerator_count:
                     accelerator_table_vals = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3080,8 +3080,7 @@ def show_gpus(
             if quantity == 0:
                 raise click.UsageError(
                     f'Invalid accelerator quantity 0. '
-                    'Expected a non-zero integer.'
-                )
+                    'Expected a non-zero integer.')
         else:
             name, quantity = accelerator_str, None
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3122,8 +3122,9 @@ def show_gpus(
                     item.spot_price) else '-'
                 region_str = item.region if not pd.isna(item.region) else '-'
 
-                requested_accelerator_count = (item.accelerator_count if not 
-                    gpu_name_and_count else int(split_gpu_name[1]))
+                requested_accelerator_count = (item.accelerator_count
+                                               if not gpu_name_and_count else
+                                               int(split_gpu_name[1]))
 
                 if requested_accelerator_count == item.accelerator_count:
                     accelerator_table_vals = [

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3141,10 +3141,18 @@ def show_gpus(
                     if not show_all:
                         accelerator_table_vals.append(region_str)
                     accelerator_table.add_row(accelerator_table_vals)
-
             if i != 0:
                 yield '\n\n'
             yield from accelerator_table.get_string()
+
+        if len(accelerator_table._rows) == 0:
+            yield f'Resource \'{new_gpu_name}\' '
+            yield f'with quantity {requested_accelerator_count} '
+            yield 'not found. '
+            yield 'Try \'sky show-gpus --all\' '
+            yield 'to show available accelerators '
+            yield 'and their quantities.'
+            return
 
     if show_all:
         click.echo_via_pager(_output())

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3064,10 +3064,10 @@ def show_gpus(
 
         # Show detailed accelerator information
 
-        name, quantity = accelerator_str.split(":")[0], None
-        has_quantity = accelerator_str.count(":") > 0
+        name, quantity = accelerator_str.split(':')[0], None
+        has_quantity = accelerator_str.count(':') > 0
         if has_quantity:
-            quantity = int(accelerator_str.split(":")[1])
+            quantity = int(accelerator_str.split(':')[1])
         result = service_catalog.list_accelerators(gpus_only=True,
                                                    name_filter=name,
                                                    quantity=quantity,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3073,10 +3073,10 @@ def show_gpus(
             # Check if quantity is valid
             try:
                 quantity = int(accelerator_split[1])
-            except ValueError:
+            except ValueError as invalid_quantity:
                 raise click.UsageError(
                     f'Invalid accelerator quantity {accelerator_split[1]}. '
-                    'Expected an integer.')
+                    'Expected an integer.') from invalid_quantity
         else:
             name, quantity = accelerator_str, None
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3063,7 +3063,6 @@ def show_gpus(
                        '(including non-common ones) and pricing.')
                 return
             
-        # Declaring new variable to to take care of changing variable name
         new_gpu_name = gpu_name 
         gpu_name_and_count = new_gpu_name.count(":") > 0
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -74,6 +74,7 @@ def list_accelerators(
             ret[gpu] += items
     return dict(ret) 
 
+
 def list_accelerator_counts(
     gpus_only: bool = True,
     name_filter: Optional[str] = None,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -106,7 +106,7 @@ def list_accelerator_counts(
                 accelerator_counts[gpu].add(item.accelerator_count)
     ret: Dict[str, List[int]] = {}
     for gpu, counts in accelerator_counts.items():
-        ret[gpu] = sorted(counts)   
+        ret[gpu] = sorted(counts)
     return ret
 
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -72,7 +72,7 @@ def list_accelerators(
     for result in results:
         for gpu, items in result.items():
             ret[gpu] += items
-    return dict(ret) 
+    return dict(ret)
 
 
 def list_accelerator_counts(

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -65,7 +65,8 @@ def list_accelerators(
     of instance type offerings. See usage in cli.py.
     """
     results = _map_clouds_catalog(clouds, 'list_accelerators', gpus_only,
-                                  name_filter, region_filter, quantity_filter, case_sensitive)
+                                  name_filter, region_filter, quantity_filter,
+                                  case_sensitive)
     if not isinstance(results, list):
         results = [results]
     ret: Dict[str,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -1,6 +1,7 @@
 """Service catalog."""
 import collections
 import importlib
+import sys
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
@@ -72,8 +73,7 @@ def list_accelerators(
     for result in results:
         for gpu, items in result.items():
             ret[gpu] += items
-    return dict(ret)
-
+    return dict(ret) 
 
 def list_accelerator_counts(
     gpus_only: bool = True,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -1,7 +1,6 @@
 """Service catalog."""
 import collections
 import importlib
-import sys
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -51,8 +51,8 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
 def list_accelerators(
     gpus_only: bool = True,
     name_filter: Optional[str] = None,
-    quantity: Optional[int] = None,
     region_filter: Optional[str] = None,
+    quantity_filter: Optional[int] = None,
     clouds: CloudFilter = None,
     case_sensitive: bool = True,
 ) -> 'Dict[str, List[common.InstanceTypeInfo]]':
@@ -65,21 +65,14 @@ def list_accelerators(
     of instance type offerings. See usage in cli.py.
     """
     results = _map_clouds_catalog(clouds, 'list_accelerators', gpus_only,
-                                  name_filter, region_filter, case_sensitive)
+                                  name_filter, region_filter, quantity_filter, case_sensitive)
     if not isinstance(results, list):
         results = [results]
     ret: Dict[str,
               List['common.InstanceTypeInfo']] = collections.defaultdict(list)
     for result in results:
         for gpu, items in result.items():
-            if quantity:
-                new_items = []
-                for item in items:
-                    if item.accelerator_count == quantity:
-                        new_items.append(item)
-                ret[gpu] += new_items
-            else:
-                ret[gpu] += items
+            ret[gpu] += items
     return dict(ret)
 
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -64,7 +64,6 @@ def list_accelerators(
     Returns: A dictionary of canonical accelerator names mapped to a list
     of instance type offerings. See usage in cli.py.
     """
-    check_count = True if quantity else False
     results = _map_clouds_catalog(clouds, 'list_accelerators', gpus_only,
                                   name_filter, region_filter, case_sensitive)
     if not isinstance(results, list):
@@ -73,7 +72,7 @@ def list_accelerators(
               List['common.InstanceTypeInfo']] = collections.defaultdict(list)
     for result in results:
         for gpu, items in result.items():
-            if check_count:
+            if quantity:
                 new_items = []
                 for item in items:
                     if item.accelerator_count == quantity:

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -249,12 +249,13 @@ def list_accelerators(
         gpus_only: bool,
         name_filter: Optional[str],
         region_filter: Optional[str],
+        quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in AWS offering accelerators."""
     return common.list_accelerators_impl('AWS', _get_df(), gpus_only,
                                          name_filter, region_filter,
-                                         case_sensitive)
+                                         quantity_filter, case_sensitive)
 
 
 def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -166,4 +166,5 @@ def list_accelerators(
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Azure offering GPUs."""
     return common.list_accelerators_impl('Azure', _df, gpus_only, name_filter,
-                                         region_filter, quantity_filter, case_sensitive)
+                                         region_filter, quantity_filter,
+                                         case_sensitive)

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -161,8 +161,9 @@ def list_accelerators(
         gpus_only: bool,
         name_filter: Optional[str],
         region_filter: Optional[str],
+        quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Azure offering GPUs."""
     return common.list_accelerators_impl('Azure', _df, gpus_only, name_filter,
-                                         region_filter, case_sensitive)
+                                         region_filter, quantity_filter, case_sensitive)

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -144,7 +144,6 @@ def read_catalog(filename: str,
             raise e
     return df
 
-
 def _get_instance_type(
     df: pd.DataFrame,
     instance_type: str,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -471,7 +471,7 @@ def list_accelerators_impl(
                                           case=case_sensitive,
                                           regex=True)]
     df['AcceleratorCount'] = df['AcceleratorCount'].astype(int)
-    if quantity_filter:
+    if quantity_filter is not None:
         df = df[df['AcceleratorCount'] == quantity_filter]
     grouped = df.groupby('AcceleratorName')
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -144,6 +144,7 @@ def read_catalog(filename: str,
             raise e
     return df
 
+
 def _get_instance_type(
     df: pd.DataFrame,
     instance_type: str,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -426,6 +426,7 @@ def list_accelerators_impl(
     gpus_only: bool,
     name_filter: Optional[str],
     region_filter: Optional[str],
+    quantity_filter: Optional[int],
     case_sensitive: bool = True,
 ) -> Dict[str, List[InstanceTypeInfo]]:
     """Lists accelerators offered in a cloud service catalog.
@@ -470,6 +471,8 @@ def list_accelerators_impl(
                                           case=case_sensitive,
                                           regex=True)]
     df['AcceleratorCount'] = df['AcceleratorCount'].astype(int)
+    if quantity_filter:
+        df = df[df['AcceleratorCount'] == quantity_filter]
     grouped = df.groupby('AcceleratorName')
 
     def make_list_from_df(rows):

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -329,7 +329,8 @@ def list_accelerators(
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in GCP offering GPUs."""
     results = common.list_accelerators_impl('GCP', _df, gpus_only, name_filter,
-                                            region_filter, quantity_filter, case_sensitive)
+                                            region_filter, quantity_filter,
+                                            case_sensitive)
 
     a100_infos = results.get('A100', []) + results.get('A100-80GB', [])
     if not a100_infos:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -324,11 +324,12 @@ def list_accelerators(
     gpus_only: bool,
     name_filter: Optional[str] = None,
     region_filter: Optional[str] = None,
+    quantity_filter: Optional[int] = None,
     case_sensitive: bool = True,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in GCP offering GPUs."""
     results = common.list_accelerators_impl('GCP', _df, gpus_only, name_filter,
-                                            region_filter, case_sensitive)
+                                            region_filter, quantity_filter, case_sensitive)
 
     a100_infos = results.get('A100', []) + results.get('A100-80GB', [])
     if not a100_infos:

--- a/sky/clouds/service_catalog/ibm_catalog.py
+++ b/sky/clouds/service_catalog/ibm_catalog.py
@@ -92,7 +92,8 @@ def list_accelerators(
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in IBM offering accelerators."""
     return common.list_accelerators_impl('IBM', _df, gpus_only, name_filter,
-                                         region_filter, quantity_filter, case_sensitive)
+                                         region_filter, quantity_filter,
+                                         case_sensitive)
 
 
 def get_default_instance_type(cpus: Optional[str] = None,

--- a/sky/clouds/service_catalog/ibm_catalog.py
+++ b/sky/clouds/service_catalog/ibm_catalog.py
@@ -87,11 +87,12 @@ def list_accelerators(
         gpus_only: bool,
         name_filter: Optional[str],
         region_filter: Optional[str],
+        quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in IBM offering accelerators."""
     return common.list_accelerators_impl('IBM', _df, gpus_only, name_filter,
-                                         region_filter, case_sensitive)
+                                         region_filter, quantity_filter, case_sensitive)
 
 
 def get_default_instance_type(cpus: Optional[str] = None,

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -128,8 +128,9 @@ def list_accelerators(
         gpus_only: bool,
         name_filter: Optional[str],
         region_filter: Optional[str],
+        quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Lambda offering GPUs."""
     return common.list_accelerators_impl('Lambda', _df, gpus_only, name_filter,
-                                         region_filter, case_sensitive)
+                                         region_filter, quantity_filter, case_sensitive)

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -133,4 +133,5 @@ def list_accelerators(
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Lambda offering GPUs."""
     return common.list_accelerators_impl('Lambda', _df, gpus_only, name_filter,
-                                         region_filter, quantity_filter, case_sensitive)
+                                         region_filter, quantity_filter,
+                                         case_sensitive)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes issue #1915. Previously, users were not able to specify the GPU quantity that they wanted. This PR allows users to do so by running sky show-gpus V100:4 to find the cloud providers and regions that offer 4 V100 GPUs.

The output is now as follows:
```
sky show-gpus V100:8

GPU   QTY  CLOUD   INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION            
V100  8    AWS     p3.16xlarge    16GB        64     488GB     $ 24.480      $ 7.344            ap-northeast-1    
V100  8    GCP     (attachable)   -           -      -         $ 19.840      $ 5.920            us-central1       
V100  8    Lambda  gpu_8x_v100    16GB        92     448GB     $ 4.400       -                  asia-northeast-1  

GPU        QTY  CLOUD  INSTANCE_TYPE       DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION          
V100-32GB  8    AWS    p3dn.24xlarge       32GB        96     768GB     $ 31.212      $ 9.364            ap-northeast-1  
V100-32GB  8    Azure  Standard_ND40rs_v2  -           40     672GB     $ 22.032      $ 3.530            eastus
```

Failure output is as follows:
```
sky show-gpus V100:5

Resource 'V100' with quantity 5 not found. Try 'sky show-gpus --all' to show available accelerators and their quantities.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
