### PR TITLE
Reorder CLIs

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1742,7 +1742,6 @@ def status(all: bool, refresh: bool, show_spot_jobs: bool, clusters: List[str]):
             click.echo('\n' + '\n'.join(hints))
 
 
-
 @cli.command()
 @click.option('--all-users',
               '-a',
@@ -2670,7 +2669,6 @@ def _down_or_stop_clusters(
         progress.refresh()
 
 
-
 @cli.command()
 @click.argument('accelerator_str', required=False)
 @click.option('--all',
@@ -3501,7 +3499,6 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
     )
 
 
-
 @cli.group(cls=_NaturalOrderGroup)
 def storage():
     """SkyPilot Storage CLI."""
@@ -3557,9 +3554,6 @@ def storage_delete(names: List[str], all: bool):  # pylint: disable=redefined-bu
 
     for name in names:
         sky.storage_delete(name)
-
-
-
 
 
 # ==============================
@@ -3673,7 +3667,6 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         'Costs for clusters with auto{stop,down} '
         'scheduled may not be accurate.',
         fg='yellow')
-
 
 
 @cli.group(cls=_NaturalOrderGroup)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to change the CLI to a more user-friendly order. 

Previously
<img width="464" alt="image" src="https://github.com/skypilot-org/skypilot/assets/6753189/dd399a92-db7d-4319-9be2-8c71a14a89cc">


Now
<img width="452" alt="image" src="https://github.com/skypilot-org/skypilot/assets/6753189/783c75c7-a6c0-4d40-a1c6-0b63bb437aef">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
