### PR TITLE
Add support for env files. 

### DIFF
--- a/examples/sample_dotenv
+++ b/examples/sample_dotenv
@@ -1,0 +1,1 @@
+TEST_ENV2="success" 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -25,7 +25,6 @@ each other.
 """
 import copy
 import datetime
-from dotenv import dotenv_values
 import functools
 import multiprocessing
 import os
@@ -41,6 +40,7 @@ import webbrowser
 
 import click
 import colorama
+import dotenv
 from rich import progress as rich_progress
 import yaml
 
@@ -331,6 +331,7 @@ def _parse_env_var(env_var: str) -> Tuple[str, str]:
             'or KEY.')
     return ret[0], ret[1]
 
+
 def _merge_env_vars(env_dict: Optional[Dict[str, str]],
                     env_list: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
     """Merges all values from env_list into env_dict, overwriting any old values."""
@@ -392,17 +393,15 @@ _TASK_OPTIONS = [
                  default=None,
                  help=('Custom image id for launching the instances. '
                        'Passing "none" resets the config.')),
-    click.option(
-        '--env-file',
-        required=False,
-        type=dotenv_values,
-        help="""\
+    click.option('--env-file',
+                 required=False,
+                 type=dotenv.dotenv_values,
+                 help="""\
         Path to a dotenv file with environment variables to set on the remote
         node.
 
         If any values from ``--env-file`` conflict with values set by
-        ``--env``, the ``--env`` value will be preferred."""
-    ),
+        ``--env``, the ``--env`` value will be preferred."""),
     click.option(
         '--env',
         required=False,
@@ -1328,8 +1327,8 @@ def launch(
     num_nodes: Optional[int],
     use_spot: Optional[bool],
     image_id: Optional[str],
-    env: List[Tuple[str, str]],
     env_file: Optional[Dict[str, str]],
+    env: List[Tuple[str, str]],
     disk_size: Optional[int],
     disk_tier: Optional[str],
     idle_minutes_to_autostop: Optional[int],
@@ -1446,8 +1445,8 @@ def exec(
     num_nodes: Optional[int],
     use_spot: Optional[bool],
     image_id: Optional[str],
-    env: List[Tuple[str, str]],
     env_file: Optional[Dict[str, str]],
+    env: List[Tuple[str, str]],
 ):
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Execute a task or a command on a cluster (skip setup).
@@ -3484,8 +3483,8 @@ def spot_launch(
     use_spot: Optional[bool],
     image_id: Optional[str],
     spot_recovery: Optional[str],
-    env: List[Tuple[str, str]],
     env_file: Optional[Dict[str, str]],
+    env: List[Tuple[str, str]],
     disk_size: Optional[int],
     disk_tier: Optional[str],
     detach_run: bool,
@@ -3934,8 +3933,8 @@ def benchmark_launch(
     num_nodes: Optional[int],
     use_spot: Optional[bool],
     image_id: Optional[str],
-    env: List[Tuple[str, str]],
     env_file: Optional[Dict[str, str]],
+    env: List[Tuple[str, str]],
     disk_size: Optional[int],
     disk_tier: Optional[str],
     idle_minutes_to_autostop: Optional[int],

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -334,7 +334,7 @@ def _parse_env_var(env_var: str) -> Tuple[str, str]:
 
 def _merge_env_vars(env_dict: Optional[Dict[str, str]],
                     env_list: List[Tuple[str, str]]) -> List[Tuple[str, str]]:
-    """Merges all values from env_list into env_dict, overwriting any old values."""
+    """Merges all values from env_list into env_dict."""
     if not env_dict:
         return env_list
     for (key, value) in env_list:

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -86,6 +86,7 @@ install_requires = [
     # PrettyTable with version >=2.0.0 is required for the support of
     # `add_rows` method.
     'PrettyTable>=2.0.0',
+    'python-dotenv==1.0.0',
     # Lower version of ray will cause dependency conflict for
     # click/grpcio/protobuf.
     'ray[default]>=2.2.0,<=2.4.0',

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -86,7 +86,7 @@ install_requires = [
     # PrettyTable with version >=2.0.0 is required for the support of
     # `add_rows` method.
     'PrettyTable>=2.0.0',
-    'python-dotenv==1.0.0',
+    'python-dotenv',
     # Lower version of ray will cause dependency conflict for
     # click/grpcio/protobuf.
     'ray[default]>=2.2.0,<=2.4.0',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2194,6 +2194,23 @@ def test_inline_env(generic_cloud: str):
     run_one_test(test)
 
 
+# ---------- Testing env file ----------
+def test_inline_env_file(generic_cloud: str):
+    """Test env"""
+    name = _get_cluster_name()
+    test = Test(
+        'test-inline-env-file',
+        [
+            f'sky launch -c {name} -y --cloud {generic_cloud} --env TEST_ENV="hello world" -- "([[ ! -z \\"\$TEST_ENV\\" ]] && [[ ! -z \\"\$SKYPILOT_NODE_IPS\\" ]] && [[ ! -z \\"\$SKYPILOT_NODE_RANK\\" ]]) || exit 1"',
+            f'sky logs {name} 1 --status',
+            f'sky exec {name} --env-file examples/sample_dotenv "([[ ! -z \\"\$TEST_ENV2\\" ]] && [[ ! -z \\"\$SKYPILOT_NODE_IPS\\" ]] && [[ ! -z \\"\$SKYPILOT_NODE_RANK\\" ]]) || exit 1"',
+            f'sky logs {name} 2 --status',
+        ],
+        f'sky down -y {name}',
+    )
+    run_one_test(test)
+
+
 # ---------- Testing custom image ----------
 @pytest.mark.aws
 def test_custom_image():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2295

A new argument is added `--env-file`.  This reads from a dotenv file to read multiple environment variables.  These are merged with any values passed via `--env` arguments with `--env` taking precedence in any conflicts.

<!-- Describe the tests ran -->

No unittests seem to exist for this.  Manually ran the command:

```sh
sky launch -c worker-unified-llama13b --env-file .env sky/fastchat_unified_llama13b.yaml
```

with a local config that depends on two env variables within `.env`.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`