### PR TITLE
[CI] Fix poetry test for master branch

### DIFF
--- a/.github/workflows/test-poetry-build.yml
+++ b/.github/workflows/test-poetry-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Create foo package
         run: |
           mkdir foo
-          MASTER_REPO_URL = ${{ github.server_url }}/${{ github.repository.html_url }}
+          MASTER_REPO_URL = ${{ github.server_url }}/${{ github.repository }}
           REPO_URL = ${{ github.event.pull_request.head.repo.html_url }}
           if [ -z "$REPO_URL" ]; then
             # This is a push, not a PR, so use the repo URL

--- a/.github/workflows/test-poetry-build.yml
+++ b/.github/workflows/test-poetry-build.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Create foo package
         run: |
           mkdir foo
-          MASTER_REPO_URL = ${{ github.server_url }}/${{ github.repository }}
-          REPO_URL = ${{ github.event.pull_request.head.repo.html_url }}
+          MASTER_REPO_URL=${{ github.server_url }}/${{ github.repository }}
+          REPO_URL=${{ github.event.pull_request.head.repo.html_url }}
           if [ -z "$REPO_URL" ]; then
             # This is a push, not a PR, so use the repo URL
-            REPO_URL = $MASTER_REPO_URL
+            REPO_URL=$MASTER_REPO_URL
           fi
           echo Master repo URL: $MASTER_REPO_URL
           echo Using repo URL: $REPO_URL

--- a/.github/workflows/test-poetry-build.yml
+++ b/.github/workflows/test-poetry-build.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Create foo package
         run: |
           mkdir foo
+          REPO_URL = ${{ github.event.pull_request.head.repo.html_url }}
+          if [ -z "$REPO_URL" ]; then
+            # This is a push, not a PR, so use the repo URL
+            REPO_URL = ${{ github.server_url }}/${{ github.repository.html_url }}
+          fi
           cat <<EOF > foo/pyproject.toml
           [tool.poetry]
           name = "foo"

--- a/.github/workflows/test-poetry-build.yml
+++ b/.github/workflows/test-poetry-build.yml
@@ -25,11 +25,14 @@ jobs:
       - name: Create foo package
         run: |
           mkdir foo
+          MASTER_REPO_URL = ${{ github.server_url }}/${{ github.repository.html_url }}
           REPO_URL = ${{ github.event.pull_request.head.repo.html_url }}
           if [ -z "$REPO_URL" ]; then
             # This is a push, not a PR, so use the repo URL
-            REPO_URL = ${{ github.server_url }}/${{ github.repository.html_url }}
+            REPO_URL = $MASTER_REPO_URL
           fi
+          echo Master repo URL: $MASTER_REPO_URL
+          echo Using repo URL: $REPO_URL
           cat <<EOF > foo/pyproject.toml
           [tool.poetry]
           name = "foo"
@@ -41,7 +44,7 @@ jobs:
           python = "3.10.x"
 
           [tool.poetry.group.dev.dependencies]
-          skypilot = {git = "${{ github.event.pull_request.head.repo.html_url }}.git", branch = "${{ github.head_ref }}"}
+          skypilot = {git = "${REPO_URL}.git", branch = "${{ github.head_ref }}"}
 
           [build-system]
           requires = ["poetry-core"]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This fixes an issue triggered by #2537, where `$github.event.pull_request.head.repo.html_url` does not exist for the master branch.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
