### PR TITLE
[GCP] Allow stopping VM with local SSD

### DIFF
--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -124,6 +124,7 @@ class GCPComputeInstance(GCPInstance):
             project=project_id,
             zone=zone,
             instance=instance,
+            discardLocalSsd=False,
         ).execute()
         return operation
 

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -124,6 +124,10 @@ class GCPComputeInstance(GCPInstance):
             project=project_id,
             zone=zone,
             instance=instance,
+            # This is needed for the instance that has local SSDs attached by
+            # default, such as a2-highgpu-8g. Otherwise, an error will be
+            # raised. Refer to issue #2586
+            # https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
             discardLocalSsd=False,
         ).execute()
         return operation


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2586 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-gcp-stop --gpus A100-80GB:1 --cloud gcp; sky stop test-gcp-stop -y; sky start test-gcp-stop -y; sky autostop -y test-gcp-stop -i 0; sky status -r test-gcp-stop; sky down -y test-gcp-stop`
  - [x] `sky launch -c test-normal-gcp --cloud gcp --cpus 2; sky stop test-normal-gcp -y; sky start test-normal-gcp -y; sky autostop -y test-normal-gcp -i 0; sky status -r test-normal-gcp; sky down -y test-normal-gcp`
  - [x] master: `sky stop` takes 1:30; this branch: `sky stop` takes 1:33.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
