### PR TITLE
[Provisioner] Gracefully handle security group cleanup and retry in AWS

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -199,8 +199,8 @@ def cleanup_ports(
             match = re.search(_DEPENDENCY_VIOLATION_PATTERN, str(e))
             if match is None:
                 raise
-            if (match.group(1) == 'DependencyViolation' and
-                    match.group(2) == 'DeleteSecurityGroup'):
+            if match.group(1) == 'DependencyViolation':
+                assert match.group(2) == 'DeleteSecurityGroup', match.group(2)
                 logger.debug(
                     f'Security group {sg_name} is still in use. Retry.')
                 time.sleep(backoff.current_backoff())

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -17,8 +17,6 @@ BOTO_MAX_RETRIES = 12
 TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'
 TAG_RAY_NODE_KIND = 'ray-node-type'
 
-INITIAL_BACKOFF_SECONDS = 7
-MAX_BACKOFF_FACTOR = 10
 MAX_ATTEMPTS = 6
 
 _DEPENDENCY_VIOLATION_PATTERN = re.compile(
@@ -191,8 +189,7 @@ def cleanup_ports(
         logger.warning(f'Expected security group {sg_name} not found. '
                        'Skip cleanup.')
         return
-    backoff = common_utils.Backoff(initial_backoff=INITIAL_BACKOFF_SECONDS,
-                                   max_backoff_factor=MAX_BACKOFF_FACTOR)
+    backoff = common_utils.Backoff()
     for _ in range(MAX_ATTEMPTS):
         try:
             list(sgs)[0].delete()

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -4,7 +4,6 @@ import time
 from typing import Any, Dict, List, Optional
 
 from botocore import config
-from botocore import exceptions
 
 from sky import sky_logging
 from sky import status_lib
@@ -196,7 +195,7 @@ def cleanup_ports(
     for _ in range(MAX_ATTEMPTS):
         try:
             list(sgs)[0].delete()
-        except exceptions.ClientError as e:
+        except aws.botocore_exceptions().ClientError as e:
             match = re.search(_DEPENDENCY_VIOLATION_PATTERN, str(e))
             if match is None:
                 raise e

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -196,15 +196,13 @@ def cleanup_ports(
         try:
             list(sgs)[0].delete()
         except aws.botocore_exceptions().ClientError as e:
-            match = re.search(_DEPENDENCY_VIOLATION_PATTERN, str(e))
-            if match is None:
-                raise
-            if match.group(1) == 'DependencyViolation':
-                assert match.group(2) == 'DeleteSecurityGroup', match.group(2)
+            match_str = 'An error occurred (DeleteSecurityGrou) when calling the DeleteSecurityGroup operation (.*): (.*)'
+            if re.findall(match_str, str(e):
                 logger.debug(
                     f'Security group {sg_name} is still in use. Retry.')
                 time.sleep(backoff.current_backoff())
                 continue
+            raise
         return
     logger.warning(f'Cannot delete security group {sg_name} after '
                    f'{MAX_ATTEMPTS} attempts. Please delete it manually.')

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -21,8 +21,9 @@ INITIAL_BACKOFF_SECONDS = 7
 MAX_BACKOFF_FACTOR = 10
 MAX_ATTEMPTS = 6
 
-_DEPENDENCY_VIOLATION_PATTERN = (
-    r'An error occurred \((.*)\) when calling the (.*) operation(.*): (.*)')
+_DEPENDENCY_VIOLATION_PATTERN = re.compile(
+    r'An error occurred \(DependencyViolation\) when calling the '
+    r'DeleteSecurityGroup operation(.*): (.*)')
 
 
 def _default_ec2_resource(region: str) -> Any:
@@ -196,8 +197,7 @@ def cleanup_ports(
         try:
             list(sgs)[0].delete()
         except aws.botocore_exceptions().ClientError as e:
-            match_str = 'An error occurred (DeleteSecurityGrou) when calling the DeleteSecurityGroup operation (.*): (.*)'
-            if re.findall(match_str, str(e):
+            if _DEPENDENCY_VIOLATION_PATTERN.findall(str(e)):
                 logger.debug(
                     f'Security group {sg_name} is still in use. Retry.')
                 time.sleep(backoff.current_backoff())

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -185,9 +185,17 @@ def cleanup_ports(
         'Name': 'group-name',
         'Values': [sg_name]
     }])
-    if len(list(sgs)) != 1:
+    num_sg = len(list(sgs))
+    if num_sg == 0:
         logger.warning(f'Expected security group {sg_name} not found. '
                        'Skip cleanup.')
+        return
+    if num_sg > 1:
+        # TODO(tian): Better handle this case. Maybe we can check when creating
+        # the SG and throw an error if there is already an existing SG with the
+        # same name.
+        logger.warning(f'Found {num_sg} security groups with name {sg_name}. '
+                       'Skip cleanup. Please delete them manually.')
         return
     backoff = common_utils.Backoff()
     for _ in range(MAX_ATTEMPTS):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR makes security group cleanup in AWS gracefully, and with retry. Now it will retry with a backoff and won't raise an error to interrupt `sky down` when cleanup is failed.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - Manually launch an AWS cluster, comment out `instance.wait_until_terminated()` and `sky down` that cluster
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
