### PR TITLE
[UX] Add currently activated account for the `sky check` and check for disk-tier options

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -28,7 +28,7 @@ def check(quiet: bool = False, show_all: bool = False) -> None:
         if ok:
             enabled_clouds.append(str(cloud))
             if show_all:
-                activated_account = cloud.get_current_user_identity()
+                activated_account = cloud.get_current_user_identity_str()
                 if activated_account is not None:
                     echo(f'    Activated account: {activated_account}')
             if reason is not None:

--- a/sky/check.py
+++ b/sky/check.py
@@ -9,7 +9,7 @@ from sky.adaptors import cloudflare
 
 
 # TODO(zhwu): add check for a single cloud to improve performance
-def check(quiet: bool = False) -> None:
+def check(quiet: bool = False, show_all: bool = False) -> None:
     echo = (lambda *_args, **_kwargs: None) if quiet else click.echo
     echo('Checking credentials to enable clouds for SkyPilot.')
 
@@ -27,6 +27,10 @@ def check(quiet: bool = False) -> None:
                  ' ' * 10)
         if ok:
             enabled_clouds.append(str(cloud))
+            if show_all:
+                activated_account = cloud.get_current_user_identity()
+                if activated_account is not None:
+                    echo(f'    Activated account: {activated_account}')
             if reason is not None:
                 echo(f'    Hint: {reason}')
         else:

--- a/sky/check.py
+++ b/sky/check.py
@@ -9,7 +9,7 @@ from sky.adaptors import cloudflare
 
 
 # TODO(zhwu): add check for a single cloud to improve performance
-def check(quiet: bool = False, show_all: bool = False) -> None:
+def check(quiet: bool = False, verbose: bool = False) -> None:
     echo = (lambda *_args, **_kwargs: None) if quiet else click.echo
     echo('Checking credentials to enable clouds for SkyPilot.')
 
@@ -27,7 +27,7 @@ def check(quiet: bool = False, show_all: bool = False) -> None:
                  ' ' * 10)
         if ok:
             enabled_clouds.append(str(cloud))
-            if show_all:
+            if verbose:
                 activated_account = cloud.get_current_user_identity_str()
                 if activated_account is not None:
                     echo(f'    Activated account: {activated_account}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -223,7 +223,8 @@ def _interactive_node_cli_command(cli_func):
                              help=('OS disk size in GBs.'))
     disk_tier = click.option('--disk-tier',
                              default=None,
-                             type=str,
+                             type=click.Choice(['low', 'medium', 'high'],
+                                               case_sensitive=False),
                              required=False,
                              help=('OS disk tier. Could be one of "low", '
                                    '"medium", "high". Default: medium'))
@@ -1207,7 +1208,7 @@ def cli():
 @click.option(
     '--disk-tier',
     default=None,
-    type=str,
+    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
     required=False,
     help=(
         'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
@@ -2977,7 +2978,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
               '-v',
               is_flag=True,
               default=False,
-              help='Show details of all clouds.')
+              help='Show the activated account for each cloud.')
 @usage_lib.entrypoint
 def check(verbose: bool):  # pylint: disable=redefined-builtin
     """Check which clouds are available to use.
@@ -3374,7 +3375,7 @@ def spot():
 @click.option(
     '--disk-tier',
     default=None,
-    type=str,
+    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
     required=False,
     help=(
         'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
@@ -3833,7 +3834,7 @@ def bench():
 @click.option(
     '--disk-tier',
     default=None,
-    type=str,
+    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
     required=False,
     help=(
         'OS disk tier. Could be one of "low", "medium", "high". Default: medium'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2974,12 +2974,12 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
 @cli.command()
 @click.option('--all',
-                '-a',
-                is_flag=True,
-                default=False,
-                help='Show details of all clouds.')
+              '-a',
+              is_flag=True,
+              default=False,
+              help='Show details of all clouds.')
 @usage_lib.entrypoint
-def check(all: bool):
+def check(all: bool): # pylint: disable=redefined-builtin
     """Check which clouds are available to use.
 
     This checks access credentials for all clouds supported by SkyPilot. If a

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2973,8 +2973,13 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
 
 @cli.command()
+@click.option('--all',
+                '-a',
+                is_flag=True,
+                default=False,
+                help='Show details of all clouds.')
 @usage_lib.entrypoint
-def check():
+def check(all: bool):
     """Check which clouds are available to use.
 
     This checks access credentials for all clouds supported by SkyPilot. If a
@@ -2984,7 +2989,7 @@ def check():
     The enabled clouds are cached and form the "search space" to be considered
     for each task.
     """
-    sky_check.check()
+    sky_check.check(show_all=all)
 
 
 @cli.command()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2979,7 +2979,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
               default=False,
               help='Show details of all clouds.')
 @usage_lib.entrypoint
-def check(all: bool): # pylint: disable=redefined-builtin
+def check(all: bool):  # pylint: disable=redefined-builtin
     """Check which clouds are available to use.
 
     This checks access credentials for all clouds supported by SkyPilot. If a

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2973,13 +2973,13 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
 
 
 @cli.command()
-@click.option('--all',
-              '-a',
+@click.option('--verbose',
+              '-v',
               is_flag=True,
               default=False,
               help='Show details of all clouds.')
 @usage_lib.entrypoint
-def check(all: bool):  # pylint: disable=redefined-builtin
+def check(verbose: bool):  # pylint: disable=redefined-builtin
     """Check which clouds are available to use.
 
     This checks access credentials for all clouds supported by SkyPilot. If a
@@ -2989,7 +2989,7 @@ def check(all: bool):  # pylint: disable=redefined-builtin
     The enabled clouds are cached and form the "search space" to be considered
     for each task.
     """
-    sky_check.check(show_all=all)
+    sky_check.check(verbose=verbose)
 
 
 @cli.command()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2980,7 +2980,7 @@ def tpunode(cluster: str, yes: bool, port_forward: Optional[List[int]],
               default=False,
               help='Show the activated account for each cloud.')
 @usage_lib.entrypoint
-def check(verbose: bool):  # pylint: disable=redefined-builtin
+def check(verbose: bool):
     """Check which clouds are available to use.
 
     This checks access credentials for all clouds supported by SkyPilot. If a

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -629,6 +629,14 @@ class AWS(clouds.Cloud):
                 ) from None
         return user_ids
 
+    @classmethod
+    def get_current_user_identity_str(cls) -> Optional[str]:
+        user_identity = cls.get_current_user_identity()
+        if user_identity is None:
+            return None
+        identity_str = f'{user_identity[0]} [account={user_identity[1]}]'
+        return identity_str
+
     def get_credential_file_mounts(self) -> Dict[str, str]:
         # The credentials file should not be uploaded if the user identity is
         # not SHARED_CREDENTIALS_FILE, since we cannot be sure if the currently

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -421,6 +421,13 @@ class Azure(clouds.Cloud):
         return [f'{account_email} [subscription_id={project_id}]']
 
     @classmethod
+    def get_current_user_identity_str(cls) -> Optional[str]:
+        user_identity = cls.get_current_user_identity()
+        if user_identity is None:
+            return None
+        return user_identity[0]
+
+    @classmethod
     def get_project_id(cls, dryrun: bool = False) -> str:
         if dryrun:
             return 'dryrun-project-id'

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -353,6 +353,14 @@ class Cloud:
         """
         return None
 
+    @classmethod
+    def get_current_user_identity_str(cls) -> Optional[str]:
+        """Returns a user friendly representation of the current identity."""
+        user_identity = cls.get_current_user_identity()
+        if user_identity is None:
+            return None
+        return ', '.join(user_identity)
+
     def get_credential_file_mounts(self) -> Dict[str, str]:
         """Returns the files necessary to access this cloud.
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -648,6 +648,13 @@ class GCP(clouds.Cloud):
                 ) from e
         return [f'{account} [project_id={project_id}]']
 
+    @classmethod
+    def get_current_user_identity_str(cls) -> Optional[str]:
+        user_identity = cls.get_current_user_identity()
+        if user_identity is None:
+            return None
+        return user_identity[0].replace('\n', '')
+
     def instance_type_exists(self, instance_type):
         return service_catalog.instance_type_exists(instance_type, 'gcp')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds an `--all` option for the `sky check`, so that the user could see more details about the enabled cloud, such as the currently activated account.

This PR also adds checks for the `--disk-tier` option

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky check -a`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
