### PR TITLE
[Fix] Fix AWS SecurityGroup cleanup when the SG is not created on default VPC

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -167,7 +167,13 @@ def cleanup_ports(
     # and backend_utils::write_cluster_config
     sg_name = (f'sky-sg-{common_utils.user_and_hostname_hash()}'
                f'-{common_utils.truncate_and_hash_cluster_name(cluster_name)}')
-    sgs = ec2.security_groups.filter(GroupNames=[sg_name])
+    # GroupNames will only filter SGs in the default VPC, so we need to use
+    # Filters here. Ref:
+    # https://boto3.amazonaws.com/v1/documentation/api/1.26.112/reference/services/ec2/service-resource/security_groups.html  # pylint: disable=line-too-long
+    sgs = ec2.security_groups.filter(Filters=[{
+        'Name': 'group-name',
+        'Values': [sg_name]
+    }])
     if len(list(sgs)) != 1:
         raise ValueError(f'Expected security group {sg_name} not found. '
                          'Cannot cleanup ports.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously our filtering API for port cleanup will only query the security group from the default VPC. When your SG is created elsewhere, the botocore will complain about it:

```
Traceback (most recent call last):
  File "/opt/conda/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/common_utils.py", line 248, in _record
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/cli.py", line 1153, in invoke
    return super().invoke(ctx)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/common_utils.py", line 269, in _record
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/cli.py", line 2577, in down
    _down_or_stop_clusters(clusters,
  File "/opt/conda/lib/python3.10/site-packages/sky/cli.py", line 2862, in _down_or_stop_clusters
    subprocess_utils.run_in_parallel(_down_or_stop, clusters)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/subprocess_utils.py", line 54, in run_in_parallel
    return list(p.imap(func, args))
  File "/opt/conda/lib/python3.10/multiprocessing/pool.py", line 873, in next
    raise value
  File "/opt/conda/lib/python3.10/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/opt/conda/lib/python3.10/site-packages/sky/cli.py", line 2834, in _down_or_stop
    core.down(name, purge=purge)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/common_utils.py", line 269, in _record
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/core.py", line 394, in down
    backend.teardown(handle, terminate=True, purge=purge)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/common_utils.py", line 269, in _record
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/utils/common_utils.py", line 248, in _record
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/backends/backend.py", line 110, in teardown
    self._teardown(handle, terminate, purge)
  File "/opt/conda/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 3292, in _teardown
    self.teardown_no_lock(
  File "/opt/conda/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 3593, in teardown_no_lock
    self.post_teardown_cleanup(handle, terminate, purge)
  File "/opt/conda/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 3815, in post_teardown_cleanup
    provision_lib.cleanup_ports(repr(cloud), handle.cluster_name,
  File "/opt/conda/lib/python3.10/site-packages/sky/provision/__init__.py", line 30, in _wrapper
    return impl(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/sky/provision/aws/instance.py", line 171, in cleanup_ports
    if len(list(sgs)) != 1:
  File "/opt/conda/lib/python3.10/site-packages/boto3/resources/collection.py", line 81, in __iter__
    for page in self.pages():
  File "/opt/conda/lib/python3.10/site-packages/boto3/resources/collection.py", line 171, in pages
    for page in pages:
  File "/opt/conda/lib/python3.10/site-packages/botocore/paginate.py", line 269, in __iter__
    response = self._make_request(current_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/botocore/paginate.py", line 357, in _make_request
    return self._method(**current_kwargs)
  File "/opt/conda/lib/python3.10/site-packages/botocore/client.py", line 535, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/opt/conda/lib/python3.10/site-packages/botocore/client.py", line 980, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidGroup.NotFound) when calling the DescribeSecurityGroups operation: The security group 'sky-sg-gcpuser-c80c-vicuna-demo-2' does not exist in default VPC 'vpc-<id>'
```

This PR fixes this bug.

For API reference, see https://boto3.amazonaws.com/v1/documentation/api/1.26.112/reference/services/ec2/service-resource/security_groups.html

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - Manually launch an aws cluster with ports and tear it down (in / not in default VPC)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
