### PR TITLE
`sky check` UX: show underlying exceptions for AWS errors.

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -90,6 +90,7 @@ class AWS(clouds.Cloud):
         'Run the following commands:'
         f'\n{_INDENT_PREFIX}  $ pip install boto3'
         f'\n{_INDENT_PREFIX}  $ aws configure'
+        f'\n{_INDENT_PREFIX}  $ aws configure list  # Ensure that this shows identity is set.'
         f'\n{_INDENT_PREFIX}For more info: '
         'https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html'  # pylint: disable=line-too-long
     )
@@ -567,17 +568,25 @@ class AWS(clouds.Cloud):
             # 2. In the case where the multiple users belong to an organization,
             # those users will have different account id, so fallback works.
             user_ids = [user_info['UserId'], user_info['Account']]
-        except aws.botocore_exceptions().NoCredentialsError:
+        except aws.botocore_exceptions().NoCredentialsError as e:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.CloudUserIdentityError(
-                    f'AWS credentials are not set. {cls._STATIC_CREDENTIAL_HELP_STR}'
+                    'AWS credentials are not set. '
+                    f'{cls._STATIC_CREDENTIAL_HELP_STR}\n'
+                    f'{cls._INDENT_PREFIX}Details: `aws sts '
+                    'get-caller-identity` failed with error:'
+                    f' {common_utils.format_exception(e, use_bracket=True)}.'
                 ) from None
-        except aws.botocore_exceptions().ClientError:
+        except aws.botocore_exceptions().ClientError as e:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.CloudUserIdentityError(
                     'Failed to access AWS services with credentials. '
                     'Make sure that the access and secret keys are correct.'
-                    f' {cls._STATIC_CREDENTIAL_HELP_STR}') from None
+                    f' {cls._STATIC_CREDENTIAL_HELP_STR}\n'
+                    f'{cls._INDENT_PREFIX}Details: `aws sts '
+                    'get-caller-identity` failed with error:'
+                    f' {common_utils.format_exception(e, use_bracket=True)}.'
+                ) from None
         except aws.botocore_exceptions().InvalidConfigError as e:
             # pylint: disable=import-outside-toplevel
             import awscli


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Several users (including https://github.com/skypilot-org/skypilot/issues/1997) have faced some `sky check` errors. This PR tries to surface the underlying exceptions to make it easier to debug.

<img width="1333" alt="Screen Shot 2023-05-31 at 13 43 33" src="https://github.com/skypilot-org/skypilot/assets/592670/f83d1ea2-e511-45a5-bc70-a8ec592200d2">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
