### PR TITLE
[GCP] Fix the path to application credential

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -714,8 +714,7 @@ class GCP(clouds.Cloud):
             raise exceptions.CloudUserIdentityError(
                 'Failed to get GCP project id. Please make sure you have '
                 'run the following: gcloud init; '
-                'gcloud auth application-default login'
-            )
+                'gcloud auth application-default login')
         return project_id
 
     @staticmethod

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -28,7 +28,7 @@ logger = sky_logging.init_logger(__name__)
 # gcloud:
 # https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key
 _GCP_APPLICATION_CREDENTIAL_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
-DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = os.path.expanduser(
+DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = (
     '~/.config/gcloud/'
     'application_default_credentials.json')
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -28,15 +28,21 @@ logger = sky_logging.init_logger(__name__)
 # gcloud:
 # https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key
 _GCP_APPLICATION_CREDENTIAL_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
+# NOTE: do not expanduser() on this path. It's used as a destination path on the
+# remote cluster.
 DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH: str = (
     '~/.config/gcloud/'
     'application_default_credentials.json')
 
 # TODO(wei-lin): config_default may not be the config in use.
 # See: https://github.com/skypilot-org/skypilot/pull/1539
+# NOTE: do not expanduser() on this path. It's used as a destination path on the
+# remote cluster.
 GCP_CONFIG_PATH = '~/.config/gcloud/configurations/config_default'
 # Do not place the backup under the gcloud config directory, as ray
 # autoscaler can overwrite that directory on the remote nodes.
+# NOTE: do not expanduser() on this path. It's used as a destination path on the
+# remote cluster.
 GCP_CONFIG_SKY_BACKUP_PATH = '~/.sky/.sky_gcp_config_default'
 
 # Minimum set of files under ~/.config/gcloud that grant GCP access.
@@ -48,6 +54,8 @@ _CREDENTIAL_FILES = [
     'active_config',
 ]
 
+# NOTE: do not expanduser() on this path. It's used as a destination path on the
+# remote cluster.
 _GCLOUD_INSTALLATION_LOG = '~/.sky/logs/gcloud_installation.log'
 _GCLOUD_VERSION = '424.0.0'
 # Need to be run with /bin/bash
@@ -705,7 +713,9 @@ class GCP(clouds.Cloud):
         if project_id is None:
             raise exceptions.CloudUserIdentityError(
                 'Failed to get GCP project id. Please make sure you have '
-                'run: gcloud init')
+                'run the following: gcloud init; '
+                'gcloud auth application-default login'
+            )
         return project_id
 
     @staticmethod

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -38,6 +38,6 @@ def print_exception_no_traceback():
         yield
     else:
         original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
-        sys.tracebacklimit = 0
+        # sys.tracebacklimit = 0
         yield
         sys.tracebacklimit = original_tracelimit


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously the `~/.config/gcloud/application_default_credentials.json` was not correctly uploaded due to the expanduser for the constant. To reproduce:

1. `sky launch -c test --cloud gcp --cpus 2`
2. `ssh test`
3. `sky check`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] The reproducible code above.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
