### PR TITLE
Stop/down clusters with new provisioner

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3327,7 +3327,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     'It might be because the cluster\'s head node has already '
                     'been terminated. It is fine to skip this.')
             if terminate:
-                provision_api.terminate_instances(repr(cloud), region, cluster_name)
+                provision_api.terminate_instances(repr(cloud), region,
+                                                  cluster_name)
             else:
                 provision_api.stop_instances(repr(cloud), region, cluster_name)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3323,10 +3323,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # even when the command was executed successfully.
                 self.run_on_head(handle, 'ray stop --force')
             except RuntimeError:
-                logger.warning(
-                    'Failed to take down Ray autoscaler on the head node. '
-                    'It might be because the cluster\'s head node has already '
-                    'been terminated. It is fine to skip this.')
+                # This error is expected if the previous cluster status is
+                # INIT/STOPPED.
+                if prev_cluster_status == status_lib.ClusterStatus.UP:
+                    logger.warning(
+                        'Failed to take down Ray autoscaler on the head node. '
+                        'It might be because the cluster\'s head node has '
+                        'already been terminated. It is fine to skip this.')
             if terminate:
                 provision_api.terminate_instances(repr(cloud), region,
                                                   cluster_name)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3323,8 +3323,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # even when the command was executed successfully.
                 self.run_on_head(handle, 'ray stop --force')
             except RuntimeError:
-                # This error is expected if the previous cluster status is
-                # INIT/STOPPED.
+                # This error is expected if the previous cluster IP is
+                # failed to be found,
+                # i.e., the cluster is already stopped/terminated.
                 if prev_cluster_status == status_lib.ClusterStatus.UP:
                     logger.warning(
                         'Failed to take down Ray autoscaler on the head node. '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3318,10 +3318,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # re-launch the worker nodes, during the termination of the
             # cluster.
             try:
-                return_code = self.run_on_head(handle, 'ray stop --force')
+                # We do not check the return code, since Ray returns
+                # non-zero return code when calling Ray stop,
+                # even when the command was executed successfully.
+                self.run_on_head(handle, 'ray stop --force')
             except RuntimeError:
-                return_code = 255
-            if not return_code:
                 logger.warning(
                     'Failed to take down Ray autoscaler on the head node. '
                     'It might be because the cluster\'s head node has already '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -27,6 +27,7 @@ from sky import clouds
 from sky import cloud_stores
 from sky import exceptions
 from sky import global_user_state
+from sky import provision as provision_api
 from sky import resources as resources_lib
 from sky import sky_logging
 from sky import optimizer
@@ -3310,6 +3311,30 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         stdout = ''
         stderr = ''
 
+        # Use the new provisioner for AWS.
+        if isinstance(cloud, clouds.AWS):
+            region = config['provider']['region']
+            # Stop the ray autoscaler first to avoid the head node trying to
+            # re-launch the worker nodes, during the termination of the
+            # cluster.
+            try:
+                return_code = self.run_on_head(handle, 'ray stop --force')
+            except RuntimeError:
+                return_code = 255
+            if not return_code:
+                logger.warning(
+                    'Failed to take down Ray autoscaler on the head node. '
+                    'It might be because the cluster\'s head node has already '
+                    'been terminated. It is fine to skip this.')
+            if terminate:
+                provision_api.terminate_instances(repr(cloud), region, cluster_name)
+            else:
+                provision_api.stop_instances(repr(cloud), region, cluster_name)
+
+            if post_teardown_cleanup:
+                self.post_teardown_cleanup(handle, terminate, purge)
+            return
+
         if terminate and isinstance(cloud, clouds.Azure):
             # Here we handle termination of Azure by ourselves instead of Ray
             # autoscaler.
@@ -3401,22 +3426,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
               (prev_cluster_status == status_lib.ClusterStatus.STOPPED or
                use_tpu_vm)):
             # For TPU VMs, gcloud CLI is used for VM termination.
-            if isinstance(cloud, clouds.AWS):
-                # TODO(zhwu): Room for optimization. We can move these cloud
-                # specific handling to the cloud class.
-                # The stopped instance on AWS will not be correctly terminated
-                # due to ray's bug.
-                region = config['provider']['region']
-                query_cmd = (
-                    f'aws ec2 describe-instances --region {region} --filters '
-                    f'Name=tag:ray-cluster-name,Values={handle.cluster_name} '
-                    '--query Reservations[].Instances[].InstanceId '
-                    '--output text')
-                terminate_cmd = (
-                    f'VMS=$({query_cmd}) && [ -n "$VMS" ] && '
-                    f'aws ec2 terminate-instances --region {region} '
-                    '--instance-ids $VMS || echo "No instances to delete."')
-            elif isinstance(cloud, clouds.GCP):
+            if isinstance(cloud, clouds.GCP):
                 zone = config['provider']['availability_zone']
                 # TODO(wei-lin): refactor by calling functions of node provider
                 # that uses Python API rather than CLI

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -1,0 +1,56 @@
+"""Cloud provision interface.
+
+This module provides a standard low-level interface that all
+providers supported by SkyPilot need to follow.
+"""
+from typing import List, Optional
+
+import functools
+import importlib
+import inspect
+
+
+def _route_to_cloud_impl(func):
+
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        # check the signature to fail early
+        inspect.signature(func).bind(*args, **kwargs)
+        if args:
+            provider_name = args[0]
+            args = args[1:]
+        else:
+            provider_name = kwargs.pop('provider_name')
+
+        module_name = provider_name
+        module = importlib.import_module(f'sky.provision.{module_name.lower()}')
+
+        impl = getattr(module, func.__name__)
+        return impl(*args, **kwargs)
+
+    return _wrapper
+
+
+# pylint: disable=unused-argument
+
+# TODO(suquark): Bring all other functions here from the
+
+
+@_route_to_cloud_impl
+def stop_instances(provider_name: str,
+                   region: str,
+                   cluster_name: str,
+                   included_instances: Optional[List[str]] = None,
+                   excluded_instances: Optional[List[str]] = None) -> None:
+    """Stop running instances."""
+    raise NotImplementedError
+
+
+@_route_to_cloud_impl
+def terminate_instances(provider_name: str,
+                        region: str,
+                        cluster_name: str,
+                        included_instances: Optional[List[str]] = None,
+                        excluded_instances: Optional[List[str]] = None) -> None:
+    """Terminate running or stopped instances."""
+    raise NotImplementedError

--- a/sky/provision/aws/__init__.py
+++ b/sky/provision/aws/__init__.py
@@ -1,0 +1,3 @@
+"""AWS provisioner for SkyPilot."""
+
+from sky.provision.aws.instance import stop_instances, terminate_instances

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -1,0 +1,89 @@
+"""AWS instance provisioning."""
+from typing import Dict, List, Any, Optional
+
+from botocore import config
+from sky.adaptors import aws
+
+BOTO_MAX_RETRIES = 12
+# Tag uniquely identifying all nodes of a cluster
+TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'
+
+
+def _filter_instances(ec2, filters: List[Dict[str, Any]],
+                      included_instances: Optional[List[str]],
+                      excluded_instances: Optional[List[str]]):
+    instances = ec2.instances.filter(Filters=filters)
+    if included_instances is not None and excluded_instances is not None:
+        raise ValueError('"included_instances" and "exclude_instances"'
+                         'cannot be specified at the same time.')
+    if included_instances is not None:
+        instances = instances.filter(InstanceIds=included_instances)
+    elif excluded_instances is not None:
+        included_instances = []
+        for inst in list(instances):
+            if inst.id not in excluded_instances:
+                included_instances.append(inst.id)
+        instances = instances.filter(InstanceIds=included_instances)
+    return instances
+
+
+def stop_instances(region: str,
+                   cluster_name: str,
+                   included_instances: Optional[List[str]] = None,
+                   excluded_instances: Optional[List[str]] = None) -> None:
+    """See sky/provision/__init__.py"""
+    ec2 = aws.resource(
+        'ec2',
+        region=region,
+        config=config.Config(retries={'max_attempts': BOTO_MAX_RETRIES}))
+    filters = [
+        {
+            'Name': 'instance-state-name',
+            'Values': ['pending', 'running'],
+        },
+        {
+            'Name': f'tag:{TAG_RAY_CLUSTER_NAME}',
+            'Values': [cluster_name],
+        },
+    ]
+    instances = _filter_instances(ec2, filters, included_instances,
+                                  excluded_instances)
+    instances.stop()
+    # TODO(suquark): Currently, the implementation of GCP and Azure will
+    #  wait util the cluster is fully terminated, while other clouds just
+    #  trigger the termination process (via http call) and then return.
+    #  It's not clear that which behavior should be expected. We will not
+    #  wait for the termination for now, since this is the default behavior
+    #  of most cloud implementations (including AWS).
+
+
+def terminate_instances(region: str,
+                        cluster_name: str,
+                        included_instances: Optional[List[str]] = None,
+                        excluded_instances: Optional[List[str]] = None) -> None:
+    """See sky/provision/__init__.py"""
+    ec2 = aws.resource(
+        'ec2',
+        region=region,
+        config=config.Config(retries={'max_attempts': BOTO_MAX_RETRIES}))
+    filters = [
+        {
+            'Name': 'instance-state-name',
+            # exclude 'shutting-down' or 'terminated' states
+            'Values': ['pending', 'running', 'stopping', 'stopped'],
+        },
+        {
+            'Name': f'tag:{TAG_RAY_CLUSTER_NAME}',
+            'Values': [cluster_name],
+        },
+    ]
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Instance
+    instances = _filter_instances(ec2, filters, included_instances,
+                                  excluded_instances)
+    instances.terminate()
+    # TODO(suquark): Currently, the implementation of GCP and Azure will
+    #  wait util the cluster is fully terminated, while other clouds just
+    #  trigger the termination process (via http call) and then return.
+    #  It's not clear that which behavior should be expected. We will not
+    #  wait for the termination for now, since this is the default behavior
+    #  of most cloud implementations (including AWS).

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -34,7 +34,7 @@ def stop_instances(region: str,
     """See sky/provision/__init__.py"""
     ec2 = aws.resource(
         'ec2',
-        region=region,
+        region_name=region,
         config=config.Config(retries={'max_attempts': BOTO_MAX_RETRIES}))
     filters = [
         {
@@ -64,7 +64,7 @@ def terminate_instances(region: str,
     """See sky/provision/__init__.py"""
     ec2 = aws.resource(
         'ec2',
-        region=region,
+        region_name=region,
         config=config.Config(retries={'max_attempts': BOTO_MAX_RETRIES}))
     filters = [
         {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR is part of the new provisioner PR, which handles stopping/terminating of clusters. This PR only includes the implementation for AWS, but it can serve as a starting point for other clouds.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
