### PR TITLE
[Storage] gsutil rsync failing to sync source with dangling symlink

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -133,7 +133,7 @@ class GcsCloudStorage(CloudStorage):
     def make_sync_dir_command(self, source: str, destination: str) -> str:
         """Downloads a directory using gsutil."""
         download_via_gsutil = (
-            f'{self._GSUTIL} -m rsync -r {source} {destination}')
+            f'{self._GSUTIL} -m rsync -e -r {source} {destination}')
         all_commands = [self._GET_GSUTIL]
         all_commands.append(download_via_gsutil)
         return ' && '.join(all_commands)

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -140,7 +140,7 @@ class GcsCloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using gsutil."""
-        download_via_gsutil = f'{self._GSUTIL} -m cp {source} {destination}'
+        download_via_gsutil = f'{self._GSUTIL} -m cp -e {source} {destination}'
         all_commands = [self._GET_GSUTIL]
         all_commands.append(download_via_gsutil)
         return ' && '.join(all_commands)

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -140,7 +140,7 @@ class GcsCloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using gsutil."""
-        download_via_gsutil = f'{self._GSUTIL} -m cp -e {source} {destination}'
+        download_via_gsutil = f'{self._GSUTIL} -m cp {source} {destination}'
         all_commands = [self._GET_GSUTIL]
         all_commands.append(download_via_gsutil)
         return ' && '.join(all_commands)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1507,13 +1507,13 @@ class GcsStore(AbstractStore):
 
         def get_file_sync_command(base_dir_path, file_names):
             sync_format = '|'.join(file_names)
-            sync_command = (f'gsutil -m rsync -ex \'^(?!{sync_format}$).*\' '
+            sync_command = (f'gsutil -m rsync -e -x \'^(?!{sync_format}$).*\' '
                             f'{base_dir_path} gs://{self.name}')
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
-            sync_command = (f'gsutil -m rsync -erx \'.git/*\' {src_dir_path} '
+            sync_command = (f'gsutil -m rsync -e -r -x \'.git/*\' {src_dir_path} '
                             f'gs://{self.name}/{dest_dir_name}')
             return sync_command
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1507,13 +1507,13 @@ class GcsStore(AbstractStore):
 
         def get_file_sync_command(base_dir_path, file_names):
             sync_format = '|'.join(file_names)
-            sync_command = (f'gsutil -m rsync -x \'^(?!{sync_format}$).*\' '
+            sync_command = (f'gsutil -m rsync -ex \'^(?!{sync_format}$).*\' '
                             f'{base_dir_path} gs://{self.name}')
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
-            sync_command = (f'gsutil -m rsync -r -x \'.git/*\' {src_dir_path} '
+            sync_command = (f'gsutil -m rsync -erx \'.git/*\' {src_dir_path} '
                             f'gs://{self.name}/{dest_dir_name}')
             return sync_command
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1513,8 +1513,9 @@ class GcsStore(AbstractStore):
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
-            sync_command = (f'gsutil -m rsync -e -r -x \'.git/*\' {src_dir_path} '
-                            f'gs://{self.name}/{dest_dir_name}')
+            sync_command = (
+                f'gsutil -m rsync -e -r -x \'.git/*\' {src_dir_path} '
+                f'gs://{self.name}/{dest_dir_name}')
             return sync_command
 
         # Generate message for upload


### PR DESCRIPTION
This PR closes #2147, which is initially raised by #2127

`aws s3 sync` is a command ran to sync Sky Storages set with `s3`/`r2` storages. When the command sees a dangling symlink, it simply ignores and continue to sync other contents. However, `gsutil rsync`, which is used to set `gcs`, does not support this and fails early. In order to have consistent behavior between `gcs` and `s3`/`r2` storages, I add an additional flag to the command to ignore all the symlinks in the source. Adding `-e` is the [solution gsutil team provides](https://github.com/GoogleCloudPlatform/gsutil/issues/222) to resolve dangling symlink issue. Also, as Sky Storage does not support symlinks, this is a suitable solution.


Tested (run the relevant ones):
- [x] Manually ran `gsutil -m rsync -erx` to sync src with dangling symlink to `gcs`
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [x] Tested with `pytest tests/test_smoke.py::test_gcp_storage_mounts
`