### PR TITLE
[Dependency] Limit pydantic version

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -110,6 +110,8 @@ install_requires = [
     'protobuf >= 3.15.3, != 3.19.5',
     'psutil',
     'pulp',
+    # Ray has an issue with pydantic>2.0.0. See
+    # https://github.com/ray-project/ray/issues/36990
     'pydantic<2.0'
 ]
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -110,7 +110,7 @@ install_requires = [
     'protobuf >= 3.15.3, != 3.19.5',
     'psutil',
     'pulp',
-    # Ray has an issue with pydantic>2.0.0. See
+    # Ray job has an issue with pydantic>2.0.0, due to API changes of pydantic. See
     # https://github.com/ray-project/ray/issues/36990
     'pydantic<2.0'
 ]

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -110,6 +110,7 @@ install_requires = [
     'protobuf >= 3.15.3, != 3.19.5',
     'psutil',
     'pulp',
+    'pydantic<2.0'
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The recent release of pydantic 2.0 is not compatible with ray's job API, causing all our job management failed.

To reproduce:
```
sky launch -c test --cpus 2 echo hi
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [ ] `sky launch -c test --cpus 2 echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
