### PR TITLE
[Provisioner] Fix docker gcs mount and re-launch

### DIFF
--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -233,13 +233,10 @@ class SkyDockerCommandRunner(DockerCommandRunner):
         self.run(
             'sudo apt-get update; '
             # Our mount script will install gcsfuse without fuse package.
-            # So if we `sky launch` on an existing cluster, we need to
-            # install fuse package first to get rid of apt-get error.
-            # Here we use --fix-broken to fix the dependency. The dpkg
-            # option is to suppress the prompt for fuse installation.
-            'sudo apt-get -o DPkg::Options::="--force-confnew" --fix-broken '
-            'install -y; sudo apt-get install -y rsync curl wget patch '
-            'openssh-server python3-pip;')
+            # We need to install fuse package first to enable storage mount.
+            # The dpkg option is to suppress the prompt for fuse installation.
+            'sudo apt-get -o DPkg::Options::="--force-confnew" install '
+            '-y rsync curl wget patch openssh-server python3-pip fuse;')
 
         # Copy local authorized_keys to docker container.
         # Stop and disable jupyter service. This is to avoid port conflict on

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -230,8 +230,16 @@ class SkyDockerCommandRunner(DockerCommandRunner):
             'echo \'[ "$(whoami)" == "root" ] && alias sudo=""\' >> ~/.bashrc;'
             'echo "export DEBIAN_FRONTEND=noninteractive" >> ~/.bashrc;')
         # Install dependencies.
-        self.run('sudo apt-get update; sudo apt-get install -y rsync curl wget '
-                 'patch openssh-server python3-pip;')
+        self.run(
+            'sudo apt-get update; '
+            # Our mount script will install gcsfuse without fuse package.
+            # So if we `sky launch` on an existing cluster, we need to
+            # install fuse package first to get rid of apt-get error.
+            # Here we use --fix-broken to fix the dependency. The dpkg
+            # option is to suppress the prompt for fuse installation.
+            'sudo apt-get -o DPkg::Options::="--force-confnew" --fix-broken '
+            'install -y; sudo apt-get install -y rsync curl wget patch '
+            'openssh-server python3-pip;')
 
         # Copy local authorized_keys to docker container.
         # Stop and disable jupyter service. This is to avoid port conflict on

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -52,7 +52,7 @@ def docker_start_cmds(
 
     Changes we made:
         1. Remove --rm flag to keep the container after `ray stop` is executed;
-        2. Add --privileged and --device=/dev/fuse to enable fuse.
+        2. Add options to enable fuse.
     """
     del user  # unused
 
@@ -83,9 +83,10 @@ def docker_start_cmds(
         env_flags,
         user_options_str,
         '--net=host',
-        # SkyPilot: Add --privileged and --device=/dev/fuse to enable fuse.
-        '--privileged',
+        # SkyPilot: Add following options to enable fuse.
+        '--cap-add=SYS_ADMIN',
         '--device=/dev/fuse',
+        '--security-opt=apparmor:unconfined',
         image,
         'bash',
     ]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes two problems:
* fix mount mode for docker;
* fix the problem that re-launch an existing cluster with docker will run setup commands twice (thus introduce some random error, also redundant information in `~/.bashrc`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - Launch following yaml and manually check;
```yaml
resources:
  cloud: gcp
  image_id: docker:ubuntu:latest

file_mounts:
  /data:
    name: <bucket-name>
    mode: MOUNT
    store: gcs
```
     - `sky launch --image-id docker:ubuntu -c doc` and `sky launch --image-id docker:ubuntu -c doc` and manually check;
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
