### PR TITLE
[Core] Fix wheel build for nightly

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           RELEASE_VERSION=$(date +%Y%m%d)
           sed -i "s/{{SKYPILOT_COMMIT_SHA}}/${{ github.sha }}/g" sky/__init__.py
-          sed -i "s/__version__ = '.*'/__version__ = '1.0.0-dev${RELEASE_VERSION}'/g" sky/__init__.py
+          sed -i "s/__version__ = '.*'/__version__ = '1.0.0.dev${RELEASE_VERSION}'/g" sky/__init__.py
           sed -i "s/name='skypilot',/name='skypilot-nightly',/g" sky/setup_files/setup.py
       - name: Build a binary wheel and a source tarball
         run: >-

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -98,7 +98,8 @@ def _build_sky_wheel():
             wheel_path = next(tmp_dir.glob(_WHEEL_PATTERN))
         except StopIteration:
             raise RuntimeError(
-                f'Fail to find pip wheel for SkyPilot under {tmp_dir} with glob pattern {_WHEEL_PATTERN!r}. '
+                f'Fail to find pip wheel for SkyPilot under {tmp_dir} with '
+                f'glob pattern {_WHEEL_PATTERN!r}. '
                 f'Found: {list(map(str, tmp_dir.glob("*")))}.'
                 'No wheel file is generated.') from None
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -98,7 +98,7 @@ def _build_sky_wheel():
             wheel_path = next(tmp_dir.glob(_WHEEL_PATTERN))
         except StopIteration:
             raise RuntimeError(
-                f'Fail to build pip wheel for SkyPilot under {tmp_dir}. '
+                f'Fail to find pip wheel for SkyPilot under {tmp_dir} with glob pattern {_WHEEL_PATTERN!r}. '
                 f'Found: {list(map(str, tmp_dir.glob("*")))}.'
                 'No wheel file is generated.') from None
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -13,6 +13,7 @@ The ray up yaml templates under sky/templates depend on the naming of the wheel.
 import hashlib
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import tempfile
@@ -63,8 +64,17 @@ def _build_sky_wheel():
         tmp_dir = pathlib.Path(tmp_dir)
         (tmp_dir / 'sky').symlink_to(SKY_PACKAGE_PATH, target_is_directory=True)
         setup_files_dir = SKY_PACKAGE_PATH / 'setup_files'
+
+        setup_content = (setup_files_dir / 'setup.py').read_text()
+        # Replace the package name with skypilot. This is important as the
+        # package could be installed with pip install skypilot-nightly.
+        setup_content = re.sub(r'\bname=[\'"](.*?)[\'"],',
+                               f'name=\'{_PACKAGE_WHEEL_NAME}\',',
+                               setup_content)
+        (tmp_dir / 'setup.py').write_text(setup_content)
+
         for f in setup_files_dir.iterdir():
-            if f.is_file():
+            if f.is_file() and f.name != 'setup.py':
                 shutil.copy(str(f), str(tmp_dir))
 
         # It is important to normalize the path, otherwise 'pip wheel' would
@@ -89,6 +99,7 @@ def _build_sky_wheel():
         except StopIteration:
             raise RuntimeError(
                 f'Fail to build pip wheel for SkyPilot under {tmp_dir}. '
+                f'Found: {list(map(str, tmp_dir.glob("*")))}.'
                 'No wheel file is generated.') from None
 
         # Use a unique temporary dir per wheel hash, because there may be many

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -36,8 +36,7 @@ class RayUpLineProcessor(LineProcessor):
 
     def __enter__(self):
         self.state = self.ProvisionStatus.LAUNCH
-        self.status_display = rich_utils.safe_status(
-            '[bold cyan]Launching')
+        self.status_display = rich_utils.safe_status('[bold cyan]Launching')
         self.status_display.start()
 
     def process_line(self, log_line):

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -37,7 +37,7 @@ class RayUpLineProcessor(LineProcessor):
     def __enter__(self):
         self.state = self.ProvisionStatus.LAUNCH
         self.status_display = rich_utils.safe_status(
-            '[bold cyan]Launching - Head node')
+            '[bold cyan]Launching')
         self.status_display.start()
 
     def process_line(self, log_line):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our nightly built is broken for launching cluster, because the built wheel has the name `skypilot_nightly-*.whl` while in our code we rely on the package name to be `skypilot`. This PR fixes the issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `pip install skypilot-nightly`, replace the `wheel_utils.py` with the file in this PR, `sky launch --cpus 2 --cloud aws echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
