### PR TITLE
Add minimal version for AWS dependencies to fix poetry

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -129,7 +129,7 @@ aws_dependencies = [
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
     'awscli>=1.27.1',
     'botocore>=1.29.1',
-    'boto3>=1.28.1',
+    'boto3>=1.26.1',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
 ]

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -127,8 +127,9 @@ aws_dependencies = [
     # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
     # should instead use CLI V2 which is not pip-installable. See
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
-    'awscli',
-    'boto3',
+    'awscli>=1.29',
+    'botocore>=1.31',
+    'boto3>=1.28',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
 ]

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -157,7 +157,7 @@ extras_require['all'] = sum(extras_require.values(), [])
 
 # Install aws requirements by default, as it is the most common cloud provider,
 # and the installation is quick.
-install_requires += extras_require['aws']
+# install_requires += extras_require['aws']
 
 long_description = ''
 readme_filepath = 'README.md'

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -127,8 +127,8 @@ aws_dependencies = [
     # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
     # should instead use CLI V2 which is not pip-installable. See
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
-    'awscli>=1.27.1',
-    'botocore>=1.29.1',
+    'awscli>=1.27.10',
+    'botocore>=1.29.10',
     'boto3>=1.26.1',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -127,9 +127,9 @@ aws_dependencies = [
     # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
     # should instead use CLI V2 which is not pip-installable. See
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
-    'awscli>=1.29',
-    'botocore>=1.31',
-    'boto3>=1.28',
+    'awscli>=1.27.1',
+    'botocore>=1.29.1',
+    'boto3>=1.28.1',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
 ]

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -130,6 +130,8 @@ aws_dependencies = [
     'awscli>=1.27.10',
     'botocore>=1.29.10',
     'boto3>=1.26.1',
+    # https://github.com/orgs/python-poetry/discussions/7937
+    'urllib3<2',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
 ]
@@ -157,7 +159,7 @@ extras_require['all'] = sum(extras_require.values(), [])
 
 # Install aws requirements by default, as it is the most common cloud provider,
 # and the installation is quick.
-# install_requires += extras_require['aws']
+install_requires += extras_require['aws']
 
 long_description = ''
 readme_filepath = 'README.md'

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -124,14 +124,16 @@ install_requires = [
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the
 # following packages dependencies are changed.
 aws_dependencies = [
+    # botocore does not work with urllib3>=2.0.0, accuroding to https://github.com/boto/botocore/issues/2926
+    # We have to explicitly pin the version to optimize the time for
+    # poetry install. See https://github.com/orgs/python-poetry/discussions/7937
+    'urllib3<2',
     # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
     # should instead use CLI V2 which is not pip-installable. See
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
     'awscli>=1.27.10',
     'botocore>=1.29.10',
     'boto3>=1.26.1',
-    # https://github.com/orgs/python-poetry/discussions/7937
-    'urllib3<2',
     # 'Crypto' module used in authentication.py for AWS.
     'pycryptodome==3.12.0',
 ]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2204 

It is hard to decide the minimal AWS dependencies. I am using the minimal dependency that works with SSO.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `poetry lock --no-update` (136s -> 96s, after pinning urllib3)
      ```
      [tool.poetry]
      name = "foo"
      version = "1.0.0"
      authors = ["ZW"]
      description = ""
      
      [tool.poetry.dependencies]
      python = "3.10.x"
      
      [tool.poetry.group.dev.dependencies]
      skypilot = { git = "https://github.com/skypilot-org/skypilot.git", branch = "fix-poetry" }
      
      [build-system]
      requires = ["poetry-core"]
      build-backend = "poetry.core.masonry.api"
      ```
  - [x] `poetry lock --no-update` (162s -> 101s, after pinning the `urllib3<2`, according to https://github.com/orgs/python-poetry/discussions/7937)
      ```
      [tool.poetry]
      name = "foo"
      version = "1.0.0"
      authors = ["ZW"]
      description = ""
      
      [tool.poetry.dependencies]
      python = "3.10.x"
      
      [tool.poetry.group.dev.dependencies]
      skypilot = { git = "https://github.com/skypilot-org/skypilot.git", branch = "fix-poetry" , extras = ["gcp"] }
      
      [build-system]
      requires = ["poetry-core"]
      build-backend = "poetry.core.masonry.api"
      ```
  - [x] `sky launch --cloud aws --cpus 2+ -i 0`; `sky status -r`. Using the minimal AWS dependencies.
  - [x] `sky launch --cloud aws --cpus 2+ -i 0`; `sky status -r`. Using the minimal AWS dependencies and SSO.
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` with the minimal aws dependencies requirement. 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
