### PR TITLE
Fix `spot launch` error if config.yaml doesn't set ssh_proxy_command

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -636,6 +636,7 @@ def spot_launch(
             proxy_command_key = ('aws', 'ssh_proxy_command')
             ssh_proxy_command = skypilot_config.get_nested(
                 proxy_command_key, None)
+            config_dict = skypilot_config.to_dict()
             if isinstance(ssh_proxy_command, str):
                 config_dict = skypilot_config.set_nested(
                     proxy_command_key, None)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -117,6 +117,14 @@ def set_nested(keys: Iterable[str], value: Any) -> Dict[str, Any]:
     return to_return
 
 
+def to_dict() -> Dict[str, Any]:
+    """Returns a deep-copied version of the current config."""
+    global _dict
+    if loaded():
+        return copy.deepcopy(_dict)
+    return {}
+
+
 def _syntax_check_for_ssh_proxy_command(cloud: str) -> None:
     ssh_proxy_command_config = get_nested((cloud.lower(), 'ssh_proxy_command'),
                                           None)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -120,7 +120,7 @@ def set_nested(keys: Iterable[str], value: Any) -> Dict[str, Any]:
 def to_dict() -> Dict[str, Any]:
     """Returns a deep-copied version of the current config."""
     global _dict
-    if loaded():
+    if _dict is not None:
         return copy.deepcopy(_dict)
     return {}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Repro

- `~/.sky/config.yaml` has some fields set, but not `aws.ssh_proxy_command`:
```
aws:
  # Tags (key-value pairs) to assign to all instances launched by SkyPilot for
  # this cloud.
  #
  # Users should guarantee that these key-values are valid AWS tags, otherwise
  # errors from the cloud provider will be surfaced.
  # instance_tags: 123
  my-tag-1: my-value-1
  my-tag-2: my-value-2
  tag with spaces: my-value
  value-with-spaces: my value
```

On master
```
» sky spot launch echo hi
...
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/execution.py", line 651, in spot_launch
    common_utils.dump_yaml(tmpfile.name, config_dict)
UnboundLocalError: local variable 'config_dict' referenced before assignment
```

With this PR, the command went through.

(Useful: VSCode's Pylance correctly warned that `config_dict` is possibly unbound.)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
