### PR TITLE
clean the username format before using as SKYPILOT_USER

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -910,7 +910,8 @@ def write_cluster_config(
                 # If the current code is run by controller, propagate the real
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).
-                'user': os.environ.get('SKYPILOT_USER', getpass.getuser()),
+                'user': get_cleaned_username(os.environ.get(
+                    'SKYPILOT_USER', "")),
 
                 # AWS only:
                 # Temporary measure, as deleting per-cluster SGs is too slow.
@@ -1323,8 +1324,8 @@ def generate_cluster_name():
     return f'sky-{uuid.uuid4().hex[:4]}-{get_cleaned_username()}'
 
 
-def get_cleaned_username() -> str:
-    """Cleans the current username to be used as part of a cluster name.
+def get_cleaned_username(username: str = "") -> str:
+    """Cleans the username to be used as part of a cluster name.
 
     Clean up includes:
      1. Making all characters lowercase
@@ -1338,7 +1339,7 @@ def get_cleaned_username() -> str:
       A cleaned username that will pass the regex in
       check_cluster_name_is_valid().
     """
-    username = getpass.getuser()
+    username = username or getpass.getuser()
     username = username.lower()
     username = re.sub(r'[^a-z0-9-]', '', username)
     username = re.sub(r'^[0-9-]+', '', username)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -911,7 +911,7 @@ def write_cluster_config(
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see spot-controller.yaml.j2).
                 'user': get_cleaned_username(os.environ.get(
-                    'SKYPILOT_USER', "")),
+                    'SKYPILOT_USER', '')),
 
                 # AWS only:
                 # Temporary measure, as deleting per-cluster SGs is too slow.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1324,7 +1324,7 @@ def generate_cluster_name():
     return f'sky-{uuid.uuid4().hex[:4]}-{get_cleaned_username()}'
 
 
-def get_cleaned_username(username: str = "") -> str:
+def get_cleaned_username(username: str = '') -> str:
     """Cleans the username to be used as part of a cluster name.
 
     Clean up includes:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix the bug reported from https://github.com/skypilot-org/skypilot/issues/2270.

In GCP, the `.` in the local OS username violates the 'resource.labels' format constraints.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
