### PR TITLE
[Spot/UX]: Spot dashboard Added delay for ssh_command to initialize

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -33,6 +33,7 @@ import signal
 import subprocess
 import sys
 import textwrap
+import time
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 import webbrowser
@@ -70,7 +71,6 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 from sky.utils.cli_utils import status_utils
 from sky.usage import usage_lib
-import time
 
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
@@ -3719,7 +3719,7 @@ def spot_dashboard(port: Optional[int]):
     click.secho('Checking if spot controller is up...', fg='yellow')
     hint = (
         'Dashboard is not available if spot controller is not up. Run a spot '
-        'job first, or use `sky start` to bring up an existing controller.')
+        'job first.')
     _, handle = spot_lib.is_spot_controller_up(stopped_message=hint,
                                                non_existent_message=hint)
     if handle is None:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3737,7 +3737,7 @@ def spot_dashboard(port: Optional[int]):
 
     with subprocess.Popen(ssh_command, shell=True,
                           start_new_session=True) as ssh_process:
-        time.sleep(5)  # Added delay for ssh_command to initialize.
+        time.sleep(3)  # Added delay for ssh_command to initialize.
         webbrowser.open(f'http://localhost:{free_port}')
         click.secho(
             f'Dashboard is now available at: http://127.0.0.1:{free_port}',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -70,6 +70,7 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 from sky.utils.cli_utils import status_utils
 from sky.usage import usage_lib
+import time
 
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
@@ -3736,6 +3737,7 @@ def spot_dashboard(port: Optional[int]):
 
     with subprocess.Popen(ssh_command, shell=True,
                           start_new_session=True) as ssh_process:
+        time.sleep(5)  # Added delay for ssh_command to initialize.
         webbrowser.open(f'http://localhost:{free_port}')
         click.secho(
             f'Dashboard is now available at: http://127.0.0.1:{free_port}',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Issue: #2123 

User feedback
> Small UX feedback: when I run sky spot dashboard, very often the page that opens first shows some error, and after a few seconds it automatically refreshes and loads. Slightly confusing user experience.

Added a delay between ssh command and webbrowser.open.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
