### PR TITLE
[LLM] Use checksum for checkpoint in Vicuna-Llama-2 example

### DIFF
--- a/llm/vicuna-llama-2/train.yaml
+++ b/llm/vicuna-llama-2/train.yaml
@@ -79,7 +79,7 @@ run: |
     --gradient_accumulation_steps $((128 * 512 / $SEQ_LEN / $PER_DEVICE_BATCH_SIZE / $NUM_NODES / $SKYPILOT_NUM_GPUS_PER_NODE)) \
     --evaluation_strategy "no" \
     --save_strategy "steps" \
-    --save_steps 60 \
+    --save_steps 600 \
     --save_total_limit 10 \
     --learning_rate 2e-5 \
     --weight_decay 0. \

--- a/llm/vicuna-llama-2/train.yaml
+++ b/llm/vicuna-llama-2/train.yaml
@@ -15,7 +15,7 @@ num_nodes: 1
 file_mounts:
   /artifacts:
     name: $ARTIFACT_BUCKET_NAME
-    mode: MOUNT
+    mode: CSYNC
 
 workdir: .
 
@@ -79,7 +79,7 @@ run: |
     --gradient_accumulation_steps $((128 * 512 / $SEQ_LEN / $PER_DEVICE_BATCH_SIZE / $NUM_NODES / $SKYPILOT_NUM_GPUS_PER_NODE)) \
     --evaluation_strategy "no" \
     --save_strategy "steps" \
-    --save_steps 600 \
+    --save_steps 60 \
     --save_total_limit 10 \
     --learning_rate 2e-5 \
     --weight_decay 0. \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The original completion indicator file does not work when the file uploads do not follow the modification time of the files, as the complete file can appear in the bucket before the other checkpoint files is uploaded, such as the new CSYNC mode we provide in #2336. To fix that issue, we instead use the checksum to check the integrity of the checkpoint folders to make it more robust

Blocked by #2336

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-vicuna train.yaml` with CSYNC mode and manually simulate the non-complete folder -- removing one checkpoint file while the checksum file exists.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
