### PR TITLE
[Spot] Fix spot failover when ibm enabled

### DIFF
--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -46,8 +46,8 @@ class IBM(clouds.Cloud):
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators  # unused
-        assert use_spot is False, (
-            'current IBM implementation doesn\'t support spot instances')
+        if use_spot:
+            return []
         regions = service_catalog.get_region_zones_for_instance_type(
             instance_type, use_spot, 'ibm')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When the IBM cloud is enabled in the `sky check`, `sky launch --use-spot` will fail due to an assertion in the `IBM` cloud, with the following error:
```
> sky launch --use-spot
...
    assert use_spot is False, (
AssertionError: current IBM implementation doesn't support spot instances
```

After this PR, SkyPilot will correctly skip IBM cloud:
```
> sky launch --use-spot
I 05-24 17:19:21 optimizer.py:636] == Optimizer ==
I 05-24 17:19:21 optimizer.py:647] Target: minimizing cost
I 05-24 17:19:21 optimizer.py:659] Estimated cost: $0.1 / hour
I 05-24 17:19:21 optimizer.py:659] 
I 05-24 17:19:21 optimizer.py:732] Considered resources (1 node):
I 05-24 17:19:21 optimizer.py:781] --------------------------------------------------------------------------------------------------
I 05-24 17:19:21 optimizer.py:781]  CLOUD   INSTANCE              vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 05-24 17:19:21 optimizer.py:781] --------------------------------------------------------------------------------------------------
I 05-24 17:19:21 optimizer.py:781]  GCP     n2-standard-8[Spot]   8       32        -              us-west4-a    0.08          ✔     
I 05-24 17:19:21 optimizer.py:781]  AWS     m6i.2xlarge[Spot]     8       32        -              eu-north-1c   0.12                
I 05-24 17:19:21 optimizer.py:781] --------------------------------------------------------------------------------------------------
I 05-24 17:19:21 optimizer.py:781] 
Launching a new cluster 'sky-2c92-zhwu'. Proceed? [Y/n]: n
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
