### PR TITLE
[SCP] Format the scp check

### DIFF
--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -44,6 +44,8 @@ class SCP(clouds.Cloud):
         clouds.CloudImplementationFeatures.MULTI_NODE: _MULTI_NODE
     }
 
+    _INDENT_PREFIX = '    '
+
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
@@ -283,14 +285,14 @@ class SCP(clouds.Cloud):
         try:
             scp_utils.SCPClient().list_instances()
         except (AssertionError, KeyError, scp_utils.SCPClientError):
-            return False, ('Failed to access SCP with credentials. '
-                           'To configure credentials, go to:\n'
-                           ' https://cloud.samsungsds.com/openapiguide\n'
-                           ' to generate API key and add the line\n'
-                           ' access_key = [YOUR API ACCESS KEY]\n'
-                           ' secret_key = [YOUR API SECRET KEY]\n'
-                           ' project_id = [YOUR PROJECT ID]\n'
-                           ' to ~/.scp/scp_credential')
+            return False, (
+                'Failed to access SCP with credentials. '
+                'To configure credentials, see: '
+                'https://cloud.samsungsds.com/openapiguide\n'
+                f'{cls._INDENT_PREFIX}Generate API key and add the following line to ~/.scp/scp_credential:\n'
+                f'{cls._INDENT_PREFIX}  access_key = [YOUR API ACCESS KEY]\n'
+                f'{cls._INDENT_PREFIX}  secret_key = [YOUR API SECRET KEY]\n'
+                f'{cls._INDENT_PREFIX}  project_id = [YOUR PROJECT ID]')
 
         return True, None
 

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -289,7 +289,8 @@ class SCP(clouds.Cloud):
                 'Failed to access SCP with credentials. '
                 'To configure credentials, see: '
                 'https://cloud.samsungsds.com/openapiguide\n'
-                f'{cls._INDENT_PREFIX}Generate API key and add the following line to ~/.scp/scp_credential:\n'
+                f'{cls._INDENT_PREFIX}Generate API key and add the '
+                'following line to ~/.scp/scp_credential:\n'
                 f'{cls._INDENT_PREFIX}  access_key = [YOUR API ACCESS KEY]\n'
                 f'{cls._INDENT_PREFIX}  secret_key = [YOUR API SECRET KEY]\n'
                 f'{cls._INDENT_PREFIX}  project_id = [YOUR PROJECT ID]')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before this PR, the `sky check` is not well formated for the SCP, as the following:
```
  SCP: disabled
    Reason: Failed to access SCP with credentials. To configure credentials, go to:
 https://cloud.samsungsds.com/openapiguide
 to generate API key and add the line
 access_key = [YOUR API ACCESS KEY]
 secret_key = [YOUR API SECRET KEY]
 project_id = [YOUR PROJECT ID]
 to ~/.scp/scp_credential
```

After this PR:
```
  SCP: disabled          
    Reason: Failed to access SCP with credentials. To configure credentials, see: https://cloud.samsungsds.com/openapiguide
    Generate API key and add the following line to ~/.scp/scp_credential:
      access_key = [YOUR API ACCESS KEY]
      secret_key = [YOUR API SECRET KEY]
      project_id = [YOUR PROJECT ID]
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
