### PR TITLE
[AWS] Faster cloud-init for disabling unattended-upgrade

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -66,7 +66,7 @@ available_node_types:
       # Reference: https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups
       # The bootcmd is to disable automatic APT updates, to avoid the lock
       # when user call `apt install` on the node.
-      # Reference: https://unix.stackexchange.com/a/471192
+      # Reference: https://askubuntu.com/questions/1322292/how-do-i-turn-off-automatic-updates-completely-and-for-real
       UserData: |
         #cloud-config
         users:
@@ -75,13 +75,16 @@ available_node_types:
             sudo: ALL=(ALL) NOPASSWD:ALL
             ssh_authorized_keys:
               - skypilot:ssh_public_key_content
-        runcmd:
-          - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
-          - echo "APT::Periodic::Update-Package-Lists \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::Download-Upgradeable-Packages \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::AutocleanInterval \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::Unattended-Upgrade \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "Removed APT" | systemd-cat
+        write_files:
+          - path: /etc/apt/apt.conf.d/20auto-upgrades
+            content: |
+              APT::Periodic::Update-Package-Lists "0";
+              APT::Periodic::Download-Upgradeable-Packages "0";
+              APT::Periodic::AutocleanInterval "0";
+              APT::Periodic::Unattended-Upgrade "0";
+          - path: /etc/apt/apt.conf.d/10cloudinit-disable
+            content: |
+              APT::Periodic::Enable "0";
       TagSpecifications:
         - ResourceType: instance
           Tags:
@@ -119,13 +122,16 @@ available_node_types:
             sudo: ALL=(ALL) NOPASSWD:ALL
             ssh_authorized_keys:
               - skypilot:ssh_public_key_content
-        runcmd:
-          - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
-          - echo "APT::Periodic::Update-Package-Lists \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::Download-Upgradeable-Packages \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::AutocleanInterval \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "APT::Periodic::Unattended-Upgrade \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
-          - echo "Removed APT" | systemd-cat
+        write_files:
+          - path: /etc/apt/apt.conf.d/20auto-upgrades
+            content: |
+              APT::Periodic::Update-Package-Lists "0";
+              APT::Periodic::Download-Upgradeable-Packages "0";
+              APT::Periodic::AutocleanInterval "0";
+              APT::Periodic::Unattended-Upgrade "0";
+          - path: /etc/apt/apt.conf.d/10cloudinit-disable
+            content: |
+              APT::Periodic::Enable "0";
       TagSpecifications:
         - ResourceType: instance
           Tags:

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -75,9 +75,12 @@ available_node_types:
             sudo: ALL=(ALL) NOPASSWD:ALL
             ssh_authorized_keys:
               - skypilot:ssh_public_key_content
-        bootcmd:
+        runcmd:
           - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
-          - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+          - echo "APT::Periodic::Update-Package-Lists \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::Download-Upgradeable-Packages \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::AutocleanInterval \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::Unattended-Upgrade \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
           - echo "Removed APT" | systemd-cat
       TagSpecifications:
         - ResourceType: instance
@@ -116,9 +119,12 @@ available_node_types:
             sudo: ALL=(ALL) NOPASSWD:ALL
             ssh_authorized_keys:
               - skypilot:ssh_public_key_content
-        bootcmd:
+        runcmd:
           - echo 'APT::Periodic::Enable "0";' > /etc/apt/apt.conf.d/10cloudinit-disable
-          - apt-get -y purge update-notifier-common ubuntu-release-upgrader-core landscape-common unattended-upgrades
+          - echo "APT::Periodic::Update-Package-Lists \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::Download-Upgradeable-Packages \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::AutocleanInterval \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
+          - echo "APT::Periodic::Unattended-Upgrade \"0\";" >> /etc/apt/apt.conf.d/20auto-upgrades
           - echo "Removed APT" | systemd-cat
       TagSpecifications:
         - ResourceType: instance


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The previous way to disable the unattended-upgrade significantly increase the provisioning time of AWS cluster, due to the apt remove run in the beginning of the system. We now switch to the configuration method which will reduce the provision time from 3m40s to 2m30s with `time sky launch -c min-aws --cloud aws -y`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `sky launch -c test --cloud aws 'sudo apt install tree'`
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` (except for the azure issue in #1952)
