### PR TITLE
[Azure] Fix status query for Azure

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -527,6 +527,8 @@ class Azure(clouds.Cloud):
             if not stdout.strip():
                 return []
             node_ids = json.loads(stdout.strip())
+            if not node_ids:
+                return []
             state_str = '[].powerState'
             if len(node_ids) == 1:
                 state_str = 'powerState'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce,
1. `sky launch -c test-azure --cloud azure`
2. delete the cluster on the Azure console
3. `sky status -r`

The status query fails.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] The reproducible script above.
