### PR TITLE
[Spot] Show logging from the controller and grace period for cluster status checking

### DIFF
--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -40,19 +40,24 @@ _logging_config = threading.local()
 print = builtins.print  # pylint: disable=redefined-builtin
 
 
+def create_handler():
+    handler = logging.StreamHandler(sys.stdout)
+    handler.flush = sys.stdout.flush  # type: ignore
+    if env_options.Options.SHOW_DEBUG_INFO.get():
+        handler.setLevel(logging.DEBUG)
+    else:
+        handler.setLevel(logging.INFO)
+    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
+    handler.setFormatter(fmt)
+    return handler
+
+
 def _setup_logger():
     _root_logger.setLevel(logging.DEBUG)
     global _default_handler
     if _default_handler is None:
-        _default_handler = logging.StreamHandler(sys.stdout)
-        _default_handler.flush = sys.stdout.flush  # type: ignore
-        if env_options.Options.SHOW_DEBUG_INFO.get():
-            _default_handler.setLevel(logging.DEBUG)
-        else:
-            _default_handler.setLevel(logging.INFO)
+        _default_handler = create_handler()
         _root_logger.addHandler(_default_handler)
-    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
-    _default_handler.setFormatter(fmt)
     # Setting this will avoid the message
     # being propagated to the parent logger.
     _root_logger.propagate = False
@@ -62,6 +67,7 @@ def _setup_logger():
 # This is thread-safe as the module is only imported once,
 # guaranteed by the Python GIL.
 _setup_logger()
+
 
 
 def init_logger(name: str):

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -40,24 +40,19 @@ _logging_config = threading.local()
 print = builtins.print  # pylint: disable=redefined-builtin
 
 
-def create_handler():
-    handler = logging.StreamHandler(sys.stdout)
-    handler.flush = sys.stdout.flush  # type: ignore
-    if env_options.Options.SHOW_DEBUG_INFO.get():
-        handler.setLevel(logging.DEBUG)
-    else:
-        handler.setLevel(logging.INFO)
-    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
-    handler.setFormatter(fmt)
-    return handler
-
-
 def _setup_logger():
     _root_logger.setLevel(logging.DEBUG)
     global _default_handler
     if _default_handler is None:
-        _default_handler = create_handler()
+        _default_handler = logging.StreamHandler(sys.stdout)
+        _default_handler.flush = sys.stdout.flush  # type: ignore
+        if env_options.Options.SHOW_DEBUG_INFO.get():
+            _default_handler.setLevel(logging.DEBUG)
+        else:
+            _default_handler.setLevel(logging.INFO)
         _root_logger.addHandler(_default_handler)
+    fmt = NewLineFormatter(_FORMAT, datefmt=_DATE_FORMAT)
+    _default_handler.setFormatter(fmt)
     # Setting this will avoid the message
     # being propagated to the parent logger.
     _root_logger.propagate = False
@@ -67,7 +62,6 @@ def _setup_logger():
 # This is thread-safe as the module is only imported once,
 # guaranteed by the Python GIL.
 _setup_logger()
-
 
 
 def init_logger(name: str):

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -171,9 +171,9 @@ class SpotController:
                     self.logger.info(
                         'The user job failed. Please check the logs below.\n'
                         f'== Logs of the user job (ID: {self._job_id}) ==\n')
-                    # TODO(zhwu): Download the logs, and stream them from the local
-                    # disk, instead of streaming them from the spot cluster, to make
-                    # it faster and more reliable.
+                    # TODO(zhwu): Download the logs, and stream them from the
+                    # local disk, instead of streaming them from the spot
+                    # cluster, to make it faster and more reliable.
                     returncode = self._backend.tail_logs(
                         handle, None, spot_job_id=self._job_id)
                     self.logger.info(f'\n== End of logs (ID: {self._job_id}, '

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -88,8 +88,8 @@ class SpotController:
                 3. Any unexpected error happens during the `sky.launch`.
         Other exceptions may be raised depending on the backend.
         """
-        logger.info(f'Started monitoring spot task {self._task_name} '
-                    f'(id: {self._job_id})')
+        logger.info(f'Started monitoring spot job {self._job_id}, '
+                    f'name: {self._task_name!r}.')
         spot_state.set_starting(self._job_id)
         job_submitted_at = self._strategy_executor.launch()
 
@@ -318,7 +318,7 @@ def start(job_id, task_yaml, retry_until_up):
         cancelling = True
     finally:
         if controller_process is not None:
-            logger.info(f'Killing controller process {controller_process.pid}')
+            logger.info(f'Killing controller process {controller_process.pid}.')
             # NOTE: it is ok to kill or join a killed process.
             # Kill the controller process first; if its child process is
             # killed first, then the controller process will raise errors.
@@ -328,7 +328,7 @@ def start(job_id, task_yaml, retry_until_up):
             controller_process.join()
             logger.info(f'Controller process {controller_process.pid} killed.')
 
-        logger.info(f'Cleaning up spot clusters of job {job_id}.')
+        logger.info(f'Cleaning up spot cluster of job {job_id}.')
         # NOTE: Originally, we send an interruption signal to the controller
         # process and the controller process handles cleanup. However, we
         # figure out the behavior differs from cloud to cloud
@@ -337,7 +337,7 @@ def start(job_id, task_yaml, retry_until_up):
         # But anyway, a clean solution is killing the controller process
         # directly, and then cleanup the cluster state.
         _cleanup(job_id, task_yaml=task_yaml)
-        logger.info(f'Spot clusters of job {job_id} has been taken down.')
+        logger.info(f'Spot cluster of job {job_id} has been taken down.')
 
         if cancelling:
             spot_state.set_cancelled(job_id)

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -61,8 +61,7 @@ class SpotController:
             self._task_name,
             self._backend.run_timestamp,
             resources_str=backend_utils.get_task_resources_str(self._task))
-        logger.info(
-            f'Submitted spot job; SKYPILOT_JOB_ID: {job_id_env_var}')
+        logger.info(f'Submitted spot job; SKYPILOT_JOB_ID: {job_id_env_var}')
         self._cluster_name = spot_utils.generate_spot_cluster_name(
             self._task_name, self._job_id)
         self._strategy_executor = recovery_strategy.StrategyExecutor.make(
@@ -91,7 +90,7 @@ class SpotController:
         Other exceptions may be raised depending on the backend.
         """
         logger.info(f'Started monitoring spot task {self._task_name} '
-                         f'(id: {self._job_id})')
+                    f'(id: {self._job_id})')
         spot_state.set_starting(self._job_id)
         job_submitted_at = self._strategy_executor.launch()
 
@@ -171,7 +170,7 @@ class SpotController:
                     returncode = self._backend.tail_logs(
                         handle, None, spot_job_id=self._job_id)
                     logger.info(f'\n== End of logs (ID: {self._job_id}, '
-                                     f'tail_log returncode: {returncode}) ==')
+                                f'tail_log returncode: {returncode}) ==')
                     spot_status_to_set = spot_state.SpotStatus.FAILED
                     if job_status == job_lib.JobStatus.FAILED_SETUP:
                         spot_status_to_set = spot_state.SpotStatus.FAILED_SETUP
@@ -189,8 +188,8 @@ class SpotController:
                 # cluster, if the cluster is healthy).
                 assert job_status is None, job_status
                 logger.info('Failed to fetch the job status while the '
-                                 'cluster is healthy. Try to recover the job '
-                                 '(the cluster will not be restarted).')
+                            'cluster is healthy. Try to recover the job '
+                            '(the cluster will not be restarted).')
 
             # When the handle is None, the cluster should be cleaned up already.
             if handle is not None:
@@ -199,8 +198,7 @@ class SpotController:
                 if resources.need_cleanup_after_preemption():
                     # Some spot resource (e.g., Spot TPU VM) may need to be
                     # cleaned up after preemption.
-                    logger.info(
-                        'Cleaning up the preempted spot cluster...')
+                    logger.info('Cleaning up the preempted spot cluster...')
                     recovery_strategy.terminate_cluster(self._cluster_name)
 
             # Try to recover the spot jobs, when the cluster is preempted

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -170,7 +170,7 @@ class SpotController:
                     returncode = self._backend.tail_logs(
                         handle, None, spot_job_id=self._job_id)
                     logger.info(f'\n== End of logs (ID: {self._job_id}, '
-                                f'tail_log returncode: {returncode}) ==')
+                                f'tail_logs returncode: {returncode}) ==')
                     spot_status_to_set = spot_state.SpotStatus.FAILED
                     if job_status == job_lib.JobStatus.FAILED_SETUP:
                         spot_status_to_set = spot_state.SpotStatus.FAILED_SETUP

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -39,7 +39,6 @@ class SpotController:
 
     def __init__(self, job_id: int, task_yaml: str,
                  retry_until_up: bool) -> None:
-
         self._job_id = job_id
         self._task, self._task_name = _get_task_and_name(task_yaml)
 

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -140,8 +140,8 @@ class SpotController:
             if job_status in [
                     job_lib.JobStatus.FAILED, job_lib.JobStatus.FAILED_SETUP
             ]:
-                # Add a grace period before the check of preemption to avoid false
-                # alarm for job failure.
+                # Add a grace period before the check of preemption to avoid
+                # false alarm for job failure.
                 time.sleep(5)
             # Pull the actual cluster status from the cloud provider to
             # determine whether the cluster is preempted.
@@ -171,6 +171,9 @@ class SpotController:
                     self.logger.info(
                         'The user job failed. Please check the logs below.\n'
                         f'== Logs of the user job (ID: {self._job_id}) ==\n')
+                    # TODO(zhwu): Download the logs, and stream them from the local
+                    # disk, instead of streaming them from the spot cluster, to make
+                    # it faster and more reliable.
                     returncode = self._backend.tail_logs(
                         handle, None, spot_job_id=self._job_id)
                     self.logger.info(f'\n== End of logs (ID: {self._job_id}, '

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -22,7 +22,9 @@ from sky.spot import spot_utils
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
 
-logger = sky_logging.init_logger(__name__)
+# Use the explicit logger name so that the logger is under the
+# `sky.spot.controller` namespace when executed directly.
+logger = sky_logging.init_logger('sky.spot.controller')
 
 
 def _get_task_and_name(task_yaml: str) -> Tuple['sky.Task', str]:
@@ -40,14 +42,8 @@ class SpotController:
         # Re-initialize the logger, as this is a new process.
         # Using the same logger will cause the log not being printed to the
         # console.
-        # Get a unique name for this process
-        process_name = multiprocessing.current_process().name
-
         # Create a logger for this process
-        self.logger = sky_logging.init_logger(process_name)
-        print(self.logger)
-        self.logger.addHandler(sky_logging.create_handler())
-        self.logger.info(f'Initialized spot controller for job {job_id}')
+        self.logger = sky_logging.init_logger(f'{logger.name}.controller_process')
         
         self._job_id = job_id
         self._task, self._task_name = _get_task_and_name(task_yaml)

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -43,8 +43,9 @@ class SpotController:
         # Using the same logger will cause the log not being printed to the
         # console.
         # Create a logger for this process
-        self.logger = sky_logging.init_logger(f'{logger.name}.controller_process')
-        
+        self.logger = sky_logging.init_logger(
+            f'{logger.name}.controller_process')
+
         self._job_id = job_id
         self._task, self._task_name = _get_task_and_name(task_yaml)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the log from the controller process was left out of the spot jobs' output, which made the debugging harder. This PR fixes the logging from the spot controller.

Another change made: add a grace period between the job status check and the cluster status check to make the annotation of the job failure more conservative. This is to avoid the case when the job fails due to the preemption while the cluster's status on the cloud has not been set to non-UP status yet.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] All smoke tests: `pytest tests/test_smoke.py --managed-spot` 
