### PR TITLE
Quick fix for `show-gpus`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3063,24 +3063,28 @@ def show_gpus(
                 return
 
         # Show detailed accelerator information
-        accelerator_split = accelerator_str.split(':')
-        if len(accelerator_split) > 2:
-            raise click.UsageError(
-                f'Invalid accelerator string {accelerator_str}. '
-                'Expected format: <accelerator_name>[:<quantity>].')
-        if len(accelerator_split) == 2:
-            name = accelerator_split[0]
-            # Check if quantity is valid
-            try:
-                quantity = int(accelerator_split[1])
-                if quantity <= 0:
-                    raise ValueError('Quantity cannot be non-positive integer.')
-            except ValueError as invalid_quantity:
-                raise click.UsageError(
-                    f'Invalid accelerator quantity {accelerator_split[1]}. '
-                    'Expected a positive integer.') from invalid_quantity
+        if accelerator_str is None:
+            name, quantity = None, None
         else:
-            name, quantity = accelerator_str, None
+            # Parse accelerator string
+            accelerator_split = accelerator_str.split(':')
+            if len(accelerator_split) > 2:
+                raise click.UsageError(
+                    f'Invalid accelerator string {accelerator_str}. '
+                    'Expected format: <accelerator_name>[:<quantity>].')
+            if len(accelerator_split) == 2:
+                name = accelerator_split[0]
+                # Check if quantity is valid
+                try:
+                    quantity = int(accelerator_split[1])
+                    if quantity <= 0:
+                        raise ValueError('Quantity cannot be non-positive integer.')
+                except ValueError as invalid_quantity:
+                    raise click.UsageError(
+                        f'Invalid accelerator quantity {accelerator_split[1]}. '
+                        'Expected a positive integer.') from invalid_quantity
+            else:
+                name, quantity = accelerator_str, None
 
         result = service_catalog.list_accelerators(gpus_only=True,
                                                    name_filter=name,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -80,6 +80,7 @@ def list_accelerators(
 def list_accelerator_counts(
     gpus_only: bool = True,
     name_filter: Optional[str] = None,
+    quantity_filter: Optional[int] = None,
     region_filter: Optional[str] = None,
     clouds: CloudFilter = None,
 ) -> Dict[str, List[int]]:
@@ -89,7 +90,8 @@ def list_accelerator_counts(
     of available counts. See usage in cli.py.
     """
     results = _map_clouds_catalog(clouds, 'list_accelerators', gpus_only,
-                                  name_filter, region_filter, False)
+                                  name_filter, region_filter, quantity_filter,
+                                  False)
     if not isinstance(results, list):
         results = [results]
     accelerator_counts: Dict[str, Set[int]] = collections.defaultdict(set)


### PR DESCRIPTION
Fixes a bug introduced by #1924 which caused `sky show-gpus` to fail if quantity str was not specified.

Tested (run the relevant ones):

- [x] `sky show-gpus`
- [x] `sky show-gpus --all`
- [x] `sky show-gpus V100:4`
- [x] `sky show-gpus --cloud lambda`
- [x] `sky show-gpus --cloud lambda --all`
- [x] `sky show-gpus V100 --cloud lambda`
- [x] `sky show-gpus V100:4 --cloud lambda`
- [x] `sky show-gpus V100:4 --cloud lambda --all` (Expected - `Error: --all is only allowed without a GPU name.`)