### PR TITLE
one byte fixing a5000 and a6000 on-prem

### DIFF
--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -278,7 +278,7 @@ def get_local_cluster_accelerators(
                             'A100',
                             '1080',
                             '2080',
-                            'A5000'
+                            'A5000',
                             'A6000']
         accelerators_dict = {}
         for acc in all_accelerators:


### PR DESCRIPTION
on prem machines with a6000 or a5000 didn't work correctly because of a missing comma in the array the grep was for `lspci | grep 'A5000A6000'` which... isn't a card anyone has. 

I think it may make sense to have a look at this script, it feels quite fragile. Probably best would be to do this via `nvidia-smi -L` and just map against the ./.sky/catalog to find supported gpus.


Also, the way this made things fail was rather frustrating. 

    Local clusters:
    NAME   USER  HEAD_IP       RESOURCES    COMMAND
    local  sky   [ip]  [(no GPUs)]  sky launch -c local --  -...

sky status showed (no GPUs) and sky launch fails predictably with `AssertionError: (Local(None), 'cloud, region and instance_type must have been set by optimizer')`  

sky launch -c local totally misreported the error as
```
Failed to rsync up: /var/folders/wp/6cmt_nw16jj79kd9rj4m777w0000gn/T/sky_local_app_ph50zoz4 -> 
/tmp/sky_local/sky_local_app_ph50zoz4. Ensure that the network is stable, then retry.
```

I think it's a good idea to detect this failure and report that (remote) ~/.sky/get_resources.py couldn't detect any GPUs or some such thing. 