### PR TITLE
[Dependency] install typin_extensions for all versions

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -79,7 +79,7 @@ install_requires = [
     'tabulate',
     # Light weight requirement, can be replaced with "typing" once
     # we deprecate Python 3.7 (this will take a while).
-    "typing_extensions; python_version < '3.8'",
+    "typing_extensions",
     'filelock >= 3.6.0',
     'packaging',
     'psutil',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is an issue introduced by #2625, as the `typing_extensions` is not installed by default after removing ray dependency. The issue did not occur during the previous testing, because the docker image `berkeleyskypilot/skypilot-debug` has `typing_extensions` installed in the base environment.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
