### PR TITLE
[Azure] Show detailed error for azure credential check

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -385,7 +385,7 @@ class Azure(clouds.Cloud):
         try:
             cls.get_current_user_identity()
         except exceptions.CloudUserIdentityError as e:
-            return False, (f'Getting user's Azure identity failed.{help_str}\n'
+            return False, (f'Getting user\'s Azure identity failed.{help_str}\n'
                            f'{cls._INDENT_PREFIX}Details: '
                            f'{common_utils.format_exception(e)}')
         return True, None

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -385,10 +385,9 @@ class Azure(clouds.Cloud):
         try:
             cls.get_current_user_identity()
         except exceptions.CloudUserIdentityError as e:
-            return False, (
-                f'Azure credential is not set.{help_str}\n'
-                f'{cls._INDENT_PREFIX}Details: '
-                f'{common_utils.format_exception(e)}')
+            return False, (f'Azure credential is not set.{help_str}\n'
+                           f'{cls._INDENT_PREFIX}Details: '
+                           f'{common_utils.format_exception(e)}')
         return True, None
 
     def get_credential_file_mounts(self) -> Dict[str, str]:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -374,7 +374,7 @@ class Azure(clouds.Cloud):
         except subprocess.CalledProcessError as e:
             return False, (
                 # TODO(zhwu): Change the installation hint to from PyPI.
-                'Azure CLI `az --version` error. Run the following commands:'
+                'Azure CLI `az --version` errored. Run the following commands:'
                 f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[azure]'
                 f'\n{cls._INDENT_PREFIX}Credentials may also need to be set.'
                 f'{help_str}\n'

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -56,6 +56,8 @@ class Azure(clouds.Cloud):
     # Reference: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.ResourceGroup.Name/ # pylint: disable=line-too-long
     _MAX_CLUSTER_NAME_LEN_LIMIT = 42
 
+    _INDENT_PREFIX = ' ' * 4
+
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
@@ -354,9 +356,9 @@ class Azure(clouds.Cloud):
         """Checks if the user has access credentials to this cloud."""
         help_str = (
             ' Run the following commands:'
-            '\n      $ az login'
-            '\n      $ az account set -s <subscription_id>'
-            '\n    For more info: '
+            f'\n{cls._INDENT_PREFIX}  $ az login'
+            f'\n{cls._INDENT_PREFIX}  $ az account set -s <subscription_id>'
+            f'\n{cls._INDENT_PREFIX}For more info: '
             'https://docs.microsoft.com/en-us/cli/azure/get-started-with-azure-cli'  # pylint: disable=line-too-long
         )
         # This file is required because it will be synced to remote VMs for
@@ -369,18 +371,24 @@ class Azure(clouds.Cloud):
 
         try:
             _run_output('az --version')
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             return False, (
                 # TODO(zhwu): Change the installation hint to from PyPI.
-                'Azure CLI returned error. Run the following commands:'
-                '\n      $ pip install skypilot[azure]'
-                '\n    Credentials may also need to be set.' + help_str)
+                'Azure CLI `az --version` error. Run the following commands:'
+                f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[azure]'
+                f'\n{cls._INDENT_PREFIX}Credentials may also need to be set.'
+                f'{help_str}\n'
+                f'{cls._INDENT_PREFIX}Details: '
+                f'{common_utils.format_exception(e)}')
         # If Azure is properly logged in, this will return the account email
         # address + subscription ID.
         try:
             cls.get_current_user_identity()
-        except exceptions.CloudUserIdentityError:
-            return False, 'Azure credential is not set.' + help_str
+        except exceptions.CloudUserIdentityError as e:
+            return False, (
+                f'Azure credential is not set.{help_str}\n'
+                f'{cls._INDENT_PREFIX}Details: '
+                f'{common_utils.format_exception(e)}')
         return True, None
 
     def get_credential_file_mounts(self) -> Dict[str, str]:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -385,7 +385,7 @@ class Azure(clouds.Cloud):
         try:
             cls.get_current_user_identity()
         except exceptions.CloudUserIdentityError as e:
-            return False, (f'Azure credential is not set.{help_str}\n'
+            return False, (f'Getting user's Azure identity failed.{help_str}\n'
                            f'{cls._INDENT_PREFIX}Details: '
                            f'{common_utils.format_exception(e)}')
         return True, None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to mitigate the problem in #2376, where the user fail to see the detailed error in `sky check`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
