### PR TITLE
[OCI fix] Nodes are not reusable if launch config changed

### DIFF
--- a/sky/skylet/providers/oci/node_provider.py
+++ b/sky/skylet/providers/oci/node_provider.py
@@ -167,6 +167,12 @@ class OCINodeProvider(NodeProvider):
         ]
         filters = {tag: tags[tag] for tag in VALIDITY_TAGS if tag in tags}
         running_nodes = self.running_nodes(filters)
+        # Make sure the running nodes (to be reused) has correct tags set, esp.
+        # ray-launch-config. Otherwise the nodes will fail to be reused and
+        # the autoscaler will stop them then start new nodes instead.
+        for running_node_id in running_nodes:
+            self.set_node_tags(running_node_id, tags)
+
         if len(running_nodes) > 0:
             logger.info(
                 f"Running nodes found {len(running_nodes)}: {list(running_nodes)}. "
@@ -228,6 +234,10 @@ class OCINodeProvider(NodeProvider):
                         "lifecycle_state",
                         "STOPPED",
                     )
+            # Make sure the stopped nodes (to be reused) has correct tags set,
+            # esp. ray-launch-config. Otherwise the nodes will fail to be reused
+            # and the autoscaler will stop them then start new nodes instead.
+            self.set_node_tags(reuse_node["id"], tags)
 
             start_time1 = round(time.time() * 1000)
             for matched_node in reuse_nodes:

--- a/sky/skylet/providers/oci/node_provider.py
+++ b/sky/skylet/providers/oci/node_provider.py
@@ -234,10 +234,10 @@ class OCINodeProvider(NodeProvider):
                         "lifecycle_state",
                         "STOPPED",
                     )
-            # Make sure the stopped nodes (to be reused) has correct tags set,
-            # esp. ray-launch-config. Otherwise the nodes will fail to be reused
-            # and the autoscaler will stop them then start new nodes instead.
-            self.set_node_tags(reuse_node["id"], tags)
+                # Make sure the stopped nodes (to be reused) has correct tags set,
+                # esp. ray-launch-config. Otherwise the nodes will fail to be reused
+                # and the autoscaler will stop them then start new nodes instead.
+                self.set_node_tags(reuse_node["id"], tags)
 
             start_time1 = round(time.time() * 1000)
             for matched_node in reuse_nodes:

--- a/sky/skylet/providers/oci/node_provider.py
+++ b/sky/skylet/providers/oci/node_provider.py
@@ -166,19 +166,6 @@ class OCINodeProvider(NodeProvider):
             TAG_RAY_USER_NODE_TYPE,
         ]
         filters = {tag: tags[tag] for tag in VALIDITY_TAGS if tag in tags}
-        running_nodes = self.running_nodes(filters)
-
-        if len(running_nodes) > 0:
-            logger.info(
-                f"Running nodes found {len(running_nodes)}: {list(running_nodes)}. "
-                " Reuse existing running nodes. ")
-            count -= len(running_nodes)
-
-        if count <= 0:
-            logger.info(
-                f"No need to create new node since there are enough running nodes"
-            )
-            return
 
         # Starting stopped nodes if cache_stopped_nodes=True
         if self.cache_stopped_nodes:

--- a/sky/templates/oci-ray.yml.j2
+++ b/sky/templates/oci-ray.yml.j2
@@ -10,6 +10,10 @@ provider:
   module: sky.skylet.providers.oci.OCINodeProvider
   region: {{region}}
   cache_stopped_nodes: True
+  # Disable launch config check for worker nodes as it can cause resource leakage.
+  # Reference: https://github.com/ray-project/ray/blob/cd1ba65e239360c8a7b130f991ed414eccc063ce/python/ray/autoscaler/_private/autoscaler.py#L1115
+  # The upper-level SkyPilot code has make sure there will not be resource leakage.
+  disable_launch_config_check: true
 
 auth:
   ssh_user: ubuntu


### PR DESCRIPTION
This is a corner case. If start an existing cluster, but the backed nodes (or part of them) now have different ray-launch-config tag   value with the tags parameter in the create_node interface, the ray autoscaler will not accept those nodes as reusable. It will then stop those nodes, which are recognized by the OCI node provider as reusable, and then start new nodes instead. This is not expected behavior. We expect the nodes in the same cluster can be reused even if the ray-launch-config tag is different. 

Tested (run the relevant ones):

- [v] Code formatting: `bash format.sh`
- [v] Any manual or new tests for this PR (please specify below)
       sky launch / sky stop / sky down
- [v] All smoke tests: `pytest tests/test_smoke.py` 
- [v] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [v] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
