### PR TITLE
[Stale Bot] Change the order of the stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,6 @@ jobs:
           days-before-pr-close: 10
           exempt-issue-labels: 'P0,P1'
           exempt-pr-labels: 'P0,P1'
-          debug-only: true
           ascending: true
           operations-per-run: 100
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,4 +23,5 @@ jobs:
           exempt-issue-labels: 'P0,P1'
           exempt-pr-labels: 'P0,P1'
           debug-only: true
-          
+          ascending: true
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,8 @@
 name: 'Close stale issues and PRs'
 on:
+  push:
+    branches:
+      - test-stale
   schedule:
     - cron: '30 1 * * *'
 
@@ -19,3 +22,5 @@ jobs:
           days-before-pr-close: 10
           exempt-issue-labels: 'P0,P1'
           exempt-pr-labels: 'P0,P1'
+          debug-only: true
+          

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,5 @@ jobs:
           exempt-pr-labels: 'P0,P1'
           debug-only: true
           ascending: true
+          operations-per-run: 100
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,5 @@
 name: 'Close stale issues and PRs'
 on:
-  push:
-    branches:
-      - test-stale
   schedule:
     - cron: '30 1 * * *'
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to make the stale bot go from the oldest issues / PRs, and increase the number of issues/PRs processed by it each run.

It will only do 100 operations per-run, this can reduce the burden for us to handle the flood of staled issues per-day.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - Manually triggered the workflow, and it works