### PR TITLE
[Examples] Fix detectron example

### DIFF
--- a/examples/detectron2_app.yaml
+++ b/examples/detectron2_app.yaml
@@ -11,7 +11,7 @@ setup: |
   if [ $? -eq 0 ]; then
     echo "conda env exists"
   else
-    conda create -n d2 python=3.7 -y
+    conda create -n d2 python=3.8 -y
     conda activate d2
     pip install torch torchvision
     git clone https://github.com/facebookresearch/detectron2


### PR DESCRIPTION
Closes #2365 by changing conda env to py 3.8. `cached_property` was  introduced in `functools` from python 3.8.

Tested:
- [x] `sky launch detectron2_app.yaml --cloud aws`
- [x] `sky launch detectron2_app.yaml --cloud gcp`