### PR TITLE
Fix redundant task creation that leads to redundant attempt to create storage

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1052,7 +1052,7 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
                     'since the yaml file contains multiple tasks.',
                     fg='yellow')
             return dag
-        task = sky.Task.from_yaml(entrypoint)
+        task = dag.tasks[0]
     else:
         task = sky.Task(name='sky-cmd', run=entrypoint)
         task.set_resources({sky.Resources()})


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR closes #2128 

Currently, when non-pipeline Task yaml is submitted, `_make_task_or_dag_from_entrypoint_with_overrides` runs `Task.from_yaml_config()` twice from `dag_utils.load_chain_dag_from_yaml()` and `sky.Task.from_yaml(entrypoint)`. This results to an attempt to create the storages defined in the yaml twice. This fix replaces the call to `Task.from_yaml` with `dag.tasks[0]` to eliminate the redundant function call.


Tested (run the relevant ones):
- [x] Manual test sky launch task.yaml, which has storages defined
- [x] pytest tests/test_smoke.py::TestStorageWithCredentials