### PR TITLE
Fix: Allow credential files with the same basename.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -198,13 +198,19 @@ def _optimize_file_mounts(yaml_path: str) -> None:
 
     # Putting these in file_mounts hurts provisioning speed, as each file
     # opens/closes an SSH connection.  Instead, we:
-    #  - cp locally them into a directory
+    #  - cp them locally into a directory, each with a unique name to avoid
+    #    basename conflicts
     #  - upload that directory as a file mount (1 connection)
     #  - use a remote command to move all runtime files to their right places.
 
     # Local tmp dir holding runtime files.
     local_runtime_files_dir = tempfile.mkdtemp()
     new_file_mounts = {_REMOTE_RUNTIME_FILES_DIR: local_runtime_files_dir}
+
+    # Generate local_src -> unique_name.
+    local_source_to_unique_name = {}
+    for local_src in file_mounts.values():
+        local_source_to_unique_name[local_src] = str(uuid.uuid4())
 
     # (For remote) Build a command that copies runtime files to their right
     # destinations.
@@ -216,7 +222,7 @@ def _optimize_file_mounts(yaml_path: str) -> None:
     commands = []
     basenames = set()
     for dst, src in file_mounts.items():
-        src_basename = os.path.basename(src)
+        src_basename = local_source_to_unique_name[src]
         dst_basename = os.path.basename(dst)
         dst_parent_dir = os.path.dirname(dst)
 
@@ -253,17 +259,18 @@ def _optimize_file_mounts(yaml_path: str) -> None:
     yaml_config['file_mounts'] = new_file_mounts
     yaml_config['setup_commands'] = setup_commands
 
-    # (For local) Move all runtime files, including the just-written yaml, to
+    # (For local) Copy all runtime files, including the just-written yaml, to
     # local_runtime_files_dir/.
-    all_local_sources = ''
+    # < 0.3s to cp 6 clouds' credentials.
     for local_src in file_mounts.values():
+        # cp <local_src> <local_runtime_files_dir>/<unique name of local_src>.
         full_local_src = str(pathlib.Path(local_src).expanduser())
-        # Add quotes for paths containing spaces.
-        all_local_sources += f'{full_local_src!r} '
-    # Takes 10-20 ms on laptop incl. 3 clouds' credentials.
-    subprocess.run(f'cp -r {all_local_sources} {local_runtime_files_dir}/',
-                   shell=True,
-                   check=True)
+        unique_name = local_source_to_unique_name[local_src]
+        # !r to add quotes for paths containing spaces.
+        subprocess.run(
+            f'cp -r {full_local_src!r} {local_runtime_files_dir}/{unique_name}',
+            shell=True,
+            check=True)
 
     common_utils.dump_yaml(yaml_path, yaml_config)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

With OCI supported and enabled, I encountered the following error on every `sky launch`:
```
...
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/backends/backend_utils.py", line 975, in write_cluster_config
    _optimize_file_mounts(tmp_yaml_path)
  File "/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/backends/backend_utils.py", line 228, in _optimize_file_mounts
    f'Duplicated src basename: {src_basename}; mounts: {file_mounts}')
AssertionError: Duplicated src basename: config; mounts: {'~/.sky/sky_ray.yml': '/Users/zongheng/.sky/generated/sky-0fe1-zongheng.yml.tmp', '~/.sky/wheels/4ae6677e0222ae99e0d7c13323ab1f16': '/var/folders/8f/56gzvwkd3n3293xjlrztr6600000gp/T/4ae6677e0222ae99e0d7c13323ab1f16', '~/.aws/credentials': '~/.aws/credentials', '~/.azure/azureProfile.json': '~/.azure/azureProfile.json', '~/.azure/clouds.config': '~/.azure/clouds.config', '~/.azure/config': '~/.azure/config', '~/.azure/msal_token_cache.json': '~/.azure/msal_token_cache.json', '~/.config/gcloud/credentials.db': '~/.config/gcloud/credentials.db', '~/.config/gcloud/application_default_credentials.json': '~/.config/gcloud/application_default_credentials.json', '~/.config/gcloud/access_tokens.db': '~/.config/gcloud/access_tokens.db', '~/.config/gcloud/configurations': '~/.config/gcloud/configurations', '~/.config/gcloud/legacy_credentials': '~/.config/gcloud/legacy_credentials', '~/.config/gcloud/active_config': '~/.config/gcloud/active_config', '~/.sky/.sky_gcp_config_default': '~/.sky/.sky_gcp_config_default', '~/.lambda_cloud/lambda_keys': '~/.lambda_cloud/lambda_keys', '~/.ibm/credentials.yaml': '~/.ibm/credentials.yaml', '~/.oci/config': '~/.oci/config', '~/.oci/oracleidentitycloudservice_gengming.chen-06-06-05-01.pem': '~/.oci/oracleidentitycloudservice_gengming.chen-06-06-05-01.pem', '~/.ssh/sky-key.pub': '~/.ssh/sky-key.pub'}
```

The root cause is because both `~/.oci/config` and `~/.azure/config` exist locally, and our previous file_mounts optimization couldn't handle basename conflicts.

Fixed by using uuids as basename when doing the file_mounts optimization.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py`: running
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
