### PR TITLE
[FIX] Fix no new line bug when installing sky auto completion

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -510,8 +510,9 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         else:
             value = os.path.basename(os.environ['SHELL'])
 
-    zshrc_diff = '# For SkyPilot shell completion\n. ~/.sky/.sky-complete.zsh'
-    bashrc_diff = '# For SkyPilot shell completion\n. ~/.sky/.sky-complete.bash'
+    zshrc_diff = '\n# For SkyPilot shell completion\n. ~/.sky/.sky-complete.zsh'
+    bashrc_diff = ('\n# For SkyPilot shell completion'
+                   '\n. ~/.sky/.sky-complete.bash')
 
     if value == 'bash':
         install_cmd = f'_SKY_COMPLETE=bash_source sky > \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, when installing, skypilot will write `# For SkyPilot shell completion\n. ~/.sky/.sky-complete.zsh` to the end of `~/.zshrc`. If there are no new line at the end of `~/.zshrc`, the comment will append at the last line, such as:

```bash
alias gs="git status"# For SkyPilot shell completion
. ~/.sky/.sky-complete.zsh
```

which will cause some bugs such as:

```bash
git: 'status#' is not a git command. See 'git --help'.

The most similar command is
        status
```

This PR add a `\n` before the comment to avoid such bug.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
