### PR TITLE
Fix duplicated SSH rules error for AWS & GCP

### DIFF
--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -2,7 +2,6 @@ import copy
 import itertools
 import json
 import logging
-import re
 import os
 import time
 from distutils.version import StrictVersion
@@ -39,8 +38,7 @@ DEFAULT_SKYPILOT_IAM_ROLE = SKYPILOT + "-v1"
 
 _DUPLICATED_INBOUND_RULES_MSG = (
     "An error occurred (InvalidParameterValue) when calling the AuthorizeSecurityGroupIngress "
-    "operation: The same permission must not appear multiple times"
-)
+    "operation: The same permission must not appear multiple times")
 
 # V61.0 has CUDA 11.2
 DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -38,7 +38,8 @@ DEFAULT_SKYPILOT_IAM_ROLE = SKYPILOT + "-v1"
 
 _DUPLICATED_INBOUND_RULES_MSG = (
     "An error occurred (InvalidParameterValue) when calling the AuthorizeSecurityGroupIngress "
-    "operation: The same permission must not appear multiple times")
+    "operation: The same permission must not appear multiple times"
+)
 
 # V61.0 has CUDA 11.2
 DEFAULT_AMI_NAME = "AWS Deep Learning AMI (Ubuntu 18.04) V61.0"

--- a/sky/skylet/providers/aws/config.py
+++ b/sky/skylet/providers/aws/config.py
@@ -1012,8 +1012,6 @@ def _update_inbound_rules(target_security_group, sgids, config):
     ip_permissions = _create_default_inbound_rules(
         sgids, user_specified_rules, extended_rules
     )
-    failed_rules = []
-    errs = []
     for ip_permission in ip_permissions:
         try:
             target_security_group.authorize_ingress(IpPermissions=[ip_permission])
@@ -1025,13 +1023,12 @@ def _update_inbound_rules(target_security_group, sgids, config):
                     "Skipping ingress rule update."
                 )
             else:
-                failed_rules.append(ip_permission)
-                errs.append(e)
-    if failed_rules:
-        raise RuntimeError(
-            f"Failed to update security group {target_security_group.group_name} "
-            f"with inbound rules: {failed_rules}. Errors: {errs}"
-        )
+                handle_boto_error(
+                    e,
+                    "Failed to update ingress rules for security group {}.",
+                    cf.bold(target_security_group.group_name),
+                )
+                raise e
 
 
 def _create_default_inbound_rules(sgids, user_specified_rules, extended_rules=None):

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -807,6 +807,9 @@ def get_usable_vpc(config):
     ports = config["provider"].get("ports", [])
     user_rules = []
     for port in ports:
+        if port == 22:
+            # Not creating a duplicate rule for port 22
+            continue
         cluster_name = config["cluster_name"]
         name = f"user-ports-{cluster_name}-{port}"
         user_rules.append(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a problem when user manually specified 22 in `ports` section, it will raise an error indicating duplicated rules.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
