### PR TITLE
os.devnull usages in Windows fix, and Temporarily disable TextWrapper register in log_lib #1950

### DIFF
--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -46,13 +46,15 @@ def process_subprocess_stream(
                               encoding='utf-8',
                               newline='',
                               errors='replace')
-    sel.register(out_io, selectors.EVENT_READ)
+    if sys.platform != 'win32':
+        sel.register(out_io, selectors.EVENT_READ)
     if proc.stderr is not None:
         err_io = io.TextIOWrapper(proc.stderr,
                                   encoding='utf-8',
                                   newline='',
                                   errors='replace')
-        sel.register(err_io, selectors.EVENT_READ)
+        if sys.platform != 'win32':
+            sel.register(err_io, selectors.EVENT_READ)
 
     stdout = ''
     stderr = ''
@@ -147,6 +149,7 @@ def run_with_log(
 
     log_path = os.path.expanduser(log_path)
     dirname = os.path.dirname(log_path)
+    dirname = dirname if dirname else os.devnull
     if use_sudo:
         # Sudo case is encountered when submitting
         # a job for Sky on-prem, when a non-admin user submits a job.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -232,6 +232,7 @@ class SSHCommandRunner:
             cmd = ' '.join(cmd)
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
+        log_dir = log_dir if log_dir else os.devnull
         os.makedirs(log_dir, exist_ok=True)
         # We need this to correctly run the cmd, and get the output.
         command = [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://github.com/skypilot-org/skypilot/issues/1950

In Windows, we can't use anything like `nul/something`, if it happens, the path is '' (empty string) and os related python functions will throw WinError.

This Pull Request just solves those simple cases, by just fallbacking to os.devnull again.

This also tries to solve Socket related selector Error, caused by TextIOWrapper usage.


Unfortunately, Windows environment is not fully solved yet, it now tries to use directory name of current file before creating or checking it in remote side, causing No such file or directory. 





<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
- [x] Codespaces test for linux environments
- [x] Windows 10 Environments


Test Code:
```py
import runhouse as rh
def num_cpus():
    import multiprocessing
    return multiprocessing.cpu_count()

# #1950 issue, this won't start up and throw WinError 3 or WinError 10038 without patch.
cluster = rh.cluster(
    name = "test",
    ips = ['private-ip'],
    ssh_creds = {
        'ssh_user': 'serveradmin',
        'ssh_private_key': r'C:\.... .rsa'
    }
)

# New issue, more headaches
num_cpus_cluster = rh.function(
    name = "num_cpus_cluster",
    fn = num_cpus
).to(cluster)



print(num_cpus_cluster())
```


