### PR TITLE
[Storage] Fix the storage cloud checking before sky.check is called.

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -8,6 +8,7 @@ from sky import global_user_state
 from sky.adaptors import cloudflare
 
 
+# TODO(zhwu): add check for a single cloud to improve performance
 def check(quiet: bool = False) -> None:
     echo = (lambda *_args, **_kwargs: None) if quiet else click.echo
     echo('Checking credentials to enable clouds for SkyPilot.')

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -94,7 +94,7 @@ class GcsCloudStorage(CloudStorage):
     # parellel workers on our end.
     # The gsutil command is part of the Google Cloud SDK, and we reuse
     # the installation logic here.
-    _GET_GSUTIL = gcp.GCLOUD_INSTALLATION_COMMAND
+    _GET_GSUTIL = gcp.GOOGLE_SDK_INSTALLATION_COMMAND
 
     _GSUTIL = ('GOOGLE_APPLICATION_CREDENTIALS='
                f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH} gsutil')

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -54,7 +54,7 @@ _GCLOUD_VERSION = '424.0.0'
 # Need to be run with /bin/bash
 # We factor out the installation logic to keep it align in both spot
 # controller and cloud stores.
-GCLOUD_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
+GOOGLE_SDK_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     gcloud --help > /dev/null 2>&1 || \
     {{ mkdir -p {os.path.dirname(_GCLOUD_INSTALLATION_LOG)} && \
     wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
@@ -65,6 +65,10 @@ GCLOUD_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> ~/.bashrc && \
     source ~/google-cloud-sdk/path.bash.inc >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
     {{ cp {GCP_CONFIG_SKY_BACKUP_PATH} {GCP_CONFIG_PATH} > /dev/null 2>&1 || true; }} && \
+    pip list | grep google-api-python-client > /dev/null 2>&1 || \
+    pip install google-api-python-client >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \
+    pip list | grep google-cloud-storage > /dev/null 2>&1 || \
+    pip install google-cloud-storage >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \
     popd &>/dev/null'
 
 # TODO(zhwu): Move the default AMI size to the catalog instead.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -65,10 +65,6 @@ GOOGLE_SDK_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> ~/.bashrc && \
     source ~/google-cloud-sdk/path.bash.inc >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }}; }} && \
     {{ cp {GCP_CONFIG_SKY_BACKUP_PATH} {GCP_CONFIG_PATH} > /dev/null 2>&1 || true; }} && \
-    {{ pip list | grep google-api-python-client > /dev/null 2>&1 || \
-    pip install google-api-python-client >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
-    {{ pip list | grep google-cloud-storage > /dev/null 2>&1 || \
-    pip install google-cloud-storage >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
     popd &>/dev/null'
 
 # TODO(zhwu): Move the default AMI size to the catalog instead.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -55,7 +55,7 @@ _GCLOUD_VERSION = '424.0.0'
 # We factor out the installation logic to keep it align in both spot
 # controller and cloud stores.
 GOOGLE_SDK_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
-    gcloud --help > /dev/null 2>&1 || \
+    {{ gcloud --help > /dev/null 2>&1 || \
     {{ mkdir -p {os.path.dirname(_GCLOUD_INSTALLATION_LOG)} && \
     wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
     tar xzf google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
@@ -63,12 +63,12 @@ GOOGLE_SDK_INSTALLATION_COMMAND = f'pushd /tmp &>/dev/null && \
     mv google-cloud-sdk ~/ && \
     ~/google-cloud-sdk/install.sh -q >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \
     echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> ~/.bashrc && \
-    source ~/google-cloud-sdk/path.bash.inc >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
+    source ~/google-cloud-sdk/path.bash.inc >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }}; }} && \
     {{ cp {GCP_CONFIG_SKY_BACKUP_PATH} {GCP_CONFIG_PATH} > /dev/null 2>&1 || true; }} && \
-    pip list | grep google-api-python-client > /dev/null 2>&1 || \
-    pip install google-api-python-client >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \
-    pip list | grep google-cloud-storage > /dev/null 2>&1 || \
-    pip install google-cloud-storage >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \
+    {{ pip list | grep google-api-python-client > /dev/null 2>&1 || \
+    pip install google-api-python-client >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
+    {{ pip list | grep google-cloud-storage > /dev/null 2>&1 || \
+    pip install google-cloud-storage >> {_GCLOUD_INSTALLATION_LOG} 2>&1; }} && \
     popd &>/dev/null'
 
 # TODO(zhwu): Move the default AMI size to the catalog instead.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -60,13 +60,17 @@ _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE = (
     'Bucket {bucket_name!r} does not exist. '
     'It may have been deleted externally.')
 
-def _is_storage_cloud_enabled(cloud_name: str, try_fix_with_sky_check: bool) -> bool:
+
+def _is_storage_cloud_enabled(cloud_name: str,
+                              try_fix_with_sky_check: bool = True) -> bool:
     enabled_storage_clouds = global_user_state.get_enabled_storage_clouds()
     if cloud_name in enabled_storage_clouds:
         return True
     if try_fix_with_sky_check:
+        # TODO(zhwu): Only check the specified cloud to speed up.
         check.check(quiet=True)
-        return _is_storage_cloud_enabled(cloud_name, try_fix_with_sky_check=False)
+        return _is_storage_cloud_enabled(cloud_name,
+                                         try_fix_with_sky_check=False)
     return False
 
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -10,6 +10,7 @@ import urllib.parse
 
 import colorama
 
+from sky import check
 from sky import clouds
 from sky.adaptors import aws
 from sky.adaptors import gcp
@@ -58,6 +59,15 @@ _BUCKET_FAIL_TO_CONNECT_MESSAGE = (
 _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE = (
     'Bucket {bucket_name!r} does not exist. '
     'It may have been deleted externally.')
+
+def _is_storage_cloud_enabled(cloud_name: str, try_fix_with_sky_check: bool) -> bool:
+    enabled_storage_clouds = global_user_state.get_enabled_storage_clouds()
+    if cloud_name in enabled_storage_clouds:
+        return True
+    if try_fix_with_sky_check:
+        check.check(quiet=True)
+        return _is_storage_cloud_enabled(cloud_name, try_fix_with_sky_check=False)
+    return False
 
 
 class StoreType(enum.Enum):
@@ -918,8 +928,7 @@ class S3Store(AbstractStore):
         self.name = self.validate_name(self.name)
 
         # Check if the storage is enabled
-        enabled_storage_clouds = global_user_state.get_enabled_storage_clouds()
-        if str(clouds.AWS()) not in enabled_storage_clouds:
+        if not _is_storage_cloud_enabled(str(clouds.AWS())):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
                     'Storage \'store: s3\' specified, but ' \
@@ -1304,8 +1313,7 @@ class GcsStore(AbstractStore):
         # Validate name
         self.name = self.validate_name(self.name)
         # Check if the storage is enabled
-        enabled_storage_clouds = global_user_state.get_enabled_storage_clouds()
-        if str(clouds.GCP()) not in enabled_storage_clouds:
+        if not _is_storage_cloud_enabled(str(clouds.GCP())):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
                     'Storage \'store: gcs\' specified, but ' \
@@ -1718,8 +1726,7 @@ class R2Store(AbstractStore):
         # Validate name
         self.name = S3Store.validate_name(self.name)
         # Check if the storage is enabled
-        enabled_storage_clouds = global_user_state.get_enabled_storage_clouds()
-        if cloudflare.NAME not in enabled_storage_clouds:
+        if not _is_storage_cloud_enabled(cloudflare.NAME):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
                     'Storage \'store: r2\' specified, but ' \

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -601,7 +601,7 @@ def spot_launch(
             'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
             'logging_user_hash': common_utils.get_user_hash(),
             'retry_until_up': retry_until_up,
-            'user': os.environ.get('USER', None),
+            'user': os.environ.get('SKYPILOT_USER', getpass.getuser()),
         }
         if skypilot_config.loaded():
             # Look up the contents of the already loaded configs via the

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -594,7 +594,8 @@ def spot_launch(
             # Note: actual spot cluster name will be <task_name>-<spot job ID>
             'task_name': name,
             'uuid': task_uuid,
-            'gcloud_installation_commands': gcp.GCLOUD_INSTALLATION_COMMAND,
+            'google_sdk_installation_commands':
+                gcp.GOOGLE_SDK_INSTALLATION_COMMAND,
             'is_dev': env_options.Options.IS_DEVELOPER.get(),
             'is_debug': env_options.Options.SHOW_DEBUG_INFO.get(),
             'disable_logging': env_options.Options.DISABLE_LOGGING.get(),

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -601,7 +601,9 @@ def spot_launch(
             'disable_logging': env_options.Options.DISABLE_LOGGING.get(),
             'logging_user_hash': common_utils.get_user_hash(),
             'retry_until_up': retry_until_up,
-            'user': os.environ.get('SKYPILOT_USER', getpass.getuser()),
+            # Should not use $USER here, as that env var can be empty when
+            # running in a container.
+            'user': getpass.getuser(),
         }
         if skypilot_config.loaded():
             # Look up the contents of the already loaded configs via the

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -28,7 +28,7 @@ setup: |
   # pip list | grep azure-cli > /dev/null 2>&1 || \
   #  pip3 install azure-cli==2.31.0 azure-core
 
-  {{gcloud_installation_commands}}
+  {{google_sdk_installation_commands}}
 
   # Internal: disable logging for manually logging into the spot controller for debugging.
   {% if is_dev %}

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -20,6 +20,7 @@ setup: |
   # Install cli dependencies
   # Not using SkyPilot wheels because the wheel can be cleaned up by another process.
   # TODO(zhwu): Keep the dependencies align with the ones in setup.py
+  echo Check and install AWS SDK
   (pip list | grep boto3 > /dev/null 2>&1 && \
    pip list | grep google-api-python-client > /dev/null 2>&1 ) || \
    pip install boto3 awscli pycryptodome==3.12.0 google-api-python-client google-cloud-storage 2>&1 > /dev/null
@@ -27,7 +28,7 @@ setup: |
   # We do not install azure dependencies for now since our subscription does not support spot instances.
   # pip list | grep azure-cli > /dev/null 2>&1 || \
   #  pip3 install azure-cli==2.31.0 azure-core
-
+  echo Check and install Google SDK
   {{google_sdk_installation_commands}}
 
   # Internal: disable logging for manually logging into the spot controller for debugging.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2016.

This PR also fixes an issue that the `$USER` is empty when under `root` account. This will cause the `SKYPILOT_USER` in `spot-controller.yaml` to be set to `None`, causing the failure for the controller to launch GCP cluster
```
Got googleapiclient.errors.HttpError: <HttpError 400 when requesting https://compute.googleapis.com/compute/v1/projects/skypilot-375900/zones/asia-south2-c/instances?alt=json returned "Invalid value for field 'resource.labels': ''. Label value 'None' violates format constraints. Th
e value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed.". Details: "[{'message': "Invalid value for field 'resource.labels': ''. Label value 'None' violates format constraints. The value can only contain lowercase letters, numeric characters, unders
cores and dashes. The value can be at most 63 characters long. International characters are allowed.", 'domain': 'global', 'reason': 'invalid'}]">
```
Note that `getpass.getuser()` works correctly for the `root` user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] `pytest tests/test_smoke.py::test_spot_storage` with a new spot controller on AWS
- [x] `pytest tests/test_smoke.py --managed-spot`