### PR TITLE
[UX] Fix confusing ValueError: Cannot specify `spot_recovery` without `use_spot` set to True.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1130,6 +1130,12 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
 
     assert len(task.resources) == 1
     old_resources = list(task.resources)[0]
+    if old_resources.use_spot_specified:
+        if not old_resources.use_spot:
+            click.secho(
+                'Field use_spot under resources section will be ignored and '
+                'use_spot will be set to True for `sky spot launch`.',
+                fg='yellow')
     new_resources = old_resources.copy(**override_params)
 
     task.set_resources({new_resources})

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3643,6 +3643,12 @@ def spot_launch(
       sky spot launch 'echo hello!'
     """
     env = _merge_env_vars(env_file, env)
+    if use_spot is not None:
+        if not use_spot:
+            click.secho(
+                'Flag --no-use-spot will be ignored and use_spot '
+                'will be set to True for `sky spot launch`.',
+                fg='yellow')
     task_or_dag = _make_task_or_dag_from_entrypoint_with_overrides(
         entrypoint,
         name=name,
@@ -3655,7 +3661,7 @@ def spot_launch(
         memory=memory,
         instance_type=instance_type,
         num_nodes=num_nodes,
-        use_spot=use_spot,
+        use_spot=True,
         image_id=image_id,
         env=env,
         disk_size=disk_size,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1061,6 +1061,8 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
     env: Optional[List[Tuple[str, str]]] = None,
     # spot launch specific
     spot_recovery: Optional[str] = None,
+    # pylint: disable=invalid-name
+    _is_called_by_sky_spot_launch: bool = False,
 ) -> Union[sky.Task, sky.Dag]:
     """Creates a task or a dag from an entrypoint with overrides.
 
@@ -1130,7 +1132,7 @@ def _make_task_or_dag_from_entrypoint_with_overrides(
 
     assert len(task.resources) == 1
     old_resources = list(task.resources)[0]
-    if old_resources.use_spot_specified:
+    if _is_called_by_sky_spot_launch and old_resources.use_spot_specified:
         if not old_resources.use_spot:
             click.secho(
                 'Field use_spot under resources section will be ignored and '
@@ -3674,6 +3676,7 @@ def spot_launch(
         disk_tier=disk_tier,
         ports=ports,
         spot_recovery=spot_recovery,
+        _is_called_by_sky_spot_launch=True,
     )
     # Deprecation.
     if retry_until_up is not None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -627,6 +627,14 @@ def spot_launch(
                 'change task names to be unique, or specify the DAG name only '
                 'and comment out the task names (so that they will be auto-'
                 'generated) .')
+        resources = list(task_.resources)[0]
+        if resources.use_spot_specified and not resources.use_spot:
+            print(
+                f'{colorama.Fore.YELLOW}Field use_spot of task {task_.name!r} '
+                'will be ignored and use_spot will be set to True for '
+                f'sky.spot_launch. {colorama.Style.RESET_ALL}')
+        new_resources = resources.copy(use_spot=True)
+        task_.set_resources(new_resources)
         task_names.add(task_.name)
 
     dag_utils.fill_default_spot_config_in_dag(dag)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2591 .

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
