### PR TITLE
[Provisioner] Accept both w/ server prefix and w/o server prefix for private docker registry

### DIFF
--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -143,7 +143,6 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 docker_login_config.password,
                 docker_login_config.server,
             ))
-            specific_image = f'{docker_login_config.server}/{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -143,7 +143,9 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 docker_login_config.password,
                 docker_login_config.server,
             ))
-            specific_image = f'{docker_login_config.server}/{specific_image}'
+            server_prefix = f'{docker_login_config.server}/'
+            if not specific_image.startswith(server_prefix):
+                specific_image = f'{server_prefix}{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -143,9 +143,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 docker_login_config.password,
                 docker_login_config.server,
             ))
-            server_prefix = f'{docker_login_config.server}/'
-            if not specific_image.startswith(server_prefix):
-                specific_image = f'{server_prefix}{specific_image}'
+            specific_image = f'{docker_login_config.server}/{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/task.py
+++ b/sky/task.py
@@ -126,13 +126,21 @@ def _with_docker_login_config(
         task_envs)
 
     def _add_docker_login_config(resources: 'resources_lib.Resources'):
-        if resources.extract_docker_image() is None:
+        docker_image = resources.extract_docker_image()
+        if docker_image is None:
             logger.warning(f'{colorama.Fore.YELLOW}Docker login configs '
                            f'{", ".join(all_keys)} are provided, but no docker '
                            'image is specified in `image_id`. The login configs'
                            f' will be ignored.{colorama.Style.RESET_ALL}')
             return resources
-        return resources.copy(_docker_login_config=docker_login_config)
+        # Already checked in extract_docker_image
+        assert len(resources.image_id) == 1
+        region = list(resources.image_id.keys())[0]
+        server_prefix = f'{docker_login_config.server}'
+        if not docker_image.startswith(server_prefix):
+            docker_image = f'{server_prefix}{docker_image}'
+        return resources.copy(image_id={region: 'docker:' + docker_image},
+                              _docker_login_config=docker_login_config)
 
     return {_add_docker_login_config(resources) for resources in resources_set}
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -147,6 +147,8 @@ def _with_docker_login_config(
         # Already checked in extract_docker_image
         assert len(resources.image_id) == 1
         region = list(resources.image_id.keys())[0]
+        # We automatically add the server prefix to the image name if
+        # the user did not add it.
         server_prefix = f'{docker_login_config.server}/'
         if not docker_image.startswith(server_prefix):
             docker_image = f'{server_prefix}{docker_image}'

--- a/sky/task.py
+++ b/sky/task.py
@@ -145,7 +145,7 @@ def _with_docker_login_config(
                            f'ignored.{colorama.Style.RESET_ALL}')
             return resources
         # Already checked in extract_docker_image
-        assert len(resources.image_id) == 1
+        assert len(resources.image_id) == 1, resources.image_id
         region = list(resources.image_id.keys())[0]
         # We automatically add the server prefix to the image name if
         # the user did not add it.

--- a/sky/task.py
+++ b/sky/task.py
@@ -136,7 +136,7 @@ def _with_docker_login_config(
         # Already checked in extract_docker_image
         assert len(resources.image_id) == 1
         region = list(resources.image_id.keys())[0]
-        server_prefix = f'{docker_login_config.server}'
+        server_prefix = f'{docker_login_config.server}/'
         if not docker_image.startswith(server_prefix):
             docker_image = f'{server_prefix}{docker_image}'
         return resources.copy(image_id={region: 'docker:' + docker_image},


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
