### PR TITLE
[GCP] Additional permission for GCP in doc

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -26,6 +26,13 @@ The easiest way to grant permissions to a user access your GCP project without t
   roles/serviceusage.serviceUsageConsumer
   roles/storage.admin
 
+If there is no :ref:`SkyPilot Service Account <gcp-service-account-creation>` in the GCP project, at least one user may need to run ``sky launch --cloud gcp`` once, with the following permission enabled to create the service account for all the users in the GCP project:
+
+.. code-block:: yaml
+
+  roles/iam.securityAdmin
+
+
 Optionally, to use TPUs, add the following role:
 
 .. code-block:: yaml

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -28,7 +28,7 @@ The easiest way to grant permissions to a user access your GCP project without t
   roles/iam.securityAdmin
 
 .. note::
-    If there is a concern for the ``roles/iam.securityAdmin`` role, you can remove it from the list above, once any user in the GCP project successfully launched a cluster with ``sky launch --cloud gcp``.
+    If the ``roles/iam.securityAdmin`` role is undesirable, you can do the following. First, include the role and have any user (e.g., the admin) run ``sky launch --cloud gcp`` successfully once. This is to create the necessary service account. Then, remove the role from the list above.
 
 
 Optionally, to use TPUs, add the following role:

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -25,12 +25,10 @@ The easiest way to grant permissions to a user access your GCP project without t
   roles/iam.serviceAccountUser
   roles/serviceusage.serviceUsageConsumer
   roles/storage.admin
-
-If there is no :ref:`SkyPilot Service Account <gcp-service-account-creation>` in the GCP project, at least one user may need to run ``sky launch --cloud gcp`` once, with the following permission enabled to create the service account for all the users in the GCP project:
-
-.. code-block:: yaml
-
   roles/iam.securityAdmin
+
+.. note::
+    If there is a concern for the ``roles/iam.securityAdmin`` role, you can remove it from the list above, once any user in the GCP project successfully launched a cluster with ``sky launch --cloud gcp``.
 
 
 Optionally, to use TPUs, add the following role:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As mentioned by @alex000kim, for a user from scratch, we need an additional permission to have the skypilot correctly create the service account on GCP.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] render the docs locally.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
