### PR TITLE
Add sky show-gpus support for Kubernetes

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3231,9 +3231,6 @@ def show_gpus(
     type is the lowest across all regions for both on-demand and spot
     instances. There may be multiple regions with the same lowest price.
     """
-    # validation for the --cloud kubernetes
-    if cloud == 'kubernetes':
-        raise click.UsageError('Kubernetes does not have a service catalog.')
     # validation for the --region flag
     if region is not None and cloud is None:
         raise click.UsageError(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3261,6 +3261,11 @@ def show_gpus(
                 clouds=cloud,
                 region_filter=region,
             )
+
+            if len(result) == 0 and cloud == 'kubernetes':
+                yield kubernetes_utils.NO_GPU_ERROR_MESSAGE
+                return
+
             # "Common" GPUs
             for gpu in service_catalog.get_common_gpus():
                 if gpu in result:
@@ -3317,6 +3322,10 @@ def show_gpus(
                                                    case_sensitive=False)
 
         if len(result) == 0:
+            if cloud == 'kubernetes':
+                yield kubernetes_utils.NO_GPU_ERROR_MESSAGE
+                return
+
             quantity_str = (f' with requested quantity {quantity}'
                             if quantity else '')
             yield f'Resources \'{name}\'{quantity_str} not found. '

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -21,8 +21,8 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
         clouds = list(_ALL_CLOUDS)
 
-        # TODO(hemil): Remove this once the common service catalog functions are refactored from clouds/kubernetes.py to kubernetes_catalog.py,
-        # and add kubernetes
+        # TODO(hemil): Remove this once the common service catalog functions are refactored
+        # from clouds/kubernetes.py to kubernetes_catalog.py and add kubernetes to _ALL_CLOUDS
         if method_name == 'list_accelerators':
             clouds.append('kubernetes')
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -22,8 +22,8 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
         clouds = list(_ALL_CLOUDS)
 
         # TODO(hemil): Remove this once the common service catalog
-        # functions are refactored from clouds/kubernetes.py to kubernetes_catalog.py
-        # and add kubernetes to _ALL_CLOUDS
+        # functions are refactored from clouds/kubernetes.py to
+        # kubernetes_catalog.py and add kubernetes to _ALL_CLOUDS
         if method_name == 'list_accelerators':
             clouds.append('kubernetes')
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -21,8 +21,9 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
         clouds = list(_ALL_CLOUDS)
 
-        # TODO(hemil): Remove this once the common service catalog functions are refactored
-        # from clouds/kubernetes.py to kubernetes_catalog.py and add kubernetes to _ALL_CLOUDS
+        # TODO(hemil): Remove this once the common service catalog
+        # functions are refactored from clouds/kubernetes.py to kubernetes_catalog.py
+        # and add kubernetes to _ALL_CLOUDS
         if method_name == 'list_accelerators':
             clouds.append('kubernetes')
 

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -20,6 +20,9 @@ _ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci')
 def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
         clouds = list(_ALL_CLOUDS)
+        if method_name == "list_accelerators":
+            clouds.append("kubernetes")
+
     single = isinstance(clouds, str)
     if single:
         clouds = [clouds]  # type: ignore

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -20,8 +20,11 @@ _ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci')
 def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
         clouds = list(_ALL_CLOUDS)
-        if method_name == "list_accelerators":
-            clouds.append("kubernetes")
+
+        # TODO(hemil): Remove this once the common service catalog functions are refactored from clouds/kubernetes.py to kubernetes_catalog.py,
+        # and add kubernetes
+        if method_name == 'list_accelerators':
+            clouds.append('kubernetes')
 
     single = isinstance(clouds, str)
     if single:

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -98,6 +98,6 @@ def list_accelerators(
 def validate_region_zone(
     region_name: Optional[str],
     zone_name: Optional[str],
-    clouds: CloudFilter = None  # type: ignore
+    clouds: CloudFilter = None  # pylint: disable=unused-argument
 ) -> Tuple[Optional[str], Optional[str]]:
     return (region_name, zone_name)

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -98,5 +98,5 @@ def list_accelerators(
 def validate_region_zone(
         region_name: Optional[str],
         zone_name: Optional[str],
-        clouds: CloudFilter = None) -> Tuple[Optional[str], Optional[str]]:
+        clouds: CloudFilter = None) -> Tuple[Optional[str], Optional[str]]: # type: ignore
     return (region_name, zone_name)

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -42,8 +42,7 @@ def list_accelerators(
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     k8s_cloud = Kubernetes()
     if not any(
-            map(lambda cloud: k8s_cloud.is_same_cloud(cloud),
-                global_user_state.get_enabled_clouds())
+            map(k8s_cloud.is_same_cloud, global_user_state.get_enabled_clouds())
     ) or not kubernetes_utils.check_credentials()[0]:
         return {}
 

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -96,7 +96,8 @@ def list_accelerators(
 
 
 def validate_region_zone(
-        region_name: Optional[str],
-        zone_name: Optional[str],
-        clouds: CloudFilter = None) -> Tuple[Optional[str], Optional[str]]: # type: ignore
+    region_name: Optional[str],
+    zone_name: Optional[str],
+    clouds: CloudFilter = None  # type: ignore
+) -> Tuple[Optional[str], Optional[str]]:
     return (region_name, zone_name)

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -40,7 +40,10 @@ def list_accelerators(
         quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
-    if Kubernetes not in global_user_state.get_enabled_clouds(
+    k8s_cloud = Kubernetes()
+    if not any(
+            map(lambda cloud: k8s_cloud.is_same_cloud(cloud),
+                global_user_state.get_enabled_clouds())
     ) or not kubernetes_utils.check_credentials()[0]:
         return {}
 

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -71,7 +71,7 @@ def list_accelerators(
                                     memory=None,
                                     price=0.0,
                                     spot_price=0.0,
-                                    region=''))
+                                    region='kubernetes'))
 
     df = pd.DataFrame(result,
                       columns=[

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -6,8 +6,8 @@ mapping SkyPilot image tags to corresponding container image tags.
 from typing import Dict, List, Optional, Set, Tuple
 
 import pandas as pd
-from sky import global_user_state
 
+from sky import global_user_state
 from sky.clouds import Kubernetes
 from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
@@ -40,7 +40,8 @@ def list_accelerators(
         quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
-    if Kubernetes not in global_user_state.get_enabled_clouds() or not kubernetes_utils.check_credentials()[0]:
+    if Kubernetes not in global_user_state.get_enabled_clouds(
+    ) or not kubernetes_utils.check_credentials()[0]:
         return {}
 
     has_gpu = kubernetes_utils.detect_gpu_resource()

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -3,10 +3,13 @@
 Kubernetes does not require a catalog of instances, but we need an image catalog
 mapping SkyPilot image tags to corresponding container image tags.
 """
+from typing import Dict, List, Optional, Set, Tuple
 
-from typing import Optional
+import pandas as pd
 
+from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
+from sky.utils import kubernetes_utils
 
 _PULL_FREQUENCY_HOURS = 7
 
@@ -26,3 +29,65 @@ def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:
 def is_image_tag_valid(tag: str, region: Optional[str]) -> bool:
     """Returns whether the image tag is valid."""
     return common.is_image_tag_valid_impl(_image_df, tag, region)
+
+
+def list_accelerators(
+        gpus_only: bool,
+        name_filter: Optional[str],
+        region_filter: Optional[str],
+        quantity_filter: Optional[int],
+        case_sensitive: bool = True
+) -> Dict[str, List[common.InstanceTypeInfo]]:
+    has_gpu = kubernetes_utils.detect_gpu_resource()
+    if not has_gpu:
+        return {}
+
+    label_formatter, _ = kubernetes_utils.detect_gpu_label_formatter()
+    if not label_formatter:
+        return {}
+
+    accelerators: Set[Tuple[str, int]] = set()
+    key = label_formatter.get_label_key()
+    nodes = kubernetes_utils.get_kubernetes_nodes()
+    for node in nodes:
+        if key in node.metadata.labels:
+            accelerator_name = label_formatter.get_accelerator_from_label_value(
+                node.metadata.labels.get(key))
+            accelerator_count = int(
+                node.status.allocatable.get('nvidia.com/gpu', 0))
+
+            if accelerator_name and accelerator_count > 0:
+                accelerators.add((accelerator_name, accelerator_count))
+
+    result = []
+    for accelerator_name, accelerator_count in accelerators:
+        result.append(
+            common.InstanceTypeInfo(cloud="Kubernetes",
+                                    instance_type=None,
+                                    accelerator_name=accelerator_name,
+                                    accelerator_count=accelerator_count,
+                                    cpu_count=None,
+                                    device_memory=None,
+                                    memory=None,
+                                    price=0.0,
+                                    spot_price=0.0,
+                                    region=''))
+
+    df = pd.DataFrame(result,
+                      columns=[
+                          'Cloud', 'InstanceType', 'AcceleratorName',
+                          'AcceleratorCount', 'vCPUs', 'DeviceMemoryGiB',
+                          'MemoryGiB', 'Price', 'SpotPrice', 'Region'
+                      ])
+    df['GpuInfo'] = True
+
+    return common.list_accelerators_impl('Kubernetes', df, gpus_only,
+                                         name_filter, region_filter,
+                                         quantity_filter, case_sensitive)
+
+
+def validate_region_zone(
+        region_name: Optional[str],
+        zone_name: Optional[str],
+        clouds: CloudFilter = None) -> Tuple[Optional[str], Optional[str]]:
+    return (region_name, zone_name)

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -6,7 +6,9 @@ mapping SkyPilot image tags to corresponding container image tags.
 from typing import Dict, List, Optional, Set, Tuple
 
 import pandas as pd
+from sky import global_user_state
 
+from sky.clouds import Kubernetes
 from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
 from sky.utils import kubernetes_utils
@@ -38,6 +40,9 @@ def list_accelerators(
         quantity_filter: Optional[int],
         case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
+    if Kubernetes not in global_user_state.get_enabled_clouds() or not kubernetes_utils.check_credentials()[0]:
+        return {}
+
     has_gpu = kubernetes_utils.detect_gpu_resource()
     if not has_gpu:
         return {}
@@ -63,7 +68,7 @@ def list_accelerators(
     result = []
     for accelerator_name, accelerator_count in accelerators:
         result.append(
-            common.InstanceTypeInfo(cloud="Kubernetes",
+            common.InstanceTypeInfo(cloud='Kubernetes',
                                     instance_type=None,
                                     accelerator_name=accelerator_name,
                                     accelerator_count=accelerator_count,

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -57,7 +57,8 @@ def list_accelerators(
                 node.status.allocatable.get('nvidia.com/gpu', 0))
 
             if accelerator_name and accelerator_count > 0:
-                accelerators.add((accelerator_name, accelerator_count))
+                for count in range(1, accelerator_count + 1):
+                    accelerators.add((accelerator_name, count))
 
     result = []
     for accelerator_name, accelerator_count in accelerators:

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -30,7 +30,10 @@ MEMORY_SIZE_UNITS = {
     'T': 2**40,
     'P': 2**50,
 }
-NO_GPU_ERROR_MESSAGE = 'No GPUs found in Kubernetes cluster. If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs (e.g., skypilot.co/accelerators) are setup correctly. To further debug, run: sky check.'
+NO_GPU_ERROR_MESSAGE = 'No GPUs found in Kubernetes cluster. \
+If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs \
+(e.g., skypilot.co/accelerators) are setup correctly. \
+To further debug, run: sky check.'
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -30,6 +30,7 @@ MEMORY_SIZE_UNITS = {
     'T': 2**40,
     'P': 2**50,
 }
+NO_GPU_ERROR_MESSAGE = 'No GPUs found in Kubernetes cluster. If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs (e.g., skypilot.co/accelerators) are setup correctly. To further debug, run: sky check.'
 
 logger = sky_logging.init_logger(__name__)
 
@@ -163,7 +164,13 @@ class GKELabelFormatter(GPULabelFormatter):
 
     @classmethod
     def get_accelerator_from_label_value(cls, value: str) -> str:
-        return value.split('-')[-1].upper()
+        if value.startswith('nvidia-tesla-'):
+            return value.replace('nvidia-tesla-', '').upper()
+        elif value.startswith('nvidia-'):
+            return value.replace('nvidia-', '').upper()
+        else:
+            raise ValueError(
+                f'Invalid accelerator name in GKE cluster: {value}')
 
 
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -79,6 +79,11 @@ class GPULabelFormatter:
         """Given a GPU type, returns the label value to be used"""
         raise NotImplementedError
 
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        """Given a label value, returns the GPU type"""
+        raise NotImplementedError
+
 
 def get_gke_accelerator_name(accelerator: str) -> str:
     """Returns the accelerator name for GKE clusters
@@ -112,6 +117,10 @@ class SkyPilotLabelFormatter(GPULabelFormatter):
         # See sky.utils.kubernetes.gpu_labeler.
         return accelerator.lower()
 
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        return value.upper()
+
 
 class CoreWeaveLabelFormatter(GPULabelFormatter):
     """CoreWeave label formatter
@@ -130,6 +139,10 @@ class CoreWeaveLabelFormatter(GPULabelFormatter):
     def get_label_value(cls, accelerator: str) -> str:
         return accelerator.upper()
 
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        return value
+
 
 class GKELabelFormatter(GPULabelFormatter):
     """GKE label formatter
@@ -147,6 +160,10 @@ class GKELabelFormatter(GPULabelFormatter):
     @classmethod
     def get_label_value(cls, accelerator: str) -> str:
         return get_gke_accelerator_name(accelerator)
+
+    @classmethod
+    def get_accelerator_from_label_value(cls, value: str) -> str:
+        return value.split('-')[-1].upper()
 
 
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Implements `list_accelerators` function for Kubernetes catalog. The function is dynamic and iterates through all nodes (checking for GPUs) currently, but the output can also be cached similar to other catalogs. Right now, it only works with `sky show-gpus --cloud kubernetes` since `_ALL_CLOUDS` in service_catalog doesn't include `kubernetes` due to the lack of implementation of other catalog functions.

Example output:
```bash
sky show-gpus --cloud kubernetes          
   
COMMON_GPU  AVAILABLE_QUANTITIES  
T4          1                     
V100        1                     

Hint: use -a/--all to see all accelerators (including non-common ones) and pricing.
```

```bash
sky show-gpus --cloud kubernetes -a

COMMON_GPU  AVAILABLE_QUANTITIES  
T4          1                     
V100        1                     



GPU  QTY  CLOUD       INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  
T4   1    Kubernetes  (attachable)   -           -      -         $ 0.000       $ 0.000            

GPU   QTY  CLOUD       INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  
V100  1    Kubernetes  (attachable)   -           -      -         $ 0.000       $ 0.000      
```
Addresses https://github.com/skypilot-org/skypilot/issues/2431.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
