### PR TITLE
check if bash version is greater than 4

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -519,7 +519,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
                 ~/.sky/.sky-complete.bash && \
                 echo "{bashrc_diff}" >> ~/.bashrc'
 
-        cmd = f'(grep -q "SkyPilot" ~/.bashrc) || ({install_cmd})'
+        cmd = f'(grep -q "SkyPilot" ~/.bashrc) || ([[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd})'
         reload_cmd = _RELOAD_BASH_CMD
 
     elif value == 'fish':

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -519,7 +519,8 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
                 ~/.sky/.sky-complete.bash && \
                 echo "{bashrc_diff}" >> ~/.bashrc'
 
-        cmd = f'(grep -q "SkyPilot" ~/.bashrc) || ([[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd})'
+        cmd = (f'(grep -q "SkyPilot" ~/.bashrc) || '
+               f'[[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd})')
         reload_cmd = _RELOAD_BASH_CMD
 
     elif value == 'fish':


### PR DESCRIPTION
https://github.com/skypilot-org/skypilot/issues/2424

- Added a check for bash version using [[ ${BASH_VERSINFO[0]} -ge 4 ]] to check major version >= 4
- Used && to only run install_cmd if both conditions are met:
  - "SkyPilot" not found
  - Bash version >= 4