### PR TITLE
fix tpu bug

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2248,7 +2248,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             ports = [head_port] + worker_ports
         else:
             # Use port 22 for other clouds
-            ports = [22] * self.launched_nodes
+            ports = [22] * self.num_node_ips
         self.stable_ssh_ports = ports
 
     def _update_stable_cluster_ips(self, max_attempts: int = 1) -> None:
@@ -2349,6 +2349,16 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         if external_ssh_ports:
             return external_ssh_ports[0]
         return None
+
+    @property
+    def num_node_ips(self):
+        is_tpu_vm_pod = tpu_utils.is_tpu_vm_pod(self.launched_resources)
+        if is_tpu_vm_pod:
+            num_ips = tpu_utils.get_num_tpu_devices(
+                self.launched_resources)
+        else:
+            num_ips = self.launched_nodes
+        return num_ips
 
     def __setstate__(self, state):
         self._version = self._VERSION

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2351,7 +2351,8 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         return None
 
     @property
-    def num_node_ips(self):
+    def num_node_ips(self) -> int:
+        """Returns number of IPs of the cluster, correctly handling TPU Pod."""
         is_tpu_vm_pod = tpu_utils.is_tpu_vm_pod(self.launched_resources)
         if is_tpu_vm_pod:
             num_ips = tpu_utils.get_num_tpu_devices(self.launched_resources)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2354,8 +2354,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
     def num_node_ips(self):
         is_tpu_vm_pod = tpu_utils.is_tpu_vm_pod(self.launched_resources)
         if is_tpu_vm_pod:
-            num_ips = tpu_utils.get_num_tpu_devices(
-                self.launched_resources)
+            num_ips = tpu_utils.get_num_tpu_devices(self.launched_resources)
         else:
             num_ips = self.launched_nodes
         return num_ips

--- a/sky/utils/tpu_utils.py
+++ b/sky/utils/tpu_utils.py
@@ -30,10 +30,9 @@ def is_tpu_vm_pod(resources: Optional[resources_lib.Resources]) -> bool:
     return acc not in ['tpu-v2-8', 'tpu-v3-8', 'tpu-v4-8']
 
 
-def get_num_tpu_devices(
-        resources: Optional[resources_lib.Resources]) -> Optional[int]:
+def get_num_tpu_devices(resources: Optional[resources_lib.Resources]) -> int:
     if resources is None or not is_tpu(resources):
-        return None
+        raise ValueError('resources must be a valid TPU resource.')
     acc, _ = list(resources.accelerators.items())[0]
     num_tpu_devices = int(int(acc.split('-')[2]) / 8)
     return num_tpu_devices


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix a bug for TPU pod where the actual number of node ips != `launched_nodes`. (from port PR https://github.com/skypilot-org/skypilot/pull/2210)
the bug caused failures in setup and workdir sync on worker nodes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
- [x] tested `tpuvm_mnist.yaml` on TPU pod v2-32