### PR TITLE
Fix retry cleanup when resource not created

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1638,11 +1638,8 @@ class RetryingVmProvisioner(object):
             # so we must terminate/stop here too. E.g., node is up, and ray
             # autoscaler proceeds to setup commands, which may fail:
             #   ERR updater.py:138 -- New status: update-failed
-            # We allow resource not found error here since user could out
-            # of capacity and the resources have not been created.
             CloudVmRayBackend().teardown_no_lock(handle,
-                                                 terminate=terminate_or_stop,
-                                                 allow_resource_not_found=True)
+                                                 terminate=terminate_or_stop)
 
         if to_provision.zone is not None:
             message = (
@@ -3490,8 +3487,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                          terminate: bool,
                          purge: bool = False,
                          post_teardown_cleanup: bool = True,
-                         refresh_cluster_status: bool = True,
-                         allow_resource_not_found: bool = False) -> None:
+                         refresh_cluster_status: bool = True) -> None:
         """Teardown the cluster without acquiring the cluster status lock.
 
         NOTE: This method should not be called without holding the cluster
@@ -3556,12 +3552,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             if terminate:
                 operation_fn = provision_lib.terminate_instances
             try:
-                provider_config = config['provider']
-                provider_config[
-                    'allow_resource_not_found'] = allow_resource_not_found
                 operation_fn(repr(cloud),
                              cluster_name,
-                             provider_config=provider_config)
+                             provider_config=config['provider'])
             except Exception as e:  # pylint: disable=broad-except
                 if purge:
                     logger.warning(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -130,8 +130,6 @@ _RAY_UP_WITH_MONKEY_PATCHED_HASH_LAUNCH_CONF_PATH = (
 # Restart skylet when the version does not match to keep the skylet up-to-date.
 _MAYBE_SKYLET_RESTART_CMD = 'python3 -m sky.skylet.attempt_skylet'
 
-_GCP_RESOURCE_NOT_FOUND_PATTERN = re.compile(r'The resource .* was not found')
-
 
 def _get_cluster_config_template(cloud):
     cloud_to_template = {
@@ -3558,9 +3556,11 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             if terminate:
                 operation_fn = provision_lib.terminate_instances
             try:
+                provider_config = config['provider']
+                provider_config['allow_resource_not_found'] = allow_resource_not_found
                 operation_fn(repr(cloud),
                              cluster_name,
-                             provider_config=config['provider'])
+                             provider_config=provider_config)
             except Exception as e:  # pylint: disable=broad-except
                 if purge:
                     logger.warning(
@@ -3568,11 +3568,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                             reason='stopping/terminating cluster nodes',
                             details=common_utils.format_exception(
                                 e, use_bracket=True)))
-                elif allow_resource_not_found:
-                    resource_not_found = _GCP_RESOURCE_NOT_FOUND_PATTERN.search(
-                        repr(e))
-                    if resource_not_found is None:
-                        raise
                 else:
                     raise
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3557,7 +3557,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 operation_fn = provision_lib.terminate_instances
             try:
                 provider_config = config['provider']
-                provider_config['allow_resource_not_found'] = allow_resource_not_found
+                provider_config[
+                    'allow_resource_not_found'] = allow_resource_not_found
                 operation_fn(repr(cloud),
                              cluster_name,
                              provider_config=provider_config)

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -136,7 +136,6 @@ def terminate_instances(
     zone = provider_config['availability_zone']
     project_id = provider_config['project_id']
     use_tpu_vms = provider_config.get('_has_tpus', False)
-    allow_resource_not_found = provider_config['allow_resource_not_found']
 
     label_filters = {TAG_RAY_CLUSTER_NAME: cluster_name}
     if worker_only:
@@ -158,8 +157,6 @@ def terminate_instances(
                     handler.terminate(project_id, zone, instance))
         _wait_for_operations(operations, project_id, zone)
     except errors.HttpError as e:
-        if not allow_resource_not_found:
-            raise
         if _RESOURCE_NOT_FOUND_PATTERN.search(e.reason) is None:
             raise
     # We don't wait for the instances to be terminated, as it can take a long

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -159,6 +159,9 @@ def terminate_instances(
             except errors.HttpError as e:
                 if _RESOURCE_NOT_FOUND_PATTERN.search(e.reason) is None:
                     errs.append(e)
+                else:
+                    logger.warning(f'Instance {instance} does not exist. '
+                                   'Skip terminating it.')
     _wait_for_operations(operations, project_id, zone)
     if errs:
         raise RuntimeError(f'Failed to terminate instances: {errs}')

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -20,7 +20,8 @@ POLL_INTERVAL = 5
 TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'
 TAG_RAY_NODE_KIND = 'ray-node-type'
 
-_RESOURCE_NOT_FOUND_PATTERN = re.compile(r'The resource .* was not found')
+_INSTANCE_RESOURCE_NOT_FOUND_PATTERN = re.compile(
+    r'The resource \'projects/.*/zones/.*/instances/.*\' was not found')
 
 
 def _filter_instances(
@@ -156,7 +157,8 @@ def terminate_instances(
                 operations[handler].append(
                     handler.terminate(project_id, zone, instance))
             except gcp.http_error_exception() as e:
-                if _RESOURCE_NOT_FOUND_PATTERN.search(e.reason) is None:
+                if _INSTANCE_RESOURCE_NOT_FOUND_PATTERN.search(
+                        e.reason) is None:
                     errs.append(e)
                 else:
                     logger.warning(f'Instance {instance} does not exist. '

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -1,9 +1,10 @@
 """GCP instance provisioning."""
 import collections
-from googleapiclient import errors
 import re
 import time
 from typing import Any, Callable, Dict, Iterable, List, Optional, Type
+
+from googleapiclient import errors
 
 from sky import sky_logging
 from sky.provision.gcp import instance_utils

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -4,9 +4,8 @@ import re
 import time
 from typing import Any, Callable, Dict, Iterable, List, Optional, Type
 
-from googleapiclient import errors
-
 from sky import sky_logging
+from sky.adaptors import gcp
 from sky.provision.gcp import instance_utils
 from sky.utils import common_utils
 
@@ -156,7 +155,7 @@ def terminate_instances(
             try:
                 operations[handler].append(
                     handler.terminate(project_id, zone, instance))
-            except errors.HttpError as e:
+            except gcp.http_error_exception() as e:
                 if _RESOURCE_NOT_FOUND_PATTERN.search(e.reason) is None:
                     errs.append(e)
                 else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, if our provision loop failed due to out-of-capacity, we’ll proceed to try to tear it down, but the VM may not be created. This PR fixes the problem by not raising exceptions if such resource is not found.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
