### PR TITLE
[Core] Support excluding regions

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1167,6 +1167,12 @@ def _fill_in_launchable_resources(
                     cloud_candidates[cloud] = feasible_resources
                 else:
                     all_fuzzy_candidates.update(fuzzy_candidate_list)
+            
+            # Filter out the configured excluded regions.
+            if resources.excluded_regions is not None:
+                for excluded_region in resources.excluded_regions:
+                    blocked_resources.append(resources.copy(region=excluded_region))
+
             if len(launchable[resources]) == 0:
                 clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                     clouds_list[0])


### PR DESCRIPTION
Stacked on top of #2498 

DO NOT SUBMIT: Tests pending.

A user can specify regions to be excluded from optimizer consideration using a prefix of `-`. This feature will be useful for implementing features like spreading instances across regions for increased availability.

The following example allows any region to be chosen except `us-east1` and `us-central1`:
```
region: [-us-east1, -us-central1]
```

A user can also specify a single exclude without using list syntax:
```
region: -us-east1
```

[Tests pending]