### PR TITLE
[Identity] Make the identity loading more robust

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1911,6 +1911,9 @@ def check_owner_identity(cluster_name: str) -> None:
         for i, (owner,
                 current) in enumerate(zip(owner_identity,
                                           current_user_identity)):
+            # Clean up the owner identiy for the backslash and newlines, caused
+            # by the cloud CLI output, e.g. gcloud.
+            owner = owner.replace('\n', '').replace('\\', '')
             if owner == current:
                 if i != 0:
                     logger.warning(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -619,6 +619,7 @@ class GCP(clouds.Cloud):
         try:
             account = _run_output('gcloud auth list --filter=status:ACTIVE '
                                   '--format="value(account)"')
+            account = account.strip()
         except subprocess.CalledProcessError as e:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.CloudUserIdentityError(

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -535,9 +535,10 @@ def _load_owner(record_owner: Optional[str]) -> Optional[List[str]]:
         if result is not None and not isinstance(result, list):
             # Backwards compatibility for old records, which were stored as
             # a string instead of a list. It is possible that json.loads
-            # will parse the string with all numbers as an int, so we need
-            # to convert it back to a list of strings.
-            return [str(result)]
+            # will parse the string with all numbers as an int or escape
+            # some characters, such as \n, so we need to use the original
+            # record_owner.
+            return [str(record_owner)]
         return result
     except json.JSONDecodeError:
         # Backwards compatibility for old records, which were stored as


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to avoid the newlines in the identity string to affect the identity comparison to make the identity checking more robust. Try to fix #2032 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
