### PR TITLE
[Spot] Fix spot pending status

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1550,7 +1550,7 @@ def get_head_ip(
             use the cached head ip if it exists, otherwise query the head
             ip from the cloud provider.
         max_attempts: The maximum number of attempts to query the head ip.
-        
+
     Returns:
         The ip of the head node.
     """

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1543,9 +1543,15 @@ def get_head_ip(
 ) -> str:
     """Returns the ip of the head node.
 
-    use_cached_head_ip: If True, use the cached head ip if it exists. If False,
-        query the head ip from the cloud provider. If None, use the cached head
-        ip if it exists, otherwise query the head ip from the cloud provider.
+    Args:
+        handle: The ResourceHandle of the cluster.
+        use_cached_head_ip: If True, use the cached head ip if it exists.
+            If False, query the head ip from the cloud provider. If None,
+            use the cached head ip if it exists, otherwise query the head
+            ip from the cloud provider.
+        max_attempts: The maximum number of attempts to query the head ip.
+    Returns:
+        The ip of the head node.
     """
     head_ip = handle.head_ip
     if use_cached_head_ip:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1538,21 +1538,28 @@ def _get_tpu_vm_pod_ips(ray_config: Dict[str, Any],
 @timeline.event
 def get_head_ip(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle',
-    use_cached_head_ip: bool = True,
+    use_cached_head_ip: Optional[bool] = True,
     max_attempts: int = 1,
 ) -> str:
-    """Returns the ip of the head node."""
+    """Returns the ip of the head node.
+    
+    use_cached_head_ip: If True, use the cached head ip if it exists. If False,
+        query the head ip from the cloud provider. If None, use the cached head
+        ip if it exists, otherwise query the head ip from the cloud provider.
+    """
+    head_ip = handle.head_ip
     if use_cached_head_ip:
-        if handle.head_ip is None:
+        if head_ip is None:
             # This happens for INIT clusters (e.g., exit 1 in setup).
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Cluster\'s head IP not found; is it up? To fix: '
                     'run a successful launch first (`sky launch`) to ensure'
                     ' the cluster status is UP (`sky status`).')
-        head_ip = handle.head_ip
-    else:
-        head_ip = _query_head_ip_with_retries(handle.cluster_yaml, max_attempts)
+        return head_ip
+    if use_cached_head_ip is None and head_ip is not None:
+        return head_ip
+    head_ip = _query_head_ip_with_retries(handle.cluster_yaml, max_attempts)
     return head_ip
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1542,7 +1542,7 @@ def get_head_ip(
     max_attempts: int = 1,
 ) -> str:
     """Returns the ip of the head node.
-    
+
     use_cached_head_ip: If True, use the cached head ip if it exists. If False,
         query the head ip from the cloud provider. If None, use the cached head
         ip if it exists, otherwise query the head ip from the cloud provider.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1550,6 +1550,7 @@ def get_head_ip(
             use the cached head ip if it exists, otherwise query the head
             ip from the cloud provider.
         max_attempts: The maximum number of attempts to query the head ip.
+        
     Returns:
         The ip of the head node.
     """

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3577,7 +3577,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         **kwargs,
     ) -> Union[int, Tuple[int, str, str]]:
         """Runs 'cmd' on the cluster's head node.
-        
+
         use_cached_head_ip: If True, use the cached head IP address. If False,
             fetch the head IP address from the cloud provider. If None, use
             the cached head IP address if it exists, otherwise fetch the head

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2795,7 +2795,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # job appears in the `sky spot queue`, when there are already 16
                 # controller process jobs running on the controller VM with 8
                 # CPU cores.
-                # The spot job should be set to PENDING state after the
+                # The spot job should be set to PENDING state *after* the
                 # controller process job has been queued, as our skylet on spot
                 # controller will set the spot job in FAILED state if the
                 # controller process job does not exist.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3892,8 +3892,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # Add the spot job to spot queue table.
             resources_str = backend_utils.get_task_resources_str(task.spot_task)
             codegen = spot_lib.SpotCodeGen()
-            code = codegen.set_spot_state(job_id, task.spot_task.name,
-                                          resources_str)
+            spot_name = task.spot_task.name
+            assert spot_name is not None, task
+            code = codegen.set_pending_state(job_id, spot_name,
+                                             resources_str)
             return code
         return None
 
@@ -3950,7 +3952,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                 job_id,
                                 executable='python3',
                                 detach_run=detach_run,
-                                extra_cmd=self._set_spot_state_code(
+                                extra_cmd=self._maybe_set_spot_state_code(
                                     job_id, task))
 
     def _execute_task_n_nodes(self, handle: CloudVmRayResourceHandle,
@@ -4025,5 +4027,5 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                 job_id,
                                 executable='python3',
                                 detach_run=detach_run,
-                                extra_cmd=self._set_spot_state_code(
+                                extra_cmd=self._maybe_set_spot_state_code(
                                     job_id, task))

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3894,8 +3894,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             codegen = spot_lib.SpotCodeGen()
             spot_name = task.spot_task.name
             assert spot_name is not None, task
-            code = codegen.set_pending_state(job_id, spot_name,
-                                             resources_str)
+            code = codegen.set_pending_state(job_id, spot_name, resources_str)
             return code
         return None
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2789,8 +2789,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 spot_codegen = spot_lib.SpotCodeGen()
                 spot_name = spot_task.name
                 assert spot_name is not None, spot_task
-                spot_code = spot_codegen.set_pending(
-                    job_id, spot_name, resources_str)
+                spot_code = spot_codegen.set_pending(job_id, spot_name,
+                                                     resources_str)
                 # Set the spot job to PENDING state to make sure that this spot
                 # job appears in the `sky spot queue`, when there are already 16
                 # controller process jobs running on the controller VM with 8

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1805,8 +1805,7 @@ class RetryingVmProvisioner(object):
         backend = CloudVmRayBackend()
 
         returncode = backend.run_on_head(
-            handle,
-            backend_utils.RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND)
+            handle, backend_utils.RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND)
         if returncode == 0:
             return
         launched_resources = handle.launched_resources
@@ -2501,10 +2500,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         # For backward compatability and robustness of skylet, it is restarted
         with log_utils.safe_rich_status('Updating remote skylet'):
-            self.run_on_head(
-                handle,
-                _MAYBE_SKYLET_RESTART_CMD
-            )
+            self.run_on_head(handle, _MAYBE_SKYLET_RESTART_CMD)
 
         # Update job queue to avoid stale jobs (when restarted), before
         # setting the cluster to be ready.
@@ -3611,8 +3607,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 command, such as replacing or skipping lines on the fly. If
                 enabled, lines are printed only when '\r' or '\n' is found.
         """
-        head_ip = backend_utils.get_head_ip(handle,
-                                            _FETCH_IP_MAX_ATTEMPTS)
+        head_ip = backend_utils.get_head_ip(handle, _FETCH_IP_MAX_ATTEMPTS)
         ssh_credentials = backend_utils.ssh_credential_from_yaml(
             handle.cluster_yaml)
         runner = command_runner.SSHCommandRunner(head_ip, **ssh_credentials)

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -133,8 +133,8 @@ def run_with_log(
         stream_logs: Whether to stream the logs to stdout/stderr.
         require_outputs: Whether to return the stdout/stderr of the command.
         process_stream: Whether to post-process the stdout/stderr of the
-          command. If enabled, lines are printed only when '\r' or '\n' is
-          found.
+            command, such as replacing or skipping lines on the fly. If
+            enabled, lines are printed only when '\r' or '\n' is found.
         ray_job_id: The id for a ray job.
         use_sudo: Whether to use sudo to create log_path.
 

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -531,6 +531,15 @@ class SpotCodeGen:
         return cls._build(code)
 
     @classmethod
+    def set_pending_state(cls, job_id: int, name: str,
+                          resources_str: str) -> str:
+        code = [
+            f'spot_state.set_pending('
+            f'{job_id}, {name!r}, {resources_str!r})',
+        ]
+        return cls._build(code)
+
+    @classmethod
     def _build(cls, code: List[str]) -> str:
         code = cls._PREFIX + code
         generated_code = '; '.join(code)

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -217,7 +217,7 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
     """Stream logs by job id."""
     controller_status = job_lib.get_status(job_id)
     status_msg = ('[bold cyan]Waiting for controller process to be RUNNING '
-                  '{status_str}[/]. It may take a few minutes.')
+                  '{status_str}[/].')
     status_display = log_utils.safe_rich_status(
         status_msg.format(status_str=''))
     with status_display:

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -531,8 +531,7 @@ class SpotCodeGen:
         return cls._build(code)
 
     @classmethod
-    def set_pending_state(cls, job_id: int, name: str,
-                          resources_str: str) -> str:
+    def set_pending(cls, job_id: int, name: str, resources_str: str) -> str:
         code = [
             f'spot_state.set_pending('
             f'{job_id}, {name!r}, {resources_str!r})',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a problem caused by #1636, where the spot job not showing up in the `sky spot queue` if the spot job is in PENDING status. This is found when running the test in #2041.

Before this PR:
Only 1 pending spot job will show up in the `sky spot queue`, other later pending jobs will only appear when it starts running.

After this PR:
All the pending spot jobs will also appear in the `sky spot queue` with PENDING status.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Any manual or new tests for this PR (please specify below)
  - [x] Submit more than 16 spot jobs, and all the spot jobs should be in the correct status.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
