### PR TITLE
Remove version upper bound on `pyyaml`

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -110,7 +110,7 @@ install_requires = [
     # https://github.com/ray-project/ray/issues/35661
     'pydantic <2.0, >=1.10.8',
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
-    'pyyaml > 3.13'
+    'pyyaml > 3.13, != 5.4.*'
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -109,6 +109,7 @@ install_requires = [
     # >=1.10.8 is needed for ray>=2.6. See
     # https://github.com/ray-project/ray/issues/35661
     'pydantic <2.0, >=1.10.8',
+    # Cython 3.0 release breaks PyYAML 5.4.* (https://github.com/yaml/pyyaml/issues/601)
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
     'pyyaml > 3.13, != 5.4.*'
 ]

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -109,11 +109,8 @@ install_requires = [
     # >=1.10.8 is needed for ray>=2.6. See
     # https://github.com/ray-project/ray/issues/35661
     'pydantic <2.0, >=1.10.8',
-    # Cython 3.0 release breaks PyYAML installed by aws-cli.
-    # https://github.com/yaml/pyyaml/issues/601
-    # https://github.com/aws/aws-cli/issues/8036
     # <= 3.13 may encounter https://github.com/ultralytics/yolov5/issues/414
-    'pyyaml > 3.13, <= 5.3.1'
+    'pyyaml > 3.13'
 ]
 
 # NOTE: Change the templates/spot-controller.yaml.j2 file if any of the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR removes the upper bound on `pyyaml`, thus allowing installation of PyYAML 6 and resolving the issues outlined in #2285. This is a blocking issue in order to use the GCP DeepLearning VM images (e.g. `projects/deeplearning-platform-release/global/images/pytorch-1-13-cpu-v20230807-debian-11-py310`), which come with PyYAML 6 already installed.


<!-- Describe the tests ran -->
I manually patched my environment and was able to spin up a GCP VM and successfully run functions using runhouse.

I apologize but I don't have the required cloud accounts need to run the smoke-tests described below.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
