### PR TITLE
[test] Default to terminate on failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,9 +63,14 @@ def pytest_addoption(parser):
         'cloud in the list of the clouds to be run.')
 
     parser.addoption('--terminate-on-failure',
+                     dest='terminate_on_failure',
                      action='store_true',
-                     default=False,
+                     default=True,
                      help='Terminate test VMs on failure.')
+    parser.addoption('--no-terminate-on-failure',
+                     dest='terminate_on_failure',
+                     action='store_false',
+                     help='Do not terminate test VMs on failure.')
 
 
 def pytest_configure(config):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to avoid the tests to have leakage resources, if the people forgot to terminate the cluster after a test fails.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `pytest tests/test_smoke.py::test_minimal` with `exit 1` in the beginning of the test
  - [x] `pytest tests/test_smoke.py::test_minimal --no-terminate-on-failure` with `exit 1` in the beginning of the test
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
