### PR TITLE
[Refactor] Move status query into the cloud class

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -17,7 +17,7 @@ from sky.resources import Resources
 from sky.task import Task
 from sky.optimizer import Optimizer, OptimizeTarget
 from sky.data import Storage, StorageMode, StoreType
-from sky.global_user_state import ClusterStatus
+from sky.status_lib import ClusterStatus
 from sky.skylet.job_lib import JobStatus
 from sky.core import (status, start, stop, down, autostop, queue, cancel,
                       tail_logs, download_logs, job_status, spot_queue,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1671,7 +1671,8 @@ def _query_cluster_status_via_cloud_api(
     # handle.launched_resources, because the latter may not be set
     # correctly yet.
     ray_config = common_utils.read_yaml(handle.cluster_yaml)
-    region = ray_config['provider']['region']
+    provider_config = ray_config['provider']
+    region = provider_config.get('region') or provider_config.get('location')
     zone = ray_config['provider'].get('availability_zone')
     kwargs = {}
     if isinstance(handle.launched_resources.cloud, clouds.GCP):

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1684,6 +1684,9 @@ def _query_cluster_status_via_cloud_api(
         **kwargs)
     # GCP does not clean up preempted TPU VMs. We remove it ourselves.
     # TODO(wei-lin): handle multi-node cases.
+    # TODO(zhwu): this should be moved into the GCP class, after we refactor
+    # the cluster termination, as the preempted TPU VM should always be
+    # removed.
     if kwargs.get('use_tpu_vm', False) and len(node_statuses) == 0:
         logger.debug(f'Terminating preempted TPU VM cluster {cluster_name}')
         backend = backends.CloudVmRayBackend()

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -6,15 +6,13 @@ import getpass
 import json
 import os
 import pathlib
-import random
 import re
 import subprocess
 import tempfile
 import textwrap
 import time
 import typing
-from typing import (Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple,
-                    Union)
+from typing import (Any, Dict, List, Optional, Sequence, Set, Tuple, Union)
 from typing_extensions import Literal
 import uuid
 
@@ -39,11 +37,10 @@ from sky import global_user_state
 from sky import skypilot_config
 from sky import sky_logging
 from sky import spot as spot_lib
+from sky import status_lib
 from sky.backends import onprem_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
-from sky.skylet.providers.lambda_cloud import lambda_utils
-from sky.skylet.providers.scp import scp_utils
 from sky.utils import common_utils
 from sky.utils import command_runner
 from sky.utils import env_options
@@ -54,7 +51,6 @@ from sky.utils import tpu_utils
 from sky.utils import ux_utils
 from sky.utils import validator
 from sky.usage import usage_lib
-from sky.adaptors import ibm
 
 if typing.TYPE_CHECKING:
     from sky import resources
@@ -1596,350 +1592,6 @@ def check_network_connection():
                                               'Network seems down.') from e
 
 
-def _process_cli_query(
-    cloud: str,
-    cluster: str,
-    query_cmd: str,
-    deliminator: str,
-    status_map: Mapping[str, Optional[global_user_state.ClusterStatus]],
-    max_retries: int = 3,
-) -> List[global_user_state.ClusterStatus]:
-    """Run the cloud CLI query and returns cluster status.
-
-    Args:
-        cloud: The cloud provider name.
-        cluster: The cluster name.
-        query_cmd: The cloud CLI query command.
-        deliminator: The deliminator separating the status in the output
-            of the query command.
-        status_map: A map from the CLI status string to the corresponding
-            global_user_state.ClusterStatus.
-        max_retries: Maximum number of retries before giving up. For AWS only.
-
-    Returns:
-        A list of global_user_state.ClusterStatus of all existing nodes in the
-        cluster. The list can be empty if none of the nodes in the clusters are
-        found, i.e. the nodes are all terminated.
-    """
-    returncode, stdout, stderr = log_lib.run_with_log(query_cmd,
-                                                      '/dev/null',
-                                                      require_outputs=True,
-                                                      shell=True)
-    logger.debug(f'{query_cmd} returned {returncode}.\n'
-                 '**** STDOUT ****\n'
-                 f'{stdout}\n'
-                 '**** STDERR ****\n'
-                 f'{stderr}')
-
-    # Cloud-specific error handling.
-    if (cloud == str(clouds.Azure()) and returncode == 2 and
-            'argument --ids: expected at least one argument' in stderr):
-        # Azure CLI has a returncode 2 when the cluster is not found, as
-        # --ids <empty> is passed to the query command. In that case, the
-        # cluster should be considered as DOWN.
-        return []
-    if (cloud == str(clouds.AWS()) and returncode != 0 and
-            'Unable to locate credentials. You can configure credentials by '
-            'running "aws configure"' in stdout + stderr):
-        # AWS: has run into this rare error with spot controller (which has an
-        # assumed IAM role and is working fine most of the time).
-        #
-        # We do not know the root cause. For now, the hypothesis is instance
-        # metadata service is temporarily unavailable. So, we retry the query.
-        if max_retries > 0:
-            logger.info('Encountered AWS "Unable to locate credentials" '
-                        'error. Retrying.')
-            time.sleep(random.uniform(0, 1) * 2)
-            return _process_cli_query(cloud, cluster, query_cmd, deliminator,
-                                      status_map, max_retries - 1)
-
-    if returncode != 0:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.ClusterStatusFetchingError(
-                f'Failed to query {cloud} cluster {cluster!r} status: '
-                f'{stdout + stderr}')
-
-    cluster_status = stdout.strip()
-    if cluster_status == '':
-        return []
-
-    statuses = []
-    for s in cluster_status.split(deliminator):
-        node_status = status_map[s]
-        if node_status is not None:
-            statuses.append(node_status)
-    return statuses
-
-
-def _query_status_aws(
-    cluster: str,
-    ray_config: Dict[str, Any],
-) -> List[global_user_state.ClusterStatus]:
-    status_map = {
-        'pending': global_user_state.ClusterStatus.INIT,
-        'running': global_user_state.ClusterStatus.UP,
-        # TODO(zhwu): stopping and shutting-down could occasionally fail
-        # due to internal errors of AWS. We should cover that case.
-        'stopping': global_user_state.ClusterStatus.STOPPED,
-        'stopped': global_user_state.ClusterStatus.STOPPED,
-        'shutting-down': None,
-        'terminated': None,
-    }
-    region = ray_config['provider']['region']
-    query_cmd = ('aws ec2 describe-instances --filters '
-                 f'Name=tag:ray-cluster-name,Values={cluster} '
-                 f'--region {region} '
-                 '--query "Reservations[].Instances[].State.Name" '
-                 '--output text')
-    return _process_cli_query('AWS', cluster, query_cmd, '\t', status_map)
-
-
-def _query_status_gcp(
-    cluster: str,
-    ray_config: Dict[str, Any],
-) -> List[global_user_state.ClusterStatus]:
-    # Note: we use ":" for filtering labels for gcloud, as the latest gcloud (v393.0)
-    # fails to filter labels with "=".
-    # Reference: https://cloud.google.com/sdk/gcloud/reference/topic/filters
-
-    use_tpu_vm = ray_config['provider'].get('_has_tpus', False)
-    zone = ray_config['provider'].get('availability_zone', '')
-    if use_tpu_vm:
-        # TPU VM's state definition is different from compute VM
-        # https://cloud.google.com/tpu/docs/reference/rest/v2alpha1/projects.locations.nodes#State # pylint: disable=line-too-long
-        status_map = {
-            'CREATING': global_user_state.ClusterStatus.INIT,
-            'STARTING': global_user_state.ClusterStatus.INIT,
-            'RESTARTING': global_user_state.ClusterStatus.INIT,
-            'READY': global_user_state.ClusterStatus.UP,
-            'REPAIRING': global_user_state.ClusterStatus.INIT,
-            # 'STOPPED' in GCP TPU VM means stopped, with disk preserved.
-            'STOPPING': global_user_state.ClusterStatus.STOPPED,
-            'STOPPED': global_user_state.ClusterStatus.STOPPED,
-            'DELETING': None,
-            'PREEMPTED': None,
-        }
-        tpu_utils.check_gcp_cli_include_tpu_vm()
-        query_cmd = ('gcloud compute tpus tpu-vm list '
-                     f'--zone {zone} '
-                     f'--filter="(labels.ray-cluster-name={cluster})" '
-                     '--format="value(state)"')
-    else:
-        # Ref: https://cloud.google.com/compute/docs/instances/instance-life-cycle
-        status_map = {
-            'PROVISIONING': global_user_state.ClusterStatus.INIT,
-            'STAGING': global_user_state.ClusterStatus.INIT,
-            'RUNNING': global_user_state.ClusterStatus.UP,
-            'REPAIRING': global_user_state.ClusterStatus.INIT,
-            # 'TERMINATED' in GCP means stopped, with disk preserved.
-            'STOPPING': global_user_state.ClusterStatus.STOPPED,
-            'TERMINATED': global_user_state.ClusterStatus.STOPPED,
-            # 'SUSPENDED' in GCP means stopped, with disk and OS memory
-            # preserved.
-            'SUSPENDING': global_user_state.ClusterStatus.STOPPED,
-            'SUSPENDED': global_user_state.ClusterStatus.STOPPED,
-        }
-        # TODO(zhwu): The status of the TPU attached to the cluster should also
-        # be checked, since TPUs are not part of the VMs.
-        query_cmd = ('gcloud compute instances list '
-                     f'--filter="(labels.ray-cluster-name={cluster})" '
-                     '--format="value(status)"')
-    status_list = _process_cli_query('GCP', cluster, query_cmd, '\n',
-                                     status_map)
-
-    # GCP does not clean up preempted TPU VMs. We remove it ourselves.
-    # TODO(wei-lin): handle multi-node cases.
-    if use_tpu_vm and len(status_list) == 0:
-        logger.debug(f'Terminating preempted TPU VM cluster {cluster}')
-        backend = backends.CloudVmRayBackend()
-        handle = global_user_state.get_handle_from_cluster_name(cluster)
-        assert isinstance(handle,
-                          backends.CloudVmRayResourceHandle), (cluster, handle)
-        # Do not use refresh cluster status during teardown, as that will
-        # cause inifinite recursion by calling cluster status refresh
-        # again.
-        # The caller of this function, `_update_cluster_status_no_lock() ->
-        # _get_cluster_status_via_cloud_cli()`, will do the post teardown
-        # cleanup, which will remove the cluster entry from the status table
-        # & the ssh config file.
-        backend.teardown_no_lock(handle,
-                                 terminate=True,
-                                 purge=False,
-                                 post_teardown_cleanup=False,
-                                 refresh_cluster_status=False)
-    return status_list
-
-
-def _query_status_azure(
-    cluster: str,
-    ray_config: Dict[str, Any],
-) -> List[global_user_state.ClusterStatus]:
-    del ray_config  # Unused.
-    status_map = {
-        'VM starting': global_user_state.ClusterStatus.INIT,
-        'VM running': global_user_state.ClusterStatus.UP,
-        # 'VM stopped' in Azure means Stopped (Allocated), which still bills
-        # for the VM.
-        'VM stopping': global_user_state.ClusterStatus.INIT,
-        'VM stopped': global_user_state.ClusterStatus.INIT,
-        # 'VM deallocated' in Azure means Stopped (Deallocated), which does not
-        # bill for the VM.
-        'VM deallocating': global_user_state.ClusterStatus.STOPPED,
-        'VM deallocated': global_user_state.ClusterStatus.STOPPED,
-    }
-    query_cmd = ('az vm show -d --ids $(az vm list --query '
-                 f'"[?tags.\\"ray-cluster-name\\" == \'{cluster}\'].id" '
-                 '-o tsv) --query "powerState" -o tsv')
-    # NOTE: Azure cli should be handled carefully. The query command above
-    # takes about 1 second to run.
-    # An alternative is the following command, but it will take more than
-    # 20 seconds to run.
-    # query_cmd = (
-    #     f'az vm list --show-details --query "['
-    #     f'?tags.\\"ray-cluster-name\\" == \'{handle.cluster_name}\' '
-    #     '&& tags.\\"ray-node-type\\" == \'head\'].powerState" -o tsv'
-    # )
-    return _process_cli_query('Azure', cluster, query_cmd, '\t', status_map)
-
-
-def _query_status_ibm(
-    cluster: str,
-    ray_config: Dict[str, Any],
-) -> List[global_user_state.ClusterStatus]:
-    """
-    returns a list of Statuses for each of the cluster's nodes.
-    this function gets called when running `sky status` with -r flag and the cluster's head node is either stopped or down.
-    """
-
-    status_map: Dict[str, Any] = {
-        'pending': global_user_state.ClusterStatus.INIT,
-        'starting': global_user_state.ClusterStatus.INIT,
-        'restarting': global_user_state.ClusterStatus.INIT,
-        'running': global_user_state.ClusterStatus.UP,
-        'stopping': global_user_state.ClusterStatus.STOPPED,
-        'stopped': global_user_state.ClusterStatus.STOPPED,
-        'deleting': None,
-        'failed': global_user_state.ClusterStatus.INIT,
-        'cluster_deleted': []
-    }
-
-    client = ibm.client(region=ray_config['provider']['region'])
-    search_client = ibm.search_client()
-    # pylint: disable=E1136
-    vpcs_filtered_by_tags_and_region = search_client.search(
-        query=
-        f'type:vpc AND tags:{cluster} AND region:{ray_config["provider"]["region"]}',
-        fields=['tags', 'region', 'type'],
-        limit=1000).get_result()['items']
-    if not vpcs_filtered_by_tags_and_region:
-        # a vpc could have been removed unkownlingly to skypilot, such as
-        # via `sky autostop --down`, or simply manually (e.g. via console).
-        logger.warning('No vpc exists in '
-                       f'{ray_config["provider"]["region"]} '
-                       f'with tag: {cluster}')
-        return status_map['cluster_deleted']
-    vpc_id = vpcs_filtered_by_tags_and_region[0]['crn'].rsplit(':', 1)[-1]
-    instances = client.list_instances(vpc_id=vpc_id).get_result()['instances']
-
-    return [status_map[instance['status']] for instance in instances]
-
-
-def _query_status_lambda(
-        cluster: str,
-        ray_config: Dict[str, Any],  # pylint: disable=unused-argument
-) -> List[global_user_state.ClusterStatus]:
-    status_map = {
-        'booting': global_user_state.ClusterStatus.INIT,
-        'active': global_user_state.ClusterStatus.UP,
-        'unhealthy': global_user_state.ClusterStatus.INIT,
-        'terminated': None,
-    }
-    # TODO(ewzeng): filter by hash_filter_string to be safe
-    status_list = []
-    vms = lambda_utils.LambdaCloudClient().list_instances()
-    possible_names = [f'{cluster}-head', f'{cluster}-worker']
-    for node in vms:
-        if node.get('name') in possible_names:
-            node_status = status_map[node['status']]
-            if node_status is not None:
-                status_list.append(node_status)
-    return status_list
-
-
-def _query_status_scp(
-    cluster: str,
-    ray_config: Dict[str, Any],
-) -> List[global_user_state.ClusterStatus]:
-    del ray_config  # Unused.
-    status_map = {
-        'CREATING': global_user_state.ClusterStatus.INIT,
-        'EDITING': global_user_state.ClusterStatus.INIT,
-        'RUNNING': global_user_state.ClusterStatus.UP,
-        'STARTING': global_user_state.ClusterStatus.INIT,
-        'RESTARTING': global_user_state.ClusterStatus.INIT,
-        'STOPPING': global_user_state.ClusterStatus.STOPPED,
-        'STOPPED': global_user_state.ClusterStatus.STOPPED,
-        'TERMINATING': None,
-        'TERMINATED': None,
-    }
-    status_list = []
-    vms = scp_utils.SCPClient().list_instances()
-    for node in vms:
-        if node['virtualServerName'] == cluster:
-            node_status = status_map[node['virtualServerState']]
-            if node_status is not None:
-                status_list.append(node_status)
-    return status_list
-
-
-#Apr, 2023 by Hysun(hysun.he@oracle.com): Added support for OCI
-def _query_status_oci(
-        cluster: str,
-        ray_config: Dict[str, Any],  # pylint: disable=unused-argument
-) -> List[global_user_state.ClusterStatus]:
-    region = ray_config['provider']['region']
-
-    # Check the lifecycleState definition from the page
-    # https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/
-    status_map = {
-        'PROVISIONING': global_user_state.ClusterStatus.INIT,
-        'STARTING': global_user_state.ClusterStatus.INIT,
-        'RUNNING': global_user_state.ClusterStatus.UP,
-        'STOPPING': global_user_state.ClusterStatus.STOPPED,
-        'STOPPED': global_user_state.ClusterStatus.STOPPED,
-        'TERMINATED': None,
-        'TERMINATING': None,
-    }
-
-    # pylint: disable=import-outside-toplevel
-    from sky.skylet.providers.oci.query_helper import oci_query_helper
-    from ray.autoscaler.tags import (
-        TAG_RAY_CLUSTER_NAME,)
-
-    status_list = []
-    vms = oci_query_helper.query_instances_by_tags(
-        tag_filters={TAG_RAY_CLUSTER_NAME: cluster}, region=region)
-    for node in vms:
-        vm_status = node.lifecycle_state
-        if vm_status in status_map:
-            sky_status = status_map[vm_status]
-            if sky_status is not None:
-                status_list.append(sky_status)
-
-    return status_list
-
-
-_QUERY_STATUS_FUNCS = {
-    'AWS': _query_status_aws,
-    'GCP': _query_status_gcp,
-    'Azure': _query_status_azure,
-    'Lambda': _query_status_lambda,
-    'IBM': _query_status_ibm,
-    'SCP': _query_status_scp,
-    'OCI': _query_status_oci,
-}
-
-
 def check_owner_identity(cluster_name: str) -> None:
     """Check if current user is the same as the user who created the cluster.
 
@@ -2010,14 +1662,41 @@ def check_owner_identity(cluster_name: str) -> None:
                 f'is {current_user_identity!r}.')
 
 
-def _get_cluster_status_via_cloud_cli(
+def _query_cluster_status_via_cloud_api(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle'
-) -> List[global_user_state.ClusterStatus]:
+) -> List[status_lib.ClusterStatus]:
     """Returns the status of the cluster."""
-    resources: sky.Resources = handle.launched_resources
-    cloud = resources.cloud
+    cluster_name = handle.cluster_name
+    # Use region and zone from the cluster config, instead of the
+    # handle.launched_resources, because the latter may not be set
+    # correctly yet.
     ray_config = common_utils.read_yaml(handle.cluster_yaml)
-    return _QUERY_STATUS_FUNCS[str(cloud)](handle.cluster_name, ray_config)
+    region = ray_config['provider']['region']
+    zone = ray_config['provider'].get('availability_zone')
+    kwargs = {}
+    if isinstance(handle.launched_resources.cloud, clouds.GCP):
+        kwargs['use_tpu_vm'] = ray_config['provider'].get('use_tpu_vm', False)
+
+    # Query the cloud provider.
+    node_statuses = handle.launched_resources.cloud.query_status(
+        cluster_name, {'ray-cluster-name': cluster_name}, region, zone,
+        **kwargs)
+    # GCP does not clean up preempted TPU VMs. We remove it ourselves.
+    # TODO(wei-lin): handle multi-node cases.
+    if kwargs.get('use_tpu_vm', False) and len(node_statuses) == 0:
+        logger.debug(f'Terminating preempted TPU VM cluster {cluster_name}')
+        backend = backends.CloudVmRayBackend()
+        # Do not use refresh cluster status during teardown, as that will
+        # cause inifinite recursion by calling cluster status refresh
+        # again.
+        # Post teardown cleanup be done later in this function, which will remove
+        # the cluster entry from the status table & the ssh config file.
+        backend.teardown_no_lock(handle,
+                                 terminate=True,
+                                 purge=False,
+                                 post_teardown_cleanup=False,
+                                 refresh_cluster_status=False)
+    return node_statuses
 
 
 def _update_cluster_status_no_lock(
@@ -2030,10 +1709,10 @@ def _update_cluster_status_no_lock(
         return record
     cluster_name = handle.cluster_name
 
-    # Query the cloud provider.
-    node_statuses = _get_cluster_status_via_cloud_cli(handle)
-    all_nodes_up = (all(status == global_user_state.ClusterStatus.UP
-                        for status in node_statuses) and
+    node_statuses = _query_cluster_status_via_cloud_api(handle)
+
+    all_nodes_up = (all(
+        status == status_lib.ClusterStatus.UP for status in node_statuses) and
                     len(node_statuses) == handle.launched_nodes)
 
     def run_ray_status_to_check_ray_cluster_healthy() -> bool:
@@ -2086,7 +1765,7 @@ def _update_cluster_status_no_lock(
         # NOTE: all_nodes_up calculation is fast due to calling cloud CLI;
         # run_ray_status_to_check_all_nodes_up() is slow due to calling `ray get
         # head-ip/worker-ips`.
-        record['status'] = global_user_state.ClusterStatus.UP
+        record['status'] = status_lib.ClusterStatus.UP
         global_user_state.add_or_update_cluster(cluster_name,
                                                 handle,
                                                 requested_resources=None,
@@ -2145,9 +1824,8 @@ def _update_cluster_status_no_lock(
     #
     # An abnormal cluster will transition to INIT and have any autostop setting
     # reset (unless it's autostopping/autodowning).
-    is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or
-                   any(status != global_user_state.ClusterStatus.STOPPED
-                       for status in node_statuses))
+    is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or any(
+        status != status_lib.ClusterStatus.STOPPED for status in node_statuses))
     if is_abnormal:
         backend = get_backend_from_handle(handle)
         if isinstance(backend,
@@ -2305,9 +1983,8 @@ def _refresh_cluster_record(
     handle = record['handle']
     if isinstance(handle, backends.CloudVmRayResourceHandle):
         use_spot = handle.launched_resources.use_spot
-        has_autostop = (
-            record['status'] != global_user_state.ClusterStatus.STOPPED and
-            record['autostop'] >= 0)
+        has_autostop = (record['status'] != status_lib.ClusterStatus.STOPPED and
+                        record['autostop'] >= 0)
         if force_refresh or has_autostop or use_spot:
             record = _update_cluster_status(
                 cluster_name,
@@ -2321,7 +1998,7 @@ def refresh_cluster_status_handle(
     *,
     force_refresh: bool = False,
     acquire_per_cluster_status_lock: bool = True,
-) -> Tuple[Optional[global_user_state.ClusterStatus],
+) -> Tuple[Optional[status_lib.ClusterStatus],
            Optional[backends.ResourceHandle]]:
     """Refresh the cluster, and return the possibly updated status and handle.
 
@@ -2336,6 +2013,9 @@ def refresh_cluster_status_handle(
     if record is None:
         return None, None
     return record['status'], record['handle']
+
+
+# =====================================
 
 
 @typing.overload
@@ -2416,7 +2096,7 @@ def check_cluster_available(
                 f'cluster {cluster_name!r}. It is only supported by backend: '
                 f'{backends.CloudVmRayBackend.NAME}.'
                 f'{reset}')
-    if cluster_status != global_user_state.ClusterStatus.UP:
+    if cluster_status != status_lib.ClusterStatus.UP:
         if onprem_utils.check_if_local_cloud(cluster_name):
             raise exceptions.ClusterNotUpError(
                 constants.UNINITIALIZED_ONPREM_CLUSTER_MESSAGE.format(
@@ -2425,7 +2105,7 @@ def check_cluster_available(
                 handle=handle)
         with ux_utils.print_exception_no_traceback():
             hint_for_init = ''
-            if cluster_status == global_user_state.ClusterStatus.INIT:
+            if cluster_status == status_lib.ClusterStatus.INIT:
                 hint_for_init = (
                     f'{reset} Wait for a launch to finish, or use this command '
                     f'to try to transition the cluster to UP: {bright}sky '
@@ -2434,7 +2114,7 @@ def check_cluster_available(
                 f'{colorama.Fore.YELLOW}{operation.capitalize()}: skipped for '
                 f'cluster {cluster_name!r} (status: {cluster_status.value}). '
                 'It is only allowed for '
-                f'{global_user_state.ClusterStatus.UP.value} clusters.'
+                f'{status_lib.ClusterStatus.UP.value} clusters.'
                 f'{hint_for_init}'
                 f'{reset}',
                 cluster_status=cluster_status,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1676,7 +1676,7 @@ def _query_cluster_status_via_cloud_api(
     zone = ray_config['provider'].get('availability_zone')
     kwargs = {}
     if isinstance(handle.launched_resources.cloud, clouds.GCP):
-        kwargs['use_tpu_vm'] = ray_config['provider'].get('use_tpu_vm', False)
+        kwargs['use_tpu_vm'] = ray_config['provider'].get('_has_tpus', False)
 
     # Query the cloud provider.
     node_statuses = handle.launched_resources.cloud.query_status(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -32,6 +32,7 @@ from sky import sky_logging
 from sky import optimizer
 from sky import skypilot_config
 from sky import spot as spot_lib
+from sky import status_lib
 from sky import task as task_lib
 from sky.data import data_utils
 from sky.data import storage as storage_lib
@@ -604,9 +605,9 @@ class RetryingVmProvisioner(object):
         """Resources to be provisioned."""
 
         def __init__(
-            self, cluster_name: str, resources: resources_lib.Resources,
-            num_nodes: int,
-            prev_cluster_status: Optional[global_user_state.ClusterStatus]
+                self, cluster_name: str, resources: resources_lib.Resources,
+                num_nodes: int,
+                prev_cluster_status: Optional[status_lib.ClusterStatus]
         ) -> None:
             assert cluster_name is not None, 'cluster_name must be specified.'
             self.cluster_name = cluster_name
@@ -1092,7 +1093,7 @@ class RetryingVmProvisioner(object):
     def _yield_zones(
         self, to_provision: resources_lib.Resources, num_nodes: int,
         cluster_name: str,
-        prev_cluster_status: Optional[global_user_state.ClusterStatus]
+        prev_cluster_status: Optional[status_lib.ClusterStatus]
     ) -> Iterable[Optional[List[clouds.Zone]]]:
         """Yield zones within the given region to try for provisioning.
 
@@ -1146,7 +1147,7 @@ class RetryingVmProvisioner(object):
             # same region and zone.
             zones = _get_previously_launched_zones()
 
-            if prev_cluster_status != global_user_state.ClusterStatus.UP:
+            if prev_cluster_status != status_lib.ClusterStatus.UP:
                 logger.info(
                     f'Cluster {cluster_name!r} (status: '
                     f'{prev_cluster_status.value}) was previously launched '
@@ -1165,7 +1166,7 @@ class RetryingVmProvisioner(object):
             # Cluster with status UP can reach here, if it was killed by the
             # cloud provider and no available resources in that region to
             # relaunch, which can happen to spot instance.
-            if prev_cluster_status == global_user_state.ClusterStatus.UP:
+            if prev_cluster_status == status_lib.ClusterStatus.UP:
                 message = (
                     f'Failed to connect to the cluster {cluster_name!r}. '
                     'It is possibly killed by cloud provider or manually '
@@ -1178,7 +1179,7 @@ class RetryingVmProvisioner(object):
                 # we may need to confirm whether the cluster is down in all
                 # cases.
                 global_user_state.set_cluster_status(
-                    cluster_name, global_user_state.ClusterStatus.UP)
+                    cluster_name, status_lib.ClusterStatus.UP)
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.ResourcesUnavailableError(message,
                                                                no_failover=True)
@@ -1186,7 +1187,7 @@ class RetryingVmProvisioner(object):
             # Check the *previous* cluster status. If the cluster is previously
             # stopped, we should not retry other regions, since the previously
             # attached volumes are not visible on another region.
-            elif prev_cluster_status == global_user_state.ClusterStatus.STOPPED:
+            elif prev_cluster_status == status_lib.ClusterStatus.STOPPED:
                 message = (
                     'Failed to acquire resources to restart the stopped '
                     f'cluster {cluster_name} in {region.name}. Please retry '
@@ -1196,12 +1197,12 @@ class RetryingVmProvisioner(object):
                 # (1) the cluster is not up (2) it ensures future `sky start`
                 # will disable auto-failover too.
                 global_user_state.set_cluster_status(
-                    cluster_name, global_user_state.ClusterStatus.STOPPED)
+                    cluster_name, status_lib.ClusterStatus.STOPPED)
 
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.ResourcesUnavailableError(message,
                                                                no_failover=True)
-            assert prev_cluster_status == global_user_state.ClusterStatus.INIT
+            assert prev_cluster_status == status_lib.ClusterStatus.INIT
             message = (f'Failed to launch cluster {cluster_name!r} '
                        f'(previous status: {prev_cluster_status.value}) '
                        f'with the original resources: {to_provision}.')
@@ -1306,7 +1307,7 @@ class RetryingVmProvisioner(object):
         stream_logs: bool,
         cluster_name: str,
         cloud_user_identity: Optional[List[str]],
-        prev_cluster_status: Optional[global_user_state.ClusterStatus],
+        prev_cluster_status: Optional[status_lib.ClusterStatus],
     ):
         """The provision retry loop."""
         style = colorama.Style
@@ -1323,8 +1324,7 @@ class RetryingVmProvisioner(object):
         # Get previous cluster status
         cluster_exists = prev_cluster_status is not None
         is_prev_cluster_healthy = prev_cluster_status in [
-            global_user_state.ClusterStatus.STOPPED,
-            global_user_state.ClusterStatus.UP
+            status_lib.ClusterStatus.STOPPED, status_lib.ClusterStatus.UP
         ]
 
         assert to_provision.region is not None, (
@@ -1396,7 +1396,7 @@ class RetryingVmProvisioner(object):
                 tpu_create_script=config_dict.get('tpu-create-script'),
                 tpu_delete_script=config_dict.get('tpu-delete-script'))
             usage_lib.messages.usage.update_final_cluster_status(
-                global_user_state.ClusterStatus.INIT)
+                status_lib.ClusterStatus.INIT)
 
             # This sets the status to INIT (even for a normal, UP cluster).
             global_user_state.add_or_update_cluster(
@@ -1943,8 +1943,8 @@ class RetryingVmProvisioner(object):
                 # STOPPED) will not trigger the failover due to `no_failover`
                 # flag; see _yield_zones(). Also, the cluster should have been
                 # terminated by _retry_zones().
-                assert (prev_cluster_status == global_user_state.ClusterStatus.
-                        INIT), prev_cluster_status
+                assert (prev_cluster_status == status_lib.ClusterStatus.INIT
+                       ), prev_cluster_status
                 assert global_user_state.get_handle_from_cluster_name(
                     cluster_name) is None, cluster_name
                 logger.info('Retrying provisioning with requested resources '
@@ -2508,12 +2508,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def _update_after_cluster_provisioned(
             self, handle: CloudVmRayResourceHandle, task: task_lib.Task,
-            prev_cluster_status: Optional[global_user_state.ClusterStatus],
+            prev_cluster_status: Optional[status_lib.ClusterStatus],
             ip_list: List[str], lock_path: str) -> None:
         usage_lib.messages.usage.update_cluster_resources(
             handle.launched_nodes, handle.launched_resources)
         usage_lib.messages.usage.update_final_cluster_status(
-            global_user_state.ClusterStatus.UP)
+            status_lib.ClusterStatus.UP)
 
         # For backward compatability and robustness of skylet, it is restarted
         with log_utils.safe_rich_status('Updating remote skylet'):
@@ -2521,7 +2521,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         # Update job queue to avoid stale jobs (when restarted), before
         # setting the cluster to be ready.
-        if prev_cluster_status == global_user_state.ClusterStatus.INIT:
+        if prev_cluster_status == status_lib.ClusterStatus.INIT:
             # update_status will query the ray job status for all INIT /
             # PENDING / RUNNING jobs for the real status, since we do not
             # know the actual previous status of the cluster.
@@ -2534,7 +2534,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             subprocess_utils.handle_returncode(returncode, cmd,
                                                'Failed to update job status.',
                                                stderr)
-        if prev_cluster_status == global_user_state.ClusterStatus.STOPPED:
+        if prev_cluster_status == status_lib.ClusterStatus.STOPPED:
             # Safely set all the previous jobs to FAILED since the cluster
             # is restarted
             # An edge case here due to racing:
@@ -2558,7 +2558,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 ready=True,
             )
             usage_lib.messages.usage.update_final_cluster_status(
-                global_user_state.ClusterStatus.UP)
+                status_lib.ClusterStatus.UP)
             auth_config = common_utils.read_yaml(handle.cluster_yaml)['auth']
             backend_utils.SSHConfigHelper.add_cluster(handle.cluster_name,
                                                       ip_list, auth_config)
@@ -3293,7 +3293,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     require_outputs=True)
 
         elif (isinstance(cloud, clouds.IBM) and terminate and
-              prev_cluster_status == global_user_state.ClusterStatus.STOPPED):
+              prev_cluster_status == status_lib.ClusterStatus.STOPPED):
             # pylint: disable= W0622 W0703 C0415
             from sky.adaptors import ibm
             from sky.skylet.providers.ibm.vpc_provider import IBMVPCProvider
@@ -3350,8 +3350,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # May, 2023 by Hysun: Allow terminate INIT cluster which may have
         # some instances provisioning in backgroud but not completed.
         elif (isinstance(cloud, clouds.OCI) and terminate and
-              prev_cluster_status in (global_user_state.ClusterStatus.STOPPED,
-                                      global_user_state.ClusterStatus.INIT)):
+              prev_cluster_status in (status_lib.ClusterStatus.STOPPED,
+                                      status_lib.ClusterStatus.INIT)):
             region = config['provider']['region']
 
             # pylint: disable=import-outside-toplevel
@@ -3365,7 +3365,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # To avoid undefined local varaiables error.
             stdout = stderr = ''
         elif (terminate and
-              (prev_cluster_status == global_user_state.ClusterStatus.STOPPED or
+              (prev_cluster_status == status_lib.ClusterStatus.STOPPED or
                use_tpu_vm)):
             # For TPU VMs, gcloud CLI is used for VM termination.
             if isinstance(cloud, clouds.AWS):

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -24,6 +24,7 @@ from sky import backends
 from sky import data
 from sky import global_user_state
 from sky import sky_logging
+from sky import status_lib
 from sky.backends import backend_utils
 from sky.benchmark import benchmark_state
 from sky.skylet import constants
@@ -313,7 +314,7 @@ def _update_benchmark_result(benchmark_result: Dict[str, Any]) -> Optional[str]:
         backend = backend_utils.get_backend_from_handle(handle)
         assert isinstance(backend, backends.CloudVmRayBackend)
 
-        if cluster_status == global_user_state.ClusterStatus.UP:
+        if cluster_status == status_lib.ClusterStatus.UP:
             # NOTE: The id of the benchmarking job must be 1.
             # TODO(woosuk): Handle exceptions.
             job_status = backend.get_job_status(handle,
@@ -321,13 +322,13 @@ def _update_benchmark_result(benchmark_result: Dict[str, Any]) -> Optional[str]:
                                                 stream_logs=False)['1']
 
     # Update the benchmark status.
-    if (cluster_status == global_user_state.ClusterStatus.INIT or
+    if (cluster_status == status_lib.ClusterStatus.INIT or
             job_status < job_lib.JobStatus.RUNNING):
         benchmark_status = benchmark_state.BenchmarkStatus.INIT
     elif job_status == job_lib.JobStatus.RUNNING:
         benchmark_status = benchmark_state.BenchmarkStatus.RUNNING
     elif (cluster_status is None or
-          cluster_status == global_user_state.ClusterStatus.STOPPED or
+          cluster_status == status_lib.ClusterStatus.STOPPED or
           (job_status is not None and job_status.is_terminal())):
         # The cluster has terminated or stopped, or
         # the cluster is UP and the job has terminated.

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -3,21 +3,28 @@ import enum
 import functools
 import json
 import os
+import random
 import re
 import subprocess
+import time
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Any
 
 from sky import clouds
 from sky import exceptions
+from sky import sky_logging
+from sky import status_lib
 from sky.adaptors import aws
 from sky.clouds import service_catalog
+from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     # renaming to avoid shadowing variables
     from sky import resources as resources_lib
+
+logger = sky_logging.init_logger(__name__)
 
 # This local file (under ~/.aws/) will be uploaded to remote nodes (any
 # cloud), if all of the following conditions hold:
@@ -687,3 +694,62 @@ class AWS(clouds.Cloud):
             'disk_throughput': tier2iops[tier] // 16,
             'custom_disk_perf': tier != 'low',
         }
+
+    @classmethod
+    def query_status(cls, name: str, tag_filters: Dict[str, str],
+                     region: Optional[str], zone: Optional[str],
+                     **kwargs) -> List['status_lib.ClusterStatus']:
+        del zone  # unused
+        status_map = {
+            'pending': status_lib.ClusterStatus.INIT,
+            'running': status_lib.ClusterStatus.UP,
+            # TODO(zhwu): stopping and shutting-down could occasionally fail
+            # due to internal errors of AWS. We should cover that case.
+            'stopping': status_lib.ClusterStatus.STOPPED,
+            'stopped': status_lib.ClusterStatus.STOPPED,
+            'shutting-down': None,
+            'terminated': None,
+        }
+
+        fitler_str = ' '.join(f'Name=tag:{key},Values={value}'
+                              for key, value in tag_filters.items())
+
+        retry_cnt = 0
+        while retry_cnt < 3:
+            query_cmd = ('aws ec2 describe-instances --filters '
+                         f'{fitler_str} '
+                         f'--region {region} '
+                         '--query "Reservations[].Instances[].State.Name" '
+                         '--output json')
+
+            returncode, stdout, stderr = log_lib.run_with_log(
+                query_cmd, '/dev/null', require_outputs=True, shell=True)
+            logger.debug(f'{query_cmd} returned {returncode}.\n'
+                         '**** STDOUT ****\n'
+                         f'{stdout}\n'
+                         '**** STDERR ****\n'
+                         f'{stderr}')
+
+            if (returncode != 0 and
+                    'Unable to locate credentials. You can configure credentials by '
+                    'running "aws configure"' in stdout + stderr):
+                retry_cnt += 1
+                time.sleep(random.uniform(0, 1) * 2)
+                continue
+            else:
+                break
+
+        if returncode != 0:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ClusterStatusFetchingError(
+                    f'Failed to query AWS cluster {name!r} status: '
+                    f'{stdout + stderr}')
+
+        original_statuses = json.loads(stdout.strip())
+
+        statuses = []
+        for s in original_statuses:
+            node_status = status_map[s]
+            if node_status is not None:
+                statuses.append(node_status)
+        return statuses

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -511,7 +511,7 @@ class Azure(clouds.Cloud):
             'VM deallocated': status_lib.ClusterStatus.STOPPED,
         }
         tag_filter_str = ' '.join(
-            f'tags.\\"{k}\\"==\\"{v}\\"' for k, v in tag_filters.items())
+            f'tags.\\"{k}\\"==\'{v}\'' for k, v in tag_filters.items())
         query_cmd = ('az vm show -d --ids $(az vm list --query '
                      f'"[?{tag_filter_str}].id" '
                      '-o tsv) --query "powerState" -o json')

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -528,8 +528,7 @@ class Azure(clouds.Cloud):
                 return []
             node_ids = json.loads(stdout.strip())
             state_str = '[].powerState'
-            if not isinstance(node_ids, list):
-                node_ids = [node_ids]
+            if len(node_ids) == 1:
                 state_str = 'powerState'
             node_ids_str = '\t'.join(node_ids)
             query_cmd = (
@@ -562,6 +561,8 @@ class Azure(clouds.Cloud):
         assert stdout.strip(), f'No status returned for {name!r}'
 
         original_statuses_list = json.loads(stdout.strip())
+        if not isinstance(original_statuses_list, list):
+            original_statuses_list = [original_statuses_list]
         statuses = []
         for s in original_statuses_list:
             node_status = status_map[s]

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -475,7 +475,7 @@ class Cloud:
         """Queries the latest status of the cluster from the cloud.
 
         The global_user_state caches the status of the clusters, but the
-        actualy status of the clusters may change on the cloud, e.g., the
+        actual status of the clusters may change on the cloud, e.g., the
         autostop happens, or the user manually stops the cluster. This
         method queries the cloud to get the latest cluster status.
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -474,18 +474,5 @@ class Cloud:
                      **kwargs) -> List['status_lib.ClusterStatus']:
         raise NotImplementedError
 
-    @classmethod
-    def create_image_from_cluster(cls, tag_filters: Dict[str, str],
-                                  image_name: str) -> str:
-        raise NotImplementedError
-
-    @classmethod
-    def move_image(cls, image_name: str, region: str) -> None:
-        raise NotImplementedError
-
-    @classmethod
-    def delete_image(cls, image_id: str) -> None:
-        raise NotImplementedError
-
     def __repr__(self):
         return self._REPR

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -472,6 +472,17 @@ class Cloud:
     def query_status(cls, name: str, tag_filters: Dict[str, str],
                      region: Optional[str], zone: Optional[str],
                      **kwargs) -> List['status_lib.ClusterStatus']:
+        """Queries the latest status of the cluster from the cloud.
+
+        The global_user_state caches the status of the clusters, but the
+        actualy status of the clusters may change on the cloud, e.g., the
+        autostop happens, or the user manually stops the cluster. This
+        method queries the cloud to get the latest cluster status.
+
+        Returns:
+            A list of ClusterStatus representing the status of all the
+            alive nodes in the cluster.
+        """
         raise NotImplementedError
 
     def __repr__(self):

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -11,6 +11,7 @@ from sky.utils import log_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    from sky import status_lib
     from sky import resources
 
 
@@ -465,6 +466,25 @@ class Cloud:
         Raises:
             exceptions.NotSupportedError: If the disk tier is not supported.
         """
+        raise NotImplementedError
+
+    @classmethod
+    def query_status(cls, name: str, tag_filters: Dict[str, str],
+                     region: Optional[str], zone: Optional[str],
+                     **kwargs) -> List['status_lib.ClusterStatus']:
+        raise NotImplementedError
+
+    @classmethod
+    def create_image_from_cluster(cls, tag_filters: Dict[str, str],
+                                  image_name: str) -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def move_image(cls, image_name: str, region: str) -> None:
+        raise NotImplementedError
+
+    @classmethod
+    def delete_image(cls, image_id: str) -> None:
         raise NotImplementedError
 
     def __repr__(self):

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -2,16 +2,17 @@
 import os
 import yaml
 import json
-from sky import clouds
-from sky.clouds import service_catalog
-from sky.adaptors import ibm
-from sky import sky_logging
 import typing
-from typing import Dict, Iterator, List, Optional, Tuple
-from sky.adaptors.ibm import CREDENTIAL_FILE
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from sky.clouds.cloud import Zone
+from sky import clouds
+from sky import sky_logging
+from sky import status_lib
+from sky.adaptors import ibm
+from sky.adaptors.ibm import CREDENTIAL_FILE
+from sky.clouds import service_catalog
 from sky.utils import ux_utils
+
 if typing.TYPE_CHECKING:
     # renaming to avoid shadowing variables
     from sky import resources as resources_lib
@@ -69,7 +70,7 @@ class IBM(clouds.Cloud):
         instance_type: str,
         accelerators: Optional[Dict[str, int]] = None,
         use_spot: bool = False,
-    ) -> Iterator[Optional[List[Zone]]]:
+    ) -> Iterator[Optional[List[clouds.Zone]]]:
         """Loops over (region, zones) to retry for provisioning.
 
         returning a single zone list with its region,
@@ -422,6 +423,44 @@ class IBM(clouds.Cloud):
         """Returns whether the accelerator is valid in the region or zone."""
         return service_catalog.accelerator_in_region_or_zone(
             accelerator, acc_count, region, zone, 'ibm')
+
+    @classmethod
+    def query_status(cls, name: str, tag_filters: Dict[str, str],
+                     region: Optional[str], zone: Optional[str],
+                     **kwargs) -> List['status_lib.ClusterStatus']:
+        del tag_filters, zone, kwargs  # unused
+
+        status_map: Dict[str, Any] = {
+            'pending': status_lib.ClusterStatus.INIT,
+            'starting': status_lib.ClusterStatus.INIT,
+            'restarting': status_lib.ClusterStatus.INIT,
+            'running': status_lib.ClusterStatus.UP,
+            'stopping': status_lib.ClusterStatus.STOPPED,
+            'stopped': status_lib.ClusterStatus.STOPPED,
+            'deleting': None,
+            'failed': status_lib.ClusterStatus.INIT,
+            'cluster_deleted': []
+        }
+
+        client = ibm.client(region=region)
+        search_client = ibm.search_client()
+        # pylint: disable=E1136
+        vpcs_filtered_by_tags_and_region = search_client.search(
+            query=f'type:vpc AND tags:{name} AND region:{region}',
+            fields=['tags', 'region', 'type'],
+            limit=1000).get_result()['items']
+        if not vpcs_filtered_by_tags_and_region:
+            # a vpc could have been removed unkownlingly to skypilot, such as
+            # via `sky autostop --down`, or simply manually (e.g. via console).
+            logger.warning('No vpc exists in '
+                           f'{region} '
+                           f'with tag: {name}')
+            return status_map['cluster_deleted']
+        vpc_id = vpcs_filtered_by_tags_and_region[0]['crn'].rsplit(':', 1)[-1]
+        instances = client.list_instances(
+            vpc_id=vpc_id).get_result()['instances']
+
+        return [status_map[instance['status']] for instance in instances]
 
 
 def _read_credential_file():

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 from sky import exceptions
+from sky import status_lib
 from sky.clouds import service_catalog
 from sky.skylet.providers.lambda_cloud import lambda_utils
 
@@ -263,3 +264,24 @@ class Lambda(clouds.Cloud):
                                 disk_tier: str) -> None:
         raise exceptions.NotSupportedError(
             'Lambda does not support disk tiers.')
+
+    @classmethod
+    def query_status(cls, name: str, tag_filters: Dict[str, str],
+                     region: Optional[str], zone: Optional[str],
+                     **kwargs) -> List[status_lib.ClusterStatus]:
+        status_map = {
+            'booting': status_lib.ClusterStatus.INIT,
+            'active': status_lib.ClusterStatus.UP,
+            'unhealthy': status_lib.ClusterStatus.INIT,
+            'terminated': None,
+        }
+        # TODO(ewzeng): filter by hash_filter_string to be safe
+        status_list = []
+        vms = lambda_utils.LambdaCloudClient().list_instances()
+        possible_names = [f'{name}-head', f'{name}-worker']
+        for node in vms:
+            if node.get('name') in possible_names:
+                node_status = status_map[node['status']]
+                if node_status is not None:
+                    status_list.append(node_status)
+        return status_list

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -1,5 +1,4 @@
 """Local/On-premise."""
-import subprocess
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
@@ -9,15 +8,6 @@ from sky import exceptions
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
     from sky import resources as resources_lib
-
-
-def _run_output(cmd):
-    proc = subprocess.run(cmd,
-                          shell=True,
-                          check=True,
-                          stderr=subprocess.PIPE,
-                          stdout=subprocess.PIPE)
-    return proc.stdout.decode('ascii')
 
 
 @clouds.CLOUD_REGISTRY.register

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -17,6 +17,7 @@ from sky import exceptions
 from sky import status_lib
 from sky.clouds import service_catalog
 from sky.utils import common_utils
+from sky.utils import ux_utils
 from sky.adaptors import oci as oci_adaptor
 from sky.skylet.providers.oci.config import oci_conf
 
@@ -504,7 +505,7 @@ class OCI(clouds.Cloud):
     def query_status(cls, name: str, tag_filters: Dict[str, str],
                      region: Optional[str], zone: Optional[str],
                      **kwargs) -> List[status_lib.ClusterStatus]:
-        del tag_filters, zone, kwargs  # Unused.
+        del zone, kwargs  # Unused.
         # Check the lifecycleState definition from the page
         # https://docs.oracle.com/en-us/iaas/api/#/en/iaas/latest/Instance/
         status_map = {
@@ -519,12 +520,18 @@ class OCI(clouds.Cloud):
 
         # pylint: disable=import-outside-toplevel
         from sky.skylet.providers.oci.query_helper import oci_query_helper
-        from ray.autoscaler.tags import (
-            TAG_RAY_CLUSTER_NAME,)
 
         status_list = []
-        vms = oci_query_helper.query_instances_by_tags(
-            tag_filters={TAG_RAY_CLUSTER_NAME: name}, region=region)
+        try:
+            vms = oci_query_helper.query_instances_by_tags(
+                tag_filters=tag_filters, region=region)
+        except Exception as e:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ClusterStatusFetchingError(
+                    f'Failed to query OCI cluster {name!r} status. '
+                    f'Details: {common_utils.format_exception(e, use_bracket=True)}'
+                )
+
         for node in vms:
             vm_status = node.lifecycle_state
             if vm_status in status_map:

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -525,13 +525,12 @@ class OCI(clouds.Cloud):
         try:
             vms = oci_query_helper.query_instances_by_tags(
                 tag_filters=tag_filters, region=region)
-        except Exception as e: # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ClusterStatusFetchingError(
                     f'Failed to query OCI cluster {name!r} status. '
                     'Details: '
-                    f'{common_utils.format_exception(e, use_bracket=True)}'
-                )
+                    f'{common_utils.format_exception(e, use_bracket=True)}')
 
         for node in vms:
             vm_status = node.lifecycle_state

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -525,11 +525,12 @@ class OCI(clouds.Cloud):
         try:
             vms = oci_query_helper.query_instances_by_tags(
                 tag_filters=tag_filters, region=region)
-        except Exception as e:
+        except Exception as e: # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ClusterStatusFetchingError(
                     f'Failed to query OCI cluster {name!r} status. '
-                    f'Details: {common_utils.format_exception(e, use_bracket=True)}'
+                    'Details: '
+                    f'{common_utils.format_exception(e, use_bracket=True)}'
                 )
 
         for node in vms:

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -500,6 +500,7 @@ class OCI(clouds.Cloud):
         # All the disk_tier are supported for any instance_type
         del instance_type, disk_tier  # unused
 
+    @classmethod
     def query_status(cls, name: str, tag_filters: Dict[str, str],
                      region: Optional[str], zone: Optional[str],
                      **kwargs) -> List[status_lib.ClusterStatus]:

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -9,6 +9,7 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
+from sky import status_lib
 from sky.clouds import service_catalog
 from sky.skylet.providers.scp import scp_utils
 from sky import exceptions
@@ -333,3 +334,29 @@ class SCP(clouds.Cloud):
                         f'Input: {resources.disk_size}')
             return False, []
         return True, [resources]
+
+    @classmethod
+    def query_status(cls, name: str, tag_filters: Dict[str, str],
+                     region: Optional[str], zone: Optional[str],
+                     **kwargs) -> List[status_lib.ClusterStatus]:
+        del tag_filters, region, zone, kwargs  # Unused.
+
+        status_map = {
+            'CREATING': status_lib.ClusterStatus.INIT,
+            'EDITING': status_lib.ClusterStatus.INIT,
+            'RUNNING': status_lib.ClusterStatus.UP,
+            'STARTING': status_lib.ClusterStatus.INIT,
+            'RESTARTING': status_lib.ClusterStatus.INIT,
+            'STOPPING': status_lib.ClusterStatus.STOPPED,
+            'STOPPED': status_lib.ClusterStatus.STOPPED,
+            'TERMINATING': None,
+            'TERMINATED': None,
+        }
+        status_list = []
+        vms = scp_utils.SCPClient().list_instances()
+        for node in vms:
+            if node['virtualServerName'] == name:
+                node_status = status_map[node['virtualServerState']]
+                if node_status is not None:
+                    status_list.append(node_status)
+        return status_list

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -341,6 +341,8 @@ class SCP(clouds.Cloud):
                      **kwargs) -> List[status_lib.ClusterStatus]:
         del tag_filters, region, zone, kwargs  # Unused.
 
+        # TODO: Multi-node is not supported yet.
+
         status_map = {
             'CREATING': status_lib.ClusterStatus.INIT,
             'EDITING': status_lib.ClusterStatus.INIT,

--- a/sky/core.py
+++ b/sky/core.py
@@ -14,6 +14,7 @@ from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
 from sky import spot
+from sky import status_lib
 from sky.backends import backend_utils
 from sky.skylet import constants
 from sky.skylet import job_lib
@@ -168,12 +169,12 @@ def _start(
         cluster_name)
     if handle is None:
         raise ValueError(f'Cluster {cluster_name!r} does not exist.')
-    if not force and cluster_status == global_user_state.ClusterStatus.UP:
+    if not force and cluster_status == status_lib.ClusterStatus.UP:
         sky_logging.print(f'Cluster {cluster_name!r} is already up.')
         return handle
     assert force or cluster_status in (
-        global_user_state.ClusterStatus.INIT,
-        global_user_state.ClusterStatus.STOPPED), cluster_status
+        status_lib.ClusterStatus.INIT,
+        status_lib.ClusterStatus.STOPPED), cluster_status
 
     backend = backend_utils.get_backend_from_handle(handle)
     if not isinstance(backend, backends.CloudVmRayBackend):
@@ -781,8 +782,7 @@ def spot_queue(refresh: bool,
     controller_status, handle = spot.is_spot_controller_up(stop_msg)
 
     if (refresh and controller_status in [
-            global_user_state.ClusterStatus.STOPPED,
-            global_user_state.ClusterStatus.INIT
+            status_lib.ClusterStatus.STOPPED, status_lib.ClusterStatus.INIT
     ]):
         sky_logging.print(f'{colorama.Fore.YELLOW}'
                           'Restarting controller for latest status...'
@@ -792,7 +792,7 @@ def spot_queue(refresh: bool,
             '[cyan] Checking spot jobs - restarting '
             'controller[/]')
         handle = _start(spot.SPOT_CONTROLLER_NAME)
-        controller_status = global_user_state.ClusterStatus.UP
+        controller_status = status_lib.ClusterStatus.UP
         log_utils.force_update_rich_status('[cyan] Checking spot jobs[/]')
 
     if handle is None or handle.head_ip is None:
@@ -914,7 +914,7 @@ def spot_tail_logs(name: Optional[str], job_id: Optional[int],
         f'`sky start {spot.SPOT_CONTROLLER_NAME}`.')
     if handle is None or handle.head_ip is None:
         msg = 'All jobs finished.'
-        if controller_status == global_user_state.ClusterStatus.INIT:
+        if controller_status == status_lib.ClusterStatus.INIT:
             msg = ''
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ClusterNotUpError(msg,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -23,6 +23,7 @@ from sky.data import mounting_utils
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky import status_lib
 from sky.utils import log_utils
 from sky.utils import ux_utils
 
@@ -33,7 +34,7 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 StorageHandle = Any
-StorageStatus = global_user_state.StorageStatus
+StorageStatus = status_lib.StorageStatus
 Path = str
 SourceType = Union[Path, List[Path]]
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -4,7 +4,7 @@ import typing
 from typing import List, Optional
 
 if typing.TYPE_CHECKING:
-    from sky import global_user_state
+    from sky import status_lib
     from sky.backends import backend
 
 # Return code for keyboard interruption and SIGTSTP
@@ -97,7 +97,7 @@ class ClusterNotUpError(Exception):
 
     def __init__(self,
                  message: str,
-                 cluster_status: Optional['global_user_state.ClusterStatus'],
+                 cluster_status: Optional['status_lib.ClusterStatus'],
                  handle: Optional['backend.ResourceHandle'] = None) -> None:
         super().__init__(message)
         self.cluster_status = cluster_status

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -10,8 +10,8 @@ from typing import Tuple
 import filelock
 
 from sky import exceptions
-from sky import global_user_state
 from sky import sky_logging
+from sky import status_lib
 from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.skylet import constants
@@ -203,7 +203,7 @@ class SpotController:
              handle) = backend_utils.refresh_cluster_status_handle(
                  cluster_name, force_refresh=True)
 
-            if cluster_status != global_user_state.ClusterStatus.UP:
+            if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster is (partially) preempted. It can be down, INIT
                 # or STOPPED, based on the interruption behavior of the cloud.
                 # Spot recovery is needed (will be done later in the code).

--- a/sky/spot/recovery_strategy.py
+++ b/sky/spot/recovery_strategy.py
@@ -8,6 +8,7 @@ import sky
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky import status_lib
 from sky import backends
 from sky.backends import backend_utils
 from sky.skylet import job_lib
@@ -190,7 +191,7 @@ class StrategyExecutor:
                 logger.info(f'Unexpected exception: {e}\nFailed to get the '
                             'refresh the cluster status. Retrying.')
                 continue
-            if cluster_status != global_user_state.ClusterStatus.UP:
+            if cluster_status != status_lib.ClusterStatus.UP:
                 # The cluster can be preempted before the job is
                 # launched.
                 # Break to let the retry launch kick in.

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -15,6 +15,7 @@ from sky import backends
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky import status_lib
 from sky.backends import backend_utils
 from sky.skylet import job_lib
 from sky.utils import common_utils
@@ -694,7 +695,7 @@ def load_job_table_cache() -> Optional[Tuple[float, str]]:
 
 def is_spot_controller_up(
     stopped_message: str,
-) -> Tuple[Optional[global_user_state.ClusterStatus],
+) -> Tuple[Optional[status_lib.ClusterStatus],
            Optional['backends.CloudVmRayResourceHandle']]:
     """Check if the spot controller is up.
 
@@ -739,12 +740,12 @@ def is_spot_controller_up(
 
     if controller_status is None:
         sky_logging.print('No managed spot jobs are found.')
-    elif controller_status != global_user_state.ClusterStatus.UP:
+    elif controller_status != status_lib.ClusterStatus.UP:
         msg = (f'Spot controller {SPOT_CONTROLLER_NAME} '
                f'is {controller_status.value}.')
-        if controller_status == global_user_state.ClusterStatus.STOPPED:
+        if controller_status == status_lib.ClusterStatus.STOPPED:
             msg += f'\n{stopped_message}'
-        if controller_status == global_user_state.ClusterStatus.INIT:
+        if controller_status == status_lib.ClusterStatus.INIT:
             msg += '\nPlease wait for the controller to be ready.'
         sky_logging.print(msg)
         handle = None

--- a/sky/status_lib.py
+++ b/sky/status_lib.py
@@ -1,0 +1,51 @@
+"""Statuses enum for SkyPilot resources."""
+
+import enum
+
+import colorama
+
+
+class ClusterStatus(enum.Enum):
+    """Cluster status as recorded in table 'clusters'."""
+    # NOTE: these statuses are as recorded in our local cache, the table
+    # 'clusters'.  The actual cluster state may be different (e.g., an UP
+    # cluster getting killed manually by the user or the cloud provider).
+
+    # Initializing.  This means a backend.provision() call has started but has
+    # not successfully finished. The cluster may be undergoing setup, may have
+    # failed setup, may be live or down.
+    INIT = 'INIT'
+
+    # The cluster is recorded as up.  This means a backend.provision() has
+    # previously succeeded.
+    UP = 'UP'
+
+    # Stopped.  This means a `sky stop` call has previously succeeded.
+    STOPPED = 'STOPPED'
+
+    def colored_str(self):
+        color = _STATUS_TO_COLOR[self]
+        return f'{color}{self.value}{colorama.Style.RESET_ALL}'
+
+
+_STATUS_TO_COLOR = {
+    ClusterStatus.INIT: colorama.Fore.BLUE,
+    ClusterStatus.UP: colorama.Fore.GREEN,
+    ClusterStatus.STOPPED: colorama.Fore.YELLOW,
+}
+
+
+class StorageStatus(enum.Enum):
+    """Storage status as recorded in table 'storage'."""
+
+    # Initializing and uploading storage
+    INIT = 'INIT'
+
+    # Initialization failed
+    INIT_FAILED = 'INIT_FAILED'
+
+    # Failed to Upload to Cloud
+    UPLOAD_FAILED = 'UPLOAD_FAILED'
+
+    # Finished uploading, in terminal state
+    READY = 'READY'

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -21,7 +21,7 @@ from sky.utils import common_utils
 from sky.utils import env_options
 
 if typing.TYPE_CHECKING:
-    from sky import global_user_state
+    from sky import status_lib
     from sky import resources as resources_lib
     from sky import task as task_lib
 
@@ -236,7 +236,7 @@ class UsageMessageToReport(MessageToReport):
         self.local_resources = [r.to_yaml_config() for r in local_resources]
 
     def update_cluster_status(
-            self, original_status: Optional['global_user_state.ClusterStatus']):
+            self, original_status: Optional['status_lib.ClusterStatus']):
         status = original_status.value if original_status else None
         if not self._original_cluster_status_specified:
             self.original_cluster_status = status
@@ -244,7 +244,7 @@ class UsageMessageToReport(MessageToReport):
         self.final_cluster_status = status
 
     def update_final_cluster_status(
-            self, status: Optional['global_user_state.ClusterStatus']):
+            self, status: Optional['status_lib.ClusterStatus']):
         self.final_cluster_status = status.value if status is not None else None
 
     def set_new_cluster(self):

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -6,8 +6,8 @@ import click
 import colorama
 
 from sky import backends
-from sky import global_user_state
 from sky import spot
+from sky import status_lib
 from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
@@ -309,8 +309,7 @@ _get_duration = (lambda cluster_record: log_utils.readable_time_duration(
     0, cluster_record['duration'], absolute=True))
 
 
-def _get_status(
-        cluster_record: _ClusterRecord) -> global_user_state.ClusterStatus:
+def _get_status(cluster_record: _ClusterRecord) -> status_lib.ClusterStatus:
     return cluster_record['status']
 
 
@@ -367,7 +366,7 @@ def _get_autostop(cluster_record: _ClusterRecord) -> str:
 def _is_pending_autostop(cluster_record: _ClusterRecord) -> bool:
     # autostop < 0 means nothing scheduled.
     return cluster_record['autostop'] >= 0 and _get_status(
-        cluster_record) != global_user_state.ClusterStatus.STOPPED
+        cluster_record) != status_lib.ClusterStatus.STOPPED
 
 
 # ---- 'sky cost-report' helper functions below ----

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1243,8 +1243,8 @@ def test_gcp_start_stop():
             f'sky start -y {name} -i 1',
             f'sky exec {name} examples/gcp_start_stop.yaml',
             f'sky logs {name} 4 --status',  # Ensure the job succeeded.
-            'sleep 100',
-            f'sky status -r {name} | grep "STOPPED"',
+            'sleep 180',
+            f'sky status -r {name} | grep "INIT\|STOPPED"',
         ],
         f'sky down -y {name}',
     )
@@ -1267,8 +1267,8 @@ def test_azure_start_stop():
             f'sky start -y {name} -i 1',
             f'sky exec {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
-            'sleep 100',
-            f'sky status -r {name} | grep "STOPPED"'
+            'sleep 180',
+            f'sky status -r {name} | grep "INIT\|STOPPED"'
         ],
         f'sky down -y {name}',
         timeout=30 * 60,  # 30 mins

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1243,7 +1243,7 @@ def test_gcp_start_stop():
             f'sky start -y {name} -i 1',
             f'sky exec {name} examples/gcp_start_stop.yaml',
             f'sky logs {name} 4 --status',  # Ensure the job succeeded.
-            'sleep 80',
+            'sleep 100',
             f'sky status -r {name} | grep "STOPPED"',
         ],
         f'sky down -y {name}',
@@ -1267,7 +1267,7 @@ def test_azure_start_stop():
             f'sky start -y {name} -i 1',
             f'sky exec {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
-            'sleep 80',
+            'sleep 100',
             f'sky status -r {name} | grep "STOPPED"'
         ],
         f'sky down -y {name}',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1240,9 +1240,11 @@ def test_gcp_start_stop():
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
             f'sky stop -y {name}',
             f'sleep 20',
-            f'sky start -y {name}',
+            f'sky start -y {name} -i 1',
             f'sky exec {name} examples/gcp_start_stop.yaml',
             f'sky logs {name} 4 --status',  # Ensure the job succeeded.
+            'sleep 80',
+            f'sky status -r {name} | grep "STOPPED"',
         ],
         f'sky down -y {name}',
     )
@@ -1262,9 +1264,11 @@ def test_azure_start_stop():
             f'sky exec {name} "prlimit -n --pid=\$(pgrep -f \'raylet/raylet --raylet_socket_name\') | grep \'"\'1048576 1048576\'"\'"',  # Ensure the raylet process has the correct file descriptor limit.
             f'sky logs {name} 2 --status',  # Ensure the job succeeded.
             f'sky stop -y {name}',
-            f'sky start -y {name}',
+            f'sky start -y {name} -i 1',
             f'sky exec {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
+            'sleep 80',
+            f'sky status -r {name} | grep "STOPPED"'
         ],
         f'sky down -y {name}',
         timeout=30 * 60,  # 30 mins

--- a/tests/test_yamls/pipeline_aws.yaml
+++ b/tests/test_yamls/pipeline_aws.yaml
@@ -13,6 +13,7 @@ run: |
   echo SKYPILOT_TASK_ID: $SKYPILOT_TASK_ID
   echo SKYPILOT_TASK_IDS
   echo "$SKYPILOT_TASK_IDS"
+  sleep 10000
   echo train ends
 
 ---


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the cloud-specific status query functions are located in the `backend_utils` making adding new clouds and features for clouds not clean.

We now move the status query to the cloud class, making each cloud more modularized.

This PR is to simplify the process of adding cluster migration #2088.

This PR also fixes the status refresh for Azure multi-node cluster! Previously, refreshing the status for the multi-node Azure cluster will remove the cluster from table immediately.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual tests:
  - [x] `sky launch -c min --cloud aws --cpus 2 echo hi -i 0; sky status -r`
  - [x] `sky launch -c min --cloud aws --cpus 2 --num-nodes 2 echo hi -i 0; sky status -r`
  - [x] `sky launch -c min --cloud aws --cpus 2 echo hi; manually terminate the VM; sky status -r`
  - [x] `sky launch --cloud gcp --cpus 2 --num-nodes 2 echo hi -i 0; sky status -r`
  - [x] `sky launch --cloud azure --cpus 2 --num-nodes 2 echo hi -i 0; sky status -r`
  - [x] `sky launch --cloud azure --cpus 2 echo hi -i 0; sky status -r`
  - [x] `sky launch --cloud ibm --cpus 2 --num-nodes 2 echo hi -i 0; sky status -r`
  - [x] `sky launch --cloud oci --cpus 2 --num-nodes 2 echo hi -i 0; sky status -r`
  - [x] `sky launch --cloud lambda --cpus 2+ --num-nodes 2 echo hi -i 0 --down; sky status -r`
  - [ ] `sky launch --cloud scp --cpus 2 echo hi -i 0; sky status -r` (not able to launch a cluster due to the test account failure)
- [x] All smoke tests: `pytest tests/test_smoke.py`
- [x] All smoke tests: `pytest tests/test_smoke.py --aws`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
