### PR TITLE
Add error message for rsync not found in image

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -767,8 +767,8 @@ class RetryingVmProvisioner(object):
             elif 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                        '`rsync` command is not found in the specified image. '
+                        'Please use an image with rsync installed.')
             else:
                 logger.info('====== stdout ======')
                 for s in stdout.split('\n'):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -764,6 +764,11 @@ class RetryingVmProvisioner(object):
                 logger.warning(f'Got \'resource not found\' in {zone.name}.')
                 self._blocked_resources.add(
                     launchable_resources.copy(zone=zone.name))
+            elif 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             else:
                 logger.info('====== stdout ======')
                 for s in stdout.split('\n'):
@@ -806,6 +811,11 @@ class RetryingVmProvisioner(object):
             line.startswith('<1/1> Setting up head node')
             for line in stdout_splits + stderr_splits)
         if not errors or head_node_up:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             # TODO: Got transient 'Failed to create security group' that goes
             # away after a few minutes.  Should we auto retry other regions, or
             # let the user retry.
@@ -858,6 +868,11 @@ class RetryingVmProvisioner(object):
                 in s.strip() or '(ReadOnlyDisabledSubscription)' in s.strip())
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -891,6 +906,11 @@ class RetryingVmProvisioner(object):
             if 'LambdaCloudError:' in s.strip()
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -927,6 +947,11 @@ class RetryingVmProvisioner(object):
             if 'SCPError:' in s.strip()
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -964,6 +989,11 @@ class RetryingVmProvisioner(object):
             if 'ERR' in s.strip() or 'PANIC' in s.strip()
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -995,6 +1025,11 @@ class RetryingVmProvisioner(object):
             if 'ERR' in s.strip() or 'PANIC' in s.strip()
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1030,6 +1065,11 @@ class RetryingVmProvisioner(object):
               'LimitExceeded' in s.strip() or 'NotAuthenticated' in s.strip()))
         ]
         if not errors:
+            if 'rsync: command not found' in stderr:
+                with ux_utils.print_exception_no_traceback():
+                    raise RuntimeError(
+                        'rsync is not installed on the specific image. '
+                        'Please install rsync and try again.')
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1757,6 +1797,11 @@ class RetryingVmProvisioner(object):
                         'Retrying due to the possibly flaky RESOURCE_NOT_FOUND '
                         'error.')
                     return True
+
+            if 'rsync: command not found' in stderr:
+                logger.info('Skipping retry due to `rsync` not found in '
+                            'the specified image.')
+                return False
 
             if ('Processing file mounts' in stdout and
                     'Running setup commands' not in stdout and

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -103,6 +103,10 @@ _TEARDOWN_PURGE_WARNING = (
     'Details: {details}'
     f'{colorama.Style.RESET_ALL}')
 
+_RSYNC_NOT_FOUND_WARNING = (
+    '`rsync` command is not found in the specified image. '
+    'Please use an image with rsync installed.')
+
 _TPU_NOT_FOUND_ERROR = 'ERROR: (gcloud.compute.tpus.delete) NOT_FOUND'
 
 _CTRL_C_TIP_MESSAGE = ('INFO: Tip: use Ctrl-C to exit log streaming '
@@ -766,9 +770,7 @@ class RetryingVmProvisioner(object):
                     launchable_resources.copy(zone=zone.name))
             elif 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        '`rsync` command is not found in the specified image. '
-                        'Please use an image with rsync installed.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             else:
                 logger.info('====== stdout ======')
                 for s in stdout.split('\n'):
@@ -813,9 +815,7 @@ class RetryingVmProvisioner(object):
         if not errors or head_node_up:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             # TODO: Got transient 'Failed to create security group' that goes
             # away after a few minutes.  Should we auto retry other regions, or
             # let the user retry.
@@ -870,9 +870,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -908,9 +906,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -949,9 +945,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -991,9 +985,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1027,9 +1019,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1067,9 +1057,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(
-                        'rsync is not installed on the specific image. '
-                        'Please install rsync and try again.')
+                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -103,7 +103,7 @@ _TEARDOWN_PURGE_WARNING = (
     'Details: {details}'
     f'{colorama.Style.RESET_ALL}')
 
-_RSYNC_NOT_FOUND_WARNING = (
+_RSYNC_NOT_FOUND_MESSAGE = (
     '`rsync` command is not found in the specified image. '
     'Please use an image with rsync installed.')
 
@@ -770,7 +770,7 @@ class RetryingVmProvisioner(object):
                     launchable_resources.copy(zone=zone.name))
             elif 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             else:
                 logger.info('====== stdout ======')
                 for s in stdout.split('\n'):
@@ -815,7 +815,7 @@ class RetryingVmProvisioner(object):
         if not errors or head_node_up:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             # TODO: Got transient 'Failed to create security group' that goes
             # away after a few minutes.  Should we auto retry other regions, or
             # let the user retry.
@@ -870,7 +870,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -906,7 +906,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -945,7 +945,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -985,7 +985,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1019,7 +1019,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)
@@ -1057,7 +1057,7 @@ class RetryingVmProvisioner(object):
         if not errors:
             if 'rsync: command not found' in stderr:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError(_RSYNC_NOT_FOUND_WARNING)
+                    raise RuntimeError(_RSYNC_NOT_FOUND_MESSAGE)
             logger.info('====== stdout ======')
             for s in stdout_splits:
                 print(s)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR partially fixes #1603 by adding an error message that indicates rsync is not found in the specified image, so that users don't need to dive deep into SkyPilot code to figure out why.

#1641 and #1910 will add cloud-init support for GCP and Azure. After these two are merged, we could have a new PR to add the installation of rsync.

An example of the error message:

```
(sky-dev) ➜  skypilot git:(fix-rsync-not-exist) ✗ sky launch --cloud gcp --image-id projects/skypilot-375900/global/images/no-rsync-centos
I 07-16 14:41:11 optimizer.py:636] == Optimizer ==
I 07-16 14:41:11 optimizer.py:648] Target: minimizing cost
I 07-16 14:41:11 optimizer.py:659] Estimated cost: $0.4 / hour
I 07-16 14:41:11 optimizer.py:659] 
I 07-16 14:41:11 optimizer.py:733] Considered resources (1 node):
I 07-16 14:41:11 optimizer.py:781] --------------------------------------------------------------------------------------------
I 07-16 14:41:11 optimizer.py:781]  CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 07-16 14:41:11 optimizer.py:781] --------------------------------------------------------------------------------------------
I 07-16 14:41:11 optimizer.py:781]  GCP     n2-standard-8   8       32        -              us-central1   0.39          ✔     
I 07-16 14:41:11 optimizer.py:781] --------------------------------------------------------------------------------------------
I 07-16 14:41:11 optimizer.py:781] 
Launching a new cluster 'sky-aae9-memory'. Proceed? [Y/n]: 
I 07-16 14:41:20 cloud_vm_ray_backend.py:3884] Creating a new cluster: "sky-aae9-memory" [1x GCP(n2-standard-8, image_id={'us-central1': 'projects/skypilot-375900/global/images/no-rsync-centos'})].
I 07-16 14:41:20 cloud_vm_ray_backend.py:3884] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
I 07-16 14:41:23 cloud_vm_ray_backend.py:1390] To view detailed progress: tail -n100 -f /home/memory/sky_logs/sky-2023-07-16-14-40-38-712846/provision.log
I 07-16 14:41:26 cloud_vm_ray_backend.py:1743] Launching on GCP us-central1 (us-central1-a)
I 07-16 14:42:10 cloud_vm_ray_backend.py:1802] Skipping retry due to `rsync` not found in the specified image.
Clusters
NAME             LAUNCHED     RESOURCES                                                                  STATUS  AUTOSTOP  COMMAND                       
sky-aae9-memory  45 secs ago  1x GCP(n2-standard-8, image_id={'us-central1': 'projects/skypilot-3759...  INIT    -         sky launch --cloud gcp --...  

RuntimeError: rsync is not installed on the specific image. Please install rsync and try again.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `sky launch --cloud gcp --image-id <some image without rsync>`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
