### PR TITLE
[Meta] Add format.sh to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 
 Tested (run the relevant ones):
 
+- [ ] Code formatting: `bash format.sh`
 - [ ] Any manual or new tests for this PR (please specify below)
 - [ ] All smoke tests: `pytest tests/test_smoke.py` 
 - [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 


### PR DESCRIPTION
Updates the PR template to include a reminder to run format.sh - useful for first-time contributors who may not know about it or may have missed it.