### PR TITLE
[Dependency] Drop Python 3.6 support, switch to Python>=3.7 and fix azure launching issue

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,9 +13,7 @@ on:
       - 'releases/**'
 jobs:
   format:
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8"]

--- a/.github/workflows/mypy-generic.yml
+++ b/.github/workflows/mypy-generic.yml
@@ -15,8 +15,6 @@ on:
       - 'releases/**'
 jobs:
   mypy:
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No mypy to run"'

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -13,9 +13,7 @@ on:
       - 'releases/**'
 jobs:
   mypy:
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8"]

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,12 +14,10 @@ on:
 
 jobs:
   pylint:
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.8"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest-generic.yml
+++ b/.github/workflows/pytest-generic.yml
@@ -14,8 +14,6 @@ on:
       - 'releases/**'
 jobs:
   python-test:
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "No tests to run"'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
   python-test:
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.8]
         test-path:
           - tests/test_cli.py
           - tests/test_config.py
@@ -26,9 +26,7 @@ jobs:
           - tests/test_storage.py
           - tests/test_wheels.py
           - tests/test_spot.py
-    # Need to specify 20.04, because ubuntu-latest does not work with
-    # python 3.6: https://github.com/actions/setup-python/issues/355#issuecomment-1335042510
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We use GitHub to track issues and features. For new contributors, we recommend l
 
 ### Installing SkyPilot for development
 ```bash
-# SkyPilot requires python >= 3.6.
+# SkyPilot requires python >= 3.7.
 # You can just install the dependencies for
 # certain clouds, e.g., ".[aws,azure,gcp,lambda]"
 pip install -e ".[all]"

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -5,7 +5,7 @@ Install SkyPilot using pip:
 
 .. code-block:: console
 
-  $ # SkyPilot requires python >= 3.6. For Apple Silicon, use >= 3.8.
+  $ # SkyPilot requires python >= 3.7. For Apple Silicon, use >= 3.8.
   $ # Recommended: use a new conda env to avoid package conflicts.
   $ conda create -y -n sky python=3.8
   $ conda activate sky

--- a/docs/source/reference/local/setup.rst
+++ b/docs/source/reference/local/setup.rst
@@ -22,7 +22,7 @@ To install Ray and SkyPilot for all users, run the following commands on all loc
 
    $ pip3 install ray[default]==2.0.1
 
-   $ # SkyPilot requires python >= 3.6.
+   $ # SkyPilot requires python >= 3.7.
    $ pip3 install skypilot
 
 

--- a/sky/design_docs/onprem-design.md
+++ b/sky/design_docs/onprem-design.md
@@ -10,7 +10,7 @@
 
 ## Installing Ray and SkyPilot 
 - Admin installs Ray==2.0.1 and SkyPilot globally on all machines. It is assumed that the admin regularly keeps SkyPilot updated on the cluster.
-- Python >= 3.6 for all users.
+- Python >= 3.7 for all users.
 - When a regular user runs `sky launch`, a local version of SkyPilot will be installed on the machine for each user. The local installation of Ray is specified in `sky/templates/local-ray.yml.j2`.
 
 ## Registering clusters as a regular user

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -90,7 +90,7 @@ install_requires = [
     'rich',
     'tabulate',
     'typing-extensions',
-    'filelock',  # TODO(mraheja): Enforce >=3.6.0 when python version is >= 3.7
+    'filelock>=3.6.0',
     # This is used by ray. The latest 1.44.0 will generate an error
     # `Fork support is only compatible with the epoll1 and poll
     # polling strategies`
@@ -159,7 +159,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     setup_requires=['wheel'],
-    requires_python='>=3.6',
+    requires_python='>=3.7',
     install_requires=install_requires,
     extras_require=extras_require,
     entry_points={
@@ -167,7 +167,6 @@ setuptools.setup(
     },
     include_package_data=True,
     classifiers=[
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -118,8 +118,10 @@ extras_require: Dict[str, List[str]] = {
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
     # Tracked in: https://github.com/Azure/azure-cli/issues/7387
     # azure-identity is needed in node_provider.
+    # We need azure-identity>=1.13.0 to enable the customization of the
+    # timeout of AzureCliCredential.
     'azure': [
-        'azure-cli>=2.31.0', 'azure-core', 'azure-identity',
+        'azure-cli>=2.31.0', 'azure-core', 'azure-identity>=1.13.0',
         'azure-mgmt-network'
     ],
     'gcp': ['google-api-python-client', 'google-cloud-storage'],

--- a/sky/skylet/providers/azure/config.py
+++ b/sky/skylet/providers/azure/config.py
@@ -48,7 +48,10 @@ def _configure_resource_group(config):
     subscription_id = config["provider"].get("subscription_id")
     if subscription_id is None:
         subscription_id = get_cli_profile().get_subscription_id()
-    resource_client = ResourceManagementClient(AzureCliCredential(), subscription_id)
+    # Increase the timeout to fix the Azure get-access-token (used by ray azure
+    # node_provider) timeout issue.
+    # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
+    resource_client = ResourceManagementClient(AzureCliCredential(process_timeout=30), subscription_id)
     config["provider"]["subscription_id"] = subscription_id
     logger.info("Using subscription id: %s", subscription_id)
 

--- a/sky/skylet/providers/azure/config.py
+++ b/sky/skylet/providers/azure/config.py
@@ -51,7 +51,9 @@ def _configure_resource_group(config):
     # Increase the timeout to fix the Azure get-access-token (used by ray azure
     # node_provider) timeout issue.
     # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
-    resource_client = ResourceManagementClient(AzureCliCredential(process_timeout=30), subscription_id)
+    resource_client = ResourceManagementClient(
+        AzureCliCredential(process_timeout=30), subscription_id
+    )
     config["provider"]["subscription_id"] = subscription_id
     logger.info("Using subscription id: %s", subscription_id)
 

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -68,7 +68,10 @@ class AzureNodeProvider(NodeProvider):
         subscription_id = provider_config["subscription_id"]
         self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes", True)
         # Sky only supports Azure CLI credential for now.
-        credential = AzureCliCredential()
+        # Increase the timeout to fix the Azure get-access-token (used by ray azure
+        # node_provider) timeout issue.
+        # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
+        credential = AzureCliCredential(process_timeout=30)
         self.compute_client = ComputeManagementClient(credential, subscription_id)
         self.network_client = NetworkManagementClient(credential, subscription_id)
         self.resource_client = ResourceManagementClient(credential, subscription_id)

--- a/sky/skylet/ray_patches/__init__.py
+++ b/sky/skylet/ray_patches/__init__.py
@@ -84,16 +84,3 @@ def patch() -> None:
 
     from ray.autoscaler._private import updater
     _run_patch(updater.__file__, _to_absolute('updater.py.patch'))
-
-    # Fix the Azure get-access-token (used by ray azure node_provider) timeout issue,
-    # by increasing the timeout.
-    # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
-    # Only patch it if azure cli is installed.
-    try:
-        import azure
-        from azure.identity._credentials import azure_cli
-        version = pkg_resources.get_distribution('azure-cli').version
-        _run_patch(azure_cli.__file__, _to_absolute('azure_cli.py.patch'),
-                   version)
-    except ImportError:
-        pass

--- a/sky/skylet/ray_patches/azure_cli.py.patch
+++ b/sky/skylet/ray_patches/azure_cli.py.patch
@@ -1,4 +1,0 @@
-147c147
-<             kwargs["timeout"] = 10
----
->             kwargs["timeout"] = 30


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our previous patch for the `azure-identity` is outdated and causing trouble launching azure cluster. Since the latest `azure-identity` contains the `process_timeout` argument, we can directly use that to solve the problem we mentioned in https://github.com/skypilot-org/skypilot/blob/bbdd5b1512aae7cb1172b91b2b74cd8b0187f002/sky/skylet/ray_patches/__init__.py#L88-L91

Also, closes #609 

Based on #1954 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-azure --cloud azure --cpus 4+`
  - [x] `sky launch -c test-azure-2 --cloud azure --cpus 4+ --num-nodes 2`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws`

