### PR TITLE
[Storage] Fix misleading storage ls table column name

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -18,7 +18,7 @@ def format_storage_table(storages: List[Dict[str, Any]]) -> str:
     """
     storage_table = log_utils.create_table([
         'NAME',
-        'CREATED',
+        'UPDATED',
         'STORE',
         'COMMAND',
         'STATUS',


### PR DESCRIPTION
This provides a solution for #2030. 



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


