### PR TITLE
[UX] Fail early from provisioning when rsync is uninstalled

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2580,3 +2580,24 @@ def run_command_and_handle_ssh_failure(runner: command_runner.SSHCommandRunner,
                                        failure_message,
                                        stderr=stderr)
     return stdout
+
+
+def check_rsync_installed() -> None:
+    """Checks if rsync is installed.
+
+    Raises:
+        RuntimeError: if rsync is not installed in the machine.
+    """
+    try:
+        subprocess.run('rsync --version',
+                       shell=True,
+                       check=True,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                '`rsync` is required for provisioning and'
+                ' it is not installed. For Debian/Ubuntu system, '
+                'install it with:\n'
+                '  $ sudo apt install rsync') from None

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2391,6 +2391,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 (e.g., cluster name invalid) or a region/zone throwing
                 resource unavailability.
             exceptions.CommandError: any ssh command error.
+            RuntimeErorr: raised when 'rsync' is not installed.
             # TODO(zhwu): complete the list of exceptions.
         """
         # FIXME: ray up for Azure with different cluster_names will overwrite

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1336,22 +1336,6 @@ class RetryingVmProvisioner(object):
         prev_cluster_status: Optional[status_lib.ClusterStatus],
     ):
         """The provision retry loop."""
-        # When rsync is not installed in the user's machine, Ray will
-        # silently retry to up the node for _MAX_RAY_UP_RETRY number of times
-        # This is time consuming so we fail early.
-        try:
-            subprocess.run('rsync --version',
-                           shell=True,
-                           check=True,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
-        except subprocess.CalledProcessError as e:
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    '`rsync` is required for provisioning and it is not '
-                    'installed. For Debian/Ubuntu system, install it with:\n'
-                    '  $ sudo apt install rsync') from e
-
         style = colorama.Style
         fore = colorama.Fore
         # Get log_path name
@@ -2423,6 +2407,22 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 task.num_nodes,
                 prev_cluster_status=None)
             if not dryrun:  # dry run doesn't need to check existing cluster.
+                # When rsync is not installed in the user's machine, Ray will
+                # silently retry to up the node for _MAX_RAY_UP_RETRY number of times
+                # This is time consuming so we fail early.
+                try:
+                    subprocess.run('rsync --version',
+                                shell=True,
+                                check=True,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+                except subprocess.CalledProcessError as e:
+                    with ux_utils.print_exception_no_traceback():
+                        raise RuntimeError(
+                            '`rsync` is required for provisioning and it is not '
+                            'installed. For Debian/Ubuntu system, install it with:\n'
+                            '  $ sudo apt install rsync') from e
+
                 # Try to launch the exiting cluster first
                 to_provision_config = self._check_existing_cluster(
                     task, to_provision, cluster_name)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2398,7 +2398,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # When rsync is not installed in the user's machine, Ray will
         # silently retry to up the node for _MAX_RAY_UP_RETRY number
         # of times. This is time consuming so we fail early.
-        CloudVmRayBackend._check_rsync_installed()
+        backend_utils.check_rsync_installed()
         # Check if the cluster is owned by the current user. Raise
         # exceptions.ClusterOwnerIdentityMismatchError
         backend_utils.check_owner_identity(cluster_name)
@@ -4171,24 +4171,3 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                 executable='python3',
                                 detach_run=detach_run,
                                 spot_dag=task.spot_dag)
-
-    @staticmethod
-    def _check_rsync_installed() -> None:
-        """Checks if rsync is installed.
-
-        Raises:
-            RuntimeError: if rsync is not installed in the machine.
-        """
-        try:
-            subprocess.run('rsync --version',
-                           shell=True,
-                           check=True,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE)
-        except subprocess.CalledProcessError:
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    '`rsync` is required for provisioning and'
-                    ' it is not installed. For Debian/Ubuntu system, '
-                    'install it with:\n'
-                    '  $ sudo apt install rsync') from None

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1348,9 +1348,9 @@ class RetryingVmProvisioner(object):
         except subprocess.CalledProcessError as e:
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(
-                    'rsync is required for provisioning and it is not '
-                    'installed. Please run the following command:\n'
-                    '    $ sudo apt-get install rsync') from e
+                    '`rsync` is required for provisioning and it is not '
+                    'installed. For Debian/Ubuntu system, install it with:\n'
+                    '  $ sudo apt install rsync') from e
 
         style = colorama.Style
         fore = colorama.Fore

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2408,19 +2408,20 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 prev_cluster_status=None)
             if not dryrun:  # dry run doesn't need to check existing cluster.
                 # When rsync is not installed in the user's machine, Ray will
-                # silently retry to up the node for _MAX_RAY_UP_RETRY number of times
-                # This is time consuming so we fail early.
+                # silently retry to up the node for _MAX_RAY_UP_RETRY number
+                # of times. This is time consuming so we fail early.
                 try:
                     subprocess.run('rsync --version',
-                                shell=True,
-                                check=True,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                   shell=True,
+                                   check=True,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
                 except subprocess.CalledProcessError as e:
                     with ux_utils.print_exception_no_traceback():
                         raise RuntimeError(
-                            '`rsync` is required for provisioning and it is not '
-                            'installed. For Debian/Ubuntu system, install it with:\n'
+                            '`rsync` is required for provisioning and'
+                            ' it is not installed. For Debian/Ubuntu system, '
+                            'install it with:\n'
                             '  $ sudo apt install rsync') from e
 
                 # Try to launch the exiting cluster first

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2422,7 +2422,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                             '`rsync` is required for provisioning and'
                             ' it is not installed. For Debian/Ubuntu system, '
                             'install it with:\n'
-                            '  $ sudo apt install rsync') from e
+                            '  $ sudo apt install rsync') from None
 
                 # Try to launch the exiting cluster first
                 to_provision_config = self._check_existing_cluster(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1336,6 +1336,22 @@ class RetryingVmProvisioner(object):
         prev_cluster_status: Optional[status_lib.ClusterStatus],
     ):
         """The provision retry loop."""
+        # When rsync is not installed in the user's machine, Ray will
+        # silently retry to up the node for _MAX_RAY_UP_RETRY number of times
+        # This is time consuming so we fail early.
+        try:
+            subprocess.run('rsync --version',
+                           shell=True,
+                           check=True,
+                           stdout=subprocess.PIPE,
+                           stderr=subprocess.PIPE)
+        except subprocess.CalledProcessError as e:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(
+                    'rsync is required for provisioning and it is not '
+                    'installed. Please run the following command:\n'
+                    '    $ sudo apt-get install rsync') from e
+
         style = colorama.Style
         fore = colorama.Fore
         # Get log_path name


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR closes #2113 

When `rsync` is not installed in the user's machine, `ray_up()` is reattempted for `_MAX_RAY_UP_RETRY` number of times without failing. As this is time consuming, this PR fails early in the provisioning step when `rsync` is not installed and gently hints the user to install `rsync`.

Considered failing from `need_ray_up()` as well, but at this point, `state.db` is already updated with `INIT` status of the cluster attempted to provisioned which isn't the most optimal scenario. Also, it takes time for single failure before reaching `need_ray_up()`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] manally tested with running `sky launch` after deleting `rsync` with and w/o `--dryrun` option