### PR TITLE
[GCP/Auth] Use the application key in the env var

### DIFF
--- a/docs/source/cloud-setup/cloud-auth.rst
+++ b/docs/source/cloud-setup/cloud-auth.rst
@@ -45,3 +45,25 @@ Example of mixing a default profile and an SSO profile:
 
     $ # A cluster launched under a different profile.
     $ AWS_PROFILE=AdministratorAccess-12345 sky launch --cloud aws -c my-sso-cluster
+
+
+GCP
+-------------------------------
+
+.. _gcp-service-account:
+
+GCP Service Account
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`GCP Service Account <https://cloud.google.com/iam/docs/service-account-overview>`__ is supported.
+
+To use it to access GCP with SkyPilot, you need to setup the credentials:
+
+1. Download the key for the service account from the `GCP console <https://console.cloud.google.com/iam-admin/serviceaccounts>`__.
+2. Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the path of the key file, and configure the gcloud CLI tool:
+
+.. code-block:: console
+
+    $ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+    $ gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    $ gcloud config set project your-project-id

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -93,6 +93,8 @@ Note: if you encounter *Authorization Error (Error 400: invalid_request)* with t
 
   If you are using multiple GCP projects, list all the projects by :code:`gcloud project list` and activate one by :code:`gcloud config set project <PROJECT_ID>` (See `GCP docs <https://cloud.google.com/sdk/gcloud/reference/config/set>`_).
 
+To use service account to access GCP for SkyPilot, see :ref:`here<gcp-service-account>` for instructions.
+
 **Optional**: To create a new GCP user with minimal permissions for SkyPilot, see :ref:`GCP User Creation <cloud-permissions-gcp>`.
 
 Azure

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -479,8 +479,8 @@ class GCP(clouds.Cloud):
         if application_key_path:
             if not os.path.isfile(os.path.expanduser(application_key_path)):
                 raise FileNotFoundError(
-                    f'{_GCP_APPLICATION_CREDENTIAL_ENV}={application_key_path}, '
-                    'but the file does not exist.')
+                    f'{_GCP_APPLICATION_CREDENTIAL_ENV}={application_key_path},'
+                    ' but the file does not exist.')
             return application_key_path
         if (not os.path.isfile(
                 os.path.expanduser(DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH))):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -44,7 +44,6 @@ GCP_PREMISSION_CHECK_LIST = [
 # Minimum set of files under ~/.config/gcloud that grant GCP access.
 _CREDENTIAL_FILES = [
     'credentials.db',
-    'application_default_credentials.json',
     'access_tokens.db',
     'configurations',
     'legacy_credentials',
@@ -471,6 +470,24 @@ class GCP(clouds.Cloud):
                                                                 clouds='gcp')
 
     @classmethod
+    def _find_application_key_path(cls) -> str:
+        # Check the application default credentials in the environment variable.
+        # If the file does not exist, fallback to the default path.
+        application_key_path = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS',
+                                              None)
+        if application_key_path:
+            if not os.path.isfile(os.path.expanduser(application_key_path)):
+                raise FileNotFoundError(
+                    f'GOOGLE_APPLICATION_CREDENTIALS={application_key_path}, '
+                    'but the file does not exist.')
+            return application_key_path
+        if (not os.path.isfile(
+                os.path.expanduser(DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH))):
+            # Fallback to the default application credential path.
+            raise FileNotFoundError(DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH)
+        return DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH
+
+    @classmethod
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud."""
         try:
@@ -485,10 +502,12 @@ class GCP(clouds.Cloud):
             for file in [
                     '~/.config/gcloud/access_tokens.db',
                     '~/.config/gcloud/credentials.db',
-                    '~/.config/gcloud/application_default_credentials.json'
             ]:
                 if not os.path.isfile(os.path.expanduser(file)):
                     raise FileNotFoundError(file)
+
+            cls._find_application_key_path()
+
             # Check the installation of google-cloud-sdk.
             _run_output('gcloud --version')
 
@@ -500,7 +519,7 @@ class GCP(clouds.Cloud):
         except (auth.exceptions.DefaultCredentialsError,
                 subprocess.CalledProcessError,
                 exceptions.CloudUserIdentityError, FileNotFoundError,
-                ImportError):
+                ImportError) as e:
             # See also: https://stackoverflow.com/a/53307505/1165051
             return False, (
                 'GCP tools are not installed or credentials are not set. '
@@ -515,6 +534,7 @@ class GCP(clouds.Cloud):
                 '  $ gcloud auth application-default login\n    '
                 'For more info: '
                 'https://skypilot.readthedocs.io/en/latest/getting-started/installation.html'  # pylint: disable=line-too-long
+                f'\nDetails: {common_utils.format_exception(e, use_bracket=True)}'
             )
 
         # Check APIs.
@@ -611,6 +631,10 @@ class GCP(clouds.Cloud):
             f'~/.config/gcloud/{filename}': f'~/.config/gcloud/{filename}'
             for filename in _CREDENTIAL_FILES
         }
+        # Upload the application key path to the default path, so that
+        # autostop and GCS can be accessed on the remote cluster.
+        credentials[DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH] = (
+            self._find_application_key_path())
         credentials[GCP_CONFIG_SKY_BACKUP_PATH] = GCP_CONFIG_SKY_BACKUP_PATH
         return credentials
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -22,6 +22,10 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
+# Env var pointing to any service account key. If it exists, this path takes priority
+# over the DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH below, and will be
+# used instead for SkyPilot-launched instances. This is the same behavior as gcloud:
+# https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key
 _GCP_APPLICATION_CREDENTIAL_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
 DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = os.path.expanduser(
     '~/.config/gcloud/'
@@ -476,7 +480,7 @@ class GCP(clouds.Cloud):
         # If the file does not exist, fallback to the default path.
         application_key_path = os.environ.get(_GCP_APPLICATION_CREDENTIAL_ENV,
                                               None)
-        if application_key_path:
+        if application_key_path is not None:
             if not os.path.isfile(os.path.expanduser(application_key_path)):
                 raise FileNotFoundError(
                     f'{_GCP_APPLICATION_CREDENTIAL_ENV}={application_key_path},'

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
+_GCP_APPLICATION_CREDENTIAL_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
 DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = os.path.expanduser(
     '~/.config/gcloud/'
     'application_default_credentials.json')
@@ -473,12 +474,12 @@ class GCP(clouds.Cloud):
     def _find_application_key_path(cls) -> str:
         # Check the application default credentials in the environment variable.
         # If the file does not exist, fallback to the default path.
-        application_key_path = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS',
+        application_key_path = os.environ.get(_GCP_APPLICATION_CREDENTIAL_ENV,
                                               None)
         if application_key_path:
             if not os.path.isfile(os.path.expanduser(application_key_path)):
                 raise FileNotFoundError(
-                    f'GOOGLE_APPLICATION_CREDENTIALS={application_key_path}, '
+                    f'{_GCP_APPLICATION_CREDENTIAL_ENV}={application_key_path}, '
                     'but the file does not exist.')
             return application_key_path
         if (not os.path.isfile(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -22,9 +22,10 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-# Env var pointing to any service account key. If it exists, this path takes priority
-# over the DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH below, and will be
-# used instead for SkyPilot-launched instances. This is the same behavior as gcloud:
+# Env var pointing to any service account key. If it exists, this path takes
+# priority over the DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH below, and will be
+# used instead for SkyPilot-launched instances. This is the same behavior as
+# gcloud:
 # https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key
 _GCP_APPLICATION_CREDENTIAL_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
 DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = os.path.expanduser(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,9 @@ def enable_all_clouds(monkeypatch):
         prefix='tmp_backup_config_default', delete=False)
     monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
                         config_file_backup.name)
+    monkeypatch.setattr(
+        'sky.clouds.gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH',
+        config_file_backup.name)
     monkeypatch.setenv('OCI_CONFIG', config_file_backup.name)
 
 

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -42,6 +42,8 @@ def _test_parse_accelerators(spec, expected_accelerators):
 # clouds are enabled, so we monkeypatch the `sky.global_user_state` module
 # to return all three clouds. We also monkeypatch `sky.check.check` so that
 # when the optimizer tries calling it to update enabled_clouds, it does not
+# TODO: Keep the cloud enabling in sync with the fixture enable_all_clouds
+# in tests/conftest.py
 # raise exceptions.
 def _make_resources(
     monkeypatch,
@@ -57,10 +59,14 @@ def _make_resources(
     )
     monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
 
+
     config_file_backup = tempfile.NamedTemporaryFile(
         prefix='tmp_backup_config_default', delete=False)
     monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
                         config_file_backup.name)
+    monkeypatch.setattr(
+        'sky.clouds.gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH',
+        config_file_backup.name)
     monkeypatch.setenv('OCI_CONFIG', config_file_backup.name)
 
     # Should create Resources here, since it uses the enabled clouds.

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -59,7 +59,6 @@ def _make_resources(
     )
     monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
 
-
     config_file_backup = tempfile.NamedTemporaryFile(
         prefix='tmp_backup_config_default', delete=False)
     monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1268,7 +1268,7 @@ def test_azure_start_stop():
             f'sky exec {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
             'sleep 200',
-            f's=(sky status -r {name}) | echo $s && echo $s | grep "INIT\|STOPPED"'
+            f's=$(sky status -r {name}) | echo $s && echo $s | grep "INIT\|STOPPED"'
         ],
         f'sky down -y {name}',
         timeout=30 * 60,  # 30 mins

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1267,8 +1267,8 @@ def test_azure_start_stop():
             f'sky start -y {name} -i 1',
             f'sky exec {name} examples/azure_start_stop.yaml',
             f'sky logs {name} 3 --status',  # Ensure the job succeeded.
-            'sleep 180',
-            f'sky status -r {name} | grep "INIT\|STOPPED"'
+            'sleep 200',
+            f's=(sky status -r {name}) | echo $s && echo $s | grep "INIT\|STOPPED"'
         ],
         f'sky down -y {name}',
         timeout=30 * 60,  # 30 mins


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2115 and #2109.

The problem causing the two issues is that we hardcoded the application default key path in our code to find the credentials. However, the user may specify the key in the environment variable `GOOGLE_APPLICATION_CREDENTIALS`

We now first check the env var to look for the credential file, if the env var does not exist, we will use the default path (same as the gcloud's behavior).

TODO:
- [x] add instruction for log in with service account.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  ```
  Download the service account key
  mv ~/.config/gcloud ~/.config/gcloud.bk
  export GOOGLE_APPLICATION_CREDENTIALS="path/to/the/key/file"
  gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
  gcloud config set project project-id
  sky launch -c test-sa --cloud gcp --cpus 2 -i 0
  sleep 120
  sky status -r test-sa
  ```
- [ ] All smoke tests: `pytest tests/test_smoke.py`  with the service account.
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
