### PR TITLE
[k8s] Add `OPEN_PORTS` to unsupported features for kubernetes

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -66,8 +66,12 @@ class Kubernetes(clouds.Cloud):
                                                              'tiers are not '
                                                              'supported in '
                                                              'Kubernetes.',
-        clouds.CloudImplementationFeatures.DOCKER_IMAGE: 'Docker image is not supported in Kubernetes.',
-        clouds.CloudImplementationFeatures.OPEN_PORTS: 'Opening ports is not supported in Kubernetes.'
+        clouds.CloudImplementationFeatures.DOCKER_IMAGE: 'Docker image is not '
+                                                         'supported in '
+                                                         'Kubernetes.',
+        clouds.CloudImplementationFeatures.OPEN_PORTS: 'Opening ports is not '
+                                                       'supported in '
+                                                       'Kubernetes.'
     }
 
     IMAGE_CPU = 'skypilot:cpu-ubuntu-2004'

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -66,10 +66,8 @@ class Kubernetes(clouds.Cloud):
                                                              'tiers are not '
                                                              'supported in '
                                                              'Kubernetes.',
-        clouds.CloudImplementationFeatures.DOCKER_IMAGE:
-            'Docker image is not supported in Kubernetes.',
-        clouds.CloudImplementationFeatures.OPEN_PORTS:
-            'Opening ports is not supported in Kubernetes.'
+        clouds.CloudImplementationFeatures.DOCKER_IMAGE: 'Docker image is not supported in Kubernetes.',
+        clouds.CloudImplementationFeatures.OPEN_PORTS: 'Opening ports is not supported in Kubernetes.'
     }
 
     IMAGE_CPU = 'skypilot:cpu-ubuntu-2004'

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -67,7 +67,9 @@ class Kubernetes(clouds.Cloud):
                                                              'supported in '
                                                              'Kubernetes.',
         clouds.CloudImplementationFeatures.DOCKER_IMAGE:
-            ('Docker image is not supported in Kubernetes. ')
+            'Docker image is not supported in Kubernetes.',
+        clouds.CloudImplementationFeatures.OPEN_PORTS:
+            'Opening ports is not supported in Kubernetes.'
     }
 
     IMAGE_CPU = 'skypilot:cpu-ubuntu-2004'


### PR DESCRIPTION
We currently do not support opening ports on Kubernetes clusters. However, it is still picked by the optimizer as a candidate cloud because `CloudImplementationFeatures.OPEN_PORTS` is not excluded in Kubernetes. This PR fixes that.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky launch -c <yaml_with_ports>`, it excludes Kubernetes now