### PR TITLE
CLI: make `sky down/stop/start` default to a unique cluster if exists.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2603,9 +2603,16 @@ def _down_or_stop_clusters(
     else:
         command = 'stop'
     if not names and apply_to_all is None:
-        raise click.UsageError(
-            f'`sky {command}` requires either a cluster name (see `sky status`)'
-            ' or --all.')
+        # UX: frequently users may have only 1 cluster. In this case, 'sky
+        # stop/down' without args should be smart and default to that unique
+        # choice.
+        all_cluster_names = global_user_state.get_cluster_names_start_with('')
+        if len(all_cluster_names) <= 1:
+            names = all_cluster_names
+        else:
+            raise click.UsageError(
+                f'`sky {command}` requires either a cluster name or glob,'
+                ' or the -a/--all flag.')
 
     operation = 'Terminating' if down else 'Stopping'
     if idle_minutes_to_autostop is not None:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2339,8 +2339,8 @@ def start(
             clusters = all_cluster_names
         else:
             raise click.UsageError(
-                '`sky start` requires either a cluster name or glob, '
-                'or the -a/--all flag.')
+                '`sky start` requires either a cluster name or glob '
+                '(see `sky status`), or the -a/--all flag.')
 
     if all:
         if len(clusters) > 0:
@@ -2354,7 +2354,11 @@ def start(
             if cluster['name'] not in backend_utils.SKY_RESERVED_CLUSTER_NAMES
         ]
 
-    if clusters:
+    if not clusters:
+        click.echo('Cluster(s) not found (tip: see `sky status`). Do you '
+                   'mean to use `sky launch` to provision a new cluster?')
+        return
+    else:
         # Get GLOB cluster names
         clusters = _get_glob_clusters(clusters)
         local_clusters = onprem_utils.check_and_get_local_clusters()
@@ -2617,8 +2621,8 @@ def _down_or_stop_clusters(
             names = all_cluster_names
         else:
             raise click.UsageError(
-                f'`sky {command}` requires either a cluster name or glob,'
-                ' or the -a/--all flag.')
+                f'`sky {command}` requires either a cluster name or glob '
+                '(see `sky status`), or the -a/--all flag.')
 
     operation = 'Terminating' if down else 'Stopping'
     if idle_minutes_to_autostop is not None:
@@ -2708,7 +2712,7 @@ def _down_or_stop_clusters(
     usage_lib.record_cluster_name_for_current_operation(clusters)
 
     if not clusters:
-        click.echo('\nCluster(s) not found (tip: see `sky status`).')
+        click.echo('Cluster(s) not found (tip: see `sky status`).')
         return
 
     if not no_confirm and len(clusters) > 0:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2332,9 +2332,15 @@ def start(
     to_start = []
 
     if not clusters and not all:
-        raise click.UsageError(
-            'sky start requires either a cluster name (see `sky status`) '
-            'or --all.')
+        # UX: frequently users may have only 1 cluster. In this case, be smart
+        # and default to that unique choice.
+        all_cluster_names = global_user_state.get_cluster_names_start_with('')
+        if len(all_cluster_names) <= 1:
+            clusters = all_cluster_names
+        else:
+            raise click.UsageError(
+                '`sky start` requires either a cluster name or glob, '
+                'or the -a/--all flag.')
 
     if all:
         if len(clusters) > 0:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Partially address #1877.

When I have only 1 cluster in `status`:

Previously
```
(py37) ~ » sky down
Usage: sky down [OPTIONS] [CLUSTERS]...
Try 'sky down -h' for help.

Error: `sky down` requires either a cluster name (see `sky status`) or --all.
```

This PR makes it so that `down/stop` defaults to it:
```
(py37) ~ » sky down                                                                                            2 ↵
Terminating 1 cluster: admin. Proceed? [Y/n]: ^CAborted!
(py37) ~ » sky stop                                                                                            1 ↵
Stopping 1 cluster: admin. Proceed? [Y/n]: ^CAborted!
```

When I have 0 cluster in `status`: this PR
```
(py37) ~ » sky down

Cluster(s) not found (tip: see `sky status`).
```

Same for `sky start`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
