### PR TITLE
[k8s_cloud_beta1] Add sshjump host support.

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -33,14 +33,17 @@ import colorama
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
+import jinja2
 import yaml
 
+import sky
 from sky import clouds
 from sky import sky_logging
-from sky.adaptors import gcp, ibm
+from sky.adaptors import gcp, ibm, kubernetes
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.skylet.providers.kubernetes import utils as kubernetes_utils
 from sky.skylet.providers.lambda_cloud import lambda_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -401,5 +404,88 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         else:
             logger.error(suffix)
             raise
+
+    sshjump_name = clouds.Kubernetes.SKY_SSH_JUMP_NAME
+    sshjump_image =  clouds.Kubernetes.IMAGE
+    namespace = kubernetes_utils.get_current_kube_config_context_namespace()
+
+    template_path = os.path.join(sky.__root_dir__, 'templates', 'kubernetes-sshjump.yml.j2')
+    if not os.path.exists(template_path):
+        raise FileNotFoundError('Template "kubernetes-sshjump.j2" does not exist.')
+    with open(template_path) as fin:
+        template = fin.read()
+    j2_template = jinja2.Template(template)
+    _content = j2_template.render(name=sshjump_name, image=sshjump_image, secret=key_label)
+
+    content = yaml.safe_load(_content)
+
+    # ServiceAccount
+    try:
+        kubernetes.core_api().create_namespaced_service_account(namespace, content['service_account'])
+    except kubernetes.api_exception() as e:
+        if e.status == 409:
+            logger.warning(
+                f'SSH Jump ServiceAcount already exists in the cluster, using it...')
+        else:
+            raise
+    else:
+        logger.info(
+            f'Creating SSH Jump ServiceAcount in the cluster...')
+    # Role
+    try:
+        kubernetes.auth_api().create_namespaced_role(namespace, content['role'])
+    except kubernetes.api_exception() as e:
+        if e.status == 409:
+            logger.warning(
+                f'SSH Jump Role already exists in the cluster, using it...')
+        else:
+            raise
+    else:
+        logger.info(
+            f'Creating SSH Jump Role in the cluster...')
+    # RoleBinding
+    try:
+        kubernetes.auth_api().create_namespaced_role_binding(namespace, content['role_binding'])
+    except kubernetes.api_exception() as e:
+        if e.status == 409:
+            logger.warning(
+                f'SSH Jump RoleBinding already exists in the cluster, using it...')
+        else:
+            raise
+    else:
+        logger.info(
+            f'Creating SSH Jump RoleBinding in the cluster...')
+
+    # Pod
+    try:
+        kubernetes.core_api().create_namespaced_pod(namespace, content['pod_spec'])
+    except kubernetes.api_exception() as e:
+        if e.status == 409:
+            logger.warning(
+                f'SSH Jump Host {sshjump_name} already exists in the cluster, using it...')
+        else:
+            raise
+    else:
+        logger.info(
+            f'Creating SSH Jump Host {sshjump_name} in the cluster...')
+    # Service
+    try:
+        kubernetes.core_api().create_namespaced_service(namespace, content['service_spec'])
+    except kubernetes.api_exception() as e:
+        if e.status == 409:
+            logger.warning(
+                f'SSH Jump Service {sshjump_name} already exists in the cluster, using it...')
+        else:
+            raise
+    else:
+        logger.info(
+            f'Creating SSH Jump Service {sshjump_name} in the cluster...')
+
+    ssh_jump_port = clouds.Kubernetes.get_port(sshjump_name)
+    ssh_jump_ip = clouds.Kubernetes.get_external_ip()
+
+    config['auth']['ssh_proxy_command'] = \
+        'ssh -tt -i {privkey} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -p {ingress} -W %h:%p sky@{ipaddress}'.format(
+        privkey=PRIVATE_SSH_KEY_PATH, ingress=ssh_jump_port, ipaddress=ssh_jump_ip)
 
     return config

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -418,8 +418,8 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         template = fin.read()
     j2_template = jinja2.Template(template)
     cont = j2_template.render(name=sshjump_name,
-                                  image=sshjump_image,
-                                  secret=key_label)
+                              image=sshjump_image,
+                              secret=key_label)
 
     content = yaml.safe_load(cont)
 
@@ -431,8 +431,7 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         if e.status == 409:
             logger.warning(
                 'SSH Jump ServiceAcount already exists in the cluster, using '
-                'it...'
-            )
+                'it...')
         else:
             raise
     else:
@@ -456,8 +455,7 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         if e.status == 409:
             logger.warning(
                 'SSH Jump RoleBinding already exists in the cluster, using '
-                'it...'
-            )
+                'it...')
         else:
             raise
     else:
@@ -471,8 +469,7 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         if e.status == 409:
             logger.warning(
                 f'SSH Jump Host {sshjump_name} already exists in the cluster, '
-                'using it...'
-            )
+                'using it...')
         else:
             raise
     else:
@@ -485,8 +482,7 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         if e.status == 409:
             logger.warning(
                 f'SSH Jump Service {sshjump_name} already exists in the '
-                'cluster, using it...'
-            )
+                'cluster, using it...')
         else:
             raise
     else:

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -406,75 +406,87 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
             raise
 
     sshjump_name = clouds.Kubernetes.SKY_SSH_JUMP_NAME
-    sshjump_image =  clouds.Kubernetes.IMAGE
+    sshjump_image = clouds.Kubernetes.IMAGE
     namespace = kubernetes_utils.get_current_kube_config_context_namespace()
 
-    template_path = os.path.join(sky.__root_dir__, 'templates', 'kubernetes-sshjump.yml.j2')
+    template_path = os.path.join(sky.__root_dir__, 'templates',
+                                 'kubernetes-sshjump.yml.j2')
     if not os.path.exists(template_path):
-        raise FileNotFoundError('Template "kubernetes-sshjump.j2" does not exist.')
+        raise FileNotFoundError(
+            'Template "kubernetes-sshjump.j2" does not exist.')
     with open(template_path) as fin:
         template = fin.read()
     j2_template = jinja2.Template(template)
-    _content = j2_template.render(name=sshjump_name, image=sshjump_image, secret=key_label)
+    cont = j2_template.render(name=sshjump_name,
+                                  image=sshjump_image,
+                                  secret=key_label)
 
-    content = yaml.safe_load(_content)
+    content = yaml.safe_load(cont)
 
     # ServiceAccount
     try:
-        kubernetes.core_api().create_namespaced_service_account(namespace, content['service_account'])
+        kubernetes.core_api().create_namespaced_service_account(
+            namespace, content['service_account'])
     except kubernetes.api_exception() as e:
         if e.status == 409:
             logger.warning(
-                f'SSH Jump ServiceAcount already exists in the cluster, using it...')
+                'SSH Jump ServiceAcount already exists in the cluster, using '
+                'it...'
+            )
         else:
             raise
     else:
-        logger.info(
-            f'Creating SSH Jump ServiceAcount in the cluster...')
+        logger.info('Creating SSH Jump ServiceAcount in the cluster...')
     # Role
     try:
         kubernetes.auth_api().create_namespaced_role(namespace, content['role'])
     except kubernetes.api_exception() as e:
         if e.status == 409:
             logger.warning(
-                f'SSH Jump Role already exists in the cluster, using it...')
+                'SSH Jump Role already exists in the cluster, using it...')
         else:
             raise
     else:
-        logger.info(
-            f'Creating SSH Jump Role in the cluster...')
+        logger.info('Creating SSH Jump Role in the cluster...')
     # RoleBinding
     try:
-        kubernetes.auth_api().create_namespaced_role_binding(namespace, content['role_binding'])
+        kubernetes.auth_api().create_namespaced_role_binding(
+            namespace, content['role_binding'])
     except kubernetes.api_exception() as e:
         if e.status == 409:
             logger.warning(
-                f'SSH Jump RoleBinding already exists in the cluster, using it...')
+                'SSH Jump RoleBinding already exists in the cluster, using '
+                'it...'
+            )
         else:
             raise
     else:
-        logger.info(
-            f'Creating SSH Jump RoleBinding in the cluster...')
+        logger.info('Creating SSH Jump RoleBinding in the cluster...')
 
     # Pod
     try:
-        kubernetes.core_api().create_namespaced_pod(namespace, content['pod_spec'])
+        kubernetes.core_api().create_namespaced_pod(namespace,
+                                                    content['pod_spec'])
     except kubernetes.api_exception() as e:
         if e.status == 409:
             logger.warning(
-                f'SSH Jump Host {sshjump_name} already exists in the cluster, using it...')
+                f'SSH Jump Host {sshjump_name} already exists in the cluster, '
+                'using it...'
+            )
         else:
             raise
     else:
-        logger.info(
-            f'Creating SSH Jump Host {sshjump_name} in the cluster...')
+        logger.info(f'Creating SSH Jump Host {sshjump_name} in the cluster...')
     # Service
     try:
-        kubernetes.core_api().create_namespaced_service(namespace, content['service_spec'])
+        kubernetes.core_api().create_namespaced_service(namespace,
+                                                        content['service_spec'])
     except kubernetes.api_exception() as e:
         if e.status == 409:
             logger.warning(
-                f'SSH Jump Service {sshjump_name} already exists in the cluster, using it...')
+                f'SSH Jump Service {sshjump_name} already exists in the '
+                'cluster, using it...'
+            )
         else:
             raise
     else:
@@ -484,8 +496,11 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     ssh_jump_port = clouds.Kubernetes.get_port(sshjump_name)
     ssh_jump_ip = clouds.Kubernetes.get_external_ip()
 
-    config['auth']['ssh_proxy_command'] = \
-        'ssh -tt -i {privkey} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -p {ingress} -W %h:%p sky@{ipaddress}'.format(
-        privkey=PRIVATE_SSH_KEY_PATH, ingress=ssh_jump_port, ipaddress=ssh_jump_ip)
+    ssh_jump_proxy_command = f'ssh -tt -i {PRIVATE_SSH_KEY_PATH} ' + \
+        '-o StrictHostKeyChecking=no ' + \
+        '-o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes ' + \
+        f'-p {ssh_jump_port} -W %h:%p sky@{ssh_jump_ip}'
+
+    config['auth']['ssh_proxy_command'] = ssh_jump_proxy_command
 
     return config

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1616,6 +1616,8 @@ def get_head_ssh_port(
     max_attempts: int = 1,
 ) -> int:
     """Returns the ip of the head node."""
+    del handle  # Unused.
+    del use_cache  # Unused.
     del max_attempts  # Unused.
     # Use port 22 for everything including Kubernetes.
     # Note: for Kubernetes we use ssh jump host to access ray head

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1617,17 +1617,10 @@ def get_head_ssh_port(
 ) -> int:
     """Returns the ip of the head node."""
     del max_attempts  # Unused.
-    # Use port 22 for everything except Kubernetes
+    # Use port 22 for everything including Kubernetes.
+    # Note: for Kubernetes we use ssh jump host to access ray head
     # TODO(romilb): Add a get port method to the cloud classes.
     head_ssh_port = 22
-    if not isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
-        return head_ssh_port
-    else:
-        if use_cache and handle.head_ssh_port is not None:
-            head_ssh_port = handle.head_ssh_port
-        else:
-            svc_name = f'{handle.get_cluster_name()}-ray-head-ssh'
-            head_ssh_port = clouds.Kubernetes.get_port(svc_name)
     return head_ssh_port
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2824,7 +2824,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def _update_envs_for_k8s(self, handle: CloudVmRayResourceHandle,
                              task: task_lib.Task) -> None:
-        """Update envs for a task with Kubernetes specific env vars if cloud is Kubernetes."""
+        """Update envs for a task with Kubernetes specific env vars if cloud is
+           Kubernetes."""
         if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
             temp_envs = copy.deepcopy(task.envs)
             cloud_env_vars = handle.launched_resources.cloud.query_env_vars(

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -129,6 +129,7 @@ class Kubernetes(clouds.Cloud):
     """Kubernetes."""
 
     SKY_SSH_KEY_SECRET_NAME = f'sky-ssh-{common_utils.get_user_hash()}'
+    SKY_SSH_JUMP_NAME = f'sshjump-{common_utils.get_user_hash()}'
 
     # Timeout for resource provisioning. This timeout determines how long to
     # wait for pod to be in pending status before giving up.
@@ -218,6 +219,10 @@ class Kubernetes(clouds.Cloud):
         return kubernetes_utils.get_port(svc_name, ns)
 
     @classmethod
+    def get_external_ip(cls) -> str:
+        return kubernetes_utils.get_external_ip()
+
+    @classmethod
     def get_default_instance_type(
             cls,
             cpus: Optional[str] = None,
@@ -303,6 +308,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_ssh_key_secret_name': self.SKY_SSH_KEY_SECRET_NAME,
             # TODO(romilb): Allow user to specify custom images
             'image_id': self.IMAGE,
+            'sshjump': self.SKY_SSH_JUMP_NAME
         }
 
     def _get_feasible_launchable_resources(

--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -2,7 +2,6 @@ import copy
 import logging
 import time
 from typing import Dict
-from urllib.parse import urlparse
 from uuid import uuid4
 
 from sky.adaptors import kubernetes
@@ -97,17 +96,7 @@ class KubernetesNodeProvider(NodeProvider):
         return pod.metadata.labels
 
     def external_ip(self, node_id):
-        # Return the IP address of the first node with an external IP
-        nodes = kubernetes.core_api().list_node().items
-        for node in nodes:
-            if node.status.addresses:
-                for address in node.status.addresses:
-                    if address.type == 'ExternalIP':
-                        return address.address
-        # If no external IP is found, use the API server IP
-        api_host = kubernetes.core_api().api_client.configuration.host
-        parsed_url = urlparse(api_host)
-        return parsed_url.hostname
+        return utils.get_external_ip()
 
     def external_port(self, node_id):
         # Extract the NodePort of the head node's SSH service

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -125,6 +125,7 @@ available_node_types:
             parent: skypilot
             component: {{cluster_name}}-ray-head
             skypilot-cluster: {{cluster_name}}
+            # This label is being used by the life cycle management of the ssh jump pod
             skypilot-sshjump: {{sshjump}}
       spec:
         # Change this if you altered the autoscaler_service_account above

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -17,7 +17,7 @@ provider:
     module: sky.skylet.providers.kubernetes.KubernetesNodeProvider
 
     # Use False if running from outside of k8s cluster
-    use_internal_ips: false
+    use_internal_ips: true
 
     timeout: {{timeout}}
 
@@ -78,7 +78,6 @@ provider:
             skypilot-cluster: {{cluster_name}}
           name: {{cluster_name}}-ray-head-ssh
         spec:
-          type: NodePort
           selector:
             component: {{cluster_name}}-ray-head
           ports:
@@ -126,6 +125,7 @@ available_node_types:
             parent: skypilot
             component: {{cluster_name}}-ray-head
             skypilot-cluster: {{cluster_name}}
+            skypilot-sshjump: {{sshjump}}
       spec:
         # Change this if you altered the autoscaler_service_account above
         # or want to provide your own.

--- a/sky/templates/kubernetes-sshjump.yml.j2
+++ b/sky/templates/kubernetes-sshjump.yml.j2
@@ -13,7 +13,7 @@ pod_spec:
                 secretName: {{ secret }}
         containers:
           - name: {{ name }}
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             image: {{ image }}
             command: ["python3", "-u", "/skypilot/sky/utils/kubernetes/sshjump-lcm.py"]
             ports:

--- a/sky/templates/kubernetes-sshjump.yml.j2
+++ b/sky/templates/kubernetes-sshjump.yml.j2
@@ -1,0 +1,83 @@
+pod_spec:
+    apiVersion: v1
+    kind: Pod
+    metadata:
+        name: {{ name }}
+        labels:
+            component: {{ name }}
+    spec:
+        serviceAccountName: sshjump
+        volumes:
+          - name: secret-volume
+            secret:
+                secretName: {{ secret }}
+        containers:
+          - name: {{ name }}
+            imagePullPolicy: Always
+            image: {{ image }}
+            command: ["python3", "-u", "/skypilot/sky/utils/kubernetes/sshjump-lcm.py"]
+            ports:
+              - containerPort: 22
+            volumeMounts:
+              - name: secret-volume
+                readOnly: true
+                mountPath: /etc/secret-volume
+            lifecycle:
+                postStart:
+                    exec:
+                        command: ["/bin/bash", "-c", "mkdir -p ~/.ssh && cp /etc/secret-volume/ssh-publickey ~/.ssh/authorized_keys && sudo service ssh restart"]
+            env:
+              - name: MY_POD_NAME
+                valueFrom:
+                    fieldRef:
+                        fieldPath: metadata.name
+              - name: MY_POD_NAMESPACE
+                valueFrom:
+                    fieldRef:
+                        fieldPath: metadata.namespace
+              - name: ALERT_THRESHOLD
+                # seconds
+                value: "600"
+              - name: RETRY_INTERVAL
+                # seconds
+                value: "60"
+        terminationGracePeriodSeconds: 0
+service_spec:
+    apiVersion: v1
+    kind: Service
+    metadata:
+        name: {{ name }}
+    spec:
+        type: NodePort
+        selector:
+            component: {{ name }}
+        ports:
+          - protocol: TCP
+            port: 22
+            targetPort: 22
+service_account:
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+        name: sshjump
+role:
+    kind: Role
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+        name: sshjump
+    rules:
+      - apiGroups: [""]
+        resources: ["pods", "pods/status", "pods/exec", "services"]
+        verbs: ["get", "list", "create", "delete"]    
+role_binding:
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+        name: sshjump
+    subjects:
+    - kind: ServiceAccount
+      name: sshjump
+    roleRef:
+        kind: Role
+        name: sshjump
+        apiGroup: rbac.authorization.k8s.io

--- a/sky/templates/kubernetes-sshjump.yml.j2
+++ b/sky/templates/kubernetes-sshjump.yml.j2
@@ -15,7 +15,7 @@ pod_spec:
           - name: {{ name }}
             imagePullPolicy: IfNotPresent
             image: {{ image }}
-            command: ["python3", "-u", "/skypilot/sky/utils/kubernetes/sshjump-lcm.py"]
+            command: ["python3", "-u", "/skypilot/sky/utils/kubernetes/sshjump_lcm.py"]
             ports:
               - containerPort: 22
             volumeMounts:

--- a/sky/templates/kubernetes-sshjump.yml.j2
+++ b/sky/templates/kubernetes-sshjump.yml.j2
@@ -55,6 +55,9 @@ service_spec:
           - protocol: TCP
             port: 22
             targetPort: 22
+
+# The following ServiceAccount/Role/RoleBinding sets up an RBAC for life cycle
+# management of the jump pod/service
 service_account:
     apiVersion: v1
     kind: ServiceAccount

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -2,10 +2,11 @@
 
 This script runs inside sshjump pod as the main process (PID 1).
 
-It terminates itself (by removing sshjump service and pod via a call to kubeapi),
-if it does not see ray pods in the duration of 10 minutes. If the user re-launches
-a task before the duration is over, then sshjump pod is being reused and will terminate
-itself when it sees that no ray cluster exist in that amount duration.
+It terminates itself (by removing sshjump service and pod via a call to
+kubeapi), if it does not see ray pods in the duration of 10 minutes. If the
+user re-launches a task before the duration is over, then sshjump pod is being
+reused and will terminate itself when it sees that no ray cluster exist in that
+amount duration.
 """
 import datetime
 import os
@@ -19,73 +20,88 @@ config.load_incluster_config()
 
 v1 = client.CoreV1Api()
 
-current_name = os.getenv("MY_POD_NAME")
-current_namespace = os.getenv("MY_POD_NAMESPACE")
+current_name = os.getenv('MY_POD_NAME')
+current_namespace = os.getenv('MY_POD_NAMESPACE')
 
 # The amount of time in seconds where no Ray pods exist in which after that time
 # sshjump pod terminates itself
-alert_threshold = int(os.getenv("ALERT_THRESHOLD", "600"))
+alert_threshold = int(os.getenv('ALERT_THRESHOLD', '600'))
 # The amount of time in seconds to wait between Ray pods existence checks
-retry_interval = int(os.getenv("RETRY_INTERVAL", "60"))
+retry_interval = int(os.getenv('RETRY_INTERVAL', '60'))
 
-# Ray pods are labeled with this value i.e sshjump name which is unique per user (based on userhash)
-label_selector=f"skypilot-sshjump={current_name}"
+# Ray pods are labeled with this value i.e sshjump name which is unique per user
+#(based on userhash)
+label_selector = f'skypilot-sshjump={current_name}'
 
 
 def poll():
-    sys.stdout.write("enter poll()\n")
+    sys.stdout.write('enter poll()\n')
 
     alert_delta = datetime.timedelta(seconds=alert_threshold)
 
     # Set delay for each retry
     retry_interval_delta = datetime.timedelta(seconds=retry_interval)
 
-    # Accumulated time of where no Ray pod exist. Used to compare against alert_threshold
+    # Accumulated time of where no Ray pod exist. Used to compare against
+    # alert_threshold
     noray_delta = datetime.timedelta()
 
     while True:
-        sys.stdout.write(f"Sleep {retry_interval} seconds..\n")
+        sys.stdout.write(f'Sleep {retry_interval} seconds..\n')
         time.sleep(retry_interval)
 
         # List the pods in the current namespace
         try:
-            ret = v1.list_namespaced_pod(current_namespace, label_selector=label_selector)
+            ret = v1.list_namespaced_pod(current_namespace,
+                                         label_selector=label_selector)
         except Exception as e:
-            sys.stdout.write(f"[ERROR] exit poll() with error: {e}\n")
+            sys.stdout.write(f'[ERROR] exit poll() with error: {e}\n')
             raise
 
         if len(ret.items) == 0:
-            sys.stdout.write(f"DID NOT FIND pods with label '{label_selector}' in namespace: '{current_namespace}'\n")
+            sys.stdout.write(
+                f'DID NOT FIND pods with label "{label_selector}" in '
+                f'namespace: "{current_namespace}"\n'
+            )
             noray_delta = noray_delta + retry_interval_delta
-            sys.stdout.write(f"noray_delta after time increment: {noray_delta}, alert threshold: {alert_delta}\n")
+            sys.stdout.write(
+                f'noray_delta after time increment: {noray_delta}, alert '
+                f'threshold: {alert_delta}\n'
+            )
         else:
-            sys.stdout.write(f"FOUND pods with label '{label_selector}' in namespace: '{current_namespace}'\n")
+            sys.stdout.write(
+                f'FOUND pods with label "{label_selector}" in namespace: '
+                f'"{current_namespace}"\n'
+            )
             # reset ..
             noray_delta = datetime.timedelta()
-            sys.stdout.write(f"noray_delta is reset: {noray_delta}\n")
+            sys.stdout.write(f'noray_delta is reset: {noray_delta}\n')
 
         if noray_delta >= alert_delta:
-            sys.stdout.write(f"noray_delta: {noray_delta} crossed alert threshold: {alert_delta}. It's time to terminate myself\n")
+            sys.stdout.write(
+                f'noray_delta: {noray_delta} crossed alert threshold: '
+                f'{alert_delta}. Time to terminate myself\n'
+            )
             try:
                 # sshjump resources created under same name
                 v1.delete_namespaced_service(current_name, current_namespace)
                 v1.delete_namespaced_pod(current_name, current_namespace)
             except Exception as e:
-                sys.stdout.write(f"[ERROR] exit poll() with error: {e}\n")
+                sys.stdout.write(f'[ERROR] exit poll() with error: {e}\n')
                 raise
 
             break
 
-    sys.stdout.write("exit poll()\n")
+    sys.stdout.write('exit poll()\n')
 
 
 def main():
-    sys.stdout.write("enter main()\n")
-    sys.stdout.write(f"*** current_name {current_name}\n")
-    sys.stdout.write(f"*** current_namespace {current_namespace}\n")
-    sys.stdout.write(f"*** alert_threshold time {alert_threshold}\n")
-    sys.stdout.write(f"*** retry_interval time {retry_interval}\n")
-    sys.stdout.write(f"*** label_selector {label_selector}\n")
+    sys.stdout.write('enter main()\n')
+    sys.stdout.write(f'*** current_name {current_name}\n')
+    sys.stdout.write(f'*** current_namespace {current_namespace}\n')
+    sys.stdout.write(f'*** alert_threshold time {alert_threshold}\n')
+    sys.stdout.write(f'*** retry_interval time {retry_interval}\n')
+    sys.stdout.write(f'*** label_selector {label_selector}\n')
 
     if not current_name or not current_namespace:
         raise Exception('[ERROR] One or more environment variables is missing '

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -1,6 +1,11 @@
 """Manages lifecycle of sshjump pod.
 
 This script runs inside sshjump pod as the main process (PID 1).
+
+It terminates itself (by removing sshjump service and pod via a call to kubeapi),
+if it does not see ray pods in the duration of 10 minutes. If the user re-launches
+a task before the duration is over, then sshjump pod is being reused and will terminate
+itself when it sees that no ray cluster exist in that amount duration.
 """
 import datetime
 import os

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -4,7 +4,6 @@ This script runs inside sshjump pod as the main process (PID 1).
 """
 import datetime
 import os
-import pytz
 import sys
 import time
 

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -1,0 +1,88 @@
+import os
+import datetime
+import pytz
+import time
+import sys
+
+from kubernetes import client, config
+
+# Load kube config
+config.load_incluster_config()
+
+v1 = client.CoreV1Api()
+
+current_name = os.getenv("MY_POD_NAME")
+current_namespace = os.getenv("MY_POD_NAMESPACE")
+
+# In seconds
+alert_threshold = int(os.getenv("ALERT_THRESHOLD", "300"))
+# In seconds
+retly_interval = int(os.getenv("RETRY_INTERVAL", "60"))
+
+label_selector=f"skypilot-sshjump={current_name}"
+
+
+def poll():
+    sys.stdout.write("enter poll()\n")
+
+    # Set alert threshold. This is the amount of time where no ray pods exist
+    # and this sshjump pod and service will get terminated
+    alert_delta = datetime.timedelta(seconds=alert_threshold)
+
+    # Set delay for each retry
+    retry_interval_delta = datetime.timedelta(seconds=retly_interval)
+
+    # Accumulated wait time to be compared with alert threshold time
+    w8time_delta = datetime.timedelta()
+
+    while True:
+        time.sleep(retly_interval)
+    
+        # List the pods in the current namespace
+        try:
+            ret = v1.list_namespaced_pod(current_namespace, label_selector=label_selector)
+        except Exception as e:
+            sys.stdout.write(f"[ERROR] exit poll() with error: {e}\n")
+            raise
+
+        if len(ret.items) == 0:
+            sys.stdout.write(f"NOT FOUND active pods with label '{label_selector}' in namespace: '{current_namespace}'\n")
+            w8time_delta = w8time_delta + retry_interval_delta
+            sys.stdout.write(f"w8time_delta after time increment: {w8time_delta}, alert threshold: {alert_delta}\n")
+        else:
+            sys.stdout.write(f"FOUND active pods with label '{label_selector}' in namespace: '{current_namespace}'\n")
+            # reset ..
+            w8time_delta = datetime.timedelta()
+            sys.stdout.write(f"w8time_delta is reset: {w8time_delta}\n")
+    
+        if w8time_delta >= alert_delta:
+            sys.stdout.write(f"w8time_delta: {w8time_delta} crossed alert threshold: {alert_delta}. It's time to terminate myself\n")
+            try:
+                # NOTE: according to template all sshjump resources under
+                # same name
+                v1.delete_namespaced_service(current_name, current_namespace)
+                v1.delete_namespaced_pod(current_name, current_namespace)
+            except Exception as e:
+                sys.stdout.write(f"[ERROR] exit poll() with error: {e}\n")
+                raise
+
+            sys.stdout.write("exit poll()\n")
+            break
+
+
+def main():
+    sys.stdout.write("enter main()\n")
+    sys.stdout.write(f"*** current_name {current_name}\n")
+    sys.stdout.write(f"*** current_namespace {current_namespace}\n")
+    sys.stdout.write(f"*** alert_threshold {alert_threshold}\n")
+    sys.stdout.write(f"*** retly_interval {retly_interval}\n")
+    sys.stdout.write(f"*** label_selector {label_selector}\n")
+
+    if not current_name or not current_namespace:
+        raise Exception('[ERROR] One or more environment variables is missing '
+                        'with an actual value.')
+    poll()
+
+
+if __name__ == '__main__':
+    main()

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -19,7 +19,7 @@ current_namespace = os.getenv("MY_POD_NAMESPACE")
 
 # The amount of time in seconds where no Ray pods exist in which after that time
 # sshjump pod terminates itself
-alert_threshold = int(os.getenv("ALERT_THRESHOLD", "300"))
+alert_threshold = int(os.getenv("ALERT_THRESHOLD", "600"))
 # The amount of time in seconds to wait between Ray pods existence checks
 retry_interval = int(os.getenv("RETRY_INTERVAL", "60"))
 

--- a/sky/utils/kubernetes/sshjump-lcm.py
+++ b/sky/utils/kubernetes/sshjump-lcm.py
@@ -18,10 +18,10 @@ v1 = client.CoreV1Api()
 current_name = os.getenv("MY_POD_NAME")
 current_namespace = os.getenv("MY_POD_NAMESPACE")
 
-# The amount of successive time where no Ray pods exist in which after that
-# sshjump pod terminates itself (seconds)
+# The amount of time in seconds where no Ray pods exist in which after that time
+# sshjump pod terminates itself
 alert_threshold = int(os.getenv("ALERT_THRESHOLD", "300"))
-# The amount of time to wait between Ray pods existence checks (seconds)
+# The amount of time in seconds to wait between Ray pods existence checks
 retry_interval = int(os.getenv("RETRY_INTERVAL", "60"))
 
 # Ray pods are labeled with this value i.e sshjump name which is unique per user (based on userhash)
@@ -63,7 +63,7 @@ def poll():
         if noray_delta >= alert_delta:
             sys.stdout.write(f"noray_delta: {noray_delta} crossed alert threshold: {alert_delta}. It's time to terminate myself\n")
             try:
-                # NOTE: sshjump resources created under same name
+                # sshjump resources created under same name
                 v1.delete_namespaced_service(current_name, current_namespace)
                 v1.delete_namespaced_pod(current_name, current_namespace)
             except Exception as e:

--- a/sky/utils/kubernetes/sshjump_lcm.py
+++ b/sky/utils/kubernetes/sshjump_lcm.py
@@ -61,18 +61,15 @@ def poll():
         if len(ret.items) == 0:
             sys.stdout.write(
                 f'DID NOT FIND pods with label "{label_selector}" in '
-                f'namespace: "{current_namespace}"\n'
-            )
+                f'namespace: "{current_namespace}"\n')
             noray_delta = noray_delta + retry_interval_delta
             sys.stdout.write(
                 f'noray_delta after time increment: {noray_delta}, alert '
-                f'threshold: {alert_delta}\n'
-            )
+                f'threshold: {alert_delta}\n')
         else:
             sys.stdout.write(
                 f'FOUND pods with label "{label_selector}" in namespace: '
-                f'"{current_namespace}"\n'
-            )
+                f'"{current_namespace}"\n')
             # reset ..
             noray_delta = datetime.timedelta()
             sys.stdout.write(f'noray_delta is reset: {noray_delta}\n')
@@ -80,8 +77,7 @@ def poll():
         if noray_delta >= alert_delta:
             sys.stdout.write(
                 f'noray_delta: {noray_delta} crossed alert threshold: '
-                f'{alert_delta}. Time to terminate myself\n'
-            )
+                f'{alert_delta}. Time to terminate myself\n')
             try:
                 # sshjump resources created under same name
                 v1.delete_namespaced_service(current_name, current_namespace)


### PR DESCRIPTION
Add an initial support for ssh jump host.

By this, only single port (nodeport) is opened on a target k8s cluster where ssh connections established from skypilot user targeted to ray cluster - are tunneled through ssh jump host pod.
