### PR TITLE
[Core] Fix version requirements for `google-api-python-client`

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -135,7 +135,9 @@ extras_require: Dict[str, List[str]] = {
         'azure-cli>=2.31.0', 'azure-core', 'azure-identity>=1.13.0',
         'azure-mgmt-network'
     ],
-    'gcp': ['google-api-python-client', 'google-cloud-storage'],
+    # We need google-api-python-client>=2.19.1 to enable 'reason' attribute
+    # of googleapiclient.errors.HttpError, which is widely used in our system.
+    'gcp': ['google-api-python-client>=2.19.1', 'google-cloud-storage'],
     'ibm': [
         'ibm-cloud-sdk-core', 'ibm-vpc', 'ibm-platform-services', 'ibm-cos-sdk'
     ],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `reason` attribute in `googleapiclient.errors.HttpError` is widely used in our system's error handling, for instance, [authentication](https://github.com/skypilot-org/skypilot/blob/bc4acc88159f3b7aa2d52b499bbf3e6e87ef6663/sky/authentication.py#L163) and [firewall rule creation](https://github.com/skypilot-org/skypilot/blob/bc4acc88159f3b7aa2d52b499bbf3e6e87ef6663/sky/provision/gcp/instance_utils.py#L272). However, this attribute is introduced in version `2.19.1` of `google-api-python-client` ([Reference](https://github.com/googleapis/google-api-python-client/releases/tag/v2.19.1)). We should add a dependency constraint for this attribute.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `pip install ".[all]"` and no dependency conflict found
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
