### PR TITLE
[Spot] Fix the handling for `spot_recovery: none`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1063,10 +1063,7 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
 
     # Spot launch specific.
     if spot_recovery is not None:
-        if spot_recovery.lower() == 'none':
-            override_params['spot_recovery'] = None
-        else:
-            override_params['spot_recovery'] = spot_recovery
+        override_params['spot_recovery'] = spot_recovery
 
     assert len(task.resources) == 1
     old_resources = list(task.resources)[0]

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -128,7 +128,8 @@ class Resources:
         self._use_spot = use_spot if use_spot is not None else False
         self._spot_recovery = None
         if spot_recovery is not None:
-            self._spot_recovery = spot_recovery.upper()
+            if spot_recovery.strip().lower() != 'none':
+                self._spot_recovery = spot_recovery.upper()
 
         if disk_size is not None:
             if round(disk_size) != disk_size:
@@ -966,10 +967,7 @@ class Resources:
         if config.get('use_spot') is not None:
             resources_fields['use_spot'] = config.pop('use_spot')
         if config.get('spot_recovery') is not None:
-            spot_recovery = config.pop('spot_recovery')
-            if spot_recovery.strip().lower() == 'none':
-                spot_recovery = None
-            resources_fields['spot_recovery'] = spot_recovery
+            resources_fields['spot_recovery'] = config.pop('spot_recovery')
         if config.get('disk_size') is not None:
             resources_fields['disk_size'] = int(config.pop('disk_size'))
         if config.get('region') is not None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -966,7 +966,10 @@ class Resources:
         if config.get('use_spot') is not None:
             resources_fields['use_spot'] = config.pop('use_spot')
         if config.get('spot_recovery') is not None:
-            resources_fields['spot_recovery'] = config.pop('spot_recovery')
+            spot_recovery = config.pop('spot_recovery')
+            if spot_recovery.strip().lower() == 'none':
+                spot_recovery = None
+            resources_fields['spot_recovery'] = spot_recovery
         if config.get('disk_size') is not None:
             resources_fields['disk_size'] = int(config.pop('disk_size'))
         if config.get('region') is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when `spot_recovery: none` is provided in the task.yaml, `sky launch task.yaml` will raise the following error, which is unexpected:
```
Task from YAML spec: test.yaml
ValueError: Spot recovery strategy NONE is not supported. The strategy should be among ['FAILOVER']
```

This PR, makes it go through the check when the `spot_recovery: none` is provided.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test task.yaml` with `spot_recovery: none` provided.
  - [x] `sky spot launch --spot-recovery none task.yaml` should automatically set the `spot_recovery` to the default one.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
