### PR TITLE
[Core] Filter out cloud that does not support multi node early

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -288,7 +288,10 @@ class Cloud:
                                                   region,
                                                   clouds=cls._REPR.lower())
 
-    def get_feasible_launchable_resources(self, resources):
+    def get_feasible_launchable_resources(
+            self,
+            resources: 'resources_lib.Resources',
+            num_nodes: int = 1) -> 'resources_lib.Resources':
         """Returns a list of feasible and launchable resources.
 
         Feasible resources refer to an offering respecting the resource
@@ -300,6 +303,9 @@ class Cloud:
         if resources.is_launchable():
             self._check_instance_type_accelerators_combination(resources)
         resources_required_features = resources.get_required_cloud_features()
+        if num_nodes > 1:
+            resources_required_features.add(
+                CloudImplementationFeatures.MULTI_NODE)
         try:
             self.check_features_are_supported(resources_required_features)
         except exceptions.NotSupportedError:

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -309,6 +309,9 @@ class Cloud:
         try:
             self.check_features_are_supported(resources_required_features)
         except exceptions.NotSupportedError:
+            # TODO(zhwu): The resources are now silently filtered out. We
+            # should have some logging telling the user why the resources
+            # are not considered.
             return ([], [])
         return self._get_feasible_launchable_resources(resources)
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -969,7 +969,8 @@ def _fill_in_launchable_resources(
             all_fuzzy_candidates = set()
             for cloud in clouds_list:
                 (feasible_resources, fuzzy_candidate_list) = (
-                    cloud.get_feasible_launchable_resources(resources))
+                    cloud.get_feasible_launchable_resources(
+                        resources, num_nodes=task.num_nodes))
                 if len(feasible_resources) > 0:
                     # Assume feasible_resources is sorted by prices.
                     cheapest = feasible_resources[0]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our unsupported feature check in the optimizer does not include the multi-node feature. That will make the optimizer output including some clouds that do not support that feature. This will help #2352 fail early, when the `specific_reservations` is specified and multiple nodes are used -- excluding it from the optimizer table, instead of failing during the provisioning.

To reproduce (SCP below does not support multiple nodes):
```
sky launch --num-nodes 2  ✱
I 08-09 14:05:10 optimizer.py:636] == Optimizer ==
I 08-09 14:05:10 optimizer.py:647] Target: minimizing cost
I 08-09 14:05:10 optimizer.py:659] Estimated cost: $0.3 / hour
I 08-09 14:05:10 optimizer.py:659] 
I 08-09 14:05:10 optimizer.py:732] Considered resources (2 nodes):
I 08-09 14:05:10 optimizer.py:781] -------------------------------------------------------------------------------------------------------------------
I 08-09 14:05:10 optimizer.py:781]  CLOUD    INSTANCE                    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE             COST ($)   CHOSEN   
I 08-09 14:05:10 optimizer.py:781] -------------------------------------------------------------------------------------------------------------------
I 08-09 14:05:10 optimizer.py:781]  OCI      VM.Standard.E4.Flex$_8_32   8       32        -              us-sanjose-1            0.30          ✔     
I 08-09 14:05:10 optimizer.py:781]  AWS      m6i.2xlarge                 8       32        -              us-east-1               0.77                
I 08-09 14:05:10 optimizer.py:781]  Azure    Standard_D8s_v5             8       32        -              eastus                  0.77                
I 08-09 14:05:10 optimizer.py:781]  IBM      bx2-8x32                    8       32        -              us-east                 0.77                
I 08-09 14:05:10 optimizer.py:781]  GCP      n2-standard-8               8       32        -              us-central1             0.78                
I 08-09 14:05:10 optimizer.py:781]  SCP      s1v8m16                     8       16        -              KOREA-EAST-1-SCP-B001   0.82                
I 08-09 14:05:10 optimizer.py:781]  Lambda   gpu_1x_a10                  30      200       A10:1          us-east-1               1.20                
I 08-09 14:05:10 optimizer.py:781] -------------------------------------------------------------------------------------------------------------------
I 08-09 14:05:10 optimizer.py:781] 
Launching a new cluster 'sky-f5f1-zhwu'. Proceed? [Y/n]:
```

New:
```
sky launch --num-nodes 2                                               ✭ ✱
I 08-09 14:04:39 optimizer.py:636] == Optimizer ==
I 08-09 14:04:39 optimizer.py:647] Target: minimizing cost
I 08-09 14:04:39 optimizer.py:659] Estimated cost: $0.3 / hour
I 08-09 14:04:39 optimizer.py:659] 
I 08-09 14:04:39 optimizer.py:732] Considered resources (2 nodes):
I 08-09 14:04:39 optimizer.py:781] ----------------------------------------------------------------------------------------------------------
I 08-09 14:04:39 optimizer.py:781]  CLOUD    INSTANCE                    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE    COST ($)   CHOSEN   
I 08-09 14:04:39 optimizer.py:781] ----------------------------------------------------------------------------------------------------------
I 08-09 14:04:39 optimizer.py:781]  OCI      VM.Standard.E4.Flex$_8_32   8       32        -              us-sanjose-1   0.30          ✔     
I 08-09 14:04:39 optimizer.py:781]  AWS      m6i.2xlarge                 8       32        -              us-east-1      0.77                
I 08-09 14:04:39 optimizer.py:781]  Azure    Standard_D8s_v5             8       32        -              eastus         0.77                
I 08-09 14:04:39 optimizer.py:781]  IBM      bx2-8x32                    8       32        -              us-east        0.77                
I 08-09 14:04:39 optimizer.py:781]  GCP      n2-standard-8               8       32        -              us-central1    0.78                
I 08-09 14:04:39 optimizer.py:781]  Lambda   gpu_1x_a10                  30      200       A10:1          us-east-1      1.20                
I 08-09 14:04:39 optimizer.py:781] ----------------------------------------------------------------------------------------------------------
I 08-09 14:04:39 optimizer.py:781] 
Launching a new cluster 'sky-6d06-zhwu'. Proceed? [Y/n]:
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
