### PR TITLE
UX: if a cluster becomes INIT, warn about autostop reset.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2167,18 +2167,27 @@ def _update_cluster_status_no_lock(
                                  f'{common_utils.format_exception(e)}')
                 global_user_state.set_cluster_autostop_value(
                     handle.cluster_name, -1, to_down=False)
+
+                # Friendly hint.
+                autostop = record['autostop']
+                maybe_down_str = ' --down' if record['to_down'] else ''
+                noun = 'autodown' if record['to_down'] else 'autostop'
                 if success:
-                    operation_str = 'canceled autostop/down on the cluster'
+                    operation_str = (f'Canceled {noun} on the cluster '
+                                     f'{cluster_name!r}')
                 else:
-                    operation_str = ('attempted to cancel autostop/down on the '
-                                     'cluster with best effort')
+                    operation_str = (
+                        f'Attempted to cancel {noun} on the '
+                        f'cluster {cluster_name!r} with best effort')
                 yellow = colorama.Fore.YELLOW
+                bright = colorama.Style.BRIGHT
                 reset = colorama.Style.RESET_ALL
+                ux_utils.console_newline()
                 logger.warning(
-                    f'\n{yellow}Cluster {cluster_name!r} is in an abnormal '
-                    f'state; {operation_str}. To fix the cluster state, '
-                    'rerun `sky launch` or `sky start` with the original '
-                    f'autostop settings.{reset}')
+                    f'{yellow}{operation_str}, since it is found to be in an '
+                    f'abnormal state. To fix, try running: {reset}{bright}sky '
+                    f'start -f -i {autostop}{maybe_down_str} {cluster_name}'
+                    f'{reset}')
             else:
                 ux_utils.console_newline()
                 operation_str = 'autodowning' if record[

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2217,7 +2217,7 @@ def autostop(
     help=
     ('Autodown the cluster: tear down the cluster after specified minutes of '
      'idle time after all jobs finish (successfully or abnormally). Requires '
-     ' --idle-minutes-to-autostop to be set.'),
+     '--idle-minutes-to-autostop to be set.'),
 )
 @click.option(
     '--retry-until-up',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User reported that it's confusing an newly-INIT (abnormal) cluster suddenly had its autostop canceled. 

This PR adds a warning when that happens.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```
sky launch -c dbg -i10
# ssh into dbg and `ray stop`
sky status -r  # Observed warning.
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
