### PR TITLE
Fix GCP port cleanup when the firewall rule is not found

### DIFF
--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -198,6 +198,8 @@ class GCPComputeInstance(GCPInstance):
     ) -> None:
         rule = cls.load_resource().firewalls().list(
             project=project_id, filter=f'name={firewall_rule_name}').execute()
+        # For the return value format, please refer to
+        # https://developers.google.com/resources/api-libraries/documentation/compute/alpha/python/latest/compute_alpha.firewalls.html#list # pylint: disable=line-too-long
         if 'items' not in rule:
             logger.warning(f'Firewall rule {firewall_rule_name} not found. '
                            'Skip cleanup.')

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -197,8 +197,8 @@ class GCPComputeInstance(GCPInstance):
         firewall_rule_name: str,
     ) -> None:
         rule = cls.load_resource().firewalls().list(
-            project=project_id, filter=f'name={firewall_rule_name}')
-        if not rule:
+            project=project_id, filter=f'name={firewall_rule_name}').execute()
+        if 'items' not in rule:
             logger.warning(f'Firewall rule {firewall_rule_name} not found. '
                            'Skip cleanup.')
             return


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a bug that will raise an error when the firewall rule corresponds to user-specified ports that cannot be found on the cloud.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `sky down` a cluster that with ports specified and created before #2403 
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
