### PR TITLE
Implement get_current_user_identity for Kubernetes cloud

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -1,5 +1,4 @@
 """Kubernetes."""
-import hashlib
 import json
 import os
 import typing
@@ -408,9 +407,6 @@ class Kubernetes(clouds.Cloud):
 
             user = current_context['context']['user']
             cluster = current_context['context']['cluster']
-            return [
-                hashlib.md5(
-                    f'{cluster}_{user}_{namespace}'.encode()).hexdigest()
-            ]
+            return [f'{cluster}_{user}_{namespace}']
         except k8s.config.config_exception.ConfigException:
             return None

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -410,7 +410,7 @@ class Kubernetes(clouds.Cloud):
             cluster = current_context['context']['cluster']
             return [
                 hashlib.md5(
-                    f"{cluster}_{user}_{namespace}".encode()).hexdigest()
+                    f'{cluster}_{user}_{namespace}'.encode()).hexdigest()
             ]
         except k8s.config.config_exception.ConfigException:
             return None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Solves https://github.com/skypilot-org/skypilot/issues/2397. The user identity is currently a md5 hash of `{cluster}_{user}_{namespace}`. Open to other suggestions.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
