### PR TITLE
[show-gpus] Change pandas groupby function to str instead of callable

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -489,7 +489,7 @@ def list_accelerators_impl(
             'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
             'MemoryGiB'
         ],
-                            dropna=False).aggregate(min).reset_index()
+                            dropna=False).aggregate('min').reset_index()
         ret = rows.apply(
             lambda row: InstanceTypeInfo(
                 cloud,


### PR DESCRIPTION
Closes #2582.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `pytest tests/test_list_accelerators.py`
- Manual tests - run `sky show-gpus`
  - [x] Tested with pandas 2.1.0
  - [x] Tested with pandas 2.0.3
  - [x] Tested with pandas 1.3.0 (the oldest version supported by SkyPilot master)
  - [x] Manually checked pricing against output of `sky show-gpus -a` on master.
