### PR TITLE
Fix creating `$PWD/~/sky_logs` in some cases.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1248,7 +1248,7 @@ class RetryingVmProvisioner(object):
         # Get log_path name
         log_path = os.path.join(self.log_dir, 'provision.log')
         log_abs_path = os.path.abspath(log_path)
-        os.makedirs(self.log_dir, exist_ok=True)
+        os.makedirs(os.path.expanduser(self.log_dir), exist_ok=True)
         os.system(f'touch {log_path}')
         tail_cmd = f'tail -n100 -f {log_path}'
         logger.info('To view detailed progress: '
@@ -2157,6 +2157,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def __init__(self):
         self.run_timestamp = backend_utils.get_run_timestamp()
+        # NOTE: do not expanduser() here, as this '~/...' path is used for
+        # remote as well to be expanded on the remote side.
         self.log_dir = os.path.join(constants.SKY_LOGS_DIRECTORY,
                                     self.run_timestamp)
         # Do not make directories to avoid create folder for commands that
@@ -2553,7 +2555,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             f'{style.BRIGHT}{workdir}{style.RESET_ALL}'
             f' -> '
             f'{style.BRIGHT}{SKY_REMOTE_WORKDIR}{style.RESET_ALL}')
-        os.makedirs(self.log_dir, exist_ok=True)
+        os.makedirs(os.path.expanduser(self.log_dir), exist_ok=True)
         os.system(f'touch {log_path}')
         tail_cmd = f'tail -n100 -f {log_path}'
         logger.info('To view detailed progress: '
@@ -3585,8 +3587,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def _execute_file_mounts(self, handle: CloudVmRayResourceHandle,
                              file_mounts: Dict[Path, Path]):
-        """Executes file mounts - rsyncing local files and
-        copying from remote stores."""
+        """Executes file mounts.
+
+        Rsyncing local files and copying from remote stores.
+        """
         # File mounts handling for remote paths possibly without write access:
         #  (1) in 'file_mounts' sections, add <prefix> to these target paths.
         #  (2) then, create symlinks from '/.../file' to '<prefix>/.../file'.
@@ -3623,7 +3627,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         f'{fore.YELLOW}Source path {src!r} is a symlink. '
                         f'Symlink contents are not uploaded.{style.RESET_ALL}')
 
-        os.makedirs(self.log_dir, exist_ok=True)
+        os.makedirs(os.path.expanduser(self.log_dir), exist_ok=True)
         os.system(f'touch {log_path}')
         tail_cmd = f'tail -n100 -f {log_path}'
         logger.info('To view detailed progress: '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Thanks for the report from a user. #1913 had a bug where sometimes we call `os.makedirs('~/sky_logs/...', ...)`, causing `$PWD/~/sky_logs` to be created in some cases.

Repro:
```
sky spot launch --cloud gcp echo hi  # Or pass a YAML where _execute_file_mounts() is to be triggered
# observe `$PWD/~/sky_logs` is created
```

With this PR, the above succeeds & `$PWD/~/sky_logs` is no longer created.

cc @cblmemo to take a look too.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below): above
- [x] All smoke tests: `pytest tests/test_smoke.py`: running
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
