### PR TITLE
[Spot] Retry until up for spot

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3436,8 +3436,8 @@ def spot_launch(
             flag_str = '--no-retry-until-up'
         click.secho(
             f'Flag {flag_str} is deprecated and will be removed in a '
-            'future release (managed spot jobs will always be retried). Please file an issue if this '
-            'does not work for you.',
+            'future release (managed spot jobs will always be retried). '
+            'Please file an issue if this does not work for you.',
             fg='yellow')
     else:
         retry_until_up = True

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3353,9 +3353,9 @@ def spot():
     help=('If True, as soon as a job is submitted, return from this call '
           'and do not stream execution logs.'))
 @click.option(
-    '--retry-until-up',
+    '--retry-until-up/--no-retry-until-up',
     '-r',
-    default=True,
+    default=None,
     is_flag=True,
     required=False,
     help=('(Default: True; this flag is deprecated and will be removed in a '
@@ -3429,6 +3429,18 @@ def spot_launch(
         disk_tier=disk_tier,
         spot_recovery=spot_recovery,
     )
+    # Deprecation.
+    if retry_until_up is not None:
+        flag_str = '--retry-until-up'
+        if not retry_until_up:
+            flag_str = '--no-retry-until-up'
+        click.secho(
+            f'Flag {flag_str} is deprecated and will be removed in a '
+            'future release (defaults to True). Please file an issue if this '
+            'does not work for you.',
+            fg='yellow')
+    else:
+        retry_until_up = True
 
     if not yes:
         prompt = f'Launching a new spot task {name!r}. Proceed?'
@@ -3444,13 +3456,6 @@ def spot_launch(
                   if resources.cloud is not None else clouds.Cloud)
     task_cloud.check_cluster_name_is_valid(name)
 
-    # Deprecation.
-    if not retry_until_up:
-        click.secho(
-            'Flag --retry-until-up is deprecated and will be removed in a '
-            'future release (defaults to True). Please file an issue if this '
-            'does not work for you.',
-            fg='yellow')
 
     sky.spot_launch(task,
                     name,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3354,7 +3354,7 @@ def spot():
           'and do not stream execution logs.'))
 @click.option(
     '--retry-until-up/--no-retry-until-up',
-    '-r',
+    '-r/-no-r',
     default=None,
     is_flag=True,
     required=False,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3456,7 +3456,6 @@ def spot_launch(
                   if resources.cloud is not None else clouds.Cloud)
     task_cloud.check_cluster_name_is_valid(name)
 
-
     sky.spot_launch(task,
                     name,
                     detach_run=detach_run,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3436,7 +3436,7 @@ def spot_launch(
             flag_str = '--no-retry-until-up'
         click.secho(
             f'Flag {flag_str} is deprecated and will be removed in a '
-            'future release (defaults to True). Please file an issue if this '
+            'future release (managed spot jobs will always be retried). Please file an issue if this '
             'does not work for you.',
             fg='yellow')
     else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when `sky spot launch --retry-until-up echo hi` is executed, the retry_until_up will be set to False (weird semantics of the click package). This PR fixes that issue from #1781 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch --retry-until-up echo hi` correctly warn and `retry_until_up is True`
  - [x] `sky spot launch --no-retry-until-up echo hi` correctly warn and `retry_until_up is False`
  - [x] `sky spot launch echo hi` no warning and `retry_until_up is True`
  - [x] `sky spot launch --r echo hi` correctly warn and `retry_until_up is True`
  - [x] `sky spot launch --no-r echo hi` correctly warn and `retry_until_up is False`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
