### PR TITLE
[GCP] Add default value for cache to fix backward compatibility

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -103,6 +103,14 @@ def is_api_disabled(endpoint: str, project_id: str) -> bool:
                           stdout=subprocess.PIPE)
     return proc.returncode != 0
 
+def _attrgetter_with_default(attr, default=None):
+    getter = operator.attrgetter(attr)
+    def wrapper(obj):
+        try:
+            return getter(obj)
+        except AttributeError:
+            return default
+    return wrapper
 
 @dataclasses.dataclass
 class SpecificReservation:
@@ -626,7 +634,7 @@ class GCP(clouds.Cloud):
         return [r for r in reservations if r.zone.endswith(f'/{zone}')]
 
     @cachetools.cachedmethod(
-        cache=operator.attrgetter('_list_reservations_cache'))
+        cache=_attrgetter_with_default('_list_reservations_cache', default=None))
     def _list_reservations_for_instance_type(
         self,
         instance_type: str,
@@ -1168,3 +1176,4 @@ class GCP(clouds.Cloud):
             error_msg=f'Failed to delete image {image_name!r}',
             stderr=stderr,
             stream_logs=True)
+

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -103,14 +103,18 @@ def is_api_disabled(endpoint: str, project_id: str) -> bool:
                           stdout=subprocess.PIPE)
     return proc.returncode != 0
 
+
 def _attrgetter_with_default(attr, default=None):
     getter = operator.attrgetter(attr)
+
     def wrapper(obj):
         try:
             return getter(obj)
         except AttributeError:
             return default
+
     return wrapper
+
 
 @dataclasses.dataclass
 class SpecificReservation:
@@ -633,8 +637,8 @@ class GCP(clouds.Cloud):
         reservations = self._list_reservations_for_instance_type(instance_type)
         return [r for r in reservations if r.zone.endswith(f'/{zone}')]
 
-    @cachetools.cachedmethod(
-        cache=_attrgetter_with_default('_list_reservations_cache', default=None))
+    @cachetools.cachedmethod(cache=_attrgetter_with_default(
+        '_list_reservations_cache', default=None))
     def _list_reservations_for_instance_type(
         self,
         instance_type: str,
@@ -1176,4 +1180,3 @@ class GCP(clouds.Cloud):
             error_msg=f'Failed to delete image {image_name!r}',
             stderr=stderr,
             stream_logs=True)
-

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -8,7 +8,6 @@ import subprocess
 import time
 import typing
 import datetime
-import operator
 from typing import Dict, Iterator, List, Optional, Tuple, Set
 
 import cachetools
@@ -102,7 +101,6 @@ def is_api_disabled(endpoint: str, project_id: str) -> bool:
                           stderr=subprocess.PIPE,
                           stdout=subprocess.PIPE)
     return proc.returncode != 0
-
 
 
 @dataclasses.dataclass
@@ -626,8 +624,10 @@ class GCP(clouds.Cloud):
         reservations = self._list_reservations_for_instance_type(instance_type)
         return [r for r in reservations if r.zone.endswith(f'/{zone}')]
 
-    @cachetools.cachedmethod(cache=lambda self: getattr(self,
-        '_list_reservations_cache', None))
+    @cachetools.cachedmethod(
+        # Default to None for backward compatibility for GCP clusters launched
+        # before #2352.
+        cache=lambda self: getattr(self, '_list_reservations_cache', None))
     def _list_reservations_for_instance_type(
         self,
         instance_type: str,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -104,17 +104,6 @@ def is_api_disabled(endpoint: str, project_id: str) -> bool:
     return proc.returncode != 0
 
 
-def _attrgetter_with_default(attr, default=None):
-    getter = operator.attrgetter(attr)
-
-    def wrapper(obj):
-        try:
-            return getter(obj)
-        except AttributeError:
-            return default
-
-    return wrapper
-
 
 @dataclasses.dataclass
 class SpecificReservation:
@@ -637,8 +626,8 @@ class GCP(clouds.Cloud):
         reservations = self._list_reservations_for_instance_type(instance_type)
         return [r for r in reservations if r.zone.endswith(f'/{zone}')]
 
-    @cachetools.cachedmethod(cache=_attrgetter_with_default(
-        '_list_reservations_cache', default=None))
+    @cachetools.cachedmethod(cache=lambda self: getattr(self,
+        '_list_reservations_cache', None))
     def _list_reservations_for_instance_type(
         self,
         instance_type: str,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -605,7 +605,11 @@ class GCP(clouds.Cloud):
         specific_reservations: Set[str],
     ) -> Dict[str, int]:
         del region  # Unused
-        assert zone is not None, 'GCP requires zone to get available reservations.'
+        if zone is None:
+            # For backward compatibility, the cluster in INIT state launched
+            # before #2352 may not have zone information. In this case, we
+            # return 0 for all reservations.
+            return {reservation: 0 for reservation in specific_reservations}
         reservations = self._list_reservations_for_instance_type_in_zone(
             instance_type, zone)
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -629,6 +629,9 @@ class GCP(clouds.Cloud):
 
     def _get_or_create_ttl_cache(self):
         if getattr(self, '_list_reservations_cache', None) is None:
+            # Backward compatibility: Clusters created before #2352 has GCP
+            # objects serialized without the attribute. So we access it this
+            # way.
             self._list_reservations_cache = cachetools.TTLCache(
                 maxsize=1,
                 ttl=datetime.timedelta(300),
@@ -636,8 +639,6 @@ class GCP(clouds.Cloud):
         return self._list_reservations_cache
 
     @cachetools.cachedmethod(
-        # Create if not found for backward compatibility for GCP clusters
-        # launched before #2352.
         cache=lambda self: self._get_or_create_ttl_cache())
     def _list_reservations_for_instance_type(
         self,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -636,8 +636,8 @@ class GCP(clouds.Cloud):
         return self._list_reservations_cache
 
     @cachetools.cachedmethod(
-        # Default to None for backward compatibility for GCP clusters launched
-        # before #2352.
+        # Create if not found for backward compatibility for GCP clusters
+        # launched before #2352.
         cache=lambda self: self._get_or_create_ttl_cache())
     def _list_reservations_for_instance_type(
         self,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -638,8 +638,7 @@ class GCP(clouds.Cloud):
                 timer=datetime.datetime.now)
         return self._list_reservations_cache
 
-    @cachetools.cachedmethod(
-        cache=lambda self: self._get_or_create_ttl_cache())
+    @cachetools.cachedmethod(cache=lambda self: self._get_or_create_ttl_cache())
     def _list_reservations_for_instance_type(
         self,
         instance_type: str,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce:
1. `sky launch -c test --cloud gcp` before #2352 
2. `sky start test -f` after #2352

```
 in wrapper
    c = cache(self)
AttributeError: 'GCP' object has no attribute '_list_reservations_cache'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
