### PR TITLE
Release 0.4.0

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -3,7 +3,7 @@ import os
 
 # Replaced with the current commit when building the wheels.
 __commit__ = '{{SKYPILOT_COMMIT_SHA}}'
-__version__ = '1.0.0-dev0'
+__version__ = '0.4.0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 # Keep this order to avoid cyclic imports


### PR DESCRIPTION
- [x] `pytest tests/test_smoke.py`
- [x] `pytest tests/test_smoke.py --aws`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] `backward_compatibility_tests.sh` run against 0.3.3.
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky spot launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky spot logs --controller
        ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --cpus 2+ --down  # with or without timeout bump
    sky down dbg  
    ```
  - [ ] ~following script~ (skipped, not enough quotas)
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot 
    sky down dbg
    ```
  - [x] following script
    ```
    sky launch -c dbg --cloud gcp --num-nodes 16 --cpus 2+ --down  # with or without timeout bump
    sky down dbg  
    ```