### PR TITLE
[k8s_cloud] Delete k8s service resources.

### DIFF
--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -268,6 +268,7 @@ class KubernetesNodeProvider(NodeProvider):
                 raise
         try:
             core_api().delete_namespaced_service(node_id, self.namespace)
+            core_api().delete_namespaced_service(f'{node_id}-ssh', self.namespace)
         except ApiException:
             pass
         try:

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -183,8 +183,7 @@ available_node_types:
       apiVersion: v1
       kind: Pod
       metadata:
-        # Automatically generates a name for the pod with this prefix.
-        generateName: {{cluster_name}}-ray-head-
+        name: {{cluster_name}}-ray-head
         # Must match the head node service selector above if a head node
         # service is required.
         labels:


### PR DESCRIPTION
- 'sky down' for `Kubernetes` cloud to remove cluster service resources.

<!-- Describe the changes in this PR -->

Tested (run the relevant ones):

- [X] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
