### PR TITLE
[Provisioner] Add docker support back

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -124,7 +124,7 @@ _REMOTE_RUNTIME_FILES_DIR = '~/.sky/.runtime_files'
 #   used for calculating the hash.
 # TODO(zhwu): Keep in sync with the fields used in https://github.com/ray-project/ray/blob/e4ce38d001dbbe09cd21c497fedd03d692b2be3e/python/ray/autoscaler/_private/commands.py#L687-L701
 _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
-    'cluster_name', 'provider', 'auth', 'node_config'
+    'cluster_name', 'provider', 'auth', 'node_config', 'docker'
 }
 # For these keys, don't use the old yaml's version and instead use the new yaml's.
 #  - zone: The zone field of the old yaml may be '1a,1b,1c' (AWS) while the actual
@@ -132,11 +132,19 @@ _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
 #    it's possible to failover to 1b, which leaves a leaked instance in 1a. Here,
 #    we use the new yaml's zone field, which is guaranteed to be the existing zone
 #    '1a'.
+# - docker_login_config: The docker_login_config field of the old yaml may be
+#   outdated or wrong. Users may want to fix the login config if a cluster fails
+#   to launch due to the login config.
 # - UserData: The UserData field of the old yaml may be outdated, and we want to
 #   use the new yaml's UserData field, which contains the authorized key setup as
 #   well as the disabling of the auto-update with apt-get.
 _RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS = [
     ('provider', 'availability_zone'),
+    # AWS with new provisioner has docker_login_config in the
+    # docker field, instead of the provider field.
+    ('docker', 'docker_login_config'),
+    # Other clouds
+    ('provider', 'docker_login_config'),
     ('available_node_types', 'ray.head.default', 'node_config', 'UserData'),
     ('available_node_types', 'ray.worker.default', 'node_config', 'UserData'),
 ]

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2877,6 +2877,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                           internal_ips=list(internal_ips),
                                           external_ips=list(external_ips))
                 handle.update_ssh_ports(max_attempts=_FETCH_IP_MAX_ATTEMPTS)
+                handle.docker_user = cluster_metadata.docker_user
 
                 # update launched resources
                 handle.launched_resources = handle.launched_resources.copy(

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -333,10 +333,9 @@ def _post_provision_setup(
 
     ssh_credentials = backend_utils.ssh_credential_from_yaml(cluster_yaml)
 
-    with rich_utils.safe_status('[bold cyan]Preparing SkyPilot '
-                                'runtime[/]') as status:
+    with rich_utils.safe_status(
+            '[bold cyan]Launching - Waiting for SSH access[/]') as status:
 
-        status.update('[bold cyan]Launching - Waiting for SSH access[/]')
         logger.debug(
             f'\nWaiting for SSH to be available for "{cluster_name}" ...')
         wait_for_ssh(cluster_metadata, ssh_credentials)
@@ -345,6 +344,19 @@ def _post_provision_setup(
         logger.info(f'{colorama.Fore.GREEN}Successfully provisioned '
                     f'or found existing instance{plural}.'
                     f'{colorama.Style.RESET_ALL}')
+
+        docker_config = config_from_yaml.get('docker', {})
+        if docker_config:
+            status.update(
+                '[bold cyan]Lauching - Initializing docker container[/]')
+        docker_user = instance_setup.initialize_docker(
+            cluster_name.name_on_cloud,
+            docker_config=docker_config,
+            cluster_metadata=cluster_metadata,
+            ssh_credentials=ssh_credentials)
+        if docker_user is not None:
+            ssh_credentials['docker_user'] = docker_user
+        logger.debug(f'Docker user: {docker_user}')
 
         # We mount the metadata with sky wheel for speedup.
         # NOTE: currently we mount all credentials for all nodes, because

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -386,7 +386,7 @@ def _post_provision_setup(
                 raise RuntimeError(
                     f'Failed to retrieve docker user for {cluster_name!r}. '
                     'Please check your docker configuration.')
-            
+
             cluster_metadata.docker_user = docker_user
             ssh_credentials['docker_user'] = docker_user
             logger.debug(f'Docker user: {docker_user}')

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -171,6 +171,7 @@ def bulk_provision(
     bootstrap_config = provision_comm.InstanceConfig(
         provider_config=original_config['provider'],
         authentication_config=original_config['auth'],
+        docker_config=original_config.get('docker', {}),
         # NOTE: (might be a legacy issue) we call it
         # 'ray_head_default' in 'gcp-ray.yaml'
         node_config=original_config['available_node_types']['ray.head.default']
@@ -355,6 +356,7 @@ def _post_provision_setup(
             cluster_metadata=cluster_metadata,
             ssh_credentials=ssh_credentials)
         if docker_user is not None:
+            cluster_metadata.docker_user = docker_user
             ssh_credentials['docker_user'] = docker_user
         logger.debug(f'Docker user: {docker_user}')
 

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -134,7 +134,7 @@ def _bulk_provision(
         status.update('[bold cyan]Launching - Checking instance statuses[/]')
         # AWS would take a very short time (<<1s) updating the state of the
         # instance.
-        time.sleep(3)
+        time.sleep(1)
         for retry_cnt in range(_MAX_RETRY):
             try:
                 provision.wait_instances(provider_name, region_name,

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -382,9 +382,13 @@ def _post_provision_setup(
                 docker_config=docker_config,
                 cluster_metadata=cluster_metadata,
                 ssh_credentials=ssh_credentials)
-            if docker_user is not None:
-                cluster_metadata.docker_user = docker_user
-                ssh_credentials['docker_user'] = docker_user
+            if docker_user is None:
+                raise RuntimeError(
+                    f'Failed to retrieve docker user for {cluster_name!r}. '
+                    'Please check your docker configuration.')
+            
+            cluster_metadata.docker_user = docker_user
+            ssh_credentials['docker_user'] = docker_user
             logger.debug(f'Docker user: {docker_user}')
 
         # We mount the metadata with sky wheel for speedup.

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -377,15 +377,15 @@ def _post_provision_setup(
         if docker_config:
             status.update(
                 '[bold cyan]Lauching - Initializing docker container[/]')
-        docker_user = instance_setup.initialize_docker(
-            cluster_name.name_on_cloud,
-            docker_config=docker_config,
-            cluster_metadata=cluster_metadata,
-            ssh_credentials=ssh_credentials)
-        if docker_user is not None:
-            cluster_metadata.docker_user = docker_user
-            ssh_credentials['docker_user'] = docker_user
-        logger.debug(f'Docker user: {docker_user}')
+            docker_user = instance_setup.initialize_docker(
+                cluster_name.name_on_cloud,
+                docker_config=docker_config,
+                cluster_metadata=cluster_metadata,
+                ssh_credentials=ssh_credentials)
+            if docker_user is not None:
+                cluster_metadata.docker_user = docker_user
+                ssh_credentials['docker_user'] = docker_user
+            logger.debug(f'Docker user: {docker_user}')
 
         # We mount the metadata with sky wheel for speedup.
         # NOTE: currently we mount all credentials for all nodes, because

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -143,8 +143,9 @@ def _bulk_provision(
                 if retry_cnt == 0:
                     # AWS would take a very short time (<<1s) updating the state
                     # of the instance. Wait 4 seconds should be enough.
-                    logger.debug('Waiting for AWS to update instance state...')
+                    logger.debug('Retry for waiting instance state...')
                     time.sleep(3)
+                    continue
                 raise
             except Exception:  # pylint: disable=broad-except
                 raise

--- a/sky/backends/provision_utils.py
+++ b/sky/backends/provision_utils.py
@@ -142,8 +142,6 @@ def _bulk_provision(
                 break
             except (aws.botocore_exceptions().WaiterError, RuntimeError):
                 time.sleep(backoff.current_backoff())
-            except Exception:  # pylint: disable=broad-except
-                raise
         logger.debug(
             f'Instances of {cluster_name!r} are ready after {retry_cnt} '
             'retries.')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -106,12 +106,7 @@ class AWS(clouds.Cloud):
     @classmethod
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
-        return {
-            clouds.CloudImplementationFeatures.DOCKER_IMAGE: (
-                f'Docker image is not supported in {cls._REPR}. '
-                'You can try running docker command inside the `run` section in task.yaml.'
-            ),
-        }
+        return {}
 
     @classmethod
     def max_cluster_name_length(cls) -> Optional[int]:

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -15,6 +15,7 @@ class InstanceConfig(pydantic.BaseModel):
     """Metadata for instance configuration."""
     provider_config: Dict[str, Any]
     authentication_config: Dict[str, Any]
+    docker_config: Dict[str, Any]
     node_config: Dict[str, Any]
     count: int
     tags: Dict[str, str]
@@ -60,6 +61,7 @@ class ClusterMetadata(pydantic.BaseModel):
     """Metadata from querying a cluster."""
     instances: Dict[str, InstanceMetadata]
     head_instance_id: Optional[str]
+    docker_user: Optional[str]
 
     def ip_tuples(self) -> List[Tuple[str, Optional[str]]]:
         """Get IP tuples of all instances. Make sure that list always

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -1,0 +1,338 @@
+import dataclasses
+import shlex
+import typing
+from typing import Dict, List
+
+from sky import sky_logging
+from sky.skylet import constants
+from sky.utils import subprocess_utils
+
+if typing.TYPE_CHECKING:
+    from sky.utils import command_runner
+
+logger = sky_logging.init_logger(__name__)
+
+
+@dataclasses.dataclass
+class DockerLoginConfig:
+    """Config for docker login. Used for pulling from private registries."""
+    username: str
+    password: str
+    server: str
+
+    @classmethod
+    def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
+        return cls(
+            username=d[constants.DOCKER_USERNAME_ENV_VAR],
+            password=d[constants.DOCKER_PASSWORD_ENV_VAR],
+            server=d[constants.DOCKER_SERVER_ENV_VAR],
+        )
+
+
+# Copied from ray.autoscaler._private.ray_constants
+# The default maximum number of bytes to allocate to the object store unless
+# overridden by the user.
+DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES = 200 * 10**9
+# The default proportion of available memory allocated to the object store
+DEFAULT_OBJECT_STORE_MEMORY_PROPORTION = 0.3
+
+
+def _check_helper(cname, template, docker_cmd):
+    return " ".join([
+        docker_cmd, "inspect", "-f", "'{{" + template + "}}'", cname, "||",
+        "true"
+    ])
+
+
+def check_docker_running_cmd(cname, docker_cmd):
+    return _check_helper(cname, ".State.Running", docker_cmd)
+
+
+def check_bind_mounts_cmd(cname, docker_cmd):
+    return _check_helper(cname, "json .Mounts", docker_cmd)
+
+
+def check_docker_image(cname, docker_cmd):
+    return _check_helper(cname, ".Config.Image", docker_cmd)
+
+
+def docker_start_cmds(
+    image,
+    container_name,
+    user_options,
+    docker_cmd,
+):
+    """Generating docker start command without --rm.
+    
+    The code is borrowed from `ray.autoscaler._private.docker`. The only
+    difference is that we don't use `--rm` flag here.
+    """
+
+    # for click, used in ray cli
+    env_vars = {'LC_ALL': 'C.UTF-8', 'LANG': 'C.UTF-8'}
+    env_flags = ' '.join(
+        ['-e {name}={val}'.format(name=k, val=v) for k, v in env_vars.items()])
+
+    user_options_str = ' '.join(user_options)
+    docker_run = [
+        docker_cmd,
+        'run',
+        # SkyPilot: Remove --rm flag to keep the container after `ray stop`
+        # is executed.
+        '--name {}'.format(container_name),
+        '-d',
+        '-it',
+        env_flags,
+        user_options_str,
+        '--net=host',
+        image,
+        'bash',
+    ]
+    return ' '.join(docker_run)
+
+
+def _with_interactive(cmd):
+    force_interactive = (
+        f"source ~/.bashrc; "
+        f"export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore && ({cmd})")
+    return ["bash", "--login", "-c", "-i", shlex.quote(force_interactive)]
+
+
+# SkyPilot: New class to initialize docker containers on a remote node.
+# Adopted from ray.autoscaler._private.command_runner.DockerCommandRunner.
+class DockerInitializer:
+    """Initializer for docker containers on a remote node."""
+
+    def __init__(self, docker_config: dict,
+                 runner: 'command_runner.SSHCommandRunner', log_path: str):
+        self.docker_config = docker_config
+        self.container_name = docker_config['container_name']
+        self.runner = runner
+        self.home_dir = None
+        self.initialized = False
+        use_podman = docker_config.get('use_podman', False)
+        self.docker_cmd = 'podman' if use_podman else 'docker'
+        self.log_path = log_path
+
+    def _run(self, cmd, run_env='host') -> str:
+        if run_env == 'docker':
+            cmd = self._docker_expand_user(cmd, any_char=True)
+            cmd = ' '.join(_with_interactive(cmd))
+            cmd = f'docker exec {self.container_name} /bin/bash -c {shlex.quote(cmd)} '
+
+        rc, stdout, stderr = self.runner.run(cmd,
+                                             require_outputs=True,
+                                             stream_logs=False,
+                                             log_path=self.log_path)
+        subprocess_utils.handle_returncode(
+            rc,
+            cmd,
+            error_msg='Failed to run docker setup commands',
+            stderr=stdout + stderr)
+        return stdout
+
+    def initialize(self) -> str:
+        specific_image = self.docker_config['image']
+
+        self._check_docker_installed()
+
+        # SkyPilot: Check if the container is exited but not removed.
+        # If true, then we can start the container directly.
+        # Notice that we will skip all setup commands, so we need to
+        # manually start the ssh service.
+        if self._check_container_exited():
+            self.initialized = True
+            self._run(f'docker start {self.container_name}')
+            self._run('sudo service ssh start', run_env='docker')
+            return self._run('whoami', run_env='docker').strip()
+
+        # SkyPilot: Docker login if user specified a private docker registry.
+        if 'docker_login_config' in self.docker_config:
+            # TODO(tian): Maybe support a command to get the login password?
+            docker_login_config: DockerLoginConfig = self.docker_config[
+                'docker_login_config']
+            self._run(
+                f'{self.docker_cmd} login --username {docker_login_config.username} '
+                f'--password {docker_login_config.password} '
+                f'{docker_login_config.server}')
+            specific_image = f'{docker_login_config.server}/{specific_image}'
+
+        if self.docker_config.get('pull_before_run', True):
+            assert specific_image, ('Image must be included in config if ' +
+                                    'pull_before_run is specified')
+            self._run(f'{self.docker_cmd} pull {specific_image}')
+        else:
+            self._run(f'{self.docker_cmd} image inspect {specific_image} '
+                      '1> /dev/null  2>&1 || '
+                      f'{self.docker_cmd} pull {specific_image}')
+
+        logger.info(f'Starting container {self.container_name} with image '
+                    f'{specific_image}')
+        container_running = self._check_container_status()
+        if container_running:
+            running_image = (self._run(
+                check_docker_image(self.container_name,
+                                   self.docker_cmd)).strip())
+            if running_image != specific_image:
+                logger.error(
+                    f'A container with name {self.container_name} is running image '
+                    f'{running_image} instead of {specific_image} (which was provided in the '
+                    'YAML)')
+
+        if (not container_running):
+            user_docker_run_options = self.docker_config.get('run_options', [])
+            start_command = docker_start_cmds(
+                specific_image,
+                self.container_name,
+                self._configure_runtime(
+                    self._auto_configure_shm(user_docker_run_options)),
+                self.docker_cmd,
+            )
+            self._run(start_command)
+
+        # SkyPilot: Setup Commands.
+        # TODO(tian): These setup commands assumed that the container is
+        # debian-based. We should make it more general.
+        # Most of docker images are using root as default user, so we set an
+        # alias for sudo to empty string, therefore any sudo in the following
+        # commands won't fail.
+        # Disable apt-get from asking user input during installation.
+        # see https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai  # pylint: disable=line-too-long
+        self._run(
+            'echo \'[ "$(whoami)" == "root" ] && alias sudo=""\' >> ~/.bashrc;'
+            'echo "export DEBIAN_FRONTEND=noninteractive" >> ~/.bashrc;',
+            run_env='docker')
+        # Install dependencies.
+        self._run(
+            'sudo apt-get update; sudo apt-get install -y rsync curl wget '
+            'patch openssh-server python3-pip;',
+            run_env='docker')
+
+        # Copy local authorized_keys to docker container.
+        # Stop and disable jupyter service. This is to avoid port conflict on
+        # 8080 if we use default deep learning image in GCP, and 8888 if we use
+        # default deep learning image in Azure.
+        # Azure also has a jupyterhub service running on 8081, so we stop and
+        # disable that too.
+        container_name = constants.DEFAULT_DOCKER_CONTAINER_NAME
+        self._run(
+            f'rsync -e "{self.docker_cmd} exec -i" -avz ~/.ssh/authorized_keys '
+            f'{container_name}:/tmp/host_ssh_authorized_keys;'
+            'sudo systemctl stop jupyter > /dev/null 2>&1 || true;'
+            'sudo systemctl disable jupyter > /dev/null 2>&1 || true;'
+            'sudo systemctl stop jupyterhub > /dev/null 2>&1 || true;'
+            'sudo systemctl disable jupyterhub > /dev/null 2>&1 || true;',
+            run_env='host')
+
+        # Change the default port of sshd from 22 to DEFAULT_DOCKER_PORT.
+        # Append the host VM's authorized_keys to the container's authorized_keys.
+        # This allows any machine that can ssh into the host VM to ssh into the
+        # container.
+        # Last command here is to eliminate the error
+        # `mesg: ttyname failed: inappropriate ioctl for device`.
+        # see https://www.educative.io/answers/error-mesg-ttyname-failed-inappropriate-ioctl-for-device  # pylint: disable=line-too-long
+        port = constants.DEFAULT_DOCKER_PORT
+        # pylint: disable=anomalous-backslash-in-string
+        self._run(
+            f'sudo sed -i "s/#Port 22/Port {port}/" /etc/ssh/sshd_config;'
+            'mkdir -p ~/.ssh;'
+            'cat /tmp/host_ssh_authorized_keys >> ~/.ssh/authorized_keys;'
+            'sudo service ssh start;'
+            'sudo sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;',
+            run_env='docker')
+
+        # SkyPilot: End of Setup Commands.
+        docker_user = self._run('whoami', run_env='docker').strip()
+        self.initialized = True
+        return docker_user
+
+    def _check_docker_installed(self):
+        no_exist = "NoExist"
+        cleaned_output = self._run(
+            f"command -v {self.docker_cmd} || echo '{no_exist}'").strip()
+        if no_exist in cleaned_output or "docker" not in cleaned_output:
+            logger.error(
+                f'{self.docker_cmd.capitalize()} not installed. Please use an '
+                'image with Docker installed.')
+
+    def _check_container_status(self):
+        if self.initialized:
+            return True
+        output = (self._run(
+            check_docker_running_cmd(self.container_name,
+                                     self.docker_cmd)).strip())
+        # Checks for the false positive where "true" is in the container name
+        return 'true' in output.lower(
+        ) and 'no such object' not in output.lower()
+
+    def _docker_expand_user(self, string, any_char=False):
+        user_pos = string.find("~")
+        if user_pos > -1:
+            if self.home_dir is None:
+                self.home_dir = (self._run(
+                    f'{self.docker_cmd} exec {self.container_name} '
+                    'printenv HOME',).strip())
+
+            if any_char:
+                return string.replace("~/", self.home_dir + "/")
+
+            elif not any_char and user_pos == 0:
+                return string.replace("~", self.home_dir, 1)
+
+        return string
+
+    def _configure_runtime(self, run_options: List[str]) -> List[str]:
+        if self.docker_config.get("disable_automatic_runtime_detection"):
+            return run_options
+
+        runtime_output = (self._run(f'{self.docker_cmd} ' +
+                                    'info -f \'{{.Runtimes}}\'').strip())
+        if 'nvidia-container-runtime' in runtime_output:
+            try:
+                self._run('nvidia-smi')
+                return run_options + ["--runtime=nvidia"]
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    "Nvidia Container Runtime is present, but no GPUs found.")
+                logger.debug(f"nvidia-smi error: {e}")
+                return run_options
+
+        return run_options
+
+    def _auto_configure_shm(self, run_options: List[str]) -> List[str]:
+        if self.docker_config.get("disable_shm_size_detection"):
+            return run_options
+        for run_opt in run_options:
+            if "--shm-size" in run_opt:
+                logger.info("Bypassing automatic SHM-Detection because of "
+                            f"`run_option`: {run_opt}")
+                return run_options
+        try:
+            shm_output = self._run('cat /proc/meminfo || true').strip()
+            available_memory = int([
+                ln for ln in shm_output.split("\n") if "MemAvailable" in ln
+            ][0].split()[1])
+            available_memory_bytes = available_memory * 1024
+            # Overestimate SHM size by 10%
+            shm_size = min(
+                (available_memory_bytes *
+                 DEFAULT_OBJECT_STORE_MEMORY_PROPORTION * 1.1),
+                DEFAULT_OBJECT_STORE_MAX_MEMORY_BYTES,
+            )
+            return run_options + [f"--shm-size='{shm_size}b'"]
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning(
+                f'Received error while trying to auto-compute SHM size {e}')
+            return run_options
+
+    # SkyPilot: New function to check whether a container is exited
+    # (but not removed). This is due to previous `sky stop` command,
+    # which will stop the container but not remove it.
+    def _check_container_exited(self) -> bool:
+        if self.initialized:
+            return True
+        output = (self._run(
+            check_docker_running_cmd(self.container_name,
+                                     self.docker_cmd)).strip())
+        return 'false' in output.lower(
+        ) and 'no such object' not in output.lower()

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -120,6 +120,7 @@ class DockerInitializer:
             cmd = ' '.join(_with_interactive(cmd))
             cmd = f'docker exec {self.container_name} /bin/bash -c {shlex.quote(cmd)} '
 
+        logger.debug(f'+ {cmd}')
         rc, stdout, stderr = self.runner.run(cmd,
                                              require_outputs=True,
                                              stream_logs=False,

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -25,9 +25,9 @@ class DockerLoginConfig:
     @classmethod
     def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
         return cls(
-            username=d[constants.DOCKER_USERNAME_ENV_VAR],
-            password=d[constants.DOCKER_PASSWORD_ENV_VAR],
-            server=d[constants.DOCKER_SERVER_ENV_VAR],
+            username=d[constants.DOCKER_USERNAME_ENV_VAR].strip(),
+            password=d[constants.DOCKER_PASSWORD_ENV_VAR].strip(),
+            server=d[constants.DOCKER_SERVER_ENV_VAR].strip(),
         )
 
 
@@ -153,8 +153,8 @@ class DockerInitializer:
         # SkyPilot: Docker login if user specified a private docker registry.
         if 'docker_login_config' in self.docker_config:
             # TODO(tian): Maybe support a command to get the login password?
-            docker_login_config: DockerLoginConfig = self.docker_config[
-                'docker_login_config']
+            docker_login_config = DockerLoginConfig(
+                **self.docker_config['docker_login_config'])
             self._run(f'{self.docker_cmd} login --username '
                       f'{docker_login_config.username} '
                       f'--password {docker_login_config.password} '

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -22,17 +22,12 @@ class DockerLoginConfig:
     password: str
     server: str
 
-    def __init__(self, username: str, password: str, server: str):
-        self.username = username.strip()
-        self.password = password.strip()
-        self.server = server.strip()
-
     @classmethod
     def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
         return cls(
-            username=d[constants.DOCKER_USERNAME_ENV_VAR].strip(),
-            password=d[constants.DOCKER_PASSWORD_ENV_VAR].strip(),
-            server=d[constants.DOCKER_SERVER_ENV_VAR].strip(),
+            username=d[constants.DOCKER_USERNAME_ENV_VAR],
+            password=d[constants.DOCKER_PASSWORD_ENV_VAR],
+            server=d[constants.DOCKER_SERVER_ENV_VAR],
         )
 
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -112,6 +112,7 @@ class DockerInitializer:
         self.runner = runner
         self.home_dir = None
         self.initialized = False
+        use_podman = docker_config.get('use_podman', False)
         self.docker_cmd = 'podman' if use_podman else 'docker'
         self.log_path = log_path
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -112,7 +112,6 @@ class DockerInitializer:
         self.runner = runner
         self.home_dir = None
         self.initialized = False
-        use_podman = docker_config.get('use_podman', False)
         self.docker_cmd = 'podman' if use_podman else 'docker'
         self.log_path = log_path
 
@@ -120,7 +119,7 @@ class DockerInitializer:
         if run_env == 'docker':
             cmd = self._docker_expand_user(cmd, any_char=True)
             cmd = ' '.join(_with_interactive(cmd))
-            cmd = (f'docker exec {self.container_name} /bin/bash -c '
+            cmd = (f'{self.docker_cmd} exec {self.container_name} /bin/bash -c '
                    f'{shlex.quote(cmd)} ')
 
         logger.debug(f'+ {cmd}')
@@ -146,7 +145,7 @@ class DockerInitializer:
         # manually start the ssh service.
         if self._check_container_exited():
             self.initialized = True
-            self._run(f'docker start {self.container_name}')
+            self._run(f'{self.docker_cmd} start {self.container_name}')
             self._run('sudo service ssh start', run_env='docker')
             return self._run('whoami', run_env='docker').strip()
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -66,7 +66,7 @@ def docker_start_cmds(
 ):
     """Generating docker start command.
 
-    The code is borrowed from `ray.autoscaler._private.command_runner`. 
+    The code is borrowed from `ray.autoscaler._private.command_runner`.
     We made the following two changes:
       1. Remove `--rm` to keep the container after `ray stop` is executed.
       2. Remove mount options, as all the file mounts will be handled after

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -184,8 +184,7 @@ class DockerInitializer:
         container_running = self._check_container_status()
         if container_running:
             running_image = (self._run(
-                check_docker_image(self.container_name,
-                                   self.docker_cmd)))
+                check_docker_image(self.container_name, self.docker_cmd)))
             if running_image != specific_image:
                 logger.error(
                     f'A container with name {self.container_name} is running '
@@ -271,8 +270,7 @@ class DockerInitializer:
         if self.initialized:
             return True
         output = (self._run(
-            check_docker_running_cmd(self.container_name,
-                                     self.docker_cmd)))
+            check_docker_running_cmd(self.container_name, self.docker_cmd)))
         # Checks for the false positive where 'true' is in the container name
         return 'true' in output.lower(
         ) and 'no such object' not in output.lower()
@@ -346,7 +344,6 @@ class DockerInitializer:
         if self.initialized:
             return True
         output = (self._run(
-            check_docker_running_cmd(self.container_name,
-                                     self.docker_cmd)))
+            check_docker_running_cmd(self.container_name, self.docker_cmd)))
         return 'false' in output.lower(
         ) and 'no such object' not in output.lower()

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -57,6 +57,7 @@ def check_bind_mounts_cmd(cname, docker_cmd):
 def check_docker_image(cname, docker_cmd):
     return _check_helper(cname, '.Config.Image', docker_cmd)
 
+
 def docker_start_cmds(
     image,
     container_name,
@@ -123,9 +124,8 @@ class DockerInitializer:
         if run_env == 'docker':
             cmd = self._docker_expand_user(cmd, any_char=True)
             cmd = ' '.join(_with_interactive(cmd))
-            cmd = (
-                f'{self.docker_cmd} exec {self.container_name} /bin/bash -c'
-                f' {shlex.quote(cmd)} ')
+            cmd = (f'{self.docker_cmd} exec {self.container_name} /bin/bash -c'
+                   f' {shlex.quote(cmd)} ')
 
         logger.debug(f'+ {cmd}')
         rc, stdout, stderr = self.runner.run(cmd,

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -22,6 +22,11 @@ class DockerLoginConfig:
     password: str
     server: str
 
+    def __init__(self, username: str, password: str, server: str):
+        self.username = username.strip()
+        self.password = password.strip()
+        self.server = server.strip()
+
     @classmethod
     def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
         return cls(

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -124,6 +124,10 @@ class DockerInitializer:
         if run_env == 'docker':
             cmd = self._docker_expand_user(cmd, any_char=True)
             cmd = ' '.join(_with_interactive(cmd))
+            # SkyPilot: We do not include `-it` flag here, as that will cause
+            # an error: `the input device is not a TTY`, and it works without
+            # `-it` flag.
+            # TODO(zhwu): ray use the `-it` flag, we need to check why.
             cmd = (f'{self.docker_cmd} exec {self.container_name} /bin/bash -c'
                    f' {shlex.quote(cmd)} ')
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -203,10 +203,11 @@ def start_ray_head_node(cluster_name: str, custom_resource: Optional[str],
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
 
-    cmd = ('ray stop; unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
-           'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
-           'ray start --disable-usage-stats --head '
-           f'{ray_options} || exit 1;' + _RAY_PRLIMIT + _DUMP_RAY_PORTS)
+    cmd = (
+        f'ray stop; unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
+        'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
+        'ray start --disable-usage-stats --head '
+        f'{ray_options} || exit 1;' + _RAY_PRLIMIT + _DUMP_RAY_PORTS)
     logger.info(f'Running command on head node: {cmd}')
     # TODO(zhwu): add the output to log files.
     returncode, stdout, stderr = ssh_runner.run(cmd,

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -71,7 +71,7 @@ def _log_start_end(func):
     def wrapper(*args, **kwargs):
         logger.info(_START_TITLE.format(func.__name__))
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         finally:
             logger.info(_END_TITLE.format(func.__name__))
 
@@ -125,8 +125,10 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
     def _initialize_docker(runner: command_runner.SSHCommandRunner,
                            metadata: common.InstanceMetadata, log_path: str):
         del metadata
-        return docker_utils.DockerInitializer(docker_config, runner,
+        docker_user = docker_utils.DockerInitializer(docker_config, runner,
                                               log_path).initialize()
+        logger.debug(f'Initialized docker user: {docker_user}')
+        return docker_user
 
     docker_users = _parallel_ssh_with_cache(
         _initialize_docker,
@@ -137,6 +139,7 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
         digest=str(time.time()),
         cluster_metadata=cluster_metadata,
         ssh_credentials=ssh_credentials)
+    logger.debug(f'All docker users: {docker_users}')
     return docker_users[0]
 
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -146,6 +146,7 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
         cluster_metadata=cluster_metadata,
         ssh_credentials=ssh_credentials)
     logger.debug(f'All docker users: {docker_users}')
+    assert len(set(docker_users)) == 1, docker_users
     return docker_users[0]
 
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -126,7 +126,7 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
                            metadata: common.InstanceMetadata, log_path: str):
         del metadata
         docker_user = docker_utils.DockerInitializer(docker_config, runner,
-                                              log_path).initialize()
+                                                     log_path).initialize()
         logger.debug(f'Initialized docker user: {docker_user}')
         return docker_user
 
@@ -203,11 +203,10 @@ def start_ray_head_node(cluster_name: str, custom_resource: Optional[str],
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
 
-    cmd = (
-        f'ray stop; unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
-        'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
-        'ray start --disable-usage-stats --head '
-        f'{ray_options} || exit 1;' + _RAY_PRLIMIT + _DUMP_RAY_PORTS)
+    cmd = (f'ray stop; unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
+           'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
+           'ray start --disable-usage-stats --head '
+           f'{ray_options} || exit 1;' + _RAY_PRLIMIT + _DUMP_RAY_PORTS)
     logger.info(f'Running command on head node: {cmd}')
     # TODO(zhwu): add the output to log files.
     returncode, stdout, stderr = ssh_runner.run(cmd,

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -12,8 +12,8 @@ from sky import skypilot_config
 from sky import spot
 from sky.backends import backend_utils
 from sky.clouds import service_catalog
+from sky.provision import docker_utils
 from sky.skylet import constants
-from sky.skylet.providers import command_runner
 from sky.utils import accelerator_registry
 from sky.utils import schemas
 from sky.utils import tpu_utils
@@ -60,7 +60,7 @@ class Resources:
         disk_tier: Optional[Literal['high', 'medium', 'low']] = None,
         ports: Optional[List[Union[int, str]]] = None,
         # Internal use only.
-        _docker_login_config: Optional[command_runner.DockerLoginConfig] = None,
+        _docker_login_config: Optional[docker_utils.DockerLoginConfig] = None,
         _is_image_managed: Optional[bool] = None,
     ):
         """Initialize a Resources object.

--- a/sky/skylet/providers/aws/node_provider.py
+++ b/sky/skylet/providers/aws/node_provider.py
@@ -25,7 +25,7 @@ from sky.skylet.providers.aws.utils import (
     client_cache,
 )
 from sky.skylet.providers.command_runner import SkyDockerCommandRunner
-from sky.skylet.providers.command_runner import DockerLoginConfig
+from sky.provision import docker_utils
 
 from ray.autoscaler._private.command_runner import SSHCommandRunner
 from ray.autoscaler._private.cli_logger import cli_logger, cf
@@ -739,7 +739,7 @@ class AWSNodeProvider(NodeProvider):
         }
         if docker_config and docker_config["container_name"] != "":
             if "docker_login_config" in self.provider_config:
-                docker_config["docker_login_config"] = DockerLoginConfig(
+                docker_config["docker_login_config"] = docker_utils.DockerLoginConfig(
                     **self.provider_config["docker_login_config"]
                 )
             return SkyDockerCommandRunner(docker_config, **common_args)

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -16,7 +16,7 @@ from sky.skylet.providers.azure.config import (
     get_azure_sdk_function,
 )
 from sky.skylet.providers.command_runner import SkyDockerCommandRunner
-from sky.skylet.providers.command_runner import DockerLoginConfig
+from sky.provision import docker_utils
 
 from ray.autoscaler._private.command_runner import SSHCommandRunner
 from ray.autoscaler.node_provider import NodeProvider
@@ -445,7 +445,7 @@ class AzureNodeProvider(NodeProvider):
         }
         if docker_config and docker_config["container_name"] != "":
             if "docker_login_config" in self.provider_config:
-                docker_config["docker_login_config"] = DockerLoginConfig(
+                docker_config["docker_login_config"] = docker_utils.DockerLoginConfig(
                     **self.provider_config["docker_login_config"]
                 )
             return SkyDockerCommandRunner(docker_config, **common_args)

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -1,5 +1,4 @@
 """Sky's DockerCommandRunner."""
-import dataclasses
 import json
 import os
 from typing import Dict

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -9,23 +9,8 @@ from ray.autoscaler._private.command_runner import DockerCommandRunner
 from ray.autoscaler._private.docker import check_docker_running_cmd
 from ray.autoscaler.sdk import get_docker_host_mount_location
 
+from sky.provision import docker_utils
 from sky.skylet import constants
-
-
-@dataclasses.dataclass
-class DockerLoginConfig:
-    """Config for docker login. Used for pulling from private registries."""
-    username: str
-    password: str
-    server: str
-
-    @classmethod
-    def from_env_vars(cls, d: Dict[str, str]) -> 'DockerLoginConfig':
-        return cls(
-            username=d[constants.DOCKER_USERNAME_ENV_VAR],
-            password=d[constants.DOCKER_PASSWORD_ENV_VAR],
-            server=d[constants.DOCKER_SERVER_ENV_VAR],
-        )
 
 
 def docker_start_cmds(
@@ -128,7 +113,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
         # SkyPilot: Docker login if user specified a private docker registry.
         if "docker_login_config" in self.docker_config:
             # TODO(tian): Maybe support a command to get the login password?
-            docker_login_config: DockerLoginConfig = self.docker_config[
+            docker_login_config: docker_utils.DockerLoginConfig = self.docker_config[
                 "docker_login_config"]
             self.run('{} login --username {} --password {} {}'.format(
                 self.docker_cmd,

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -13,7 +13,7 @@ from sky.skylet.providers.gcp.config import (
     get_node_type,
 )
 from sky.skylet.providers.command_runner import SkyDockerCommandRunner
-from sky.skylet.providers.command_runner import DockerLoginConfig
+from sky.provision import docker_utils
 
 from ray.autoscaler._private.command_runner import SSHCommandRunner
 from ray.autoscaler.tags import (
@@ -389,7 +389,7 @@ class GCPNodeProvider(NodeProvider):
         }
         if docker_config and docker_config["container_name"] != "":
             if "docker_login_config" in self.provider_config:
-                docker_config["docker_login_config"] = DockerLoginConfig(
+                docker_config["docker_login_config"] = docker_utils.DockerLoginConfig(
                     **self.provider_config["docker_login_config"]
                 )
             return SkyDockerCommandRunner(docker_config, **common_args)

--- a/sky/task.py
+++ b/sky/task.py
@@ -18,8 +18,8 @@ from sky import sky_logging
 from sky.backends import backend_utils
 from sky.data import data_utils
 from sky.data import storage as storage_lib
+from sky.provision import docker_utils
 from sky.skylet import constants
-from sky.skylet.providers import command_runner
 from sky.utils import common_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
@@ -107,7 +107,7 @@ def _fill_in_env_vars_in_file_mounts(
 def _with_docker_login_config(
     resources_set: Set['resources_lib.Resources'],
     task_envs: Dict[str, str],
-) -> 'resources_lib.Resources':
+) -> Set['resources_lib.Resources']:
     all_keys = {
         constants.DOCKER_USERNAME_ENV_VAR,
         constants.DOCKER_PASSWORD_ENV_VAR,
@@ -121,7 +121,7 @@ def _with_docker_login_config(
             raise ValueError(
                 f'If any of {", ".join(all_keys)} is set, all of them must '
                 f'be set. Missing envs: {all_keys - existing_keys}')
-    docker_login_config = command_runner.DockerLoginConfig.from_env_vars(
+    docker_login_config = docker_utils.DockerLoginConfig.from_env_vars(
         task_envs)
 
     def _add_docker_login_config(resources: 'resources_lib.Resources'):

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -19,12 +19,9 @@ docker:
   # additionalProperties for docker config.
   # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
   docker_login_config:
-    username: |
-      {{docker_login_config.username}}
-    password: |
-      {{docker_login_config.password}}
-    server: |
-      {{docker_login_config.server}}
+    username: "{{docker_login_config.username}}"
+    password: "{{docker_login_config.password}}"
+    server: "{{docker_login_config.server}}"
   {%- endif %}
 {%- endif %}
 

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -14,6 +14,15 @@ docker:
     {%- if custom_resources is not none %}
       --gpus all
     {%- endif %}
+  {%- if docker_login_config is not none %}
+  # We put docker login config in provider section because ray's schema disabled
+  # additionalProperties for docker config.
+  # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
+  docker_login_config:
+    username: {{docker_login_config.username}}
+    password: {{docker_login_config.password}}
+    server: {{docker_login_config.server}}
+  {%- endif %}
 {%- endif %}
 
 provider:
@@ -37,15 +46,6 @@ provider:
 {%- for port in ports %}
     - {{port}}
 {%- endfor %}
-{%- endif %}
-{%- if docker_login_config is not none %}
-  # We put docker login config in provider section because ray's schema disabled
-  # additionalProperties for docker config.
-  # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
-  docker_login_config:
-    username: {{docker_login_config.username}}
-    password: {{docker_login_config.password}}
-    server: {{docker_login_config.server}}
 {%- endif %}
   use_internal_ips: {{use_internal_ips}}
   # Disable launch config check for worker nodes as it can cause resource

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -15,13 +15,13 @@ docker:
       --gpus all
     {%- endif %}
   {%- if docker_login_config is not none %}
-  # We put docker login config in provider section because ray's schema disabled
-  # additionalProperties for docker config.
-  # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
   docker_login_config:
-    username: "{{docker_login_config.username}}"
-    password: "{{docker_login_config.password}}"
-    server: "{{docker_login_config.server}}"
+    username: |-
+      {{docker_login_config.username}}
+    password: |-
+      {{docker_login_config.password}}
+    server: |-
+      {{docker_login_config.server}}
   {%- endif %}
 {%- endif %}
 
@@ -103,7 +103,7 @@ available_node_types:
             shell: /bin/bash
             sudo: ALL=(ALL) NOPASSWD:ALL
             ssh_authorized_keys:
-              - |
+              - |-
                 skypilot:ssh_public_key_content
         write_files:
           - path: /etc/apt/apt.conf.d/20auto-upgrades

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -19,9 +19,12 @@ docker:
   # additionalProperties for docker config.
   # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
   docker_login_config:
-    username: {{docker_login_config.username}}
-    password: {{docker_login_config.password}}
-    server: {{docker_login_config.server}}
+    username: |
+      {{docker_login_config.username}}
+    password: |
+      {{docker_login_config.password}}
+    server: |
+      {{docker_login_config.server}}
   {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-docker --cloud aws --cpus 2 --image-id docker:ubuntu:latest "echo hi; whoami"`
  - [x] `sky launch -c test-docker --cloud aws --cpus 2 --image-id docker:ubuntu:latest "echo hi; whoami"`
  - [x] `sky autostop -i 0 test-docker`
  - [x] `sky autostop -i 0 --down test-docker`
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
