### PR TITLE
[k8s_cloud_beta1] Add minio object store support.

### DIFF
--- a/examples/storage/minio/1-create-new-bucket.yaml
+++ b/examples/storage/minio/1-create-new-bucket.yaml
@@ -1,0 +1,28 @@
+num_nodes: 1
+
+resources:
+  memory: 2
+  cpus: 1
+  cloud: kubernetes
+
+# Working directory (optional) containing the project codebase.
+# Its contents are synced to ~/sky_workdir/ on the cluster.
+workdir: .
+
+file_mounts:
+
+  /dataset-demo:
+    # sky-demo-dataset bucket is going to get created (if not exists)
+    name: sky-demo-dataset
+    store: minio
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "Running setup."
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "Hello, how are you?"
+  conda env list

--- a/examples/storage/minio/2-copy-local-files-to-new-bucket.yaml
+++ b/examples/storage/minio/2-copy-local-files-to-new-bucket.yaml
@@ -1,0 +1,31 @@
+num_nodes: 1
+
+resources:
+  memory: 2
+  cpus: 1
+  cloud: kubernetes
+
+# Working directory (optional) containing the project codebase.
+# Its contents are synced to ~/sky_workdir/ on the cluster.
+workdir: .
+
+file_mounts:
+
+  /dataset-demo:
+    # sky-demo-dataset bucket is going to get created (if not exists) and the
+    # contents /local/path/datasets on laptop will be copied into
+    name: sky-demo-dataset
+    source: /local/path/datasets
+    store: minio
+    mode: COPY
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "Running setup."
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "Hello, how are you?"
+  conda env list

--- a/examples/storage/minio/3-copy-bucket-objects-to-cluster.yaml
+++ b/examples/storage/minio/3-copy-bucket-objects-to-cluster.yaml
@@ -1,0 +1,26 @@
+num_nodes: 1
+
+resources:
+  memory: 2
+  cpus: 1
+  cloud: kubernetes
+
+file_mounts:
+
+  /dataset-demo:
+    # sky-demo-dataset bucket copied under /dataset-demo folder
+    # in ray cluster
+    source: minio://sky-demo-dataset
+    mode: COPY
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "Running setup."
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "Hello, how are you?"
+  conda env list
+  ls -l /dataset-demo/

--- a/examples/storage/minio/3-copy-bucket-objects-to-cluster2.yaml
+++ b/examples/storage/minio/3-copy-bucket-objects-to-cluster2.yaml
@@ -1,0 +1,23 @@
+num_nodes: 1
+
+resources:
+  memory: 2
+  cpus: 1
+  cloud: kubernetes
+
+file_mounts:
+  # sky-demo-dataset bucket copied under /dataset-demo folder
+  # in ray cluster
+  /dataset-demo: minio://sky-demo-dataset
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "Running setup."
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "Hello, how are you?"
+  conda env list
+  ls -l /dataset-demo/

--- a/examples/storage/minio/4-mount-and-write-to-bucket.yaml
+++ b/examples/storage/minio/4-mount-and-write-to-bucket.yaml
@@ -1,0 +1,30 @@
+num_nodes: 1
+
+resources:
+  memory: 2
+  cpus: 1
+  cloud: kubernetes
+
+file_mounts:
+
+  /dataset-demo:
+    # sky-demo-dataset bucket mounted under /dataset-demo folder
+    # in ray cluster
+    source: minio://sky-demo-dataset
+    mode: MOUNT
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "Running setup."
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "Hello, how are you?"
+  conda env list
+
+  # ensure sky/data contents are listed
+  ls -l /dataset-demo
+  # Write to bucket in MOUNT mode should pass
+  echo "hello" > /dataset-demo/hello.txt

--- a/sky/adaptors/minio.py
+++ b/sky/adaptors/minio.py
@@ -1,0 +1,221 @@
+"""Minio cloud adaptors"""
+# pylint: disable=import-outside-toplevel
+
+import contextlib
+import functools
+import threading
+import os
+from typing import Dict, Optional, Tuple
+
+from sky import skypilot_config
+from sky.utils import ux_utils
+
+boto3 = None
+botocore = None
+_session_creation_lock = threading.RLock()
+MINIO_CREDENTIALS_PATH = '~/.minio/minio.credentials'
+MINIO_PROFILE_NAME = 'minio'
+_INDENT_PREFIX = '    '
+NAME = 'Minio'
+
+
+def import_package(func):
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        global boto3, botocore
+        if boto3 is None or botocore is None:
+            try:
+                import boto3 as _boto3
+                import botocore as _botocore
+                boto3 = _boto3
+                botocore = _botocore
+            except ImportError:
+                raise ImportError('Fail to import dependencies for Minio.'
+                                  'Try pip install "skypilot[aws]"') from None
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@contextlib.contextmanager
+def _load_minio_credentials_env():
+    """Context manager to temporarily change the AWS credentials file path."""
+    prev_credentials_path = os.environ.get('AWS_SHARED_CREDENTIALS_FILE')
+    os.environ['AWS_SHARED_CREDENTIALS_FILE'] = MINIO_CREDENTIALS_PATH
+    try:
+        yield
+    finally:
+        if prev_credentials_path is None:
+            del os.environ['AWS_SHARED_CREDENTIALS_FILE']
+        else:
+            os.environ['AWS_SHARED_CREDENTIALS_FILE'] = prev_credentials_path
+
+
+def get_minio_credentials(boto3_session):
+    """Gets the MINIO credentials from the boto3 session object.
+
+    Args:
+        boto3_session: The boto3 session object.
+    Returns:
+        botocore.credentials.ReadOnlyCredentials object with the MINIO credentials.
+    """
+    with _load_minio_credentials_env():
+        minio_credentials = boto3_session.get_credentials()
+        if minio_credentials is None:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError('Minio credentials not found. Run '
+                                 '`sky check` to verify credentials are '
+                                 'correctly set up.')
+        else:
+            return minio_credentials.get_frozen_credentials()
+
+
+# lru_cache() is thread-safe and it will return the same session object
+# for different threads.
+# Reference: https://docs.python.org/3/library/functools.html#functools.lru_cache # pylint: disable=line-too-long
+@functools.lru_cache()
+@import_package
+def session():
+    """Create a Minio session."""
+    # Creating the session object is not thread-safe for boto3,
+    # so we add a reentrant lock to synchronize the session creation.
+    # Reference: https://github.com/boto/boto3/issues/1592
+    # However, the session object itself is thread-safe, so we are
+    # able to use lru_cache() to cache the session object.
+    with _session_creation_lock:
+        with _load_minio_credentials_env():
+            session_ = boto3.session.Session(profile_name=MINIO_PROFILE_NAME)
+        return session_
+
+
+@functools.lru_cache()
+@import_package
+def resource(resource_name: str, **kwargs):
+    """Create a Minio resource.
+
+    Args:
+        resource_name: Minio resource name (e.g., 's3').
+        kwargs: Other options.
+    """
+    # Need to use the resource retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.resource() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    minio_credentials = get_minio_credentials(session_)
+    endpoint = create_endpoint()
+
+    return session_.resource(
+        resource_name,
+        endpoint_url=endpoint,
+        aws_access_key_id=minio_credentials.access_key,
+        aws_secret_access_key=minio_credentials.secret_key,
+        region_name='auto',
+        **kwargs)
+
+
+@functools.lru_cache()
+def client(service_name: str, region):
+    """Create an Minio client of a certain service.
+
+    Args:
+        service_name: MINIO service name (e.g., 's3').
+        kwargs: Other options.
+    """
+    # Need to use the client retrieved from the per-thread session
+    # to avoid thread-safety issues (Directly creating the client
+    # with boto3.client() is not thread-safe).
+    # Reference: https://stackoverflow.com/a/59635814
+
+    session_ = session()
+    minio_credentials = get_minio_credentials(session_)
+    endpoint = create_endpoint()
+
+    return session_.client(
+        service_name,
+        endpoint_url=endpoint,
+        aws_access_key_id=minio_credentials.access_key,
+        aws_secret_access_key=minio_credentials.secret_key,
+        region_name=region)
+
+
+@import_package
+def botocore_exceptions():
+    """AWS botocore exception."""
+    from botocore import exceptions
+    return exceptions
+
+
+def create_endpoint():
+    """
+    Read minio endpoint from skypilot's config.yaml
+
+    minio:
+        endpoint: "http://my-minio-host:9000"
+
+    """
+    endpoint = skypilot_config.get_nested(("minio", "endpoint"), None)
+    return endpoint
+
+
+def check_credentials() -> Tuple[bool, Optional[str]]:
+    """Checks if the user has access credentials to Minio.
+
+    Returns:
+        A tuple of a boolean value and a hint message where the bool
+        is True when both credentials needed for MINIO is set. It is False
+        when either of those are not set, which would hint with a
+        string on unset credential.
+    """
+
+    hints = None
+    if not minio_profile_in_aws_cred():
+        hints = f'[{MINIO_PROFILE_NAME}] profile is not set in {MINIO_CREDENTIALS_PATH}.'
+    if not skypilot_config.get_nested(("minio", "endpoint"), None):
+        if hints:
+            hints += ' Additionally, '
+        else:
+            hints = ''
+        hints += 'endpoint for MINIO is not set.'
+
+    if hints:
+        hints += ' Run the following commands:'
+        if not minio_profile_in_aws_cred():
+            hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
+            hints += f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE={MINIO_CREDENTIALS_PATH} aws configure --profile minio'  # pylint: disable=line-too-long
+        if not skypilot_config.get_nested(("minio", "endpoint"), None):
+            hints += f'\n{_INDENT_PREFIX}  $ echo {{"minio": {{ "endpoint": "<YOUR MINIO ENDPOINT HERE>" }} }} > ~/.sky/config.yaml'  # pylint: disable=line-too-long
+        hints += f'\n{_INDENT_PREFIX}For more info: '
+        hints += 'https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#minio-minio'  # pylint: disable=line-too-long
+
+    return (False, hints) if hints else (True, hints)
+
+
+def minio_profile_in_aws_cred() -> bool:
+    """Checks if MINIO profile is set in minio credentials"""
+
+    profile_path = os.path.expanduser(MINIO_CREDENTIALS_PATH)
+    minio_profile_exists = False
+    if os.path.isfile(profile_path):
+        with open(profile_path, 'r') as file:
+            for line in file:
+                if f'[{MINIO_PROFILE_NAME}]' in line:
+                    minio_profile_exists = True
+                    break
+    return minio_profile_exists
+
+
+def get_credential_file_mounts() -> Dict[str, str]:
+    """Checks if minio credential file is set and update if not
+       Updates file containing account ID information
+
+    Args:
+        file_mounts: stores path to credential files of clouds
+    """
+
+    minio_credential_mounts = {
+        MINIO_CREDENTIALS_PATH: MINIO_CREDENTIALS_PATH
+    }
+    return minio_credential_mounts

--- a/sky/adaptors/minio.py
+++ b/sky/adaptors/minio.py
@@ -58,7 +58,8 @@ def get_minio_credentials(boto3_session):
     Args:
         boto3_session: The boto3 session object.
     Returns:
-        botocore.credentials.ReadOnlyCredentials object with the MINIO credentials.
+        botocore.credentials.ReadOnlyCredentials object with the MINIO
+        credentials.
     """
     with _load_minio_credentials_env():
         minio_credentials = boto3_session.get_credentials()
@@ -107,13 +108,12 @@ def resource(resource_name: str, **kwargs):
     minio_credentials = get_minio_credentials(session_)
     endpoint = create_endpoint()
 
-    return session_.resource(
-        resource_name,
-        endpoint_url=endpoint,
-        aws_access_key_id=minio_credentials.access_key,
-        aws_secret_access_key=minio_credentials.secret_key,
-        region_name='auto',
-        **kwargs)
+    return session_.resource(resource_name,
+                             endpoint_url=endpoint,
+                             aws_access_key_id=minio_credentials.access_key,
+                             aws_secret_access_key=minio_credentials.secret_key,
+                             region_name='auto',
+                             **kwargs)
 
 
 @functools.lru_cache()
@@ -133,12 +133,11 @@ def client(service_name: str, region):
     minio_credentials = get_minio_credentials(session_)
     endpoint = create_endpoint()
 
-    return session_.client(
-        service_name,
-        endpoint_url=endpoint,
-        aws_access_key_id=minio_credentials.access_key,
-        aws_secret_access_key=minio_credentials.secret_key,
-        region_name=region)
+    return session_.client(service_name,
+                           endpoint_url=endpoint,
+                           aws_access_key_id=minio_credentials.access_key,
+                           aws_secret_access_key=minio_credentials.secret_key,
+                           region_name=region)
 
 
 @import_package
@@ -156,7 +155,7 @@ def create_endpoint():
         endpoint: "http://my-minio-host:9000"
 
     """
-    endpoint = skypilot_config.get_nested(("minio", "endpoint"), None)
+    endpoint = skypilot_config.get_nested(('minio', 'endpoint'), None)
     return endpoint
 
 
@@ -173,7 +172,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
     hints = None
     if not minio_profile_in_aws_cred():
         hints = f'[{MINIO_PROFILE_NAME}] profile is not set in {MINIO_CREDENTIALS_PATH}.'
-    if not skypilot_config.get_nested(("minio", "endpoint"), None):
+    if not skypilot_config.get_nested(('minio', 'endpoint'), None):
         if hints:
             hints += ' Additionally, '
         else:
@@ -185,7 +184,7 @@ def check_credentials() -> Tuple[bool, Optional[str]]:
         if not minio_profile_in_aws_cred():
             hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
             hints += f'\n{_INDENT_PREFIX}  $ AWS_SHARED_CREDENTIALS_FILE={MINIO_CREDENTIALS_PATH} aws configure --profile minio'  # pylint: disable=line-too-long
-        if not skypilot_config.get_nested(("minio", "endpoint"), None):
+        if not skypilot_config.get_nested(('minio', 'endpoint'), None):
             hints += f'\n{_INDENT_PREFIX}  $ echo {{"minio": {{ "endpoint": "<YOUR MINIO ENDPOINT HERE>" }} }} > ~/.sky/config.yaml'  # pylint: disable=line-too-long
         hints += f'\n{_INDENT_PREFIX}For more info: '
         hints += 'https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#minio-minio'  # pylint: disable=line-too-long
@@ -215,7 +214,5 @@ def get_credential_file_mounts() -> Dict[str, str]:
         file_mounts: stores path to credential files of clouds
     """
 
-    minio_credential_mounts = {
-        MINIO_CREDENTIALS_PATH: MINIO_CREDENTIALS_PATH
-    }
+    minio_credential_mounts = {MINIO_CREDENTIALS_PATH: MINIO_CREDENTIALS_PATH}
     return minio_credential_mounts

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2824,7 +2824,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
     def _update_envs_for_k8s(self, handle: CloudVmRayResourceHandle,
                              task: task_lib.Task) -> None:
-        """Update envs for a task with Kubernetes specific env vars if cloud is Kubernetes."""
+        """Update envs for a task with Kubernetes specific env vars if cloud is
+        Kubernetes."""
         if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
             temp_envs = copy.deepcopy(task.envs)
             cloud_env_vars = handle.launched_resources.cloud.query_env_vars(

--- a/sky/check.py
+++ b/sky/check.py
@@ -5,7 +5,7 @@ import click
 
 from sky import clouds
 from sky import global_user_state
-from sky.adaptors import cloudflare
+from sky.adaptors import cloudflare, minio
 
 
 # TODO(zhwu): add check for a single cloud to improve performance
@@ -52,7 +52,19 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
     if not r2_is_enabled:
         echo(f'    Reason: {reason}')
 
-    if len(enabled_clouds) == 0 and not r2_is_enabled:
+    cloud = 'minio (for Minio object store)'
+    echo(f'  Checking {cloud}...', nl=False)
+    minio_is_enabled, reason = minio.check_credentials()
+    echo('\r', nl=False)
+    status_msg = 'enabled' if minio_is_enabled else 'disabled'
+    status_color = 'green' if minio_is_enabled else 'red'
+    echo('  ' +
+         click.style(f'{cloud}: {status_msg}', fg=status_color, bold=True) +
+         ' ' * 10)
+    if not minio_is_enabled:
+        echo(f'    Reason: {reason}')
+
+    if len(enabled_clouds) == 0 and not r2_is_enabled and not minio_is_enabled:
         click.echo(
             click.style(
                 'No cloud is enabled. SkyPilot will not be able to run any '
@@ -91,4 +103,11 @@ def get_cloud_credential_file_mounts() -> Dict[str, str]:
     if r2_is_enabled:
         r2_credential_mounts = cloudflare.get_credential_file_mounts()
         file_mounts.update(r2_credential_mounts)
+    # get_enabled_clouds() does not support minio
+    # as only clouds with computing instances are marked
+    # as enabled by skypilot, therefore we explicitly add this here
+    minio_is_enabled, _ = minio.check_credentials()
+    if minio_is_enabled:
+        minio_credential_mounts = minio.get_credential_file_mounts()
+        file_mounts.update(minio_credential_mounts)
     return file_mounts

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -230,9 +230,9 @@ class MinioCloudStorage(CloudStorage):
         In cloud object stores, a "directory" refers to a regular object whose
         name is a prefix of other objects.
         """
-        _minio = minio.resource('s3')
+        minio_res = minio.resource('s3')
         bucket_name, path = data_utils.split_minio_path(url)
-        bucket = _minio.Bucket(bucket_name)
+        bucket = minio_res.Bucket(bucket_name)
 
         num_objects = 0
         for obj in bucket.objects.filter(Prefix=path):

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -240,7 +240,7 @@ class MinioCloudStorage(CloudStorage):
             if obj.key == path:
                 return False
             # If there are more than 1 object in filter, then it is a directory
-            if num_objects == 3:
+            if num_objects > 1:
                 return True
 
         # A directory with few or no items

--- a/sky/data/data_transfer.py
+++ b/sky/data/data_transfer.py
@@ -188,6 +188,24 @@ def r2_to_s3(r2_bucket_name: str, s3_bucket_name: str) -> None:
                               'a local source for the storage object.')
 
 
+def minio_to_s3(minio_bucket_name: str, s3_bucket_name: str) -> None:
+    raise NotImplementedError('Moving data directly from MINIO to clouds is '
+                              'currently not supported. Please specify '
+                              'a local source for the storage object.')
+
+
+def minio_to_gcs(minio_bucket_name: str, s3_bucket_name: str) -> None:
+    raise NotImplementedError('Moving data directly from MINIO to clouds is '
+                              'currently not supported. Please specify '
+                              'a local source for the storage object.')
+
+
+def minio_to_r2(minio_bucket_name: str, s3_bucket_name: str) -> None:
+    raise NotImplementedError('Moving data directly from MINIO to clouds is '
+                              'currently not supported. Please specify '
+                              'a local source for the storage object.')
+
+
 def _add_bucket_iam_member(bucket_name: str, role: str, member: str) -> None:
     storage_client = gcp.storage_client()
     bucket = storage_client.bucket(bucket_name)

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -167,9 +167,9 @@ def verify_minio_bucket(name: str) -> bool:
     Args:
       name: str; Name of MINIO Bucket (without minio:// prefix)
     """
-    _minio = minio.resource('s3')
-    bucket = _minio.Bucket(name)
-    return bucket in _minio.buckets.all()
+    minio_res = minio.resource('s3')
+    bucket = minio_res.Bucket(name)
+    return bucket in minio_res.buckets.all()
 
 
 def verify_ibm_cos_bucket(name: str) -> bool:
@@ -293,8 +293,8 @@ def parallel_upload(source_path_list: List[str],
                     max_concurrent_uploads: Optional[int] = None) -> None:
     """Helper function to run parallel uploads for a list of paths.
 
-    Used by S3Store, GCSStore, R2Store and MINIOStore to run rsync commands in parallel by
-    providing appropriate command generators.
+    Used by S3Store, GCSStore, R2Store and MINIOStore to run rsync commands in
+    parallel by providing appropriate command generators.
 
     Args:
         source_path_list: List of paths to local files or directories

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -15,7 +15,7 @@ from sky import clouds
 from sky.adaptors import aws
 from sky.adaptors import gcp
 from sky.adaptors import cloudflare
-from sky.adaptors import ibm
+from sky.adaptors import ibm, minio
 from sky.backends import backend_utils
 from sky.utils import schemas
 from sky.data import data_transfer
@@ -87,6 +87,7 @@ class StoreType(enum.Enum):
     AZURE = 'AZURE'
     R2 = 'R2'
     IBM = 'IBM'
+    MINIO = 'MINIO'
 
     @classmethod
     def from_cloud(cls, cloud: clouds.Cloud) -> 'StoreType':
@@ -111,6 +112,8 @@ class StoreType(enum.Enum):
             return StoreType.R2
         elif isinstance(store, IBMCosStore):
             return StoreType.IBM
+        elif isinstance(store, MINIOStore):
+            return StoreType.MINIO
         else:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Unknown store type: {store}')
@@ -150,6 +153,9 @@ def get_store_prefix(storetype: StoreType) -> str:
     # R2 storages use 's3://' as a prefix for various aws cli commands
     elif storetype == StoreType.R2:
         return 's3://'
+    # MINIO storages use 's3://' as a prefix for various aws cli commands
+    elif storetype == StoreType.MINIO:
+        return 'minio://'
     elif storetype == StoreType.IBM:
         return 'cos://'
     elif storetype == StoreType.AZURE:
@@ -476,6 +482,11 @@ class Storage(object):
                         s_metadata,
                         source=self.source,
                         sync_on_reconstruction=self.sync_on_reconstruction)
+                elif s_type == StoreType.MINIO:
+                    store = MINIOStore.from_metadata(
+                        s_metadata,
+                        source=self.source,
+                        sync_on_reconstruction=self.sync_on_reconstruction)
                 elif s_type == StoreType.IBM:
                     store = IBMCosStore.from_metadata(
                         s_metadata,
@@ -519,6 +530,8 @@ class Storage(object):
                         self.add_store(StoreType.GCS)
                     elif self.source.startswith('r2://'):
                         self.add_store(StoreType.R2)
+                    elif self.source.startswith('minio://'):
+                        self.add_store(StoreType.MINIO)
                     elif self.source.startswith('cos://'):
                         self.add_store(StoreType.IBM)
 
@@ -601,7 +614,7 @@ class Storage(object):
                             'using a bucket by writing <destination_path>: '
                             f'{source} in the file_mounts section of your YAML')
                 is_local_source = True
-            elif split_path.scheme in ['s3', 'gs', 'r2', 'cos']:
+            elif split_path.scheme in ['s3', 'gs', 'r2', 'minio', 'cos']:
                 is_local_source = False
                 # Storage mounting does not support mounting specific files from
                 # cloud store - ensure path points to only a directory
@@ -624,7 +637,7 @@ class Storage(object):
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageSourceError(
                         f'Supported paths: local, s3://, gs://, '
-                        f'r2://, cos://. Got: {source}')
+                        f'r2://, minio://, cos://. Got: {source}')
         return source, is_local_source
 
     def _validate_storage_spec(self, name: Optional[str]) -> None:
@@ -635,13 +648,13 @@ class Storage(object):
         def validate_name(name):
             """ Checks for validating the storage name.
 
-            Checks if the name starts the s3, gcs or r2 prefix and raise error
+            Checks if the name starts the s3, gcs, r2 or minio prefix and raise error
             if it does. Store specific validation checks (e.g., S3 specific
             rules) happen in the corresponding store class.
             """
             prefix = name.split('://')[0]
             prefix = prefix.lower()
-            if prefix in ['s3', 'gs', 'r2', 'cos']:
+            if prefix in ['s3', 'gs', 'r2', 'minio', 'cos']:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageNameError(
                         'Prefix detected: `name` cannot start with '
@@ -722,7 +735,7 @@ class Storage(object):
         add it to Storage.
 
         Args:
-          store_type: StoreType; Type of the storage [S3, GCS, AZURE, R2, IBM]
+          store_type: StoreType; Type of the storage [S3, GCS, AZURE, R2, MINIO, IBM]
         """
         if isinstance(store_type, str):
             store_type = StoreType(store_type)
@@ -738,6 +751,8 @@ class Storage(object):
             store_cls = GcsStore
         elif store_type == StoreType.R2:
             store_cls = R2Store
+        elif store_type == StoreType.MINIO:
+            store_cls = MINIOStore
         elif store_type == StoreType.IBM:
             store_cls = IBMCosStore
         else:
@@ -962,6 +977,13 @@ class S3Store(AbstractStore):
                 assert data_utils.verify_r2_bucket(self.name), (
                     f'Source specified as {self.source}, a R2 bucket. ',
                     'R2 Bucket should exist.')
+            elif self.source.startswith('minio://'):
+                assert self.name == data_utils.split_minio_path(self.source)[0], (
+                    'MINIO Bucket is specified as path, the name should be '
+                    'the same as MINIO bucket.')
+                assert data_utils.verify_minio_bucket(self.name), (
+                    f'Source specified as {self.source}, a MINIO bucket. ',
+                    'MINIO Bucket should exist.')
             elif self.source.startswith('cos://'):
                 assert self.name == data_utils.split_cos_path(self.source)[0], (
                     'COS Bucket is specified as path, the name should be '
@@ -1080,6 +1102,8 @@ class S3Store(AbstractStore):
                     self._transfer_to_s3()
                 elif self.source.startswith('r2://'):
                     self._transfer_to_s3()
+                elif self.source.startswith('minio://'):
+                    self._transfer_to_s3()
                 else:
                     self.batch_aws_rsync([self.source])
         except exceptions.StorageUploadError:
@@ -1166,6 +1190,8 @@ class S3Store(AbstractStore):
             data_transfer.gcs_to_s3(self.name, self.name)
         elif self.source.startswith('r2://'):
             data_transfer.r2_to_s3(self.name, self.name)
+        elif self.source.startswith('minio://'):
+            data_transfer.minio_to_s3(self.name, self.name)
 
     def _get_bucket(self) -> Tuple[Optional[StorageHandle], bool]:
         """Obtains the S3 bucket.
@@ -1359,6 +1385,14 @@ class GcsStore(AbstractStore):
                     assert data_utils.verify_r2_bucket(self.name), (
                         f'Source specified as {self.source}, a R2 bucket. ',
                         'R2 Bucket should exist.')
+                elif self.source.startswith('minio://'):
+                    assert self.name == data_utils.split_minio_path(
+                        self.source
+                    )[0], ('MINIO Bucket is specified as path, the name should be '
+                           'the same as MINIO bucket.')
+                    assert data_utils.verify_minio_bucket(self.name), (
+                        f'Source specified as {self.source}, a MINIO bucket. ',
+                        'MINIO Bucket should exist.')
                 elif self.source.startswith('cos://'):
                     assert self.name == data_utils.split_cos_path(
                         self.source
@@ -1475,6 +1509,8 @@ class GcsStore(AbstractStore):
                 elif self.source.startswith('s3://'):
                     self._transfer_to_gcs()
                 elif self.source.startswith('r2://'):
+                    self._transfer_to_gcs()
+                elif self.source.startswith('minio://'):
                     self._transfer_to_gcs()
                 else:
                     # If a single directory is specified in source, upload
@@ -1602,6 +1638,8 @@ class GcsStore(AbstractStore):
             data_transfer.s3_to_gcs(self.name, self.name)
         elif isinstance(self.source, str) and self.source.startswith('r2://'):
             data_transfer.r2_to_gcs(self.name, self.name)
+        elif isinstance(self.source, str) and self.source.startswith('minio://'):
+            data_transfer.minio_to_gcs(self.name, self.name)
 
     def _get_bucket(self) -> Tuple[StorageHandle, bool]:
         """Obtains the GCS bucket.
@@ -1792,6 +1830,13 @@ class R2Store(AbstractStore):
                 assert self.name == data_utils.split_r2_path(self.source)[0], (
                     'R2 Bucket is specified as path, the name should be '
                     'the same as R2 bucket.')
+            elif self.source.startswith('minio://'):
+                assert self.name == data_utils.split_minio_path(self.source)[0], (
+                    'MINIO Bucket is specified as path, the name should be '
+                    'the same as MINIO bucket.')
+                assert data_utils.verify_minio_bucket(self.name), (
+                    f'Source specified as {self.source}, a MINIO bucket. ',
+                    'MINIO Bucket should exist.')
             elif self.source.startswith('cos://'):
                 assert self.name == data_utils.split_cos_path(self.source)[0], (
                     'IBM COS Bucket is specified as path, the name should be '
@@ -1850,6 +1895,8 @@ class R2Store(AbstractStore):
                     self._transfer_to_r2()
                 elif self.source.startswith('r2://'):
                     pass
+                elif self.source.startswith('minio://'):
+                    self._transfer_to_r2()
                 else:
                     self.batch_aws_rsync([self.source])
         except exceptions.StorageUploadError:
@@ -1947,6 +1994,8 @@ class R2Store(AbstractStore):
             data_transfer.gcs_to_r2(self.name, self.name)
         elif self.source.startswith('s3://'):
             data_transfer.s3_to_r2(self.name, self.name)
+        elif self.source.startswith('minio://'):
+            data_transfer.minio_to_r2(self.name, self.name)
 
     def _get_bucket(self) -> Tuple[StorageHandle, bool]:
         """Obtains the R2 bucket.
@@ -2110,6 +2159,346 @@ class R2Store(AbstractStore):
 
         # Wait until bucket deletion propagates on AWS servers
         while data_utils.verify_r2_bucket(bucket_name):
+            time.sleep(0.1)
+        return True
+
+
+class MINIOStore(AbstractStore):
+    _ACCESS_DENIED_MESSAGE = 'Access Denied'
+
+    def __init__(self,
+                 name: str,
+                 source: str,
+                 region: Optional[str] = 'auto',
+                 is_sky_managed: Optional[bool] = None,
+                 sync_on_reconstruction: Optional[bool] = True):
+        self.client: 'boto3.client.Client'
+        self.bucket: 'StorageHandle'
+        super().__init__(name, source, region, is_sky_managed,
+                         sync_on_reconstruction)
+
+    def _validate(self):
+        if self.source is not None and isinstance(self.source, str):
+            if self.source.startswith('s3://'):
+                assert self.name == data_utils.split_s3_path(self.source)[0], (
+                    'S3 Bucket is specified as path, the name should be the'
+                    ' same as S3 bucket.')
+                assert data_utils.verify_s3_bucket(self.name), (
+                    f'Source specified as {self.source}, a S3 bucket. ',
+                    'S3 Bucket should exist.')
+            elif self.source.startswith('gs://'):
+                assert self.name == data_utils.split_gcs_path(self.source)[0], (
+                    'GCS Bucket is specified as path, the name should be '
+                    'the same as GCS bucket.')
+                assert data_utils.verify_gcs_bucket(self.name), (
+                    f'Source specified as {self.source}, a GCS bucket. ',
+                    'GCS Bucket should exist.')
+            elif self.source.startswith('r2://'):
+                assert self.name == data_utils.split_r2_path(self.source)[0], (
+                    'R2 Bucket is specified as path, the name should be '
+                    'the same as R2 bucket.')
+                assert data_utils.verify_r2_bucket(self.name), (
+                    f'Source specified as {self.source}, a R2 bucket. ',
+                    'R2 Bucket should exist.')
+            elif self.source.startswith('minio://'):
+                assert self.name == data_utils.split_minio_path(self.source)[0], (
+                    'MINIO Bucket is specified as path, the name should be '
+                    'the same as MINIO bucket.')
+
+    def initialize(self):
+        """Initializes the MINIO store object on the cloud.
+
+        Initialization involves fetching bucket if exists, or creating it if
+        it does not.
+
+        Raises:
+          StorageBucketCreateError: If bucket creation fails
+          StorageBucketGetError: If fetching existing bucket fails
+          StorageInitError: If general initialization fails.
+        """
+        self.client = data_utils.create_minio_client(self.region)
+        self.bucket, is_new_bucket = self._get_bucket()
+        if self.is_sky_managed is None:
+            # If is_sky_managed is not specified, then this is a new storage
+            # object (i.e., did not exist in global_user_state) and we should
+            # set the is_sky_managed property.
+            # If is_sky_managed is specified, then we take no action.
+            self.is_sky_managed = is_new_bucket
+
+    def upload(self):
+        """Uploads source to store bucket.
+
+        Upload must be called by the Storage handler - it is not called on
+        Store initialization.
+
+        Raises:
+            StorageUploadError: if upload fails.
+        """
+        try:
+            if isinstance(self.source, list):
+                self.batch_minio_rsync(self.source, create_dirs=True)
+            elif self.source is not None:
+                if self.source.startswith('s3://'):
+                    self._transfer_to_minio()
+                elif self.source.startswith('gs://'):
+                    self._transfer_to_minio()
+                elif self.source.startswith('r2://'):
+                    self._transfer_to_minio()
+                elif self.source.startswith('minio://'):
+                    pass
+                else:
+                    self.batch_minio_rsync([self.source])
+        except exceptions.StorageUploadError:
+            raise
+        except Exception as e:
+            raise exceptions.StorageUploadError(
+                f'Upload failed for store {self.name}') from e
+
+    def delete(self) -> None:
+        deleted_by_skypilot = self._delete_minio_bucket(self.name)
+        if deleted_by_skypilot:
+            msg_str = f'Deleted MINIO bucket {self.name}.'
+        else:
+            msg_str = f'MINIO bucket {self.name} may have been deleted ' \
+                      f'externally. Removing from local state.'
+        logger.info(f'{colorama.Fore.GREEN}{msg_str}'
+                    f'{colorama.Style.RESET_ALL}')
+
+    def get_handle(self) -> StorageHandle:
+        return cloudflare.resource('s3').Bucket(self.name)
+
+    def batch_minio_rsync(self,
+                        source_path_list: List[Path],
+                        create_dirs: bool = False) -> None:
+        """Invokes aws s3 sync to batch upload a list of local paths to Minio
+
+        AWS Sync by default uses 10 threads to upload files to the bucket.  To
+        increase parallelism, modify max_concurrent_requests in your aws config
+        file (Default path: ~/.aws/config).
+
+        Since aws s3 sync does not support batch operations, we construct
+        multiple commands to be run in parallel.
+
+        Args:
+            source_path_list: List of paths to local files or directories
+            create_dirs: If the local_path is a directory and this is set to
+                False, the contents of the directory are directly uploaded to
+                root of the bucket. If the local_path is a directory and this is
+                set to True, the directory is created in the bucket root and
+                contents are uploaded to it.
+        """
+
+        def get_file_sync_command(base_dir_path, file_names):
+            includes = ' '.join(
+                [f'--include "{file_name}"' for file_name in file_names])
+            endpoint_url = minio.create_endpoint()
+            sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
+                            f'{minio.MINIO_CREDENTIALS_PATH} '
+                            'aws s3 sync --no-follow-symlinks --exclude="*" '
+                            f'{includes} {base_dir_path} '
+                            f's3://{self.name} '
+                            f'--endpoint {endpoint_url} '
+                            f'--profile={minio.MINIO_PROFILE_NAME}')
+            return sync_command
+
+        def get_dir_sync_command(src_dir_path, dest_dir_name):
+            # we exclude .git directory from the sync
+            excluded_list = storage_utils.get_excluded_files_from_gitignore(
+                src_dir_path)
+            excluded_list.append('.git/*')
+            excludes = ' '.join(
+                [f'--exclude "{file_name}"' for file_name in excluded_list])
+            endpoint_url = minio.create_endpoint()
+            sync_command = (
+                'AWS_SHARED_CREDENTIALS_FILE='
+                f'{minio.MINIO_CREDENTIALS_PATH} '
+                'aws s3 sync --no-follow-symlinks {excludes} '
+                f'{src_dir_path} '
+                f's3://{self.name}/{dest_dir_name} '
+                f'--endpoint {endpoint_url} '
+                f'--profile={minio.MINIO_PROFILE_NAME}')
+            return sync_command
+
+        # Generate message for upload
+        if len(source_path_list) > 1:
+            source_message = f'{len(source_path_list)} paths'
+        else:
+            source_message = source_path_list[0]
+
+        with log_utils.safe_rich_status(
+                f'[bold cyan]Syncing '
+                f'[green]{source_message}[/] to [green]minio://{self.name}/[/]'):
+            data_utils.parallel_upload(
+                source_path_list,
+                get_file_sync_command,
+                get_dir_sync_command,
+                self.name,
+                self._ACCESS_DENIED_MESSAGE,
+                create_dirs=create_dirs,
+                max_concurrent_uploads=_MAX_CONCURRENT_UPLOADS)
+
+    def _transfer_to_minio(self) -> None:
+        raise NotImplementedError('Moving data directly from clouds to MINIO is '
+                                  'currently not supported. Please specify '
+                                  'a local source for the storage object.')
+
+    def _get_bucket(self) -> Tuple[StorageHandle, bool]:
+        """Obtains the R2 bucket.
+
+        If the bucket exists, this method will return the bucket.
+        If the bucket does not exist, there are three cases:
+          1) Raise an error if the bucket source starts with s3://
+          2) Return None if bucket has been externally deleted and
+             sync_on_reconstruction is False
+          3) Create and return a new bucket otherwise
+
+        Raises:
+            StorageBucketCreateError: If creating the bucket fails
+            StorageBucketGetError: If fetching a bucket fails
+        """
+        _minio = minio.resource('s3')
+        bucket = _minio.Bucket(self.name)
+        endpoint_url = minio.create_endpoint()
+        try:
+            # Try Public bucket case.
+            # This line does not error out if the bucket is an external public
+            # bucket or if it is a user's bucket that is publicly
+            # accessible.
+            self.client.head_bucket(Bucket=self.name)
+            return bucket, False
+        except aws.botocore_exceptions().ClientError as e:
+            error_code = e.response['Error']['Code']
+            # AccessDenied error for buckets that are private and not owned by
+            # user.
+            if error_code == '403':
+                command = ('AWS_SHARED_CREDENTIALS_FILE='
+                           f'{minio.MINIO_CREDENTIALS_PATH} '
+                           f'aws s3 ls s3://{self.name} '
+                           f'--endpoint {endpoint_url} '
+                           f'--profile={minio.MINIO_PROFILE_NAME}')
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageBucketGetError(
+                        _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(name=self.name) +
+                        f' To debug, consider running `{command}`.') from e
+
+        if isinstance(self.source, str) and self.source.startswith('minio://'):
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketGetError(
+                    'Attempted to connect to a non-existent bucket: '
+                    f'{self.source}. Consider using '
+                    '`AWS_SHARED_CREDENTIALS_FILE='
+                    f'{minio.MINIO_CREDENTIALS_PATH} aws s3 ls '
+                    f's3://{self.name} '
+                    f'--endpoint {endpoint_url} '
+                    f'--profile={minio.MINIO_PROFILE_NAME}\' '
+                    'to debug.')
+
+        # If bucket cannot be found in both private and public settings,
+        # the bucket is to be created by Sky. However, skip creation if
+        # Store object is being reconstructed for deletion.
+        if self.sync_on_reconstruction:
+            bucket = self._create_minio_bucket(self.name)
+            return bucket, True
+        else:
+            return None, False
+
+    def _download_file(self, remote_path: str, local_path: str) -> None:
+        """Downloads file from remote to local on minio bucket
+        using the boto3 API
+
+        Args:
+          remote_path: str; Remote path on R2 bucket
+          local_path: str; Local path on user's device
+        """
+        self.bucket.download_file(remote_path, local_path)
+
+    def mount_command(self, mount_path: str) -> str:
+        """Returns the command to mount the bucket to the mount_path.
+
+        Uses goofys to mount the bucket.
+
+        Args:
+          mount_path: str; Path to mount the bucket to.
+        """
+        install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
+                       'releases/download/0.24.0-romilb-upstream/goofys '
+                       '-O /usr/local/bin/goofys && '
+                       'sudo chmod +x /usr/local/bin/goofys')
+        endpoint_url = minio.create_endpoint()
+        mount_cmd = (
+            f'AWS_SHARED_CREDENTIALS_FILE={minio.MINIO_CREDENTIALS_PATH} '
+            f'AWS_PROFILE={minio.MINIO_PROFILE_NAME} goofys -o allow_other '
+            f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
+            f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
+            f'--endpoint {endpoint_url} '
+            f'{self.bucket.name} {mount_path}')
+        return mounting_utils.get_mounting_command(mount_path, install_cmd,
+                                                   mount_cmd)
+
+    def _create_minio_bucket(self,
+                          bucket_name: str,
+                          region='auto') -> StorageHandle:
+        """Creates Minio bucket with specific name in specific region
+
+        Args:
+          bucket_name: str; Name of bucket
+          region: str; Region name, r2 automatically sets region
+        Raises:
+          StorageBucketCreateError: If bucket creation fails.
+        """
+        minio_client = self.client
+        try:
+            # NOTE (weit) region not currently relevant
+            minio_client.create_bucket(Bucket=bucket_name)
+        except aws.botocore_exceptions().ClientError as e:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.StorageBucketCreateError(
+                    f'Attempted to create a bucket '
+                    f'{self.name} but failed.') from e
+        return minio.resource('s3').Bucket(bucket_name)
+
+    def _delete_minio_bucket(self, bucket_name: str) -> bool:
+        """Deletes MINIO bucket, including all objects in bucket
+
+        Args:
+          bucket_name: str; Name of bucket
+
+        Returns:
+         bool; True if bucket was deleted, False if it was deleted externally.
+        """
+        # Deleting objects is very slow programatically
+        # (i.e. bucket.objects.all().delete() is slow).
+        # In addition, standard delete operations (i.e. via `aws s3 rm`)
+        # are slow, since AWS puts deletion markers.
+        # https://stackoverflow.com/questions/49239351/why-is-it-so-much-slower-to-delete-objects-in-aws-s3-than-it-is-to-create-them
+        # The fastest way to delete is to run `aws s3 rb --force`,
+        # which removes the bucket by force.
+        endpoint_url = minio.create_endpoint()
+        remove_command = (
+            f'AWS_SHARED_CREDENTIALS_FILE={minio.MINIO_CREDENTIALS_PATH} '
+            f'aws s3 rb s3://{bucket_name} --force '
+            f'--endpoint {endpoint_url} '
+            f'--profile={minio.MINIO_PROFILE_NAME}')
+        try:
+            with log_utils.safe_rich_status(
+                    f'[bold cyan]Deleting MINIO bucket {bucket_name}[/]'):
+                subprocess.check_output(remove_command,
+                                        stderr=subprocess.STDOUT,
+                                        shell=True)
+        except subprocess.CalledProcessError as e:
+            if 'NoSuchBucket' in e.output.decode('utf-8'):
+                logger.debug(
+                    _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE.format(
+                        bucket_name=bucket_name))
+                return False
+            else:
+                logger.error(e.output)
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.StorageBucketDeleteError(
+                        f'Failed to delete MINIO bucket {bucket_name}.')
+
+        # Wait until bucket deletion propagates on AWS servers
+        while data_utils.verify_minio_bucket(bucket_name):
             time.sleep(0.1)
         return True
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2312,7 +2312,7 @@ class MINIOStore(AbstractStore):
             sync_command = (
                 'AWS_SHARED_CREDENTIALS_FILE='
                 f'{minio.MINIO_CREDENTIALS_PATH} '
-                'aws s3 sync --no-follow-symlinks {excludes} '
+                f'aws s3 sync --no-follow-symlinks {excludes} '
                 f'{src_dir_path} '
                 f's3://{self.name}/{dest_dir_name} '
                 f'--endpoint {endpoint_url} '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -648,9 +648,9 @@ class Storage(object):
         def validate_name(name):
             """ Checks for validating the storage name.
 
-            Checks if the name starts the s3, gcs, r2 or minio prefix and raise error
-            if it does. Store specific validation checks (e.g., S3 specific
-            rules) happen in the corresponding store class.
+            Checks if the name starts the s3, gcs, r2 or minio prefix and raise
+            error if it does. Store specific validation checks (e.g., S3
+            specific rules) happen in the corresponding store class.
             """
             prefix = name.split('://')[0]
             prefix = prefix.lower()
@@ -735,7 +735,8 @@ class Storage(object):
         add it to Storage.
 
         Args:
-          store_type: StoreType; Type of the storage [S3, GCS, AZURE, R2, MINIO, IBM]
+          store_type: StoreType; Type of the storage [S3, GCS, AZURE, R2,
+          MINIO, IBM]
         """
         if isinstance(store_type, str):
             store_type = StoreType(store_type)
@@ -978,9 +979,10 @@ class S3Store(AbstractStore):
                     f'Source specified as {self.source}, a R2 bucket. ',
                     'R2 Bucket should exist.')
             elif self.source.startswith('minio://'):
-                assert self.name == data_utils.split_minio_path(self.source)[0], (
-                    'MINIO Bucket is specified as path, the name should be '
-                    'the same as MINIO bucket.')
+                assert self.name == data_utils.split_minio_path(
+                    self.source)[0], (
+                        'MINIO Bucket is specified as path, the name should be '
+                        'the same as MINIO bucket.')
                 assert data_utils.verify_minio_bucket(self.name), (
                     f'Source specified as {self.source}, a MINIO bucket. ',
                     'MINIO Bucket should exist.')
@@ -1388,8 +1390,9 @@ class GcsStore(AbstractStore):
                 elif self.source.startswith('minio://'):
                     assert self.name == data_utils.split_minio_path(
                         self.source
-                    )[0], ('MINIO Bucket is specified as path, the name should be '
-                           'the same as MINIO bucket.')
+                    )[0], (
+                        'MINIO Bucket is specified as path, the name should be '
+                        'the same as MINIO bucket.')
                     assert data_utils.verify_minio_bucket(self.name), (
                         f'Source specified as {self.source}, a MINIO bucket. ',
                         'MINIO Bucket should exist.')
@@ -1638,7 +1641,8 @@ class GcsStore(AbstractStore):
             data_transfer.s3_to_gcs(self.name, self.name)
         elif isinstance(self.source, str) and self.source.startswith('r2://'):
             data_transfer.r2_to_gcs(self.name, self.name)
-        elif isinstance(self.source, str) and self.source.startswith('minio://'):
+        elif isinstance(self.source,
+                        str) and self.source.startswith('minio://'):
             data_transfer.minio_to_gcs(self.name, self.name)
 
     def _get_bucket(self) -> Tuple[StorageHandle, bool]:
@@ -1831,9 +1835,10 @@ class R2Store(AbstractStore):
                     'R2 Bucket is specified as path, the name should be '
                     'the same as R2 bucket.')
             elif self.source.startswith('minio://'):
-                assert self.name == data_utils.split_minio_path(self.source)[0], (
-                    'MINIO Bucket is specified as path, the name should be '
-                    'the same as MINIO bucket.')
+                assert self.name == data_utils.split_minio_path(
+                    self.source)[0], (
+                        'MINIO Bucket is specified as path, the name should be '
+                        'the same as MINIO bucket.')
                 assert data_utils.verify_minio_bucket(self.name), (
                     f'Source specified as {self.source}, a MINIO bucket. ',
                     'MINIO Bucket should exist.')
@@ -2164,6 +2169,10 @@ class R2Store(AbstractStore):
 
 
 class MINIOStore(AbstractStore):
+    """MINIOStore inherits from S3Store Object and represents the backend
+    for minio buckets.
+    """
+
     _ACCESS_DENIED_MESSAGE = 'Access Denied'
 
     def __init__(self,
@@ -2201,9 +2210,10 @@ class MINIOStore(AbstractStore):
                     f'Source specified as {self.source}, a R2 bucket. ',
                     'R2 Bucket should exist.')
             elif self.source.startswith('minio://'):
-                assert self.name == data_utils.split_minio_path(self.source)[0], (
-                    'MINIO Bucket is specified as path, the name should be '
-                    'the same as MINIO bucket.')
+                assert self.name == data_utils.split_minio_path(
+                    self.source)[0], (
+                        'MINIO Bucket is specified as path, the name should be '
+                        'the same as MINIO bucket.')
 
     def initialize(self):
         """Initializes the MINIO store object on the cloud.
@@ -2268,8 +2278,8 @@ class MINIOStore(AbstractStore):
         return cloudflare.resource('s3').Bucket(self.name)
 
     def batch_minio_rsync(self,
-                        source_path_list: List[Path],
-                        create_dirs: bool = False) -> None:
+                          source_path_list: List[Path],
+                          create_dirs: bool = False) -> None:
         """Invokes aws s3 sync to batch upload a list of local paths to Minio
 
         AWS Sync by default uses 10 threads to upload files to the bucket.  To
@@ -2309,14 +2319,13 @@ class MINIOStore(AbstractStore):
             excludes = ' '.join(
                 [f'--exclude "{file_name}"' for file_name in excluded_list])
             endpoint_url = minio.create_endpoint()
-            sync_command = (
-                'AWS_SHARED_CREDENTIALS_FILE='
-                f'{minio.MINIO_CREDENTIALS_PATH} '
-                f'aws s3 sync --no-follow-symlinks {excludes} '
-                f'{src_dir_path} '
-                f's3://{self.name}/{dest_dir_name} '
-                f'--endpoint {endpoint_url} '
-                f'--profile={minio.MINIO_PROFILE_NAME}')
+            sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
+                            f'{minio.MINIO_CREDENTIALS_PATH} '
+                            f'aws s3 sync --no-follow-symlinks {excludes} '
+                            f'{src_dir_path} '
+                            f's3://{self.name}/{dest_dir_name} '
+                            f'--endpoint {endpoint_url} '
+                            f'--profile={minio.MINIO_PROFILE_NAME}')
             return sync_command
 
         # Generate message for upload
@@ -2327,7 +2336,8 @@ class MINIOStore(AbstractStore):
 
         with log_utils.safe_rich_status(
                 f'[bold cyan]Syncing '
-                f'[green]{source_message}[/] to [green]minio://{self.name}/[/]'):
+                f'[green]{source_message}[/] to [green]minio://{self.name}/[/]'
+        ):
             data_utils.parallel_upload(
                 source_path_list,
                 get_file_sync_command,
@@ -2338,9 +2348,10 @@ class MINIOStore(AbstractStore):
                 max_concurrent_uploads=_MAX_CONCURRENT_UPLOADS)
 
     def _transfer_to_minio(self) -> None:
-        raise NotImplementedError('Moving data directly from clouds to MINIO is '
-                                  'currently not supported. Please specify '
-                                  'a local source for the storage object.')
+        raise NotImplementedError(
+            'Moving data directly from clouds to MINIO is '
+            'currently not supported. Please specify '
+            'a local source for the storage object.')
 
     def _get_bucket(self) -> Tuple[StorageHandle, bool]:
         """Obtains the R2 bucket.
@@ -2356,8 +2367,8 @@ class MINIOStore(AbstractStore):
             StorageBucketCreateError: If creating the bucket fails
             StorageBucketGetError: If fetching a bucket fails
         """
-        _minio = minio.resource('s3')
-        bucket = _minio.Bucket(self.name)
+        minio_res = minio.resource('s3')
+        bucket = minio_res.Bucket(self.name)
         endpoint_url = minio.create_endpoint()
         try:
             # Try Public bucket case.
@@ -2436,8 +2447,8 @@ class MINIOStore(AbstractStore):
                                                    mount_cmd)
 
     def _create_minio_bucket(self,
-                          bucket_name: str,
-                          region='auto') -> StorageHandle:
+                             bucket_name: str,
+                             region='auto') -> StorageHandle:
         """Creates Minio bucket with specific name in specific region
 
         Args:
@@ -2448,7 +2459,8 @@ class MINIOStore(AbstractStore):
         """
         minio_client = self.client
         try:
-            # NOTE (weit) region not currently relevant
+            # NOTE: region not relevant
+            del region
             minio_client.create_bucket(Bucket=bucket_name)
         except aws.botocore_exceptions().ClientError as e:
             with ux_utils.print_exception_no_traceback():

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -18,7 +18,7 @@ import uuid
 
 from sky import status_lib
 from sky import clouds
-from sky.adaptors import cloudflare
+from sky.adaptors import cloudflare, minio
 from sky.data import storage as storage_lib
 from sky.utils import common_utils
 from sky.utils import db_utils
@@ -639,6 +639,9 @@ def get_enabled_storage_clouds() -> List[str]:
     r2_is_enabled, _ = cloudflare.check_credentials()
     if r2_is_enabled:
         enabled_storage_clouds.append(cloudflare.NAME)
+    minio_is_enabled, _ = minio.check_credentials()
+    if minio_is_enabled:
+        enabled_storage_clouds.append(minio.NAME)
     return enabled_storage_clouds
 
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -817,6 +817,16 @@ class Task:
                     self.update_file_mounts({
                         mnt_path: blob_path,
                     })
+                elif store_type is storage_lib.StoreType.MINIO:
+                    if storage.source is not None and not isinstance(
+                            storage.source,
+                            list) and storage.source.startswith('minio://'):
+                        blob_path = storage.source
+                    else:
+                        blob_path = 'minio://' + storage.name
+                    self.update_file_mounts({
+                        mnt_path: blob_path,
+                    })
                 elif store_type is storage_lib.StoreType.IBM:
                     if isinstance(storage.source,
                                   str) and storage.source.startswith('cos://'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ import pandas as pd
 # To only run tests for managed spot (without generic tests), use --managed-spot.
 all_clouds_in_smoke_tests = [
     'aws', 'gcp', 'azure', 'lambda', 'cloudflare', 'ibm', 'scp', 'oci',
-    'kubernetes'
+    'kubernetes', 'minio'
 ]
 default_clouds_to_run = ['gcp', 'azure']
 
@@ -38,7 +38,8 @@ cloud_to_pytest_keyword = {
     'ibm': 'ibm',
     'scp': 'scp',
     'oci': 'oci',
-    'kubernetes': 'kubernetes'
+    'kubernetes': 'kubernetes',
+    'minio': 'minio'
 }
 
 
@@ -93,6 +94,8 @@ def _get_cloud_to_run(config) -> List[str]:
         if config.getoption(f'--{cloud}'):
             if cloud == 'cloudflare':
                 cloud_to_run.append(default_clouds_to_run[0])
+            if cloud == 'minio':
+                cloud_to_run.append('kubernetes')
             else:
                 cloud_to_run.append(cloud)
     if not cloud_to_run:
@@ -125,6 +128,8 @@ def pytest_collection_modifyitems(config, items):
                 # Need to check both conditions as 'gcp' is added to cloud_to_run
                 # when tested for cloudflare
                 if config.getoption('--cloudflare') and cloud == 'cloudflare':
+                    continue
+                if config.getoption('--minio') and cloud == 'minio':
                     continue
                 item.add_marker(skip_marks[cloud])
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3162,7 +3162,7 @@ class TestStorageWithCredentials:
         's3://{random_name}', 'gs://{random_name}',
         pytest.param('cos://us-east/{random_name}', marks=pytest.mark.ibm),
         pytest.param('r2://{random_name}', marks=pytest.mark.cloudflare),
-        pytest.param(storage_lib.StoreType.MINIO, marks=pytest.mark.minio)
+        pytest.param('minio://{random_name}', marks=pytest.mark.minio)
     ])
     def test_nonexistent_bucket(self, nonexist_bucket_url):
         # Attempts to create fetch a stroage with a non-existent source.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2793,7 +2793,7 @@ class TestStorageWithCredentials:
                 url = f's3://{bucket_name}/{suffix}'
             else:
                 url = f's3://{bucket_name}'
-            return f'AWS_SHARED_CREDENTIALS_FILE={minio.MINIO_CREDENTIALS_PATH} aws s3 ls {url} --endpoint {endpoint_url} --profile=minio'        
+            return f'AWS_SHARED_CREDENTIALS_FILE={minio.MINIO_CREDENTIALS_PATH} aws s3 ls {url} --endpoint {endpoint_url} --profile=minio'
         if store_type == storage_lib.StoreType.IBM:
             bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
                 bucket_name, Rclone.RcloneClouds.IBM)
@@ -3244,19 +3244,19 @@ class TestStorageWithCredentials:
                     name=private_bucket_name)):
             storage_obj = storage_lib.Storage(source=private_bucket)
 
-    @pytest.mark.parametrize('ext_bucket_fixture, store_type',
-                             [('tmp_awscli_bucket', storage_lib.StoreType.S3),
-                              ('tmp_gsutil_bucket', storage_lib.StoreType.GCS),
-                              pytest.param('tmp_ibm_cos_bucket',
-                                           storage_lib.StoreType.IBM,
-                                           marks=pytest.mark.ibm),
-                              pytest.param('tmp_awscli_bucket_r2',
-                                           storage_lib.StoreType.R2,
-                                           marks=pytest.mark.cloudflare),
-                              pytest.param('tmp_awscli_bucket_minio',
-                                           storage_lib.StoreType.MINIO,
-                                           marks=pytest.mark.minio),
-                              ])
+    @pytest.mark.parametrize('ext_bucket_fixture, store_type', [
+        ('tmp_awscli_bucket', storage_lib.StoreType.S3),
+        ('tmp_gsutil_bucket', storage_lib.StoreType.GCS),
+        pytest.param('tmp_ibm_cos_bucket',
+                     storage_lib.StoreType.IBM,
+                     marks=pytest.mark.ibm),
+        pytest.param('tmp_awscli_bucket_r2',
+                     storage_lib.StoreType.R2,
+                     marks=pytest.mark.cloudflare),
+        pytest.param('tmp_awscli_bucket_minio',
+                     storage_lib.StoreType.MINIO,
+                     marks=pytest.mark.minio),
+    ])
     def test_upload_to_existing_bucket(self, ext_bucket_fixture, request,
                                        tmp_source, store_type):
         # Tries uploading existing files to newly created bucket (outside of
@@ -3300,7 +3300,7 @@ class TestStorageWithCredentials:
         storage_lib.StoreType.S3, storage_lib.StoreType.GCS,
         pytest.param(storage_lib.StoreType.IBM, marks=pytest.mark.ibm),
         pytest.param(storage_lib.StoreType.R2, marks=pytest.mark.cloudflare),
-         pytest.param(storage_lib.StoreType.MINIO, marks=pytest.mark.minio)
+        pytest.param(storage_lib.StoreType.MINIO, marks=pytest.mark.minio)
     ])
     def test_list_source(self, tmp_local_list_storage_obj, store_type):
         # Uses a list in the source field to specify a file and a directory to
@@ -3323,20 +3323,19 @@ class TestStorageWithCredentials:
             'File not found in bucket - output was : {}'.format(out.decode
                                                                 ('utf-8'))
 
-    @pytest.mark.parametrize('invalid_name_list, store_type',
-                             [(AWS_INVALID_NAMES, storage_lib.StoreType.S3),
-                              (GCS_INVALID_NAMES, storage_lib.StoreType.GCS),
-                              pytest.param(IBM_INVALID_NAMES,
-                                           storage_lib.StoreType.IBM,
-                                           marks=pytest.mark.ibm),
-                              pytest.param(AWS_INVALID_NAMES,
-                                           storage_lib.StoreType.R2,
-                                           marks=pytest.mark.cloudflare),
-                              pytest.param(AWS_INVALID_NAMES,
-                                           storage_lib.StoreType.MINIO,
-                                           marks=pytest.mark.minio),
-                              ]
-                             )
+    @pytest.mark.parametrize('invalid_name_list, store_type', [
+        (AWS_INVALID_NAMES, storage_lib.StoreType.S3),
+        (GCS_INVALID_NAMES, storage_lib.StoreType.GCS),
+        pytest.param(IBM_INVALID_NAMES,
+                     storage_lib.StoreType.IBM,
+                     marks=pytest.mark.ibm),
+        pytest.param(AWS_INVALID_NAMES,
+                     storage_lib.StoreType.R2,
+                     marks=pytest.mark.cloudflare),
+        pytest.param(AWS_INVALID_NAMES,
+                     storage_lib.StoreType.MINIO,
+                     marks=pytest.mark.minio),
+    ])
     def test_invalid_names(self, invalid_name_list, store_type):
         # Uses a list in the source field to specify a file and a directory to
         # be uploaded to the storage object.
@@ -3354,8 +3353,7 @@ class TestStorageWithCredentials:
                       marks=pytest.mark.cloudflare),
          pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
                       storage_lib.StoreType.MINIO,
-                      marks=pytest.mark.minio)
-         ])
+                      marks=pytest.mark.minio)])
     def test_excluded_file_cloud_storage_upload_copy(self, gitignore_structure,
                                                      store_type,
                                                      tmp_gitignore_storage_obj):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2833,6 +2833,9 @@ class TestStorageWithCredentials:
         elif store_type == storage_lib.StoreType.R2:
             endpoint_url = cloudflare.create_endpoint()
             return f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} aws s3 ls s3://{bucket_name} --recursive --endpoint {endpoint_url} --profile=r2 | wc -l'
+        elif store_type == storage_lib.StoreType.MINIO:
+            endpoint_url = minio.create_endpoint()
+            return f'AWS_SHARED_CREDENTIALS_FILE={minio.MINIO_CREDENTIALS_PATH} aws s3 ls s3://{bucket_name} --recursive --endpoint {endpoint_url} --profile=minio | wc -l'
 
     @pytest.fixture
     def tmp_source(self, tmp_path):
@@ -3351,7 +3354,7 @@ class TestStorageWithCredentials:
                       marks=pytest.mark.cloudflare),
          pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
                       storage_lib.StoreType.MINIO,
-                      marks=pytest.mark.minio),
+                      marks=pytest.mark.minio)
          ])
     def test_excluded_file_cloud_storage_upload_copy(self, gitignore_structure,
                                                      store_type,

--- a/tests/test_yamls/test_minio_storage_mounting.yaml
+++ b/tests/test_yamls/test_minio_storage_mounting.yaml
@@ -1,0 +1,43 @@
+resources:
+  memory: 2
+  cpus: 1
+
+file_mounts:
+  # Mounting private buckets in COPY mode with a source dir
+  /mount_private_copy:
+    name: {{storage_name}}
+    source: ~/tmp-workdir
+    store: minio
+    mode: COPY
+
+  # Mounting private buckets in COPY mode with a list of files as source
+  /mount_private_copy_lof:
+    name: {{storage_name}}
+    source: ['~/tmp-workdir/tmp file', '~/tmp-workdir/tmp file2']
+    store: minio
+    mode: COPY
+
+  # Mounting private buckets in MOUNT mode
+  /mount_private_mount:
+    name: {{storage_name}}
+    source: ~/tmp-workdir
+    store: minio
+    mode: MOUNT
+
+run: |
+  set -ex
+
+  # Check private bucket contents
+  ls -ltr /mount_private_copy/foo
+  ls -ltr /mount_private_copy/tmp\ file
+  ls -ltr /mount_private_copy_lof/tmp\ file
+  ls -ltr /mount_private_copy_lof/tmp\ file2
+  ls -ltr /mount_private_mount/foo
+  ls -ltr /mount_private_mount/tmp\ file
+  
+  # Symlinks are not copied to buckets
+  ! ls /mount_private_copy/circle-link
+  ! ls /mount_private_mount/circle-link
+  
+  # Write to private bucket in MOUNT mode should pass
+  echo "hello" > /mount_private_mount/hello.txt


### PR DESCRIPTION
We have an on-prem installation of minio object store, which is S3 compatible. We had been able to add minio support to SkyPilot and test it against our local installation with Kubernetes (`kubeadm` based and `kind`).

We added example tasks under `examples/storage/minio` and updated `tests/test_smoke.py` that can be invoked via:

```
pytest -v tests/test_smoke.py  --generic-cloud kubernetes -m minio --minio
```

Please find below a setup example:

1. Start minio container: 

```
docker run -p 9000:9000 -d -p 9001:9001 -e "MINIO_ROOT_USER=minio99" -e "MINIO_ROOT_PASSWORD=minio123" quay.io/minio/minio server /data --console-address ":9001"
```

2. Loginto minio web ui (localhost port 9001) with above minio root user/password. Select Access Key at left pane and generate it.

3. Create ~/.sky/config.yaml with minio endpoint:
```
    minio:
        endpoint: "http://<your minio host name>:9000"
```

4. Invoke AWS CLI to set access and secretes keys (generated in the step above). For rest prompts - enter defaults.
```
AWS_SHARED_CREDENTIALS_FILE=~/.minio/minio.credentials aws configure --profile minio
```

5. Invoke `sky check`. Kubernetes and minio should pass.
