### PR TITLE
[SkyServe] Fix interrupt process group and format

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2108,10 +2108,15 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
             arg_str = '--all'
         else:
             arg_str = ' '.join(map(str, jobs))
-        error_str = ('Cancelling the spot controller\'s jobs is not allowed.'
-                     f'\nTo cancel spot jobs, use: sky spot cancel <spot '
-                     f'job IDs> [--all]'
-                     f'\nDo you mean: {bold}sky spot cancel {arg_str}{reset}')
+        if cluster == spot_lib.SPOT_CONTROLLER_NAME:
+            error_str = (
+                'Cancelling the spot controller\'s jobs is not allowed.'
+                f'\nTo cancel spot jobs, use: sky spot cancel <spot '
+                f'job IDs> [--all]'
+                f'\nDo you mean: {bold}sky spot cancel {arg_str}{reset}')
+        else:
+            error_str = (
+                'Cancelling the sky serve controller\'s jobs is not allowed.')
         click.echo(error_str)
         sys.exit(1)
     except ValueError as e:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2115,6 +2115,7 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
                 f'job IDs> [--all]'
                 f'\nDo you mean: {bold}sky spot cancel {arg_str}{reset}')
         else:
+            assert cluster.startswith(serve_lib.CONTROLLER_PREFIX)
             error_str = (
                 'Cancelling the sky serve controller\'s jobs is not allowed.')
         click.echo(error_str)

--- a/sky/serve/examples/gorilla/run_gorilla.py
+++ b/sky/serve/examples/gorilla/run_gorilla.py
@@ -1,29 +1,36 @@
 # Code is borrowed from gorilla's colab
 # https://colab.research.google.com/drive/1DEBPsccVLF_aUnmD0FwPeHFrtdC0QIUP?usp=sharing  # pylint: disable=line-too-long
 
-import openai
 import urllib.parse
 
-openai.api_key = "EMPTY" # Key is ignored and does not matter
+import openai
+
+openai.api_key = "EMPTY"  # Key is ignored and does not matter
 # SkyServe endpoint
 endpoint = input("Enter SkyServe endpoint: ")
 # endpoint = '34.132.127.197:8000'
 openai.api_base = f"http://{endpoint}/v1"
 
+
 # Report issues
 def raise_issue(e, model, prompt):
     issue_title = urllib.parse.quote("[bug] Hosted Gorilla: <Issue>")
-    issue_body = urllib.parse.quote(f"Exception: {e}\nFailed model: {model}, for prompt: {prompt}")
+    issue_body = urllib.parse.quote(
+        f"Exception: {e}\nFailed model: {model}, for prompt: {prompt}")
     issue_url = f"https://github.com/ShishirPatil/gorilla/issues/new?assignees=&labels=hosted-gorilla&projects=&template=hosted-gorilla-.md&title={issue_title}&body={issue_body}"
-    print(f"An exception has occurred: {e} \nPlease raise an issue here: {issue_url}")
+    print(
+        f"An exception has occurred: {e} \nPlease raise an issue here: {issue_url}"
+    )
+
 
 # Query Gorilla server
 def get_gorilla_response(prompt, model="gorilla-mpt-7b-hf-v0"):
     try:
-        completion = openai.ChatCompletion.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}]
-        )
+        completion = openai.ChatCompletion.create(model=model,
+                                                  messages=[{
+                                                      "role": "user",
+                                                      "content": prompt
+                                                  }])
         return completion.choices[0].message.content
     except Exception as e:
         raise_issue(e, model, prompt)

--- a/sky/serve/examples/misc/cancel/send_cancel_request.py
+++ b/sky/serve/examples/misc/cancel/send_cancel_request.py
@@ -1,7 +1,9 @@
-import aiohttp
 import asyncio
 
+import aiohttp
+
 redirector_endpoint = input('Enter redirector endpoint: ')
+
 
 async def fetch(session, url):
     try:
@@ -12,11 +14,13 @@ async def fetch(session, url):
         print("Request was cancelled!")
         raise
 
+
 async def main():
     timeout = 2
 
     async with aiohttp.ClientSession() as session:
-        task = asyncio.create_task(fetch(session, f'http://{redirector_endpoint}/'))
+        task = asyncio.create_task(
+            fetch(session, f'http://{redirector_endpoint}/'))
 
         await asyncio.sleep(timeout)
         # We manually cancel requests for test purposes.
@@ -27,5 +31,6 @@ async def main():
             await task
         except asyncio.CancelledError:
             print("Main function caught the cancelled exception.")
+
 
 asyncio.run(main())

--- a/sky/serve/examples/misc/cancel/server.py
+++ b/sky/serve/examples/misc/cancel/server.py
@@ -1,6 +1,8 @@
-from aiohttp import web
 import argparse
 import asyncio
+
+from aiohttp import web
+
 
 async def handle(request):
     response = web.StreamResponse()
@@ -19,9 +21,11 @@ async def handle(request):
 
     return response
 
+
 async def health_check(request):
     print("Received health check")
     return web.Response(text="Healthy")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='SkyServe HTTP Test Server')

--- a/sky/serve/examples/vllm.yaml
+++ b/sky/serve/examples/vllm.yaml
@@ -17,7 +17,7 @@ setup: |
     # Setup the environment
     conda create -n chatbot python=3.10 -y
     conda activate chatbot
-    pip install pip install git+https://github.com/lm-sys/FastChat.git
+    pip install git+https://github.com/lm-sys/FastChat.git
     pip install vllm
     pip install accelerate
   fi

--- a/sky/serve/infra_providers.py
+++ b/sky/serve/infra_providers.py
@@ -498,6 +498,8 @@ class SkyPilotInfraProvider(InfraProvider):
             # process_pool_refresher terminates
             if p.poll() is None:
                 assert p.pid is not None
+                # Interrupt the launch process and its children. We use SIGINT
+                # here since sky.launch has great handling for it.
                 _interrupt_process_and_children(p.pid)
                 p.wait()
                 logger.info(f'Interrupted launch process for cluster {name} '

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2606,7 +2606,8 @@ def test_gcp_zero_quota_failover():
 # ---------- Testing skyserve ----------
 
 
-def _get_skyserve_test_task(name: str, suffix: str, timeout_minutes: int) -> Test:
+def _get_skyserve_test_task(name: str, suffix: str,
+                            timeout_minutes: int) -> Test:
     url_regex = r'([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5}'
     test = Test(
         f'test-skyserve-{suffix.replace("_", "-")}',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, the termination of the launch process will kill the whole process group, including the controller process. Thanks for the `SIGINT` signal we used, the controller will keep processing any incoming requests and it won't cause a problem since it is only called in `terminate` method. This PR fixes this bug. (And also some code formatting)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
