### PR TITLE
[R2] Change credentials path for R2

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -118,7 +118,7 @@ SkyPilot can download/upload data to R2 buckets and mount them as local filesyst
   $ # Install boto
   $ pip install boto3
   $ # Configure your R2 credentials
-  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/credentials aws configure --profile r2
+  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/r2credentials aws configure --profile r2
 
 In the prompt, enter your R2 Access Key ID and Secret Access Key (see `instructions to generate R2 credentials <https://developers.cloudflare.com/r2/data-access/s3-api/tokens/>`_). Select :code:`auto` for the default region and :code:`json` for the default output format.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -118,7 +118,7 @@ SkyPilot can download/upload data to R2 buckets and mount them as local filesyst
   $ # Install boto
   $ pip install boto3
   $ # Configure your R2 credentials
-  $ aws configure --profile r2
+  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/credentials aws configure --profile r2
 
 In the prompt, enter your R2 Access Key ID and Secret Access Key (see `instructions to generate R2 credentials <https://developers.cloudflare.com/r2/data-access/s3-api/tokens/>`_). Select :code:`auto` for the default region and :code:`json` for the default output format.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -118,7 +118,7 @@ SkyPilot can download/upload data to R2 buckets and mount them as local filesyst
   $ # Install boto
   $ pip install boto3
   $ # Configure your R2 credentials
-  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/r2credentials aws configure --profile r2
+  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/r2.credentials aws configure --profile r2
 
 In the prompt, enter your R2 Access Key ID and Secret Access Key (see `instructions to generate R2 credentials <https://developers.cloudflare.com/r2/data-access/s3-api/tokens/>`_). Select :code:`auto` for the default region and :code:`json` for the default output format.
 

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -1,7 +1,7 @@
 """Cloudflare cloud adaptors"""
-
 # pylint: disable=import-outside-toplevel
 
+import contextlib
 import functools
 import threading
 import os
@@ -11,7 +11,7 @@ boto3 = None
 botocore = None
 _session_creation_lock = threading.RLock()
 ACCOUNT_ID_PATH = '~/.cloudflare/accountid'
-AWS_R2_PROFILE_PATH = '~/.aws/credentials'
+AWS_R2_CREDENTIALS_PATH = '~/.cloudflare/credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 
@@ -35,6 +35,19 @@ def import_package(func):
     return wrapper
 
 
+@contextlib.contextmanager
+def _load_r2_credentials():
+    """Context manager to temporarily change the AWS shared credentials file path."""
+    prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
+    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = AWS_R2_CREDENTIALS_PATH
+    try:
+        yield
+    finally:
+        if prev_credentials_path is None:
+            del os.environ['AWS_SHARED_CREDENTIALS_FILE']
+        else:
+            os.environ['AWS_SHARED_CREDENTIALS_FILE'] = prev_credentials_path
+
 # lru_cache() is thread-safe and it will return the same session object
 # for different threads.
 # Reference: https://docs.python.org/3/library/functools.html#functools.lru_cache # pylint: disable=line-too-long
@@ -48,8 +61,9 @@ def session():
     # However, the session object itself is thread-safe, so we are
     # able to use lru_cache() to cache the session object.
     with _session_creation_lock:
-        return boto3.session.Session(profile_name=R2_PROFILE_NAME)
-
+        with _load_r2_credentials():
+            session_ = boto3.session.Session(profile_name=R2_PROFILE_NAME)
+        return session_
 
 @functools.lru_cache()
 @import_package
@@ -66,7 +80,8 @@ def resource(resource_name: str, **kwargs):
     # Reference: https://stackoverflow.com/a/59635814
 
     session_ = session()
-    cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
+    with _load_r2_credentials():
+        cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
     endpoint = create_endpoint()
 
     return session_.resource(
@@ -92,7 +107,8 @@ def client(service_name: str, region):
     # Reference: https://stackoverflow.com/a/59635814
 
     session_ = session()
-    cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
+    with _load_r2_credentials():
+        cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
     endpoint = create_endpoint()
 
     return session_.client(
@@ -137,7 +153,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
     hints = None
     accountid_path = os.path.expanduser(ACCOUNT_ID_PATH)
     if not r2_profile_in_aws_cred():
-        hints = f'[{R2_PROFILE_NAME}] profile is not set in ~/.aws/credentials.'
+        hints = f'[{R2_PROFILE_NAME}] profile is not set in {AWS_R2_CREDENTIALS_PATH}'
     if not os.path.exists(accountid_path):
         if hints:
             hints += ' Additionally, '
@@ -148,7 +164,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
         hints += ' Run the following commands:'
         if not r2_profile_in_aws_cred():
             hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
-            hints += f'\n{_INDENT_PREFIX}  $ aws configure --profile r2'
+            hints += f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/credentials aws configure --profile r2'
         if not os.path.exists(accountid_path):
             hints += f'\n{_INDENT_PREFIX}  $ mkdir -p ~/.cloudflare'
             hints += f'\n{_INDENT_PREFIX}  $ echo <YOUR_ACCOUNT_ID_HERE> > ~/.cloudflare/accountid'  # pylint: disable=line-too-long
@@ -161,7 +177,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
 def r2_profile_in_aws_cred() -> bool:
     """Checks if Cloudflare R2 profile is set in aws credentials"""
 
-    profile_path = os.path.expanduser(AWS_R2_PROFILE_PATH)
+    profile_path = os.path.expanduser(AWS_R2_CREDENTIALS_PATH)
     r2_profile_exists = False
     if os.path.isfile(profile_path):
         with open(profile_path, 'r') as file:
@@ -181,7 +197,7 @@ def get_credential_file_mounts() -> Dict[str, str]:
     """
 
     r2_credential_mounts = {
-        AWS_R2_PROFILE_PATH: AWS_R2_PROFILE_PATH,
+        AWS_R2_CREDENTIALS_PATH: AWS_R2_CREDENTIALS_PATH,
         ACCOUNT_ID_PATH: ACCOUNT_ID_PATH
     }
     return r2_credential_mounts

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -11,7 +11,7 @@ boto3 = None
 botocore = None
 _session_creation_lock = threading.RLock()
 ACCOUNT_ID_PATH = '~/.cloudflare/accountid'
-AWS_R2_CREDENTIALS_PATH = '~/.cloudflare/credentials'
+AWS_R2_CREDENTIALS_PATH = '~/.cloudflare/r2credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -13,7 +13,7 @@ boto3 = None
 botocore = None
 _session_creation_lock = threading.RLock()
 ACCOUNT_ID_PATH = '~/.cloudflare/accountid'
-AWS_R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
+R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 
@@ -41,7 +41,7 @@ def import_package(func):
 def _load_r2_credentials_env():
     """Context manager to temporarily change the AWS credentials file path."""
     prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
-    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = AWS_R2_CREDENTIALS_PATH
+    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = R2_CREDENTIALS_PATH
     try:
         yield
     finally:
@@ -174,7 +174,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
     hints = None
     accountid_path = os.path.expanduser(ACCOUNT_ID_PATH)
     if not r2_profile_in_aws_cred():
-        hints = f'[{R2_PROFILE_NAME}] profile is not set in {AWS_R2_CREDENTIALS_PATH}'
+        hints = f'[{R2_PROFILE_NAME}] profile is not set in {R2_CREDENTIALS_PATH}'
     if not os.path.exists(accountid_path):
         if hints:
             hints += ' Additionally, '
@@ -185,7 +185,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
         hints += ' Run the following commands:'
         if not r2_profile_in_aws_cred():
             hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
-            hints += f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE={AWS_R2_CREDENTIALS_PATH} aws configure --profile r2'  # pylint: disable=line-too-long
+            hints += f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE={R2_CREDENTIALS_PATH} aws configure --profile r2'  # pylint: disable=line-too-long
         if not os.path.exists(accountid_path):
             hints += f'\n{_INDENT_PREFIX}  $ mkdir -p ~/.cloudflare'
             hints += f'\n{_INDENT_PREFIX}  $ echo <YOUR_ACCOUNT_ID_HERE> > ~/.cloudflare/accountid'  # pylint: disable=line-too-long
@@ -198,7 +198,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
 def r2_profile_in_aws_cred() -> bool:
     """Checks if Cloudflare R2 profile is set in aws credentials"""
 
-    profile_path = os.path.expanduser(AWS_R2_CREDENTIALS_PATH)
+    profile_path = os.path.expanduser(R2_CREDENTIALS_PATH)
     r2_profile_exists = False
     if os.path.isfile(profile_path):
         with open(profile_path, 'r') as file:
@@ -218,7 +218,7 @@ def get_credential_file_mounts() -> Dict[str, str]:
     """
 
     r2_credential_mounts = {
-        AWS_R2_CREDENTIALS_PATH: AWS_R2_CREDENTIALS_PATH,
+        R2_CREDENTIALS_PATH: R2_CREDENTIALS_PATH,
         ACCOUNT_ID_PATH: ACCOUNT_ID_PATH
     }
     return r2_credential_mounts

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -37,7 +37,7 @@ def import_package(func):
 
 @contextlib.contextmanager
 def _load_r2_credentials():
-    """Context manager to temporarily change the AWS shared credentials file path."""
+    """Context manager to temporarily change the AWS credentials file path."""
     prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
     os.environ['AWS_SHARED_CREDENTIALS_FILE'] = AWS_R2_CREDENTIALS_PATH
     try:
@@ -47,6 +47,7 @@ def _load_r2_credentials():
             del os.environ['AWS_SHARED_CREDENTIALS_FILE']
         else:
             os.environ['AWS_SHARED_CREDENTIALS_FILE'] = prev_credentials_path
+
 
 # lru_cache() is thread-safe and it will return the same session object
 # for different threads.
@@ -65,6 +66,7 @@ def session():
             session_ = boto3.session.Session(profile_name=R2_PROFILE_NAME)
         return session_
 
+
 @functools.lru_cache()
 @import_package
 def resource(resource_name: str, **kwargs):
@@ -81,7 +83,8 @@ def resource(resource_name: str, **kwargs):
 
     session_ = session()
     with _load_r2_credentials():
-        cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
+        cloudflare_credentials = session_.get_credentials(
+        ).get_frozen_credentials()
     endpoint = create_endpoint()
 
     return session_.resource(
@@ -108,7 +111,8 @@ def client(service_name: str, region):
 
     session_ = session()
     with _load_r2_credentials():
-        cloudflare_credentials = session_.get_credentials().get_frozen_credentials()
+        cloudflare_credentials = session_.get_credentials(
+        ).get_frozen_credentials()
     endpoint = create_endpoint()
 
     return session_.client(

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -63,6 +63,7 @@ def get_r2_credentials():
         else:
             return cloudflare_credentials.get_frozen_credentials()
 
+
 # lru_cache() is thread-safe and it will return the same session object
 # for different threads.
 # Reference: https://docs.python.org/3/library/functools.html#functools.lru_cache # pylint: disable=line-too-long

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -185,7 +185,7 @@ class R2CloudStorage(CloudStorage):
         if 'r2://' in source:
             source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
-                               f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                               f'{cloudflare.R2_CREDENTIALS_PATH} '
                                'aws s3 sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--endpoint {endpoint_url} '
@@ -199,7 +199,7 @@ class R2CloudStorage(CloudStorage):
         """Downloads a file using AWS CLI."""
         endpoint_url = cloudflare.create_endpoint()
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
-                               f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                               f'{cloudflare.R2_CREDENTIALS_PATH} '
                                f'aws s3 cp s3://{source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -184,7 +184,9 @@ class R2CloudStorage(CloudStorage):
         endpoint_url = cloudflare.create_endpoint()
         if 'r2://' in source:
             source = source.replace('r2://', 's3://')
-        download_via_awscli = ('aws s3 sync --no-follow-symlinks '
+        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
+                               f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                               'aws s3 sync --no-follow-symlinks '
                                f'{source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -196,7 +198,9 @@ class R2CloudStorage(CloudStorage):
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
         endpoint_url = cloudflare.create_endpoint()
-        download_via_awscli = (f'aws s3 cp s3://{source} {destination} '
+        download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
+                               f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                               f'aws s3 cp s3://{source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1777,7 +1777,7 @@ class R2Store(AbstractStore):
                 [f'--include "{file_name}"' for file_name in file_names])
             endpoint_url = cloudflare.create_endpoint()
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
-                            f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                            f'{cloudflare.R2_CREDENTIALS_PATH} '
                             'aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name} '
@@ -1790,7 +1790,7 @@ class R2Store(AbstractStore):
             endpoint_url = cloudflare.create_endpoint()
             sync_command = (
                 'AWS_SHARED_CREDENTIALS_FILE='
-                f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                f'{cloudflare.R2_CREDENTIALS_PATH} '
                 'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
                 f'{src_dir_path} '
                 f's3://{self.name}/{dest_dir_name} '
@@ -1853,7 +1853,7 @@ class R2Store(AbstractStore):
             # user.
             if error_code == '403':
                 command = ('AWS_SHARED_CREDENTIALS_FILE='
-                           f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                           f'{cloudflare.R2_CREDENTIALS_PATH} '
                            f'aws s3 ls s3://{self.name} '
                            f'--endpoint {endpoint_url} '
                            f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -1868,7 +1868,7 @@ class R2Store(AbstractStore):
                     'Attempted to connect to a non-existent bucket: '
                     f'{self.source}. Consider using '
                     '`AWS_SHARED_CREDENTIALS_FILE='
-                    f'{cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls '
+                    f'{cloudflare.R2_CREDENTIALS_PATH} aws s3 ls '
                     f's3://{self.name} '
                     f'--endpoint {endpoint_url} '
                     f'--profile={cloudflare.R2_PROFILE_NAME}\' '
@@ -1907,7 +1907,7 @@ class R2Store(AbstractStore):
                        'sudo chmod +x /usr/local/bin/goofys')
         endpoint_url = cloudflare.create_endpoint()
         mount_cmd = (
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} '
             f'AWS_PROFILE={cloudflare.R2_PROFILE_NAME} goofys -o allow_other '
             f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
             f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
@@ -1961,7 +1961,7 @@ class R2Store(AbstractStore):
         # which removes the bucket by force.
         endpoint_url = cloudflare.create_endpoint()
         remove_command = (
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} '
             f'aws s3 rb s3://{bucket_name} --force '
             f'--endpoint {endpoint_url} '
             f'--profile={cloudflare.R2_PROFILE_NAME}')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1776,7 +1776,8 @@ class R2Store(AbstractStore):
             includes = ' '.join(
                 [f'--include "{file_name}"' for file_name in file_names])
             endpoint_url = cloudflare.create_endpoint()
-            sync_command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+            sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
+                            f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
                             'aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name} '
@@ -1788,7 +1789,8 @@ class R2Store(AbstractStore):
             # we exclude .git directory from the sync
             endpoint_url = cloudflare.create_endpoint()
             sync_command = (
-                f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                'AWS_SHARED_CREDENTIALS_FILE='
+                f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
                 'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
                 f'{src_dir_path} '
                 f's3://{self.name}/{dest_dir_name} '
@@ -1850,7 +1852,8 @@ class R2Store(AbstractStore):
             # AccessDenied error for buckets that are private and not owned by
             # user.
             if error_code == '403':
-                command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                command = ('AWS_SHARED_CREDENTIALS_FILE='
+                           f'{cloudflare.AWS_R2_CREDENTIALS_PATH} '
                            f'aws s3 ls s3://{self.name} '
                            f'--endpoint {endpoint_url} '
                            f'--profile={cloudflare.R2_PROFILE_NAME}')
@@ -1863,7 +1866,9 @@ class R2Store(AbstractStore):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketGetError(
                     'Attempted to connect to a non-existent bucket: '
-                    f'{self.source}. Consider using `AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls '
+                    f'{self.source}. Consider using '
+                    '`AWS_SHARED_CREDENTIALS_FILE='
+                    f'{cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls '
                     f's3://{self.name} '
                     f'--endpoint {endpoint_url} '
                     f'--profile={cloudflare.R2_PROFILE_NAME}\' '
@@ -1955,9 +1960,11 @@ class R2Store(AbstractStore):
         # The fastest way to delete is to run `aws s3 rb --force`,
         # which removes the bucket by force.
         endpoint_url = cloudflare.create_endpoint()
-        remove_command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb s3://{bucket_name} --force '
-                          f'--endpoint {endpoint_url} '
-                          f'--profile={cloudflare.R2_PROFILE_NAME}')
+        remove_command = (
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+            f'aws s3 rb s3://{bucket_name} --force '
+            f'--endpoint {endpoint_url} '
+            f'--profile={cloudflare.R2_PROFILE_NAME}')
         try:
             with log_utils.safe_rich_status(
                     f'[bold cyan]Deleting R2 bucket {bucket_name}[/]'):

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1776,7 +1776,8 @@ class R2Store(AbstractStore):
             includes = ' '.join(
                 [f'--include "{file_name}"' for file_name in file_names])
             endpoint_url = cloudflare.create_endpoint()
-            sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
+            sync_command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                            'aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name} '
                             f'--endpoint {endpoint_url} '
@@ -1787,6 +1788,7 @@ class R2Store(AbstractStore):
             # we exclude .git directory from the sync
             endpoint_url = cloudflare.create_endpoint()
             sync_command = (
+                f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
                 'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
                 f'{src_dir_path} '
                 f's3://{self.name}/{dest_dir_name} '
@@ -1848,7 +1850,8 @@ class R2Store(AbstractStore):
             # AccessDenied error for buckets that are private and not owned by
             # user.
             if error_code == '403':
-                command = (f'aws s3 ls s3://{self.name} '
+                command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
+                           f'aws s3 ls s3://{self.name} '
                            f'--endpoint {endpoint_url} '
                            f'--profile={cloudflare.R2_PROFILE_NAME}')
                 with ux_utils.print_exception_no_traceback():
@@ -1860,7 +1863,7 @@ class R2Store(AbstractStore):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketGetError(
                     'Attempted to connect to a non-existent bucket: '
-                    f'{self.source}. Consider using `aws s3 ls '
+                    f'{self.source}. Consider using `AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls '
                     f's3://{self.name} '
                     f'--endpoint {endpoint_url} '
                     f'--profile={cloudflare.R2_PROFILE_NAME}\' '
@@ -1899,6 +1902,7 @@ class R2Store(AbstractStore):
                        'sudo chmod +x /usr/local/bin/goofys')
         endpoint_url = cloudflare.create_endpoint()
         mount_cmd = (
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} '
             f'AWS_PROFILE={cloudflare.R2_PROFILE_NAME} goofys -o allow_other '
             f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
             f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
@@ -1951,14 +1955,15 @@ class R2Store(AbstractStore):
         # The fastest way to delete is to run `aws s3 rb --force`,
         # which removes the bucket by force.
         endpoint_url = cloudflare.create_endpoint()
-        remove_command = (f'aws s3 rb s3://{bucket_name} --force '
+        remove_command = (f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb s3://{bucket_name} --force '
                           f'--endpoint {endpoint_url} '
                           f'--profile={cloudflare.R2_PROFILE_NAME}')
         try:
             with log_utils.safe_rich_status(
                     f'[bold cyan]Deleting R2 bucket {bucket_name}[/]'):
-                subprocess.check_output(remove_command.split(' '),
-                                        stderr=subprocess.STDOUT)
+                subprocess.check_output(remove_command,
+                                        stderr=subprocess.STDOUT,
+                                        shell=True)
         except subprocess.CalledProcessError as e:
             if 'NoSuchBucket' in e.output.decode('utf-8'):
                 logger.debug(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2124,7 +2124,6 @@ class TestStorageWithCredentials:
             timestamp = str(time.time()).replace('.', '')
             store_obj = storage_lib.Storage(name=f'sky-test-{timestamp}',
                                             source=tmpdir)
-            print(tmpdir)
             store_obj.add_store(store_type)
 
         subprocess.check_output(['sky', 'storage', 'delete', store_obj.name])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -732,7 +732,7 @@ def test_cloudflare_storage_mounts(generic_cloud: str):
             *storage_setup_commands,
             f'sky launch -y -c {name} --cloud {generic_cloud} {file_path}',
             f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls s3://{storage_name}/hello.txt --endpoint {endpoint_url} --profile=r2'
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 ls s3://{storage_name}/hello.txt --endpoint {endpoint_url} --profile=r2'
         ]
 
         test = Test(
@@ -1921,7 +1921,7 @@ class TestStorageWithCredentials:
         if store_type == storage_lib.StoreType.R2:
             endpoint_url = cloudflare.create_endpoint()
             url = f's3://{bucket_name}'
-            return f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb {url} --force --endpoint {endpoint_url} --profile=r2'
+            return f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 rb {url} --force --endpoint {endpoint_url} --profile=r2'
 
     @staticmethod
     def cli_ls_cmd(store_type, bucket_name, suffix=''):
@@ -1943,7 +1943,7 @@ class TestStorageWithCredentials:
                 url = f's3://{bucket_name}/{suffix}'
             else:
                 url = f's3://{bucket_name}'
-            return f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls {url} --endpoint {endpoint_url} --profile=r2'
+            return f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 ls {url} --endpoint {endpoint_url} --profile=r2'
 
     @pytest.fixture
     def tmp_source(self, tmp_path):
@@ -2041,11 +2041,11 @@ class TestStorageWithCredentials:
         # Creates a temporary bucket using awscli
         endpoint_url = cloudflare.create_endpoint()
         subprocess.check_call(
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 mb s3://{tmp_bucket_name} --endpoint {endpoint_url} --profile=r2',
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 mb s3://{tmp_bucket_name} --endpoint {endpoint_url} --profile=r2',
             shell=True)
         yield tmp_bucket_name
         subprocess.check_call(
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb s3://{tmp_bucket_name} --force --endpoint {endpoint_url} --profile=r2',
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 rb s3://{tmp_bucket_name} --force --endpoint {endpoint_url} --profile=r2',
             shell=True)
 
     @pytest.fixture
@@ -2164,7 +2164,7 @@ class TestStorageWithCredentials:
                 expected_output = 'BucketNotFoundException'
             elif nonexist_bucket_url.startswith('r2'):
                 endpoint_url = cloudflare.create_endpoint()
-                command = f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3api head-bucket --bucket {nonexist_bucket_name} --endpoint {endpoint_url} --profile=r2'
+                command = f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3api head-bucket --bucket {nonexist_bucket_name} --endpoint {endpoint_url} --profile=r2'
                 expected_output = '404'
             else:
                 raise ValueError('Unsupported bucket type '

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -732,7 +732,7 @@ def test_cloudflare_storage_mounts(generic_cloud: str):
             *storage_setup_commands,
             f'sky launch -y -c {name} --cloud {generic_cloud} {file_path}',
             f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'aws s3 ls s3://{storage_name}/hello.txt --endpoint {endpoint_url} --profile=r2'
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 ls s3://{storage_name}/hello.txt --endpoint {endpoint_url} --profile=r2'
         ]
 
         test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2040,9 +2040,13 @@ class TestStorageWithCredentials:
     def tmp_awscli_bucket_r2(self, tmp_bucket_name):
         # Creates a temporary bucket using awscli
         endpoint_url = cloudflare.create_endpoint()
-        subprocess.check_call(f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 mb s3://{tmp_bucket_name} --endpoint {endpoint_url} --profile=r2', shell=True)
+        subprocess.check_call(
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 mb s3://{tmp_bucket_name} --endpoint {endpoint_url} --profile=r2',
+            shell=True)
         yield tmp_bucket_name
-        subprocess.check_call(f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb s3://{tmp_bucket_name} --force --endpoint {endpoint_url} --profile=r2', shell=True)
+        subprocess.check_call(
+            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.AWS_R2_CREDENTIALS_PATH} aws s3 rb s3://{tmp_bucket_name} --force --endpoint {endpoint_url} --profile=r2',
+            shell=True)
 
     @pytest.fixture
     def tmp_public_storage_obj(self, request):
@@ -2169,7 +2173,9 @@ class TestStorageWithCredentials:
 
             # Check if bucket exists using the cli:
             try:
-                out = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
+                out = subprocess.check_output(command,
+                                              stderr=subprocess.STDOUT,
+                                              shell=True)
             except subprocess.CalledProcessError as e:
                 out = e.output
             out = out.decode('utf-8')
@@ -2216,7 +2222,8 @@ class TestStorageWithCredentials:
         storage_obj.add_store(store_type)
 
         # Check if tmp_source/tmp-file exists in the bucket using aws cli
-        out = subprocess.check_output(self.cli_ls_cmd(store_type, bucket_name), shell=True)
+        out = subprocess.check_output(self.cli_ls_cmd(store_type, bucket_name),
+                                      shell=True)
         assert 'tmp-file' in out.decode('utf-8'), \
             'File not found in bucket - output was : {}'.format(out.decode
                                                                 ('utf-8'))
@@ -2255,16 +2262,17 @@ class TestStorageWithCredentials:
         tmp_local_list_storage_obj.add_store(store_type)
 
         # Check if tmp-file exists in the bucket root using cli
-        out = subprocess.check_output(
-            self.cli_ls_cmd(store_type, tmp_local_list_storage_obj.name), shell=True)
+        out = subprocess.check_output(self.cli_ls_cmd(
+            store_type, tmp_local_list_storage_obj.name),
+                                      shell=True)
         assert 'tmp-file' in out.decode('utf-8'), \
             'File not found in bucket - output was : {}'.format(out.decode
                                                                 ('utf-8'))
 
         # Check if tmp-file exists in the bucket/tmp-source using cli
-        out = subprocess.check_output(
-            self.cli_ls_cmd(store_type, tmp_local_list_storage_obj.name,
-                            'tmp-source/'), shell=True)
+        out = subprocess.check_output(self.cli_ls_cmd(
+            store_type, tmp_local_list_storage_obj.name, 'tmp-source/'),
+                                      shell=True)
         assert 'tmp-file' in out.decode('utf-8'), \
             'File not found in bucket - output was : {}'.format(out.decode
                                                                 ('utf-8'))


### PR DESCRIPTION
Closes #1979.

These changes may potentially disrupt existing R2 users since the credentials path has changed. To mitigate, added a nicer message suggesting them to run `sky check`, which tells precisely the commands need to be run to get them running again.

E.g: switched from master to new branch -> run `sky launch` with R2 storage:
```
$ SKYPILOT_DEBUG=0 sky launch -c storage --cloud gcp test.yaml
Task from YAML spec: test.yaml
ValueError: Cloudflare credentials not found. Run `sky check` to verify credentials are correctly setup.

$ sky check
...
  Cloudflare (for R2 object store): disabled          
    Reason: [r2] profile is not set in ~/.cloudflare/r2credentials Run the following commands:
      $ pip install boto3
      $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/r2credentials aws configure --profile r2
    For more info: https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#cloudflare-r2
```

Tested (run the relevant ones):

- [x] `pytest tests/test_smoke.py::TestStorageWithCredentials --cloudflare`
- [x] `pytest tests/test_smoke.py::test_cloudflare_storage_mounts --cloudflare`
