### PR TITLE
feat(update): Adding CoreWeave label to identify GPUs in K8s

### DIFF
--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -93,24 +93,6 @@ def get_gke_accelerator_name(accelerator: str) -> str:
         return 'nvidia-tesla-{}'.format(accelerator.lower())
 
 
-class GKELabelFormatter(GPULabelFormatter):
-    """GKE label formatter
-
-    GKE nodes by default are populated with `cloud.google.com/gke-accelerator`
-    label, which is used to identify the GPU type.
-    """
-
-    LABEL_KEY = 'cloud.google.com/gke-accelerator'
-
-    @classmethod
-    def get_label_key(cls) -> str:
-        return cls.LABEL_KEY
-
-    @classmethod
-    def get_label_value(cls, accelerator: str) -> str:
-        return get_gke_accelerator_name(accelerator)
-
-
 class SkyPilotLabelFormatter(GPULabelFormatter):
     """Custom label formatter for SkyPilot
 
@@ -131,10 +113,46 @@ class SkyPilotLabelFormatter(GPULabelFormatter):
         return accelerator.lower()
 
 
+class CoreWeaveLabelFormatter(GPULabelFormatter):
+    """CoreWeave label formatter
+
+    Uses gpu.nvidia.com/class as the key, and the uppercase SkyPilot
+    accelerator str as the value. 
+    """
+
+    LABEL_KEY = 'gpu.nvidia.com/class'
+
+    @classmethod
+    def get_label_key(cls) -> str:
+        return cls.LABEL_KEY
+
+    @classmethod
+    def get_label_value(cls, accelerator: str) -> str:
+        return accelerator.upper() 
+    
+
+class GKELabelFormatter(GPULabelFormatter):
+    """GKE label formatter
+
+    GKE nodes by default are populated with `cloud.google.com/gke-accelerator`
+    label, which is used to identify the GPU type.
+    """
+
+    LABEL_KEY = 'cloud.google.com/gke-accelerator'
+
+    @classmethod
+    def get_label_key(cls) -> str:
+        return cls.LABEL_KEY
+
+    @classmethod
+    def get_label_value(cls, accelerator: str) -> str:
+        return get_gke_accelerator_name(accelerator)
+
+
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to
 # discover the accelerator type from. The order of the list is important, as
 # it will be used to determine the priority of the label formats.
-LABEL_FORMATTER_REGISTRY = [SkyPilotLabelFormatter, GKELabelFormatter]
+LABEL_FORMATTER_REGISTRY = [SkyPilotLabelFormatter, CoreWeaveLabelFormatter, GKELabelFormatter]
 
 
 def detect_gpu_label_formatter(
@@ -957,3 +975,6 @@ def check_port_forward_mode_dependencies() -> None:
                     f'  $ sudo apt install {name}\n'
                     f'On MacOS, install it with: \n'
                     f'  $ brew install {name}') from None
+
+
+a = CoreWeaveLabelFormatter

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -975,6 +975,3 @@ def check_port_forward_mode_dependencies() -> None:
                     f'  $ sudo apt install {name}\n'
                     f'On MacOS, install it with: \n'
                     f'  $ brew install {name}') from None
-
-
-a = CoreWeaveLabelFormatter

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -128,8 +128,8 @@ class CoreWeaveLabelFormatter(GPULabelFormatter):
 
     @classmethod
     def get_label_value(cls, accelerator: str) -> str:
-        return accelerator.upper() 
-    
+        return accelerator.upper()
+
 
 class GKELabelFormatter(GPULabelFormatter):
     """GKE label formatter
@@ -152,7 +152,9 @@ class GKELabelFormatter(GPULabelFormatter):
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to
 # discover the accelerator type from. The order of the list is important, as
 # it will be used to determine the priority of the label formats.
-LABEL_FORMATTER_REGISTRY = [SkyPilotLabelFormatter, CoreWeaveLabelFormatter, GKELabelFormatter]
+LABEL_FORMATTER_REGISTRY = [
+    SkyPilotLabelFormatter, CoreWeaveLabelFormatter, GKELabelFormatter
+]
 
 
 def detect_gpu_label_formatter(
@@ -178,6 +180,9 @@ def detect_gpu_label_formatter(
             if label.startswith(label_key):
                 label_formatter = lf()
                 break
+
+        if label_formatter is not None:
+            break
 
     return label_formatter, node_labels
 
@@ -322,6 +327,7 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
         # Check if the cluster has GPU labels setup correctly
         label_formatter, node_labels = \
             detect_gpu_label_formatter()
+
         if label_formatter is None:
             # If none of the GPU labels from LABEL_FORMATTER_REGISTRY are
             # detected, raise error
@@ -345,6 +351,7 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
                 return '', ''
             k8s_acc_label_key = label_formatter.get_label_key()
             k8s_acc_label_value = label_formatter.get_label_value(acc_type)
+
             # Search in node_labels to see if any node has the requested
             # GPU type.
             # Note - this only checks if the label is available on a

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -117,7 +117,7 @@ class CoreWeaveLabelFormatter(GPULabelFormatter):
     """CoreWeave label formatter
 
     Uses gpu.nvidia.com/class as the key, and the uppercase SkyPilot
-    accelerator str as the value. 
+    accelerator str as the value.
     """
 
     LABEL_KEY = 'gpu.nvidia.com/class'
@@ -327,7 +327,6 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
         # Check if the cluster has GPU labels setup correctly
         label_formatter, node_labels = \
             detect_gpu_label_formatter()
-
         if label_formatter is None:
             # If none of the GPU labels from LABEL_FORMATTER_REGISTRY are
             # detected, raise error
@@ -351,7 +350,6 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
                 return '', ''
             k8s_acc_label_key = label_formatter.get_label_key()
             k8s_acc_label_value = label_formatter.get_label_value(acc_type)
-
             # Search in node_labels to see if any node has the requested
             # GPU type.
             # Note - this only checks if the label is available on a


### PR DESCRIPTION
This PR adds:

-  `CoreWeaveLabelFormatter` to identify GPU nodes within our K8s cluster. 
- Code is formatted using `format.sh`.