### PR TITLE
[Spot, Example] Fix failing example: lightning_cifar10

### DIFF
--- a/examples/spot/lightning_cifar10.yaml
+++ b/examples/spot/lightning_cifar10.yaml
@@ -9,7 +9,7 @@ resources:
 num_nodes: 1
 
 file_mounts:
-    /checkpoint:
+    ~/checkpoint:
         name: # NOTE: Fill in your bucket name for checkpoint
         mode: MOUNT
 
@@ -30,4 +30,4 @@ setup: |
 
 run: |
     cd ~/lit
-    python train.py --root_dir /checkpoint/ --resume --num_epochs 1000
+    python train.py --root_dir ~/checkpoint/ --resume --num_epochs 1000

--- a/examples/spot/lightning_cifar10.yaml
+++ b/examples/spot/lightning_cifar10.yaml
@@ -9,7 +9,7 @@ resources:
 num_nodes: 1
 
 file_mounts:
-    ~/checkpoint:
+    /checkpoint:
         name: # NOTE: Fill in your bucket name for checkpoint
         mode: MOUNT
 
@@ -30,4 +30,4 @@ setup: |
 
 run: |
     cd ~/lit
-    python train.py --root_dir ~/checkpoint/ --resume --num_epochs 1000
+    python train.py --root_dir /checkpoint/ --resume --num_epochs 1000

--- a/examples/spot/lightning_cifar10/requirements.txt
+++ b/examples/spot/lightning_cifar10/requirements.txt
@@ -1,6 +1,6 @@
 pytorch-lightning>=1.3
 torchvision
 wandb
-torchmetrics>=0.3
+torchmetrics==0.4.1
 torch>=1.6, <1.9
 lightning-bolts


### PR DESCRIPTION
This PR closes #2224 

With the current [`requirements.txt`](https://github.com/skypilot-org/skypilot/blob/master/examples/spot/lightning_cifar10/requirements.txt), the example fails. After some investigation, figured out that the version of `torchmetrics` installed with `torchmetrics >= 0.3`, 0.11.4(most recent version), has issues of confusing `torchmetrics.functional.accuracy` with `torchmetrics.Accuracy`, which results in an error. `torchmetrics.functional.accuracy`, which is meant to be used in the example, does not take `task` as an argument, but `torchmetrics.Accuracy` [does](https://torchmetrics.readthedocs.io/en/stable/classification/accuracy.html). As other requirements(`pytorch-lightning` and `lightning-bolts`) require `torchmetrics >= 0.4.1`, I am setting `torchmetrics==0.4.1` in the `requirements.txt` after confirming the example works smoothly.

Fixed:
<img width="858" alt="Screenshot 2023-07-12 at 3 57 37 PM" src="https://github.com/skypilot-org/skypilot/assets/34902420/81ba85e6-32b3-4e2c-9a3d-65faf04680b5">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Manual test running the example with `spot launch`
