### PR TITLE
API/YAML: Support using env vars to define file_mounts.

### DIFF
--- a/examples/using_file_mounts_with_env_vars.yaml
+++ b/examples/using_file_mounts_with_env_vars.yaml
@@ -5,12 +5,15 @@
 envs:
   MY_BUCKET: skypilot-temp-gcs-test
   MY_LOCAL_PATH: tmp-workdir
+  MODEL_SIZE: 13b
 
 resources:
   cloud: gcp
 
-# Use env vars in the "name" (bucket name) and "source" (local dir/file to
-# upload) fields.
+# You can use env vars in
+#   - the destination: source paths
+#   - for SkyPilot Storage
+#     - the "name" (bucket name) and "source" (local dir/file to upload) fields.
 #
 # Both syntaxes work: ${MY_BUCKET} and $MY_BUCKET.
 file_mounts:
@@ -36,6 +39,8 @@ file_mounts:
     store: gcs
     mode: MOUNT
 
+  /checkpoint/${MODEL_SIZE}: ~/${MY_LOCAL_PATH}
+
 run: |
   echo Env var MY_BUCKET has value: ${MY_BUCKET}
   echo Env var MY_LOCAL_PATH has value: ${MY_LOCAL_PATH}
@@ -44,3 +49,4 @@ run: |
   ls -lthr /mydir2
   ls -lthr /another-dir
   ls -lthr /another-dir2
+  ls -lthr /checkpoint/${MODEL_SIZE}

--- a/examples/using_file_mounts_with_env_vars.yaml
+++ b/examples/using_file_mounts_with_env_vars.yaml
@@ -1,0 +1,46 @@
+# Example showcasing how env vars can be used in the file_mounts section.
+
+# You can set the default values for env vars in this 'envs' section.
+# When launching, `sky launch --env ENV=val` will override the default.
+envs:
+  MY_BUCKET: skypilot-temp-gcs-test
+  MY_LOCAL_PATH: tmp-workdir
+
+resources:
+  cloud: gcp
+
+# Use env vars in the "name" (bucket name) and "source" (local dir/file to
+# upload) fields.
+#
+# Both syntaxes work: ${MY_BUCKET} and $MY_BUCKET.
+file_mounts:
+  /mydir:
+    name: ${MY_BUCKET}  # Name of the bucket.
+    store: gcs
+    mode: MOUNT
+
+  /mydir2:
+    name: $MY_BUCKET  # Name of the bucket.
+    store: gcs
+    mode: MOUNT
+
+  /another-dir:
+    name: ${MY_BUCKET}-2
+    source: ["~/${MY_LOCAL_PATH}"]
+    store: gcs
+    mode: MOUNT
+
+  /another-dir2:
+    name: $MY_BUCKET-2
+    source: ["~/${MY_LOCAL_PATH}"]
+    store: gcs
+    mode: MOUNT
+
+run: |
+  echo Env var MY_BUCKET has value: ${MY_BUCKET}
+  echo Env var MY_LOCAL_PATH has value: ${MY_LOCAL_PATH}
+
+  ls -lthr /mydir
+  ls -lthr /mydir2
+  ls -lthr /another-dir
+  ls -lthr /another-dir2

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -622,7 +622,7 @@ class GCP(clouds.Cloud):
         # be modified on the remote cluster by ray causing authentication
         # problems. The backup file will be updated to the remote cluster
         # whenever the original file is not empty and will be applied
-        # appropriately on the remote cluster when neccessary.
+        # appropriately on the remote cluster when necessary.
         if (os.path.exists(os.path.expanduser(GCP_CONFIG_PATH)) and
                 os.path.getsize(os.path.expanduser(GCP_CONFIG_PATH)) > 0):
             subprocess.run(f'cp {GCP_CONFIG_PATH} {GCP_CONFIG_SKY_BACKUP_PATH}',

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1321,11 +1321,10 @@ class GcsStore(AbstractStore):
         if not _is_storage_cloud_enabled(str(clouds.GCP())):
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
-                    'Storage \'store: gcs\' specified, but ' \
-                    'GCP access is disabled. To fix, enable '\
-                    'GCP by running `sky check`. '\
-                    'More info: https://skypilot.readthedocs.io/en/latest/getting-started/installation.html.' # pylint: disable=line-too-long
-                    )
+                    'Storage \'store: gcs\' specified, but '
+                    'GCP access is disabled. To fix, enable '
+                    'GCP by running `sky check`. '
+                    'More info: https://skypilot.readthedocs.io/en/latest/getting-started/installation.html.')  # pylint: disable=line-too-long
 
     @classmethod
     def validate_name(cls, name) -> str:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -337,6 +337,7 @@ def _execute(
                 backend.sync_workdir(handle, task.workdir)
 
         if Stage.SYNC_FILE_MOUNTS in stages:
+            task.fill_env_vars_in_storage_mounts()
             backend.sync_file_mounts(handle, task.file_mounts,
                                      task.storage_mounts)
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -337,7 +337,6 @@ def _execute(
                 backend.sync_workdir(handle, task.workdir)
 
         if Stage.SYNC_FILE_MOUNTS in stages:
-            task.fill_env_vars_in_storage_mounts()
             backend.sync_file_mounts(handle, task.file_mounts,
                                      task.storage_mounts)
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -282,6 +282,13 @@ class Task:
             new_envs = config.get('envs', {})
             new_envs.update(env_overrides)
             config['envs'] = new_envs
+        # More robust handling for 'envs': explicitly convert keys and values to
+        # str, since users may pass '123' as values which will get parsed as
+        # int causing validate_schema() to fail.
+        if config.get('envs', None) is not None:
+            config['envs'] = {
+                str(k): str(v) for k, v in config['envs'].items()
+            }
 
         backend_utils.validate_schema(config, schemas.get_task_schema(),
                                       'Invalid task YAML: ')

--- a/sky/task.py
+++ b/sky/task.py
@@ -288,11 +288,9 @@ class Task:
 
         # Fill in any Task.envs into file_mounts (src/dst paths, storage
         # name/source).
-        print(config['file_mounts'])
         if config.get('file_mounts') is not None:
             config['file_mounts'] = _fill_in_env_vars_in_file_mounts(
                 config['file_mounts'], config.get('envs', {}))
-        print('after\n', config['file_mounts'])
 
         task = Task(
             config.pop('name', None),
@@ -330,11 +328,7 @@ class Task:
             mount_path = storage[0]
             assert mount_path, 'Storage mount path cannot be empty.'
             try:
-                # storage_config = _fill_in_env_vars_in_storage_config(
-                #     storage[1], task.envs)
-                storage_config = storage[1]
-                storage_obj = storage_lib.Storage.from_yaml_config(
-                    storage_config)
+                storage_obj = storage_lib.Storage.from_yaml_config(storage[1])
             except exceptions.StorageSourceError as e:
                 # Patch the error message to include the mount path, if included
                 e.args = (e.args[0].replace('<destination_path>',

--- a/sky/task.py
+++ b/sky/task.py
@@ -73,8 +73,8 @@ def _fill_in_env_vars_in_storage_config(
                                                         str]) -> Dict[str, Any]:
     """Detects env vars in storage_config and fills them with task.envs.
 
-    This func tries to replace two fields  in storage_config: 'source'
-    and 'name'.
+    This func tries to replace two fields in storage_config: 'source' and
+    'name'.
 
     Env vars of the following forms are detected:
         - ${ENV}

--- a/sky/task.py
+++ b/sky/task.py
@@ -91,10 +91,15 @@ def _fill_in_env_vars_in_file_mounts(
     """
     # TODO(zongheng): support ${ENV:-default}?
     file_mounts_str = json.dumps(file_mounts)
-    for key, value in task_envs.items():
-        pattern = r'\$\{?\b' + key + r'\b\}?'
-        env_var_pattern = re.compile(pattern)
-        file_mounts_str = env_var_pattern.sub(value, file_mounts_str)
+
+    def replace_var(match):
+        var_name = match.group(1)
+        # If the variable isn't in the dictionary, return it unchanged
+        return task_envs.get(var_name, match.group(0))
+
+    # Pattern for valid env var names in bash.
+    pattern = r'\$\{?\b([a-zA-Z_][a-zA-Z0-9_]*)\b\}?'
+    file_mounts_str = re.sub(pattern, replace_var, file_mounts_str)
     return json.loads(file_mounts_str)
 
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -182,7 +182,11 @@ def read_yaml(path) -> Dict[str, Any]:
 def read_yaml_all(path: str) -> List[Dict[str, Any]]:
     with open(path, 'r') as f:
         config = yaml.safe_load_all(f)
-        return list(config)
+        configs = list(config)
+        if not configs:
+            # Empty YAML file.
+            return [{}]
+        return configs
 
 
 def dump_yaml(path, config) -> None:

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -16,7 +16,8 @@ def load_chain_dag_from_yaml(
     Has special handling for an initial section in YAML that contains only the
     'name' field, which is the DAG name.
 
-    Returns: a chain Dag with 0 or more tasks.
+    Returns: a chain Dag with 1 or more tasks (an empty entrypoint would create
+      a trivial task).
     """
     configs = common_utils.read_yaml_all(path)
     dag_name = None

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -16,8 +16,13 @@ def load_chain_dag_from_yaml(
     Has special handling for an initial section in YAML that contains only the
     'name' field, which is the DAG name.
 
-    Returns: a chain Dag with 1 or more tasks (an empty entrypoint would create
-      a trivial task).
+    'env_overrides' is in effect only when there's exactly one task. It is a
+    list of (key, value) pairs that will be used to update the task's 'envs'
+    section.
+
+    Returns:
+      A chain Dag with 1 or more tasks (an empty entrypoint would create a
+      trivial task).
     """
     configs = common_utils.read_yaml_all(path)
     dag_name = None
@@ -30,6 +35,12 @@ def load_chain_dag_from_yaml(
     if len(configs) == 0:
         # YAML has only `name: xxx`. Still instantiate a task.
         configs = [{'name': dag_name}]
+
+    if len(configs) > 1:
+        # TODO(zongheng): in a chain DAG of N tasks, cli.py currently makes the
+        # decision to not apply overrides. Here we maintain this behavior. We
+        # can listen to user feedback to change this.
+        env_overrides = None
 
     current_task = None
     with dag_lib.Dag() as dag:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -170,7 +170,13 @@ def get_task_schema():
             'envs': {
                 'type': 'object',
                 'required': [],
-                'additionalProperties': True,
+                'patternProperties': {
+                    # Checks env keys are valid env var names.
+                    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+                        "type": "string"
+                    }
+                },
+                'additionalProperties': False,
             },
             # inputs and outputs are experimental
             'inputs': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -172,8 +172,8 @@ def get_task_schema():
                 'required': [],
                 'patternProperties': {
                     # Checks env keys are valid env var names.
-                    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
-                        "type": "string"
+                    '^[a-zA-Z_][a-zA-Z0-9_]*$': {
+                        'type': 'string'
                     }
                 },
                 'additionalProperties': False,

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -9,31 +9,38 @@ from sky import clouds
 from sky import exceptions
 
 
-def _test_parse_cpus(spec, expected_cpus):
+def _test_parse_task_yaml(spec: str, test_fn):
+    """Tests parsing a task from a YAML spec and running a test_fn."""
     with tempfile.NamedTemporaryFile('w') as f:
         f.write(spec)
         f.flush()
         with sky.Dag():
             task = sky.Task.from_yaml(f.name)
-            assert list(task.resources)[0].cpus == expected_cpus
+            test_fn(task)
+
+
+def _test_parse_cpus(spec, expected_cpus):
+
+    def test_fn(task):
+        assert list(task.resources)[0].cpus == expected_cpus
+
+    _test_parse_task_yaml(spec, test_fn)
 
 
 def _test_parse_memory(spec, expected_memory):
-    with tempfile.NamedTemporaryFile('w') as f:
-        f.write(spec)
-        f.flush()
-        with sky.Dag():
-            task = sky.Task.from_yaml(f.name)
-            assert list(task.resources)[0].memory == expected_memory
+
+    def test_fn(task):
+        assert list(task.resources)[0].memory == expected_memory
+
+    _test_parse_task_yaml(spec, test_fn)
 
 
 def _test_parse_accelerators(spec, expected_accelerators):
-    with tempfile.NamedTemporaryFile('w') as f:
-        f.write(spec)
-        f.flush()
-        with sky.Dag():
-            task = sky.Task.from_yaml(f.name)
-            assert list(task.resources)[0].accelerators == expected_accelerators
+
+    def test_fn(task):
+        assert list(task.resources)[0].accelerators == expected_accelerators
+
+    _test_parse_task_yaml(spec, test_fn)
 
 
 # Monkey-patching is required because in the test environment, no cloud is
@@ -547,3 +554,24 @@ def test_invalid_num_nodes():
                 task = sky.Task()
                 task.num_nodes = invalid_value
             assert 'num_nodes should be a positive int' in str(e.value)
+
+
+def test_parse_empty_yaml():
+    spec = textwrap.dedent("""\
+        """)
+
+    def test_fn(task):
+        assert task.to_yaml_config == {}
+
+    _test_parse_task_yaml(spec, test_fn)
+
+
+def test_parse_name_only_yaml():
+    spec = textwrap.dedent("""\
+        name: test_task
+        """)
+
+    def test_fn(task):
+        assert task.name == 'test_task'
+
+    _test_parse_task_yaml(spec, test_fn)

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -561,7 +561,7 @@ def test_parse_empty_yaml():
         """)
 
     def test_fn(task):
-        assert task.to_yaml_config == {}
+        assert task.num_nodes == 1
 
     _test_parse_task_yaml(spec, test_fn)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,7 +4,7 @@
 # Run all tests except for AWS and Lambda Cloud
 # > pytest tests/test_smoke.py
 #
-# Terminate failed clusetrs after test finishes
+# Terminate failed clusters after test finishes
 # > pytest tests/test_smoke.py --terminate-on-failure
 #
 # Re-run last failed tests

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -738,6 +738,28 @@ def test_scp_file_mounts():
     run_one_test(test)
 
 
+def test_using_file_mounts_with_env_vars(generic_cloud: str):
+    name = _get_cluster_name()
+    test_commands = [
+        *storage_setup_commands,
+        (f'sky launch -y -c {name} --cpus 2+ --cloud {generic_cloud} '
+         'examples/using_file_mounts_with_env_vars.yaml'),
+        f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+        # Override with --env:
+        (f'sky launch -y -c {name}-2 --cpus 2+ --cloud {generic_cloud} '
+         'examples/using_file_mounts_with_env_vars.yaml '
+         '--env MY_LOCAL_PATH=tmpfile'),
+        f'sky logs {name}-2 1 --status',  # Ensure the job succeeded.
+    ]
+    test = Test(
+        'using_file_mounts_with_env_vars',
+        test_commands,
+        f'sky down -y {name} {name}-2',
+        timeout=20 * 60,  # 20 mins
+    )
+    run_one_test(test)
+
+
 # ---------- storage ----------
 @pytest.mark.aws
 def test_aws_storage_mounts():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```
# Use env vars in the "name" (bucket name) and "source" (local dir/file to
# upload) fields.
#
# Both syntaxes work: ${MY_BUCKET} and $MY_BUCKET.
file_mounts:
  /mydir:
    name: ${MY_BUCKET}  # Name of the bucket.
    store: gcs
    mode: MOUNT

  /another-dir:
    name: ${MY_BUCKET}-2
    source: ["~/${MY_LOCAL_PATH}"]
    store: gcs
    mode: MOUNT
```
Overriding with `sky launch --env` works too.

Also fixes `sky launch` parsing errors: 
- Do not load YAML twice (which creates storage twice)
- Properly load empty / name-only YAMLs

Fixes #2093.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `pytest tests/test_smoke.py::test_using_file_mounts_with_env_vars`
  - `pytest tests/test_optimizer_dryruns.py`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
