### PR TITLE
add H100 to supported GPUs

### DIFF
--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -281,6 +281,7 @@ def get_common_gpus() -> List[str]:
         'A10G',
         'A100',
         'A100-80GB',
+        'H100',
         'K80',
         'L4',
         'M60',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2317 

<!-- Describe the tests ran -->
I manually tested with using the CLI
```
$ sky show-gpus --cloud lambda
COMMON_GPU  AVAILABLE_QUANTITIES  
A10         1                     
A100        1, 2, 4, 8            
A100-80GB   8                     
H100        1                     
V100        8 

$ sky show-gpus --cloud aws
COMMON_GPU  AVAILABLE_QUANTITIES  
A10G        1, 4, 8               
A100        8                     
A100-80GB   8                     
H100        8                     
K80         1, 8, 16              
M60         1, 2, 4               
T4          1, 4, 8               
V100        1, 4, 8               
V100-32GB   8   
``` 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
