### PR TITLE
[Spot] Make the controller resources configurable

### DIFF
--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -250,7 +250,6 @@ You may customize the resources of the spot controller for the following reasons
 1. Enforcing the spot controller to run on a specific location. (Default: cheapest location)
 2. Changing the maximum number of spot jobs that can be run concurrently. (Default: 16)
 3. Changing the disk_size of the spot controller to store more logs. (Default: 50GB)
-4. Using a specific instance type for the spot controller. (Default: choose automatically)
 
 To achieve the above, you can specify custom configs in :code:`~/.sky/skypilot_config.yaml` with the following fields (the :code:`resources` field has the same spec as a normal SkyPilot job; see `here <https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html>`_):
 
@@ -267,8 +266,6 @@ To achieve the above, you can specify custom configs in :code:`~/.sky/skypilot_c
           cpus: 4+ # number of vCPUs, max # spot jobs = 2 * cpus
           # 3. Specify the disk_size of the spot controller.
           disk_size: 100
-          # 4. Specify the instance type of the spot controller.
-          instance_type: n1-standard-4
 
 
 

--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -241,3 +241,34 @@ you can still tear it down manually with
 
 .. note::
   Tearing down the spot controller will lose all logs and status information for the spot jobs and can cause resource leakage when there are still in-progress spot jobs.
+
+Customize spot controller resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although the default setting works for most of people, you may want to customize the resources of the spot controller for the following reasons:
+
+1. Enforcing the spot controller to run on a specific location. (Default: cheapest location)
+2. Changing the maximum number of spot jobs that can be run concurrently. (Default: 16)
+3. Changing the disk_size of the spot controller to store more logs. (Default: 50GB)
+4. Using a specific instance type for the spot controller. (Default: choose automatically)
+
+To achieve the above goals, you can specify the configs in the :code:`~/.sky/skypilot_config.yaml` with the following fields (the :code:`resources` field has the same spec as a normal SkyPilot job, see `here <https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html>`_):
+
+.. code-block:: yaml
+
+    spot:
+      controller:
+        resources:
+          # All the configs below are optional
+          # 1. Specify the location of the spot controller.
+          cloud: gcp
+          region: us-central1
+          # 2. Specify the maximum number of spot jobs that can be run concurrently.
+          cpus: 4+ # number of vCPUs, max # spot jobs = 2 * cpus
+          # 3. Specify the disk_size of the spot controller.
+          disk_size: 100
+          # 4. Specify the instance type of the spot controller.
+          instance_type: n1-standard-4
+
+
+

--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -242,8 +242,8 @@ you can still tear it down manually with
 .. note::
   Tearing down the spot controller will lose all logs and status information for the spot jobs and can cause resource leakage when there are still in-progress spot jobs.
 
-Customize spot controller resources
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Customizing spot controller resources
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Although the default setting works for most of people, you may want to customize the resources of the spot controller for the following reasons:
 

--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -251,7 +251,7 @@ You may customize the resources of the spot controller for the following reasons
 2. Changing the maximum number of spot jobs that can be run concurrently. (Default: 16)
 3. Changing the disk_size of the spot controller to store more logs. (Default: 50GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/skypilot_config.yaml` with the following fields (the :code:`resources` field has the same spec as a normal SkyPilot job; see `here <https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html>`_):
+To achieve the above, you can specify custom configs in :code:`~/.sky/config.yaml` with the following fields (the :code:`resources` field has the same spec as a normal SkyPilot job; see `here <https://skypilot.readthedocs.io/en/latest/reference/yaml-spec.html>`_):
 
 .. code-block:: yaml
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2652,6 +2652,11 @@ def stop_handler(signum, frame):
 
 
 def validate_schema(obj, schema, err_msg_prefix=''):
+    """Validates an object against a JSON schema.
+
+    Raises:
+        ValueError: if the object does not match the schema.
+    """
     err_msg = None
     try:
         validator.SchemaValidator(schema).validate(obj)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -676,7 +676,7 @@ def spot_launch(
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Spot controller resources is not valid, please check '
-                    '~/.sky/skypilot_config.yaml file and make sure it\'s a '
+                    '~/.sky/config.yaml file and make sure it\'s a '
                     'valid resources spec. Details:\n'
                     f'  {common_utils.format_exception(e, use_bracket=True)}'
                 ) from e

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -676,8 +676,9 @@ def spot_launch(
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Spot controller resources is not valid, please check '
-                    '~/.sky/config.yaml file and make sure spot.controller.resources is a '
-                    'valid resources spec. Details:\n'
+                    '~/.sky/config.yaml file and make sure '
+                    'spot.controller.resources is a valid resources spec. '
+                    'Details:\n'
                     f'  {common_utils.format_exception(e, use_bracket=True)}'
                 ) from e
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -686,8 +686,9 @@ def spot_launch(
                                     output_path=yaml_path)
         controller_task = task_lib.Task.from_yaml(yaml_path)
         assert len(controller_task.resources) == 1, controller_task
-        # Backward compatibility: if the user changed the spot-controller.yaml.j2
-        # to customize the controller resources, we should use it.
+        # Backward compatibility: if the user changed the
+        # spot-controller.yaml.j2 to customize the controller resources,
+        # we should use it.
         controller_task_resources = list(controller_task.resources)[0]
         if not controller_task_resources.is_same_resources(sky.Resources()):
             controller_resources = controller_task_resources

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -673,11 +673,13 @@ def spot_launch(
             controller_resources = sky.Resources.from_yaml_config(
                 controller_resources_config)
         except ValueError as e:
-            raise ValueError(
-                'Spot controller resources is not valid, please check '
-                '~/.sky/skypilot_config.yaml file. Details:\n'
-                f'  {common_utils.format_exception(e, use_bracket=True)}'
-            ) from e
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'Spot controller resources is not valid, please check '
+                    '~/.sky/skypilot_config.yaml file and make sure it\'s a '
+                    'valid resources spec. Details:\n'
+                    f'  {common_utils.format_exception(e, use_bracket=True)}'
+                ) from e
 
         yaml_path = os.path.join(spot.SPOT_CONTROLLER_YAML_PREFIX,
                                  f'{name}-{task_uuid}.yaml')
@@ -690,7 +692,7 @@ def spot_launch(
         # spot-controller.yaml.j2 to customize the controller resources,
         # we should use it.
         controller_task_resources = list(controller_task.resources)[0]
-        if not controller_task_resources.is_same_resources(sky.Resources()):
+        if not controller_task_resources.is_empty():
             controller_resources = controller_task_resources
         controller_task.set_resources(controller_resources)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -676,7 +676,7 @@ def spot_launch(
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Spot controller resources is not valid, please check '
-                    '~/.sky/config.yaml file and make sure it\'s a '
+                    '~/.sky/config.yaml file and make sure spot.controller.resources is a '
                     'valid resources spec. Details:\n'
                     f'  {common_utils.format_exception(e, use_bracket=True)}'
                 ) from e

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -799,6 +799,9 @@ class Resources:
         # self <= other
         return True
 
+    def is_same_resources(self, other: 'Resources') -> bool:
+        return self.to_yaml_config() == other.to_yaml_config()
+
     def should_be_blocked_by(self, blocked: 'Resources') -> bool:
         """Whether this Resources matches the blocked Resources.
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -799,9 +799,6 @@ class Resources:
         # self <= other
         return True
 
-    def is_same_resources(self, other: 'Resources') -> bool:
-        return self.to_yaml_config() == other.to_yaml_config()
-
     def should_be_blocked_by(self, blocked: 'Resources') -> bool:
         """Whether this Resources matches the blocked Resources.
 
@@ -834,6 +831,8 @@ class Resources:
             self.accelerators is None,
             self.accelerator_args is None,
             not self._use_spot_specified,
+            self.disk_size == _DEFAULT_DISK_SIZE_GB,
+            self._image_id is None,
         ])
 
     def copy(self, **override) -> 'Resources':

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -13,7 +13,8 @@ SPOT_FM_FILE_ONLY_BUCKET_NAME = 'skypilot-filemounts-files-{username}-{id}'
 SPOT_FM_LOCAL_TMP_DIR = 'skypilot-filemounts-files-{id}'
 SPOT_FM_REMOTE_TMP_DIR = '/tmp/sky-spot-filemounts-files'
 
-# It is now using default CPU instance type for spot controller, i.e.
+# Resources as a dict for the spot controller.
+# Use default CPU instance type for spot controller, i.e.
 # m6i.2xlarge (8vCPUs, 32 GB) for AWS, Standard_D8s_v4 (8vCPUs, 32 GB)
 # for Azure, and n1-standard-8 (8 vCPUs, 32 GB) for GCP.
 # We use 50 GB disk size to reduce the cost.

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -13,4 +13,8 @@ SPOT_FM_FILE_ONLY_BUCKET_NAME = 'skypilot-filemounts-files-{username}-{id}'
 SPOT_FM_LOCAL_TMP_DIR = 'skypilot-filemounts-files-{id}'
 SPOT_FM_REMOTE_TMP_DIR = '/tmp/sky-spot-filemounts-files'
 
+# It is now using default CPU instance type for spot controller, i.e.
+# m6i.2xlarge (8vCPUs, 32 GB) for AWS, Standard_D8s_v4 (8vCPUs, 32 GB)
+# for Azure, and n1-standard-8 (8 vCPUs, 32 GB) for GCP.
+# We use 50 GB disk size to reduce the cost.
 CONTROLLER_RESOURCES = {'disk_size': 50}

--- a/sky/spot/constants.py
+++ b/sky/spot/constants.py
@@ -12,3 +12,5 @@ SPOT_FM_BUCKET_NAME = 'skypilot-filemounts-folder-{username}-{id}'
 SPOT_FM_FILE_ONLY_BUCKET_NAME = 'skypilot-filemounts-files-{username}-{id}'
 SPOT_FM_LOCAL_TMP_DIR = 'skypilot-filemounts-files-{id}'
 SPOT_FM_REMOTE_TMP_DIR = '/tmp/sky-spot-filemounts-files'
+
+CONTROLLER_RESOURCES = {'disk_size': 50}

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -2,14 +2,6 @@
 
 name: {{task_name}}
 
-resources:
-  disk_size: 50
-# It is now using default CPU instance type hard-coded in code for spot controller,
-# i.e. m6i.2xlarge (8vCPUs, 32 GB) for AWS, Standard_D8s_v4 (8vCPUs, 32 GB) for Azure, and n1-highmem-8 (8 vCPUs, 52 GB) for GCP.
-# This allows users without the credits for some of the clouds available to use managed spot instances.
-# TODO(zhwu): Fix this to be able to failvoer across clouds with cheaper instance.
-#  instance_type: t3.xlarge
-
 file_mounts:
   {{remote_user_yaml_prefix}}/{{task_name}}-{{uuid}}.yaml: {{user_yaml_path}}
 {% if user_config_path is not none %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Closing #2007, #1974, #1078.

It also mitigates #1094, as the user now can specify more CPUs for the controller.

With this PR, the user can specify resources spec for the spot controller so as to change the default cloud, customize the disk size or change the number of CPU cores (the maximum number of spot jobs == 2x #CPUs).

To customize the spot controller resources, the user can have a `~/.sky/config.yaml` with the following fields:
```
spot:
  controller:
    resources:
      cloud: gcp
      cpus: 20+
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch -n test echo hi` with the `~/.sky/skypilot_config.yaml` above.
  - [x] `sky spot launch -n test2 echo hi` run again to test the availability to  launch a second job.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
