### PR TITLE
CLI/UX: make `sky cancel cluster` cancel latest running job.

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3445,7 +3445,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 If set to True, asserts `jobs` is set to None.
         """
         if cancel_all:
-            assert jobs is None, ('Cannot specify both jobs and all')
+            assert not jobs, ('Cannot specify both jobs and all')
         job_owner = onprem_utils.get_job_owner(handle.cluster_yaml,
                                                handle.docker_user)
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs, cancel_all)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3440,9 +3440,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         Args:
             handle: The cluster handle.
-            jobs: Job IDs to cancel. If None, cancel all jobs.
-            cancel_latest_running_job: Whether to cancel the latest running job.
-                If set to True, asserts `jobs` is set to None.
+            jobs: Job IDs to cancel. If None or empty, cancel the latest running
+                job.
+            cancel_all: Whether to cancel all the jobs. If set to True, asserts
+                `jobs` is set to None or empty.
         """
         if cancel_all:
             assert not jobs, ('Cannot specify both jobs and all')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3159,8 +3159,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                                       require_outputs=True)
 
         # Happens when someone calls `sky exec` but remote is outdated
-        # necessicating calling `sky launch`
-        common_utils.check_staled_runtime_on_remote(returncode, stdout,
+        # necessitating calling `sky launch`.
+        backend_utils.check_stale_runtime_on_remote(returncode, stdout,
                                                     handle.cluster_name)
         subprocess_utils.handle_returncode(returncode,
                                            job_submit_cmd,
@@ -3451,11 +3451,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs, cancel_all)
 
         # All error messages should have been redirected to stdout.
-        returncode, stdout, _ = self.run_on_head(handle,
-                                                 code,
-                                                 stream_logs=False,
-                                                 require_outputs=True)
-        common_utils.check_staled_runtime_on_remote(returncode, stdout,
+        returncode, stdout, stderr = self.run_on_head(handle,
+                                                      code,
+                                                      stream_logs=False,
+                                                      require_outputs=True)
+        # TODO(zongheng): remove after >=0.5.0.
+        backend_utils.check_stale_runtime_on_remote(returncode, stdout + stderr,
                                                     handle.cluster_name)
         subprocess_utils.handle_returncode(
             returncode, code,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3438,7 +3438,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
     def cancel_jobs(self,
                     handle: CloudVmRayResourceHandle,
                     jobs: Optional[List[int]],
-                    cancel_latest_running_job: bool = False) -> None:
+                    cancel_all: bool = False) -> None:
         """Cancel jobs.
 
         CloudVMRayBackend specific method.
@@ -3449,13 +3449,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             cancel_latest_running_job: Whether to cancel the latest running job.
                 If set to True, asserts `jobs` is set to None.
         """
-        if cancel_latest_running_job:
+        if cancel_all:
             assert jobs is None, (
-                'Cannot specify both jobs and cancel_latest_running_job')
+                'Cannot specify both jobs and all')
         job_owner = onprem_utils.get_job_owner(handle.cluster_yaml,
                                                handle.docker_user)
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs,
-                                                 cancel_latest_running_job)
+                                                 cancel_all)
 
         # All error messages should have been redirected to stdout.
         returncode, stdout, _ = self.run_on_head(handle,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3434,19 +3434,20 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     handle: CloudVmRayResourceHandle,
                     jobs: Optional[List[int]],
                     cancel_all: bool = False) -> None:
-        """Cancel jobs.
+        """Cancels jobs.
 
         CloudVMRayBackend specific method.
 
         Args:
             handle: The cluster handle.
-            jobs: Job IDs to cancel. If None or empty, cancel the latest running
-                job.
-            cancel_all: Whether to cancel all the jobs. If set to True, asserts
-                `jobs` is set to None or empty.
+            jobs: Job IDs to cancel. (See `cancel_all` for special semantics.)
+            cancel_all: Whether to cancel all jobs. If True, asserts `jobs` is
+                set to None. If False and `jobs` is None, cancel the latest
+                running job.
         """
         if cancel_all:
-            assert not jobs, ('Cannot specify both jobs and all')
+            assert jobs is None, (
+                'If cancel_all=True, usage is to set jobs=None')
         job_owner = onprem_utils.get_job_owner(handle.cluster_yaml,
                                                handle.docker_user)
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs, cancel_all)
@@ -3456,7 +3457,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                                       code,
                                                       stream_logs=False,
                                                       require_outputs=True)
-        # TODO(zongheng): remove after >=0.5.0.
+        # TODO(zongheng): remove after >=0.5.0, 2 minor versions after.
         backend_utils.check_stale_runtime_on_remote(returncode, stdout + stderr,
                                                     handle.cluster_name)
         subprocess_utils.handle_returncode(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3457,6 +3457,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs,
                                                  cancel_all)
 
+        # TODO(zhwu): backward compatibility for old clusters. We need to hint
+        # users to upgrade their clusters with `sky start`.
+
         # All error messages should have been redirected to stdout.
         returncode, stdout, _ = self.run_on_head(handle,
                                                  code,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3160,7 +3160,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         # Happens when someone calls `sky exec` but remote is outdated
         # necessicating calling `sky launch`
-        common_utils.check_staled_runtime_on_remote(returncode, stdout, handle.cluster_name)
+        common_utils.check_staled_runtime_on_remote(returncode, stdout,
+                                                    handle.cluster_name)
         subprocess_utils.handle_returncode(returncode,
                                            job_submit_cmd,
                                            f'Failed to submit job {job_id}.',
@@ -3449,20 +3450,16 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                                handle.docker_user)
         code = job_lib.JobLibCodeGen.cancel_jobs(job_owner, jobs, cancel_all)
 
-        # TODO(zhwu): backward compatibility for old clusters. We need to hint
-        # users to upgrade their clusters with `sky start`.
-
         # All error messages should have been redirected to stdout.
         returncode, stdout, _ = self.run_on_head(handle,
                                                  code,
                                                  stream_logs=False,
                                                  require_outputs=True)
-        common_utils.check_staled_runtime_on_remote(
-            returncode, stdout, handle.cluster_name)
+        common_utils.check_staled_runtime_on_remote(returncode, stdout,
+                                                    handle.cluster_name)
         subprocess_utils.handle_returncode(
             returncode, code,
-            f'Failed to cancel jobs on cluster {handle.cluster_name}.',
-            stdout)
+            f'Failed to cancel jobs on cluster {handle.cluster_name}.', stdout)
 
         cancelled_ids = common_utils.decode_payload(stdout)
         if cancelled_ids:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2054,6 +2054,7 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
     bold = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
     job_identity_str = None
+    job_ids_to_set = None
     if not jobs and not all:
         click.echo(f'{colorama.Fore.YELLOW}No job IDs or --all provided; '
                    'cancelling the latest running job.'
@@ -2062,11 +2063,14 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
 
     if not yes:
         if job_identity_str is None:
+            job_ids_to_set = jobs
             job_ids = ' '.join(map(str, jobs))
             plural = 's' if len(job_ids) > 1 else ''
             job_identity_str = f'job{plural} {job_ids}'
             if all:
                 job_identity_str = 'all jobs'
+                job_ids_to_set = None
+
         job_identity_str += f' on cluster {cluster!r}'
         click.confirm(f'Cancelling {job_identity_str}. Proceed?',
                       default=True,
@@ -2074,7 +2078,7 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
                       show_default=True)
 
     try:
-        core.cancel(cluster, all, jobs)
+        core.cancel(cluster, all=all, job_ids=job_ids_to_set)
     except exceptions.NotSupportedError:
         # Friendly message for usage like 'sky cancel <spot controller> -a/<job
         # id>'.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2053,14 +2053,12 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
     """
     bold = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
-    cancel_latest_running_job = False
     job_identity_str = None
     if not jobs and not all:
         click.echo(f'{colorama.Fore.YELLOW}No job IDs or --all provided; '
                    'cancelling the latest running job.'
                    f'{colorama.Style.RESET_ALL}')
         job_identity_str = 'the latest running job'
-        cancel_latest_running_job = True
 
     if not yes:
         if job_identity_str is None:
@@ -2076,7 +2074,7 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
                       show_default=True)
 
     try:
-        core.cancel(cluster, all, jobs, cancel_latest_running_job)
+        core.cancel(cluster, all, jobs)
     except exceptions.NotSupportedError:
         # Friendly message for usage like 'sky cancel <spot controller> -a/<job
         # id>'.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2032,7 +2032,25 @@ def logs(
 @usage_lib.entrypoint
 def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disable=redefined-builtin
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
-    """Cancel job(s)."""
+    """Cancel job(s).
+
+    Example usage:
+
+    .. code-block:: bash
+
+      \b
+      # Cancel specific jobs on a cluster.
+      sky cancel cluster_name 1
+      sky cancel cluster_name 1 2 3
+      \b
+      # Cancel all jobs on a cluster.
+      sky cancel cluster_name -a
+      \b
+      # Cancel the latest running job on a cluster.
+      sky cancel cluster_name
+
+    Job IDs can be looked up by ``sky queue cluster_name``.
+    """
     bold = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
     cancel_latest_running_job = False
@@ -2043,14 +2061,6 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
                    f'{colorama.Style.RESET_ALL}')
         job_identity_str = 'the latest running job'
         cancel_latest_running_job = True
-        # # Friendly message for usage like 'sky cancel 1' / 'sky cancel myclus'.
-        # message = textwrap.dedent(f"""\
-        #   Use:
-        #     {bold}sky cancel <cluster_name> <job IDs>{reset}   -- cancel one or more jobs on a cluster
-        #     {bold}sky cancel <cluster_name> -a / --all{reset}  -- cancel all jobs on a cluster
-
-        #   Job IDs can be looked up by {bold}sky queue{reset}.""")
-        # raise click.UsageError(message)
 
     if not yes:
         if job_identity_str is None:
@@ -2070,15 +2080,9 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
     except exceptions.NotSupportedError:
         # Friendly message for usage like 'sky cancel <spot controller> -a/<job
         # id>'.
-        # FIXME(zongheng)
-        if all:
-            arg_str = '--all'
-        else:
-            arg_str = ' '.join(map(str, jobs))
         error_str = ('Cancelling the spot controller\'s jobs is not allowed.'
-                     f'\nTo cancel spot jobs, use: sky spot cancel <spot '
-                     f'job IDs> [--all]'
-                     f'\nDo you mean: {bold}sky spot cancel {arg_str}{reset}')
+                     f'\nTo cancel spot jobs, use: {bold}sky spot cancel <spot '
+                     f'job IDs> [--all]{reset}')
         click.echo(error_str)
         sys.exit(1)
     except ValueError as e:

--- a/sky/core.py
+++ b/sky/core.py
@@ -558,7 +558,7 @@ def cancel(
     backend_utils.check_cluster_name_not_reserved(
         cluster_name, operation_str='Cancelling jobs')
 
-    if all and job_ids is not None:
+    if all and job_ids:
         raise ValueError('Cannot specify both `all` and `job_ids`.')
 
     # Check the status of the cluster.
@@ -590,7 +590,12 @@ def cancel(
         sky_logging.print(f'{colorama.Fore.YELLOW}'
                           f'Cancelling all jobs on cluster {cluster_name!r}...'
                           f'{colorama.Style.RESET_ALL}')
-    elif job_ids is not None:
+    elif not job_ids:
+        sky_logging.print(
+            f'{colorama.Fore.YELLOW}'
+            f'Cancelling latest running job on cluster {cluster_name!r}...'
+            f'{colorama.Style.RESET_ALL}')
+    else:
         jobs_str = ', '.join(map(str, job_ids))
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'

--- a/sky/core.py
+++ b/sky/core.py
@@ -537,7 +537,7 @@ def cancel(
 
     Please refer to the sky.cli.cancel for the document.
 
-    When job_ids is None, cancel the last running job.
+    When `all` is False and `job_ids` is None, cancel the latest running job.
 
     Additional arguments:
         _try_cancel_if_cluster_is_init: (bool) whether to try cancelling the job
@@ -559,7 +559,8 @@ def cancel(
         cluster_name, operation_str='Cancelling jobs')
 
     if all and job_ids:
-        raise ValueError('Cannot specify both `all` and `job_ids`.')
+        raise ValueError('Cannot specify both `all` and `job_ids`. To cancel '
+                         'all jobs, set `job_ids` to None.')
 
     # Check the status of the cluster.
     handle = None
@@ -590,18 +591,22 @@ def cancel(
         sky_logging.print(f'{colorama.Fore.YELLOW}'
                           f'Cancelling all jobs on cluster {cluster_name!r}...'
                           f'{colorama.Style.RESET_ALL}')
-    elif not job_ids:
-        # job_ids is not None or empty.
+    elif job_ids is None:
+        # all = False, job_ids is None => cancel the latest running job.
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Cancelling latest running job on cluster {cluster_name!r}...'
             f'{colorama.Style.RESET_ALL}')
-    else:
+    elif len(job_ids):
+        # all = False, len(job_ids) > 0 => cancel the specified jobs.
         jobs_str = ', '.join(map(str, job_ids))
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Cancelling jobs ({jobs_str}) on cluster {cluster_name!r}...'
             f'{colorama.Style.RESET_ALL}')
+    else:
+        # all = False, len(job_ids) == 0 => no jobs to cancel.
+        return
 
     backend.cancel_jobs(handle, job_ids, all)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -538,7 +538,7 @@ def cancel(
     Please refer to the sky.cli.cancel for the document.
 
     When job_ids is None, cancel the last running job.
-    
+
     Additional arguments:
         _try_cancel_if_cluster_is_init: (bool) whether to try cancelling the job
             even if the cluster is not UP, but the head node is still alive.

--- a/sky/core.py
+++ b/sky/core.py
@@ -529,7 +529,6 @@ def cancel(
     cluster_name: str,
     all: bool = False,
     job_ids: Optional[List[int]] = None,
-    cancel_latest_running_job: bool = False,
     # pylint: disable=invalid-name
     _try_cancel_if_cluster_is_init: bool = False,
 ) -> None:
@@ -537,9 +536,10 @@ def cancel(
     """Cancel jobs on a cluster.
 
     Please refer to the sky.cli.cancel for the document.
+
+    When job_ids is None, cancel the last running job.
+    
     Additional arguments:
-        cancel_latest_running_job: (bool) whether to cancel the latest running
-            job on the cluster. If True, ``job_ids`` and ``all`` are ignored.
         _try_cancel_if_cluster_is_init: (bool) whether to try cancelling the job
             even if the cluster is not UP, but the head node is still alive.
             This is used by the spot controller to cancel the job when the
@@ -558,8 +558,8 @@ def cancel(
     backend_utils.check_cluster_name_not_reserved(
         cluster_name, operation_str='Cancelling jobs')
 
-    if cancel_latest_running_job:
-        job_ids = None
+    if all and job_ids is not None:
+        raise ValueError('Cannot specify both `all` and `job_ids`.')
 
     # Check the status of the cluster.
     handle = None
@@ -590,16 +590,14 @@ def cancel(
         sky_logging.print(f'{colorama.Fore.YELLOW}'
                           f'Cancelling all jobs on cluster {cluster_name!r}...'
                           f'{colorama.Style.RESET_ALL}')
-        job_ids = None
-    elif not cancel_latest_running_job:
-        assert job_ids is not None, 'job_ids should not be None'
+    elif job_ids is not None:
         jobs_str = ', '.join(map(str, job_ids))
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Cancelling jobs ({jobs_str}) on cluster {cluster_name!r}...'
             f'{colorama.Style.RESET_ALL}')
 
-    backend.cancel_jobs(handle, job_ids, cancel_latest_running_job)
+    backend.cancel_jobs(handle, job_ids, all)
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -538,6 +538,8 @@ def cancel(
 
     Please refer to the sky.cli.cancel for the document.
     Additional arguments:
+        cancel_latest_running_job: (bool) whether to cancel the latest running
+            job on the cluster. If True, ``job_ids`` and ``all`` are ignored.
         _try_cancel_if_cluster_is_init: (bool) whether to try cancelling the job
             even if the cluster is not UP, but the head node is still alive.
             This is used by the spot controller to cancel the job when the
@@ -553,12 +555,6 @@ def cancel(
         sky.exceptions.CloudUserIdentityError: if we fail to get the current
           user identity.
     """
-    # FIXME(zongheng)
-    # if not job_ids and not all:
-    #     raise ValueError(
-    #         'sky cancel requires either a job id '
-    #         f'(see `sky queue {cluster_name} -s`) or the --all flag.')
-
     backend_utils.check_cluster_name_not_reserved(
         cluster_name, operation_str='Cancelling jobs')
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -591,6 +591,7 @@ def cancel(
                           f'Cancelling all jobs on cluster {cluster_name!r}...'
                           f'{colorama.Style.RESET_ALL}')
     elif not job_ids:
+        # job_ids is not None or empty.
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Cancelling latest running job on cluster {cluster_name!r}...'

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -720,6 +720,7 @@ def cancel_jobs_encoded_results(job_owner: str,
     """
     if cancel_all:
         # Cancel all in-progress jobs.
+        # Cancel all in-progress jobs.
         assert jobs is None, ('If cancel_all=True, usage is to set jobs=None')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -720,7 +720,6 @@ def cancel_jobs_encoded_results(job_owner: str,
     """
     if cancel_all:
         # Cancel all in-progress jobs.
-        # Cancel all in-progress jobs.
         assert jobs is None, ('If cancel_all=True, usage is to set jobs=None')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -719,7 +719,7 @@ def cancel_jobs_encoded_results(job_owner: str,
     """
     if cancel_all:
         # Cancel the latest (largest job ID) running job.
-        assert jobs is None, ('Cannot specify both jobs and all')
+        assert not jobs, ('Cannot specify both jobs and all')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -720,8 +720,7 @@ def cancel_jobs_encoded_results(job_owner: str,
     """
     if cancel_all:
         # Cancel all in-progress jobs.
-        assert jobs is None, (
-            'If cancel_all=True, usage is to set jobs=None')
+        assert jobs is None, ('If cancel_all=True, usage is to set jobs=None')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -705,29 +705,29 @@ def load_job_queue(payload: str) -> List[Dict[str, Any]]:
 
 def cancel_jobs_encoded_results(job_owner: str,
                                 jobs: Optional[List[int]],
-                                cancel_latest_running_job: bool = False) -> str:
+                                cancel_all: bool = False) -> str:
     """Cancel jobs.
 
     Args:
-        jobs: Job IDs to cancel. If None, cancel all jobs.
-        cancel_latest_running_job: Whether to cancel the latest running job. If
+        jobs: Job IDs to cancel. If None, cancel the latest running job.
+        all: Whether to cancel all the jobs. If
             set to True, asserts `jobs` is set to None.
 
     Returns:
         Encoded job IDs that are actually cancelled. Caller should use
         common_utils.decode_payload() to parse.
     """
-    if cancel_latest_running_job:
+    if cancel_all:
         # Cancel the latest (largest job ID) running job.
         assert jobs is None, (
-            'Cannot specify both jobs and cancel_latest_running_job')
-        job_records = _get_jobs(None, [JobStatus.RUNNING])[:1]
-    else:
-        if jobs is None:
-            # Cancel all in-progress jobs.
-            job_records = _get_jobs(
+            'Cannot specify both jobs and all')
+        job_records = _get_jobs(
                 None,
                 [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
+    else:
+        if jobs is None:
+            # Cancel the latest running job.
+            job_records = _get_jobs(None, [JobStatus.RUNNING])[:1]
         else:
             # Cancel jobs with specified IDs.
             job_records = _get_jobs_by_ids(jobs)
@@ -843,11 +843,11 @@ class JobLibCodeGen:
     def cancel_jobs(cls,
                     job_owner: str,
                     job_ids: Optional[List[int]],
-                    cancel_latest_running_job: bool = False) -> str:
+                    cancel_all: bool = False) -> str:
         """See job_lib.cancel_jobs()."""
         code = [
             (f'cancelled = job_lib.cancel_jobs_encoded_results({job_owner!r},'
-             f' {job_ids!r}, {cancel_latest_running_job})'),
+             f' {job_ids!r}, {cancel_all})'),
             # Print cancelled IDs. Caller should parse by decoding.
             'print(cancelled, flush=True)',
         ]

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -723,7 +723,7 @@ def cancel_jobs_encoded_results(job_owner: str,
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:
-        if jobs is None:
+        if not jobs:
             # Cancel the latest running job.
             job_records = _get_jobs(None, [JobStatus.RUNNING])[:1]
         else:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -709,21 +709,23 @@ def cancel_jobs_encoded_results(job_owner: str,
     """Cancel jobs.
 
     Args:
-        jobs: Job IDs to cancel. If None or empty, cancel the latest running
-            job.
-        all: Whether to cancel all the jobs. If set to True, asserts `jobs` is
-            set to None or empty.
+        jobs: Job IDs to cancel. (See `cancel_all` for special semantics.)
+        cancel_all: Whether to cancel all jobs. If True, asserts `jobs` is
+            set to None. If False and `jobs` is None, cancel the latest
+            running job.
 
     Returns:
         Encoded job IDs that are actually cancelled. Caller should use
         common_utils.decode_payload() to parse.
     """
     if cancel_all:
-        assert not jobs, ('Cannot specify both jobs and all')
+        # Cancel all in-progress jobs.
+        assert jobs is None, (
+            'If cancel_all=True, usage is to set jobs=None')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:
-        if not jobs:
+        if jobs is None:
             # Cancel the latest (largest job ID) running job.
             job_records = _get_jobs(None, [JobStatus.RUNNING])[:1]
         else:

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -709,22 +709,22 @@ def cancel_jobs_encoded_results(job_owner: str,
     """Cancel jobs.
 
     Args:
-        jobs: Job IDs to cancel. If None, cancel the latest running job.
-        all: Whether to cancel all the jobs. If
-            set to True, asserts `jobs` is set to None.
+        jobs: Job IDs to cancel. If None or empty, cancel the latest running
+            job.
+        all: Whether to cancel all the jobs. If set to True, asserts `jobs` is
+            set to None or empty.
 
     Returns:
         Encoded job IDs that are actually cancelled. Caller should use
         common_utils.decode_payload() to parse.
     """
     if cancel_all:
-        # Cancel the latest (largest job ID) running job.
         assert not jobs, ('Cannot specify both jobs and all')
         job_records = _get_jobs(
             None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:
         if not jobs:
-            # Cancel the latest running job.
+            # Cancel the latest (largest job ID) running job.
             job_records = _get_jobs(None, [JobStatus.RUNNING])[:1]
         else:
             # Cancel jobs with specified IDs.

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -719,11 +719,9 @@ def cancel_jobs_encoded_results(job_owner: str,
     """
     if cancel_all:
         # Cancel the latest (largest job ID) running job.
-        assert jobs is None, (
-            'Cannot specify both jobs and all')
+        assert jobs is None, ('Cannot specify both jobs and all')
         job_records = _get_jobs(
-                None,
-                [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
+            None, [JobStatus.PENDING, JobStatus.SETTING_UP, JobStatus.RUNNING])
     else:
         if jobs is None:
             # Cancel the latest running job.

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -410,21 +410,3 @@ def find_free_port(start_port: int) -> int:
             except OSError:
                 pass
     raise OSError('No free ports available.')
-
-
-def check_staled_runtime_on_remote(returncode: int, stderr: str,
-                                   cluster_name: str) -> None:
-    """Raise RuntimeError for staled SkyPilot runtime."""
-
-    pattern = re.compile(r'AttributeError: module \'sky\.(.*)\' has no '
-                         r'attribute \'(.*)\'')
-    if returncode != 0:
-        attribute_error = re.findall(pattern, stderr)
-        if attribute_error:
-            with ux_utils.print_exception_no_traceback():
-                raise RuntimeError(
-                    f'{colorama.Fore.RED}SkyPilot runtime is stale on the '
-                    'remote cluster. To update, run: '
-                    f'{colorama.Style.BRIGHT}sky launch -c {cluster_name}'
-                    f'{colorama.Style.RESET_ALL}'
-                    f'\n--- Details ---\n{stderr.strip()}\n')

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -413,7 +413,7 @@ def find_free_port(start_port: int) -> int:
 
 
 def check_staled_runtime_on_remote(returncode: int, stderr: str,
-                                cluster_name: str) -> None:
+                                   cluster_name: str) -> None:
     """Raise RuntimeError for staled SkyPilot runtime."""
 
     pattern = re.compile(r'AttributeError: module \'sky\.(.*)\' has no '
@@ -427,5 +427,4 @@ def check_staled_runtime_on_remote(returncode: int, stderr: str,
                     'remote cluster. To update, run: '
                     f'{colorama.Style.BRIGHT}sky start -f {cluster_name}'
                     f'{colorama.Style.RESET_ALL}'
-                    f'\n--- Details ---\n{stderr.strip()}\n'
-                )
+                    f'\n--- Details ---\n{stderr.strip()}\n')

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -295,8 +295,8 @@ def retry(method, max_retries=3, initial_backoff=1):
 def encode_payload(payload: Any) -> str:
     """Encode a payload to make it more robust for parsing.
 
-    The make the message transfer more robust to any additional
-    strings added to the message during transfering.
+    This makes message transfer more robust to any additional strings added to
+    the message during transfer.
 
     An example message that is polluted by the system warning:
     "LC_ALL: cannot change locale (en_US.UTF-8)\n<sky-payload>hello, world</sky-payload>" # pylint: disable=line-too-long

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -19,6 +19,7 @@ import colorama
 import yaml
 
 from sky import sky_logging
+from sky.utils import ux_utils
 
 _USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
 USER_HASH_LENGTH = 8
@@ -409,3 +410,22 @@ def find_free_port(start_port: int) -> int:
             except OSError:
                 pass
     raise OSError('No free ports available.')
+
+
+def check_staled_runtime_on_remote(returncode: int, stderr: str,
+                                cluster_name: str) -> None:
+    """Raise RuntimeError for staled SkyPilot runtime."""
+
+    pattern = re.compile(r'AttributeError: module \'sky\.(.*)\' has no '
+                         r'attribute \'(.*)\'')
+    if returncode != 0:
+        attribute_error = re.findall(pattern, stderr)
+        if attribute_error:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError(
+                    f'{colorama.Fore.RED}SkyPilot runtime is stale on the '
+                    'remote cluster. To update, run: '
+                    f'{colorama.Style.BRIGHT}sky start -f {cluster_name}'
+                    f'{colorama.Style.RESET_ALL}'
+                    f'\n--- Details ---\n{stderr.strip()}\n'
+                )

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -19,7 +19,6 @@ import colorama
 import yaml
 
 from sky import sky_logging
-from sky.utils import ux_utils
 
 _USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
 USER_HASH_LENGTH = 8

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -425,6 +425,6 @@ def check_staled_runtime_on_remote(returncode: int, stderr: str,
                 raise RuntimeError(
                     f'{colorama.Fore.RED}SkyPilot runtime is stale on the '
                     'remote cluster. To update, run: '
-                    f'{colorama.Style.BRIGHT}sky start -f {cluster_name}'
+                    f'{colorama.Style.BRIGHT}sky launch -c {cluster_name}'
                     f'{colorama.Style.RESET_ALL}'
                     f'\n--- Details ---\n{stderr.strip()}\n')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #2316.

Changes
- Make `sky cancel <cluster>` default to cancel the latest running job of a cluster (From user feedback)
- Print actually cancelled job IDs in all cases

Examples
```console
» sky cancel dbg                                      
No job IDs or --all provided; cancelling the latest running job.
Cancelling the latest running job on cluster 'dbg'. Proceed? [Y/n]:
I 08-18 08:31:23 cloud_vm_ray_backend.py:3461] Cancelled jobs: 10

» sky cancel dbg
No job IDs or --all provided; cancelling the latest running job.
Cancelling the latest running job on cluster 'dbg'. Proceed? [Y/n]:
I 08-18 08:32:09 cloud_vm_ray_backend.py:3465] No jobs cancelled. They may already be in terminal states.

» sky cancel dbg -a
Cancelling all jobs on cluster 'dbg'. Proceed? [Y/n]:
Cancelling all jobs on cluster 'dbg'...
I 08-18 08:32:46 cloud_vm_ray_backend.py:3465] No jobs cancelled. They may already be in terminal states.

» sky cancel dbg 2
Cancelling job 2 on cluster 'dbg'. Proceed? [Y/n]:
Cancelling jobs (2) on cluster 'dbg'...
I 08-18 08:33:18 cloud_vm_ray_backend.py:3465] No jobs cancelled. They may already be in terminal states.

» sky cancel dbg 11
Cancelling jobs 11 on cluster 'dbg'. Proceed? [Y/n]:
Cancelling jobs (11) on cluster 'dbg'...
I 08-18 08:33:31 cloud_vm_ray_backend.py:3462] Cancelled job ID(s): 11

» sky cancel sky-spot-controller-8a3968f2    
No job IDs or --all provided; cancelling the latest running job.
Cancelling the latest running job on cluster 'sky-spot-controller-8a3968f2'. Proceed? [Y/n]:
Cancelling the spot controller's jobs is not allowed.
To cancel spot jobs, use: sky spot cancel <spot job IDs> [--all]
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
