### PR TITLE
[SkyServe] Add Ray Serve example

### DIFF
--- a/examples/serve/ray_serve/ray_serve.yaml
+++ b/examples/serve/ray_serve/ray_serve.yaml
@@ -1,0 +1,15 @@
+resources:
+  cloud: gcp
+
+workdir: examples/serve/ray_serve
+
+setup: pip install "ray[serve]"
+
+run: serve run serve:app --host 0.0.0.0
+
+service:
+  port: 8000
+  readiness_probe: /
+  replicas: 1
+  controller_resources:
+    cloud: gcp

--- a/examples/serve/ray_serve/ray_serve.yaml
+++ b/examples/serve/ray_serve/ray_serve.yaml
@@ -1,5 +1,5 @@
 resources:
-  cloud: gcp
+  cpus: 2+
 
 workdir: examples/serve/ray_serve
 
@@ -11,5 +11,3 @@ service:
   port: 8000
   readiness_probe: /
   replicas: 1
-  controller_resources:
-    cloud: gcp

--- a/examples/serve/ray_serve/serve.py
+++ b/examples/serve/ray_serve/serve.py
@@ -1,0 +1,17 @@
+from typing import Dict
+
+from ray import serve
+from starlette.requests import Request
+
+
+@serve.deployment(route_prefix="/", num_replicas=2)
+class ModelDeployment:
+
+    def __init__(self, msg: str):
+        self._msg = msg
+
+    def __call__(self, request: Request) -> Dict:
+        return {"result": self._msg}
+
+
+app = ModelDeployment.bind(msg="Hello Ray Serve!")


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adds an example for running a simple Ray Serve application via SkyServe.

```
> sky serve up examples/serve/ray_serve/ray_serve.yaml
> curl -L 34.41.136.95:30007
{"result": "Hello Ray Serve!"}
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Ran successfully and tested working
