### PR TITLE
[LLM] Use `--ip` CLI to get cluster IPs

### DIFF
--- a/llm/vllm/README.md
+++ b/llm/vllm/README.md
@@ -54,9 +54,7 @@ sky launch -c vllm-llama2 serve-openai-api.yaml --gpus V100:1
 ```
 2. Check the IP for the cluster with:
 ```
-sky status -a
-# Or get the IP with Python API:
-IP=$(python -c "import sky; print(sky.status('vllm-llama2')[0]['handle'].head_ip)")
+IP=$(sky status --ip vllm-llama2)
 ```
 3. You can now use the OpenAI API to interact with the model.
   - Query the models hosted on the cluster:


### PR DESCRIPTION
This is a minor update to use `sky status --ip` to simplify the fetching of IP.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
