### PR TITLE
UX: hint fuzzy candidates on 'catalog doesn't have offerings' error.

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -368,7 +368,8 @@ class AWS(clouds.Cloud):
         }
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -279,23 +279,26 @@ class Azure(clouds.Cloud):
             'cloud_init_setup_commands': cloud_init_setup_commands
         }
 
-    def _get_feasible_launchable_resources(self, resources):
+    def _get_feasible_launchable_resources(
+        self, resources: 'resources.Resources'
+    ) -> Tuple[List['resources.Resources'], List[str]]:
 
         def failover_disk_tier(
                 instance_type: str,
                 disk_tier: Optional[str]) -> Tuple[bool, Optional[str]]:
-            """Figure out the actual disk tier to be used
+            """Figure out the actual disk tier to be used.
 
             Check the disk_tier specified by the user with the instance type to
             be used. If not valid, return False.
+
             When the disk_tier is not specified, failover through the possible
             disk tiers.
 
             Returns:
-                A tuple of a boolean value and an optional string to represent the
-                instance_type to use. If the boolean value is False, the specified
-                configuration is not a valid combination, and should not be used
-                for launching a VM.
+                A tuple of a boolean value and an optional string to represent
+                the instance_type to use. If the boolean value is False, the
+                specified configuration is not a valid combination, and should
+                not be used for launching a VM.
             """
             if disk_tier is not None:
                 ok, _ = Azure.check_disk_tier(instance_type, disk_tier)

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -270,16 +270,22 @@ class Cloud:
                                                   clouds=cls._REPR.lower())
 
     def get_feasible_launchable_resources(
-            self,
-            resources: 'resources_lib.Resources',
-            num_nodes: int = 1) -> 'resources_lib.Resources':
-        """Returns a list of feasible and launchable resources.
+        self,
+        resources: 'resources_lib.Resources',
+        num_nodes: int = 1
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
+        """Returns ([feasible and launchable resources], [fuzzy candidates]).
 
         Feasible resources refer to an offering respecting the resource
         requirements.  Currently, this function implements "filtering" the
         cloud's offerings only w.r.t. accelerators constraints.
 
         Launchable resources require a cloud and an instance type be assigned.
+
+        Fuzzy candidates example: when the requested GPU is A100:1 but is not
+        available in a cloud/region, the fuzzy candidates are results of a fuzzy
+        search in the catalog that are offered in the location. E.g.,
+          ['A100-80GB:1', 'A100-80GB:2', 'A100-80GB:4', 'A100:8']
         """
         if resources.is_launchable():
             self._check_instance_type_accelerators_combination(resources)
@@ -296,7 +302,10 @@ class Cloud:
             return ([], [])
         return self._get_feasible_launchable_resources(resources)
 
-    def _get_feasible_launchable_resources(self, resources):
+    def _get_feasible_launchable_resources(
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
+        """See get_feasible_launchable_resources()."""
         raise NotImplementedError
 
     def get_reservations_available_resources(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -495,7 +495,9 @@ class GCP(clouds.Cloud):
 
         return resources_vars
 
-    def _get_feasible_launchable_resources(self, resources):
+    def _get_feasible_launchable_resources(
+        self, resources: 'resources.Resources'
+    ) -> Tuple[List['resources.Resources'], List[str]]:
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             return ([resources], [])

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -258,7 +258,7 @@ class IBM(clouds.Cloud):
     def _get_feasible_launchable_resources(
         self, resources: 'resources_lib.Resources'
     ) -> Tuple[List['resources_lib.Resources'], List[str]]:
-        fuzzy_candidate_list = []
+        fuzzy_candidate_list: List[str] = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             resources = resources.copy(accelerators=None)

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -256,16 +256,9 @@ class IBM(clouds.Cloud):
                                                          clouds='ibm')
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
-        """Returns a list of feasible and launchable resources.
-
-        Feasible resources refer to an offering respecting the resource
-        requirements.  Currently, this function implements "filtering" the
-        cloud's offerings only w.r.t. accelerators constraints.
-
-        Launchable resources require a cloud and an instance type be assigned.
-        """
-        fuzzy_candidate_list: Optional[List[str]] = []
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
+        fuzzy_candidate_list = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             resources = resources.copy(accelerators=None)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -229,7 +229,8 @@ class Kubernetes(clouds.Cloud):
         return deploy_vars
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         fuzzy_candidate_list: List[str] = []
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
@@ -264,18 +265,17 @@ class Kubernetes(clouds.Cloud):
             acc_type, acc_count = list(accelerators.items())[0]
 
             # Parse into KubernetesInstanceType
-            k8s_instance_type = kubernetes_utils.KubernetesInstanceType.\
-                from_instance_type(
-                default_instance_type)
+            k8s_instance_type = (kubernetes_utils.KubernetesInstanceType.
+                                 from_instance_type(default_instance_type))
 
             gpu_task_cpus = k8s_instance_type.cpus
             # Special handling to bump up memory multiplier for GPU instances
-            gpu_task_memory = float(resources.memory.strip('+')) \
-                if resources.memory is not None \
-                else gpu_task_cpus * self._DEFAULT_MEMORY_CPU_RATIO_WITH_GPU
-            chosen_instance_type = kubernetes_utils.KubernetesInstanceType.\
-                from_resources(
-                gpu_task_cpus, gpu_task_memory, acc_count, acc_type).name
+            gpu_task_memory = (float(resources.memory.strip('+')) if
+                               resources.memory is not None else gpu_task_cpus *
+                               self._DEFAULT_MEMORY_CPU_RATIO_WITH_GPU)
+            chosen_instance_type = (
+                kubernetes_utils.KubernetesInstanceType.from_resources(
+                    gpu_task_cpus, gpu_task_memory, acc_count, acc_type).name)
 
         # Check if requested instance type will fit in the cluster.
         # TODO(romilb): This will fail early for autoscaling clusters.

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -172,7 +172,8 @@ class Lambda(clouds.Cloud):
         }
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Accelerators are part of the instance type in Lambda Cloud

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -141,7 +141,8 @@ class Local(clouds.Cloud):
         return {}
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         if resources.disk_tier is not None:
             return ([], [])
         # The entire local cluster's resources is considered launchable, as the

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -282,7 +282,8 @@ class OCI(clouds.Cloud):
         }
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             resources = resources.copy(accelerators=None)

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -239,7 +239,8 @@ class SCP(clouds.Cloud):
             f'{region_name}. Try setting a valid image_id.')
 
     def _get_feasible_launchable_resources(
-            self, resources: 'resources_lib.Resources'):
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         # Check if the host VM satisfies the min/max disk size limits.
         is_allowed = self._is_disk_size_allowed(resources)
         if not is_allowed:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -23,6 +23,7 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import networkx as nx
+
     # pylint: disable=ungrouped-imports
     from sky import dag as dag_lib
 
@@ -248,7 +249,7 @@ class Optimizer:
             if do_print:
                 logger.debug('#### {} ####'.format(node))
 
-            fuzzy_candidates = []
+            fuzzy_candidates: List[str] = []
             if node_i < len(topo_order) - 1:
                 # Convert partial resource labels to launchable resources.
                 launchable_resources, cloud_candidates, fuzzy_candidates = (


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Minor UX change for a common error. 

Hopefully make the error hint more noticeable.

Before
<img width="1060" alt="Screen Shot 2023-08-26 at 09 30 12" src="https://github.com/skypilot-org/skypilot/assets/592670/3cee0c40-f57f-483f-8df3-3bf6bd26f9b3">

This PR
<img width="1160" alt="Screen Shot 2023-08-30 at 08 35 35" src="https://github.com/skypilot-org/skypilot/assets/592670/8e59da48-db46-4e47-8f10-7383ff5f02e3">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
