### PR TITLE
[Storage] Truncate long command str in `sky storage ls`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3241,6 +3241,7 @@ def storage():
               required=False,
               help='Show all information in full.')
 @usage_lib.entrypoint
+# pylint: disable=redefined-builtin
 def storage_ls(all: bool):
     """List storage objects managed by SkyPilot."""
     storages = sky.storage_ls()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3234,11 +3234,17 @@ def storage():
 
 
 @storage.command('ls', cls=_DocumentedCodeCommand)
+@click.option('--all',
+              '-a',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Show all information in full.')
 @usage_lib.entrypoint
-def storage_ls():
-    """List storage objects created."""
+def storage_ls(all: bool):
+    """List storage objects managed by SkyPilot."""
     storages = sky.storage_ls()
-    storage_table = storage_utils.format_storage_table(storages)
+    storage_table = storage_utils.format_storage_table(storages, show_all=all)
     click.echo(storage_table)
 
 

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 from sky import sky_logging
 from sky.utils import log_utils
+from sky.utils.cli_utils import status_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -34,7 +35,7 @@ def format_storage_table(storages: List[Dict[str, Any]]) -> str:
             # CLOUDS
             ', '.join([s.value for s in row['store']]),
             # COMMAND
-            row['last_use'],
+            status_utils.truncate_long_string(row['last_use'], status_utils.COMMAND_TRUNC_LENGTH),
             # STATUS
             row['status'].value,
         ])

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -8,7 +8,8 @@ from sky.utils.cli_utils import status_utils
 logger = sky_logging.init_logger(__name__)
 
 
-def format_storage_table(storages: List[Dict[str, Any]], show_all: bool = False) -> str:
+def format_storage_table(storages: List[Dict[str, Any]],
+                         show_all: bool = False) -> str:
     """Format the storage table for display.
 
     Args:

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -35,7 +35,8 @@ def format_storage_table(storages: List[Dict[str, Any]]) -> str:
             # CLOUDS
             ', '.join([s.value for s in row['store']]),
             # COMMAND
-            status_utils.truncate_long_string(row['last_use'], status_utils.COMMAND_TRUNC_LENGTH),
+            status_utils.truncate_long_string(
+                row['last_use'], status_utils.COMMAND_TRUNC_LENGTH),
             # STATUS
             row['status'].value,
         ])

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -8,7 +8,7 @@ from sky.utils.cli_utils import status_utils
 logger = sky_logging.init_logger(__name__)
 
 
-def format_storage_table(storages: List[Dict[str, Any]]) -> str:
+def format_storage_table(storages: List[Dict[str, Any]], show_all: bool = False) -> str:
     """Format the storage table for display.
 
     Args:
@@ -27,6 +27,11 @@ def format_storage_table(storages: List[Dict[str, Any]]) -> str:
 
     for row in storages:
         launched_at = row['launched_at']
+        if show_all:
+            command = row['last_use']
+        else:
+            command = status_utils.truncate_long_string(
+                row['last_use'], status_utils.COMMAND_TRUNC_LENGTH)
         storage_table.add_row([
             # NAME
             row['name'],
@@ -34,9 +39,8 @@ def format_storage_table(storages: List[Dict[str, Any]]) -> str:
             log_utils.readable_time_duration(launched_at),
             # CLOUDS
             ', '.join([s.value for s in row['store']]),
-            # COMMAND
-            status_utils.truncate_long_string(
-                row['last_use'], status_utils.COMMAND_TRUNC_LENGTH),
+            # COMMAND,
+            command,
             # STATUS
             row['status'].value,
         ])

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -12,7 +12,7 @@ from sky.backends import backend_utils
 from sky.utils import common_utils
 from sky.utils import log_utils
 
-_COMMAND_TRUNC_LENGTH = 25
+COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
 
 # A record in global_user_state's 'clusters' table.
@@ -21,7 +21,7 @@ _ClusterRecord = Dict[str, Any]
 _ClusterCostReportRecord = Dict[str, Any]
 
 
-def _truncate_long_string(s: str, max_length: int = 35) -> str:
+def truncate_long_string(s: str, max_length: int = 35) -> str:
     if len(s) <= max_length:
         return s
     splits = s.split(' ')
@@ -56,7 +56,7 @@ class StatusColumn:
     def calc(self, record):
         val = self.calc_func(record)
         if self.trunc_length != 0:
-            val = _truncate_long_string(str(val), self.trunc_length)
+            val = truncate_long_string(str(val), self.trunc_length)
         return val
 
 
@@ -82,7 +82,7 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         StatusColumn('AUTOSTOP', _get_autostop),
         StatusColumn('COMMAND',
                      _get_command,
-                     trunc_length=_COMMAND_TRUNC_LENGTH if not show_all else 0),
+                     trunc_length=COMMAND_TRUNC_LENGTH if not show_all else 0),
     ]
 
     columns = []
@@ -268,7 +268,7 @@ def show_local_status_table(local_clusters: List[str]):
             # RESOURCES
             resources_str,
             # COMMAND
-            _truncate_long_string(command_str, _COMMAND_TRUNC_LENGTH),
+            truncate_long_string(command_str, COMMAND_TRUNC_LENGTH),
         ]
         names.append(cluster_name)
         cluster_table.add_row(row)


### PR DESCRIPTION
Truncates long `COMMAND` strs in `sky storage ls`, like we do in `sky status`.

Before:
```
(base) ➜  ~ sky storage ls
NAME                       CREATED     STORE  COMMAND                                   STATUS
romil-debug-parq           22 hrs ago  S3     sky launch parquet_test.yaml --cloud gcp  READY
```

After:
```
(base) ➜  ~ sky storage ls
NAME                       CREATED     STORE  COMMAND                       STATUS
romil-debug-parq           22 hrs ago  S3     sky launch parquet_test.y...  READY

...

(base) ➜  ~ sky storage ls -a    
NAME                 CREATED    STORE  COMMAND                                                                                                                            STATUS  
sky-test-1688589264  1 day ago  S3     sky launch -y -c t-kubernetes-sto363-2ea4-d7 --cloud kubernetes /var/folders/98/hhq8wrtx6y13196q61xphjsm0000gn/T/tmp4ev9pbqq.yaml  INIT    
sky-test-1688589292  1 day ago  S3     sky launch -y -c t-kubernetes-sto363-2ea4-54 --cloud kubernetes /var/folders/98/hhq8wrtx6y13196q61xphjsm0000gn/T/tmpwbfcbv4x.yaml  READY  
```




Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `pytest tests/test_smoke.py::TestStorageWithCredentials` 
