### PR TITLE
[Storage] Replacing aws s3 sync with s5cmd with much faster speed

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -73,6 +73,10 @@ To use AWS IAM Identity Center (AWS SSO), see :ref:`here<aws-sso>` for instructi
 
 **Optional**: To create a new AWS user with minimal permissions for SkyPilot, see :ref:`AWS User Creation <cloud-permissions-aws>`.
 
+.. tip::
+
+  If you are using S3 storage, consider installing :code:`s5cmd` for improved performance on syncing local machine to S3 bucket. (See `s5cmd repository <https://github.com/peak/s5cmd#installation>`_ for installation).
+
 .. _installation-gcp:
 
 Google Cloud Platform (GCP)

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -70,7 +70,7 @@ class S3CloudStorage(CloudStorage):
         # AWS Sync by default uses 10 threads to upload files to the bucket.
         # To increase parallelism, modify max_concurrent_requests in your
         # aws config file (Default path: ~/.aws/config).
-        bucket_name = source.replace('s3://','')
+        bucket_name = source.replace('s3://', '')
         region = data_utils.get_s3_bucket_region(bucket_name)
         download_via_awscli = (f's5cmd sync --destination-region {region} '
                                f'--no-follow-symlinks {source} {destination}')
@@ -81,7 +81,7 @@ class S3CloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
-        bucket_name = source.replace('s3://','')
+        bucket_name = source.replace('s3://', '')
         region = data_utils.get_s3_bucket_region(bucket_name)
         download_via_awscli = (f's5cmd cp --destination-region {region} '
                                f'{source} {destination}')

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -70,8 +70,10 @@ class S3CloudStorage(CloudStorage):
         # AWS Sync by default uses 10 threads to upload files to the bucket.
         # To increase parallelism, modify max_concurrent_requests in your
         # aws config file (Default path: ~/.aws/config).
-        download_via_awscli = ('aws s3 sync --no-follow-symlinks '
-                               f'{source} {destination}')
+        bucket_name = source.replace('s3://','')
+        region = data_utils.get_s3_bucket_region(bucket_name)
+        download_via_awscli = (f's5cmd sync --destination-region {region} '
+                               f'--no-follow-symlinks {source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)
@@ -79,7 +81,10 @@ class S3CloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
-        download_via_awscli = f'aws s3 cp {source} {destination}'
+        bucket_name = source.replace('s3://','')
+        region = data_utils.get_s3_bucket_region(bucket_name)
+        download_via_awscli = (f's5cmd cp --destination-region {region} '
+                               f'{source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -72,6 +72,13 @@ def verify_s3_bucket(name: str) -> bool:
     return bucket in s3.buckets.all()
 
 
+def get_s3_bucket_region(bucket_name: str) -> bool:
+    s3 = aws.client('s3')
+    bucket_location = s3.get_bucket_location(Bucket=bucket_name)
+    region = bucket_location['LocationConstraint']
+    return region
+
+
 def verify_gcs_bucket(name: str) -> bool:
     """Helper method that checks if the GCS bucket exists
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -72,13 +72,6 @@ def verify_s3_bucket(name: str) -> bool:
     return bucket in s3.buckets.all()
 
 
-def get_s3_bucket_region(bucket_name: str) -> bool:
-    s3 = aws.client('s3')
-    bucket_location = s3.get_bucket_location(Bucket=bucket_name)
-    region = bucket_location['LocationConstraint']
-    return region
-
-
 def verify_gcs_bucket(name: str) -> bool:
     """Helper method that checks if the GCS bucket exists
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -232,3 +232,15 @@ def run_upload_cli(command: str, access_denied_message: str, bucket_name: str):
                 raise exceptions.StorageUploadError(
                     f'Upload to bucket failed for store {bucket_name}. '
                     'Please check the logs.')
+
+def s5cmd_installed() -> bool:
+    """Checks if s5cmd is installed in local machine."""
+    try:
+        subprocess.run('s5cmd version',
+                       shell=True,
+                       check=True,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.PIPE)
+        return True
+    except subprocess.CalledProcessError:
+        return False

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1100,11 +1100,9 @@ class S3Store(AbstractStore):
                     src_dir_path += '/'
                 if dest_dir_name and not dest_dir_name.endswith('/'):
                     dest_dir_name += '/'
-                region = data_utils.get_s3_bucket_region(self.name)
-                d = self.region
                 # we exclude .git directory from the sync
                 sync_command = (
-                    f's5cmd sync --destination-region {region} '
+                    f's5cmd sync --destination-region {self.region} '
                     f'--no-follow-symlinks --exclude ".git/*" {src_dir_path} '
                     f's3://{self.name}/{dest_dir_name}')
             else:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1091,8 +1091,10 @@ class S3Store(AbstractStore):
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
-            # we exclude .git directory from the sync
+            if not src_dir_path.endswith('/'):
+                src_dir_path += '/'
             region = data_utils.get_s3_bucket_region(self.name)
+            # we exclude .git directory from the sync
             sync_command = (
                 f's5cmd sync --destination-region {region} '
                 f'--no-follow-symlinks --exclude ".git/*" {src_dir_path} '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1092,9 +1092,10 @@ class S3Store(AbstractStore):
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
+            region = data_utils.get_s3_bucket_region(self.name)
             sync_command = (
-                'aws s3 sync --no-follow-symlinks --exclude ".git/*" '
-                f'{src_dir_path} '
+                f's5cmd sync --destination-region {region} '
+                f'--no-follow-symlinks --exclude ".git/*" {src_dir_path} '
                 f's3://{self.name}/{dest_dir_name}')
             return sync_command
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1094,14 +1094,17 @@ class S3Store(AbstractStore):
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             if data_utils.s5cmd_installed():
+                # s5cmd copies the directory itself as well without
+                # / appeneded to the end of src path unlike aws s3 sync
                 if not src_dir_path.endswith('/'):
                     src_dir_path += '/'
                 if dest_dir_name and not dest_dir_name.endswith('/'):
                     dest_dir_name += '/'
                 region = data_utils.get_s3_bucket_region(self.name)
+                d = self.region
                 # we exclude .git directory from the sync
                 sync_command = (
-                    f's5cmd sync --destination-region {self.region} '
+                    f's5cmd sync --destination-region {region} '
                     f'--no-follow-symlinks --exclude ".git/*" {src_dir_path} '
                     f's3://{self.name}/{dest_dir_name}')
             else:

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -125,6 +125,7 @@ aws_dependencies = [
     'boto3',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
+    's5cmd',
 ]
 extras_require: Dict[str, List[str]] = {
     'aws': aws_dependencies,

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2576,7 +2576,9 @@ class TestStorageWithCredentials:
     @pytest.fixture
     def tmp_awscli_bucket(self, tmp_bucket_name):
         # Creates a temporary bucket using awscli
-        subprocess.check_call(['aws', 's3', 'mb', f's3://{tmp_bucket_name}'])
+        # Region is set to us-east-2 as it is the region set as default
+        # when bucket is created within Skypilot
+        subprocess.check_call(['aws', 's3', 'mb', f's3://{tmp_bucket_name}', '--region', 'us-east-2'])
         yield tmp_bucket_name
         subprocess.check_call(
             ['aws', 's3', 'rb', f's3://{tmp_bucket_name}', '--force'])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR closes #2176 

User requested to use `s5cmd sync` instead of `aws s3 sync` for our storage upload and downloads due to it's speed. [Confirmed it has most of necessary functionalities with a much faster speed](https://github.com/skypilot-org/skypilot/issues/2176#issuecomment-1636993365). As `s5cmd` does not have `--include` option implemented yet, I will leave `storage.py/S3Store.get_file_sync_command` as it is. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] `sky launch s3_storage.yaml` which s3_storage.yaml has `COPY` mode s3 store written
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
