### PR TITLE
[Examples] Remove extra `memory` arg from Llama2 example

### DIFF
--- a/llm/llama-2/chatbot-hf.yaml
+++ b/llm/llama-2/chatbot-hf.yaml
@@ -1,5 +1,4 @@
 resources:
-  memory: 32+
   accelerators: A100:1
   disk_size: 1024
   disk_tier: high


### PR DESCRIPTION
`chatbot-hf.yaml` has a duplicated `memory` argument. This PR removes it.