### PR TITLE
Add support for conditional exclusion of features (specific to a cloud) during provisioning

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -640,7 +640,6 @@ class RetryingVmProvisioner(object):
         self._dag = dag
         self._optimize_target = optimize_target
         self._requested_features = requested_features
-        self.granted_features = None
         self._local_wheel_path = local_wheel_path
         self._wheel_hash = wheel_hash
 
@@ -2011,9 +2010,15 @@ class RetryingVmProvisioner(object):
                 else:
                     cloud_user = to_provision.cloud.get_current_user_identity()
                 # Skip if to_provision.cloud does not support requested features
-                self.granted_features = to_provision.cloud.grant_features(
+                granted_features = to_provision.cloud.grant_features(
                     self._requested_features,
                     ExcludableFeatureCheckConfig(cluster_name=cluster_name))
+
+                if self._requested_features != granted_features:
+                    logger.info(
+                        f'{colorama.Fore.CYAN}The following features will be skipped since they are not supported by {to_provision.cloud.__class__.__name__} and were deemed optional : '
+                        f'{", ".join(map(lambda x: x.value, self._requested_features - granted_features))}{style.RESET_ALL}'
+                    )
 
                 config_dict = self._retry_zones(
                     to_provision,
@@ -2398,8 +2403,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         self._dag = None
         self._optimize_target = None
         self._requested_features = set()
-        self._granted_features: Optional[Set[
-            clouds.CloudImplementationFeatures]] = None
 
         # Command for running the setup script. It is only set when the
         # setup needs to be run outside the self._setup() and as part of
@@ -2567,7 +2570,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         self._requested_features, local_wheel_path, wheel_hash)
                     config_dict = provisioner.provision_with_retries(
                         task, to_provision_config, dryrun, stream_logs)
-                    self._granted_features = provisioner.granted_features
                     break
                 except exceptions.ResourcesUnavailableError as e:
                     # Do not remove the stopped cluster from the global state
@@ -3764,14 +3766,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                      idle_minutes_to_autostop: Optional[int],
                      down: bool = False,
                      stream_logs: bool = True) -> None:
-        if (self._granted_features is not None and
-                clouds.CloudImplementationFeatures.AUTOSTOP
-                not in self._granted_features) or (
-                    handle.launched_resources.cloud and
-                    clouds.CloudImplementationFeatures.AUTOSTOP not in handle.
-                    launched_resources.cloud._cloud_unsupported_features()):
+        if (handle.launched_resources.cloud and
+                clouds.CloudImplementationFeatures.AUTOSTOP in
+                handle.launched_resources.cloud._cloud_unsupported_features()):
             logger.info(
-                f'{colorama.Fore.YELLOW}Autostop is not supported for '
+                f'{colorama.Fore.YELLOW}Skipping set_autostop since it is not supported for '
                 f'{handle.get_cluster_name()}.{colorama.Style.RESET_ALL}')
             return
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -36,6 +36,7 @@ from sky import skypilot_config
 from sky import spot as spot_lib
 from sky import status_lib
 from sky import task as task_lib
+from sky.clouds.cloud import ExcludableFeatureCheckConfig
 from sky.data import data_utils
 from sky.data import storage as storage_lib
 from sky.backends import backend_utils
@@ -639,6 +640,7 @@ class RetryingVmProvisioner(object):
         self._dag = dag
         self._optimize_target = optimize_target
         self._requested_features = requested_features
+        self.granted_features = None
         self._local_wheel_path = local_wheel_path
         self._wheel_hash = wheel_hash
 
@@ -2009,8 +2011,9 @@ class RetryingVmProvisioner(object):
                 else:
                     cloud_user = to_provision.cloud.get_current_user_identity()
                 # Skip if to_provision.cloud does not support requested features
-                to_provision.cloud.check_features_are_supported(
-                    self._requested_features)
+                self.granted_features = to_provision.cloud.grant_features(
+                    self._requested_features,
+                    ExcludableFeatureCheckConfig(cluster_name=cluster_name))
 
                 config_dict = self._retry_zones(
                     to_provision,
@@ -2395,6 +2398,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         self._dag = None
         self._optimize_target = None
         self._requested_features = set()
+        self._granted_features: Optional[Set[
+            clouds.CloudImplementationFeatures]] = None
 
         # Command for running the setup script. It is only set when the
         # setup needs to be run outside the self._setup() and as part of
@@ -2562,6 +2567,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         self._requested_features, local_wheel_path, wheel_hash)
                     config_dict = provisioner.provision_with_retries(
                         task, to_provision_config, dryrun, stream_logs)
+                    self._granted_features = provisioner.granted_features
                     break
                 except exceptions.ResourcesUnavailableError as e:
                     # Do not remove the stopped cluster from the global state
@@ -3758,6 +3764,17 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                      idle_minutes_to_autostop: Optional[int],
                      down: bool = False,
                      stream_logs: bool = True) -> None:
+        if (self._granted_features is not None and
+                clouds.CloudImplementationFeatures.AUTOSTOP
+                not in self._granted_features) or (
+                    handle.launched_resources.cloud and
+                    clouds.CloudImplementationFeatures.AUTOSTOP not in handle.
+                    launched_resources.cloud._cloud_unsupported_features()):
+            logger.info(
+                f'{colorama.Fore.YELLOW}Autostop is not supported for '
+                f'{handle.get_cluster_name()}.{colorama.Style.RESET_ALL}')
+            return
+
         if idle_minutes_to_autostop is not None:
             code = autostop_lib.AutostopCodeGen.set_autostop(
                 idle_minutes_to_autostop, self.NAME, down)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2016,7 +2016,7 @@ class RetryingVmProvisioner(object):
 
                 if self._requested_features != granted_features:
                     logger.info(
-                        f'{colorama.Fore.CYAN}The following features will be skipped since they are not supported by {to_provision.cloud.__class__.__name__} and were deemed optional : '
+                        f'{colorama.Fore.CYAN}The following features will be skipped since they are not supported by {to_provision.cloud} and were deemed optional : '
                         f'{", ".join(map(lambda x: x.value, self._requested_features - granted_features))}{style.RESET_ALL}'
                     )
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -111,7 +111,7 @@ class Cloud:
     ) -> Dict[CloudImplementationFeatures, ExcludableFeatureCheckProtocol]:
         """The features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
 
-        This method is used by check_excludable_featurs() to check if the
+        This method is used by get_excludable_features() to check if the
         cloud implementation can exclude features if their condition is met.
 
         Returns:
@@ -484,8 +484,8 @@ class Cloud:
         """Returns the features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
 
         For instance, Kubernetes Cloud can exclude autostop for spot controller, so
-        Kubernetes.check_excludable_features({
-            CloudImplementationFeatures.AUTOSTOP
+        Kubernetes.get_excludable_features({
+            CloudImplementationFeatures.AUTOSTOP, ExcludableFeatureCheckConfig(cluster_name=cluster_name)
         }) returns {CloudImplementationFeatures.AUTOSTOP} if the cluster is a spot controller else {}.
         """
         excludable_features = set()

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -31,11 +31,11 @@ class ExcludableFeatureCheckProtocol(typing.Protocol):
 class CloudImplementationFeatures(enum.Enum):
     """Features that might not be implemented for all clouds.
 
-    Used by Cloud.check_features_are_supported().
+    Used by Cloud.check_features_are_supported() and Cloud.grant_features().
 
     Note: If any new feature is added, please check and update
-    _cloud_unsupported_features in all clouds to make sure the
-    check_features_are_supported() works as expected.
+    _cloud_unsupported_features and _cloud_excludable_features in all clouds to make sure
+    check_features_are_supported() and grant_features() work as expected.
     """
     STOP = 'stop'
     AUTOSTOP = 'autostop'

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -500,7 +500,7 @@ class Cloud:
         cls, requested_features: Set[CloudImplementationFeatures],
         config: ExcludableFeatureCheckConfig
     ) -> Set[CloudImplementationFeatures]:
-        """Returns the features that can be granted by the cloud implementation.
+        """Returns the features that can be granted by the cloud implementation after running cloud.check_features_are_supported on mandatory features.
 
         This function performs the following steps:
         1. Get excludable features from the cloud implementation.

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -15,6 +15,19 @@ if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
 
 
+class ExcludableFeatureCheckConfig(
+        collections.namedtuple('ExcludableFeatureCheckConfig',
+                               ['cluster_name'])):
+    """Config for excludable feature check."""
+    cluster_name: str
+
+
+class ExcludableFeatureCheckProtocol(typing.Protocol):
+
+    def __call__(self, config: ExcludableFeatureCheckConfig) -> bool:
+        ...
+
+
 class CloudImplementationFeatures(enum.Enum):
     """Features that might not be implemented for all clouds.
 
@@ -91,6 +104,21 @@ class Cloud:
             cloud implementation.
         """
         raise NotImplementedError
+
+    @classmethod
+    def _cloud_excludable_features(
+        cls
+    ) -> Dict[CloudImplementationFeatures, ExcludableFeatureCheckProtocol]:
+        """The features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
+
+        This method is used by check_excludable_featurs() to check if the
+        cloud implementation can exclude features if their condition is met.
+
+        Returns:
+            A dict of {feature: condition} for the features excludable by the
+            cloud implementation.
+        """
+        return {}
 
     @classmethod
     def _max_cluster_name_length(cls) -> Optional[int]:
@@ -447,6 +475,44 @@ class Cloud:
                 raise exceptions.NotSupportedError(
                     f'The following features are not supported by {cls._REPR}:'
                     '\n\t' + table.get_string().replace('\n', '\n\t'))
+
+    @classmethod
+    def get_excludable_features(
+        cls, requested_features: Set[CloudImplementationFeatures],
+        config: ExcludableFeatureCheckConfig
+    ) -> Set[CloudImplementationFeatures]:
+        """Returns the features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
+
+        For instance, Kubernetes Cloud can exclude autostop for spot controller, so
+        Kubernetes.check_excludable_features({
+            CloudImplementationFeatures.AUTOSTOP
+        }) returns {CloudImplementationFeatures.AUTOSTOP} if the cluster is a spot controller else {}.
+        """
+        excludable_features = set()
+        excludable_features2condition = cls._cloud_excludable_features()
+        for feature, condition in excludable_features2condition.items():
+            if feature in requested_features and condition(config):
+                excludable_features.add(feature)
+        return excludable_features
+
+    @classmethod
+    def grant_features(
+        cls, requested_features: Set[CloudImplementationFeatures],
+        config: ExcludableFeatureCheckConfig
+    ) -> Set[CloudImplementationFeatures]:
+        """Returns the features that can be granted by the cloud implementation.
+
+        This function performs the following steps:
+        1. Get excludable features from the cloud implementation.
+        2. Remove excludable features from the requested features.
+        3. Check if the remaining features are supported by the cloud implementation.
+        4. Return the remaining features.
+        """
+        excludable_features = cls.get_excludable_features(
+            requested_features, config)
+        remaining_features = requested_features - excludable_features
+        cls.check_features_are_supported(remaining_features)
+        return remaining_features
 
     @classmethod
     def check_cluster_name_is_valid(cls, cluster_name: str) -> None:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -9,9 +9,12 @@ from sky import clouds
 from sky import exceptions
 from sky import status_lib
 from sky.adaptors import kubernetes
+from sky.clouds.cloud import ExcludableFeatureCheckProtocol
 from sky.utils import common_utils
 from sky.utils import ux_utils
 from sky.skylet.providers.kubernetes import utils as kubernetes_utils
+
+from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -164,6 +167,12 @@ class Kubernetes(clouds.Cloud):
                                                              'supported in '
                                                              'Kubernetes.',
     }
+    _CLOUD_EXCLUDABLE_FEATURES: Dict[
+        clouds.CloudImplementationFeatures, ExcludableFeatureCheckProtocol] = {
+            clouds.CloudImplementationFeatures.AUTOSTOP:
+                lambda config: config.cluster_name.startswith(
+                    'sky-spot-controller-')
+        }
 
     IMAGE = 'us-central1-docker.pkg.dev/' \
             'skypilot-375900/skypilotk8s/skypilot:latest'
@@ -172,6 +181,13 @@ class Kubernetes(clouds.Cloud):
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
         return cls._CLOUD_UNSUPPORTED_FEATURES
+
+    @classmethod
+    def _cloud_excludable_features(
+        cls
+    ) -> Dict[clouds.CloudImplementationFeatures,
+              ExcludableFeatureCheckProtocol]:
+        return cls._CLOUD_EXCLUDABLE_FEATURES
 
     @classmethod
     def regions(cls) -> List[clouds.Region]:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds a backbone to conditionally exclude some unsupported features in a cloud instead of raising an error if even one of the requested features is unsupported. It accomplishes this by maintaining a per cloud map of excludable features -> exclusion condition. During provisioning, if the exclusion condition is met for any of the requested features, it excludes that feature from the corresponding `check_features_are_supported`. As of now, this aims to address https://github.com/skypilot-org/skypilot/issues/2249

This is a proof of concept PR and I've tested in locally (only have k8s cloud enabled). If this is a direction that we want to proceed in, I can work on adding tests for it and running existing smoke/integration tests.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
