### PR TITLE
Docs: fix blockquotes by adding back click<=8.0.4

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -67,6 +67,8 @@ install_requires = [
     'wheel',
     # NOTE: ray requires click>=7.0. Also, click 8.1.x makes our rendered CLI
     # docs display weird blockquotes.
+    # TODO(zongheng): investigate how to make click 8.1.x display nicely and
+    # remove the upper bound.
     'click<=8.0.4,>=7.0',
     # NOTE: required by awscli. To avoid ray automatically installing
     # the latest version.

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -65,8 +65,9 @@ def parse_readme(readme: str) -> str:
 
 install_requires = [
     'wheel',
-    # NOTE: ray requires click>=7.0
-    'click>=7.0',
+    # NOTE: ray requires click>=7.0. Also, click 8.1.x makes our rendered CLI
+    # docs display weird blockquotes.
+    'click<=8.0.4,>=7.0',
     # NOTE: required by awscli. To avoid ray automatically installing
     # the latest version.
     'colorama<0.4.5',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Current: https://skypilot.readthedocs.io/en/latest/reference/cli.html

This PR: https://skypilot.readthedocs.io/en/fix-docs-blockquotes/reference/cli.html

ef08910142723fe50bd97 changed `click<=8.0.4,>=7.0` to `click>=7.0`, which generated some weird blockquotes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
