### PR TITLE
[UX] Fix unexpected output for ctrl-c during `sky launch`

### DIFF
--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -260,14 +260,10 @@ def run_with_log(
                 return proc.returncode, stdout, stderr
             return proc.returncode
         except KeyboardInterrupt:
-            # Send SIGINT to the process directly, otherwise, the underlying
+            # Kill the subprocess directly, otherwise, the underlying
             # process will only be killed after the python program exits,
             # causing the stream handling stuck at `readline`.
-            if sys.platform == 'win32':
-                subprocess_utils.kill_children_processes(
-                    sig=signal.CTRL_C_EVENT)
-            else:
-                subprocess_utils.kill_children_processes(sig=signal.SIGINT)
+            subprocess_utils.kill_children_processes()
             raise
 
 

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -262,7 +262,12 @@ def run_with_log(
             # Send SIGINT to the process directly, otherwise, the underlying
             # process will only be killed after the python program exits,
             # causing the stream handling stuck at `readline`.
-            os.killpg(proc.pid, signal.SIGINT)
+            try:
+                os.killpg(proc.pid, signal.SIGINT)
+            except Exception:  # pylint: disable=broad-except
+                # The killing is ok to fail, as the proc might be finished
+                # already.
+                pass
             raise
 
 

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -6,7 +6,6 @@ import copy
 import io
 import multiprocessing.pool
 import os
-import signal
 import subprocess
 import sys
 import time

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -20,6 +20,7 @@ from sky import sky_logging
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.utils import log_utils
+from sky.utils import subprocess_utils
 
 _SKY_LOG_WAITING_GAP_SECONDS = 1
 _SKY_LOG_WAITING_MAX_RETRY = 5
@@ -262,12 +263,11 @@ def run_with_log(
             # Send SIGINT to the process directly, otherwise, the underlying
             # process will only be killed after the python program exits,
             # causing the stream handling stuck at `readline`.
-            try:
-                os.killpg(proc.pid, signal.SIGINT)
-            except Exception:  # pylint: disable=broad-except
-                # The killing is ok to fail, as the proc might be finished
-                # already.
-                pass
+            if sys.platform == 'win32':
+                subprocess_utils.kill_children_processes(
+                    sig=signal.CTRL_C_EVENT)
+            else:
+                subprocess_utils.kill_children_processes(sig=signal.SIGINT)
             raise
 
 

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -81,8 +81,7 @@ def handle_returncode(returncode: int,
 
 
 def kill_children_processes(first_pid_to_kill: Optional[int] = None,
-                            force: bool = False,
-                            sig: Optional[int] = None):
+                            force: bool = False):
     """Kill children processes recursively.
 
     We need to kill the children, so that
@@ -96,16 +95,12 @@ def kill_children_processes(first_pid_to_kill: Optional[int] = None,
          This is for guaranteeing the order of cleaning up and suppress
          flaky errors.
     """
-    assert not force or sig is None, ('At most one of force and sig '
-                                      f'can be set {force}, {sig}')
     parent_process = psutil.Process()
     child_processes = []
     for child in parent_process.children(recursive=True):
         if child.pid == first_pid_to_kill:
             try:
-                if sig is not None:
-                    child.send_signal(sig)
-                elif force:
+                if force:
                     child.kill()
                 else:
                     child.terminate()
@@ -118,9 +113,7 @@ def kill_children_processes(first_pid_to_kill: Optional[int] = None,
 
     for child in child_processes:
         try:
-            if sig is not None:
-                child.send_signal(sig)
-            elif force:
+            if force:
                 child.kill()
             else:
                 child.terminate()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2205.

The `os.killpg` might be applied to a subprocess that was attached under the root user, due the parent process being killed first. This will cause the `PermissionError: [Errno 1] Operation not permitted`

@concretevitamin Could you verify if this solve the problem?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `ctrl-c` during the `Launching` progress spinner
  - [x] `ctrl-c` during the `sky logs` (originally will show `ProcessLookupError`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
