### PR TITLE
[AWS] Adopt new provisioner to query clusters 

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1834,7 +1834,7 @@ def check_can_clone_disk_and_override_task(
 def _update_cluster_status_no_lock(
         cluster_name: str) -> Optional[Dict[str, Any]]:
     """Updates the status of the cluster.
-    
+
     Raises:
         exceptions.ClusterStatusFetchingError: the cluster status cannot be
           fetched from the cloud provider.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1685,7 +1685,12 @@ def tag_filter_for_cluster(cluster_name: str) -> Dict[str, str]:
 def _query_cluster_status_via_cloud_api(
     handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle'
 ) -> List[status_lib.ClusterStatus]:
-    """Returns the status of the cluster."""
+    """Returns the status of the cluster.
+
+    Raises:
+        exceptions.ClusterStatusFetchingError: the cluster status cannot be
+          fetched from the cloud provider.
+    """
     cluster_name = handle.cluster_name
     # Use region and zone from the cluster config, instead of the
     # handle.launched_resources, because the latter may not be set
@@ -1828,6 +1833,12 @@ def check_can_clone_disk_and_override_task(
 
 def _update_cluster_status_no_lock(
         cluster_name: str) -> Optional[Dict[str, Any]]:
+    """Updates the status of the cluster.
+    
+    Raises:
+        exceptions.ClusterStatusFetchingError: the cluster status cannot be
+          fetched from the cloud provider.
+    """
     record = global_user_state.get_cluster_from_name(cluster_name)
     if record is None:
         return None

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -13,7 +13,6 @@ from sky import clouds
 from sky import exceptions
 from sky import provision as provision_lib
 from sky import sky_logging
-from sky import status_lib
 from sky.adaptors import aws
 from sky.clouds import service_catalog
 from sky.utils import common_utils
@@ -24,6 +23,7 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     # renaming to avoid shadowing variables
     from sky import resources as resources_lib
+    from sky import status_lib
 
 logger = sky_logging.init_logger(__name__)
 
@@ -796,7 +796,7 @@ class AWS(clouds.Cloud):
         wait_image_cmd = (
             f'aws ec2 wait image-available --region {region} --image-ids {image_id}'
         )
-        returncode, stdout, stderr = subprocess_utils.run_with_retries(
+        returncode, _, stderr = subprocess_utils.run_with_retries(
             wait_image_cmd,
             retry_returncode=[255],
         )

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -11,6 +11,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Any
 
 from sky import clouds
 from sky import exceptions
+from sky import provision as provision_lib
 from sky import sky_logging
 from sky import status_lib
 from sky.adaptors import aws
@@ -742,79 +743,29 @@ class AWS(clouds.Cloud):
         return True
 
     @classmethod
-    def _query_instance_property_with_retries(
-        cls,
-        tag_filters: Dict[str, str],
-        region: str,
-        query: str,
-    ) -> Tuple[int, str, str]:
-        filter_str = ' '.join(f'Name=tag:{key},Values={value}'
-                              for key, value in tag_filters.items())
-        query_cmd = (f'aws ec2 describe-instances --filters {filter_str} '
-                     f'--region {region} --query "{query}" --output json')
-        returncode, stdout, stderr = subprocess_utils.run_with_retries(
-            query_cmd,
-            retry_returncode=[255],
-            retry_stderrs=[
-                'Unable to locate credentials. You can configure credentials by '
-                'running "aws configure"'
-            ])
-        return returncode, stdout, stderr
-
-    @classmethod
     def query_status(cls, name: str, tag_filters: Dict[str, str],
                      region: Optional[str], zone: Optional[str],
                      **kwargs) -> List['status_lib.ClusterStatus']:
-        del zone  # unused
-        status_map = {
-            'pending': status_lib.ClusterStatus.INIT,
-            'running': status_lib.ClusterStatus.UP,
-            # TODO(zhwu): stopping and shutting-down could occasionally fail
-            # due to internal errors of AWS. We should cover that case.
-            'stopping': status_lib.ClusterStatus.STOPPED,
-            'stopped': status_lib.ClusterStatus.STOPPED,
-            'shutting-down': None,
-            'terminated': None,
-        }
-
-        assert region is not None, (tag_filters, region)
-        returncode, stdout, stderr = cls._query_instance_property_with_retries(
-            tag_filters, region, query='Reservations[].Instances[].State.Name')
-
-        if returncode != 0:
-            with ux_utils.print_exception_no_traceback():
-                raise exceptions.ClusterStatusFetchingError(
-                    f'Failed to query AWS cluster {name!r} status: '
-                    f'{stdout + stderr}')
-
-        original_statuses = json.loads(stdout.strip())
-
-        statuses = []
-        for s in original_statuses:
-            node_status = status_map[s]
-            if node_status is not None:
-                statuses.append(node_status)
-        return statuses
+        # TODO(suquark): deprecate this method
+        assert False, 'This could path should not be used.'
 
     @classmethod
     def create_image_from_cluster(cls, cluster_name: str,
                                   tag_filters: Dict[str,
                                                     str], region: Optional[str],
                                   zone: Optional[str]) -> str:
-        del zone  # unused
         assert region is not None, (tag_filters, region)
+        del tag_filters, zone  # unused
+
         image_name = f'skypilot-{cluster_name}-{int(time.time())}'
-        returncode, stdout, stderr = cls._query_instance_property_with_retries(
-            tag_filters, region, query='Reservations[].Instances[].InstanceId')
 
-        subprocess_utils.handle_returncode(
-            returncode,
-            '',
-            error_msg='Failed to find the source cluster on AWS.',
-            stderr=stderr,
-            stream_logs=False)
+        status = provision_lib.query_instances('AWS', cluster_name,
+                                               {'region': region})
+        instance_ids = list(status.keys())
+        if not instance_ids:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError('Failed to find the source cluster on AWS.')
 
-        instance_ids = json.loads(stdout.strip())
         if len(instance_ids) != 1:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -43,6 +43,7 @@ def query_instances(
     provider_name: str,
     cluster_name: str,
     provider_config: Optional[Dict[str, Any]] = None,
+    non_terminated_only: bool = True,
 ) -> Dict[str, Optional[status_lib.ClusterStatus]]:
     """Query instances.
 

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 import functools
 import importlib
 import inspect
+
 from sky import status_lib
 
 
@@ -46,6 +47,9 @@ def query_instances(
     """Query instances.
 
     Returns a dictionary of instance IDs and status.
+
+    A None status means the instance is marked as "terminated"
+    or "terminating".
     """
     raise NotImplementedError
 

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 import functools
 import importlib
 import inspect
+from sky import status_lib
 
 
 def _route_to_cloud_impl(func):
@@ -34,6 +35,19 @@ def _route_to_cloud_impl(func):
 # pylint: disable=unused-argument
 
 # TODO(suquark): Bring all other functions here from the
+
+
+@_route_to_cloud_impl
+def query_instances(
+    provider_name: str,
+    cluster_name: str,
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Optional[status_lib.ClusterStatus]]:
+    """Query instances.
+
+    Returns a dictionary of instance IDs and status.
+    """
+    raise NotImplementedError
 
 
 @_route_to_cloud_impl

--- a/sky/provision/aws/__init__.py
+++ b/sky/provision/aws/__init__.py
@@ -1,3 +1,4 @@
 """AWS provisioner for SkyPilot."""
 
-from sky.provision.aws.instance import stop_instances, terminate_instances
+from sky.provision.aws.instance import (query_instances, terminate_instances,
+                                        stop_instances)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -47,6 +47,7 @@ def _filter_instances(ec2, filters: List[Dict[str, Any]],
 def query_instances(
     cluster_name: str,
     provider_config: Optional[Dict[str, Any]] = None,
+    non_terminated_only: bool = True,
 ) -> Dict[str, Optional[status_lib.ClusterStatus]]:
     """See sky/provision/__init__.py"""
     assert provider_config is not None, (cluster_name, provider_config)
@@ -66,8 +67,10 @@ def query_instances(
     }
     statuses = {}
     for inst in instances:
-        state = inst.state['Name']
-        statuses[inst.id] = status_map[state]
+        status = status_map[inst.state['Name']]
+        if non_terminated_only and status is None:
+            continue
+        statuses[inst.id] = status
     return statuses
 
 

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -80,7 +80,7 @@ def stop_instances(
     assert provider_config is not None, (cluster_name, provider_config)
     region = provider_config['region']
     ec2 = _default_ec2_resource(region)
-    filters = [
+    filters: List[Dict[str, Any]] = [
         {
             'Name': 'instance-state-name',
             'Values': ['pending', 'running'],

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -44,6 +44,10 @@ def _filter_instances(ec2, filters: List[Dict[str, Any]],
     return instances
 
 
+# TODO(suquark): Does it make sense to not expose this and always assume
+# non_terminated_only=True?
+# Will there be callers who would want this to be False?
+# stop() and terminate() for example already implicitly assume non-terminated.
 def query_instances(
     cluster_name: str,
     provider_config: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adopt new provisioner to query cluster status, i.e. instances and their status.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
