### PR TITLE
UX: Allow inferring cloud from region or zone.

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -410,8 +410,17 @@ class Cloud:
         """Returns whether the instance type exists for this cloud."""
         raise NotImplementedError
 
-    def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        """Validates the region and zone."""
+    def validate_region_zone(
+            self, region: Optional[str],
+            zone: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        """Validates whether region and zone exist in the catalog.
+
+        Returns:
+            A tuple of region and zone, if validated.
+
+        Raises:
+            ValueError: If region or zone is invalid or not supported.
+        """
         return service_catalog.validate_region_zone(region,
                                                     zone,
                                                     clouds=self._REPR.lower())

--- a/sky/clouds/cloud_registry.py
+++ b/sky/clouds/cloud_registry.py
@@ -15,6 +15,15 @@ class _CloudRegistry(dict):
     def from_str(self, name: Optional[str]) -> Optional['cloud.Cloud']:
         if name is None:
             return None
+        if name.lower() == 'local':
+            # Backward compatibility. global_user_state's DB may have recorded
+            # Local cloud, and we've just removed it from the registry, and
+            # global_user_state.get_enabled_clouds() would call into this func
+            # and fail.
+            #
+            # TODO(skypilot): have a better way to handle clouds removed from
+            # registry if needed.
+            return None
         if name.lower() not in self:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Cloud {name!r} is not a valid cloud among '

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -46,7 +46,8 @@ class Kubernetes(clouds.Cloud):
     _DEFAULT_MEMORY_CPU_RATIO = 1
     _DEFAULT_MEMORY_CPU_RATIO_WITH_GPU = 4  # Allocate more memory for GPU tasks
     _REPR = 'Kubernetes'
-    _regions: List[clouds.Region] = [clouds.Region('kubernetes')]
+    _SINGLETON_REGION = 'kubernetes'
+    _regions: List[clouds.Region] = [clouds.Region(_SINGLETON_REGION)]
     _CLOUD_UNSUPPORTED_FEATURES = {
         # TODO(romilb): Stopping might be possible to implement with
         #  container checkpointing introduced in Kubernetes v1.25. See:
@@ -329,7 +330,13 @@ class Kubernetes(clouds.Cloud):
             instance_type)
 
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        # Kubernetes doesn't have regions or zones, so we don't need to validate
+        if region != self._SINGLETON_REGION:
+            raise ValueError(
+                'Kubernetes support does not support setting region.'
+                ' Cluster used is determined by the kubeconfig.')
+        if zone is not None:
+            raise ValueError('Kubernetes support does not support setting zone.'
+                             ' Cluster used is determined by the kubeconfig.')
         return region, zone
 
     def accelerator_in_region_or_zone(self,

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -10,7 +10,7 @@ if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
 
 
-@clouds.CLOUD_REGISTRY.register
+# TODO(skypilot): remove Local now that we're using Kubernetes.
 class Local(clouds.Cloud):
     """Local/on-premise cloud.
 

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -191,7 +191,8 @@ class Local(clouds.Cloud):
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
         # Returns true if the region name is same as Local cloud's
         # one and only region: 'Local'.
-        assert zone is None
+        if zone is not None:
+            raise ValueError('Local cloud does not support zones.')
         if region is None or region != Local.LOCAL_REGION.name:
             raise ValueError(f'Region {region!r} does not match the Local'
                              ' cloud region {Local.LOCAL_REGION.name!r}.')

--- a/sky/clouds/local.py
+++ b/sky/clouds/local.py
@@ -195,7 +195,7 @@ class Local(clouds.Cloud):
             raise ValueError('Local cloud does not support zones.')
         if region is None or region != Local.LOCAL_REGION.name:
             raise ValueError(f'Region {region!r} does not match the Local'
-                             ' cloud region {Local.LOCAL_REGION.name!r}.')
+                             f' cloud region {Local.LOCAL_REGION.name!r}.')
         return region, zone
 
     @classmethod

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -174,6 +174,7 @@ def validate_region_zone_impl(
     Raises:
         ValueError: If region or zone is invalid or not supported.
     """
+
     def _get_candidate_str(loc: str, all_loc: List[str]) -> str:
         candidate_loc = difflib.get_close_matches(loc, all_loc, n=5, cutoff=0.9)
         candidate_loc = sorted(candidate_loc)

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -166,8 +166,14 @@ def instance_type_exists_impl(df: pd.DataFrame, instance_type: str) -> bool:
 def validate_region_zone_impl(
         cloud_name: str, df: pd.DataFrame, region: Optional[str],
         zone: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
-    """Validates whether region and zone exist in the catalog."""
+    """Validates whether region and zone exist in the catalog.
 
+    Returns:
+        A tuple of region and zone, if validated.
+
+    Raises:
+        ValueError: If region or zone is invalid or not supported.
+    """
     def _get_candidate_str(loc: str, all_loc: List[str]) -> str:
         candidate_loc = difflib.get_close_matches(loc, all_loc, n=5, cutoff=0.9)
         candidate_loc = sorted(candidate_loc)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -553,14 +553,19 @@ class Resources:
                 else:
                     cloud_str = f'for any cloud among {enabled_clouds}'
                 with ux_utils.print_exception_no_traceback():
-                    table = log_utils.create_table(['Cloud', 'Hint'])
-                    table.add_row(['-----', '----'])
-                    for cloud, error in cloud_to_errors.items():
-                        reason_str = '\n'.join(textwrap.wrap(str(error), 80))
-                        table.add_row([str(cloud), reason_str])
+                    if len(cloud_to_errors) == 1:
+                        # UX: if 1 cloud, don't print a table.
+                        hint = list(cloud_to_errors.items())[0][-1]
+                    else:
+                        table = log_utils.create_table(['Cloud', 'Hint'])
+                        table.add_row(['-----', '----'])
+                        for cloud, error in cloud_to_errors.items():
+                            reason_str = '\n'.join(textwrap.wrap(str(error), 80))
+                            table.add_row([str(cloud), reason_str])
+                        hint = table.get_string()
                     raise ValueError(
                         f'Invalid (region {region!r}, zone {zone!r}) '
-                        f'{cloud_str}. Details:\n{table.get_string()}')
+                        f'{cloud_str}. Details:\n{hint}')
             elif len(valid_clouds) > 1:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -560,7 +560,8 @@ class Resources:
                         table = log_utils.create_table(['Cloud', 'Hint'])
                         table.add_row(['-----', '----'])
                         for cloud, error in cloud_to_errors.items():
-                            reason_str = '\n'.join(textwrap.wrap(str(error), 80))
+                            reason_str = '\n'.join(textwrap.wrap(
+                                str(error), 80))
                             table.add_row([str(cloud), reason_str])
                         hint = table.get_string()
                     raise ValueError(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,5 +1,6 @@
 """Resources: compute requirements of Tasks."""
 import functools
+import textwrap
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import colorama
@@ -15,6 +16,7 @@ from sky.clouds import service_catalog
 from sky.provision import docker_utils
 from sky.skylet import constants
 from sky.utils import accelerator_registry
+from sky.utils import log_utils
 from sky.utils import resources_utils
 from sky.utils import schemas
 from sky.utils import tpu_utils
@@ -134,7 +136,7 @@ class Resources:
         self._cloud = cloud
         self._region: Optional[str] = None
         self._zone: Optional[str] = None
-        self._set_region_zone(region, zone)
+        self._validate_and_set_region_zone(region, zone)
 
         self._instance_type = instance_type
 
@@ -522,22 +524,56 @@ class Resources:
         return self.cloud is not None and self._instance_type is not None
 
     def need_cleanup_after_preemption(self) -> bool:
-        """Returns whether a spot resource needs cleanup after preeemption."""
+        """Returns whether a spot resource needs cleanup after preemption."""
         assert self.is_launchable(), self
         return self.cloud.need_cleanup_after_preemption(self)
 
-    def _set_region_zone(self, region: Optional[str],
-                         zone: Optional[str]) -> None:
+    def _validate_and_set_region_zone(self, region: Optional[str],
+                                      zone: Optional[str]) -> None:
         if region is None and zone is None:
             return
 
         if self._cloud is None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cloud must be specified when region/zone are specified.')
+            # Try to infer the cloud from region/zone, if unique. If 0 or >1
+            # cloud corresponds to region/zone, errors out.
+            valid_clouds = []
+            enabled_clouds = global_user_state.get_enabled_clouds()
+            cloud_to_errors = {}
+            for cloud in enabled_clouds:
+                try:
+                    cloud.validate_region_zone(region, zone)
+                except ValueError as e:
+                    cloud_to_errors[repr(cloud)] = e
+                    continue
+                valid_clouds.append(cloud)
 
-        # Validate whether region and zone exist in the catalog, and set the
-        # region if zone is specified.
+            if len(valid_clouds) == 0:
+                if len(enabled_clouds) == 1:
+                    cloud_str = f'for cloud {enabled_clouds[0]}'
+                else:
+                    cloud_str = f'for any cloud among {enabled_clouds}'
+                with ux_utils.print_exception_no_traceback():
+                    table = log_utils.create_table(['Cloud', 'Hint'])
+                    table.add_row(['-----', '----'])
+                    for cloud, error in cloud_to_errors.items():
+                        reason_str = '\n'.join(textwrap.wrap(str(error), 80))
+                        table.add_row([str(cloud), reason_str])
+                    raise ValueError(
+                        f'Invalid (region {region!r}, zone {zone!r}) '
+                        f'{cloud_str}. Details:\n{table.get_string()}')
+            elif len(valid_clouds) > 1:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'Cannot infer cloud from (region {region!r}, zone '
+                        f'{zone!r}). Multiple enabled clouds have region/zone '
+                        f'of the same names: {valid_clouds}. '
+                        f'To fix: explicitly specify `cloud`.')
+            logger.debug(f'Cloud is not specified, using {valid_clouds[0]} '
+                         f'inferred from region {region!r} and zone {zone!r}')
+            self._cloud = valid_clouds[0]
+
+        # Validate if region and zone exist in the catalog, and set the region
+        # if zone is specified.
         self._region, self._zone = self._cloud.validate_region_zone(
             region, zone)
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,62 @@
+import tempfile
+from typing import List, Optional
+
+import pandas as pd
+import pytest
+
+from sky import clouds
+from sky.utils import kubernetes_utils
+
+
+def enable_all_clouds_in_monkeypatch(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled_clouds: Optional[List[str]] = None,
+) -> None:
+    # Monkey-patching is required because in the test environment, no cloud is
+    # enabled. The optimizer checks the environment to find enabled clouds, and
+    # only generates plans within these clouds. The tests assume that all three
+    # clouds are enabled, so we monkeypatch the `sky.global_user_state` module
+    # to return all three clouds. We also monkeypatch `sky.check.check` so that
+    # when the optimizer tries calling it to update enabled_clouds, it does not
+    # raise exceptions.
+    if enabled_clouds is None:
+        enabled_clouds = list(clouds.CLOUD_REGISTRY.values())
+    monkeypatch.setattr(
+        'sky.global_user_state.get_enabled_clouds',
+        lambda: enabled_clouds,
+    )
+    monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
+    config_file_backup = tempfile.NamedTemporaryFile(
+        prefix='tmp_backup_config_default', delete=False)
+    monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
+                        config_file_backup.name)
+    monkeypatch.setattr(
+        'sky.clouds.gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH',
+        config_file_backup.name)
+    monkeypatch.setenv('OCI_CONFIG', config_file_backup.name)
+
+    az_mappings = pd.read_csv('tests/default_aws_az_mappings.csv')
+
+    def _get_az_mappings(_):
+        return az_mappings
+
+    monkeypatch.setattr(
+        'sky.clouds.service_catalog.aws_catalog._get_az_mappings',
+        _get_az_mappings)
+
+    monkeypatch.setattr('sky.backends.backend_utils.check_owner_identity',
+                        lambda _: None)
+
+    monkeypatch.setattr(
+        'sky.clouds.gcp.GCP._list_reservations_for_instance_type',
+        lambda *_args, **_kwargs: [])
+
+    # Monkey patch Kubernetes resource detection since it queries
+    # the cluster to detect available cluster resources.
+    monkeypatch.setattr(
+        'sky.utils.kubernetes_utils.detect_gpu_label_formatter',
+        lambda *_args, **_kwargs: [kubernetes_utils.SkyPilotLabelFormatter, []])
+    monkeypatch.setattr('sky.utils.kubernetes_utils.detect_gpu_resource',
+                        lambda *_args, **_kwargs: [True, []])
+    monkeypatch.setattr('sky.utils.kubernetes_utils.check_instance_fits',
+                        lambda *_args, **_kwargs: [True, ''])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 from typing import List
 
+import common  # TODO(zongheng): for some reason isort places it here.
 import pytest
-
-import common
 
 # Usage: use
 #   @pytest.mark.slow
@@ -19,7 +18,8 @@ import common
 # To only run tests for a specific cloud (as well as generic tests), use
 # --aws, --gcp, --azure, or --lambda.
 #
-# To only run tests for managed spot (without generic tests), use --managed-spot.
+# To only run tests for managed spot (without generic tests), use
+# --managed-spot.
 all_clouds_in_smoke_tests = [
     'aws', 'gcp', 'azure', 'lambda', 'cloudflare', 'ibm', 'scp', 'oci',
     'kubernetes'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
-import tempfile
 from typing import List
-from unittest.mock import patch
 
-import pandas as pd
 import pytest
+
+import common
 
 # Usage: use
 #   @pytest.mark.slow
@@ -180,61 +179,12 @@ def generic_cloud(request) -> str:
 
 
 @pytest.fixture
-def enable_all_clouds(monkeypatch):
-    from sky import clouds
-    from sky.utils import kubernetes_utils
-
-    # Monkey-patching is required because in the test environment, no cloud is
-    # enabled. The optimizer checks the environment to find enabled clouds, and
-    # only generates plans within these clouds. The tests assume that all three
-    # clouds are enabled, so we monkeypatch the `sky.global_user_state` module
-    # to return all three clouds. We also monkeypatch `sky.check.check` so that
-    # when the optimizer tries calling it to update enabled_clouds, it does not
-    # raise exceptions.
-    enabled_clouds = list(clouds.CLOUD_REGISTRY.values())
-    monkeypatch.setattr(
-        'sky.global_user_state.get_enabled_clouds',
-        lambda: enabled_clouds,
-    )
-    monkeypatch.setattr('sky.check.check', lambda *_args, **_kwargs: None)
-    config_file_backup = tempfile.NamedTemporaryFile(
-        prefix='tmp_backup_config_default', delete=False)
-    monkeypatch.setattr('sky.clouds.gcp.GCP_CONFIG_SKY_BACKUP_PATH',
-                        config_file_backup.name)
-    monkeypatch.setattr(
-        'sky.clouds.gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH',
-        config_file_backup.name)
-    monkeypatch.setenv('OCI_CONFIG', config_file_backup.name)
-
-    az_mappings = pd.read_csv('tests/default_aws_az_mappings.csv')
-
-    def _get_az_mappings(_):
-        return az_mappings
-
-    monkeypatch.setattr(
-        'sky.clouds.service_catalog.aws_catalog._get_az_mappings',
-        _get_az_mappings)
-
-    monkeypatch.setattr('sky.backends.backend_utils.check_owner_identity',
-                        lambda _: None)
-
-    monkeypatch.setattr(
-        'sky.clouds.gcp.GCP._list_reservations_for_instance_type',
-        lambda *_args, **_kwargs: [])
-
-    # Monkey patch Kubernetes resource detection since it queries
-    # the cluster to detect available cluster resources.
-    monkeypatch.setattr(
-        'sky.utils.kubernetes_utils.detect_gpu_label_formatter',
-        lambda *_args, **_kwargs: [kubernetes_utils.SkyPilotLabelFormatter, []])
-    monkeypatch.setattr('sky.utils.kubernetes_utils.detect_gpu_resource',
-                        lambda *_args, **_kwargs: [True, []])
-    monkeypatch.setattr('sky.utils.kubernetes_utils.check_instance_fits',
-                        lambda *_args, **_kwargs: [True, ''])
+def enable_all_clouds(monkeypatch: pytest.MonkeyPatch):
+    common.enable_all_clouds_in_monkeypatch(monkeypatch)
 
 
 @pytest.fixture
-def aws_config_region(monkeypatch) -> str:
+def aws_config_region(monkeypatch: pytest.MonkeyPatch) -> str:
     from sky import skypilot_config
     region = 'us-west-2'
     if skypilot_config.loaded():

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -3,13 +3,12 @@ import textwrap
 import time
 from typing import Callable, List, Optional
 
+import common  # TODO(zongheng): for some reason isort places it here.
 import pytest
 
 import sky
 from sky import clouds
 from sky import exceptions
-
-import common
 
 
 def _test_parse_task_yaml(spec: str, test_fn: Optional[Callable] = None):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1882. Also, unregisters `Local` cloud, which is done to provide good 1-cloud hints.

Tested (added to unit tests too) with all clouds enabled incl. k8s:

OK cases:
```
# Maps to GCP.
» sky launch --region us-east1
» sky launch --zone us-west2-a

# Maps to AWS.
» sky launch --region us-east-2
» sky launch --zone us-west-2a

# OK: Optimizer prints.
» sky launch
» sky launch --region us-east-1 --cloud aws
» sky launch --region us-east-1 --cloud lambda
```
Not OK cases:
```
» sky launch --region us-east-1
ValueError: Cannot infer cloud from (region 'us-east-1', zone None). Multiple enabled clouds have region/zone of the same names: [AWS, Lambda]. To fix: explicitly specify `cloud`.

» sky launch --zone us-west-2-a --cloud aws
ValueError: Invalid zone 'us-west-2-a'
Did you mean one of these: 'us-west-2a'?

» sky launch --zone us-west-2-a                                            
ValueError: Invalid (region None, zone 'us-west-2-a') for any cloud among [AWS, Azure, GCP, IBM, Kubernetes, Lambda, OCI, SCP]. Details:
Cloud       Hint
-----       ----
AWS         Invalid zone 'us-west-2-a' Did you mean one of these: 'us-west-2a'?
Azure       Azure does not support zones.
GCP         Invalid zone 'us-west-2-a' Did you mean one of these: 'us-west2-a'?
IBM         Invalid zone 'us-west-2-a'
Kubernetes  Kubernetes support does not support setting region. Cluster used is determined
            by the kubeconfig.
Lambda      Lambda Cloud does not support zones.
OCI         Invalid zone 'us-west-2-a'
SCP         SCP Cloud does not support zones.

» sky launch --zone us-west-2z
ValueError: Invalid (region None, zone 'us-west-2z') for any cloud among [AWS, Azure, GCP, IBM, Kubernetes, Lambda, OCI, SCP]. Details:
Cloud       Hint
-----       ----
AWS         Invalid zone 'us-west-2z' Did you mean one of these: 'us-west-2a, us-west-2b,
            us-west-2c, us-west-2d'?
Azure       Azure does not support zones.
GCP         Invalid zone 'us-west-2z'
IBM         Invalid zone 'us-west-2z'
Kubernetes  Kubernetes support does not support setting region. Cluster used is determined
            by the kubeconfig.
Lambda      Lambda Cloud does not support zones.
Local       Local cloud does not support zones.
OCI         Invalid zone 'us-west-2z'
SCP         SCP Cloud does not support zones.


» sky launch --region us-east1 --zone us-west2-a                         
ValueError: Invalid (region 'us-east1', zone 'us-west2-a') for any cloud among [AWS, Azure, GCP, IBM, Kubernetes, Lambda, OCI, SCP]. Details:
Cloud       Hint
-----       ----
AWS         Invalid region 'us-east1' Did you mean one of these: 'us-east-1'?
Azure       Azure does not support zones.
GCP         Invalid zone 'us-west2-a' for region 'us-east1'
IBM         Invalid region 'us-east1' Did you mean one of these: 'us-east'?
Kubernetes  Kubernetes support does not support setting region. Cluster used is determined
            by the kubeconfig.
Lambda      Lambda Cloud does not support zones.
OCI         Invalid region 'us-east1' List of supported oci regions: 'us-sanjose-1'
SCP         SCP Cloud does not support zones.
```

In docker, with AWS enabled only:

- [x] TODO: improve on this output, 1-cloud only situations should not need the verbose table
```
# OK
» sky launch --region us-east-1

» sky launch --zone us-west-2-a
ValueError: Invalid (region None, zone 'us-west-2-a') for cloud AWS. Details:
Invalid zone 'us-west-2-a'
Did you mean one of these: 'us-west-2a'?

» sky launch --region us-east1 --zone us-west2-a
ValueError: Invalid (region 'us-east1', zone 'us-west2-a') for cloud AWS. Details:
Invalid region 'us-east1'
Did you mean one of these: 'us-east-1'?
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
