### PR TITLE
[Lambda Cloud] Update Regex of Internal IP for H100 Support

### DIFF
--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -26,7 +26,7 @@ _TAG_PATH_PREFIX = '~/.sky/generated/lambda_cloud/metadata'
 _REMOTE_SSH_KEY_NAME = '~/.lambda_cloud/ssh_key_name'
 _REMOTE_RAY_SSH_KEY = '~/ray_bootstrap_key.pem'
 _REMOTE_RAY_YAML = '~/ray_bootstrap_config.yaml'
-_GET_INTERNAL_IP_CMD = 'ip -4 -br addr show | grep -Eo "10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"'
+_GET_INTERNAL_IP_CMD = 'ip -4 -br addr show | grep -Eo "(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(1[6-9]|2[0-9]|3[0-1]))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"'
 
 logger = logging.getLogger(__name__)
 

--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -26,7 +26,7 @@ _TAG_PATH_PREFIX = '~/.sky/generated/lambda_cloud/metadata'
 _REMOTE_SSH_KEY_NAME = '~/.lambda_cloud/ssh_key_name'
 _REMOTE_RAY_SSH_KEY = '~/ray_bootstrap_key.pem'
 _REMOTE_RAY_YAML = '~/ray_bootstrap_config.yaml'
-_GET_INTERNAL_IP_CMD = 'ip -4 -br addr show | grep -Eo "(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(1[6-9]|2[0-9]|3[0-1]))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"'
+_GET_INTERNAL_IP_CMD = 'ip -4 -br addr show | grep UP | grep -Eo "(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(1[6-9]|2[0-9]|3[0-1]))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"'
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

According to [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918#section-3), the IP range `172.16.0.0` - `172.31.255.255` can be used as internal IP address, which Lambda Cloud seems to be actually doing so for the new H100 GPU instances. ([img](https://github.com/skypilot-org/skypilot/assets/3784687/cf35dbe7-1783-4dc5-bcf2-19a6aeb2f14e))

Therefore, users may get a `Failed to obtain private IP from node` error while launching those new instances on Lambda Cloud. ([#1948](https://github.com/skypilot-org/skypilot/issues/1948#issuecomment-1552988437))

This PR modifies the regex used by `ray get-head-ip` to also match IPs `172.16.*` - `172.32.*`.

The new Regex is tested as: https://regex101.com/r/jHHWti/2 and with

```
curl https://gist.githubusercontent.com/zetavg/8712abde098f3b287dca0f3f9ea9e40f/raw/ee924d9a8ad4c98f0798233f846b43c35caf798c/ip.txt | grep -Eo "(10\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|172\.(1[6-9]|2[0-9]|3[0-1]))\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
```

on a Lambda Cloud H100 instance.

### Breaking Changes / Possible Issues

With old instance types that do have a `10.x.x.x` internal IP, the updated command tends to use the later-listed `172.x.x.x` IP instead of the original `10.x`.

I haven't used multiple clusters yet and I have not test if this will break anything.

```
I 05-20 00:53:55 cloud_vm_ray_backend.py:1480] Launching on Lambda us-east-1
I 05-20 00:54:06 log_utils.py:89] Head node is up.
I 05-20 00:54:34 cloud_vm_ray_backend.py:1293] Successfully provisioned or found existing VM.
W 05-20 00:54:40 backend_utils.py:1277] Detected more than 1 IP from the output of the `ray get-head-ip` command. This could happen if there is extra output from it, which should be inspected below.
W 05-20 00:54:40 backend_utils.py:1277] Proceeding with the last detected IP (172.17.0.1) as head IP.
W 05-20 00:54:40 backend_utils.py:1277] == Output ==
W 05-20 00:54:40 backend_utils.py:1277] 10.19.94.189
W 05-20 00:54:40 backend_utils.py:1277] 172.17.0.1
W 05-20 00:54:40 backend_utils.py:1277] == Output ends ==
```


<!-- Describe the tests ran -->

Still trying to resolve `tests/test_smoke.py:41 ModuleNotFoundError: No module named 'sky'` while running `pytest tests/test_smoke.py`.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
