### PR TITLE
[SkyServe] Introducing `sky serve reload` CLI

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -34,6 +34,7 @@ from sky.data import StoreType
 from sky.execution import exec  # pylint: disable=redefined-builtin
 from sky.execution import launch
 from sky.execution import serve_down
+from sky.execution import serve_reload
 from sky.execution import serve_up
 from sky.execution import spot_launch
 from sky.optimizer import Optimizer

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4371,6 +4371,7 @@ def serve_logs(
         core.serve_tail_logs(service_record, replica_id, follow=follow)
 
 
+# TODO(tian): Add more options
 @serve.command('reload', cls=_DocumentedCodeCommand)
 @click.option(
     '--cloud',
@@ -4378,6 +4379,13 @@ def serve_logs(
     type=str,
     help=('The cloud to use. If specified, overrides the "resources.cloud" '
           'config. Passing "none" resets the config.'))
+@click.option('--cpus',
+              default=None,
+              type=str,
+              required=False,
+              help=('Number of vCPUs each instance must have (e.g., '
+                    '``--cpus=4`` (exactly 4) or ``--cpus=4+`` (at least 4)). '
+                    'This is used to automatically select the instance type.'))
 @click.option(
     '--gpus',
     required=False,
@@ -4400,6 +4408,7 @@ def serve_logs(
 @usage_lib.entrypoint
 def serve_reload(
     cloud: Optional[str],
+    cpus: Optional[str],
     gpus: Optional[str],
     service_name: str,
     replica_id: int,
@@ -4437,6 +4446,8 @@ def serve_reload(
     resources_override_cli: List[str] = []
     if cloud is not None:
         resources_override_cli.extend(['--cloud', cloud])
+    if cpus is not None:
+        resources_override_cli.extend(['--cpus', cpus])
     if gpus is not None:
         resources_override_cli.extend(['--gpus', gpus])
     sky.serve_reload(service_name, replica_id, resources_override_cli)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4450,6 +4450,11 @@ def serve_reload(
         resources_override_cli.extend(['--cpus', cpus])
     if gpus is not None:
         resources_override_cli.extend(['--gpus', gpus])
+    click.confirm(
+        f'Reloading replica {replica_id} of service {service_name!r}. Proceed?',
+        default=True,
+        abort=True,
+        show_default=True)
     sky.serve_reload(service_name, replica_id, resources_override_cli)
 
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -1284,9 +1284,9 @@ def serve_reload(service_name: str, replica_id: int,
         'Failed when submit reload request to controller.',
         stderr,
         stream_logs=False)
-    resp = serve.load_reload_replica_result(reload_replica_payload)
-    if resp.json()['msg']:
+    message = serve.load_reload_replica_result(reload_replica_payload)
+    if message:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
                 f'Unexpected message when reloading replica of service '
-                f'{service_name}: {resp.json()["msg"]}')
+                f'{service_name}: {message}')

--- a/sky/serve/__init__.py
+++ b/sky/serve/__init__.py
@@ -7,6 +7,7 @@ from sky.serve.serve_utils import generate_controller_cluster_name
 from sky.serve.serve_utils import generate_controller_yaml_file_name
 from sky.serve.serve_utils import generate_remote_task_yaml_file_name
 from sky.serve.serve_utils import load_latest_info
+from sky.serve.serve_utils import load_reload_replica_result
 from sky.serve.serve_utils import load_terminate_service_result
 from sky.serve.serve_utils import SERVE_PREHOOK_COMMANDS
 from sky.serve.serve_utils import ServeCodeGen

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -91,8 +91,8 @@ class Controller:
             logger.info(f'Reloading replica {replica_id} with resources '
                         f'override {resources_override_cli}...')
             try:
-                msg = self.infra_provider.reload_replica(replica_id,
-                                                        resources_override_cli)
+                msg = self.infra_provider.reload_replica(
+                    replica_id, resources_override_cli)
             except Exception as e:  # pylint: disable=broad-except
                 msg = repr(e)
             return {'message': msg}

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -83,6 +83,15 @@ class Controller:
             }
             return latest_info
 
+        @self.app.post('/controller/reload_replica')
+        async def reload_replica(request: fastapi.Request):
+            body = await request.json()
+            replica_id = body['replica_id']
+            resources_override_cli = body['resources_override_cli']
+            msg = self.infra_provider.reload_replica(replica_id,
+                                                     resources_override_cli)
+            return {'message': msg}
+
         @self.app.post('/controller/terminate')
         def terminate(request: fastapi.Request):
             del request

--- a/sky/serve/examples/http_server/task.yaml
+++ b/sky/serve/examples/http_server/task.yaml
@@ -1,4 +1,5 @@
 resources:
+  cloud: gcp
   cpus: 2+
 
 workdir: sky/serve/examples/http_server
@@ -10,4 +11,4 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 20
-  replicas: 2
+  replicas: 1

--- a/sky/serve/examples/http_server/task.yaml
+++ b/sky/serve/examples/http_server/task.yaml
@@ -1,5 +1,4 @@
 resources:
-  cloud: gcp
   cpus: 2+
 
 workdir: sky/serve/examples/http_server
@@ -11,4 +10,4 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 20
-  replicas: 1
+  replicas: 2

--- a/sky/serve/infra_providers.py
+++ b/sky/serve/infra_providers.py
@@ -2,15 +2,14 @@
 from concurrent import futures
 import enum
 import logging
-import os
 import random
 import signal
 import subprocess
-import psutil
 import threading
 import time
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+import psutil
 import requests
 
 from sky import backends
@@ -402,9 +401,10 @@ class SkyPilotInfraProvider(InfraProvider):
                 ready_replicas.add(info.ip)
         return ready_replicas
 
-    def _launch_cluster(self,
-                        replica_id: int,
-                        resources_override_cli: Optional[List[str]] = None) -> None:
+    def _launch_cluster(
+            self,
+            replica_id: int,
+            resources_override_cli: Optional[List[str]] = None) -> None:
         cluster_name = serve_utils.generate_replica_cluster_name(
             self.service_name, replica_id)
         if cluster_name in self.launch_process_pool:
@@ -527,7 +527,10 @@ class SkyPilotInfraProvider(InfraProvider):
             del self.launch_process_pool[replica_cluster_name]
             # For correctly display as shutting down
             info.status_property.sky_launch_status = ProcessStatus.SUCCESS
-        if info.status not in [status_lib.ReplicaStatus.SHUTTING_DOWN, status_lib.ReplicaStatus.FAILED]:
+        if info.status not in [
+                status_lib.ReplicaStatus.SHUTTING_DOWN,
+                status_lib.ReplicaStatus.FAILED
+        ]:
             self._teardown_cluster(replica_cluster_name, sync_down_logs=False)
         # Wait until the down process finishes
         while replica_cluster_name in self.down_process_pool:

--- a/sky/serve/infra_providers.py
+++ b/sky/serve/infra_providers.py
@@ -417,9 +417,6 @@ class SkyPilotInfraProvider(InfraProvider):
         cmd.extend(['--detach-setup', '--detach-run', '--retry-until-up'])
         if resources_override_cli is not None:
             cmd.extend(resources_override_cli)
-        # TODO(tian): Remove this hack
-        # if replica_id == 1:
-        #     cmd.extend(['--cloud', 'azure'])
         fn = serve_utils.generate_replica_launch_log_file_name(cluster_name)
         with open(fn, 'w') as f:
             # pylint: disable=consider-using-with

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -297,6 +297,22 @@ def stream_logs(service_name: str,
     return ''
 
 
+def reload_replica(replica_id: int, resources_override_cli: str) -> str:
+    resp = requests.post(_CONTROLLER_URL + '/controller/reload_replica',
+                         json={
+                             'replica_id': replica_id,
+                             'resources_override_cli': resources_override_cli
+                         })
+    resp = base64.b64encode(pickle.dumps(resp)).decode('utf-8')
+    return common_utils.encode_payload(resp)
+
+
+def load_reload_replica_result(payload: str) -> Any:
+    reload_resp = common_utils.decode_payload(payload)
+    reload_resp = pickle.loads(base64.b64decode(reload_resp))
+    return reload_resp
+
+
 class ServeCodeGen:
     """Code generator for SkyServe.
 
@@ -333,6 +349,15 @@ class ServeCodeGen:
             f'msg = serve_utils.stream_logs({service_name!r}, {replica_id!r}, '
             f'follow={follow}, skip_local_log_file_check='
             f'{skip_local_log_file_check})', 'print(msg, flush=True)'
+        ]
+        return cls._build(code)
+
+    @classmethod
+    def reload_replica(cls, replica_id: int,
+                       resources_override_cli: List[str]) -> str:
+        code = [
+            f'msg = serve_utils.reload_replica({replica_id!r}, '
+            f'{resources_override_cli!r})', 'print(msg, end="", flush=True)'
         ]
         return cls._build(code)
 

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -303,14 +303,12 @@ def reload_replica(replica_id: int, resources_override_cli: str) -> str:
                              'replica_id': replica_id,
                              'resources_override_cli': resources_override_cli
                          })
-    resp = base64.b64encode(pickle.dumps(resp)).decode('utf-8')
-    return common_utils.encode_payload(resp)
+    return common_utils.encode_payload(resp['message'])
 
 
-def load_reload_replica_result(payload: str) -> Any:
-    reload_resp = common_utils.decode_payload(payload)
-    reload_resp = pickle.loads(base64.b64decode(reload_resp))
-    return reload_resp
+def load_reload_replica_result(payload: str) -> Optional[str]:
+    message = common_utils.decode_payload(payload)
+    return message
 
 
 class ServeCodeGen:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2606,7 +2606,8 @@ def test_gcp_zero_quota_failover():
 # ---------- Testing skyserve ----------
 
 
-def _get_skyserve_test_task(name: str, suffix: str, timeout_minutes: int) -> Test:
+def _get_skyserve_test_task(name: str, suffix: str,
+                            timeout_minutes: int) -> Test:
     url_regex = r'([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5}'
     test = Test(
         f'test-skyserve-{suffix.replace("_", "-")}',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduces `sky serve reload` CLI. Usage:

```bash
sky serve reload [SERVICE_NAME] [REPLICA_ID] (OPTIONS)
```

This CLI will reload the target replica with specified resources. It will terminate the replica and re-launch it with extra resources override. It is helpful for:
* Retry a FAILED replica;
* Change resources requirement.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
