### PR TITLE
[Setup] Pin cython < 3

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -74,6 +74,9 @@ install_requires = [
     # the latest version.
     'colorama<0.4.5',
     'cryptography',
+    # Cython 3.0 release breaks PyYAML and other dependencies.
+    # https://github.com/yaml/pyyaml/issues/601
+    'Cython<0.3',
     # Jinja has a bug in older versions because of the lack of pinning
     # the version of the underlying markupsafe package. See:
     # https://github.com/pallets/jinja/issues/1585


### PR DESCRIPTION
Fixes #2255.

[Cython 3.0.0](https://pypi.org/project/Cython/) just landed an hour ago and caused pyyaml to break. See https://github.com/yaml/pyyaml/issues/601

Pinning Cython<3 till dependencies are fixed.

Tested (run the relevant ones):

- [x] `pip install -e ".[aws]"` in a docker container
