### PR TITLE
[UX] Add network failure handling for Lambda `sky check`

### DIFF
--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -1,5 +1,6 @@
 """Lambda Cloud."""
 import json
+import requests
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple
 
@@ -227,6 +228,10 @@ class Lambda(clouds.Cloud):
                            'to generate API key and add the line\n    '
                            '  api_key = [YOUR API KEY]\n    '
                            'to ~/.lambda_cloud/lambda_keys')
+        except requests.exceptions.ConnectionError:
+            return False, ('Failed to verify Lambda Cloud credentials. '
+                           'Check your network connection '
+                           'and try again.')
         return True, None
 
     def get_credential_file_mounts(self) -> Dict[str, str]:


### PR DESCRIPTION
If your internet is down (e.g., wifi is off) or lambda cloud is inaccessible, `sky check` would fail for lambda cloud with a fatal error:

```
 Checking Lambda...socket.gaierror: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x16d9c7e80>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known

During handling of the above exception, another exception occurred:

urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='cloud.lambdalabs.com', port=443): Max retries exceeded with url: /api/v1/instances (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x16d9c7e80>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))

During handling of the above exception, another exception occurred:

requests.exceptions.ConnectionError: HTTPSConnectionPool(host='cloud.lambdalabs.com', port=443): Max retries exceeded with url: /api/v1/instances (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x16d9c7e80>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known'))
(base) ➜  sky-experiments git:(master) ✗ 
```

After:
```
  Lambda: disabled          
    Reason: Failed to verify Lambda Cloud credentials. Check your network connection and try again.
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky check` without wifi
- [x] `sky check` with wifi