### PR TITLE
[SkyServe] add http server example

### DIFF
--- a/sky/serve/examples/http_server/README.md
+++ b/sky/serve/examples/http_server/README.md
@@ -1,0 +1,11 @@
+# HTTP Server example for SkyServe
+
+## Usage
+
+```bash
+# Run controller.
+python -m sky.serve.controller --task-yaml sky/serve/examples/http_server/task.yaml
+
+# Run redirector.
+python -m sky.serve.redirector --task-yaml sky/serve/examples/http_server/task.yaml
+```

--- a/sky/serve/examples/http_server/server.py
+++ b/sky/serve/examples/http_server/server.py
@@ -1,0 +1,30 @@
+import http.server
+import socketserver
+
+PORT = 8081
+
+class MyHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        # Return 200 for all paths
+        # Therefore, readiness_probe will return 200 at path '/health'
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        html = '''
+            <html>
+            <head>
+                <title>SkyPilot Test Page</title>
+            </head>
+            <body>
+                <h1>Hi, SkyPilot here!</h1>
+            </body>
+            </html>
+        '''
+        self.wfile.write(bytes(html, 'utf8'))
+        return
+
+Handler = MyHttpRequestHandler
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print("serving at port", PORT)
+    httpd.serve_forever()

--- a/sky/serve/examples/http_server/task.yaml
+++ b/sky/serve/examples/http_server/task.yaml
@@ -1,0 +1,12 @@
+resources:
+  cloud: gcp
+  ports:
+    - 8081
+
+workdir: .
+
+run: python3 server.py
+
+service:
+  port: 8081
+  readiness_probe: /health


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add an HTTP server example for SkyServe.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
