### PR TITLE
[k8s_cloud] Ray pod not created under current context namespace.

### DIFF
--- a/sky/skylet/providers/kubernetes/utils.py
+++ b/sky/skylet/providers/kubernetes/utils.py
@@ -83,8 +83,8 @@ def get_current_kube_config_context_namespace() -> str:
     k8s = kubernetes.get_kubernetes()
     try:
         _, current_context = k8s.config.list_kube_config_contexts()
-        if 'namespace' in current_context:
-            return current_context['namespace']
+        if 'namespace' in current_context['context']:
+            return current_context['context']['namespace']
         else:
             return DEFAULT_NAMESPACE
     except k8s.config.config_exception.ConfigException:


### PR DESCRIPTION
Hi @romilbhardwaj ,

I encountered an issue where ray pods and services are not created under the namespace defined in the current context (by defining it via `kubectl config set-context --current --namespace=<namespace name>`).

This PR seems to fix the issue under my environment. Can you please review it?
Thanks.

Please find below what I did:

`sky local up` # wait for kind to create skypilot cluster
`kubectl config set-context --current --namespace=test`
`kubectl create ns test`
`sky launch   ../tasks/hi.yaml` # very simple task that echoes

Ray pod and services are created under `default` namespace rather than `test`. The provision seems to hang since the secret is being created under `test` namespace.

Looking into it more, it seems that namespace of the current context is located under `context` key

e.g. in my kubeadm cluster

```
{'context': {'cluster': 'kubernetes', 'namespace': 'test', 'user': 'kubernetes-admin'}, 'name': 'kubernetes-admin@kubernetes'}
```

in my kind cluster

```
 {'context': {'cluster': 'kind-skypilot', 'namespace': 'test', 'user': 'kind-skypilot'}, 'name': 'kind-skypilot'}
```
