### PR TITLE
[Provisioner] Accept single port argument

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -58,7 +58,7 @@ class Resources:
         image_id: Union[Dict[str, str], str, None] = None,
         disk_size: Optional[int] = None,
         disk_tier: Optional[Literal['high', 'medium', 'low']] = None,
-        ports: Optional[List[Union[int, str]]] = None,
+        ports: Optional[Union[int, str, List[Union[int, str]]]] = None,
         # Internal use only.
         _docker_login_config: Optional[command_runner.DockerLoginConfig] = None,
         _is_image_managed: Optional[bool] = None,
@@ -168,6 +168,9 @@ class Resources:
         self._is_image_managed = _is_image_managed
 
         self._disk_tier = disk_tier
+        if ports is not None:
+            if not isinstance(ports, list):
+                ports = [ports]
         self._ports = ports
         self._docker_login_config = _docker_login_config
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -68,14 +68,20 @@ def get_resources_schema():
                 'type': 'string',
             },
             'ports': {
-                'type': 'array',
-                'items': {
-                    'anyOf': [{
-                        'type': 'string',
-                    }, {
-                        'type': 'integer',
-                    }]
-                }
+                'anyOf': [{
+                    'type': 'string',
+                }, {
+                    'type': 'number',
+                }, {
+                    'type': 'array',
+                    'items': {
+                        'anyOf': [{
+                            'type': 'string',
+                        }, {
+                            'type': 'integer',
+                        }]
+                    }
+                }],
             },
             'accelerator_args': {
                 'type': 'object',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, `ports` section was limited to a list of ports/ranges, which is hard to type in the yaml config. This PR introduces the following format:

```yaml
# port.yaml
resources:
  cloud: gcp
  ports: 10022
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `sky launch port.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
