### PR TITLE
[Storage/R2] Fix possible invalid bucket name.

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -202,9 +202,11 @@ class R2CloudStorage(CloudStorage):
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
         endpoint_url = cloudflare.create_endpoint()
+        if 'r2://' in source:
+            source = source.replace('r2://', 's3://')
         download_via_awscli = ('AWS_SHARED_CREDENTIALS_FILE='
                                f'{cloudflare.R2_CREDENTIALS_PATH} '
-                               f'aws s3 cp s3://{source} {destination} '
+                               f'aws s3 cp {source} {destination} '
                                f'--endpoint {endpoint_url} '
                                f'--profile={cloudflare.R2_PROFILE_NAME}')
 


### PR DESCRIPTION
During the work on adding minio support I have encountered an issue related to Bucket name where I fixed it in:
https://github.com/skypilot-org/skypilot/pull/2315/commits/e4424db1ba12bf99f0ff8fbeeaab1dc8445b7523

I then noticed that this possible issue can also exist in R2 (which is also S3 compatible). I added this fix in this PR.

I can not validate it since I do not have an R2 account.

- [ v ] Code formatting: `bash format.sh`
