### PR TITLE
Docs: minor touches on env vars doc.

### DIFF
--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -45,7 +45,22 @@ Using in ``setup`` and ``run``
 
 All user-specified environment variables are exported to a task's ``setup`` and ``run`` commands (i.e., accessible when they are being run).
 
-For example, this is useful for passing secrets to the task (see below).
+For example, this is useful for passing secrets (see below) or passing configurations:
+
+.. code-block:: yaml
+
+    # Sets default values for some variables; can be overridden by --env.
+    envs:
+      MODEL_NAME: decapoda-research/llama-65b-hf
+
+    run: |
+      python train.py --model_name ${MODEL_NAME} <other args>
+
+.. code-block:: console
+
+    $ sky launch --env MODEL_NAME=huggyllama/llama-7b task.yaml  # Override.
+
+See complete examples at `llm/vllm/serve.yaml <https://github.com/skypilot-org/skypilot/blob/596c1415b5039adec042594f45b342374e5e6a00/llm/vllm/serve.yaml#L4-L5>`_ and `llm/vicuna/train.yaml <https://github.com/skypilot-org/skypilot/blob/596c1415b5039adec042594f45b342374e5e6a00/llm/vicuna/train.yaml#L111-L116>`_.
 
 Passing secrets
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -58,7 +58,7 @@ For example, this is useful for passing secrets (see below) or passing configura
 
 .. code-block:: console
 
-    $ sky launch --env MODEL_NAME=huggyllama/llama-7b task.yaml  # Override.
+    $ sky launch --env MODEL_NAME=decapoda-research/llama-7b-hf task.yaml  # Override.
 
 See complete examples at `llm/vllm/serve.yaml <https://github.com/skypilot-org/skypilot/blob/596c1415b5039adec042594f45b342374e5e6a00/llm/vllm/serve.yaml#L4-L5>`_ and `llm/vicuna/train.yaml <https://github.com/skypilot-org/skypilot/blob/596c1415b5039adec042594f45b342374e5e6a00/llm/vicuna/train.yaml#L111-L116>`_.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In last PR, forgot to add a clear snippet to copy paste & adapt.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): rendered
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
