### PR TITLE
Query cloud specific env vars in task setup

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -138,3 +138,8 @@ def config_exception():
 @import_package
 def max_retry_error():
     return urllib3.exceptions.MaxRetryError
+
+
+@import_package
+def stream():
+    return kubernetes.stream.stream

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2821,9 +2821,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         style = colorama.Style
         fore = colorama.Fore
 
-        cloud_env_vars = handle.launched_resources.cloud.query_env_vars(
-            handle.cluster_name)
-        task.update_envs(cloud_env_vars)
+        if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
+            cloud_env_vars = handle.launched_resources.cloud.query_env_vars(
+                handle.cluster_name)
+            task.update_envs(cloud_env_vars)
 
         if task.setup is None:
             return

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2821,6 +2821,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         style = colorama.Style
         fore = colorama.Fore
 
+        cloud_env_vars = handle.launched_resources.cloud.query_env_vars(
+            handle.cluster_name)
+        task.update_envs(cloud_env_vars)
+
         if task.setup is None:
             return
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -608,20 +608,6 @@ class Cloud:
         """
         raise NotImplementedError
 
-    @classmethod
-    def query_env_vars(cls, name: str) -> Dict[str, str]:
-        """Queries cloud specific environment variables of the cluster.
-        
-        Since all commands in the cluster are executed using ssh, we need
-        to query the cloud specific environment variables which may be missed when using ssh.
-        For instance, on K8s, environment variables when using kubectl exec are different from
-        those when using ssh.
-
-        Returns:
-            A dictionary of environment variables.
-        """
-        return {}
-
     # === Image related methods ===
     # These three methods are used to create, move and delete images. They
     # are currently only used in `sky launch --clone-disk-from` to clone a

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -608,6 +608,20 @@ class Cloud:
         """
         raise NotImplementedError
 
+    @classmethod
+    def query_env_vars(cls, name: str) -> Dict[str, str]:
+        """Queries cloud specific environment variables of the cluster.
+        
+        Since all commands in the cluster are executed using ssh, we need
+        to query the cloud specific environment variables which may be missed when using ssh.
+        For instance, on K8s, environment variables when using kubectl exec are different from
+        those when using ssh.
+
+        Returns:
+            A dictionary of environment variables.
+        """
+        return {}
+
     # === Image related methods ===
     # These three methods are used to create, move and delete images. They
     # are currently only used in `sky launch --clone-disk-from` to clone a

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -406,3 +406,27 @@ class Kubernetes(clouds.Cloud):
                 cluster_status.append(status_lib.ClusterStatus.INIT)
         # If pods are not found, we don't add them to the return list
         return cluster_status
+
+    @classmethod
+    def query_env_vars(cls, name: str) -> Dict[str, str]:
+        namespace = kubernetes_utils.get_current_kube_config_context_namespace()
+        pod = kubernetes.core_api().list_namespaced_pod(
+            namespace,
+            label_selector=f'skypilot-cluster={name},ray-node-type=head'
+        ).items[0]
+        response = kubernetes.stream()(
+            kubernetes.core_api().connect_get_namespaced_pod_exec,
+            pod.metadata.name,
+            namespace,
+            command=['env'],
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+        )
+        return dict([
+            line.split('=', 1)
+            for line in response.split('\n')
+            if '=' in line and
+            common_utils.is_valid_env_var(line.split('=', 1)[0])
+        ])

--- a/sky/task.py
+++ b/sky/task.py
@@ -18,6 +18,7 @@ from sky.data import data_utils
 from sky.skylet import constants
 from sky.utils import schemas
 from sky.utils import ux_utils
+from sky.utils.common_utils import is_valid_env_var
 
 if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
@@ -27,7 +28,6 @@ CommandGen = Callable[[int, List[str]], Optional[str]]
 CommandOrCommandGen = Union[str, CommandGen]
 
 _VALID_NAME_REGEX = '[a-z0-9]+(?:[._-]{1,2}[a-z0-9]+)*'
-_VALID_ENV_VAR_REGEX = '[a-zA-Z_][a-zA-Z0-9_]*'
 _VALID_NAME_DESCR = ('ASCII characters and may contain lowercase and'
                      ' uppercase letters, digits, underscores, periods,'
                      ' and dashes. Must start and end with alphanumeric'
@@ -62,11 +62,6 @@ def _is_valid_name(name: str) -> bool:
     if name is None:
         return True
     return bool(re.fullmatch(_VALID_NAME_REGEX, name))
-
-
-def _is_valid_env_var(name: str) -> bool:
-    """Checks if the task environment variable name is valid."""
-    return bool(re.fullmatch(_VALID_ENV_VAR_REGEX, name))
 
 
 def _fill_in_env_vars_in_file_mounts(
@@ -446,7 +441,7 @@ class Task:
                 if not isinstance(key, str):
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError('Env keys must be strings.')
-                if not _is_valid_env_var(key):
+                if not is_valid_env_var(key):
                     with ux_utils.print_exception_no_traceback():
                         raise ValueError(f'Invalid env key: {key}')
         else:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -28,6 +28,8 @@ _COLOR_PATTERN = re.compile(r'\x1b[^m]*m')
 _PAYLOAD_PATTERN = re.compile(r'<sky-payload>(.*)</sky-payload>')
 _PAYLOAD_STR = '<sky-payload>{}</sky-payload>'
 
+_VALID_ENV_VAR_REGEX = '[a-zA-Z_][a-zA-Z0-9_]*'
+
 logger = sky_logging.init_logger(__name__)
 
 _usage_run_id = None
@@ -400,3 +402,8 @@ def find_free_port(start_port: int) -> int:
             except OSError:
                 pass
     raise OSError('No free ports available.')
+
+
+def is_valid_env_var(name: str) -> bool:
+    """Checks if the task environment variable name is valid."""
+    return bool(re.fullmatch(_VALID_ENV_VAR_REGEX, name))


### PR DESCRIPTION
Adds a class method to `Cloud` called `query_env_vars` which can query cloud specific env vars. Addresses https://github.com/skypilot-org/skypilot/issues/2287



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] Ran `sky launch -- printenv` and verified that `KUBERNETES_SERVICE_PORT` etc are included
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
