### PR TITLE
Remove unintended warning message when provisioning Azure

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -63,7 +63,8 @@ logger = sky_logging.init_logger(__name__)
 # NOTE: keep in sync with the cluster template 'file_mounts'.
 SKY_REMOTE_APP_DIR = '~/.sky/sky_app'
 SKY_RAY_YAML_REMOTE_PATH = '~/.sky/sky_ray.yml'
-IP_ADDR_REGEX = r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
+# Exclude subnet mask from IP address regex.
+IP_ADDR_REGEX = r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}(?!/\d{1,2})\b'
 SKY_REMOTE_PATH = '~/.sky/wheels'
 SKY_USER_FILE_PATH = '~/.sky/generated'
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, when launching with Azure, it will generate a warning message indicating multiple IPs found for the `ray get-head-ip` command:

```bash
(sky-dev) ➜  skypilot git:(75ccbf4a) sky launch -c az --cloud azure
I 07-08 16:46:58 optimizer.py:636] == Optimizer ==
I 07-08 16:46:58 optimizer.py:648] Target: minimizing cost
I 07-08 16:46:58 optimizer.py:659] Estimated cost: $0.4 / hour
I 07-08 16:46:58 optimizer.py:659] 
I 07-08 16:46:58 optimizer.py:733] Considered resources (1 node):
I 07-08 16:46:58 optimizer.py:781] ----------------------------------------------------------------------------------------------
I 07-08 16:46:58 optimizer.py:781]  CLOUD   INSTANCE          vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 07-08 16:46:58 optimizer.py:781] ----------------------------------------------------------------------------------------------
I 07-08 16:46:58 optimizer.py:781]  Azure   Standard_D8s_v5   8       32        -              eastus        0.38          ✔     
I 07-08 16:46:58 optimizer.py:781] ----------------------------------------------------------------------------------------------
I 07-08 16:46:58 optimizer.py:781] 
Launching a new cluster 'az'. Proceed? [Y/n]: 
I 07-08 16:46:59 cloud_vm_ray_backend.py:3842] Creating a new cluster: "az" [1x Azure(Standard_D8s_v5)].
I 07-08 16:46:59 cloud_vm_ray_backend.py:3842] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
I 07-08 16:47:01 cloud_vm_ray_backend.py:1348] To view detailed progress: tail -n100 -f /home/memory/sky_logs/sky-2023-07-08-16-46-58-597546/provision.log
I 07-08 16:47:01 cloud_vm_ray_backend.py:1701] Launching on Azure eastus
I 07-08 16:55:07 cloud_vm_ray_backend.py:1514] Successfully provisioned or found existing VM.
W 07-08 16:56:19 backend_utils.py:1365] Detected more than 1 IP from the output of the `ray get-head-ip` command. This could happen if there is extra output from it, which should be inspected below.
W 07-08 16:56:19 backend_utils.py:1365] Proceeding with the last detected IP (20.124.194.47) as head IP.
W 07-08 16:56:19 backend_utils.py:1365] == Output ==
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:09 config.py:57] Using subscription id: aa86df77-e703-453e-b2f4-955c3b33e534
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:09 config.py:72] Creating/Updating resource group: az-eastus
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:10 config.py:84] Using cluster name: az
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:10 config.py:95] Using unique id: 80b5
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:10 config.py:103] Using subnet mask: 10.13.0.0/16
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:42 config.py:57] Using subscription id: aa86df77-e703-453e-b2f4-955c3b33e534
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:42 config.py:72] Creating/Updating resource group: az-eastus
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:43 config.py:84] Using cluster name: az
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:43 config.py:95] Using unique id: 80b5
W 07-08 16:56:19 backend_utils.py:1365] I 07-08 16:55:43 config.py:103] Using subnet mask: 10.13.0.0/16
W 07-08 16:56:19 backend_utils.py:1365] 20.124.194.47
W 07-08 16:56:19 backend_utils.py:1365] == Output ends ==
W 07-08 16:57:30 backend_utils.py:1365] Detected more than 1 IP from the output of the `ray get-head-ip` command. This could happen if there is extra output from it, which should be inspected below.
W 07-08 16:57:30 backend_utils.py:1365] Proceeding with the last detected IP (10.13.0.4) as head IP.
W 07-08 16:57:30 backend_utils.py:1365] == Output ==
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:20 config.py:57] Using subscription id: aa86df77-e703-453e-b2f4-955c3b33e534
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:20 config.py:72] Creating/Updating resource group: az-eastus
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:21 config.py:84] Using cluster name: az
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:21 config.py:95] Using unique id: 80b5
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:21 config.py:103] Using subnet mask: 10.13.0.0/16
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:53 config.py:57] Using subscription id: aa86df77-e703-453e-b2f4-955c3b33e534
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:53 config.py:72] Creating/Updating resource group: az-eastus
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:55 config.py:84] Using cluster name: az
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:55 config.py:95] Using unique id: 80b5
W 07-08 16:57:30 backend_utils.py:1365] I 07-08 16:56:55 config.py:103] Using subnet mask: 10.13.0.0/16
W 07-08 16:57:30 backend_utils.py:1365] 10.13.0.4
W 07-08 16:57:30 backend_utils.py:1365] == Output ends ==
I 07-08 16:57:34 cloud_vm_ray_backend.py:3011] Run commands not specified or empty.
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] 
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] Cluster name: az
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] To log into the head VM: ssh az
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] To submit a job:         sky exec az yaml_file
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] To stop the cluster:     sky stop az
I 07-08 16:57:34 cloud_vm_ray_backend.py:3040] To teardown the cluster: sky down az
Clusters
NAME  LAUNCHED        RESOURCES                  STATUS  AUTOSTOP  COMMAND                       
az    a few secs ago  1x Azure(Standard_D8s_v5)  UP      -         sky launch -c az --cloud ...  
```

In fact, it is because the `IP_ADDR_REGEX` matches with subnet mask (in the example above, `10.13.0.0/16`). This PR updates `IP_ADDR_REGEX` to get rid of this warning.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
