### PR TITLE
[FIX] SkyCallback not working on newer version of Python

### DIFF
--- a/sky/callbacks/setup.py
+++ b/sky/callbacks/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='sky-callback',
-    version='0.1.0-dev0',
+    version='0.1.1-dev0',
     packages=setuptools.find_packages(),
     install_requires=['psutil'],
 )

--- a/sky/callbacks/sky_callback/api.py
+++ b/sky/callbacks/sky_callback/api.py
@@ -139,7 +139,7 @@ class step_iterator:
         create/use this class.
     """
 
-    def __init__(self, iterable: collections.Iterable) -> None:
+    def __init__(self, iterable: collections.abc.Iterable) -> None:
         self._iterable = iterable
         if _DISABLE_CALLBACK:
             return


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix #2363 

According to [docs](https://docs.python.org/3.7/library/collections.html#:~:text=Deprecated%20since%20version%203.3%2C%20will%20be%20removed%20in%20version%203.9%3A%20Moved%20Collections%20Abstract%20Base%20Classes%20to%20the%20collections.abc%20module.%20For%20backwards%20compatibility%2C%20they%20continue%20to%20be%20visible%20in%20this%20module%20through%20Python%203.8.), It looks like Collections Abstract Base Classes are moved to the second-level module since Python 3.3, but had been available for backwards compatibility through Python 3.8. So existing code can be ran on Python 3.8, but no on Python >= 3.9.
Since SkyPilot's Python dependency is Python >= 3.7 according to [your docs](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#enabling-shell-completion:~:text=SkyPilot%20requires%20python%20%3E%3D%203.7), it should works as intended.
Fortunately, this change was made in Python 3.3, the second-level module is available for Python >= 3.3. So the fix is very simple, and works fine.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
