### PR TITLE
API: fix a possibly unbound error in core.cancel().

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -560,6 +560,7 @@ def cancel(
         cluster_name, operation_str='Cancelling jobs')
 
     # Check the status of the cluster.
+    handle = None
     try:
         handle = backend_utils.check_cluster_available(
             cluster_name,
@@ -572,10 +573,14 @@ def cancel(
                 isinstance(e.handle, backends.CloudVmRayResourceHandle)), e
         if (e.handle is None or e.handle.head_ip is None):
             raise
+        handle = e.handle
         # Even if the cluster is not UP, we can still try to cancel the job if
         # the head node is still alive. This is useful when a spot cluster's
         # worker node is preempted, but we can still cancel the job on the head
         # node.
+
+    assert handle is not None, (
+        f'handle for cluster {cluster_name!r} should not be None')
 
     backend = backend_utils.get_backend_from_handle(handle)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Reported by Pylance in vscode.

Related: `pyright sky` found a ton of errors, a lot of them related to typing errors caused by decorators (pyright is what Pylance uses: https://microsoft.github.io/pyright/#/). The same as my vscode showing tons of warnings/errors. So we can’t integrate in one go into CI.
```
» pyright sky/core.py                           1 ↵
/Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:167:30 - error: "_Wrapped[(...), Unknown, (*args: Unknown, **kwargs: Unknown), Unknown]" is not iterable
    "__iter__" method not defined (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:204:32 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:319:15 - error: "check_features_are_supported" is not a known member of "None" (reportOptionalMemberAccess)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:332:22 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:364:22 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:454:15 - error: "check_features_are_supported" is not a known member of "None" (reportOptionalMemberAccess)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:513:60 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:746:23 - error: No parameter named "refresh" (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:746:12 - error: Argument missing for parameter "f" (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:813:9 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
  /Users/zongheng/Dropbox/workspace/riselab/sky-computing/sky/core.py:875:49 - error: Expected 0 positional arguments (reportGeneralTypeIssues)
11 errors, 0 warnings, 0 informations
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py --managed-spot`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
