### PR TITLE
[Spot] Stop the cluster if the cancellation fails

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2287,7 +2287,8 @@ def check_cluster_available(
             raise exceptions.ClusterNotUpError(
                 constants.UNINITIALIZED_ONPREM_CLUSTER_MESSAGE.format(
                     cluster_name),
-                cluster_status=cluster_status)
+                cluster_status=cluster_status,
+                handle=handle)
         with ux_utils.print_exception_no_traceback():
             hint_for_init = ''
             if cluster_status == global_user_state.ClusterStatus.INIT:
@@ -2302,14 +2303,16 @@ def check_cluster_available(
                 f'{global_user_state.ClusterStatus.UP.value} clusters.'
                 f'{hint_for_init}'
                 f'{reset}',
-                cluster_status=cluster_status)
+                cluster_status=cluster_status,
+                handle=handle)
 
     if handle.head_ip is None:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterNotUpError(
                 f'Cluster {cluster_name!r} has been stopped or not properly '
                 'set up. Please re-launch it with `sky start`.',
-                cluster_status=cluster_status)
+                cluster_status=cluster_status,
+                handle=handle)
     return handle
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -524,10 +524,13 @@ def queue(cluster_name: str,
 
 @usage_lib.entrypoint
 # pylint: disable=redefined-builtin
-def cancel(cluster_name: str,
-           all: bool = False,
-           job_ids: Optional[List[int]] = None,
-           _ignore_server_aliveness: bool = False) -> None:
+def cancel(
+    cluster_name: str,
+    all: bool = False,
+    job_ids: Optional[List[int]] = None,
+    # pylint: disable=invalid-name
+    _ignore_server_aliveness: bool = False,
+) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancel jobs on a cluster.
 
@@ -547,7 +550,7 @@ def cancel(cluster_name: str,
         raise ValueError(
             'sky cancel requires either a job id '
             f'(see `sky queue {cluster_name} -s`) or the --all flag.')
-    
+
     backend_utils.check_cluster_name_not_reserved(
         cluster_name, operation_str='Cancelling jobs')
 
@@ -558,7 +561,7 @@ def cancel(cluster_name: str,
             operation='cancelling jobs',
         )
     else:
-        handle = backend_utils.refresh_cluster_status_handle(cluster_name)
+        _, handle = backend_utils.refresh_cluster_status_handle(cluster_name)
     backend = backend_utils.get_backend_from_handle(handle)
 
     if all:

--- a/sky/core.py
+++ b/sky/core.py
@@ -568,6 +568,8 @@ def cancel(
     except exceptions.ClusterNotUpError as e:
         if not _try_cancel_if_cluster_is_init:
             raise
+        assert (e.handle is None or
+                isinstance(e.handle, backends.CloudVmRayResourceHandle)), e
         if (e.handle is None or e.handle.head_ip is None):
             raise
         # Even if the cluster is not UP, we can still try to cancel the job if

--- a/sky/core.py
+++ b/sky/core.py
@@ -529,14 +529,14 @@ def cancel(
     all: bool = False,
     job_ids: Optional[List[int]] = None,
     # pylint: disable=invalid-name
-    _ignore_cluster_aliveness: bool = False,
+    _try_cancel_if_cluster_is_init: bool = False,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancel jobs on a cluster.
 
     Please refer to the sky.cli.cancel for the document.
     Additional arguments:
-        _ignore_cluster_aliveness: (bool) whether to try cancelling the job
+        _try_cancel_if_cluster_is_init: (bool) whether to try cancelling the job
             even if the cluster is not UP, but the head node is still alive.
             This is used by the spot controller to cancel the job when the
             worker node is preempted in the spot cluster.
@@ -566,10 +566,9 @@ def cancel(
             operation='cancelling jobs',
         )
     except exceptions.ClusterNotUpError as e:
-        if not _ignore_cluster_aliveness:
+        if not _try_cancel_if_cluster_is_init:
             raise
-        if (not isinstance(e.handle, backends.CloudVmRayResourceHandle) or
-                e.handle.head_ip is None):
+        if (e.handle is None or e.handle.head_ip is None):
             raise
         # Even if the cluster is not UP, we can still try to cancel the job if
         # the head node is still alive. This is useful when a spot cluster's

--- a/sky/core.py
+++ b/sky/core.py
@@ -529,7 +529,7 @@ def cancel(
     all: bool = False,
     job_ids: Optional[List[int]] = None,
     # pylint: disable=invalid-name
-    _ignore_server_aliveness: bool = False,
+    _ignore_cluster_aliveness: bool = False,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Cancel jobs on a cluster.
@@ -555,7 +555,7 @@ def cancel(
         cluster_name, operation_str='Cancelling jobs')
 
     # Check the status of the cluster.
-    if not _ignore_server_aliveness:
+    if not _ignore_cluster_aliveness:
         handle = backend_utils.check_cluster_available(
             cluster_name,
             operation='cancelling jobs',

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 if typing.TYPE_CHECKING:
     from sky import global_user_state
+    from sky.backends import backend
 
 # Return code for keyboard interruption and SIGTSTP
 KEYBOARD_INTERRUPT_CODE = 130
@@ -94,12 +95,13 @@ class CommandError(Exception):
 class ClusterNotUpError(Exception):
     """Raised when a cluster is not up."""
 
-    def __init__(
-            self, message: str,
-            cluster_status: Optional['global_user_state.ClusterStatus']
-    ) -> None:
+    def __init__(self,
+                 message: str,
+                 cluster_status: Optional['global_user_state.ClusterStatus'],
+                 handle: Optional['backend.ResourceHandle'] = None) -> None:
         super().__init__(message)
         self.cluster_status = cluster_status
+        self.handle = handle
 
 
 class ClusterSetUpError(Exception):

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -138,16 +138,9 @@ class StrategyExecutor:
                         'might be already down or the head node is preempted. '
                         '\n  Detailed exception: '
                         f'{common_utils.format_exception(e)}\n'
-                        'Stopping the cluster again to make sure there is no '
+                        'Terminating the cluster again to make sure there is no '
                         'remaining job on the worker nodes.')
-            try:
-                usage_lib.messages.usage.set_internal()
-                sky.stop(cluster_name=self.cluster_name)
-            except Exception as e:  # pylint: disable=broad-except
-                logger.info('  Ignoring the cluster stopping failure; '
-                            'the spot cluster is likely completely stopped.'
-                            '\n    Detailed exception: '
-                            f'{common_utils.format_exception(e)}')
+            terminate_cluster(self.cluster_name)
 
     def _wait_until_job_starts_on_cluster(self) -> Optional[float]:
         """Wait for MAX_JOB_CHECKING_RETRY times until job starts on the cluster

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -130,7 +130,7 @@ class StrategyExecutor:
             return
         try:
             usage_lib.messages.usage.set_internal()
-            sky.cancel(cluster_name=self.cluster_name, all=True)
+            sky.cancel(cluster_name=self.cluster_name, all=True, _ignore_server_aliveness=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.info('Failed to cancel the job on the cluster. The cluster '
                         'might be already down or the head node is preempted. '

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -130,7 +130,9 @@ class StrategyExecutor:
             return
         try:
             usage_lib.messages.usage.set_internal()
-            sky.cancel(cluster_name=self.cluster_name, all=True, _ignore_server_aliveness=True)
+            sky.cancel(cluster_name=self.cluster_name,
+                       all=True,
+                       _ignore_server_aliveness=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.info('Failed to cancel the job on the cluster. The cluster '
                         'might be already down or the head node is preempted. '

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -132,7 +132,7 @@ class StrategyExecutor:
             usage_lib.messages.usage.set_internal()
             sky.cancel(cluster_name=self.cluster_name,
                        all=True,
-                       _ignore_server_aliveness=True)
+                       _ignore_cluster_aliveness=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.info(
                 'Failed to cancel the job on the cluster. The cluster '

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -134,12 +134,13 @@ class StrategyExecutor:
                        all=True,
                        _ignore_server_aliveness=True)
         except Exception as e:  # pylint: disable=broad-except
-            logger.info('Failed to cancel the job on the cluster. The cluster '
-                        'might be already down or the head node is preempted. '
-                        '\n  Detailed exception: '
-                        f'{common_utils.format_exception(e)}\n'
-                        'Terminating the cluster again to make sure there is no '
-                        'remaining job on the worker nodes.')
+            logger.info(
+                'Failed to cancel the job on the cluster. The cluster '
+                'might be already down or the head node is preempted. '
+                '\n  Detailed exception: '
+                f'{common_utils.format_exception(e)}\n'
+                'Terminating the cluster again to make sure there is no '
+                'remaining job on the worker nodes.')
             terminate_cluster(self.cluster_name)
 
     def _wait_until_job_starts_on_cluster(self) -> Optional[float]:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -146,16 +146,16 @@ class StrategyExecutor:
             # remaining nodes first.
             #
             # In the case where the worker node is preempted, the `sky.cancel()`
-            # should be functional with the `_ignore_cluster_aliveness` flag,
+            # should be functional with the `_try_cancel_if_cluster_is_init` flag,
             # i.e. it sends the cancel signal to the head node, which will then
             # kill the user process on remaining worker nodes.
             sky.cancel(cluster_name=self.cluster_name,
                        all=True,
-                       _ignore_cluster_aliveness=True)
+                       _try_cancel_if_cluster_is_init=True)
         except Exception as e:  # pylint: disable=broad-except
             logger.info(
                 'Failed to cancel the job on the cluster. The cluster '
-                'might be already down or the head node is preempted. '
+                'might be already down or the head node is preempted.'
                 '\n  Detailed exception: '
                 f'{common_utils.format_exception(e)}\n'
                 'Terminating the cluster again to make sure there is no '

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -146,9 +146,9 @@ class StrategyExecutor:
             # remaining nodes first.
             #
             # In the case where the worker node is preempted, the `sky.cancel()`
-            # should be functional with the `_try_cancel_if_cluster_is_init` flag,
-            # i.e. it sends the cancel signal to the head node, which will then
-            # kill the user process on remaining worker nodes.
+            # should be functional with the `_try_cancel_if_cluster_is_init`
+            # flag, i.e. it sends the cancel signal to the head node, which will
+            # then kill the user process on remaining worker nodes.
             sky.cancel(cluster_name=self.cluster_name,
                        all=True,
                        _try_cancel_if_cluster_is_init=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR is an attempt to fix a potential bug when running multi-node spot job. If the head node is preempted, the worker nodes may still have the job remaining there holding the system resources (e.g. GPU memory) and our original cancellation of the job will take no effect as the head node does not exist. We add a safeguard to stop all the nodes if the cancellation fails. 

Previously, the `sky.cancel` in the recovery_strategy does not take effect even if the worker node is preempted. To reproduce:
1. `sky launch -c test-4-nodes --cloud aws --use-spot --cpus 2+ sleep 10000`
2. manually terminate a worker node
3. `python -c "sky.cancel('test-4-nodes', all=True)` The cancel fails, and if we log into the cluster and run `ray job list` the job is still running.

To fix this issue, we add `_ignore_server_aliveness` to the `sky.cancel` function, so that we try our best to cancel the job, even if the cluster is partially up. If the cancellation fails, in the recovery_strategy, we will stop the cluster to be safe.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch --num-nodes 4 sleep 1000`; kill the head node in the console; the whole cluster is terminated and re-launched.
  - [x] `sky spot launch --num-nodes 4 sleep 1000`; kill the worker node in the console; the worker node is re-launched and check the ray job in the head node and the previous job is cancelled correctly.
- [x] All spot smoke tests: `pytest tests/test_smoke.py --managed-spot` 
