### PR TITLE
Minor: require pyyaml > 3.13 to avoid an error.

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -116,7 +116,8 @@ install_requires = [
     # Cython 3.0 release breaks PyYAML installed by aws-cli.
     # https://github.com/yaml/pyyaml/issues/601
     # https://github.com/aws/aws-cli/issues/8036
-    'pyyaml<=5.3.1'
+    # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
+    'pyyaml > 3.13, <= 5.3.1'
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

<= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414.

Tested `pip install -e`:
```
Collecting pyyaml<=5.3.1,>3.13
  Downloading PyYAML-5.3.1.tar.gz (269 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 269.4/269.4 kB 4.2 MB/s eta 0:00:00
  Preparing metadata (setup.py) ... done
```

Note however at the end
```
kubernetes 26.1.0 requires pyyaml>=5.4.1, but you have pyyaml 5.3.1 which is incompatible.
Successfully installed pyyaml-5.3.1 skypilot-1.0.0.dev0
```
which means our k8s support seems to conflict with the explicit `<= 5.3.1` pin. @romilbhardwaj 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
