### PR TITLE
Fix AWS secret access key typo in autostop codepath

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -153,7 +153,7 @@ class AutostopEvent(SkyletEvent):
             # by the env vars).  See #1880 for details.
             env = dict(os.environ, RAY_USAGE_STATS_ENABLED='0')
             env.pop('AWS_ACCESS_KEY_ID', None)
-            env.pop('AWS_SECRETE_ACCESS_KEY', None)
+            env.pop('AWS_SECRET_ACCESS_KEY', None)
 
             # We do "initial ray up + ray down --workers-only" only for
             # multinode clusters as they are not needed for single-node.


### PR DESCRIPTION
`AWS_SECRETE_ACCESS_KEY` -> `AWS_SECRET_ACCESS_KEY`.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
