### PR TITLE
[Catalog] Fix aws catalog fetcher for removed offerings

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -268,7 +268,7 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
                 return float(row['vCPU'])
             try:
                 return float(row['VCpuInfo']['DefaultVCpus'])
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 print('Error occured for row:', row)
                 print('Error:', e)
                 raise

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -10,6 +10,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import traceback
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -265,7 +266,12 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         def get_vcpus(row) -> float:
             if not np.isnan(row['vCPU']):
                 return float(row['vCPU'])
-            return float(row['VCpuInfo']['DefaultVCpus'])
+            try:
+                return float(row['VCpuInfo']['DefaultVCpus'])
+            except Exception as e:
+                print('Error occured for row:', row)
+                print('Error:', e)
+                raise
 
         def get_memory_gib(row) -> float:
             if isinstance(row['MemoryInfo'], dict):
@@ -303,7 +309,7 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
         df = df.merge(spot_pricing_df,
                       left_on=['InstanceType', 'AvailabilityZoneName'],
                       right_index=True,
-                      how='outer')
+                      how='left')
 
         # Extract vCPUs, memory, and accelerator info from the columns.
         df = pd.concat(
@@ -316,6 +322,7 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
             df['GpuInfo'] = np.nan
         df = df[USEFUL_COLUMNS]
     except Exception as e:  # pylint: disable=broad-except
+        print(traceback.format_exc())
         print(f'{region} failed with {e}', file=sys.stderr)
         return region
     return df


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The g2.8xlarge has been removed from the list of offerings on eu-west-1, which causes the [recent failure ](https://github.com/skypilot-org/skypilot-catalog/actions/runs/6318325483/job/17157750092)of catalog fetcher. We now avoid the spot pricing table introducing `nan` rows.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_aws`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
