### PR TITLE
[OCI fix] Add tenancy specific prefix to zone in runtime (use general catalog file)

### DIFF
--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -15,6 +15,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 from sky import clouds
 from sky.clouds import service_catalog
 from sky import exceptions
+from sky.utils import common_utils
 from sky.adaptors import oci as oci_adaptor
 from sky.skylet.providers.oci.config import oci_conf
 
@@ -368,12 +369,13 @@ class OCI(clouds.Cloud):
             return True, None
         except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
                 oci_adaptor.get_oci().exceptions.InvalidConfig,
-                oci_adaptor.service_exception()):
-            return False, (f'OCI credential is not correctly set. '
-                           f'Check the credential file at {conf_file}\n'
-                           f'{cls._INDENT_PREFIX}{credential_help_str}\n'
-                           f'{cls._INDENT_PREFIX}Error details: '
-                           f'{common_utils.format_exception(e, use_bracket=True)}')
+                oci_adaptor.service_exception()) as e:
+            return False, (
+                f'OCI credential is not correctly set. '
+                f'Check the credential file at {conf_file}\n'
+                f'{cls._INDENT_PREFIX}{credential_help_str}\n'
+                f'{cls._INDENT_PREFIX}Error details: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
         """Returns a dict of credential file paths to mount paths."""

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -244,7 +244,8 @@ class OCI(clouds.Cloud):
             except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
                     oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
                 # This should only happen in testing where oci config is
-                # monkeypatched.
+                # monkeypatched. In real use, if the OCI config is not
+                # valid, the 'sky check' would fail(OCI disabled).
                 logger.debug(f'It is OK goes here when testing: {str(e)}')
                 pass
 

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -245,7 +245,7 @@ class OCI(clouds.Cloud):
                     oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
                 # This should only happen in testing where oci config is
                 # monkeypatched. In real use, if the OCI config is not
-                # valid, the 'sky check' would fail(OCI disabled).
+                # valid, the 'sky check' would fail (OCI disabled).
                 logger.debug(f'It is OK goes here when testing: {str(e)}')
                 pass
 
@@ -368,8 +368,7 @@ class OCI(clouds.Cloud):
             return True, None
         except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
                 oci_adaptor.get_oci().exceptions.InvalidConfig,
-                oci_adaptor.service_exception()) as e:
-            logger.warning(f'OCI config error: {str(e)}')
+                oci_adaptor.service_exception()):
             return False, (f'OCI credential is not correctly set. '
                            f'Check the credential file at {conf_file}\n'
                            f'{cls._INDENT_PREFIX}{credential_help_str}')

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -371,7 +371,9 @@ class OCI(clouds.Cloud):
                 oci_adaptor.service_exception()):
             return False, (f'OCI credential is not correctly set. '
                            f'Check the credential file at {conf_file}\n'
-                           f'{cls._INDENT_PREFIX}{credential_help_str}')
+                           f'{cls._INDENT_PREFIX}{credential_help_str}\n'
+                           f'{cls._INDENT_PREFIX}Error details: '
+                           f'{common_utils.format_exception(e, use_bracket=True)}')
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
         """Returns a dict of credential file paths to mount paths."""

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -366,13 +366,9 @@ class OCI(clouds.Cloud):
             # TODO[Hysun]: More privilege check can be added
             return True, None
         except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
-                oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
-            # This should only happen in testing where oci config is
-            # monkeypatched.
-            logger.debug(f'It is OK goes here when testing: {str(e)}')
-            return True, None
-
-        except oci_adaptor.service_exception():
+                oci_adaptor.get_oci().exceptions.InvalidConfig,
+                oci_adaptor.service_exception()) as e:
+            logger.warning(f'OCI config error: {str(e)}')
             return False, (f'OCI credential is not correctly set. '
                            f'Check the credential file at {conf_file}\n'
                            f'{cls._INDENT_PREFIX}{credential_help_str}')

--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -47,8 +47,9 @@ def _get_df() -> 'pd.DataFrame':
 
         except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
                 oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
-
-            # This should only happen in testing where oci config is missing.
+            # This should only happen in testing where oci config is
+            # missing, because it means the 'sky check' will fail if
+            # enter here (meaning OCI disabled).
             logger.debug(f'It is OK goes here when testing: {str(e)}')
             subscribed_regions = []
 

--- a/sky/skylet/providers/oci/query_helper.py
+++ b/sky/skylet/providers/oci/query_helper.py
@@ -131,7 +131,10 @@ class oci_query_helper:
             return skypilot_compartment
 
         # If not specified, we try to find the one skypilot-compartment
-        root = oci_adaptor.get_oci_config(region)['tenancy']
+        # Pass-in a profile parameter so that multiple profile in oci
+        # config file is supported (2023/06/09).
+        root = oci_adaptor.get_oci_config(region,
+                                          oci_conf.get_profile())['tenancy']
         list_compartments_response = oci_adaptor.get_identity_client(
             region,
             oci_conf.get_profile()).list_compartments(compartment_id=root,


### PR DESCRIPTION
This is a change made corresponding with the OCI catalog file (please kindly review the catalog file PR as well). In previous catalog file, there is a prefix in the AvailabilityZone, which is tenancy specific. So customer need to manually replace this prefix with according to his tenancy. This fix removes this neccesarity. The prefix in the catalog file is removed, and the program will find the correct prefix in runtime.

Tested (run the relevant ones):
- Sky launch / sky down
- [v] Any manual or new tests for this PR (please specify below)
- [v] All smoke tests: `pytest tests/test_smoke.py` 
- [v] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [v] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
