### PR TITLE
[OCI] disk_tier to VPU mapping

### DIFF
--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -516,7 +516,7 @@ class OCI(clouds.Cloud):
                     f'Automatically set the VPU to {oci_conf.DISK_TIER_LOW}'
                     f' as only 2x vCPU is configured.')
                 vpu = oci_conf.DISK_TIER_LOW
-        elif cpus <= 8:
+        elif cpus < 8:
             # If less than 4 OCPU is configured, best not to set the disk_tier
             # to 'high' (vpu=100). Even if the disk_tier is configured to high
             # (no error to launch the instance), we cannot fully achieve its

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -531,5 +531,4 @@ class OCI(clouds.Cloud):
                     f'Automatically set the VPU to {oci_conf.DISK_TIER_MEDIUM}'
                     f' as less than {cpus}x vCPU is configured.')
                 vpu = oci_conf.DISK_TIER_MEDIUM
-
         return vpu

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -251,8 +251,9 @@ class OCI(clouds.Cloud):
                 pass
 
         # Disk performane: Volume Performance Units.
-        vpu = self.get_vpu_from_disktier(cpus=float(cpus),
-                                         disk_tier=resources.disk_tier)
+        vpu = self.get_vpu_from_disktier(
+            cpus=None if cpus is None else float(cpus),
+            disk_tier=resources.disk_tier)
 
         return {
             'instance_type': instance_type,
@@ -503,8 +504,12 @@ class OCI(clouds.Cloud):
         # All the disk_tier are supported for any instance_type
         del instance_type, disk_tier  # unused
 
-    def get_vpu_from_disktier(self, cpus: float, disk_tier: str) -> int:
+    def get_vpu_from_disktier(self, cpus: Optional[float],
+                              disk_tier: Optional[str]) -> int:
         vpu = oci_conf.BOOT_VOLUME_VPU[disk_tier]
+        if cpus is None:
+            return vpu
+
         if cpus <= 2:
             vpu = oci_conf.DISK_TIER_LOW if disk_tier is None else vpu
             if vpu > oci_conf.DISK_TIER_LOW:

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -529,6 +529,6 @@ class OCI(clouds.Cloud):
             if vpu > oci_conf.DISK_TIER_MEDIUM:
                 logger.warning(
                     f'Automatically set the VPU to {oci_conf.DISK_TIER_MEDIUM}'
-                    f' as less than {cpus}x vCPU is configured.')
+                    f' as less than 8x vCPU is configured.')
                 vpu = oci_conf.DISK_TIER_MEDIUM
         return vpu

--- a/sky/skylet/providers/oci/config.py
+++ b/sky/skylet/providers/oci/config.py
@@ -41,14 +41,30 @@ class oci_conf:
     MAX_RETRY_COUNT = 3
     RETRY_INTERVAL_BASE_SECONDS = 5
 
+    # Map SkyPilot disk_tier to OCI VPU (Volume Performance Units) for Boot Volume.
+    # Tested with fio, bs=(R) 64.0KiB-64.0KiB, (W) 64.0KiB-64.0KiB, (T) 64.0KiB-64.0KiB
+    # -----------vpu=10------------
+    # Use --numjobs=2 in fio command
+    # read: IOPS=1932, BW=121MiB/s (127MB/s)(4096MiB/33904msec)
+    # write: IOPS=2007, BW=125MiB/s (132MB/s)(4096MiB/32642msec)
+    DISK_TIER_LOW = 10
+    # -----------vpu=30------------
+    # Use --numjobs=4 in fio command
+    # read: IOPS=3104, BW=194MiB/s (203MB/s)(4096MiB/21113msec)
+    # write: IOPS=3079, BW=192MiB/s (202MB/s)(4096MiB/21280msec)
+    DISK_TIER_MEDIUM = 30
+    # -----------vpu=100------------
+    # Use --numjobs=8 in fio command
+    # read: IOPS=6698, BW=419MiB/s (439MB/s)(8192MiB/19568msec)
+    # write: IOPS=6707, BW=419MiB/s (440MB/s)(8192MiB/19540msec)
+    DISK_TIER_HIGH = 100
+
     # disk_tier to OCI VPU mapping
-    # TODO(HysunHe): Confirm that the performance of each tier
-    # roughly matches the other clouds.
     BOOT_VOLUME_VPU = {
-        None: 20,  # Default to medium
-        "low": 10,  # 60 IOPS/GB, Balanced performance
-        "medium": 20,  # 75 IOPS/GB, Higher performance
-        "high": 50,  # 120 IOPS/GB, Ultra-high performance
+        None: DISK_TIER_MEDIUM,  # Default to medium
+        "low": DISK_TIER_LOW,
+        "medium": DISK_TIER_HIGH,
+        "high": DISK_TIER_HIGH,
     }
 
     @classmethod

--- a/sky/skylet/providers/oci/config.py
+++ b/sky/skylet/providers/oci/config.py
@@ -53,6 +53,10 @@ class oci_conf:
     # read: IOPS=3104, BW=194MiB/s (203MB/s)(4096MiB/21113msec)
     # write: IOPS=3079, BW=192MiB/s (202MB/s)(4096MiB/21280msec)
     DISK_TIER_MEDIUM = 30
+    # -----------vpu=90------------
+    # Use --numjobs=8 in fio command
+    # read: IOPS=5843, BW=365MiB/s (383MB/s)(8192MiB/22429msec)
+    # write: IOPS=5833, BW=365MiB/s (382MB/s)(8192MiB/22469msec);
     # -----------vpu=100------------
     # Use --numjobs=8 in fio command
     # read: IOPS=6698, BW=419MiB/s (439MB/s)(8192MiB/19568msec)
@@ -63,7 +67,7 @@ class oci_conf:
     BOOT_VOLUME_VPU = {
         None: DISK_TIER_MEDIUM,  # Default to medium
         "low": DISK_TIER_LOW,
-        "medium": DISK_TIER_HIGH,
+        "medium": DISK_TIER_MEDIUM,
         "high": DISK_TIER_HIGH,
     }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR is to fix the TODO action item for OCI disk_tier support. Detail test is performanced to map the skypiot disk_tier value to OCI VPU value:

disk_tier value in skypilot:
    low: 500 IOPS; read 20MB/s; write 40 MB/s
    medium: 3000 IOPS; read 220 MB/s; write 200 MB/s
    high: 6000 IOPS; 340 MB/s; write 250 MB/s

oci vpu (Tested with fio tool, bs=(R) 64.0KiB-64.0KiB, (W) 64.0KiB-64.0KiB, (T) 64.0KiB-64.0KiB):
  10:  2000 IOPS; read 127MB/s; write 132MB/s  (This is the default and minimal in OCI)
  30:  3100 IOPS; read 203MB/s; write 202MB/s
  100: 6700 IOPS; read 439MB/s; write 440MB/s

Relevant constants are defined in config.py (oci provider) with detailed test result information, as following:
 
    # -----------vpu=10------------
    # Use --numjobs=2 in fio command
    # read: IOPS=1932, BW=121MiB/s (127MB/s)(4096MiB/33904msec)
    # write: IOPS=2007, BW=125MiB/s (132MB/s)(4096MiB/32642msec)
    DISK_TIER_LOW = 10

    # -----------vpu=30------------
    # Use --numjobs=4 in fio command
    # read: IOPS=3104, BW=194MiB/s (203MB/s)(4096MiB/21113msec)
    # write: IOPS=3079, BW=192MiB/s (202MB/s)(4096MiB/21280msec)
    DISK_TIER_MEDIUM = 30

    # -----------vpu=100------------
    # Use --numjobs=8 in fio command
    # read: IOPS=6698, BW=419MiB/s (439MB/s)(8192MiB/19568msec)
    # write: IOPS=6707, BW=419MiB/s (440MB/s)(8192MiB/19540msec)
    DISK_TIER_HIGH = 100


Tested (run the relevant ones):

- [v] Code formatting: `bash format.sh`
- [v] Any manual or new tests for this PR (please specify below)
       sky launch (disk_tier low/medium/high)
- [v] All smoke tests: `pytest tests/test_smoke.py` 
- [v] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [v] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

Test Commands:
        fio --name=sync_rand_64k_read  --rw=read  --direct=1 --ioengine=sync --bs=64k --numjobs=4 --iodepth=128 --size=1G --group_reporting --directory=/tmp/
        fio --name=sync_rand_64k_write  --rw=write  --direct=1 --ioengine=sync --bs=64k --numjobs=4 --iodepth=128 --size=1G --group_reporting --directory=/tmp/
