### PR TITLE
Speed up refresh: delay the slower `ray status` call & use cached IPs.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2028,62 +2028,64 @@ def _update_cluster_status_no_lock(
     handle = record['handle']
     if not isinstance(handle, backends.CloudVmRayResourceHandle):
         return record
-
     cluster_name = handle.cluster_name
-    use_spot = handle.launched_resources.use_spot
-    ray_cluster_up = False
-    try:
-        # TODO(zhwu): This function cannot distinguish transient network error
-        # in ray's get IPs vs. ray runtime failing.
-        external_ips = handle.external_ips(use_cached_ips=False)
-        # This happens to a stopped TPU VM as we use gcloud to query the IP.
-        if external_ips is None or len(external_ips) == 0:
-            raise exceptions.FetchIPError(
-                reason=exceptions.FetchIPError.Reason.HEAD)
-        # Check if ray cluster status is healthy.
-        ssh_credentials = ssh_credential_from_yaml(handle.cluster_yaml)
-        runner = command_runner.SSHCommandRunner(external_ips[0],
-                                                 **ssh_credentials)
-        rc, output, _ = runner.run(RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND,
-                                   stream_logs=False,
-                                   require_outputs=True,
-                                   separate_stderr=True)
-        if rc:
-            raise exceptions.FetchIPError(
-                reason=exceptions.FetchIPError.Reason.HEAD)
 
-        ready_head, ready_workers = _count_healthy_nodes_from_ray(output)
-
-        if ready_head + ready_workers == handle.launched_nodes:
-            ray_cluster_up = True
-
-        # For non-spot clusters:
-        # If ray status shows all nodes are healthy, it is safe to set
-        # the status to UP as starting ray is the final step of sky launch.
-        # For spot clusters, the above can be unsafe because the Ray cluster
-        # may remain healthy for a while before the cloud completely
-        # preempts the VMs.
-        # Additionally, we query the VM state from the cloud provider.
-        if ray_cluster_up and not use_spot:
-            record['status'] = global_user_state.ClusterStatus.UP
-            global_user_state.add_or_update_cluster(cluster_name,
-                                                    handle,
-                                                    requested_resources=None,
-                                                    ready=True,
-                                                    is_launch=False)
-            return record
-    except exceptions.FetchIPError:
-        logger.debug('Refreshing status: Failed to get IPs from cluster '
-                     f'{cluster_name!r}, trying to fetch from provider.')
-    # For all code below, we query cluster status by cloud CLI for two cases:
-    # 1) ray fails to get IPs for the cluster.
-    # 2) the cluster is a spot cluster.
+    # Query the cloud provider.
     node_statuses = _get_cluster_status_via_cloud_cli(handle)
-
     all_nodes_up = (all(status == global_user_state.ClusterStatus.UP
                         for status in node_statuses) and
                     len(node_statuses) == handle.launched_nodes)
-    if ray_cluster_up and all_nodes_up:
+
+    def run_ray_status_to_check_ray_cluster_healthy() -> bool:
+        try:
+            # TODO(zhwu): This function cannot distinguish transient network
+            # error in ray's get IPs vs. ray runtime failing.
+            #
+            # NOTE: using use_cached_ips=False is very slow as it calls into
+            # `ray get head-ip/worker-ips`. Setting it to True is safe because
+            # in the worst case we time out in the `ray status` SSH command
+            # below.
+            external_ips = handle.external_ips(use_cached_ips=True)
+            # This happens to a stopped TPU VM as we use gcloud to query the IP.
+            if external_ips is None or len(external_ips) == 0:
+                raise exceptions.FetchIPError(
+                    reason=exceptions.FetchIPError.Reason.HEAD)
+            # Check if ray cluster status is healthy.
+            ssh_credentials = ssh_credential_from_yaml(handle.cluster_yaml)
+            runner = command_runner.SSHCommandRunner(external_ips[0],
+                                                     **ssh_credentials)
+            rc, output, _ = runner.run(RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND,
+                                       stream_logs=False,
+                                       require_outputs=True,
+                                       separate_stderr=True)
+            if rc:
+                raise exceptions.FetchIPError(
+                    reason=exceptions.FetchIPError.Reason.HEAD)
+
+            ready_head, ready_workers = _count_healthy_nodes_from_ray(output)
+            if ready_head + ready_workers == handle.launched_nodes:
+                return True
+        except exceptions.FetchIPError:
+            logger.debug(
+                'Refreshing status: Failed to use `ray` to get IPs from cluster'
+                f' {cluster_name!r}.')
+        return False
+
+    # Determining if the cluster is healthy (UP):
+    #
+    # For non-spot clusters: If ray status shows all nodes are healthy, it is
+    # safe to set the status to UP as starting ray is the final step of sky
+    # launch. But we found that ray status is way too slow (see NOTE below) so
+    # we always query the cloud provider first which is faster.
+    #
+    # For spot clusters: the above can be unsafe because the Ray cluster may
+    # remain healthy for a while before the cloud completely preempts the VMs.
+    # We have mitigated this by again first querying the VM state from the cloud
+    # provider.
+    if all_nodes_up and run_ray_status_to_check_ray_cluster_healthy():
+        # NOTE: all_nodes_up calculation is fast due to calling cloud CLI;
+        # run_ray_status_to_check_all_nodes_up() is slow due to calling `ray get
+        # head-ip/worker-ips`.
         record['status'] = global_user_state.ClusterStatus.UP
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
@@ -2091,6 +2093,8 @@ def _update_cluster_status_no_lock(
                                                 ready=True,
                                                 is_launch=False)
         return record
+
+    # All cases below are transitioning the cluster to non-UP states.
 
     if len(node_statuses) > handle.launched_nodes:
         # Unexpected: in the queried region more than 1 cluster with the same
@@ -2110,13 +2114,14 @@ def _update_cluster_status_no_lock(
         # Since we failed to refresh, raise the status fetching error.
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterStatusFetchingError(
-                f'Found {len(node_statuses)} node(s) with the same cluster name tag in the '
-                f'cloud provider for cluster {cluster_name!r}, which should have '
-                f'{handle.launched_nodes} nodes. This normally should not happen. '
-                f'{colorama.Fore.RED}Please check the cloud console and fix any possible '
-                'resources leakage (e.g., if there are any stopped nodes and they do not '
-                f'have data or are unhealthy, terminate them).{colorama.Style.RESET_ALL}'
-            )
+                f'Found {len(node_statuses)} node(s) with the same cluster name'
+                f' tag in the cloud provider for cluster {cluster_name!r}, '
+                f'which should have {handle.launched_nodes} nodes. This '
+                f'normally should not happen. {colorama.Fore.RED}Please check '
+                'the cloud console and fix any possible resources leakage '
+                '(e.g., if there are any stopped nodes and they do not have '
+                'data or are unhealthy, terminate them).'
+                f'{colorama.Style.RESET_ALL}')
     assert len(node_statuses) <= handle.launched_nodes
 
     # If the node_statuses is empty, all the nodes are terminated. We can
@@ -2139,7 +2144,7 @@ def _update_cluster_status_no_lock(
     #     abnormal.
     #
     # An abnormal cluster will transition to INIT and have any autostop setting
-    # reset (unless it's autostopping/autodowning.).
+    # reset (unless it's autostopping/autodowning).
     is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or
                    any(status != global_user_state.ClusterStatus.STOPPED
                        for status in node_statuses))

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -163,8 +163,8 @@ class StrategyExecutor:
                 'might be already down or the head node is preempted.'
                 '\n  Detailed exception: '
                 f'{common_utils.format_exception(e)}\n'
-                'Terminating the cluster again to make sure there is no '
-                'remaining job on the worker nodes.')
+                'Terminating the cluster explicitly to ensure no '
+                'remaining job process interferes with recovery.')
             terminate_cluster(self.cluster_name)
 
     def _wait_until_job_starts_on_cluster(self) -> Optional[float]:

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -158,13 +158,12 @@ class StrategyExecutor:
                        all=True,
                        _try_cancel_if_cluster_is_init=True)
         except Exception as e:  # pylint: disable=broad-except
-            logger.info(
-                'Failed to cancel the job on the cluster. The cluster '
-                'might be already down or the head node is preempted.'
-                '\n  Detailed exception: '
-                f'{common_utils.format_exception(e)}\n'
-                'Terminating the cluster explicitly to ensure no '
-                'remaining job process interferes with recovery.')
+            logger.info('Failed to cancel the job on the cluster. The cluster '
+                        'might be already down or the head node is preempted.'
+                        '\n  Detailed exception: '
+                        f'{common_utils.format_exception(e)}\n'
+                        'Terminating the cluster explicitly to ensure no '
+                        'remaining job process interferes with recovery.')
             terminate_cluster(self.cluster_name)
 
     def _wait_until_job_starts_on_cluster(self) -> Optional[float]:

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -1,5 +1,7 @@
 """Utilities for sky status."""
+import re
 from typing import Any, Callable, Dict, List, Optional
+
 import click
 import colorama
 
@@ -325,6 +327,14 @@ def _get_resources(cluster_record: _ClusterRecord) -> str:
         if (handle.launched_nodes is not None and
                 handle.launched_resources is not None):
             launched_resource_str = str(handle.launched_resources)
+            # accelerator_args is way too long.
+            # Convert from:
+            #  GCP(n1-highmem-8, {'tpu-v2-8': 1}, accelerator_args={'runtime_version': '2.5.0'}  # pylint: disable=line-too-long
+            # to:
+            #  GCP(n1-highmem-8, {'tpu-v2-8': 1}...)
+            pattern = ', accelerator_args={.*}'
+            launched_resource_str = re.sub(pattern, '...',
+                                           launched_resource_str)
             resources_str = (f'{handle.launched_nodes}x '
                              f'{launched_resource_str}')
     else:
@@ -341,14 +351,14 @@ def _get_zone(cluster_record: _ClusterRecord) -> str:
 
 def _get_autostop(cluster_record: _ClusterRecord) -> str:
     autostop_str = ''
-    separtion = ''
+    separation = ''
     if cluster_record['autostop'] >= 0:
         # TODO(zhwu): check the status of the autostop cluster.
         autostop_str = str(cluster_record['autostop']) + 'm'
-        separtion = ' '
+        separation = ' '
 
     if cluster_record['to_down']:
-        autostop_str += f'{separtion}(down)'
+        autostop_str += f'{separation}(down)'
     if autostop_str == '':
         autostop_str = '-'
     return autostop_str


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I noticed that `status -r` is taking way too long. With some investigation with @Michaelvll, this PR Implemented two optimizations:
- delay the slower `ray status` call 
- use cached IPs

All tests below are 1-node on-demand GCP clusters. These are all "normal" case where the runtime on the cluster did not become problematic.


- TODO: we should keep speeding up refresh in the future.
  - [ ] identified `handle.external_ips(use_cached_ips=False) -> ray get head-ip/worker-ips` is too slow; replace with NodeProvider calls or cloud CLI/SDK calls?


Results:

**do `ray status` last + use_cached_ips=True**

STOPPED -> STOPPED
- before: 31s
- now: 3.7s

UP, autostop not set -> UP  
- before: 8.9s
- now: 7.1s

UP, autostopped -> STOPPED
- before: 22.2s
- now: 4.2s

UP, autostop set -> UP
- before: 7.6s
- now: 7.3s

INIT -> INIT
- before: 25.7s
- now: 22.3s

**(if we do the first optimization only) do `ray status` last** 

STOPPED -> STOPPED
- before: 31s
- now: 3.9s

UP, autostop not set -> UP  
- before: 8.9s
- now: 10.9s

UP, autostopped -> STOPPED
- before: 22.2s
- now: 6s

UP, autostop set -> UP
- before: 7.6s
- now: 11.4s

INIT -> INIT
- before: 25.7s
- now: 22.4s




<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [x] All smoke tests: `pytest tests/test_smoke.py` : `pytest tests/test_smoke.py --generic-cloud aws`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
