### PR TITLE
[Spot, doc] Update transformer repository version from bert_qa example

### DIFF
--- a/docs/source/examples/spot-jobs.rst
+++ b/docs/source/examples/spot-jobs.rst
@@ -47,7 +47,7 @@ We can launch it with the following:
 
   # Assume your working directory is under `~/transformers`.
   # To make this example work, please run the following command:
-  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
+  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.30.1
   workdir: ~/transformers
 
   setup: |
@@ -122,7 +122,7 @@ Below we show an `example <https://github.com/skypilot-org/skypilot/blob/master/
 
   # Assume your working directory is under `~/transformers`.
   # To make this example work, please run the following command:
-  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
+  # git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.30.1
   workdir: ~/transformers
 
   file_mounts:

--- a/examples/spot/bert_qa.yaml
+++ b/examples/spot/bert_qa.yaml
@@ -5,7 +5,7 @@ resources:
 
 # Assume your working directory is under `~/transformers`.
 # To make this example work, please run the following command:
-# git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
+# git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.30.1
 workdir: ~/transformers
 
 file_mounts:

--- a/examples/spot_pipeline/bert_qa_train_eval.yaml
+++ b/examples/spot_pipeline/bert_qa_train_eval.yaml
@@ -9,7 +9,7 @@ resources:
 
 # Assume your working directory is under `~/transformers`.
 # To make this example work, please run the following command:
-# git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.18.0
+# git clone https://github.com/huggingface/transformers.git ~/transformers -b v4.30.1
 workdir: ~/transformers
 
 file_mounts:


### PR DESCRIPTION
This PR resolves #2127 

Currently, bert_qa example uses v4.18.0 [transformer repository](https://github.com/huggingface/transformers) from Huggingface. And this version contains a symlink that is dangling. The symlink set for directory transformers/examples/legacy/seq2seq/test_data/test_data does not exist in v4.18.0. This corrupted symlink was [recently fixed](https://github.com/huggingface/transformers/pull/22876). Hence, I'm updating the example doc to inform users to `git clone` the recent version, v4.30.1, of the transformer repo.
 
v4.18.0 will not have an issue when using S3 storage to store `workdir`, since `aws s3 sync` ignores such courrpted symlink and moves on with syncing. But the user with error in #2127 has set GCS to be the `workdir` storage, and `gsutil rsync -r` does not ignore corrupted symlink and fails the command.


Tested (run the relevant ones):
- [x] Test workdir sync with newest version of transformer repo