### PR TITLE
Shutdown jupyter services to avoid port conflict

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -249,8 +249,6 @@ class Azure(clouds.Cloud):
         # This script will modify /etc/ssh/sshd_config and add a bash script
         # into .bashrc. The bash script will restart sshd if it has not been
         # restarted, identified by a file /tmp/__restarted is existing.
-        # We also stop jupyterhub and jupyter to avoid port conflict on 8081
-        # and 8888.
         # pylint: disable=line-too-long
         cloud_init_setup_commands = base64.b64encode(
             textwrap.dedent("""\

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -258,10 +258,6 @@ class Azure(clouds.Cloud):
             runcmd:
               - sed -i 's/#Banner none/Banner none/' /etc/ssh/sshd_config
               - echo '\\nif [ ! -f "/tmp/__restarted" ]; then\\n  sudo systemctl restart ssh\\n  sleep 2\\n  touch /tmp/__restarted\\nfi' >> /home/azureuser/.bashrc
-              - systemctl stop jupyterhub
-              - systemctl disable jupyterhub
-              - systemctl stop jupyter
-              - systemctl disable jupyter
             write_files:
               - path: /etc/apt/apt.conf.d/20auto-upgrades
                 content: |

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -249,6 +249,8 @@ class Azure(clouds.Cloud):
         # This script will modify /etc/ssh/sshd_config and add a bash script
         # into .bashrc. The bash script will restart sshd if it has not been
         # restarted, identified by a file /tmp/__restarted is existing.
+        # We also stop jupyterhub and jupyter to avoid port conflict on 8081
+        # and 8888.
         # pylint: disable=line-too-long
         cloud_init_setup_commands = base64.b64encode(
             textwrap.dedent("""\
@@ -256,6 +258,10 @@ class Azure(clouds.Cloud):
             runcmd:
               - sed -i 's/#Banner none/Banner none/' /etc/ssh/sshd_config
               - echo '\\nif [ ! -f "/tmp/__restarted" ]; then\\n  sudo systemctl restart ssh\\n  sleep 2\\n  touch /tmp/__restarted\\nfi' >> /home/azureuser/.bashrc
+              - systemctl stop jupyterhub
+              - systemctl disable jupyterhub
+              - systemctl stop jupyter
+              - systemctl disable jupyter
             write_files:
               - path: /etc/apt/apt.conf.d/20auto-upgrades
                 content: |

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -195,14 +195,19 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                  'patch openssh-server python3-pip;')
 
         # Copy local authorized_keys to docker container.
-        # Stop jupyter service. This is to avoid port conflict on 8080 if we use
-        # default deep learning image in GCP.
+        # Stop and disable jupyter service. This is to avoid port conflict on
+        # 8080 if we use default deep learning image in GCP, and 8888 if we use
+        # default deep learning image in Azure.
+        # Azure also has a jupyterhub service running on 8081, so we stop and
+        # disable that too.
         container_name = constants.DEFAULT_DOCKER_CONTAINER_NAME
         self.run(
             'rsync -e "docker exec -i" -avz ~/.ssh/authorized_keys '
             f'{container_name}:/tmp/host_ssh_authorized_keys;'
             'sudo systemctl stop jupyter > /dev/null 2>&1 || true;'
-            'sudo systemctl disable jupyter > /dev/null 2>&1 || true;',
+            'sudo systemctl disable jupyter > /dev/null 2>&1 || true;'
+            'sudo systemctl stop jupyterhub > /dev/null 2>&1 || true;'
+            'sudo systemctl disable jupyterhub > /dev/null 2>&1 || true;',
             run_env='host')
 
         # Change the default port of sshd from 22 to DEFAULT_DOCKER_PORT.

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -195,10 +195,14 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                  'patch openssh-server python3-pip;')
 
         # Copy local authorized_keys to docker container.
+        # Stop jupyter service. This is to avoid port conflict on 8080 if we use
+        # default deep learning image in GCP.
         container_name = constants.DEFAULT_DOCKER_CONTAINER_NAME
         self.run(
             'rsync -e "docker exec -i" -avz ~/.ssh/authorized_keys '
-            f'{container_name}:/tmp/host_ssh_authorized_keys',
+            f'{container_name}:/tmp/host_ssh_authorized_keys;'
+            'sudo systemctl stop jupyter > /dev/null 2>&1 || true;'
+            'sudo systemctl disable jupyter > /dev/null 2>&1 || true;',
             run_env='host')
 
         # Change the default port of sshd from 22 to DEFAULT_DOCKER_PORT.

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -133,6 +133,8 @@ setup_commands:
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
+  # Line 'sudo systemctl stop jupyterhub ..': stop jupyterhub service to avoid port conflict on 8081
+  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8888
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
@@ -148,6 +150,8 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf');
+    sudo systemctl stop jupyterhub > /dev/null 2>&1 || true;
+    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -130,6 +130,8 @@ setup_commands:
   # Create ~/.ssh/config file in case the file does not exist in the image.
   # Line 'sudo bash ..': set the ulimit as suggested by ray docs for performance. https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html#system-configuration
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
+  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8888
+  # Line 'sudo systemctl stop jupyterhub ..': stop jupyterhub service to avoid port conflict on 8081
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
@@ -144,6 +146,10 @@ setup_commands:
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     {%- if docker_image is none %}
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
+    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
+    sudo systemctl disable jupyter > /dev/null 2>&1 || true;
+    sudo systemctl stop jupyterhub > /dev/null 2>&1 || true;
+    sudo systemctl disable jupyterhub > /dev/null 2>&1 || true;
     {%- endif %}
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -133,8 +133,6 @@ setup_commands:
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
-  # Line 'sudo systemctl stop jupyterhub ..': stop jupyterhub service to avoid port conflict on 8081
-  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8888
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
@@ -150,8 +148,6 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf');
-    sudo systemctl stop jupyterhub > /dev/null 2>&1 || true;
-    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -267,13 +267,13 @@ initialization_commands: []
 #   current num items (num SSH connections): 1  (+1 if tpu_vm)
 setup_commands:
   # Disable `unattended-upgrades` to prevent apt-get from hanging. It should be called at the beginning before the process started to avoid being blocked. (This is a temporary fix.)
-  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   # Line 'mkdir -p ..': Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Line 'which conda ..': some images (TPU VM) do not install conda by
   # default. 'source ~/.bashrc' is needed so conda takes effect for the next
   # commands.
   # Line 'sudo bash ..': set the ulimit as suggested by ray docs for performance. https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html#system-configuration
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
+  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
@@ -281,8 +281,6 @@ setup_commands:
     sudo systemctl stop unattended-upgrades || true;
     sudo systemctl disable unattended-upgrades || true;
     sudo sed -i 's/Unattended-Upgrade "1"/Unattended-Upgrade "0"/g' /etc/apt/apt.conf.d/20auto-upgrades || true;
-    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
-    sudo systemctl disable jupyter > /dev/null 2>&1 || true;
     {%- endif %}
     p=$(mylsof "/var/lib/dpkg/lock-frontend"); echo "$p";
     sudo kill -9 `echo "$p" | tail -n 1` || true;
@@ -305,6 +303,8 @@ setup_commands:
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     {%- if docker_image is none %}
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
+    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
+    sudo systemctl disable jupyter > /dev/null 2>&1 || true;
     {%- endif %}
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -267,6 +267,7 @@ initialization_commands: []
 #   current num items (num SSH connections): 1  (+1 if tpu_vm)
 setup_commands:
   # Disable `unattended-upgrades` to prevent apt-get from hanging. It should be called at the beginning before the process started to avoid being blocked. (This is a temporary fix.)
+  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   # Line 'mkdir -p ..': Create ~/.ssh/config file in case the file does not exist in the custom image.
   # Line 'which conda ..': some images (TPU VM) do not install conda by
   # default. 'source ~/.bashrc' is needed so conda takes effect for the next
@@ -275,12 +276,13 @@ setup_commands:
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   - function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
     {%- if docker_image is none %}
     sudo systemctl stop unattended-upgrades || true;
     sudo systemctl disable unattended-upgrades || true;
     sudo sed -i 's/Unattended-Upgrade "1"/Unattended-Upgrade "0"/g' /etc/apt/apt.conf.d/20auto-upgrades || true;
+    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
+    sudo systemctl disable jupyter > /dev/null 2>&1 || true;
     {%- endif %}
     p=$(mylsof "/var/lib/dpkg/lock-frontend"); echo "$p";
     sudo kill -9 `echo "$p" | tail -n 1` || true;
@@ -307,7 +309,6 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf');
-    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -275,6 +275,7 @@ setup_commands:
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
+  # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   - function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
     {%- if docker_image is none %}
     sudo systemctl stop unattended-upgrades || true;
@@ -306,6 +307,7 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf');
+    sudo systemctl stop jupyter > /dev/null 2>&1 || true;
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR shut down all jupyter services that were default enabled by our deep learning image in GCP and Azure.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `sky launch -c gc --cloud gcp` and check ports
     - [x] `sky launch -c gc-docker --cloud gcp --image-id docker:ubuntu` and check ports
     - [x] `sky launch -c az --cloud azure` and check ports
     - [x] `sky launch -c az-docker --cloud azure --image-id docker:ubuntu` and check ports
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
