### PR TITLE
Docs: add a "Scaling out" hint to Quickstart.

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -165,8 +165,26 @@ Stop/terminate a cluster
 =========================
 
 When you are done, run :code:`sky stop mycluster` to stop the cluster. To
-terminate a cluster instead, run :code:`sky down mycluster`.  Find more commands that
-manage the lifecycle of clusters :ref:`here <interactive-nodes>`.
+terminate a cluster instead, run :code:`sky down mycluster`.
+
+Find more commands that manage the lifecycle of clusters in the :ref:`CLI reference <cli>`.
+
+Scaling out
+=========================
+
+So far, we have used the `serverful` CLIs of SkyPilot, where the notion of clusters is central.
+This is useful for development since it is convenient to log into a cluster and perform debugging.
+
+When you are ready to scale out (e.g., run 10s or 100s of jobs), SkyPilot supports two options:
+
+- Queue jobs on a cluster (see :ref:`Job Queue <job-queue>`); or
+- Use :ref:`Managed Spot Jobs <spot-jobs>`, which is a `serverless` style API where clusters are not directly exposed.
+
+Managed spot jobs run on much cheaper spot instances, with automatic preemption recovery. Try it out with:
+
+.. code-block:: console
+
+  $ sky spot launch hello_sky.yaml
 
 Next steps
 -----------
@@ -178,5 +196,5 @@ Next steps:
 - Adapt :ref:`Tutorial: DNN Training <dnn-training>` to start running your own project on SkyPilot!
 - See the :ref:`Task YAML reference <yaml-spec>`, :ref:`CLI reference <cli>`, and `more examples <https://github.com/skypilot-org/skypilot/tree/master/examples>`_
 - To learn more, try out `SkyPilot Tutorials <https://github.com/skypilot-org/skypilot-tutorial>`_ in Jupyter notebooks
-- Try :ref:`Interactive Nodes <interactive-nodes>` -- launch VMs in one command without a YAML file
-- Explore SkyPilot's unique features in the rest of the documentation
+
+We invite you to explore SkyPilot's unique features in the rest of the documentation.

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -172,13 +172,12 @@ Find more commands that manage the lifecycle of clusters in the :ref:`CLI refere
 Scaling out
 =========================
 
-So far, we have used the `serverful` CLIs of SkyPilot, where the notion of clusters is central.
-This is useful for development since it is convenient to log into a cluster and perform debugging.
-
+So far, we have used SkyPilot's CLI to submit work to and interact with a single cluster.
 When you are ready to scale out (e.g., run 10s or 100s of jobs), SkyPilot supports two options:
 
-- Queue jobs on a cluster (see :ref:`Job Queue <job-queue>`); or
-- Use :ref:`Managed Spot Jobs <spot-jobs>`, which is a `serverless` style API where clusters are not directly exposed.
+- Queue jobs on one or more clusters with ``sky exec`` (see :ref:`Job Queue <job-queue>`); or
+- Use :ref:`Managed Spot Jobs <spot-jobs>` to run on auto-managed spot instances
+  (users need not interact with the underlying clusters)
 
 Managed spot jobs run on much cheaper spot instances, with automatic preemption recovery. Try it out with:
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2911,6 +2911,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     f'{backend_utils.RESET_BOLD}'
                     '\nTo view all spot jobs:\t\t'
                     f'{backend_utils.BOLD}sky spot queue'
+                    f'{backend_utils.RESET_BOLD}'
+                    '\nTo view the spot job dashboard:\t'
+                    f'{backend_utils.BOLD}sky spot dashboard'
                     f'{backend_utils.RESET_BOLD}')
             else:
                 logger.info(f'{fore.CYAN}Job ID: '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Motivation: Current Quickstart does not give any pointers on how to go from the simple 1-task example to a more advanced scaling-out mode, which is where SkyPilot shines.

This PR adds a small section there as a hint rather than a complete guide.   I think it's important to give some impression right at Quickstart that we can do it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): rendered
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
