### PR TITLE
Fix Lambda rate limit by backoff and retry when exceeding

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1759,6 +1759,12 @@ class RetryingVmProvisioner(object):
                         'error.')
                     return True
 
+            if isinstance(to_provision_cloud, clouds.Lambda):
+                if 'Your API requests are being rate limited.' in stderr:
+                    logger.info(
+                        'Retrying due to Lambda API rate limit exceeded.')
+                    return True
+
             if ('Processing file mounts' in stdout and
                     'Running setup commands' not in stdout and
                     'Failed to setup head node.' in stderr):

--- a/sky/skylet/providers/lambda_cloud/lambda_utils.py
+++ b/sky/skylet/providers/lambda_cloud/lambda_utils.py
@@ -92,9 +92,9 @@ def raise_lambda_error(response: requests.Response) -> None:
 
 
 def _try_request_with_backoff(method,
-                             url: str,
-                             headers: Dict[str, str],
-                             data: Optional[str] = None):
+                              url: str,
+                              headers: Dict[str, str],
+                              data: Optional[str] = None):
     backoff = common_utils.Backoff(initial_backoff=INITIAL_BACKOFF_SECONDS,
                                    max_backoff_factor=MAX_BACKOFF_FACTOR)
     for i in range(MAX_ATTEMPTS):
@@ -180,15 +180,15 @@ class LambdaCloudClient:
     def list_instances(self) -> List[Dict[str, Any]]:
         """List existing instances."""
         response = _try_request_with_backoff(requests.get,
-                                            f'{API_ENDPOINT}/instances',
-                                            headers=self.headers)
+                                             f'{API_ENDPOINT}/instances',
+                                             headers=self.headers)
         return response.json().get('data', [])
 
     def list_ssh_keys(self) -> List[Dict[str, str]]:
         """List ssh keys."""
         response = _try_request_with_backoff(requests.get,
-                                            f'{API_ENDPOINT}/ssh-keys',
-                                            headers=self.headers)
+                                             f'{API_ENDPOINT}/ssh-keys',
+                                             headers=self.headers)
         return response.json().get('data', [])
 
     def get_unique_ssh_key_name(self, prefix: str,
@@ -225,13 +225,13 @@ class LambdaCloudClient:
         """Register ssh key with Lambda."""
         data = json.dumps({'name': name, 'public_key': pub_key})
         _try_request_with_backoff(requests.post,
-                                 f'{API_ENDPOINT}/ssh-keys',
-                                 data=data,
-                                 headers=self.headers)
+                                  f'{API_ENDPOINT}/ssh-keys',
+                                  data=data,
+                                  headers=self.headers)
 
     def list_catalog(self) -> Dict[str, Any]:
         """List offered instances and their availability."""
         response = _try_request_with_backoff(requests.get,
-                                            f'{API_ENDPOINT}/instance-types',
-                                            headers=self.headers)
+                                             f'{API_ENDPOINT}/instance-types',
+                                             headers=self.headers)
         return response.json().get('data', [])

--- a/sky/skylet/providers/lambda_cloud/lambda_utils.py
+++ b/sky/skylet/providers/lambda_cloud/lambda_utils.py
@@ -91,14 +91,19 @@ def raise_lambda_error(response: requests.Response) -> None:
     raise LambdaCloudError(f'{code}: {message}')
 
 
-def _try_request_with_backoff(method,
+def _try_request_with_backoff(method: str,
                               url: str,
                               headers: Dict[str, str],
                               data: Optional[str] = None):
     backoff = common_utils.Backoff(initial_backoff=INITIAL_BACKOFF_SECONDS,
                                    max_backoff_factor=MAX_BACKOFF_FACTOR)
     for i in range(MAX_ATTEMPTS):
-        response = method(url, data=data, headers=headers)
+        if method == 'get':
+            response = requests.get(url, headers=headers)
+        elif method == 'post':
+            response = requests.post(url, headers=headers, data=data)
+        else:
+            raise ValueError(f'Unsupported requests method: {method}')
         # If rate limited, wait and try again
         if response.status_code == 429 and i != MAX_ATTEMPTS - 1:
             time.sleep(backoff.current_backoff())
@@ -157,7 +162,7 @@ class LambdaCloudClient:
             'name': name
         })
         response = _try_request_with_backoff(
-            requests.post,
+            'post',
             f'{API_ENDPOINT}/instance-operations/launch',
             data=data,
             headers=self.headers)
@@ -171,7 +176,7 @@ class LambdaCloudClient:
             ]
         })
         response = _try_request_with_backoff(
-            requests.post,
+            'post',
             f'{API_ENDPOINT}/instance-operations/terminate',
             data=data,
             headers=self.headers)
@@ -179,14 +184,14 @@ class LambdaCloudClient:
 
     def list_instances(self) -> List[Dict[str, Any]]:
         """List existing instances."""
-        response = _try_request_with_backoff(requests.get,
+        response = _try_request_with_backoff('get',
                                              f'{API_ENDPOINT}/instances',
                                              headers=self.headers)
         return response.json().get('data', [])
 
     def list_ssh_keys(self) -> List[Dict[str, str]]:
         """List ssh keys."""
-        response = _try_request_with_backoff(requests.get,
+        response = _try_request_with_backoff('get',
                                              f'{API_ENDPOINT}/ssh-keys',
                                              headers=self.headers)
         return response.json().get('data', [])
@@ -224,14 +229,14 @@ class LambdaCloudClient:
     def register_ssh_key(self, name: str, pub_key: str) -> None:
         """Register ssh key with Lambda."""
         data = json.dumps({'name': name, 'public_key': pub_key})
-        _try_request_with_backoff(requests.post,
+        _try_request_with_backoff('post',
                                   f'{API_ENDPOINT}/ssh-keys',
                                   data=data,
                                   headers=self.headers)
 
     def list_catalog(self) -> Dict[str, Any]:
         """List offered instances and their availability."""
-        response = _try_request_with_backoff(requests.get,
+        response = _try_request_with_backoff('get',
                                              f'{API_ENDPOINT}/instance-types',
                                              headers=self.headers)
         return response.json().get('data', [])

--- a/sky/skylet/providers/lambda_cloud/lambda_utils.py
+++ b/sky/skylet/providers/lambda_cloud/lambda_utils.py
@@ -10,7 +10,7 @@ from sky.utils import common_utils
 CREDENTIALS_PATH = '~/.lambda_cloud/lambda_keys'
 API_ENDPOINT = 'https://cloud.lambdalabs.com/api/v1'
 # TODO(tian): Determine best backoff factors.
-INITIAL_BACKOFF = 3
+INITIAL_BACKOFF_SECONDS = 3
 MAX_BACKOFF_FACTOR = 10
 MAX_ATTEMPTS = 6
 

--- a/sky/skylet/providers/lambda_cloud/lambda_utils.py
+++ b/sky/skylet/providers/lambda_cloud/lambda_utils.py
@@ -9,6 +9,9 @@ from sky.utils import common_utils
 
 CREDENTIALS_PATH = '~/.lambda_cloud/lambda_keys'
 API_ENDPOINT = 'https://cloud.lambdalabs.com/api/v1'
+# TODO(tian): Determine best backoff factors.
+INITIAL_BACKOFF = 3
+MAX_BACKOFF_FACTOR = 10
 MAX_ATTEMPTS = 6
 
 
@@ -90,7 +93,8 @@ def raise_lambda_error(response: requests.Response) -> None:
 
 
 def try_post_with_backoff(url: str, data: str, headers: Dict[str, str]):
-    backoff = common_utils.Backoff(initial_backoff=3, max_backoff_factor=10)
+    backoff = common_utils.Backoff(initial_backoff=INITIAL_BACKOFF,
+                                   max_backoff_factor=MAX_BACKOFF_FACTOR)
     for i in range(MAX_ATTEMPTS):
         response = requests.post(url, data=data, headers=headers)
         # If rate limited, wait and try again
@@ -103,7 +107,8 @@ def try_post_with_backoff(url: str, data: str, headers: Dict[str, str]):
 
 
 def try_get_with_backoff(url: str, headers: Dict[str, str]):
-    backoff = common_utils.Backoff(initial_backoff=3, max_backoff_factor=10)
+    backoff = common_utils.Backoff(initial_backoff=INITIAL_BACKOFF,
+                                   max_backoff_factor=MAX_BACKOFF_FACTOR)
     for i in range(MAX_ATTEMPTS):
         response = requests.get(url, headers=headers)
         # If rate limited, wait and try again


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes #2261 by:
* Add retry with backoff to all Lambda API requests when the rate limit exceeds;
* Retry launching when exceeding the rate limit.

TODO: debug and verify it works properly

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
