### PR TITLE
[GCP] Add L4 support

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -331,8 +331,8 @@ class GCP(clouds.Cloud):
             else:
                 # Convert to GCP names:
                 # https://cloud.google.com/compute/docs/gpus
-                if acc == 'A100-80GB':
-                    # A100-80GB has a different name pattern.
+                if acc == 'A100-80GB' or acc == 'L4':
+                    # A100-80GB and L4 have a different name pattern.
                     resources_vars['gpu'] = 'nvidia-{}'.format(acc.lower())
                 else:
                     resources_vars['gpu'] = 'nvidia-tesla-{}'.format(
@@ -343,6 +343,9 @@ class GCP(clouds.Cloud):
                     # versions of CUDA as noted below.
                     # CUDA driver version 470.57.02, CUDA Library 11.4
                     image_id = 'skypilot:k80-debian-10'
+                elif acc == 'L4':
+                    # CUDA driver version 525.105.17, CUDA Library 11.8
+                    image_id = 'skypilot:l4-debian-11'
                 else:
                     # Though the image is called cu113, it actually has later
                     # versions of CUDA as noted below.

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -298,6 +298,7 @@ def get_common_gpus() -> List[str]:
         'A100',
         'A100-80GB',
         'K80',
+        'L4',
         'M60',
         'P100',
         'T4',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -59,8 +59,7 @@ TPU_V4_HOST_DF = pd.read_csv(
 
 # TODO(woosuk): Make this more robust.
 # Refer to: https://github.com/skypilot-org/skypilot/issues/1006
-# G2 series has L4 GPU, which is not supported by SkyPilot yet
-# Unsupported Series: 'f1', 'm2', 'g2'
+# Unsupported Series: 'f1', 'm2'
 SERIES_TO_DISCRIPTION = {
     'a2': 'A2 Instance',
     'c2': 'Compute optimized',
@@ -69,6 +68,7 @@ SERIES_TO_DISCRIPTION = {
     'e2': 'E2 Instance',
     'f1': 'Micro Instance with burstable CPU',
     'g1': 'Small Instance with 1 VCPU',
+    'g2': 'G2 Instance',
     'm1': 'Memory-optimized Instance',
     # FIXME(woosuk): Support M2 series.
     'm3': 'M3 Memory-optimized Instance',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Adds support for GCP's L4 GPU. (Fixes #2048) This is together with a pull request for the catalog: [link](https://github.com/skypilot-org/skypilot-catalog/pull/39).

In GCP, L4 GPUs can only be used with G2 instances; this is similar to how A100 GPUs can only be used with A2 instances. Thus, much of the code/behavior for L4 is similar to what was already implemented for A100/A2.

When testing, be sure to have the catalog updates as well: we changed `v5/gcp/images.csv` and `v5/gcp/vms.csv`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
    - [x] `sky show-gpus -a`
    - [x] `sky launch --gpus l4`
    - [x] `sky launch --gpus l4:2 --cloud gcp --region asia-southeast1 --env MY_ENV=1`
    - [x] `sky launch --gpus a100:2 --cloud gcp --region europe-west4 --env MY_ENV=1` (checking A100 still works)
    - [x] Ran some LLM models on the GPU (@infwinston)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
