### PR TITLE
[Catalog/Azure] Add westus3 to the fetcher

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -171,7 +171,7 @@ class Azure(clouds.Cloud):
             instance_type, use_spot, 'azure')
 
         if region is not None:
-            regions = [r for r in regions if r.name == region]
+            regions = [r for r in regions if r.name.lower() == region.lower()]
         return regions
 
     @classmethod

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -171,7 +171,7 @@ class Azure(clouds.Cloud):
             instance_type, use_spot, 'azure')
 
         if region is not None:
-            regions = [r for r in regions if r.name.lower() == region.lower()]
+            regions = [r for r in regions if r.name == region]
         return regions
 
     @classmethod

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -11,7 +11,14 @@ from sky.clouds import Azure
 from sky.clouds.service_catalog import common
 from sky.utils import ux_utils
 
-_df = common.read_catalog('azure/vms.csv')
+# The frequency of pulling the latest catalog from the cloud provider.
+# Though the catalog update is manual in our skypilot-catalog repo, we
+# still want to pull the latest catalog periodically to make sure the
+# user is using the latest catalog.
+_PULL_FREQUENCY_HOURS = 7
+
+_df = common.read_catalog('azure/vms.csv',
+                          pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 
 # We will select from the following three instance families:
 _DEFAULT_INSTANCE_FAMILY = [

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -200,6 +200,7 @@ def validate_region_zone_impl(
                     raise ValueError(error_msg)
                 error_msg += candidate_strs
                 raise ValueError(error_msg)
+        validated_region = filter_df['Region'].unique()[0]
 
     if zone is not None:
         maybe_region_df = filter_df

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -469,8 +469,8 @@ def list_accelerators_impl(
                                                    regex=True)]
     if region_filter is not None:
         df = df[df['Region'].str.contains(region_filter,
-                                                  case=case_sensitive,
-                                                  regex=True)]
+                                          case=case_sensitive,
+                                          regex=True)]
     df['AcceleratorCount'] = df['AcceleratorCount'].astype(int)
     if quantity_filter is not None:
         df = df[df['AcceleratorCount'] == quantity_filter]

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -164,7 +164,7 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
     df['merge_name'] = df['armSkuName']
     # Use lower case for the Region, as for westus3, the SKU API returns WestUS3.
     # This is inconsistent with the region name used in the pricing API, and
-    # keeping the case does not 
+    # keeping the case does not
     df['Region'] = df['armRegionName'].str.lower()
     df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
     df.rename(columns={
@@ -177,10 +177,8 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
         'is_promo', 'InstanceType', 'Region', 'unitPrice'
     ]]
 
-    demand_df.set_index(['InstanceType', 'Region', 'is_promo'],
-                        inplace=True)
-    spot_df.set_index(['InstanceType', 'Region', 'is_promo'],
-                      inplace=True)
+    demand_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
+    spot_df.set_index(['InstanceType', 'Region', 'is_promo'], inplace=True)
 
     demand_df = demand_df.rename(columns={'unitPrice': 'Price'})
     spot_df = spot_df.rename(columns={'unitPrice': 'SpotPrice'})

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -162,9 +162,11 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
 
     print('Getting price df')
     df['merge_name'] = df['armSkuName']
-    # Use lower case for the Region, as for westus3, the SKU API returns WestUS3.
+    # Use lower case for the Region, as for westus3, the SKU API returns 
+    # WestUS3.
     # This is inconsistent with the region name used in the pricing API, and
-    # keeping the case does not
+    # the case does not matter for launching instances, so we can safely
+    # discard the case.
     df['Region'] = df['armRegionName'].str.lower()
     df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
     df.rename(columns={

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -23,7 +23,7 @@ US_REGIONS = [
     'westcentralus',
     'westus',
     'westus2',
-    # 'WestUS3',   # WestUS3 pricing table is broken as of 2021/11.
+    'westus3',
 ]
 
 # Exclude the following regions as they do not have ProductName in the
@@ -101,7 +101,7 @@ def get_sku_df(region_set: Set[str]) -> pd.DataFrame:
     print('Fetching SKU list')
     # To get a complete list, --all option is necessary.
     proc = subprocess.run(
-        'az vm list-skus --all',
+        'az vm list-skus --all --resource-type virtualMachines -o json',
         shell=True,
         check=True,
         stdout=subprocess.PIPE,
@@ -112,13 +112,12 @@ def get_sku_df(region_set: Set[str]) -> pd.DataFrame:
     for item in items:
         # zones = item['locationInfo'][0]['zones']
         region = item['locations'][0]
-        if region not in region_set:
+        if region.lower() not in region_set:
             continue
         item['Region'] = region
         filtered_items.append(item)
 
     df = pd.DataFrame(filtered_items)
-    df = df[(df['resourceType'] == 'virtualMachines')]
     return df
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -166,8 +166,7 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
     df['is_promo'] = df['skuName'].str.endswith(' Low Priority')
     df.rename(columns={
         'armSkuName': 'InstanceType',
-    },
-              inplace=True)
+    }, inplace=True)
     demand_df = df[~df['skuName'].str.contains(' Spot')][[
         'is_promo', 'InstanceType', 'merge_region', 'unitPrice'
     ]]
@@ -175,8 +174,10 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
         'is_promo', 'InstanceType', 'merge_region', 'unitPrice'
     ]]
 
-    demand_df.set_index(['InstanceType', 'merge_region', 'is_promo'], inplace=True)
-    spot_df.set_index(['InstanceType', 'merge_region', 'is_promo'], inplace=True)
+    demand_df.set_index(['InstanceType', 'merge_region', 'is_promo'],
+                        inplace=True)
+    spot_df.set_index(['InstanceType', 'merge_region', 'is_promo'],
+                      inplace=True)
 
     demand_df = demand_df.rename(columns={'unitPrice': 'Price'})
     print(demand_df)
@@ -193,7 +194,9 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
     df = df_sku.join(demand_df,
                      on=['merge_name', 'merge_region', 'is_promo'],
                      how='left')
-    df = df.join(spot_df, on=['merge_name', 'merge_region', 'is_promo'], how='left')
+    df = df.join(spot_df,
+                 on=['merge_name', 'merge_region', 'is_promo'],
+                 how='left')
 
     def get_capabilities(row):
         gpu_name = None

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -162,7 +162,7 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
 
     print('Getting price df')
     df['merge_name'] = df['armSkuName']
-    # Use lower case for the Region, as for westus3, the SKU API returns 
+    # Use lower case for the Region, as for westus3, the SKU API returns
     # WestUS3.
     # This is inconsistent with the region name used in the pricing API, and
     # the case does not matter for launching instances, so we can safely

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -183,7 +183,6 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
                       inplace=True)
 
     demand_df = demand_df.rename(columns={'unitPrice': 'Price'})
-    print(demand_df)
     spot_df = spot_df.rename(columns={'unitPrice': 'SpotPrice'})
 
     print('Getting sku df')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2148

Related to https://github.com/skypilot-org/skypilot-catalog/pull/37


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_azure `
  - [x] `sky show-gpus --cloud azure --region westus3`
  - [x] `sky launch --cloud azure --region westus3`
  - [x] `sky launch --cloud azure --region WestUS3`
  - [x] `sky launch --cloud azure`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
