### PR TITLE
Update lambda data fetcher with new region (us-west-3) and H100

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -16,8 +16,7 @@ import requests
 ENDPOINT = 'https://cloud.lambdalabs.com/api/v1/instance-types'
 DEFAULT_LAMBDA_KEYS_PATH = os.path.expanduser('~/.lambda_cloud/lambda_keys')
 
-# List of all possible regions. The best way to obtain this list is to ask
-# Lambda. Could not find this list online.
+# List of all possible regions.
 REGIONS = [
     'australia-southeast-1',
     'europe-central-1',
@@ -31,6 +30,7 @@ REGIONS = [
     'us-west-1',
     'us-south-1',
     'us-west-3',
+    'us-midwest-1',
 ]
 
 # Source: https://lambdalabs.com/service/gpu-cloud

--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -16,7 +16,7 @@ import requests
 ENDPOINT = 'https://cloud.lambdalabs.com/api/v1/instance-types'
 DEFAULT_LAMBDA_KEYS_PATH = os.path.expanduser('~/.lambda_cloud/lambda_keys')
 
-# This is the list that Lambda Labs gave us.
+# List of all regions
 REGIONS = [
     'australia-southeast-1',
     'europe-central-1',
@@ -29,7 +29,6 @@ REGIONS = [
     'us-west-2',
     'us-west-1',
     'us-south-1',
-    # New regions (not part of the original list)
     'us-west-3',
 ]
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -16,7 +16,8 @@ import requests
 ENDPOINT = 'https://cloud.lambdalabs.com/api/v1/instance-types'
 DEFAULT_LAMBDA_KEYS_PATH = os.path.expanduser('~/.lambda_cloud/lambda_keys')
 
-# List of all regions
+# List of all possible regions. The best way to obtain this list is to ask
+# Lambda. Could not find this list online.
 REGIONS = [
     'australia-southeast-1',
     'europe-central-1',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -29,6 +29,8 @@ REGIONS = [
     'us-west-2',
     'us-west-1',
     'us-south-1',
+    # New regions (not part of the original list)
+    'us-west-3',
 ]
 
 # Source: https://lambdalabs.com/service/gpu-cloud
@@ -39,6 +41,7 @@ GPU_TO_MEMORY = {
     'A10': 24576,
     'RTX6000': 24576,
     'V100': 16384,
+    'H100': 81920,
 }
 
 


### PR DESCRIPTION
Update lambda data fetcher with new region (us-west-3) and H100.

The generated catalog can be found [here](https://github.com/skypilot-org/skypilot-catalog/pull/29)
