### PR TITLE
[k8s] Fix GPU count detection from autoscaler YAML

### DIFF
--- a/sky/skylet/providers/kubernetes/config.py
+++ b/sky/skylet/providers/kubernetes/config.py
@@ -133,7 +133,8 @@ def get_resource(container_resources: Dict[str, Any],
     rounded_count = math.ceil(res_count)
     if resource_name == 'cpu':
         # For CPU, we set minimum count to 1 because if CPU count is set to 0,
-        # (e.g., when request=0.5), ray will not be able to schedule any tasks.
+        # (e.g. when the user sets --cpu 0.5), ray will not be able to schedule
+        # any tasks.
         return max(1, rounded_count)
     else:
         # For GPU and memory, return the rounded count.

--- a/sky/skylet/providers/kubernetes/config.py
+++ b/sky/skylet/providers/kubernetes/config.py
@@ -128,11 +128,16 @@ def get_resource(container_resources: Dict[str, Any],
     # float('inf') means there's no limit set
     res_count = request if limit == float('inf') else limit
     # Convert to int since Ray autoscaler expects int.
-    # Cap the minimum resource to 1 because if resource count is set to 0,
-    # (e.g., when request=0.5), ray will not be able to schedule any tasks.
     # We also round up the resource count to the nearest integer to provide the
     # user at least the amount of resource they requested.
-    return max(1, math.ceil(res_count))
+    rounded_count = math.ceil(res_count)
+    if resource_name == 'cpu':
+        # For CPU, we set minimum count to 1 because if CPU count is set to 0,
+        # (e.g., when request=0.5), ray will not be able to schedule any tasks.
+        return max(1, rounded_count)
+    else:
+        # For GPU and memory, return the rounded count.
+        return rounded_count
 
 
 def _get_resource(container_resources: Dict[str, Any], resource_name: str,
@@ -144,7 +149,7 @@ def _get_resource(container_resources: Dict[str, Any], resource_name: str,
 
     Args:
         container_resources: Container's resource field.
-        resource_name: One of 'cpu', 'gpu' or memory.
+        resource_name: One of 'cpu', 'gpu' or 'memory'.
         field_name: One of 'requests' or 'limits'.
 
     Returns:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2644,7 +2644,6 @@ def test_gcp_zero_quota_failover():
 
 
 # ------- Testing user ray cluster --------
-@pytest.mark.no_kubernetes  # Kubernetes does not support sky status -r yet.
 def test_user_ray_cluster(generic_cloud: str):
     name = _get_cluster_name()
     test = Test(


### PR DESCRIPTION
Closes #2608. 

Our resource detection from pod spec puts a minimum of 1 on CPU resource so that fractional CPU sized clusters can also be launched on k8s clusters. However, this was being incorrectly applied to GPU resources too, causing all clusters to be initialized with 1 GPU resource.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR - `sky launch --cloud kubernetes -- ray status` now does not show GPUs.
- [x] k8s smoke tests: `pytest tests/test_smoke.py--kubernetes -k "not TestStorageWithCredentials"`
