### PR TITLE
[Docs] Add instructions for ssh-ing into multi-node jobs

### DIFF
--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -104,3 +104,20 @@ To execute a task on the head node only (a common scenario for tools like
      if [ "${SKYPILOT_NODE_RANK}" == "0" ]; then
          # Launch the head-only command here.
      fi
+
+
+SSH into worker nodes
+---------------------
+In addition to the head node, the worker nodes of a multi-node cluster also added to ``~/.ssh/config`` as ``<cluster_name>-worker<n>``.
+This allows you directly to SSH into the worker nodes, if required.
+
+.. code-block:: console
+
+  # Assuming 3 nodes in a cluster named mycluster
+
+  # Head node.
+  $ ssh mycluster
+
+  # Worker nodes.
+  $ ssh mycluster-worker1
+  $ ssh mycluster-worker2

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -108,7 +108,7 @@ To execute a task on the head node only (a common scenario for tools like
 
 SSH into worker nodes
 ---------------------
-In addition to the head node, the worker nodes of a multi-node cluster also added to ``~/.ssh/config`` as ``<cluster_name>-worker<n>``.
+In addition to the head node, the SSH configurations for the worker nodes of a multi-node cluster are also added to ``~/.ssh/config`` as ``<cluster_name>-worker<n>``.
 This allows you directly to SSH into the worker nodes, if required.
 
 .. code-block:: console


### PR DESCRIPTION
Users can't find how to ssh into worker nodes in multi-node clusters. Distributed jobs page is missing instructions on how to ssh.

User comments:
> When launching multi-node clusters, is there an easy way to ssh into non-head nodes (other than looking up the public DNS on e.g., AWS)?  I understand that the necessary ssh config is automatically set up such that ssh cluster-name works -- possible to do this for other cluster nodes as well?
> ...
> I read through most of the docs
> ...
> remember coming across ssh mycluster somewhere but couldn't find anything on worker node login

> I agree with this matter. I was also looking for a way to ssh into non-head nodes recently and found the instruction in [getting-started](https://skypilot.readthedocs.io/en/latest/getting-started/quickstart.html?highlight=ssh#ssh-into-clusters) after browsing for a couple of minutes and searching for 'ssh' in the search bar. Thankfully, the instruction appeared at the top of the search result. (edited)

Tested (run the relevant ones):

- [x] Docs rendered locally
