### PR TITLE
[AWS] Fix fetching AZ when describe zones permission does not exist in all regions

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -24,7 +24,7 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
         if not isinstance(cloud, clouds.Local):
             echo('  ' + click.style(
                 f'{cloud}: {status_msg}', fg=status_color, bold=True) +
-                 ' ' * 10)
+                 ' ' * 30)
         if ok:
             enabled_clouds.append(str(cloud))
             if verbose:
@@ -48,7 +48,7 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
     status_color = 'green' if r2_is_enabled else 'red'
     echo('  ' +
          click.style(f'{cloud}: {status_msg}', fg=status_color, bold=True) +
-         ' ' * 10)
+         ' ' * 30)
     if not r2_is_enabled:
         echo(f'    Reason: {reason}')
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -76,8 +76,10 @@ def _get_az_mappings(aws_user_hash: str) -> Optional[pd.DataFrame]:
         az_mappings = None
         if aws_user_hash != 'default':
             # Fetch az mapping from AWS.
-            logger.info(f'{colorama.Style.DIM}Fetching availability zones '
-                        f'mapping for AWS...{colorama.Style.RESET_ALL}')
+            print(
+                f'\r{colorama.Style.DIM}AWS: Fetching availability zones '
+                f'mapping...{colorama.Style.RESET_ALL}',
+                end='')
             az_mappings = fetch_aws.fetch_availability_zone_mappings()
         else:
             return None

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -136,7 +136,7 @@ def _get_availability_zones(region: str) -> pd.DataFrame:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.AWSAzFetchingError(
                     region,
-                    reason=exceptions.AWSAzFetchingError.Reason.AUTHENTICATION
+                    reason=exceptions.AWSAzFetchingError.Reason.AUTH_FAILURE
                 ) from None
         elif e.response['Error']['Code'] == 'UnauthorizedOperation':
             with ux_utils.print_exception_no_traceback():

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -440,7 +440,7 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
         table = log_utils.create_table(['Regions', 'Reason'])
         for reason, regions in errored_regions.items():
             reason_str = '\n'.join(textwrap.wrap(str(reason.message), 80))
-            region_str = '\n'.join(textwrap.wrap(str(regions), 40))
+            region_str = '\n'.join(textwrap.wrap(str(regions), 60))
             table.add_row([region_str, reason_str])
         if not az_mappings:
             raise RuntimeError('Failed to fetch availability zone mappings for '

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -9,6 +9,7 @@ from multiprocessing import pool as mp_pool
 import os
 import subprocess
 import sys
+import textwrap
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -436,9 +437,11 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
     if errored_regions:
         # This could happen if a AWS API glitch happens, it is to make sure
         # that the availability zone does not get lost silently.
-        table = log_utils.create_table(['Reason', 'Regions'])
+        table = log_utils.create_table(['Regions', 'Reason'])
         for reason, regions in errored_regions.items():
-            table.add_row([reason.message, regions])
+            reason_str = '\n'.join(textwrap.wrap(str(reason.message), 80))
+            region_str = '\n'.join(textwrap.wrap(str(regions), 40))
+            table.add_row([region_str, reason_str])
         if not az_mappings:
             raise RuntimeError('Failed to fetch availability zone mappings for '
                                f'all enabled regions.\n{table}')

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -444,7 +444,9 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
         table = log_utils.create_table(['Region', 'Reason'])
         for reason, region_set in errored_regions.items():
             reason_str = '\n'.join(textwrap.wrap(str(reason.message), 80))
-            region_str = '\n'.join(textwrap.wrap(', '.join(region_set), 60))
+            region_str = '\n'.join(
+                textwrap.wrap(', '.join(region_set), 60,
+                              break_on_hyphens=False))
             table.add_row([region_str, reason_str])
         if not az_mappings:
             raise RuntimeError('Failed to fetch availability zone mappings for '

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -446,7 +446,7 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
             raise RuntimeError('Failed to fetch availability zone mappings for '
                                f'all enabled regions.\n{table}')
         else:
-            print('WARNING: Missing availability zone mappings for the '
+            print('\rAWS: [WARNING] Missing availability zone mappings for the '
                   f'following enabled regions:\n{table}')
     az_mappings = pd.concat(az_mappings)
     return az_mappings

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -423,7 +423,8 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
         try:
             azs = _get_availability_zones(region)
         except exceptions.AWSAzFetchingError as e:
-            errored_region_reasons.append((region, e.reason))  # GIL means it's thread-safe.
+            errored_region_reasons.append(
+                (region, e.reason))  # GIL means it's thread-safe.
             return None
         return azs
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -441,7 +441,7 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
         # This could happen if (1) an AWS API glitch happens, (2) permission
         # error happens for specific availability zones. We print those zones to
         # make sure that those zone does not get lost silently.
-        table = log_utils.create_table(['Region', 'Reason'])
+        table = log_utils.create_table(['Regions', 'Reason'])
         for reason, region_set in errored_regions.items():
             reason_str = '\n'.join(textwrap.wrap(str(reason.message), 80))
             region_str = '\n'.join(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -442,9 +442,9 @@ def fetch_availability_zone_mappings() -> pd.DataFrame:
         # error happens for specific availability zones. We print those zones to
         # make sure that those zone does not get lost silently.
         table = log_utils.create_table(['Region', 'Reason'])
-        for reason, regions in errored_regions.items():
+        for reason, region_set in errored_regions.items():
             reason_str = '\n'.join(textwrap.wrap(str(reason.message), 80))
-            region_str = '\n'.join(textwrap.wrap(str(regions), 60))
+            region_str = '\n'.join(textwrap.wrap(', '.join(region_set), 60))
             table.add_row([region_str, reason_str])
         if not az_mappings:
             raise RuntimeError('Failed to fetch availability zone mappings for '

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -223,13 +223,13 @@ class AWSAzFetchingError(Exception):
     class Reason(enum.Enum):
         """Reason for fetching availability zone failure."""
 
-        CREDENTIAL = 'REGION_NOT_ENABLED'
+        AUTHENTICATION = 'AUTHENTICATION'
         AZ_PERMISSION_DENIED = 'AZ_PERMISSION_DENIED'
 
         @property
         def message(self) -> str:
-            if self == self.CREDENTIAL:
-                return ('Failed to access the region. Please check your AWS '
+            if self == self.AUTHENTICATION:
+                return ('Failed to access AWS services. Please check your AWS '
                         'credentials.')
             elif self == self.AZ_PERMISSION_DENIED:
                 return (

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -215,3 +215,35 @@ class ClusterOwnerIdentityMismatchError(Exception):
 class NoCloudAccessError(Exception):
     """Raised when all clouds are disabled."""
     pass
+
+
+class AWSAzFetchingError(Exception):
+    """Raised when fetching the AWS availability zone fails."""
+
+    class Reason(enum.Enum):
+        """Reason for fetching availability zone failure."""
+
+        CREDENTIAL = 'REGION_NOT_ENABLED'
+        AZ_PERMISSION_DENIED = 'AZ_PERMISSION_DENIED'
+
+        @property
+        def message(self) -> str:
+            if self == self.CREDENTIAL:
+                return ('Failed to access the region. Please check your AWS '
+                        'credentials.')
+            elif self == self.AZ_PERMISSION_DENIED:
+                return (
+                    'Failed to retrieve availability zones. '
+                    'Please ensure that the `ec2:DescribeAvailabilityZones` '
+                    'action is enabled for your AWS account in IAM. '
+                    'Ref: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html.'  # pylint: disable=line-too-long
+                )
+            else:
+                raise ValueError(f'Unknown reason {self}')
+
+    def __init__(self, region: str,
+                 reason: 'AWSAzFetchingError.Reason') -> None:
+        self.region = region
+        self.reason = reason
+
+        super().__init__(reason.message)

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -223,12 +223,12 @@ class AWSAzFetchingError(Exception):
     class Reason(enum.Enum):
         """Reason for fetching availability zone failure."""
 
-        AUTHENTICATION = 'AUTHENTICATION'
+        AUTH_FAILURE = 'AUTH_FAILURE'
         AZ_PERMISSION_DENIED = 'AZ_PERMISSION_DENIED'
 
         @property
         def message(self) -> str:
-            if self == self.AUTHENTICATION:
+            if self == self.AUTH_FAILURE:
                 return ('Failed to access AWS services. Please check your AWS '
                         'credentials.')
             elif self == self.AZ_PERMISSION_DENIED:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2451 

Current logging for `sky check`:
```console
$ sky check                                                                                                                                                                                          
Checking credentials to enable clouds for SkyPilot.
AWS: [WARNING] Missing availability zone mappings for the following enabled regions:
Regions                                                       Reason                                                                            
['us-east-1', 'ca-central-1', 'ap-southeast-2', 'ap-          Failed to retrieve availability zones. Please ensure that the                     
northeast-2', 'ap-northeast-1', 'ap-south-1', 'eu-north-1',   `ec2:DescribeAvailabilityZones` action is enabled for your AWS account in IAM.    
'us-west-2', 'eu-west-1', 'eu-west-3', 'us-east-2', 'ap-      Ref: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabi  
northeast-3', 'eu-central-1', 'ap-southeast-1', 'eu-west-2']  lityZones.html.                                                                   
  AWS: enabled          
  Azure: enabled          
  GCP: enabled          
  IBM: enabled          
  Kubernetes: enabled          
  Lambda: enabled          
  OCI: enabled          
  SCP: enabled          
  Cloudflare (for R2 object store): enabled 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky check` with an AWS account with the following IAM policy (only allow the permission for a single region:
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Deny",
            "Action": "ec2:DescribeAvailabilityZones",
            "Resource": "*"
        },
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": "ec2:DescribeAvailabilityZones",
            "Resource": "*",
            "Condition": {
                "StringEquals": {
                    "aws:RequestedRegion": "us-west-1"
                }
            }
        }
    ]
}
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
