### PR TITLE
Add support for conditional exclusion of features (specific to a cloud) during provisioning

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2023,7 +2023,7 @@ class RetryingVmProvisioner(object):
 
                 if self._requested_features != granted_features:
                     logger.info(
-                        f'{colorama.Fore.CYAN}The following features will be skipped since they are not supported by {to_provision.cloud.__class__.__name__} and were deemed optional : '
+                        f'{colorama.Fore.CYAN}The following features will be skipped since they are not supported by {to_provision.cloud} and were deemed optional : '
                         f'{", ".join(map(lambda x: x.value, self._requested_features - granted_features))}{style.RESET_ALL}'
                     )
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -112,7 +112,7 @@ class Cloud:
     ) -> Dict[CloudImplementationFeatures, ExcludableFeatureCheckProtocol]:
         """The features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
 
-        This method is used by check_excludable_featurs() to check if the
+        This method is used by get_excludable_features() to check if the
         cloud implementation can exclude features if their condition is met.
 
         Returns:
@@ -485,8 +485,8 @@ class Cloud:
         """Returns the features that can be excluded/ignored by the cloud implementation, given their exclusion condition is met.
 
         For instance, Kubernetes Cloud can exclude autostop for spot controller, so
-        Kubernetes.check_excludable_features({
-            CloudImplementationFeatures.AUTOSTOP
+        Kubernetes.get_excludable_features({
+            CloudImplementationFeatures.AUTOSTOP, ExcludableFeatureCheckConfig(cluster_name=cluster_name)
         }) returns {CloudImplementationFeatures.AUTOSTOP} if the cluster is a spot controller else {}.
         """
         excludable_features = set()

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -31,11 +31,11 @@ class ExcludableFeatureCheckProtocol(typing.Protocol):
 class CloudImplementationFeatures(enum.Enum):
     """Features that might not be implemented for all clouds.
 
-    Used by Cloud.check_features_are_supported().
+    Used by Cloud.check_features_are_supported() and Cloud.grant_features().
 
     Note: If any new feature is added, please check and update
-    _cloud_unsupported_features in all clouds to make sure the
-    check_features_are_supported() works as expected.
+    _cloud_unsupported_features and _cloud_excludable_features in all clouds to make sure
+    check_features_are_supported() and grant_features() work as expected.
     """
     STOP = 'stop'
     AUTOSTOP = 'autostop'

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -501,7 +501,7 @@ class Cloud:
         cls, requested_features: Set[CloudImplementationFeatures],
         config: ExcludableFeatureCheckConfig
     ) -> Set[CloudImplementationFeatures]:
-        """Returns the features that can be granted by the cloud implementation.
+        """Returns the features that can be granted by the cloud implementation after running cloud.check_features_are_supported on mandatory features.
 
         This function performs the following steps:
         1. Get excludable features from the cloud implementation.

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -9,9 +9,12 @@ from sky import clouds
 from sky import exceptions
 from sky import status_lib
 from sky.adaptors import kubernetes
+from sky.clouds.cloud import ExcludableFeatureCheckProtocol
 from sky.utils import common_utils
 from sky.utils import ux_utils
 from sky.skylet.providers.kubernetes import utils as kubernetes_utils
+
+from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -164,6 +167,12 @@ class Kubernetes(clouds.Cloud):
                                                              'supported in '
                                                              'Kubernetes.',
     }
+    _CLOUD_EXCLUDABLE_FEATURES: Dict[
+        clouds.CloudImplementationFeatures, ExcludableFeatureCheckProtocol] = {
+            clouds.CloudImplementationFeatures.AUTOSTOP:
+                lambda config: config.cluster_name.startswith(
+                    'sky-spot-controller-')
+        }
 
     IMAGE = 'us-central1-docker.pkg.dev/' \
             'skypilot-375900/skypilotk8s/skypilot:latest'
@@ -172,6 +181,13 @@ class Kubernetes(clouds.Cloud):
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
         return cls._CLOUD_UNSUPPORTED_FEATURES
+
+    @classmethod
+    def _cloud_excludable_features(
+        cls
+    ) -> Dict[clouds.CloudImplementationFeatures,
+              ExcludableFeatureCheckProtocol]:
+        return cls._CLOUD_EXCLUDABLE_FEATURES
 
     @classmethod
     def regions(cls) -> List[clouds.Region]:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Some context and comments are in https://github.com/skypilot-org/skypilot/pull/2293 which couldn't be reopened.

This PR adds a backbone to conditionally exclude some unsupported features in a cloud instead of raising an error if even one of the requested features is unsupported. It accomplishes this by maintaining a per cloud map of excludable features -> exclusion condition. During provisioning, if the exclusion condition is met for any of the requested features, it excludes that feature from the corresponding `check_features_are_supported`. As of now, this aims to address https://github.com/skypilot-org/skypilot/issues/2249

This is a proof of concept PR and I've tested in locally (only have k8s cloud enabled). If this is a direction that we want to proceed in, I can work on adding tests for it and running existing smoke/integration tests.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
