### PR TITLE
[Docs] Add code blocks for down and stop in Quickstart

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -164,8 +164,17 @@ For uploading files to the cluster, see :ref:`Syncing Code and Artifacts <sync-c
 Stop/terminate a cluster
 =========================
 
-When you are done, run :code:`sky stop mycluster` to stop the cluster. To
-terminate a cluster instead, run :code:`sky down mycluster`.
+When you are done, stop the cluster with:
+
+.. code-block:: console
+
+  $ sky stop mycluster
+
+To terminate a cluster instead, run:
+
+.. code-block:: console
+
+  $ sky down mycluster
 
 Find more commands that manage the lifecycle of clusters in the :ref:`CLI reference <cli>`.
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -164,13 +164,13 @@ For uploading files to the cluster, see :ref:`Syncing Code and Artifacts <sync-c
 Stop/terminate a cluster
 =========================
 
-When you are done, stop the cluster with:
+When you are done, stop the cluster with :code:`sky stop`:
 
 .. code-block:: console
 
   $ sky stop mycluster
 
-To terminate a cluster instead, run:
+To terminate a cluster instead, run :code:`sky down`:
 
 .. code-block:: console
 


### PR DESCRIPTION
Our quickstart uses codeblocks to visually indicate important commands that the user should know/run. Example:

<img width="845" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/4ef02f8b-989f-4134-81ff-ae50a9157813">

However, in the `Stop/terminate a cluster` section, we use inline code, which is easy to miss:
<img width="833" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/22885e2a-855e-43f9-9964-0b05a17daef5">

This PR changes the down/stop commands to be code blocks:
<img width="884" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/b9261781-744c-4aae-8fe5-d2a885427bf3">



- [x] Rendered locally