### PR TITLE
[Storage] Update gcsfuse to 1.0.1

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1318,7 +1318,7 @@ class GcsStore(AbstractStore):
     """
 
     _ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
-    GCSFUSE_VERSION = '0.42.3'
+    GCSFUSE_VERSION = '1.0.1'
 
     def __init__(self,
                  name: str,


### PR DESCRIPTION
Google [announced](https://cloud.google.com/blog/products/storage-data-transfer/google-clouds-latest-storage-solutions-target-ai-workloads) GA for gcsfuse. This PR upgrades gcsfuse from `0.42.3` -> `1.0.1` for potential perf/functionality fixes. 

Tested (run the relevant ones):

- [x] `pytest tests/test_smoke.py::test_gcp_storage_mounts`