### PR TITLE
GCP provisioning: handle 'wait_ready timeout exceeded'.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1691,10 +1691,11 @@ def _query_cluster_status_via_cloud_api(
         logger.debug(f'Terminating preempted TPU VM cluster {cluster_name}')
         backend = backends.CloudVmRayBackend()
         # Do not use refresh cluster status during teardown, as that will
-        # cause inifinite recursion by calling cluster status refresh
+        # cause infinite recursion by calling cluster status refresh
         # again.
-        # Post teardown cleanup be done later in this function, which will remove
-        # the cluster entry from the status table & the ssh config file.
+
+        # Post teardown cleanup be done later in this function, which will
+        # remove the cluster entry from the status table & the ssh config file.
         backend.teardown_no_lock(handle,
                                  terminate=True,
                                  purge=False,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -656,13 +656,14 @@ class RetryingVmProvisioner(object):
                 exception_dict = ast.literal_eval(exception_str)
             except Exception as e:
                 if 'wait_ready timeout exceeded' in exception_str:
-                    # It's not clear we should block the current
-                    # resource/location, because this error seems to occur when
-                    # the provisioning process went through partially (e.g., for
-                    # spot, initial provisioning succeeded, but while waiting
-                    # for ssh/setting up it got preempted).
+                    # This error seems to occur when the provisioning process
+                    # went through partially (e.g., for spot, initial
+                    # provisioning succeeded, but while waiting for ssh/setting
+                    # up it got preempted).
                     logger.error('Got the following exception, continuing: '
                                  f'{exception_list[0]}')
+                    self._blocked_resources.add(
+                        launchable_resources.copy(zone=zone.name))
                     return
                 raise RuntimeError(
                     f'Failed to parse exception: {exception_str}') from e

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3291,6 +3291,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         config = common_utils.read_yaml(handle.cluster_yaml)
         cluster_name = handle.cluster_name
         use_tpu_vm = config['provider'].get('_has_tpus', False)
+
+        # Avoid possibly unbound warnings. Code below must overwrite these vars:
+        returncode = 0
+        stdout = ''
+        stderr = ''
+
         if terminate and isinstance(cloud, clouds.Azure):
             # Here we handle termination of Azure by ourselves instead of Ray
             # autoscaler.
@@ -3322,6 +3328,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 query=f'type:vpc AND tags:{cluster_name} AND region:{region}',
                 fields=['tags', 'region', 'type'],
                 limit=1000).get_result()['items']
+            vpc_id = None
             try:
                 # pylint: disable=line-too-long
                 vpc_id = vpcs_filtered_by_tags_and_region[0]['crn'].rsplit(
@@ -3361,7 +3368,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         # Apr, 2023 by Hysun(hysun.he@oracle.com): Added support for OCI
         # May, 2023 by Hysun: Allow terminate INIT cluster which may have
-        # some instances provisioning in backgroud but not completed.
+        # some instances provisioning in background but not completed.
         elif (isinstance(cloud, clouds.OCI) and terminate and
               prev_cluster_status in (status_lib.ClusterStatus.STOPPED,
                                       status_lib.ClusterStatus.INIT)):
@@ -3375,7 +3382,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             returncode = oci_query_helper.terminate_instances_by_tags(
                 {TAG_RAY_CLUSTER_NAME: cluster_name}, region)
 
-            # To avoid undefined local varaiables error.
+            # To avoid undefined local variables error.
             stdout = stderr = ''
         elif (terminate and
               (prev_cluster_status == status_lib.ClusterStatus.STOPPED or
@@ -3406,9 +3413,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     query_cmd = (f'gcloud compute instances list --filter='
                                  f'"(labels.ray-cluster-name={cluster_name})" '
                                  f'--zones={zone} --format=value\\(name\\)')
+                    # If there are no instances, exit with 0 rather than causing
+                    # the delete command to fail.
                     terminate_cmd = (
-                        f'gcloud compute instances delete --zone={zone}'
-                        f' --quiet $({query_cmd})')
+                        f'NAMES=$({query_cmd}) && [ -n "$NAMES" ] && '
+                        f'gcloud compute instances delete --zone={zone} --quiet'
+                        ' $NAMES || echo "No instances to delete."')
             else:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(f'Unsupported cloud {cloud} for stopped '

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -816,8 +816,8 @@ class GCP(clouds.Cloud):
                 'SUSPENDING': status_lib.ClusterStatus.STOPPED,
                 'SUSPENDED': status_lib.ClusterStatus.STOPPED,
             }
-            # TODO(zhwu): The status of the TPU attached to the cluster should also
-            # be checked, since TPUs are not part of the VMs.
+            # TODO(zhwu): The status of the TPU attached to the cluster should
+            # also be checked, since TPUs are not part of the VMs.
             query_cmd = ('gcloud compute instances list '
                          f'--filter="({label_filter_str})" '
                          '--format="value(status)"')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Sometimes we see this error in GCP provisioning (see e.g., https://github.com/skypilot-org/skypilot/issues/1006). Here we make sure the provisioning loop doesn't get crashed.

This seems hard to reproduce. Running
```
sky launch --use-spot --gpus A100:8 --down --cloud gcp -c dbg --region us-central1 -ry
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
