### PR TITLE
[Core] Fix type of `job_id` when querying job status

### DIFF
--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -317,8 +317,8 @@ def _update_benchmark_result(benchmark_result: Dict[str, Any]) -> Optional[str]:
             # NOTE: The id of the benchmarking job must be 1.
             # TODO(woosuk): Handle exceptions.
             job_status = backend.get_job_status(handle,
-                                                job_ids=['1'],
-                                                stream_logs=False)['1']
+                                                job_ids=[1],
+                                                stream_logs=False)[1]
 
     # Update the benchmark status.
     if (cluster_status == status_lib.ClusterStatus.INIT or

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1997,6 +1997,8 @@ def logs(
     if status:
         job_statuses = core.job_status(cluster, job_ids)
         job_id = list(job_statuses.keys())[0]
+        # If job_ids is None and no job has been submitted to the cluster,
+        # it will return {None: None}.
         if job_id is None:
             click.secho(f'No job found on cluster {cluster!r}.', fg='red')
             sys.exit(1)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1947,12 +1947,12 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
                 required=True,
                 type=str,
                 **_get_shell_complete_args(_complete_cluster_name))
-@click.argument('job_ids', type=str, nargs=-1)
+@click.argument('job_ids', type=int, nargs=-1)
 # TODO(zhwu): support logs by job name
 @usage_lib.entrypoint
 def logs(
     cluster: str,
-    job_ids: Tuple[str],
+    job_ids: Tuple[int],
     sync_down: bool,
     status: bool,  # pylint: disable=redefined-outer-name
     follow: bool,
@@ -1979,8 +1979,9 @@ def logs(
             '(ambiguous). To fix: specify at most one of them.')
 
     if len(job_ids) > 1 and not sync_down:
+        job_ids_str = ', '.join([str(id) for id in job_ids])
         raise click.UsageError(
-            f'Cannot stream logs of multiple jobs (IDs: {", ".join(job_ids)}).'
+            f'Cannot stream logs of multiple jobs (IDs: {job_ids_str}).'
             '\nPass -s/--sync-down to download the logs instead.')
 
     job_ids = None if not job_ids else job_ids
@@ -1993,12 +1994,12 @@ def logs(
     job_id = None
     if job_ids:
         job_id = job_ids[0]
-        if not job_id.isdigit():
-            raise click.UsageError(f'Invalid job ID {job_id}. '
-                                   'Job ID must be integers.')
     if status:
         job_statuses = core.job_status(cluster, job_ids)
         job_id = list(job_statuses.keys())[0]
+        if job_id is None:
+            click.secho(f'No job found on cluster {cluster!r}.', fg='red')
+            sys.exit(1)
         job_status = list(job_statuses.values())[0]
         job_status_str = job_status.value if job_status is not None else 'None'
         click.echo(f'Job {job_id}: {job_status_str}')

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -375,6 +375,8 @@ def load_statuses_payload(
         # become string representations of integers, e.g. "1" instead of 1;
         # For None, it will become "null" instead of None. Here we use
         # json.loads to convert them back to their original values.
+        # For possible case for original_statuses, see doc string of
+        # core.py::job_status.
         statuses[json.loads(job_id)] = (JobStatus(status)
                                         if status is not None else None)
     return statuses

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -368,10 +368,15 @@ def get_statuses_payload(job_ids: List[Optional[int]]) -> str:
 
 def load_statuses_payload(
         statuses_payload: str) -> Dict[Optional[int], Optional[JobStatus]]:
-    statuses = common_utils.decode_payload(statuses_payload)
-    for job_id, status in statuses.items():
-        if status is not None:
-            statuses[job_id] = JobStatus(status)
+    original_statuses = common_utils.decode_payload(statuses_payload)
+    statuses = dict()
+    for job_id, status in original_statuses.items():
+        # json.dumps will convert all keys to strings. For integers, they will
+        # become string representations of integers, e.g. "1" instead of 1;
+        # For None, it will become "null" instead of None. Here we use
+        # json.loads to convert them back to their original values.
+        statuses[json.loads(job_id)] = (JobStatus(status)
+                                        if status is not None else None)
     return statuses
 
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -371,12 +371,11 @@ def load_statuses_payload(
     original_statuses = common_utils.decode_payload(statuses_payload)
     statuses = dict()
     for job_id, status in original_statuses.items():
-        # json.dumps will convert all keys to strings. For integers, they will
+        # json.dumps will convert all keys to strings. Integers will
         # become string representations of integers, e.g. "1" instead of 1;
-        # For None, it will become "null" instead of None. Here we use
+        # `None` will become "null" instead of None. Here we use
         # json.loads to convert them back to their original values.
-        # For possible case for original_statuses, see doc string of
-        # core.py::job_status.
+        # See docstr of core::job_status for the meaning of `statuses`.
         statuses[json.loads(job_id)] = (JobStatus(status)
                                         if status is not None else None)
     return statuses

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -414,11 +414,11 @@ def tail_logs(job_owner: str,
         follow: Whether to follow the logs or print the logs so far and exit.
     """
     if job_id is None:
-        # This is only happened when job_lib.get_latest_job_id() returns None,
-        # which means no job has been submitted on this cluster. See
+        # This only happens when job_lib.get_latest_job_id() returns None,
+        # which means no job has been submitted to this cluster. See
         # sky.skylet.job_lib.JobLibCodeGen.tail_logs for more details.
         logger.info(
-            'Skip streaming logs as no job has been submitted on this cluster.')
+            'Skip streaming logs as no job has been submitted.')
         return
     job_str = f'job {job_id}'
     if spot_job_id is not None:

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -400,7 +400,7 @@ def _follow_job_logs(file,
 
 
 def tail_logs(job_owner: str,
-              job_id: int,
+              job_id: Optional[int],
               log_dir: Optional[str],
               spot_job_id: Optional[int] = None,
               follow: bool = True) -> None:
@@ -413,6 +413,12 @@ def tail_logs(job_owner: str,
         spot_job_id: The spot job id (for logging info only to avoid confusion).
         follow: Whether to follow the logs or print the logs so far and exit.
     """
+    if job_id is None:
+        # This is only happened when job_lib.get_latest_job_id() returns None,
+        # which means no job has been submitted on this cluster. See
+        # sky.skylet.job_lib.JobLibCodeGen.tail_logs for more details.
+        print('No job has been submitted on this cluster.', file=sys.stderr)
+        return
     job_str = f'job {job_id}'
     if spot_job_id is not None:
         job_str = f'spot job {spot_job_id}'

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -417,7 +417,8 @@ def tail_logs(job_owner: str,
         # This is only happened when job_lib.get_latest_job_id() returns None,
         # which means no job has been submitted on this cluster. See
         # sky.skylet.job_lib.JobLibCodeGen.tail_logs for more details.
-        print('No job has been submitted on this cluster.', file=sys.stderr)
+        logger.info(
+            'Skip streaming logs as no job has been submitted on this cluster.')
         return
     job_str = f'job {job_id}'
     if spot_job_id is not None:

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -417,8 +417,7 @@ def tail_logs(job_owner: str,
         # This only happens when job_lib.get_latest_job_id() returns None,
         # which means no job has been submitted to this cluster. See
         # sky.skylet.job_lib.JobLibCodeGen.tail_logs for more details.
-        logger.info(
-            'Skip streaming logs as no job has been submitted.')
+        logger.info('Skip streaming logs as no job has been submitted.')
         return
     job_str = f'job {job_id}'
     if spot_job_id is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, our `common_utils.encode_payload` used `json.dumps` to handle a dictionary with integer and `None` type as key, which will not be restored as the original type in default `json.loads` implementation; also, our click treat `job_id` as string, causing a lot of problems. This PR fixes these problems.

```bash
$ sky logs --status g 1
Getting job status...
{'1': None, 1: 'SUCCEEDED'}
<sky-payload>{"1": null, "1": "SUCCEEDED"}</sky-payload>

{'1': <JobStatus.SUCCEEDED: 'SUCCEEDED'>}
Job 1: SUCCEEDED
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
     - `sky logs --status cluster-with-no-job-submitted`
     - `sky logs --status cluster-with-job`
```python
>>> import sky
>>> sky.core.job_status('cluster-with-no-job-submitted', None)
Getting job status...
{None: None}
>>> sky.core.job_status('cluster-with-job', None)
Getting job status...
{1: <JobStatus.SUCCEEDED: 'SUCCEEDED'>}
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
