### PR TITLE
Minor: shorten `cost-report` display.

### DIFF
--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -154,7 +154,7 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
         StatusColumn('STATUS',
                      _get_status_for_cost_report,
                      show_by_default=True),
-        StatusColumn('HOURLY_PRICE',
+        StatusColumn('COST/hr',
                      _get_price_for_cost_report,
                      show_by_default=True),
         StatusColumn('COST (est.)',
@@ -397,7 +397,7 @@ def _get_price_for_cost_report(
     launched_resources = cluster_cost_report_record['resources']
 
     hourly_cost = (launched_resources.get_cost(3600) * launched_nodes)
-    price_str = f'$ {hourly_cost:.3f}'
+    price_str = f'$ {hourly_cost:.2f}'
     return price_str
 
 
@@ -408,4 +408,4 @@ def _get_estimated_cost_for_cost_report(
     if not cost:
         return '-'
 
-    return f'${cost:.3f}'
+    return f'$ {cost:.2f}'

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -145,6 +145,12 @@ def readable_time_duration(start: Optional[float],
         diff = diff.replace(' minute', 'm')
         diff = diff.replace(' hours', 'h')
         diff = diff.replace(' hour', 'h')
+        diff = diff.replace(' days', 'd')
+        diff = diff.replace(' day', 'd')
+        diff = diff.replace(' weeks', 'w')
+        diff = diff.replace(' week', 'w')
+        diff = diff.replace(' months', 'mo')
+        diff = diff.replace(' month', 'mo')
     else:
         diff = start_time.diff_for_humans(end)
         if duration.in_seconds() < 1:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Noticed that some fields are too long (see attached pic) when making a screenshot.
<img width="1602" alt="cost-report" src="https://github.com/skypilot-org/skypilot/assets/592670/d495591a-f5ad-451c-92c2-210c0f7704da">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

