### PR TITLE
[CLI] Support `--ip` option in `sky status` to output cluster IP only

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1731,7 +1731,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
                     raise RuntimeError(
                         f'{len(cluster_records)} cluster found. Please specify '
                         'exactly one cluster (or glob that only matches one '
-                        'cluster) to show its IP address.')
+                        'cluster) to show its IP address. \nUsage: `sky status --ip <cluster>`')
             cluster_record = cluster_records[0]
             if cluster_record['status'] != status_lib.ClusterStatus.UP:
                 with ux_utils.print_exception_no_traceback():

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1761,14 +1761,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError('Querying IP address is not supported '
                                      'for local clusters.')
-            head_ip = handle.head_ip
-            if head_ip is None:
-                # Try fetching the IP address again.
-                head_ip = handle.external_ips()[0]
-                if head_ip is None:
-                    with ux_utils.print_exception_no_traceback():
-                        raise RuntimeError('Failed to fetch IP address. '
-                                           'Please try again later.')
+            head_ip = handle.external_ips()[0]
             click.echo(head_ip)
             return
         nonreserved_cluster_records = []

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1662,7 +1662,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
 
     Only display the IP address of the cluster using
     ``sky status --ip <cluster-name>``. This option will override all other
-    options.
+    options. For Kubernetes clusters, the returned IP address is the internal IP of the head pod, and may not be accessible from outside the cluster. 
 
     Each cluster can have one of the following statuses:
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1638,7 +1638,11 @@ def _get_spot_jobs(
               default=False,
               is_flag=True,
               required=False,
-              help='Get the IP address of the head node of a cluster. ')
+              help=('Get the IP address of the head node of a cluster. This '
+                    'option will override all other options. For Kubernetes '
+                    'clusters, the returned IP address is the internal IP '
+                    'of the head pod, and may not be accessible from outside '
+                    'the cluster.'))
 @click.option('--show-spot-jobs/--no-show-spot-jobs',
               default=True,
               is_flag=True,
@@ -1663,11 +1667,6 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
     command.
 
     Display all fields using ``sky status -a``.
-
-    Only display the IP address of the cluster using
-    ``sky status --ip <cluster-name>``. This option will override all other
-    options. For Kubernetes clusters, the returned IP address is the internal IP
-    of the head pod, and may not be accessible from outside the cluster.
 
     Each cluster can have one of the following statuses:
 
@@ -1755,7 +1754,8 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
             cluster_record = cluster_records[0]
             if cluster_record['status'] != status_lib.ClusterStatus.UP:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError('Cluster {cluster_record["name"]!r} is not in UP status.')
+                    raise RuntimeError(f'Cluster {cluster_record["name"]!r} '
+                                       'is not in UP status.')
             handle = cluster_record['handle']
             if not isinstance(handle, backends.CloudVmRayResourceHandle):
                 with ux_utils.print_exception_no_traceback():

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1634,7 +1634,7 @@ def _get_spot_jobs(
               default=False,
               is_flag=True,
               required=False,
-              help='Only query the IP address of the cluster. ')
+              help='Get the IP address of the head node of a cluster. ')
 @click.option('--show-spot-jobs/--no-show-spot-jobs',
               default=True,
               is_flag=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1755,7 +1755,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
             cluster_record = cluster_records[0]
             if cluster_record['status'] != status_lib.ClusterStatus.UP:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError('Cluster is not in UP status.')
+                    raise RuntimeError('Cluster {cluster_record["name"]!r} is not in UP status.')
             handle = cluster_record['handle']
             if not isinstance(handle, backends.CloudVmRayResourceHandle):
                 with ux_utils.print_exception_no_traceback():

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1726,9 +1726,11 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
             if len(clusters) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(clusters) > 1 else ''
-                    raise RuntimeError(
+                    cluster_num = (str(len(clusters))
+                                   if len(clusters) > 0 else 'No')
+                    raise ValueError(
                         _STATUS_IP_CLUSTER_NUM_ERROR_MESSAGE.format(
-                            cluster_num=len(clusters),
+                            cluster_num=cluster_num,
                             plural=plural,
                             verb='specified'))
         else:
@@ -1743,15 +1745,17 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
             if len(cluster_records) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(cluster_records) > 1 else ''
-                    raise RuntimeError(
+                    cluster_num = (str(len(cluster_records))
+                                   if len(clusters) > 0 else 'No')
+                    raise ValueError(
                         _STATUS_IP_CLUSTER_NUM_ERROR_MESSAGE.format(
-                            cluster_num=len(cluster_records),
+                            cluster_num=cluster_num,
                             plural=plural,
                             verb='found'))
             cluster_record = cluster_records[0]
             if cluster_record['status'] != status_lib.ClusterStatus.UP:
                 with ux_utils.print_exception_no_traceback():
-                    raise RuntimeError('Cluster is not in UP status. ')
+                    raise RuntimeError('Cluster is not in UP status.')
             handle = cluster_record['handle']
             if not isinstance(handle, backends.CloudVmRayResourceHandle):
                 with ux_utils.print_exception_no_traceback():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolved #2439 .

To discuss: Do we want to enable this feature for multiple clusters? If so, what delimiter shall we use? space or newline?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
