### PR TITLE
[GCP] Avoid dumping cachetools for backward compatibilty

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1209,6 +1209,7 @@ class GCP(clouds.Cloud):
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
-        # Remove the cached property.
+        # We should avoid saving third-party object to the state, as it may
+        # cause unpickling error when the third-party API is updated.
         state.pop('_list_reservations_cache', None)
         return state

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import time
 import typing
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 import cachetools
 
@@ -1206,3 +1206,9 @@ class GCP(clouds.Cloud):
             error_msg=f'Failed to delete image {image_name!r}',
             stderr=stderr,
             stream_logs=True)
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        # Remove the cached property.
+        state.pop('_list_reservations_cache', None)
+        return state


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`cachetools > 5.0` will have different APIs. Dumping the Cache will cause backward compatibility issues.

To reproduce:
1. `pip install "cachetools<5.0"; sky launch -c test --cloud gcp --cpus 2` 
2. `pip install "cachetools>=5.0"; sky launch -c test`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Reproducible code above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
