### PR TITLE
[OCI] Remove duplicated entries in images.csv (cross-region images)

### DIFF
--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -183,7 +183,7 @@ def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:
     image_str = common.get_image_id_from_tag_impl(_image_df, tag, region)
     if image_str is None:
         # Support cross-region (general) imageid
-        image_str = common.get_image_id_from_tag_impl(_image_df, tag, 'general')
+        image_str = common.get_image_id_from_tag_impl(_image_df, tag, None)
 
     df = _image_df[_image_df['Tag'].str.fullmatch(tag)]
     app_catalog_listing_id = df['AppCatalogListingId'].iloc[0]

--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -184,11 +184,11 @@ def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:
     if image_str is None:
         # Support cross-region (general) imageid
         image_str = common.get_image_id_from_tag_impl(_image_df, tag, 'general')
-    
+
     df = _image_df[_image_df['Tag'].str.fullmatch(tag)]
     app_catalog_listing_id = df['AppCatalogListingId'].iloc[0]
     resource_version = df['ResourceVersion'].iloc[0]
-    
+
     return (f'{image_str}{oci_conf.IMAGE_TAG_SPERATOR}{app_catalog_listing_id}'
             f'{oci_conf.IMAGE_TAG_SPERATOR}{resource_version}')
 

--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -179,10 +179,16 @@ def get_vcpus_mem_from_instance_type(
 
 def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:
     """Returns the image id from the tag."""
+    # Always try get region-specific imageid first (for backward compatible)
     image_str = common.get_image_id_from_tag_impl(_image_df, tag, region)
+    if image_str is None:
+        # Support cross-region (general) imageid
+        image_str = common.get_image_id_from_tag_impl(_image_df, tag, 'general')
+    
     df = _image_df[_image_df['Tag'].str.fullmatch(tag)]
     app_catalog_listing_id = df['AppCatalogListingId'].iloc[0]
     resource_version = df['ResourceVersion'].iloc[0]
+    
     return (f'{image_str}{oci_conf.IMAGE_TAG_SPERATOR}{app_catalog_listing_id}'
             f'{oci_conf.IMAGE_TAG_SPERATOR}{resource_version}')
 


### PR DESCRIPTION
This is a small enhancement for OCI catalog. The OCI standard images are region specific (different region has different imageid for the same image), however, there are some images that have same imageid across regions, for example, Marketplace listing images. So this kind of cross-region images, we do not need to specify duplicated entries for each region, instead, we can configure a "general" one.

Please kindly also review the OCI catalog file (image.csv) as well. Note that this feature is backward compatible, means that the original images file also works fine.

Tested (run the relevant ones):

- [v] Code formatting: `bash format.sh`
- [v] Any manual or new tests for this PR (please specify below)
       sky launch (gputask)
- [v] All smoke tests: `pytest tests/test_smoke.py` 
- [v] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [v] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
