### PR TITLE
[AWS] Fix check/status failure when no permission is granted for the account

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3096,7 +3096,7 @@ def check(verbose: bool):
     ('The region to use. If not specified, shows accelerators from all regions.'
     ),
 )
-@service_catalog.use_default_catalog_if_failed
+@service_catalog.fallback_to_default_catalog
 @usage_lib.entrypoint
 def show_gpus(
         accelerator_str: Optional[str],

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3096,7 +3096,7 @@ def check(verbose: bool):
     ('The region to use. If not specified, shows accelerators from all regions.'
     ),
 )
-@service_catalog.use_default_catalog
+@service_catalog.use_default_catalog_if_failed
 @usage_lib.entrypoint
 def show_gpus(
         accelerator_str: Optional[str],

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -482,7 +482,15 @@ class AWS(clouds.Cloud):
         from sky.clouds.service_catalog import aws_catalog
 
         # Trigger the fetch of the availability zones mapping.
-        aws_catalog.get_default_instance_type()
+        try:
+            aws_catalog.get_default_instance_type()
+        except RuntimeError as e:
+            return False, (
+                'Failed to fetch the availability zones for the account. It is '
+                'likely due to permission issues, please check the minimal '
+                'permission required for AWS: https://skypilot.readthedocs.io/en/latest/cloud-setup/cloud-permissions/aws.html'  # pylint: disable=
+                f'\n{cls._INDENT_PREFIX}Details: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
         return True, hints
 
     @classmethod

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -4,7 +4,7 @@ import importlib
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from sky.clouds.service_catalog.config import use_default_catalog
+from sky.clouds.service_catalog.config import use_default_catalog_if_failed
 from sky.clouds.service_catalog.constants import CATALOG_SCHEMA_VERSION
 from sky.clouds.service_catalog.constants import HOSTED_CATALOG_DIR_URL
 from sky.clouds.service_catalog.constants import LOCAL_CATALOG_DIR
@@ -45,7 +45,7 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     return results
 
 
-@use_default_catalog
+@use_default_catalog_if_failed
 def list_accelerators(
     gpus_only: bool = True,
     name_filter: Optional[str] = None,
@@ -330,7 +330,7 @@ __all__ = [
     'get_image_id_from_tag',
     'is_image_tag_valid',
     # Configuration
-    'use_default_catalog',
+    'use_default_catalog_if_failed',
     # Constants
     'HOSTED_CATALOG_DIR_URL',
     'CATALOG_SCHEMA_VERSION',

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -4,7 +4,7 @@ import importlib
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from sky.clouds.service_catalog.config import use_default_catalog_if_failed
+from sky.clouds.service_catalog.config import fallback_to_default_catalog
 from sky.clouds.service_catalog.constants import CATALOG_SCHEMA_VERSION
 from sky.clouds.service_catalog.constants import HOSTED_CATALOG_DIR_URL
 from sky.clouds.service_catalog.constants import LOCAL_CATALOG_DIR
@@ -45,7 +45,7 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     return results
 
 
-@use_default_catalog_if_failed
+@fallback_to_default_catalog
 def list_accelerators(
     gpus_only: bool = True,
     name_filter: Optional[str] = None,
@@ -330,7 +330,7 @@ __all__ = [
     'get_image_id_from_tag',
     'is_image_tag_valid',
     # Configuration
-    'use_default_catalog_if_failed',
+    'fallback_to_default_catalog',
     # Constants
     'HOSTED_CATALOG_DIR_URL',
     'CATALOG_SCHEMA_VERSION',

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -165,9 +165,12 @@ def _get_df() -> pd.DataFrame:
 
 
 def get_quota_code(instance_type: str, use_spot: bool) -> Optional[str]:
-    # Get the quota code from the accelerator instance type
-    # This will be used in the botocore command to check for
-    # a non-zero quota
+    """Get the quota code based on `instance_type` and `use_spot`.
+
+    The quota code is fetched from `_quotas_df` based on the instance type
+    specified, and will then be utilized in a botocore API command in order
+    to check its quota.
+    """
 
     if use_spot:
         spot_header = 'SpotInstanceCode'

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -19,6 +19,7 @@ from sky.clouds import aws
 from sky.clouds.service_catalog import common
 from sky.clouds.service_catalog import config
 from sky.clouds.service_catalog.data_fetchers import fetch_aws
+from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:
     from sky.clouds import cloud
@@ -159,12 +160,9 @@ def _get_df() -> pd.DataFrame:
 
 
 def get_quota_code(instance_type: str, use_spot: bool) -> Optional[str]:
-    """Get the quota code based on `instance_type` and `use_spot`.
-
-    The quota code is fetched from `_quotas_df` based on the instance type
-    specified, and will then be utilized in a botocore API command in order
-    to check its quota.
-    """
+    # Get the quota code from the accelerator instance type
+    # This will be used in the botocore command to check for
+    # a non-zero quota
 
     if use_spot:
         spot_header = 'SpotInstanceCode'
@@ -245,8 +243,7 @@ def get_instance_type_for_accelerator(
     region: Optional[str] = None,
     zone: Optional[str] = None,
 ) -> Tuple[Optional[List[str]], List[str]]:
-    """Filter the instance types based on resource requirements.
-
+    """
     Returns a list of instance types satisfying the required count of
     accelerators with sorted prices and a list of candidates with fuzzy search.
     """

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -149,14 +149,19 @@ def _fetch_and_apply_az_mapping(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _get_df() -> pd.DataFrame:
-    if config.get_use_default_catalog():
-        return _default_df
-    else:
-        global _user_df
-        with _apply_az_mapping_lock:
-            if _user_df is None:
+    global _user_df
+    with _apply_az_mapping_lock:
+        if _user_df is None:
+            try:
                 _user_df = _fetch_and_apply_az_mapping(_default_df)
-        return _user_df
+            except RuntimeError as e:
+                if config.get_use_default_catalog_if_failed():
+                    logger.warning('Failed to fetch availability zone mapping. '
+                                   f'{common_utils.format_exception(e)}')
+                    return _default_df
+                else:
+                    raise
+    return _user_df
 
 
 def get_quota_code(instance_type: str, use_spot: bool) -> Optional[str]:
@@ -243,9 +248,11 @@ def get_instance_type_for_accelerator(
     region: Optional[str] = None,
     zone: Optional[str] = None,
 ) -> Tuple[Optional[List[str]], List[str]]:
-    """
+    """Filter the instance types based on resource requirements.
+
     Returns a list of instance types satisfying the required count of
-    accelerators with sorted prices and a list of candidates with fuzzy search.
+    accelerators/cpus/memory with sorted prices and a list of candidates with
+    fuzzy search.
     """
     return common.get_instance_type_for_accelerator_impl(df=_get_df(),
                                                          acc_name=acc_name,

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -25,8 +25,9 @@ def get_use_default_catalog_if_failed() -> bool:
     or use zone name assigned to the AWS account).
 
     When set to True, the caller allows to use the default service catalog,
-    which may have inaccurate information (e.g., AWS's zone names are account-specific), but it is ok for the
-    read-only operators, such as `show-gpus` or `sky status`.
+    which may have inaccurate information (e.g., AWS's zone names are account-
+    specific), but it is ok for the read-only operators, such as `show-gpus` or
+    `sky status`.
     """
     if not hasattr(_thread_local_config, 'use_default_catalog'):
         # Should not set it globally, as the global assignment

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -8,8 +8,8 @@ _thread_local_config = threading.local()
 
 
 @contextlib.contextmanager
-def _set_use_default_catalog(value: bool):
-    old_value = get_use_default_catalog()
+def _set_use_default_catalog_if_failed(value: bool):
+    old_value = get_use_default_catalog_if_failed()
     _thread_local_config.use_default_catalog = value
     try:
         yield
@@ -17,13 +17,17 @@ def _set_use_default_catalog(value: bool):
         _thread_local_config.use_default_catalog = old_value
 
 
-# Whether the caller requires the catalog to be narrowed down
-# to the account-specific catalog (e.g., removing regions not
-# enabled for the current account) or just the raw catalog
-# fetched from SkyPilot catalog service. The former is used
-# for launching clusters, while the latter for commands like
-# `show-gpus`.
-def get_use_default_catalog() -> bool:
+def get_use_default_catalog_if_failed() -> bool:
+    """Whether to use default catalog if failed to fetch account-specific one.
+
+    Whether the caller requires the catalog to be narrowed down to the account-
+    specific catalog (e.g., removing regions not enabled for the current account
+    or use region name for the AWS account).
+
+    When set to True, the caller allows to use the default service catalog,
+    which may have staled information, e.g. region names, but it is ok for the
+    read-only operators, such as `show-gpus` or `sky status`.
+    """
     if not hasattr(_thread_local_config, 'use_default_catalog'):
         # Should not set it globally, as the global assignment
         # will be executed only once if the module is imported
@@ -33,8 +37,8 @@ def get_use_default_catalog() -> bool:
     return _thread_local_config.use_default_catalog
 
 
-def use_default_catalog(func):
-    """Decorator: disable fetching account-specific catalog.
+def use_default_catalog_if_failed(func):
+    """Decorator: allow failure for fetching account-specific catalog.
 
     The account-specific catalog requires the credentials of the
     cloud to be set.
@@ -42,7 +46,7 @@ def use_default_catalog(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with _set_use_default_catalog(True):
+        with _set_use_default_catalog_if_failed(True):
             return func(*args, **kwargs)
 
     return wrapper

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -25,7 +25,7 @@ def get_use_default_catalog_if_failed() -> bool:
     or use zone name assigned to the AWS account).
 
     When set to True, the caller allows to use the default service catalog,
-    which may have stale information, e.g. zone names, but it is ok for the
+    which may have inaccurate information (e.g., AWS's zone names are account-specific), but it is ok for the
     read-only operators, such as `show-gpus` or `sky status`.
     """
     if not hasattr(_thread_local_config, 'use_default_catalog'):

--- a/sky/clouds/service_catalog/config.py
+++ b/sky/clouds/service_catalog/config.py
@@ -22,10 +22,10 @@ def get_use_default_catalog_if_failed() -> bool:
 
     Whether the caller requires the catalog to be narrowed down to the account-
     specific catalog (e.g., removing regions not enabled for the current account
-    or use region name for the AWS account).
+    or use zone name assigned to the AWS account).
 
     When set to True, the caller allows to use the default service catalog,
-    which may have staled information, e.g. region names, but it is ok for the
+    which may have stale information, e.g. zone names, but it is ok for the
     read-only operators, such as `show-gpus` or `sky status`.
     """
     if not hasattr(_thread_local_config, 'use_default_catalog'):
@@ -37,7 +37,7 @@ def get_use_default_catalog_if_failed() -> bool:
     return _thread_local_config.use_default_catalog
 
 
-def use_default_catalog_if_failed(func):
+def fallback_to_default_catalog(func):
     """Decorator: allow failure for fetching account-specific catalog.
 
     The account-specific catalog requires the credentials of the

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -10,6 +10,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky import spot
 from sky.backends import backend_utils
+from sky.clouds import service_catalog
 from sky.skylet import constants
 from sky.utils import accelerator_registry
 from sky.utils import schemas
@@ -171,6 +172,7 @@ class Resources:
         self._try_validate_disk_tier()
         self._try_validate_ports()
 
+    @service_catalog.use_default_catalog_if_failed
     def __repr__(self) -> str:
         """Returns a string representation for display.
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,4 +1,5 @@
 """Resources: compute requirements of Tasks."""
+import functools
 from typing import Dict, List, Optional, Set, Union
 
 import colorama
@@ -24,6 +25,10 @@ _DEFAULT_DISK_SIZE_GB = 256
 
 class Resources:
     """Resources: compute requirements of Tasks.
+
+    This class is immutable once created to make sure the checks is applied
+    whenever the properties change. To update the property of an instance of
+    Resources, use `resources.copy(**new_properties)`.
 
     Used:
 
@@ -172,7 +177,11 @@ class Resources:
         self._try_validate_disk_tier()
         self._try_validate_ports()
 
-    @service_catalog.use_default_catalog_if_failed
+    # When querying the accelerators for the instance type, we will check the
+    # cloud's catalog, whcih can cause error when it fails to fetch some account
+    # specific catalog information. It is fine to use the default catalog as the
+    # this function is only for display purpose.
+    @service_catalog.fallback_to_default_catalog
     def __repr__(self) -> str:
         """Returns a string representation for display.
 
@@ -305,6 +314,7 @@ class Resources:
         return self._memory
 
     @property
+    @functools.lru_cache()
     def accelerators(self) -> Optional[Dict[str, int]]:
         """Returns the accelerators field directly or by inferring.
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -177,10 +177,10 @@ class Resources:
         self._try_validate_disk_tier()
         self._try_validate_ports()
 
-    # When querying the accelerators for the instance type, we will check the
-    # cloud's catalog, whcih can cause error when it fails to fetch some account
-    # specific catalog information. It is fine to use the default catalog as the
-    # this function is only for display purpose.
+    # When querying the accelerators inside this func (we call self.accelerators which is a @property), we will check the
+    # cloud's catalog, which can error if it fails to fetch some account
+    # specific catalog information (e.g., AWS zone mapping). It is fine to use the default catalog as
+    # this function is only for display purposes.
     @service_catalog.fallback_to_default_catalog
     def __repr__(self) -> str:
         """Returns a string representation for display.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -177,10 +177,11 @@ class Resources:
         self._try_validate_disk_tier()
         self._try_validate_ports()
 
-    # When querying the accelerators inside this func (we call self.accelerators which is a @property), we will check the
-    # cloud's catalog, which can error if it fails to fetch some account
-    # specific catalog information (e.g., AWS zone mapping). It is fine to use the default catalog as
-    # this function is only for display purposes.
+    # When querying the accelerators inside this func (we call self.accelerators
+    # which is a @property), we will check the cloud's catalog, which can error
+    # if it fails to fetch some account specific catalog information (e.g., AWS
+    # zone mapping). It is fine to use the default catalog as this function is
+    # only for display purposes.
     @service_catalog.fallback_to_default_catalog
     def __repr__(self) -> str:
         """Returns a string representation for display.
@@ -314,7 +315,7 @@ class Resources:
         return self._memory
 
     @property
-    @functools.lru_cache()
+    @functools.lru_cache(maxsize=1)
     def accelerators(self) -> Optional[Dict[str, int]]:
         """Returns the accelerators field directly or by inferring.
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -26,8 +26,8 @@ _DEFAULT_DISK_SIZE_GB = 256
 class Resources:
     """Resources: compute requirements of Tasks.
 
-    This class is immutable once created to make sure the checks is applied
-    whenever the properties change. To update the property of an instance of
+    This class is immutable once created (to ensure some validations are done
+    whenever properties change). To update the property of an instance of
     Resources, use `resources.copy(**new_properties)`.
 
     Used:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2414

This PR fixes the following:
1. The read-only operators (`sky show-gpus`/`sky status`) should not require the actual az mapping.
2. The `sky check` should disable AWS if the permission is not enough for fetching the availability zone mappings

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


Future TODO: #2416 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  1. setup an aws account with no permission granted, and have an AWS cluster in the cluster table.
  2. `sky status`
  3. `sky check`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
