### PR TITLE
[SkyServe] Add service schema and change to new service YAML

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -98,7 +98,7 @@ class RequestRateAutoscaler(Autoscaler):
         """
         super().__init__(*args, **kwargs)
         self.min_nodes = min_nodes
-        self.max_nodes = max_nodes or 2 * min_nodes
+        self.max_nodes = max_nodes or min_nodes
         self.query_interval = 60  # Therefore thresholds represent queries per minute.
         self.upper_threshold = upper_threshold or 1
         self.lower_threshold = lower_threshold or 0

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -81,9 +81,9 @@ class RequestRateAutoscaler(Autoscaler):
     def __init__(self,
                  *args,
                  min_nodes: int = 1,
-                 max_nodes: Optional[int] = 10,
-                 upper_threshold: Optional[int] = 1,
-                 lower_threshold: Optional[int] = 0,
+                 max_nodes: Optional[int] = None,
+                 upper_threshold: Optional[int] = None,
+                 lower_threshold: Optional[int] = None,
                  cooldown: int = 60,
                  **kwargs):
         """
@@ -100,8 +100,8 @@ class RequestRateAutoscaler(Autoscaler):
         self.min_nodes = min_nodes
         self.max_nodes = max_nodes or min_nodes
         self.query_interval = 60  # Therefore thresholds represent queries per minute.
-        self.upper_threshold = upper_threshold or 1
-        self.lower_threshold = lower_threshold or 0
+        self.upper_threshold = upper_threshold
+        self.lower_threshold = lower_threshold
         self.cooldown = cooldown
         self.last_scale_operation = 0  # Time of last scale operation.
 
@@ -135,15 +135,15 @@ class RequestRateAutoscaler(Autoscaler):
         scaled = True
         # Bootstrap case
         logger.info(f'Number of nodes: {num_nodes}')
-        if num_nodes == 0 and requests_per_node > 0:
+        if num_nodes < self.min_nodes:
             logger.info(f'Bootstrapping autoscaler.')
             self.scale_up(1)
             self.last_scale_operation = current_time
-        elif requests_per_node > self.upper_threshold:
+        elif self.upper_threshold is not None and requests_per_node > self.upper_threshold:
             if self.infra_provider.total_servers() < self.max_nodes:
                 self.scale_up(1)
                 self.last_scale_operation = current_time
-        elif requests_per_node < self.lower_threshold:
+        elif self.lower_threshold is not None and requests_per_node < self.lower_threshold:
             if self.infra_provider.total_servers() > self.min_nodes:
                 self.scale_down(1)
                 self.last_scale_operation = current_time

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -99,7 +99,7 @@ class RequestRateAutoscaler(Autoscaler):
         super().__init__(*args, **kwargs)
         self.min_nodes = min_nodes
         self.max_nodes = max_nodes or 2 * min_nodes
-        self.query_interval = 1  # Therefore thresholds represent queries per second.
+        self.query_interval = 60  # Therefore thresholds represent queries per minute.
         self.upper_threshold = upper_threshold or 1
         self.lower_threshold = lower_threshold or 0
         self.cooldown = cooldown

--- a/sky/serve/common.py
+++ b/sky/serve/common.py
@@ -1,5 +1,8 @@
 import yaml
 
+# from sky.backends import backend_utils
+# from sky.utils import schemas
+
 
 class SkyServiceSpec:
 
@@ -12,6 +15,11 @@ class SkyServiceSpec:
             raise ValueError('Task YAML must have a "port" section')
         if 'readiness_probe' not in self.task['service']:
             raise ValueError('Task YAML must have a "readiness_probe" section')
+        # TODO(tian): Enable schema when refactoring current code to accept new
+        # version of service YAML.
+        # service = self.task['service']
+        # backend_utils.validate_schema(service, schemas.get_service_schema(),
+        #                               'Invalid service YAML:')
         self._readiness_path = self.get_readiness_path()
         self._app_port = self.get_app_port()
 

--- a/sky/serve/common.py
+++ b/sky/serve/common.py
@@ -1,4 +1,5 @@
 import yaml
+from typing import Optional, Dict
 
 from sky.backends import backend_utils
 from sky.utils import schemas
@@ -6,23 +7,44 @@ from sky.utils import schemas
 
 class SkyServiceSpec:
 
-    def __init__(self, yaml_path: str):
-        with open(yaml_path, 'r') as f:
-            task = yaml.safe_load(f)
-        if 'service' not in self.task:
-            raise ValueError('Task YAML must have a "service" section')
-        self.service = task['service']
-        backend_utils.validate_schema(self.service, schemas.get_service_schema(),
-                                      'Invalid service YAML:')
+    def __init__(
+            self,
+            readiness_path: str,
+            readiness_timeout: int,
+            app_port: int,
+            min_replica: int,
+            max_replica: Optional[int] = None,
+            qpm_upper_threshold: Optional[int] = None,
+            qpm_lower_threshold: Optional[int] = None,
+    ):
         # TODO: check if the path is valid
-        self._readiness_path = f':{self.service["port"]}{self.service["readiness_probe"]["path"]}'
-        self._readiness_timeout = self.service['readiness_probe']['timeout']
+        self._readiness_path = f':{app_port}{readiness_path}'
+        self._readiness_timeout = readiness_timeout
         # TODO: check if the port is valid
-        self._app_port = str(self.service["port"])
-        self._min_replica = self.service['replica_policy']['min_replica']
-        self._max_replica = self.service['replica_policy'].get('max_replica', None)
-        self._qpm_upper_threshold = self.service['replica_policy'].get('qpm_upper_threshold', None)
-        self._qpm_lower_threshold = self.service['replica_policy'].get('qpm_lower_threshold', None)
+        self._app_port = str(app_port)
+        self._min_replica = min_replica
+        self._max_replica = max_replica
+        self._qpm_upper_threshold = qpm_upper_threshold
+        self._qpm_lower_threshold = qpm_lower_threshold
+
+    @classmethod
+    def from_yaml_config(cls, config: Optional[Dict[str, str]]):
+        if config is None:
+            return SkyServiceSpec()
+
+        backend_utils.validate_schema(config, schemas.get_service_schema(),
+                                      'Invalid service YAML:')
+
+        service_config = {}
+        service_config['readiness_path'] = config['readiness_probe']['path']
+        service_config['readiness_timeout'] = config['readiness_probe']['timeout']
+        service_config['app_port'] = config['port']
+        service_config['min_replica'] = config['replica_policy']['min_replica']
+        service_config['max_replica'] = config['replica_policy'].get('max_replica', None)
+        service_config['qpm_upper_threshold'] = config['replica_policy'].get('qpm_upper_threshold', None)
+        service_config['qpm_lower_threshold'] = config['replica_policy'].get('qpm_lower_threshold', None)
+
+        return SkyServiceSpec(**service_config)
 
     @property
     def readiness_path(self):

--- a/sky/serve/common.py
+++ b/sky/serve/common.py
@@ -1,22 +1,26 @@
-import yaml
 from typing import Optional, Dict
 
 from sky.backends import backend_utils
 from sky.utils import schemas
+from sky.utils import ux_utils
 
 
 class SkyServiceSpec:
 
     def __init__(
-            self,
-            readiness_path: str,
-            readiness_timeout: int,
-            app_port: int,
-            min_replica: int,
-            max_replica: Optional[int] = None,
-            qpm_upper_threshold: Optional[int] = None,
-            qpm_lower_threshold: Optional[int] = None,
+        self,
+        readiness_path: str,
+        readiness_timeout: int,
+        app_port: int,
+        min_replica: int,
+        max_replica: Optional[int] = None,
+        qpm_upper_threshold: Optional[int] = None,
+        qpm_lower_threshold: Optional[int] = None,
     ):
+        if max_replica is not None and max_replica < min_replica:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'max_replica must be greater than or equal to min_replica')
         # TODO: check if the path is valid
         self._readiness_path = f':{app_port}{readiness_path}'
         self._readiness_timeout = readiness_timeout
@@ -37,12 +41,16 @@ class SkyServiceSpec:
 
         service_config = {}
         service_config['readiness_path'] = config['readiness_probe']['path']
-        service_config['readiness_timeout'] = config['readiness_probe']['timeout']
+        service_config['readiness_timeout'] = config['readiness_probe'][
+            'readiness_timeout']
         service_config['app_port'] = config['port']
         service_config['min_replica'] = config['replica_policy']['min_replica']
-        service_config['max_replica'] = config['replica_policy'].get('max_replica', None)
-        service_config['qpm_upper_threshold'] = config['replica_policy'].get('qpm_upper_threshold', None)
-        service_config['qpm_lower_threshold'] = config['replica_policy'].get('qpm_lower_threshold', None)
+        service_config['max_replica'] = config['replica_policy'].get(
+            'max_replica', None)
+        service_config['qpm_upper_threshold'] = config['replica_policy'].get(
+            'qpm_upper_threshold', None)
+        service_config['qpm_lower_threshold'] = config['replica_policy'].get(
+            'qpm_lower_threshold', None)
 
         return SkyServiceSpec(**service_config)
 

--- a/sky/serve/common.py
+++ b/sky/serve/common.py
@@ -30,7 +30,7 @@ class SkyServiceSpec:
     @classmethod
     def from_yaml_config(cls, config: Optional[Dict[str, str]]):
         if config is None:
-            return SkyServiceSpec()
+            return None
 
         backend_utils.validate_schema(config, schemas.get_service_schema(),
                                       'Invalid service YAML:')

--- a/sky/serve/common.py
+++ b/sky/serve/common.py
@@ -21,8 +21,8 @@ class SkyServiceSpec:
         self._app_port = str(self.service["port"])
         self._min_replica = self.service['replica_policy']['min_replica']
         self._max_replica = self.service['replica_policy'].get('max_replica', None)
-        self._qps_upper_threshold = self.service['replica_policy'].get('qps_upper_threshold', None)
-        self._qps_lower_threshold = self.service['replica_policy'].get('qps_lower_threshold', None)
+        self._qpm_upper_threshold = self.service['replica_policy'].get('qpm_upper_threshold', None)
+        self._qpm_lower_threshold = self.service['replica_policy'].get('qpm_lower_threshold', None)
 
     @property
     def readiness_path(self):
@@ -45,9 +45,9 @@ class SkyServiceSpec:
         return self._max_replica
 
     @property
-    def qps_upper_threshold(self):
-        return self._qps_upper_threshold
+    def qpm_upper_threshold(self):
+        return self._qpm_upper_threshold
 
     @property
-    def qps_lower_threshold(self):
-        return self._qps_lower_threshold
+    def qpm_lower_threshold(self):
+        return self._qpm_lower_threshold

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -108,8 +108,8 @@ if __name__ == '__main__':
                                        frequency=5,
                                        min_nodes=service_spec.min_replica,
                                        max_nodes=service_spec.max_replica,
-                                       upper_threshold=service_spec.qps_upper_threshold,
-                                       lower_threshold=service_spec.qps_lower_threshold,
+                                       upper_threshold=service_spec.qpm_upper_threshold,
+                                       lower_threshold=service_spec.qpm_lower_threshold,
                                        cooldown=60)
 
     # ======= Controller =========

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -101,7 +101,7 @@ if __name__ == '__main__':
     load_balancer = RoundRobinLoadBalancer(
         infra_provider=infra_provider,
         endpoint_path=service_spec.readiness_path,
-        timeout=service_spec.readiness_timeout)
+        readiness_timeout=service_spec.readiness_timeout)
     # load_balancer = LeastLoadedLoadBalancer(n=5)
     # autoscaler = LatencyThresholdAutoscaler(load_balancer,
     #                                         upper_threshold=0.5,    # 500ms
@@ -109,14 +109,15 @@ if __name__ == '__main__':
 
     # ======= Autoscaler =========
     # Create an autoscaler with the RequestRateAutoscaler policy. Thresholds are defined as requests per node in the defined interval.
-    autoscaler = RequestRateAutoscaler(infra_provider,
-                                       load_balancer,
-                                       frequency=5,
-                                       min_nodes=service_spec.min_replica,
-                                       max_nodes=service_spec.max_replica,
-                                       upper_threshold=service_spec.qpm_upper_threshold,
-                                       lower_threshold=service_spec.qpm_lower_threshold,
-                                       cooldown=60)
+    autoscaler = RequestRateAutoscaler(
+        infra_provider,
+        load_balancer,
+        frequency=5,
+        min_nodes=service_spec.min_replica,
+        max_nodes=service_spec.max_replica,
+        upper_threshold=service_spec.qpm_upper_threshold,
+        lower_threshold=service_spec.qpm_lower_threshold,
+        cooldown=60)
 
     # ======= Controller =========
     # Create a controller object and run it.

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -83,10 +83,6 @@ if __name__ == '__main__':
                         type=int,
                         help='Port to run the controller',
                         default=8082)
-    parser.add_argument('--min-nodes',
-                        type=int,
-                        default=1,
-                        help='Minimum nodes to keep running')
     args = parser.parse_args()
 
     # ======= Infra Provider =========
@@ -98,7 +94,8 @@ if __name__ == '__main__':
     # Select the load balancing policy: RoundRobinLoadBalancer or LeastLoadedLoadBalancer
     load_balancer = RoundRobinLoadBalancer(
         infra_provider=infra_provider,
-        endpoint_path=service_spec.readiness_path)
+        endpoint_path=service_spec.readiness_path,
+        timeout=service_spec.readiness_timeout)
     # load_balancer = LeastLoadedLoadBalancer(n=5)
     # autoscaler = LatencyThresholdAutoscaler(load_balancer,
     #                                         upper_threshold=0.5,    # 500ms
@@ -109,10 +106,10 @@ if __name__ == '__main__':
     autoscaler = RequestRateAutoscaler(infra_provider,
                                        load_balancer,
                                        frequency=5,
-                                       query_interval=60,
-                                       lower_threshold=0,
-                                       upper_threshold=1,
-                                       min_nodes=args.min_nodes,
+                                       min_nodes=service_spec.min_replica,
+                                       max_nodes=service_spec.max_replica,
+                                       upper_threshold=service_spec.qps_upper_threshold,
+                                       lower_threshold=service_spec.qps_lower_threshold,
                                        cooldown=60)
 
     # ======= Controller =========

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -9,6 +9,7 @@ from sky.serve.load_balancers import RoundRobinLoadBalancer, LoadBalancer
 
 import time
 import threading
+import yaml
 
 from typing import Optional
 
@@ -90,7 +91,12 @@ if __name__ == '__main__':
     infra_provider = SkyPilotInfraProvider(args.task_yaml)
 
     # ======= Load Balancer =========
-    service_spec = SkyServiceSpec(args.task_yaml)
+    with open(args.task_yaml, 'r') as f:
+        task = yaml.safe_load(f)
+    if 'service' not in task:
+        raise ValueError('Task YAML must have a "service" section')
+    service_config = task['service']
+    service_spec = SkyServiceSpec.from_yaml_config(service_config)
     # Select the load balancing policy: RoundRobinLoadBalancer or LeastLoadedLoadBalancer
     load_balancer = RoundRobinLoadBalancer(
         infra_provider=infra_provider,

--- a/sky/serve/examples/http_server/server.py
+++ b/sky/serve/examples/http_server/server.py
@@ -3,7 +3,9 @@ import socketserver
 
 PORT = 8081
 
+
 class MyHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
+
     def do_GET(self):
         # Return 200 for all paths
         # Therefore, readiness_probe will return 200 at path '/health'
@@ -22,6 +24,7 @@ class MyHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
         '''
         self.wfile.write(bytes(html, 'utf8'))
         return
+
 
 Handler = MyHttpRequestHandler
 

--- a/sky/serve/examples/http_server/task.yaml
+++ b/sky/serve/examples/http_server/task.yaml
@@ -11,7 +11,7 @@ service:
   port: 8081
   readiness_probe:
     path: /health
-    timeout: 12000
+    readiness_timeout: 12000
   replica_policy:
     min_replica: 1
     max_replica: 1

--- a/sky/serve/examples/http_server/task.yaml
+++ b/sky/serve/examples/http_server/task.yaml
@@ -9,4 +9,9 @@ run: python3 server.py
 
 service:
   port: 8081
-  readiness_probe: /health
+  readiness_probe:
+    path: /health
+    timeout: 12000
+  replica_policy:
+    min_replica: 1
+    max_replica: 1

--- a/sky/serve/load_balancers.py
+++ b/sky/serve/load_balancers.py
@@ -12,13 +12,13 @@ logger = logging.getLogger(__name__)
 
 class LoadBalancer:
 
-    def __init__(self, infra_provider, endpoint_path, timeout, post_data=None):
+    def __init__(self, infra_provider, endpoint_path, readiness_timeout, post_data=None):
         self.available_servers = []
         self.request_count = 0
         self.request_timestamps = deque()
         self.infra_provider = infra_provider
         self.endpoint_path = endpoint_path
-        self.timeout = timeout
+        self.readiness_timeout = readiness_timeout
         self.post_data = post_data
 
     def increment_request_count(self, count=1):
@@ -101,7 +101,7 @@ class RoundRobinLoadBalancer(LoadBalancer):
                 if server not in self.first_unhealthy_time:
                     self.first_unhealthy_time[server] = time.time()
                 elif time.time() - self.first_unhealthy_time[
-                        server] > self.timeout:  # cooldown before terminating a dead server to avoid hysterisis
+                        server] > self.readiness_timeout:  # cooldown before terminating a dead server to avoid hysterisis
                     servers_to_terminate.append(server)
             self.infra_provider.terminate_servers(servers_to_terminate)
 

--- a/sky/serve/load_balancers.py
+++ b/sky/serve/load_balancers.py
@@ -12,12 +12,13 @@ logger = logging.getLogger(__name__)
 
 class LoadBalancer:
 
-    def __init__(self, infra_provider, endpoint_path, post_data=None):
+    def __init__(self, infra_provider, endpoint_path, timeout, post_data=None):
         self.available_servers = []
         self.request_count = 0
         self.request_timestamps = deque()
         self.infra_provider = infra_provider
         self.endpoint_path = endpoint_path
+        self.timeout = timeout
         self.post_data = post_data
 
     def increment_request_count(self, count=1):
@@ -37,7 +38,6 @@ class RoundRobinLoadBalancer(LoadBalancer):
         super().__init__(*args, **kwargs)
         self.servers_queue = deque()
         self.first_unhealthy_time = {}
-        self.timeout = 18000
         logger.info(f'Endpoint path: {self.endpoint_path}')
 
     def probe_endpoints(self, endpoint_ips):

--- a/sky/serve/redirector.py
+++ b/sky/serve/redirector.py
@@ -1,5 +1,6 @@
 import time
 import logging
+import yaml
 from collections import deque
 
 from sky.serve.common import SkyServiceSpec
@@ -113,7 +114,13 @@ if __name__ == '__main__':
                         help='Controller address (ip:port).')
     args = parser.parse_args()
 
-    service_spec = SkyServiceSpec(args.task_yaml)
+    with open(args.task_yaml, 'r') as f:
+        task = yaml.safe_load(f)
+    if 'service' not in task:
+        raise ValueError('Task YAML must have a "service" section')
+    service_config = task['service']
+    service_spec = SkyServiceSpec.from_yaml_config(service_config)
+
     redirector = SkyServeRedirector(controller_url=args.controller_addr,
                                     service_spec=service_spec,
                                     port=args.port)

--- a/sky/task.py
+++ b/sky/task.py
@@ -15,6 +15,7 @@ from sky import global_user_state
 from sky.backends import backend_utils
 from sky.data import storage as storage_lib
 from sky.data import data_utils
+from sky.serve import common
 from sky.skylet import constants
 from sky.utils import schemas
 from sky.utils import ux_utils
@@ -365,10 +366,12 @@ class Task:
         resources = config.pop('resources', None)
         resources = sky.Resources.from_yaml_config(resources)
 
-        # FIXME: find a better way to exclude unused fields.
-        config.pop('service', None)
-
         task.set_resources({resources})
+
+        service = config.pop('service', None)
+        service = common.SkyServiceSpec.from_yaml_config(service)
+        task.service = service
+
         assert not config, f'Invalid task args: {config.keys()}'
         return task
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -143,6 +143,52 @@ def get_storage_schema():
     }
 
 
+def get_service_schema():
+    return {
+        '$schema': 'http://json-schema.org/draft-07/schema#',
+        'type': 'object',
+        'required': ['port', 'readiness_probe', 'replica_policy'],
+        'additionalProperties': False,
+        'properties': {
+            'port': {
+                'type': 'integer',
+            },
+            'readiness_probe': {
+                'type': 'object',
+                'required': ['path', 'timeout'],
+                'additionalProperties': False,
+                'properties': {
+                    'path': {
+                        'type': 'string',
+                    },
+                    'timeout': {
+                        'type': 'integer',
+                    },
+                }
+            },
+            'replica_policy': {
+                'type': 'object',
+                'required': ['min_replica'],
+                'additionalProperties': False,
+                'properties': {
+                    'min_replica': {
+                        'type': 'integer',
+                    },
+                    'max_replica': {
+                        'type': 'integer',
+                    },
+                    'qps_upper_threshold': {
+                        'type': 'integer',
+                    },
+                    'qps_lower_threshold': {
+                        'type': 'integer',
+                    },
+                }
+            }
+        }
+    }
+
+
 def get_task_schema():
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
@@ -168,6 +214,10 @@ def get_task_schema():
             },
             # storage config is validated separately using STORAGE_SCHEMA
             'file_mounts': {
+                'type': 'object',
+            },
+            # service config is validated separately using SERVICE_SCHEMA
+            'service': {
                 'type': 'object',
             },
             'setup': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -161,8 +161,8 @@ def get_service_schema():
                     'path': {
                         'type': 'string',
                     },
-                    'timeout': {
-                        'type': 'integer',
+                    'readiness_timeout': {
+                        'type': 'number',
                     },
                 }
             },
@@ -178,10 +178,10 @@ def get_service_schema():
                         'type': 'integer',
                     },
                     'qpm_upper_threshold': {
-                        'type': 'integer',
+                        'type': 'number',
                     },
                     'qpm_lower_threshold': {
-                        'type': 'integer',
+                        'type': 'number',
                     },
                 }
             }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -177,10 +177,10 @@ def get_service_schema():
                     'max_replica': {
                         'type': 'integer',
                     },
-                    'qps_upper_threshold': {
+                    'qpm_upper_threshold': {
                         'type': 'integer',
                     },
-                    'qps_lower_threshold': {
+                    'qpm_lower_threshold': {
                         'type': 'integer',
                     },
                 }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a schema checking for our newer version service YAML, and change to new YAML config pattern.

An example:

```yaml
service:
  port: 8082
  readiness_probe:
    path: /health
    timeout: 1200
  replica_policy:
    min_replica: 1
    max_replica: 5             # optional
    qpm_upper_threshold: 10    # optional, if qpm is higher, scale up
    qpm_lower_threshold: 1     # optional, if qpm is lower, scale down
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
