### PR TITLE
[Spot] Support both managed on-demand and spot instances

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -65,7 +65,7 @@ Available fields:
       use_spot: False
 
       # Launch a managed on-demand job.
-      use_managed_demand: False
+      managed: 'ON_DEMAND'
 
       # The recovery strategy for spot jobs (optional).
       # `use_spot` must be True for this to have any effect. For now, only

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -64,6 +64,9 @@ Available fields:
       # If unspecified, defaults to False (on-demand instances).
       use_spot: False
 
+      # Launch a managed on-demand job.
+      use_managed_demand: False
+
       # The recovery strategy for spot jobs (optional).
       # `use_spot` must be True for this to have any effect. For now, only
       # `FAILOVER` strategy is supported.

--- a/examples/spot_demand_scheduling.yaml
+++ b/examples/spot_demand_scheduling.yaml
@@ -2,8 +2,7 @@ name: spot-demand-scheduling
 
 resources:
   cloud: gcp
-  use_spot: False
-  use_managed_demand: True
+  managed: ON_DEMAND
 
 run: |
   echo "Hello World!"

--- a/examples/spot_demand_scheduling.yaml
+++ b/examples/spot_demand_scheduling.yaml
@@ -2,7 +2,7 @@ name: spot-demand-scheduling
 
 resources:
   cloud: gcp
-  use_spot: True
+  use_spot: False
   use_managed_demand: True
 
 run: |

--- a/examples/spot_demand_scheduling.yaml
+++ b/examples/spot_demand_scheduling.yaml
@@ -2,7 +2,7 @@ name: spot-demand-scheduling
 
 resources:
   cloud: gcp
-  # use_spot: True
+  use_spot: True
   use_managed_demand: True
 
 run: |

--- a/examples/spot_demand_scheduling.yaml
+++ b/examples/spot_demand_scheduling.yaml
@@ -2,7 +2,7 @@ name: spot-demand-scheduling
 
 resources:
   cloud: gcp
-  use_spot: False
+  # use_spot: True
   use_managed_demand: True
 
 run: |

--- a/examples/spot_demand_scheduling.yaml
+++ b/examples/spot_demand_scheduling.yaml
@@ -1,0 +1,10 @@
+name: spot-demand-scheduling
+
+resources:
+  cloud: gcp
+  use_spot: False
+  use_managed_demand: True
+
+run: |
+  echo "Hello World!"
+  sleep 600

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3619,6 +3619,11 @@ def spot_launch(
     else:
         dag = task_or_dag
 
+    if not use_spot and not use_managed_demand:
+        click.secho(
+            'Both use_spot and use_managed_demand are False or not specified')
+        sys.exit(1)
+
     if name is not None:
         dag.name = name
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3553,6 +3553,7 @@ def spot_launch(
     instance_type: Optional[str],
     num_nodes: Optional[int],
     use_spot: Optional[bool],
+    use_managed_demand: Optional[bool],
     image_id: Optional[str],
     spot_recovery: Optional[str],
     env_file: Optional[Dict[str, str]],

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -993,7 +993,7 @@ def _fill_in_launchable_resources(
         List[resources_lib.Resources])
     if blocked_resources is None:
         blocked_resources = []
-    for resources in task.get_resources():
+    for resources in task.get_resources_both_spot_and_demand():
         if resources.cloud is not None and not _cloud_in_list(
                 resources.cloud, enabled_clouds):
             if try_fix_with_sky_check:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -678,10 +678,6 @@ class Resources:
                 raise ValueError(
                     'Cannot specify spot_recovery without use_spot set to True.'
                 )
-        if self._use_spot and self._use_managed_demand:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cannot specify both use_spot and use_managed_demand')
         if self._spot_recovery not in spot.SPOT_STRATEGIES:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -533,6 +533,14 @@ class Resources:
         self._region, self._zone = self._cloud.validate_region_zone(
             region, zone)
 
+    def switch_from_spot_to_on_demand(self):
+        self._use_managed_demand = True
+        self._use_spot = False
+
+    def switch_from_on_demand_to_spot(self):
+        self._use_managed_demand = False
+        self._use_spot = True
+
     def get_valid_regions_for_launchable(self) -> List[clouds.Region]:
         """Returns a set of `Region`s that can provision this Resources.
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -533,14 +533,6 @@ class Resources:
         self._region, self._zone = self._cloud.validate_region_zone(
             region, zone)
 
-    def switch_from_spot_to_on_demand(self):
-        self._use_managed_demand = True
-        self._use_spot = False
-
-    def switch_from_on_demand_to_spot(self):
-        self._use_managed_demand = False
-        self._use_spot = True
-
     def get_valid_regions_for_launchable(self) -> List[clouds.Region]:
         """Returns a set of `Region`s that can provision this Resources.
 
@@ -1109,9 +1101,22 @@ class Resources:
                 config.pop('accelerator_args'))
         if config.get('use_spot') is not None:
             resources_fields['use_spot'] = config.pop('use_spot')
-        if config.get('use_managed_demand') is not None:
-            resources_fields['use_managed_demand'] = config.pop(
-                'use_managed_demand')
+        if config.get('managed') is not None:
+            managed_str = config.pop('managed')
+            if managed_str == 'SPOT':
+                resources_fields['use_spot'] = True
+                resources_fields['use_managed_demand'] = False
+            elif managed_str == 'ON_DEMAND':
+                resources_fields['use_spot'] = False
+                resources_fields['use_managed_demand'] = True
+            elif managed_str == 'CONSIDER_BOTH':
+                resources_fields['use_spot'] = True
+                resources_fields['use_managed_demand'] = True
+            else:
+                raise ValueError(
+                    f'Invalid value {managed_str} for managed. '
+                    'Please use one of "SPOT", "ON_DEMAND", or "CONSIDER_BOTH".'
+                )
         if config.get('spot_recovery') is not None:
             resources_fields['spot_recovery'] = config.pop('spot_recovery')
         if config.get('disk_size') is not None:

--- a/sky/task.py
+++ b/sky/task.py
@@ -576,6 +576,18 @@ class Task:
     def get_resources(self):
         return self.resources
 
+    def get_resources_both_spot_and_demand(self):
+
+        return_resoruces = set()
+        for r in self.resources:
+            if r.use_managed_demand is True:
+                return_resoruces.add(
+                    r.copy(use_spot=False, use_managed_demand=True))
+            if r.use_spot is True:
+                return_resoruces.add(
+                    r.copy(use_spot=True, use_managed_demand=False))
+        return return_resoruces
+
     def set_time_estimator(self, func: Callable[['sky.Resources'],
                                                 int]) -> 'Task':
         """Sets a func mapping resources to estimated time (secs).

--- a/sky/task.py
+++ b/sky/task.py
@@ -580,12 +580,14 @@ class Task:
 
         return_resoruces = set()
         for r in self.resources:
-            if r.use_managed_demand is True:
+            if r.use_managed_demand:
                 return_resoruces.add(
                     r.copy(use_spot=False, use_managed_demand=True))
-            if r.use_spot is True:
+            if r.use_spot:
                 return_resoruces.add(
                     r.copy(use_spot=True, use_managed_demand=False))
+            if not r.use_managed_demand and not r.use_spot:
+                return_resoruces.add(r.copy())
         return return_resoruces
 
     def set_time_estimator(self, func: Callable[['sky.Resources'],

--- a/sky/task.py
+++ b/sky/task.py
@@ -504,14 +504,6 @@ class Task:
     def use_spot(self) -> bool:
         return any(r.use_spot for r in self.resources)
 
-    def switch_from_spot_to_on_demand(self):
-        for r in self.resources:
-            r.switch_from_spot_to_on_demand()
-
-    def switch_from_on_demand_to_spot(self):
-        for r in self.resources:
-            r.switch_from_on_demand_to_spot()
-
     def set_inputs(self, inputs: str,
                    estimated_size_gigabytes: float) -> 'Task':
         # E.g., 's3://bucket', 'gs://bucket', or None.

--- a/sky/task.py
+++ b/sky/task.py
@@ -504,6 +504,14 @@ class Task:
     def use_spot(self) -> bool:
         return any(r.use_spot for r in self.resources)
 
+    def switch_from_spot_to_on_demand(self):
+        for r in self.resources:
+            r.switch_from_spot_to_on_demand()
+
+    def switch_from_on_demand_to_spot(self):
+        for r in self.resources:
+            r.switch_from_on_demand_to_spot()
+
     def set_inputs(self, inputs: str,
                    estimated_size_gigabytes: float) -> 'Task':
         # E.g., 's3://bucket', 'gs://bucket', or None.

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -58,8 +58,8 @@ def get_resources_schema():
             'use_spot': {
                 'type': 'boolean',
             },
-            'use_managed_demand': {
-                'type': 'boolean',
+            'managed': {
+                'type': 'string',
             },
             'spot_recovery': {
                 'type': 'string',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -58,6 +58,9 @@ def get_resources_schema():
             'use_spot': {
                 'type': 'boolean',
             },
+            'use_managed_demand': {
+                'type': 'boolean',
+            },
             'spot_recovery': {
                 'type': 'string',
             },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

From discussion with @Michaelvll 
- Allow serverless style job submission for on-demand jobs.
   - Conceptually, the API contains two kinds of jobs, serverful (launch, exec, start, stop), and serverless (spot launch). 
   - However, the serverless API is only spot oriented. It could be better to have on-demand support as well, and rename the spot launch to something like serverless launch.
   - This will benefit the TPU users, as the on-demand TPUs can still have quite frequent restart due to stability issue. 
   - Small cloud users may benefit from this as well, for improved reliability
- Design a way to select from both on-demand and spot instances.
   - Smaller cloud have quite cheap on-demand with similar price points as spot
   - Good for optimizer to choose among both on-demand instances and spot.

Possibly replace `use_spot: True` with
```
managed: SPOT
# managed: ON_DEMAND
# managed: CONSIDER_BOTH
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
