### PR TITLE
Minor: fix backend_utils.path_size_megabytes() rounding.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -274,7 +274,7 @@ def path_size_megabytes(path: str) -> int:
             f'{git_exclude_filter} --dry-run {path!r}',
             shell=True).splitlines()[-1])
     total_bytes = rsync_output.split(' ')[3].replace(',', '')
-    return int(total_bytes) // 10**6
+    return int(float(total_bytes)) // 10**6
 
 
 class FileMountHelper(object):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A minor issue from user where `total_bytes` in this func can be a str of a float.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
