### PR TITLE
[GCP] Support reservations for multi-node

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -78,11 +78,13 @@ _SKY_REMOTE_FILE_MOUNTS_DIR = '~/.sky/file_mounts/'
 _LAUNCHED_HEAD_PATTERN = re.compile(r'(\d+) ray[._]head[._]default')
 _LAUNCHED_LOCAL_WORKER_PATTERN = re.compile(r'(\d+) node_')
 _LAUNCHED_WORKER_PATTERN = re.compile(r'(\d+) ray[._]worker[._]default')
+_LAUNCHED_RESERVED_WORKER_PATTERN = re.compile(
+    r'(\d+) ray[._]worker[._]reserved')
 # Intentionally not using prefix 'rf' for the string format because yapf have a
 # bug with python=3.6.
 # 10.133.0.5: ray.worker.default,
 _LAUNCHING_IP_PATTERN = re.compile(
-    r'({}): ray[._]worker[._]default'.format(IP_ADDR_REGEX))
+    r'({}): ray[._]worker[._](?:default|reserved)'.format(IP_ADDR_REGEX))
 WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 
 # We check network connection by going through _TEST_IP_LIST. We may need to
@@ -1153,6 +1155,9 @@ def _count_healthy_nodes_from_ray(output: str,
     else:
         ready_head = get_ready_nodes(_LAUNCHED_HEAD_PATTERN, output)
         ready_workers = get_ready_nodes(_LAUNCHED_WORKER_PATTERN, output)
+        ready_reserved_workers = get_ready_nodes(
+            _LAUNCHED_RESERVED_WORKER_PATTERN, output)
+        ready_workers += ready_reserved_workers
     assert ready_head <= 1, f'#head node should be <=1 (Got {ready_head}).'
     return ready_head, ready_workers
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -7,7 +7,6 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from sky import exceptions
 from sky.clouds import service_catalog
-from sky import skypilot_config
 from sky.utils import log_utils
 from sky.utils import ux_utils
 

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -440,17 +440,6 @@ class Cloud:
         """
         unsupported_features2reason = cls._cloud_unsupported_features()
 
-        # Multi-node is not supported when specific_reservations is specified
-        # because if the node count is greater than the number of available
-        # resources in the specific reservations, the Google API will throw
-        # an error when trying to create the instance.
-        multi_node = CloudImplementationFeatures.MULTI_NODE
-        specific_reservations = skypilot_config.get_nested(
-            (cls._REPR.lower(), 'specific_reservations'), set())
-        if (specific_reservations and multi_node in requested_features):
-            unsupported_features2reason[multi_node] = (
-                'Multi-node is not supported when the `specific_reservations` '
-                f'is specified: {specific_reservations}')
 
         unsupported_features = set(unsupported_features2reason.keys())
         unsupported_features = requested_features.intersection(

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -440,7 +440,6 @@ class Cloud:
         """
         unsupported_features2reason = cls._cloud_unsupported_features()
 
-
         unsupported_features = set(unsupported_features2reason.keys())
         unsupported_features = requested_features.intersection(
             unsupported_features)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,7 +180,7 @@ def generic_cloud(request) -> str:
 
 
 @pytest.fixture
-def enable_all_clouds(monkeypatch, patch_gcloud_list_reservations):
+def enable_all_clouds(monkeypatch):
     from sky import clouds
     # Monkey-patching is required because in the test environment, no cloud is
     # enabled. The optimizer checks the environment to find enabled clouds, and
@@ -216,6 +216,10 @@ def enable_all_clouds(monkeypatch, patch_gcloud_list_reservations):
     monkeypatch.setattr('sky.backends.backend_utils.check_owner_identity',
                         lambda _: None)
 
+    monkeypatch.setattr(
+        'sky.clouds.gcp.GCP._list_reservations_for_instance_type',
+        lambda *_args, **_kwargs: [])
+
 
 @pytest.fixture
 def aws_config_region(monkeypatch) -> str:
@@ -227,10 +231,3 @@ def aws_config_region(monkeypatch) -> str:
         if isinstance(ssh_proxy_command, dict) and ssh_proxy_command:
             region = list(ssh_proxy_command.keys())[0]
     return region
-
-
-@pytest.fixture
-def patch_gcloud_list_reservations():
-    with patch('sky.clouds.gcp.GCP._list_reservations_for_instance_type',
-               return_value=[]) as mock:
-        yield mock

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -76,6 +76,10 @@ def _make_resources(
         config_file_backup.name)
     monkeypatch.setenv('OCI_CONFIG', config_file_backup.name)
 
+    monkeypatch.setattr(
+        'sky.clouds.gcp.GCP._list_reservations_for_instance_type',
+        lambda *_args, **_kwargs: [])
+
     # Should create Resources here, since it uses the enabled clouds.
     return sky.Resources(*resources_args, **resources_kwargs)
 
@@ -118,23 +122,23 @@ def test_resources_azure(monkeypatch):
     _test_resources_launch(monkeypatch, sky.Azure(), 'Standard_NC24s_v3')
 
 
-def test_resources_gcp(monkeypatch, patch_gcloud_list_reservations):
+def test_resources_gcp(monkeypatch):
     _test_resources_launch(monkeypatch, sky.GCP(), 'n1-standard-16')
 
 
-def test_partial_cpus(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_cpus(monkeypatch):
     _test_resources_launch(monkeypatch, cpus=4)
     _test_resources_launch(monkeypatch, cpus='4')
     _test_resources_launch(monkeypatch, cpus='7+')
 
 
-def test_partial_memory(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_memory(monkeypatch):
     _test_resources_launch(monkeypatch, memory=32)
     _test_resources_launch(monkeypatch, memory='32')
     _test_resources_launch(monkeypatch, memory='32+')
 
 
-def test_partial_k80(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_k80(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='K80')
 
 
@@ -142,16 +146,16 @@ def test_partial_m60(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='M60')
 
 
-def test_partial_p100(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_p100(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='P100')
 
 
-def test_partial_t4(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_t4(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='T4')
     _test_resources_launch(monkeypatch, accelerators={'T4': 8}, use_spot=True)
 
 
-def test_partial_tpu(monkeypatch, patch_gcloud_list_reservations):
+def test_partial_tpu(monkeypatch):
     _test_resources_launch(monkeypatch, accelerators='tpu-v3-8')
 
 
@@ -224,8 +228,7 @@ def test_instance_type_mismatches_memory(monkeypatch):
         assert 'does not have the requested memory' in str(e.value)
 
 
-def test_instance_type_matches_cpus(monkeypatch,
-                                    patch_gcloud_list_reservations):
+def test_instance_type_matches_cpus(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.AWS(),
                            instance_type='c6i.8xlarge',
@@ -244,8 +247,7 @@ def test_instance_type_matches_cpus(monkeypatch,
                            cpus=8.0)
 
 
-def test_instance_type_matches_memory(monkeypatch,
-                                      patch_gcloud_list_reservations):
+def test_instance_type_matches_memory(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.AWS(),
                            instance_type='c6i.8xlarge',
@@ -264,8 +266,7 @@ def test_instance_type_matches_memory(monkeypatch,
                            memory=32)
 
 
-def test_instance_type_from_cpu_memory(monkeypatch, capfd,
-                                       patch_gcloud_list_reservations):
+def test_instance_type_from_cpu_memory(monkeypatch, capfd):
     _test_resources_launch(monkeypatch, cpus=8)
     stdout, _ = capfd.readouterr()
     # Choose General Purpose instance types
@@ -361,8 +362,7 @@ def test_instance_type_mistmatches_accelerators(monkeypatch):
         assert 'Infeasible resource demands found' in str(e.value)
 
 
-def test_instance_type_matches_accelerators(monkeypatch,
-                                            patch_gcloud_list_reservations):
+def test_instance_type_matches_accelerators(monkeypatch):
     _test_resources_launch(monkeypatch,
                            sky.AWS(),
                            instance_type='p3.2xlarge',


### PR DESCRIPTION
This is a follow-up of #2352. 

Since our backend matches the worker name to see if the cluster has been provisioned, we need to update our regex for that matching.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below) 
  - [x] multiple nodes with the following configuration
      - 2 nodes: 1 specific, 1 auto
      - 2 nodes: 2 specific
      - 1 node: 1 specific
      - 3 nodes: 2 specific, 1 auto
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
