### PR TITLE
[Spot/UX] Spot dashboard filtering by status

### DIFF
--- a/sky/spot/dashboard/templates/index.html
+++ b/sky/spot/dashboard/templates/index.html
@@ -44,7 +44,32 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
     <script
         src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.33/moment-timezone-with-data.min.js"></script>
-
+    <script>
+        function filterByStatus() {
+            var select, filter, table, tr, td, i;
+            select = document.getElementById("statusFilter");
+            filter = select.value.toUpperCase();
+            table = document.getElementById("spotTable");
+            tr = table.getElementsByTagName("tr");
+            
+            for (i = 1; i < tr.length; i++) {
+                td = tr[i].getElementsByTagName("td")[8];
+                if (td) {
+                    tr[i].style.display = "none";
+                    if (filter === "") {
+                        tr[i].style.display = "";
+                    }
+                    var span = td.getElementsByTagName("span");
+                    if (span) {
+                        var txtValue = span[0].textContent;
+                        if (txtValue.toUpperCase() === filter) {
+                            tr[i].style.display = "";
+                        } 
+                    }
+                }
+            }
+        }
+    </script>
 </head>
 
 <body>
@@ -60,11 +85,28 @@
             </div>
         </header>
 
-        <table class="table table-hover table-hover-selected fixed-header-table">
+        <table class="table table-hover table-hover-selected fixed-header-table" id="spotTable">
             <thead>
                 <tr>
                     {% for column in columns %}
+                    {% if column == "Status" %}
+                    <th>
+                        <select id="statusFilter" onchange="filterByStatus()">
+                            <option value="">All Status</option>
+                            <option value="RUNNING">RUNNING</option>
+                            <option value="PENDING">PENDING</option>
+                            <option value="SUBMITTED">SUBMITTED</option>
+                            <option value="RECOVERING">RECOVERING</option>
+                            <option value="CANCELLING">CANCELLING</option>
+                            <option value="STARTING">STARTING</option>
+                            <option value="SUCCEEDED">SUCCEEDED</option>
+                            <option value="CANCELLED">CANCELLED</option>
+                            <option value="FAILED">FAILED</option>
+                        </select>
+                    </th>
+                    {% else %}
                     <th>{{ column }}</th>
+                    {% endif %}
                     {% endfor %}
                 </tr>
             </thead>

--- a/sky/spot/dashboard/templates/index.html
+++ b/sky/spot/dashboard/templates/index.html
@@ -65,15 +65,15 @@
                     {% for column in columns %}
                     {% if column == "Status" %}
                     <th>
-                        <select id="statusFilter" onchange="filterByStatus(this)">
+                        <select id="statusFilter" onchange="filterByStatus(this.value)">
                             <option value="">All Status</option>
-                            <option value="RUNNING">RUNNING</option>
-                            <option value="PENDING">PENDING</option>
                             <option value="SUBMITTED">SUBMITTED</option>
-                            <option value="RECOVERING">RECOVERING</option>
-                            <option value="CANCELLING">CANCELLING</option>
+                            <option value="PENDING">PENDING</option>
                             <option value="STARTING">STARTING</option>
+                            <option value="RUNNING">RUNNING</option>
+                            <option value="RECOVERING">RECOVERING</option>
                             <option value="SUCCEEDED">SUCCEEDED</option>
+                            <option value="CANCELLING">CANCELLING</option>
                             <option value="CANCELLED">CANCELLED</option>
                             <option value="FAILED">FAILED</option>
                         </select>
@@ -158,28 +158,25 @@
         handleAutoRefresh();
     </script>
     <script>
-        function filterByStatus(select) {
-            var filter, table, tr, td, i;
-            filter = select.value.toUpperCase();
-            table = document.getElementById("spotTable");
-            tr = table.getElementsByTagName("tr");
+        function filterByStatus(status) {
+            var table = document.getElementById("spotTable");
+            var rows = table.getElementsByTagName("tr");
             
-            for (i = 1; i < tr.length; i++) {
-                td = tr[i].getElementsByTagName("td")[8];
-                if (td) {
-                    tr[i].style.display = "none";
-                    if (filter === "") {
-                        tr[i].style.display = "";
+            for (row of rows) {
+                var statusCell = row.getElementsByTagName("td")[8];
+                if (statusCell) {
+                    row.style.display = "none";
+                    if (status === "") {
+                        row.style.display = "";
                     }
-                    var span = td.getElementsByTagName("span");
+                    var span = statusCell.getElementsByTagName("span");
                     if (span) {
-                        var txtValue = span[0].textContent;
-                        if (txtValue.toUpperCase() === filter) {
-                            tr[i].style.display = "";
+                        if (span[0].textContent === status) {
+                            row.style.display = "";
                         } 
                     }
                 }
-            }
+            };
         }
     </script>
 </body>

--- a/sky/spot/dashboard/templates/index.html
+++ b/sky/spot/dashboard/templates/index.html
@@ -44,32 +44,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
     <script
         src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.33/moment-timezone-with-data.min.js"></script>
-    <script>
-        function filterByStatus() {
-            var select, filter, table, tr, td, i;
-            select = document.getElementById("statusFilter");
-            filter = select.value.toUpperCase();
-            table = document.getElementById("spotTable");
-            tr = table.getElementsByTagName("tr");
-            
-            for (i = 1; i < tr.length; i++) {
-                td = tr[i].getElementsByTagName("td")[8];
-                if (td) {
-                    tr[i].style.display = "none";
-                    if (filter === "") {
-                        tr[i].style.display = "";
-                    }
-                    var span = td.getElementsByTagName("span");
-                    if (span) {
-                        var txtValue = span[0].textContent;
-                        if (txtValue.toUpperCase() === filter) {
-                            tr[i].style.display = "";
-                        } 
-                    }
-                }
-            }
-        }
-    </script>
 </head>
 
 <body>
@@ -91,7 +65,7 @@
                     {% for column in columns %}
                     {% if column == "Status" %}
                     <th>
-                        <select id="statusFilter" onchange="filterByStatus()">
+                        <select id="statusFilter" onchange="filterByStatus(this)">
                             <option value="">All Status</option>
                             <option value="RUNNING">RUNNING</option>
                             <option value="PENDING">PENDING</option>
@@ -184,20 +158,30 @@
         handleAutoRefresh();
     </script>
     <script>
-        function filterStatus(status) {
-            var rows = document.querySelectorAll("#spot-jobs-table tbody tr");
-            rows.forEach(function (row) {
-                var statusCell = row.querySelector("td:nth-child(9)");
-
-                if (status === '' || statusCell.textContent === status) {
-                    row.style.display = "";
-                } else {
-                    row.style.display = "none";
+        function filterByStatus(select) {
+            var filter, table, tr, td, i;
+            filter = select.value.toUpperCase();
+            table = document.getElementById("spotTable");
+            tr = table.getElementsByTagName("tr");
+            
+            for (i = 1; i < tr.length; i++) {
+                td = tr[i].getElementsByTagName("td")[8];
+                if (td) {
+                    tr[i].style.display = "none";
+                    if (filter === "") {
+                        tr[i].style.display = "";
+                    }
+                    var span = td.getElementsByTagName("span");
+                    if (span) {
+                        var txtValue = span[0].textContent;
+                        if (txtValue.toUpperCase() === filter) {
+                            tr[i].style.display = "";
+                        } 
+                    }
                 }
-            });
+            }
         }
     </script>
-
 </body>
 
 </html>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
#2107. Added a simple dropdown for filtering rows by status

<img width="488" alt="image" src="https://github.com/skypilot-org/skypilot/assets/63817381/12be29aa-9817-4311-833e-dfe26da97ca2">

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
