### PR TITLE
UX: drop image_id warning, and print a hint for a corner case.

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -2,6 +2,8 @@
 from typing import Dict, List, Optional, Union
 from typing_extensions import Literal
 
+import colorama
+
 from sky import clouds
 from sky import global_user_state
 from sky import sky_logging
@@ -473,6 +475,18 @@ class Resources:
                 continue
             # TODO: filter out the zones not available in the vpc_name
             filtered_regions.append(region)
+
+        # Friendlier UX. Otherwise users only get a generic
+        # ResourcesUnavailableError message without mentioning
+        # ssh_proxy_command.
+        if not filtered_regions:
+            yellow = colorama.Fore.YELLOW
+            reset = colorama.Style.RESET_ALL
+            logger.warning(
+                f'{yellow}Request {self} cannot be satisfied by any feasible '
+                'region. To fix, check that ssh_proxy_command\'s region keys '
+                f'include the regions to use.{reset}')
+
         return filtered_regions
 
     def _try_validate_instance_type(self) -> None:
@@ -902,8 +916,6 @@ class Resources:
         if config.get('zone') is not None:
             resources_fields['zone'] = config.pop('zone')
         if config.get('image_id') is not None:
-            logger.warning('image_id in resources is experimental. It only '
-                           'supports AWS/GCP/IBM/OCI.')
             resources_fields['image_id'] = config.pop('image_id')
         if config.get('disk_tier') is not None:
             resources_fields['disk_tier'] = config.pop('disk_tier')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User got this error
> I 05-26 15:09:51 optimizer.py:1002] No resource satisfying AWS({'T4': 8}, image_id={'us-west-2': 'ami-1234'}) on AWS.
sky.exceptions.ResourcesUnavailableError: No launchable resource found for task train-1234. Region: us-west-2.
This means the catalog does not contain any instance types that satisfy this request.
To fix: relax or change the resource requirements.
Hint: 'sky show-gpus --all' to list available accelerators.
      'sky check' to check the enabled clouds.

and mentioned
> But the actual reason was because I did not configure ssh_proxy_command in us-west-2

This change adds a friendlier warning.

Repro:


```
# ~/.sky/config.yaml
aws:
  ssh_proxy_command:
    us-east-2: ...
```

```
# ~/test.yaml
resources:
  cloud: aws
  region: us-east-1
  image_id: ami-0d8c624d9d0f9af69
  # or:
  # image_id:
  #   us-east-1: ami-0d8c624d9d0f9af69
  #   us-west-1: ami-0257857e3e25bf4d8
```

We now show:
> » sky launch ~/test.yaml                                         
Task from YAML spec: /Users/zongheng/test.yaml
W 06-14 14:31:27 resources.py:486] Request AWS(m6i.2xlarge, image_id={'us-east-1': 'ami-0d8c624d9d0f9af69'}) cannot be satisfied by any feasible region. To fix, check that ssh_proxy_command's region keys include the regions to use.
I 06-14 14:31:27 optimizer.py:1009] No resource satisfying AWS(image_id={'us-east-1': 'ami-0d8c624d9d0f9af69'}) on AWS.
...


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
