### PR TITLE
[Provisioner] Use new termination for autostop

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -27,7 +27,7 @@ from sky import clouds
 from sky import cloud_stores
 from sky import exceptions
 from sky import global_user_state
-from sky import provision as provision_api
+from sky import provision as provision_lib
 from sky import resources as resources_lib
 from sky import sky_logging
 from sky import optimizer
@@ -3376,16 +3376,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         'It might be because the cluster\'s head node has '
                         'already been terminated. It is fine to skip this.')
             try:
-                if terminate:
-                    provision_api.terminate_instances(
-                        repr(cloud),
-                        cluster_name,
-                        provider_config=config['provider'])
-                else:
-                    provision_api.stop_instances(
-                        repr(cloud),
-                        cluster_name,
-                        provider_config=config['provider'])
+                provision_lib.stop_or_terminate_instances(
+                    repr(cloud),
+                    cluster_name,
+                    provider_config=config['provider'],
+                    terminate=terminate)
             except Exception as e:  # pylint: disable=broad-except
                 if purge:
                     logger.warning(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3375,12 +3375,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         'Failed to take down Ray autoscaler on the head node. '
                         'It might be because the cluster\'s head node has '
                         'already been terminated. It is fine to skip this.')
+            operation_fn = provision_lib.stop_instances
+            if terminate:
+                operation_fn = provision_lib.terminate_instances
             try:
-                provision_lib.stop_or_terminate_instances(
-                    repr(cloud),
-                    cluster_name,
-                    provider_config=config['provider'],
-                    terminate=terminate)
+                operation_fn(repr(cloud),
+                             cluster_name,
+                             provider_config=config['provider'])
             except Exception as e:  # pylint: disable=broad-except
                 if purge:
                     logger.warning(

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -36,13 +36,27 @@ def _route_to_cloud_impl(func):
 # TODO(suquark): Bring all other functions here from the
 
 
+def stop_or_terminate_instances(provider_name: str,
+                                cluster_name: str,
+                                provider_config: Optional[Dict[str,
+                                                               Any]] = None,
+                                worker_only: bool = False,
+                                terminate: bool = False) -> None:
+    """Stop or terminate running instances."""
+    if terminate:
+        terminate_instances(provider_name, cluster_name, provider_config,
+                            worker_only)
+    else:
+        stop_instances(provider_name, cluster_name, provider_config,
+                       worker_only)
+
+
 @_route_to_cloud_impl
 def stop_instances(
     provider_name: str,
     cluster_name: str,
     provider_config: Optional[Dict[str, Any]] = None,
-    included_instances: Optional[List[str]] = None,
-    excluded_instances: Optional[List[str]] = None,
+    worker_only: bool = False,
 ) -> None:
     """Stop running instances."""
     raise NotImplementedError
@@ -53,8 +67,7 @@ def terminate_instances(
     provider_name: str,
     cluster_name: str,
     provider_config: Optional[Dict[str, Any]] = None,
-    included_instances: Optional[List[str]] = None,
-    excluded_instances: Optional[List[str]] = None,
+    worker_only: bool = False,
 ) -> None:
     """Terminate running or stopped instances."""
     raise NotImplementedError

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -36,21 +36,6 @@ def _route_to_cloud_impl(func):
 # TODO(suquark): Bring all other functions here from the
 
 
-def stop_or_terminate_instances(provider_name: str,
-                                cluster_name: str,
-                                provider_config: Optional[Dict[str,
-                                                               Any]] = None,
-                                worker_only: bool = False,
-                                terminate: bool = False) -> None:
-    """Stop or terminate running instances."""
-    if terminate:
-        terminate_instances(provider_name, cluster_name, provider_config,
-                            worker_only)
-    else:
-        stop_instances(provider_name, cluster_name, provider_config,
-                       worker_only)
-
-
 @_route_to_cloud_impl
 def stop_instances(
     provider_name: str,

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -209,19 +209,18 @@ class AutostopEvent(SkyletEvent):
 
         subprocess.run('ray stop', shell=True, check=True)
 
-        subprocess.run('ray stop', shell=True, check=True)
+        operation_fn = provision_lib.stop_instances
+        if autostop_config.down:
+            operation_fn = provision_lib.terminate_instances
+
         if is_cluster_multinode:
-            provision_lib.stop_or_terminate_instances(
-                provider_name=provider_name,
-                cluster_name=cluster_name,
-                provider_config=cluster_config['provider'],
-                worker_only=True,
-                terminate=autostop_config.down)
-        provision_lib.stop_or_terminate_instances(
-            provider_name=provider_name,
-            cluster_name=cluster_name,
-            provider_config=cluster_config['provider'],
-            terminate=autostop_config.down)
+            operation_fn(provider_name=provider_name,
+                         cluster_name=cluster_name,
+                         provider_config=cluster_config['provider'],
+                         worker_only=True)
+        operation_fn(provider_name=provider_name,
+                     cluster_name=cluster_name,
+                     provider_config=cluster_config['provider'])
 
     def _replace_yaml_for_stopping(self, yaml_path: str, down: bool):
         with open(yaml_path, 'r') as f:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -124,8 +124,8 @@ class AutostopEvent(SkyletEvent):
 
             config = common_utils.read_yaml(self._ray_yaml_path)
 
-            provider_type = config['provider']['type']
-            provider_search = re.search(r'providers\.(.*)\.', provider_type)
+            provider_module = config['provider']['module']
+            provider_search = re.search(r'providers\.(.*)\.', provider_module)
             assert provider_search is not None, config
             provider_name = provider_search.group(1).lower()
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -203,10 +203,11 @@ class AutostopEvent(SkyletEvent):
         cluster_name = cluster_config['cluster_name']
         is_cluster_multinode = cluster_config['max_workers'] > 0
 
-        os.environ['RAY_USAGE_STATS_ENABLED'] = '0'
         os.environ.pop('AWS_ACCESS_KEY_ID', None)
         os.environ.pop('AWS_SECRET_ACCESS_KEY', None)
 
+        # Stop the ray autoscaler to avoid scaling up, during
+        # stopping/terminating of the cluster.
         subprocess.run('ray stop', shell=True, check=True)
 
         operation_fn = provision_lib.stop_instances


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2247 

This is a quick draft for the implementation. @suquark please feel free to check it out.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud aws --num-nodes 8 --cpus 2 -i 0 echo hi`
  - [x] `sky launch --cloud aws --num-nodes 8 --cpus 2 -i 0 echo hi --down`
  - [x] `sky launch -c test-gcp-mn --cloud gcp --cpus 2 --num-nodes 8 -i 0`
  - [x] `sky launch -c test-gcp-mn --cloud gcp --cpus 2 --num-nodes 8 -i 0 --down`
  - [x] `sky launch -c test-aws-access-key --cloud aws --cpus 2 --num-nodes 8 -i 0 "echo AWS_ACCESS_KEY_ID="random-key" >> ~/.bashrc"`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
