### PR TITLE
Handle kube config management for sky local commands

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4419,15 +4419,6 @@ def local():
 def local_up():
     """Creates a local cluster."""
     cluster_created = False
-    # Check if ~/.kube/config exists:
-    if os.path.exists(os.path.expanduser('~/.kube/config')):
-        # Check if kubeconfig is valid, `kind delete` leaves an empty kubeconfig
-        valid, reason = kubernetes_utils.check_credentials()
-        if valid or (not valid and 'Invalid configuration' not in reason):
-            # Could be a valid kubeconfig or a non-empty but non-functioning
-            # kubeconfig - check if user wants to overwrite it
-            prompt = 'Cluster config found at ~/.kube/config. Overwrite it?'
-            click.confirm(prompt, default=True, abort=True, show_default=True)
     with log_utils.safe_rich_status('Creating local cluster...'):
         path_to_package = os.path.dirname(os.path.dirname(__file__))
         up_script_path = os.path.join(path_to_package, 'sky/utils/kubernetes',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4419,6 +4419,15 @@ def local():
 def local_up():
     """Creates a local cluster."""
     cluster_created = False
+    # Check if ~/.kube/config exists:
+    if os.path.exists(os.path.expanduser('~/.kube/config')):
+        current_context = kubernetes_utils.get_current_kube_config_context()
+        skypilot_context = "kind-skypilot"
+        if current_context is not None and current_context != skypilot_context:
+            click.echo(
+                f'Current context in kube config: {current_context}'
+                '\nWill automatically switch to kind-skypilot after the local cluster is created.'
+            )
     with log_utils.safe_rich_status('Creating local cluster...'):
         path_to_package = os.path.dirname(os.path.dirname(__file__))
         up_script_path = os.path.join(path_to_package, 'sky/utils/kubernetes',

--- a/sky/skylet/providers/kubernetes/utils.py
+++ b/sky/skylet/providers/kubernetes/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional, Union
+from typing import List, Tuple, Optional
 
 from sky import status_lib
 from sky.adaptors import kubernetes
@@ -68,7 +68,7 @@ def get_cluster_status(cluster_name: str,
     return cluster_status
 
 
-def get_current_kube_config_context() -> Union[str, None]:
+def get_current_kube_config_context() -> Optional[str]:
     """
     Get the current kubernetes context from the kubeconfig file
 

--- a/sky/skylet/providers/kubernetes/utils.py
+++ b/sky/skylet/providers/kubernetes/utils.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Union
 
 from sky import status_lib
 from sky.adaptors import kubernetes
@@ -66,3 +66,18 @@ def get_cluster_status(cluster_name: str,
             cluster_status.append(status_lib.ClusterStatus.INIT)
     # If pods are not found, we don't add them to the return list
     return cluster_status
+
+
+def get_current_kube_config_context() -> Union[str, None]:
+    """
+    Get the current kubernetes context from the kubeconfig file
+
+    Returns:
+        str | None: The current kubernetes context if it exists, None otherwise
+    """
+    k8s = kubernetes.get_kubernetes()
+    try:
+        _, current_context = k8s.config.list_kube_config_contexts()
+        return current_context['name']
+    except k8s.config.config_exception.ConfigException:
+        return None

--- a/sky/utils/kubernetes/delete_cluster.sh
+++ b/sky/utils/kubernetes/delete_cluster.sh
@@ -24,3 +24,10 @@ fi
 
 kind delete cluster --name skypilot
 echo "Local cluster deleted!"
+
+# Switch to the first available context
+AVAILABLE_CONTEXT=$(kubectl config get-contexts -o name | head -n 1)
+if [ ! -z "$AVAILABLE_CONTEXT" ]; then
+    echo "Switching to context $AVAILABLE_CONTEXT"
+    kubectl config use-context $AVAILABLE_CONTEXT
+fi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Changes:

1. Remove prompt asking for confirmation to override `~/.kube/config` in `sky local up` since `kind` does not override the kube config (it just adds new entries to the `clusters`, `users` and `contexts` list)
2. Set the first available context as `current-context` in kube config after deletion of `kind` cluster in `sky local down`. Upon deletion, `kind` sets the `current-context` field to empty in the kube config, which causes `kubectl` commands to fail. So we set a previous context (if available).



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky local up` with missing `~/.kube/config`
    - [x] `sky local up` with empty `~/.kube/config`
    - [x] `sky local down` with no other contexts in `~/.kube/config`
    - [x] `sky local down` with available contexts in `~/.kube/config`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
