### PR TITLE
[GCP reservation] Avoid using reservation for spot VMs

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -855,7 +855,8 @@ class Resources:
         """Returns the number of available reservation resources."""
         if self.use_spot:
             # GCP's & AWS's reservations do not support spot instances. We
-            # assume other clouds behave the same.
+            # assume other clouds behave the same. We can move this check down
+            # to each cloud if any cloud supports reservations for spot.
             return {}
         return self.cloud.get_reservations_available_resources(
             self._instance_type, self._region, self._zone,

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -854,6 +854,8 @@ class Resources:
             self, specific_reservations: Set[str]) -> Dict[str, int]:
         """Returns the number of available reservation resources."""
         if self.use_spot:
+            # GCP's & AWS's reservations do not support spot instances. We
+            # assume other clouds behave the same.
             return {}
         return self.cloud.get_reservations_available_resources(
             self._instance_type, self._region, self._zone,

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -853,6 +853,8 @@ class Resources:
     def get_reservations_available_resources(
             self, specific_reservations: Set[str]) -> Dict[str, int]:
         """Returns the number of available reservation resources."""
+        if self.use_spot:
+            return {}
         return self.cloud.get_reservations_available_resources(
             self._instance_type, self._region, self._zone,
             specific_reservations)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The reservation pool is not available for the spot VMs. We should avoid using reservations for spot.

To reproduce:
1. Have a specific reservation in us-central1-c with n2-standard-2
2. `sky launch -c test-spot --cpus 2 --cloud gcp`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
