### PR TITLE
Fix `is_empty` when disk tier is not None

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -902,6 +902,7 @@ class Resources:
             self.accelerator_args is None,
             not self._use_spot_specified,
             self.disk_size == _DEFAULT_DISK_SIZE_GB,
+            self.disk_tier is None,
             self._image_id is None,
         ])
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As shown in the title, this PR fixes the `is_empty` function in `resources` class when `disk_tier` is not None.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
