### PR TITLE
[TPU] Update default runtime version for TPU node

### DIFF
--- a/examples/tpu/tpu_node_mnist.yaml
+++ b/examples/tpu/tpu_node_mnist.yaml
@@ -4,7 +4,7 @@ resources:
   instance_type: n1-highmem-8
   accelerators: tpu-v2-8
   accelerator_args:
-    runtime_version: 2.5.0
+    runtime_version: 2.12.0
 
 file_mounts:
   /dataset:
@@ -23,7 +23,7 @@ setup: |
   else
     conda create -n mnist python=3.8 -y
     conda activate mnist
-    pip install tensorflow==2.5.0 tensorflow-datasets tensorflow-model-optimization cloud-tpu-client
+    pip install tensorflow==2.12.0 tensorflow-datasets tensorflow-model-optimization cloud-tpu-client
   fi
 
 # The command to run.  Will be run under the working directory.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -100,7 +100,7 @@ _INTERACTIVE_NODE_DEFAULT_RESOURCES = {
     'tpunode': sky.Resources(cloud=sky.GCP(),
                              instance_type=None,
                              accelerators={'tpu-v2-8': 1},
-                             accelerator_args={'runtime_version': '2.5.0'},
+                             accelerator_args={'runtime_version': '2.12.0'},
                              use_spot=False),
 }
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -510,7 +510,7 @@ class Resources:
                     if use_tpu_vm:
                         accelerator_args['runtime_version'] = 'tpu-vm-base'
                     else:
-                        accelerator_args['runtime_version'] = '2.5.0'
+                        accelerator_args['runtime_version'] = '2.12.0'
                     logger.info(
                         'Missing runtime_version in accelerator_args, using'
                         f' default ({accelerator_args["runtime_version"]})')

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -329,7 +329,7 @@ def _get_resources(cluster_record: _ClusterRecord) -> str:
             launched_resource_str = str(handle.launched_resources)
             # accelerator_args is way too long.
             # Convert from:
-            #  GCP(n1-highmem-8, {'tpu-v2-8': 1}, accelerator_args={'runtime_version': '2.5.0'}  # pylint: disable=line-too-long
+            #  GCP(n1-highmem-8, {'tpu-v2-8': 1}, accelerator_args={'runtime_version': '2.12.0'}  # pylint: disable=line-too-long
             # to:
             #  GCP(n1-highmem-8, {'tpu-v2-8': 1}...)
             pattern = ', accelerator_args={.*}'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The original version for tensorflow runtime `2.5.0` is no longer supported by TPU node. We now upgrade it `2.12.0`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-mnist examples/tpu/tpu_node_mnist.yaml `
  - [x] `sky launch -c test-tpu --gpus tpu-v3-8`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
