### PR TITLE
skip v5 catalog fetching

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -390,6 +390,9 @@ def _get_tpu_for_zone(zone: str) -> pd.DataFrame:
     new_tpus = []
     for tpu in tpus:
         tpu_name = tpu['type']
+        # skip tpu v5 as we currently don't support it
+        if 'v5' in tpu_name:
+            continue
         new_tpus.append({
             'AcceleratorName': f'tpu-{tpu_name}',
             'AcceleratorCount': 1,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We skip the catalog fetching for TPU v5 for now as we currently don't support it yet.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
