### PR TITLE
[Examples] Fix resnet family of examples

### DIFF
--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -4,7 +4,11 @@ import sky
 
 # The working directory contains all code and will be synced to remote.
 workdir = '~/Downloads/tpu'
-subprocess.run(f'cd {workdir} && git checkout 222cc86', shell=True, check=True)
+
+# Clone the repo locally to workdir
+subprocess.run('git clone https://github.com/concretevitamin/tpu '
+               f'{workdir} || true', shell=True, check=True)
+subprocess.run(f'cd {workdir} && git checkout 9459fee', shell=True, check=True)
 
 # The setup command.  Will be run under the working directory.
 setup = """\
@@ -18,6 +22,9 @@ setup = """\
         conda install cudatoolkit=11.0 -y
         pip install tensorflow==2.4.0 pyyaml
         pip install protobuf==3.20
+        mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+        echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+        echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
         cd models && pip install -e .
     fi
     """

--- a/examples/resnet_app.py
+++ b/examples/resnet_app.py
@@ -6,8 +6,11 @@ import sky
 workdir = '~/Downloads/tpu'
 
 # Clone the repo locally to workdir
-subprocess.run('git clone https://github.com/concretevitamin/tpu '
-               f'{workdir} || true', shell=True, check=True)
+subprocess.run(
+    'git clone https://github.com/concretevitamin/tpu '
+    f'{workdir} || true',
+    shell=True,
+    check=True)
 subprocess.run(f'cd {workdir} && git checkout 9459fee', shell=True, check=True)
 
 # The setup command.  Will be run under the working directory.

--- a/examples/resnet_app.yaml
+++ b/examples/resnet_app.yaml
@@ -35,7 +35,6 @@ setup: |
     conda install cudatoolkit=11.0 -y
     pip install tensorflow==2.4.0 pyyaml
     pip install protobuf==3.20
-    pip install nvidia-cudnn-cu11==8.6.0.163
     
     # Automatically set CUDNN envvars when conda activate is run
     mkdir -p $CONDA_PREFIX/etc/conda/activate.d

--- a/examples/resnet_app.yaml
+++ b/examples/resnet_app.yaml
@@ -35,6 +35,13 @@ setup: |
     conda install cudatoolkit=11.0 -y
     pip install tensorflow==2.4.0 pyyaml
     pip install protobuf==3.20
+    pip install nvidia-cudnn-cu11==8.6.0.163
+    
+    # Automatically set CUDNN envvars when conda activate is run
+    mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+    echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+
     cd models
     pip install -e .
   fi

--- a/examples/resnet_app_storage.py
+++ b/examples/resnet_app_storage.py
@@ -9,9 +9,13 @@ with sky.Dag() as dag:
     data_mount_path = '/tmp/imagenet'
 
     # Clone the repo locally to workdir
-    subprocess.run('git clone https://github.com/concretevitamin/tpu '
-                   f'{workdir} || true', shell=True, check=True)
-    subprocess.run(f'cd {workdir} && git checkout 9459fee', shell=True,
+    subprocess.run(
+        'git clone https://github.com/concretevitamin/tpu '
+        f'{workdir} || true',
+        shell=True,
+        check=True)
+    subprocess.run(f'cd {workdir} && git checkout 9459fee',
+                   shell=True,
                    check=True)
 
     # The setup command.  Will be run under the working directory.

--- a/examples/resnet_app_storage.py
+++ b/examples/resnet_app_storage.py
@@ -5,38 +5,50 @@ import sky
 with sky.Dag() as dag:
     # The working directory contains all code and will be synced to remote.
     workdir = '~/Downloads/tpu'
+
     data_mount_path = '/tmp/imagenet'
-    subprocess.run(f'cd {workdir} && git checkout 222cc86',
-                   shell=True,
+
+    # Clone the repo locally to workdir
+    subprocess.run('git clone https://github.com/concretevitamin/tpu '
+                   f'{workdir} || true', shell=True, check=True)
+    subprocess.run(f'cd {workdir} && git checkout 9459fee', shell=True,
                    check=True)
 
     # The setup command.  Will be run under the working directory.
-    setup = 'echo \"alias python=python3\" >> ~/.bashrc && \
-        echo \"alias pip3=pip\" >> ~/.bashrc && \
-        source ~/.bashrc && \
-        pip install --upgrade pip && \
-        pip install awscli botocore boto3 && \
-        conda init bash && \
-        conda activate resnet || \
-          (conda create -n resnet python=3.7 -y && \
-           conda activate resnet && \
-           conda install cudatoolkit=11.0 -y && \
-           pip install tensorflow==2.4.0 pyyaml && \
-           cd models && pip install -e .)'
+    setup = """\
+        set -e
+        pip install --upgrade pip
+        conda init bash
+        conda activate resnet && exists=1 || exists=0
+        if [ $exists -eq 0 ]; then
+            conda create -n resnet python=3.7 -y
+            conda activate resnet
+            conda install cudatoolkit=11.0 -y
+            pip install tensorflow==2.4.0 pyyaml
+            pip install protobuf==3.20
+            mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+            echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+            echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+            cd models && pip install -e .
+        fi
+        """
 
     # The command to run.  Will be run under the working directory.
-    run = f'conda activate resnet && \
+    run = f"""\
+        conda activate resnet
+        export XLA_FLAGS=\'--xla_gpu_cuda_data_dir=/usr/local/cuda/\'
         python -u models/official/resnet/resnet_main.py --use_tpu=False \
-        --mode=train --train_batch_size=256 --train_steps=250 \
-        --iterations_per_loop=125 \
-        --data_dir={data_mount_path} \
-        --model_dir=resnet-model-dir \
-        --amp --xla --loss_scale=128'
+            --mode=train --train_batch_size=256 --train_steps=250 \
+            --iterations_per_loop=125 \
+            --data_dir={data_mount_path} \
+            --model_dir=resnet-model-dir \
+            --amp --xla --loss_scale=128
+        """
 
     # If the backend to be added is not specified, then SkyPilot's optimizer
     # will choose the backend bucket to be stored.
     # S3 Example
-    storage = sky.Storage(name="imagenet-bucket", source="s3://imagenet-bucket")
+    storage = sky.Storage(source="s3://imagenet-bucket")
     # GCS Example
     #storage = sky.Storage(name="imagenet_test_mluo",source="gs://imagenet_test_mluo")
     # Can also be from a local dir

--- a/examples/resnet_app_storage.yaml
+++ b/examples/resnet_app_storage.yaml
@@ -31,6 +31,12 @@ setup: |
     conda activate resnet
     conda install cudatoolkit=11.0 -y
     pip install tensorflow==2.4.0 pyyaml
+  
+    # Automatically set CUDNN envvars when conda activate is run
+    mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+    echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+
     cd models
     pip install -e .
   fi

--- a/examples/resnet_app_storage_spot.yaml
+++ b/examples/resnet_app_storage_spot.yaml
@@ -29,6 +29,12 @@ setup: |
     conda activate resnet
     conda install cudatoolkit=11.0 -y
     pip install tensorflow==2.4.0 pyyaml
+      
+    # Automatically set CUDNN envvars when conda activate is run
+    mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+    echo 'CUDNN_PATH=$(dirname $(python -c "import nvidia.cudnn;print(nvidia.cudnn.__file__)"))' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+    echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib/:$CUDNN_PATH/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh
+
     cd models
     pip install -e .
   fi


### PR DESCRIPTION
Closes #2358.

Resnet examples (`resnet_app*.py/yaml`) were not working on master because `CUDNN_PATH` and `LD_LIBRARY_PATH` environment variables were not set correctly. Python examples also had issues with up local workdir.

Fixed by following [tensorflow docs](https://www.tensorflow.org/install/pip#software_requirements) to setup envvars correctly. 

Tested (run the relevant ones):

- [x] `./format.sh`
- [x] `sky launch resnet_app.yaml --cloud aws`
- [x] `sky launch resnet_app.yaml --cloud gcp`
- [x] `sky launch resnet_app_storage.yaml`
- [x] `sky spot launch resnet_app_storage_spot.yaml`
- [x] `python resnet_app.py`
- [x] `python resnet_app_storage.py`
- [x] `python resnet_app_storage.py`
