### PR TITLE
Docs: add `sky cost-report` docstr to docs.

### DIFF
--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -97,8 +97,8 @@ Storage CLI
    :prog: sky storage delete
    :nested: full
 
-Utils: ``show-gpus``, ``check``
----------------------------------------
+Utils: ``show-gpus``, ``check``, ``cost-report``
+-------------------------------------------------
 
 
 .. click:: sky.cli:show_gpus
@@ -107,4 +107,8 @@ Utils: ``show-gpus``, ``check``
 
 .. click:: sky.cli:check
    :prog: sky check
+   :nested: full
+
+.. click:: sky.cli:cost_report
+   :prog: sky cost-report
    :nested: full

--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -97,7 +97,7 @@ Storage CLI
    :prog: sky storage delete
    :nested: full
 
-Utils: ``show-gpus``, ``check``, ``cost-report``
+Utils: ``show-gpus``/``check``/``cost-report``
 -------------------------------------------------
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1714,12 +1714,12 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     means if the cluster is UP, successive calls to cost-report will show
     increasing price.
 
-    The estimated cost is calculated based on the local cache of the cluster
-    status, and may not be accurate for:
+    This CLI is experimental: The estimated cost is calculated based on the
+    local cache of the cluster status, and may not be accurate for:
 
-      - clusters with autostop/use_spot set; or
+    - Clusters with autostop/use_spot set; or
 
-      - clusters that were terminated/stopped on the cloud console.
+    - Clusters that were terminated/stopped on the cloud console.
     """
     cluster_records = core.cost_report()
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1714,7 +1714,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     means if the cluster is UP, successive calls to cost-report will show
     increasing price.
 
-    This CLI is experimental: The estimated cost is calculated based on the
+    This CLI is experimental. The estimated cost is calculated based on the
     local cache of the cluster status, and may not be accurate for:
 
     - Clusters with autostop/use_spot set; or


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky cost-report -h`
  - [x] rendered docs HTML locally
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
