### PR TITLE
[GCP] Fix unbounded return value

### DIFF
--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 import logging
 import time
 import copy
@@ -292,6 +291,7 @@ class GCPNodeProvider(NodeProvider):
     @_retry
     def terminate_node(self, node_id: str):
         with self.lock:
+            result = None
             resource = self._get_resource_depending_on_node_name(node_id)
             try:
                 if self.cache_stopped_nodes:
@@ -337,7 +337,6 @@ class GCPNodeProvider(NodeProvider):
                         f"Tried to delete the node with id {node_id} "
                         "but it was already gone."
                     )
-                    result = None
                 else:
                     raise http_error from None
 

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -289,69 +289,59 @@ class GCPNodeProvider(NodeProvider):
                 )
             return result_dict
 
-    def _thread_unsafe_terminate_node(self, node_id: str):
-        # Assumes the global lock is held for the duration of this operation.
-        # The lock may be held by a different thread if in `terminate_nodes()` case.
-        logger.info("NodeProvider: {}: Terminating node".format(node_id))
-        resource = self._get_resource_depending_on_node_name(node_id)
-        try:
-            if self.cache_stopped_nodes:
-                cli_logger.print(
-                    f"Stopping instance {node_id} "
-                    + cf.dimmed(
-                        "(to terminate instead, "
-                        "set `cache_stopped_nodes: False` "
-                        "under `provider` in the cluster configuration)"
-                    ),
-                )
-                resource.stop_instance(node_id=node_id)
-
-                # Check if the instance is actually stopped.
-                # GCP does not fully stop an instance even after
-                # the stop operation is finished.
-                for _ in range(MAX_POLLS_STOP):
-                    instance = resource.get_instance(node_id=node_id)
-                    if instance.is_stopped():
-                        logger.info(f"Instance {node_id} is stopped.")
-                        break
-                    elif instance.is_stopping():
-                        time.sleep(POLL_INTERVAL)
-                    else:
-                        raise RuntimeError(
-                            f"Unexpected instance status." " Details: {instance}"
-                        )
-
-                if instance.is_stopping():
-                    raise RuntimeError(
-                        f"Maximum number of polls: "
-                        f"{MAX_POLLS_STOP} reached. "
-                        f"Instance {node_id} is still in "
-                        "STOPPING status."
-                    )
-            else:
-                resource.delete_instance(
-                    node_id=node_id,
-                )
-        except googleapiclient.errors.HttpError as http_error:
-            if http_error.resp.status == 404:
-                logger.warning(
-                    f"Tried to delete the node with id {node_id} "
-                    "but it was already gone."
-                )
-            else:
-                raise http_error from None
-
     @_retry
     def terminate_node(self, node_id: str):
         with self.lock:
-            self._thread_unsafe_terminate_node(node_id)
+            resource = self._get_resource_depending_on_node_name(node_id)
+            try:
+                if self.cache_stopped_nodes:
+                    cli_logger.print(
+                        f"Stopping instance {node_id} "
+                        + cf.dimmed(
+                            "(to terminate instead, "
+                            "set `cache_stopped_nodes: False` "
+                            "under `provider` in the cluster configuration)"
+                        ),
+                    )
+                    result = resource.stop_instance(node_id=node_id)
 
-    def terminate_nodes(self, node_ids: List[str]):
-        if not node_ids:
-            return None
+                    # Check if the instance is actually stopped.
+                    # GCP does not fully stop an instance even after
+                    # the stop operation is finished.
+                    for _ in range(MAX_POLLS_STOP):
+                        instance = resource.get_instance(node_id=node_id)
+                        if instance.is_stopped():
+                            logger.info(f"Instance {node_id} is stopped.")
+                            break
+                        elif instance.is_stopping():
+                            time.sleep(POLL_INTERVAL)
+                        else:
+                            raise RuntimeError(
+                                f"Unexpected instance status." " Details: {instance}"
+                            )
 
-        with self.lock, concurrent.futures.ThreadPoolExecutor() as executor:
-            executor.map(self._thread_unsafe_terminate_node, node_ids)
+                    if instance.is_stopping():
+                        raise RuntimeError(
+                            f"Maximum number of polls: "
+                            f"{MAX_POLLS_STOP} reached. "
+                            f"Instance {node_id} is still in "
+                            "STOPPING status."
+                        )
+                else:
+                    result = resource.delete_instance(
+                        node_id=node_id,
+                    )
+            except googleapiclient.errors.HttpError as http_error:
+                if http_error.resp.status == 404:
+                    logger.warning(
+                        f"Tried to delete the node with id {node_id} "
+                        "but it was already gone."
+                    )
+                    result = None
+                else:
+                    raise http_error from None
+
+        return result
 
     @_retry
     def _get_node(self, node_id: str) -> GCPNode:

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -353,7 +353,6 @@ class GCPNodeProvider(NodeProvider):
         with self.lock, concurrent.futures.ThreadPoolExecutor() as executor:
             executor.map(self._thread_unsafe_terminate_node, node_ids)
 
-
     @_retry
     def _get_node(self, node_id: str) -> GCPNode:
         self.non_terminated_nodes({})  # Side effect: updates cache

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -338,7 +338,6 @@ class GCPNodeProvider(NodeProvider):
                     )
                 else:
                     raise http_error from None
-            return result
 
     @_retry
     def _get_node(self, node_id: str) -> GCPNode:

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -302,7 +302,7 @@ class GCPNodeProvider(NodeProvider):
                             "under `provider` in the cluster configuration)"
                         ),
                     )
-                    result = resource.stop_instance(node_id=node_id)
+                    resource.stop_instance(node_id=node_id)
 
                     # Check if the instance is actually stopped.
                     # GCP does not fully stop an instance even after
@@ -327,7 +327,7 @@ class GCPNodeProvider(NodeProvider):
                             "STOPPING status."
                         )
                 else:
-                    result = resource.delete_instance(
+                    resource.delete_instance(
                         node_id=node_id,
                     )
             except googleapiclient.errors.HttpError as http_error:

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -304,7 +304,7 @@ class GCPNodeProvider(NodeProvider):
                         "under `provider` in the cluster configuration)"
                     ),
                 )
-                result = resource.stop_instance(node_id=node_id)
+                resource.stop_instance(node_id=node_id)
 
                 # Check if the instance is actually stopped.
                 # GCP does not fully stop an instance even after
@@ -329,7 +329,7 @@ class GCPNodeProvider(NodeProvider):
                         "STOPPING status."
                     )
             else:
-                result = resource.delete_instance(
+                resource.delete_instance(
                     node_id=node_id,
                 )
         except googleapiclient.errors.HttpError as http_error:
@@ -338,24 +338,21 @@ class GCPNodeProvider(NodeProvider):
                     f"Tried to delete the node with id {node_id} "
                     "but it was already gone."
                 )
-                result = None
             else:
                 raise http_error from None
-        return result
 
     @_retry
     def terminate_node(self, node_id: str):
         with self.lock:
-            return self._thread_unsafe_terminate_node(node_id)
+            self._thread_unsafe_terminate_node(node_id)
 
     def terminate_nodes(self, node_ids: List[str]):
         if not node_ids:
             return None
 
         with self.lock, concurrent.futures.ThreadPoolExecutor() as executor:
-            result = executor.map(self._thread_unsafe_terminate_node, node_ids)
+            executor.map(self._thread_unsafe_terminate_node, node_ids)
 
-        return list(result)
 
     @_retry
     def _get_node(self, node_id: str) -> GCPNode:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is a bug in GCP node_provider, where an unnecessary variable is returned, which is not defined in one code path.

Reference: https://github.com/ray-project/ray/blob/547dd8c125b0e2007b1fb8960b514bd2c89e1963/python/ray/autoscaler/_private/gcp/node_provider.py#L183-L205

~~The parallel termination is adopted from: https://github.com/ray-project/ray/commit/46fc66390cb136a52afd6d70808f7c01eb31deb0~~

We revert the adoption of the parallel termination as that implementation is buggy with the following repro:
1. `sky launch -c test --cloud gcp --cpus 2 --num-nodes 8`
2. `sky stop test`, the following error shows up:
```
malloc(): unsorted double linked list corrupted
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --num-nodes 8 --cloud gcp -c test-mn`; `sky stop test-mn`
  - [x] `sky launch --num-nodes 8 --cloud gcp -c test-mn`; `sky down -y test-mn`
- [x] All smoke tests: `pytest tests/test_smoke.py` 

