### PR TITLE
[Storage] Fix test_multiple_buckets_creation_and_deletion from test_smoke.py

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2606,7 +2606,9 @@ class TestStorageWithCredentials:
         assert all([item in out for item in storage_obj_name])
 
         # Run sky storage delete all to delete all storage objects
-        subprocess.check_output(['sky', 'storage', 'delete', '-a'])
+        delete_cmd = ['sky', 'storage', 'delete']
+        delete_cmd += storage_obj_name
+        subprocess.check_output(delete_cmd)
 
         # Run sky storage ls to check if all storage objects filtered by store
         # type are deleted


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This resolves #2258 

This fixes by running `sky storage delete` on the storage objects created from the test rather than all with `-a`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] All smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [x] Confirmed the reproduction steps in #2258 does not occur.
