### PR TITLE
Minor: `show-gpus --cloud ibm -a` fix (int parsing).

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3099,8 +3099,8 @@ def show_gpus(
                 cpu_count = item.cpu_count
                 if pd.isna(cpu_count):
                     cpu_str = '-'
-                elif isinstance(cpu_count, float):
-                    if cpu_count.is_integer():
+                elif isinstance(cpu_count, (float, int)):
+                    if int(cpu_count) == cpu_count:
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously `sky show-gpus --cloud ibm -a` was failing. This PR fixes it. Thanks to @Cohen-J-Omer for pointing out the fix.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
```
sky show-gpus --cloud ibm -a
sky show-gpus --cloud aws -a
sky show-gpus --cloud gcp -a
sky show-gpus --cloud lambda -a
sky show-gpus --cloud azure -a
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
