### PR TITLE
[Core] Avoid checking the returncode for ray stop in autostop

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -211,7 +211,12 @@ class AutostopEvent(SkyletEvent):
 
         # Stop the ray autoscaler to avoid scaling up, during
         # stopping/terminating of the cluster.
-        subprocess.run('ray stop', shell=True, check=True)
+        proc = subprocess.run('ray stop', shell=True, check=False)
+        if proc.returncode != 0:
+            operator_str = 'terminate' if autostop_config.down else 'stop'
+            logger.warning('Failed to stop ray autoscaler. Continuing to '
+                           f'{operator_str} the cluster. Please be careful of '
+                           'any possible leaked VMs.')
 
         operation_fn = provision_lib.stop_instances
         if autostop_config.down:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This avoids the `ray stop` failure to interrupt the autostop process. It is to avoid the case where the user launched their own ray cluster in a different linux user and cause permission denied for the termination.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
