### PR TITLE
Release v0.3.2

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -3,7 +3,7 @@ import os
 
 # Replaced with the current commit when building the wheels.
 __commit__ = '{{SKYPILOT_COMMIT_SHA}}'
-__version__ = '1.0.0-dev0'
+__version__ = '0.3.2'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 # Keep this order to avoid cyclic imports

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -67,8 +67,7 @@ class Resources:
             sky.Resources(clouds.GCP(), 'n1-standard-8', 'V100')
 
             # Specifying required resources; the system decides the
-            cloud/instance
-            # type. The below are equivalent:
+            # cloud/instance type. The below are equivalent:
             sky.Resources(accelerators='V100')
             sky.Resources(accelerators='V100:1')
             sky.Resources(accelerators={'V100': 1})


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- [x] `pytest tests/test_smoke.py`
- [x] `pytest tests/test_smoke.py --aws`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky spot launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky spot logs --controller
        ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --cpus 2+ --down  # with or without timeout bump
    sky down dbg  
    ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot 
    sky down dbg
    ```
  - [x] following script
    ```
    sky launch -c dbg --cloud gcp --num-nodes 16 --cpus 2+ --down  # with or without timeout bump
    sky down dbg  
    ```
  - [ ] ~~following script~~ (skipped, need to fix)
    ```
    sky launch -c dbg --cloud gcp --num-nodes 16 --gpus T4 --down 
    sky down dbg
    ```

