### PR TITLE
Refactor failover when resources have some unsupported features on certain cloud

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -63,7 +63,7 @@ class Azure(clouds.Cloud):
             clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: f'Migrating disk is not supported in {cls._REPR}.',
             # TODO(zhwu): our azure subscription offer ID does not support spot.
             # Need to support it.
-            clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instance is not supported in {cls._REPR}.',
+            clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instances are not supported in {cls._REPR}.',
         }
 
     @classmethod

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -61,6 +61,9 @@ class Azure(clouds.Cloud):
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
         return {
             clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: f'Migrating disk is not supported in {cls._REPR}.',
+            # TODO(zhwu): our azure subscription offer ID does not support spot.
+            # Need to support it.
+            clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instance is not supported in {cls._REPR}.',
         }
 
     @classmethod
@@ -282,10 +285,6 @@ class Azure(clouds.Cloud):
             else:
                 return True, None
 
-        if resources.use_spot:
-            # TODO(zhwu): our azure subscription offer ID does not support spot.
-            # Need to support it.
-            return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             ok, disk_tier = failover_disk_tier(resources.instance_type,

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -28,6 +28,8 @@ class CloudImplementationFeatures(enum.Enum):
     AUTOSTOP = 'autostop'
     MULTI_NODE = 'multi-node'
     CLONE_DISK_FROM_CLUSTER = 'clone_disk_from_cluster'
+    SPOT_INSTANCE = 'spot_instance'
+    CUSTOM_DOSK_TIER = 'custom_disk_tier'
 
 
 class Region(collections.namedtuple('Region', ['name'])):
@@ -296,6 +298,11 @@ class Cloud:
         """
         if resources.is_launchable():
             self._check_instance_type_accelerators_combination(resources)
+        resources_required_features = resources.get_required_cloud_features()
+        try:
+            self.check_features_are_supported(resources_required_features)
+        except exceptions.NotSupportedError:
+            return ([], [])
         return self._get_feasible_launchable_resources(resources)
 
     def _get_feasible_launchable_resources(self, resources):

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -38,6 +38,8 @@ class IBM(clouds.Cloud):
         return {
             clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
                 (f'Migrating disk is not supported in {cls._REPR}.'),
+            clouds.CloudImplementationFeatures.CUSTOM_DOSK_TIER:
+                (f'Custom disk tier is not supported in {cls._REPR}.'),
         }
 
     @classmethod

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -37,6 +37,8 @@ class Lambda(clouds.Cloud):
         clouds.CloudImplementationFeatures.STOP: 'Lambda cloud does not support stopping VMs.',
         clouds.CloudImplementationFeatures.AUTOSTOP: 'Lambda cloud does not support stopping VMs.',
         clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: f'Migrating disk is not supported in {_REPR}.',
+        clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instances are not supported in {_REPR}.',
+        clouds.CloudImplementationFeatures.CUSTOM_DOSK_TIER: f'Custom disk tiers are not supported in {_REPR}.',
     }
 
     @classmethod
@@ -165,8 +167,6 @@ class Lambda(clouds.Cloud):
 
     def _get_feasible_launchable_resources(
             self, resources: 'resources_lib.Resources'):
-        if resources.use_spot or resources.disk_tier is not None:
-            return ([], [])
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Accelerators are part of the instance type in Lambda Cloud

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -45,6 +45,10 @@ class SCP(clouds.Cloud):
         clouds.CloudImplementationFeatures.MULTI_NODE: _MULTI_NODE,
         clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
             (f'Migrating disk is not supported in {_REPR}.'),
+        clouds.CloudImplementationFeatures.SPOT_INSTANCE:
+            (f'Spot instances are not supported in {_REPR}.'),
+        clouds.CloudImplementationFeatures.CUSTOM_DOSK_TIER:
+            (f'Custom disk tiers are not supported in {_REPR}.'),
     }
 
     _INDENT_PREFIX = '    '
@@ -230,8 +234,6 @@ class SCP(clouds.Cloud):
 
     def _get_feasible_launchable_resources(
             self, resources: 'resources_lib.Resources'):
-        if resources.use_spot or resources.disk_tier is not None:
-            return ([], [])
         # Check if the host VM satisfies the min/max disk size limits.
         is_allowed = self._is_disk_size_allowed(resources)
         if not is_allowed:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,5 +1,5 @@
 """Resources: compute requirements of Tasks."""
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Set
 from typing_extensions import Literal
 
 import colorama
@@ -890,6 +890,16 @@ class Resources:
             if None not in self.image_id and region not in self.image_id:
                 return False
         return True
+
+    def get_required_cloud_features(
+            self) -> Set[clouds.CloudImplementationFeatures]:
+        """Returns the set of cloud features required by this Resources."""
+        features = set()
+        if self.use_spot:
+            features.add(clouds.CloudImplementationFeatures.SPOT_INSTANCE)
+        if self.disk_tier is not None:
+            features.add(clouds.CloudImplementationFeatures.CUSTOM_DOSK_TIER)
+        return features
 
     @classmethod
     def from_yaml_config(cls, config: Optional[Dict[str, str]]) -> 'Resources':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The failover function in the optimizer helps us get rid of invalid resources for a certain cloud. Say if we specify `--disk-tier high` when `sky launch`, we wanted the optimizer only pick clouds that support the customized `disk_tier` feature.

Previously, we have to manually modify `_get_feasible_launchable_resources` function in all cloud to handle the special case: return an empty list to the optimizer when one unsupported feature is used, so that the optimizer will skip this cloud since no valid resources are found. This PR refactors the implementation of this function, by describing unsupported features in resources with `clouds.CloudImplementationFeatures`, and adding a check before we step in cloud-specific `_get_feasible_launchable_resources` functions.

After this PR is merged, #1910 and #2210 could have similar implementations when docker/ports are specified.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (NOTICE: I only have a subscription for AWS & GCP & Azure & Lambda)
     - `sky launch --disk-tier high` and only AWS & GCP are listed
     - `sky launch --disk-tier medium` and only AWS & GCP & Azure are listed
     - `sky launch --disk-tier low` and only AWS & GCP & Azure are listed
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
