### PR TITLE
Hot fix `sky cancel -y` bug that ignored job ids.

### DIFF
--- a/examples/env_check.yaml
+++ b/examples/env_check.yaml
@@ -1,6 +1,4 @@
-num_nodes: 2  
-
-workdir: .
+num_nodes: 2
 
 setup: |
   echo "here"
@@ -15,13 +13,6 @@ run: |
     exit 1
   else
     echo "TEST_VAR is set to ${TEST_VAR}"
-  fi
-
-  if [[ -d ~/sky_workdir/sky ]]; then
-    echo "~/sky_workdir/sky exists"
-  else
-    echo "~/sky_workdir/sky does not exist"
-    exit 1
   fi
 
   if [[ -z "$SKYPILOT_NODE_RANK" ]]; then

--- a/examples/job_queue/cluster.yaml
+++ b/examples/job_queue/cluster.yaml
@@ -7,4 +7,4 @@
 #   sky exec jq job.yaml
 
 resources:
-  accelerators: K80
+  accelerators: T4

--- a/examples/job_queue/job.yaml
+++ b/examples/job_queue/job.yaml
@@ -9,7 +9,7 @@
 name: job
 
 resources:
-  accelerators: K80:0.5
+  accelerators: T4:0.5
 
 setup: |
   echo "running setup"

--- a/examples/multi_echo.py
+++ b/examples/multi_echo.py
@@ -23,7 +23,7 @@ def run(cluster: Optional[str] = None, cloud: Optional[str] = None):
 
     # Create the cluster.
     with sky.Dag() as dag:
-        cluster_resources = sky.Resources(cloud, accelerators={'K80': 1})
+        cluster_resources = sky.Resources(cloud, accelerators={'T4': 1})
         task = sky.Task(num_nodes=2).set_resources(cluster_resources)
     # `detach_run` will only detach the `run` command. The provision and
     # `setup` are still blocking.
@@ -32,7 +32,7 @@ def run(cluster: Optional[str] = None, cloud: Optional[str] = None):
     # Submit multiple tasks in parallel to trigger queueing behaviors.
     def _exec(i):
         task = sky.Task(run=f'echo {i}; sleep 5')
-        resources = sky.Resources(accelerators={'K80': 0.5})
+        resources = sky.Resources(accelerators={'T4': 0.5})
         task.set_resources(resources)
         sky.exec(task, cluster_name=cluster, detach_run=True)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2055,31 +2055,31 @@ def cancel(cluster: str, all: bool, jobs: List[int], yes: bool):  # pylint: disa
     bold = colorama.Style.BRIGHT
     reset = colorama.Style.RESET_ALL
     job_identity_str = None
-    job_ids_to_set = None
+    job_ids_to_cancel = None
     if not jobs and not all:
         click.echo(f'{colorama.Fore.YELLOW}No job IDs or --all provided; '
                    'cancelling the latest running job.'
                    f'{colorama.Style.RESET_ALL}')
         job_identity_str = 'the latest running job'
+    else:
+        # Cancelling specific jobs or --all.
+        job_ids = ' '.join(map(str, jobs))
+        plural = 's' if len(job_ids) > 1 else ''
+        job_identity_str = f'job{plural} {job_ids}'
+        job_ids_to_cancel = jobs
+        if all:
+            job_identity_str = 'all jobs'
+            job_ids_to_cancel = None
+    job_identity_str += f' on cluster {cluster!r}'
 
     if not yes:
-        if job_identity_str is None:
-            job_ids_to_set = jobs
-            job_ids = ' '.join(map(str, jobs))
-            plural = 's' if len(job_ids) > 1 else ''
-            job_identity_str = f'job{plural} {job_ids}'
-            if all:
-                job_identity_str = 'all jobs'
-                job_ids_to_set = None
-
-        job_identity_str += f' on cluster {cluster!r}'
         click.confirm(f'Cancelling {job_identity_str}. Proceed?',
                       default=True,
                       abort=True,
                       show_default=True)
 
     try:
-        core.cancel(cluster, all=all, job_ids=job_ids_to_set)
+        core.cancel(cluster, all=all, job_ids=job_ids_to_cancel)
     except exceptions.NotSupportedError:
         # Friendly message for usage like 'sky cancel <spot controller> -a/<job
         # id>'.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -989,10 +989,10 @@ def test_scp_logs():
 
 
 # ---------- Job Queue. ----------
-@pytest.mark.no_lambda_cloud  # Lambda Cloud does not have K80 gpus
-@pytest.mark.no_ibm  # IBM Cloud does not have K80 gpus. run test_ibm_job_queue instead
-@pytest.mark.no_scp  # SCP does not have K80 gpus. Run test_scp_job_queue instead
-@pytest.mark.no_oci  # OCI does not have K80 gpus
+@pytest.mark.no_lambda_cloud  # Lambda Cloud does not have T4 gpus
+@pytest.mark.no_ibm  # IBM Cloud does not have T4 gpus. run test_ibm_job_queue instead
+@pytest.mark.no_scp  # SCP does not have T4 gpus. Run test_scp_job_queue instead
+@pytest.mark.no_oci  # OCI does not have T4 gpus
 @pytest.mark.no_kubernetes  # Kubernetes not have gpus
 def test_job_queue(generic_cloud: str):
     name = _get_cluster_name()
@@ -1010,8 +1010,8 @@ def test_job_queue(generic_cloud: str):
             'sleep 5',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-3 | grep RUNNING',
             f'sky cancel -y {name} 3',
-            f'sky exec {name} --gpus K80:0.2 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
-            f'sky exec {name} --gpus K80:1 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
+            f'sky exec {name} --gpus T4:0.2 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
+            f'sky exec {name} --gpus T4:1 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
             f'sky logs {name} 4 --status',
             f'sky logs {name} 5 --status',
         ],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Thanks to @romilbhardwaj who discovered this bug introduced by #2423. When `-y` is passed, job IDs passed in were ignored.
```
+ sky cancel -y t-job-queue-multc40-2040-1b 4
Cancelling latest running job on cluster 't-job-queue-multc40-2040-1b'...
I 08-24 10:10:36 cloud_vm_ray_backend.py:3469] Cancelled job ID(s): 3
```

Running entire smoke tests now.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py`: running
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
