### PR TITLE
[UX] Show head ip in `sky status -a` 

### DIFF
--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -80,7 +80,7 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         StatusColumn('ZONE', _get_zone, show_by_default=False),
         StatusColumn('STATUS', _get_status_colored),
         StatusColumn('AUTOSTOP', _get_autostop),
-        StatusColumn('HEAD_IP', _get_head_ip),
+        StatusColumn('HEAD_IP', _get_head_ip, show_by_default=False),
         StatusColumn('COMMAND',
                      _get_command,
                      trunc_length=COMMAND_TRUNC_LENGTH if not show_all else 0),
@@ -367,6 +367,8 @@ def _get_autostop(cluster_record: _ClusterRecord) -> str:
 def _get_head_ip(cluster_record: _ClusterRecord) -> str:
     handle = cluster_record['handle']
     if not isinstance(handle, backends.CloudVmRayResourceHandle):
+        return '-'
+    if handle.head_ip is None:
         return '-'
     return handle.head_ip
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -80,6 +80,7 @@ def show_status_table(cluster_records: List[_ClusterRecord],
         StatusColumn('ZONE', _get_zone, show_by_default=False),
         StatusColumn('STATUS', _get_status_colored),
         StatusColumn('AUTOSTOP', _get_autostop),
+        StatusColumn('HEAD_IP', _get_head_ip),
         StatusColumn('COMMAND',
                      _get_command,
                      trunc_length=COMMAND_TRUNC_LENGTH if not show_all else 0),
@@ -361,6 +362,13 @@ def _get_autostop(cluster_record: _ClusterRecord) -> str:
     if autostop_str == '':
         autostop_str = '-'
     return autostop_str
+
+
+def _get_head_ip(cluster_record: _ClusterRecord) -> str:
+    handle = cluster_record['handle']
+    if not isinstance(handle, backends.CloudVmRayResourceHandle):
+        return '-'
+    return handle.head_ip
 
 
 def _is_pending_autostop(cluster_record: _ClusterRecord) -> bool:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes #1779 by introducing `HEAD_IP` column in `sky status -a`.

One example:

```bash
(sky-dev) ➜  skypilot git:(show-ip-in-status) ✗ sky status -a
Clusters
NAME             LAUNCHED        RESOURCES              REGION       ZONE           STATUS  AUTOSTOP  HEAD_IP        COMMAND                 
sky-0a05-memory  a few secs ago  1x GCP(n2-standard-8)  us-central1  us-central1-a  UP      -         34.122.179.25  sky launch --cloud gcp  

Managed spot jobs
No in progress jobs. (See: sky spot -h)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
