### PR TITLE
[GCP] Fix TPU VM ssh key setup

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -64,7 +64,8 @@ def _generate_rsa_key_pair() -> Tuple[str, str]:
     private_key = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption()).decode('utf-8').strip()
+        encryption_algorithm=serialization.NoEncryption()).decode(
+            'utf-8').strip()
 
     public_key = key.public_key().public_bytes(
         serialization.Encoding.OpenSSH,

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -64,11 +64,11 @@ def _generate_rsa_key_pair() -> Tuple[str, str]:
     private_key = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.NoEncryption()).decode('utf-8')
+        encryption_algorithm=serialization.NoEncryption()).decode('utf-8').strip()
 
     public_key = key.public_key().public_bytes(
         serialization.Encoding.OpenSSH,
-        serialization.PublicFormat.OpenSSH).decode('utf-8')
+        serialization.PublicFormat.OpenSSH).decode('utf-8').strip()
 
     return public_key, private_key
 
@@ -121,7 +121,7 @@ def _replace_ssh_info_in_config(config: Dict[str, Any],
 def setup_aws_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
     config = _replace_ssh_info_in_config(config, public_key)
     return config
 
@@ -136,7 +136,7 @@ def setup_aws_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
 def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
     config = copy.deepcopy(config)
 
     project_id = config['provider']['project_id']
@@ -268,7 +268,7 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
 def setup_azure_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
     return _replace_ssh_info_in_config(config, public_key)
 
 
@@ -279,7 +279,7 @@ def setup_lambda_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     lambda_client = lambda_utils.LambdaCloudClient()
     public_key_path = os.path.expanduser(PUBLIC_SSH_KEY_PATH)
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
     prefix = f'sky-key-{common_utils.get_user_hash()}'
     name, exists = lambda_client.get_unique_ssh_key_name(prefix, public_key)
     if not exists:
@@ -317,7 +317,7 @@ def setup_ibm_authentication(config):
     with open(os.path.abspath(os.path.expanduser(public_key_path)),
               'r',
               encoding='utf-8') as file:
-        ssh_key_data = file.read()
+        ssh_key_data = file.read().strip()
     # pylint: disable=E1136
     try:
         res = client.create_key(public_key=ssh_key_data,
@@ -362,7 +362,7 @@ def setup_ibm_authentication(config):
 def setup_oci_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
 
     return _replace_ssh_info_in_config(config, public_key)
 
@@ -370,5 +370,5 @@ def setup_oci_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
 def setup_scp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r') as f:
-        public_key = f.read()
+        public_key = f.read().strip()
     return _replace_ssh_info_in_config(config, public_key)

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -67,11 +67,19 @@ available_node_types:
   {%- endif %}
       metadata:
         items:
+        {%- if tpu_vm %}
+          - key: startup-script
+            value: |
+              #! /bin/bash
+              echo "# Added by SkyPilot\nskypilot:ssh_public_key_content" >> ~/.ssh/authorized_keys
+              EOF
+        {%- else %}
           - key: ssh-keys
             # After replacing the variables, this will become username:ssh_public_key_content.
             # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
             value: |
               skypilot:ssh_user:skypilot:ssh_public_key_content
+        {%- endif %}
   {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"
@@ -122,9 +130,19 @@ available_node_types:
     {%- endif %}
       metadata:
         items:
+          {%- if tpu_vm %}
+          - key: startup-script
+            value: |
+              #! /bin/bash
+              echo "# Added by SkyPilot\nskypilot:ssh_public_key_content" >> ~/.ssh/authorized_keys
+              EOF
+        {%- else %}
           - key: ssh-keys
+            # After replacing the variables, this will become username:ssh_public_key_content.
+            # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
             value: |
               skypilot:ssh_user:skypilot:ssh_public_key_content
+        {%- endif %}
     {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -41,7 +41,7 @@ available_node_types:
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}
       metadata:
-        # TPU VM's metadata as different format than normal VMs.
+        # TPU VM's metadata has different format than normal VMs.
         # After replacing the variables, this will become username:ssh_public_key_content.
         # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
         ssh-keys: |
@@ -72,7 +72,6 @@ available_node_types:
           acceleratorCount: {{gpu_count}}
   {%- endif %}
       metadata:
-        # TPU VM's metadata as different format than normal VMs.
         items:
           - key: ssh-keys
             # After replacing the variables, this will become username:ssh_public_key_content.
@@ -103,6 +102,7 @@ available_node_types:
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}
       metadata:
+        # TPU VM's metadata has different format than normal VMs.
         # After replacing the variables, this will become username:ssh_public_key_content.
         # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
         ssh-keys: |

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -134,24 +134,11 @@ available_node_types:
     {%- endif %}
       metadata:
         items:
-          {%- if tpu_vm %}
-          - key: user-data
-            value: |
-              #cloud-config
-              users:
-                - name: skypilot:ssh_user
-                  shell: /bin/bash
-                  sudo: ALL=(ALL) NOPASSWD:ALL
-                  ssh_authorized_keys:
-                    - |
-                      skypilot:ssh_public_key_content
-        {%- else %}
           - key: ssh-keys
             # After replacing the variables, this will become username:ssh_public_key_content.
             # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
             value: |
               skypilot:ssh_user:skypilot:ssh_public_key_content
-        {%- endif %}
     {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -40,6 +40,12 @@ available_node_types:
 {%- if tpu_vm %}
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}
+      metadata:
+        # TPU VM's metadata as different format than normal VMs.
+        # After replacing the variables, this will become username:ssh_public_key_content.
+        # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
+        ssh-keys: |
+              skypilot:ssh_user:skypilot:ssh_public_key_content
   {%- if use_spot %}
       schedulingConfig:
         preemptible: true
@@ -66,20 +72,13 @@ available_node_types:
           acceleratorCount: {{gpu_count}}
   {%- endif %}
       metadata:
+        # TPU VM's metadata as different format than normal VMs.
         items:
-        {%- if tpu_vm %}
-          - key: startup-script
-            value: |
-              #! /bin/bash
-              echo "# Added by SkyPilot\nskypilot:ssh_public_key_content" >> ~/.ssh/authorized_keys
-              EOF
-        {%- else %}
           - key: ssh-keys
             # After replacing the variables, this will become username:ssh_public_key_content.
             # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
             value: |
               skypilot:ssh_user:skypilot:ssh_public_key_content
-        {%- endif %}
   {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"
@@ -103,6 +102,11 @@ available_node_types:
   {%- if tpu_vm %}
       acceleratorType: {{tpu_type}}
       runtimeVersion: {{runtime_version}}
+      metadata:
+        # After replacing the variables, this will become username:ssh_public_key_content.
+        # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
+        ssh-keys: |
+              skypilot:ssh_user:skypilot:ssh_public_key_content
     {%- if use_spot %}
       schedulingConfig:
         preemptible: true
@@ -131,11 +135,16 @@ available_node_types:
       metadata:
         items:
           {%- if tpu_vm %}
-          - key: startup-script
+          - key: user-data
             value: |
-              #! /bin/bash
-              echo "# Added by SkyPilot\nskypilot:ssh_public_key_content" >> ~/.ssh/authorized_keys
-              EOF
+              #cloud-config
+              users:
+                - name: skypilot:ssh_user
+                  shell: /bin/bash
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  ssh_authorized_keys:
+                    - |
+                      skypilot:ssh_public_key_content
         {%- else %}
           - key: ssh-keys
             # After replacing the variables, this will become username:ssh_public_key_content.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2309

We did not include the metadata ssh key setup code path for the TPU VM in our ray yaml causing the provisioned cluster failed to be connected with the user's ssh key.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-tpuvm-4 examples/tpu/tpuvm_mnist.yaml --use-spot` with a new pair of ssh key
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
