### PR TITLE
[GCP] Remove unsupported GPUs from the list_accelerators

### DIFF
--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -335,9 +335,9 @@ def list_accelerators(
     # Remove GPUs that are unsupported by SkyPilot.
     new_results = {}
     for acc_name, acc_info in results.items():
-        if (acc_name.starts_with('tpu') or acc_name in
-            _NUM_ACC_TO_MAX_CPU_AND_MEMORY or acc_name in
-            _A100_INSTANCE_TYPE_DICTS):
+        if (acc_name.startswith('tpu') or
+                acc_name in _NUM_ACC_TO_MAX_CPU_AND_MEMORY or
+                acc_name in _A100_INSTANCE_TYPE_DICTS):
             new_results[acc_name] = acc_info
             new_results[acc_name] = acc_info
     results = new_results

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -337,7 +337,7 @@ def list_accelerators(
         k: v
         for k, v in results.items()
         if (k in list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY.keys()) +
-        list(_A100_INSTANCE_TYPE_DICTS.keys()) or 'tpu' in k.lower())
+            list(_A100_INSTANCE_TYPE_DICTS.keys()) or 'tpu' in k.lower())
     }
 
     a100_infos = results.get('A100', []) + results.get('A100-80GB', [])

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -335,9 +335,10 @@ def list_accelerators(
     # Remove GPUs that are unsupported by SkyPilot.
     new_results = {}
     for acc_name, acc_info in results.items():
-        if (acc_name in list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY.keys()) +
-                list(_A100_INSTANCE_TYPE_DICTS.keys()) or
-                'tpu' in acc_name.lower()):
+        if (acc_name.starts_with('tpu') or acc_name in
+            _NUM_ACC_TO_MAX_CPU_AND_MEMORY or acc_name in
+            _A100_INSTANCE_TYPE_DICTS):
+            new_results[acc_name] = acc_info
             new_results[acc_name] = acc_info
     results = new_results
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -333,12 +333,13 @@ def list_accelerators(
                                             case_sensitive)
 
     # Remove GPUs that are unsupported by SkyPilot.
-    results = {
-        k: v
-        for k, v in results.items()
-        if (k in list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY.keys()) +
-            list(_A100_INSTANCE_TYPE_DICTS.keys()) or 'tpu' in k.lower())
-    }
+    new_results = {}
+    for acc_name, acc_info in results.items():
+        if (acc_name in list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY.keys()) +
+                list(_A100_INSTANCE_TYPE_DICTS.keys()) or
+                'tpu' in acc_name.lower()):
+            new_results[acc_name] = acc_info
+    results = new_results
 
     a100_infos = results.get('A100', []) + results.get('A100-80GB', [])
     if not a100_infos:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -332,6 +332,14 @@ def list_accelerators(
                                             region_filter, quantity_filter,
                                             case_sensitive)
 
+    # Remove GPUs that are unsupported by SkyPilot.
+    results = {
+        k: v
+        for k, v in results.items()
+        if (k in list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY.keys()) +
+        list(_A100_INSTANCE_TYPE_DICTS.keys()) or 'tpu' in k.lower())
+    }
+
     a100_infos = results.get('A100', []) + results.get('A100-80GB', [])
     if not a100_infos:
         return results
@@ -462,6 +470,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
     if acc_name in _A100_INSTANCE_TYPE_DICTS:
         valid_counts = list(_A100_INSTANCE_TYPE_DICTS[acc_name].keys())
     else:
+        assert acc_name in _NUM_ACC_TO_MAX_CPU_AND_MEMORY, acc_name
         valid_counts = list(_NUM_ACC_TO_MAX_CPU_AND_MEMORY[acc_name].keys())
     if acc_count not in valid_counts:
         with ux_utils.print_exception_no_traceback():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, since we recently added the `L4` GPU in the GCP catalog, but have not supported it in SkyPilot yet. It causes the KeyError when the following command is called:
```
sky launch --cloud gcp --gpus L4 -t n1-highmem-8
```

It also causes the CI error here: https://github.com/skypilot-org/skypilot/actions/runs/5154043404/jobs/9294593850?pr=1909

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky show-gpus --cloud gcp --all`
  - [x] `sky launch --cloud gcp --gpus L4 -t n1-highmem-8`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
