### PR TITLE
[Core] Fix optimizer for dag when some resources provided are not feasible

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1033,7 +1033,10 @@ def _fill_in_launchable_resources(
             if len(launchable[resources]) == 0:
                 clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                     clouds_list[0])
-                logger.info(f'No resource satisfying {resources} '
+                num_node_str = ''
+                if task.num_nodes > 1:
+                    num_node_str = f'{task.num_nodes}x'
+                logger.info(f'No resource satisfying {num_node_str}{resources} '
                             f'on {clouds_str}.')
                 if len(all_fuzzy_candidates) > 0:
                     logger.info('Did you mean: '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -319,9 +319,12 @@ class Optimizer:
                 # in the error message.
                 enabled_clouds = global_user_state.get_enabled_clouds()
                 if _cloud_in_list(clouds.Kubernetes(), enabled_clouds):
-                    if any(orig_resources.cloud is None for orig_resources in node.get_resources()):
+                    if any(orig_resources.cloud is None
+                           for orig_resources in node.get_resources()):
                         source_hint = 'catalog and kubernetes cluster'
-                    elif all(isinstance(orig_resources.cloud, clouds.Kubernetes) for orig_resources in node.get_resources()):
+                    elif all(
+                            isinstance(orig_resources.cloud, clouds.Kubernetes)
+                            for orig_resources in node.get_resources()):
                         source_hint = 'kubernetes cluster'
 
                 # TODO(romilb): When `sky show-gpus` supports Kubernetes,
@@ -1028,8 +1031,6 @@ def _fill_in_launchable_resources(
                 else:
                     all_fuzzy_candidates.update(fuzzy_candidate_list)
             if len(launchable[resources]) == 0:
-                logger.debug(f'Original resources: {resources}')
-                logger.debug(f'get_feasible_launchable_resources: {resources.cloud.get_feasible_launchable_resources(resources, num_nodes=task.num_nodes)}')
                 clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                     clouds_list[0])
                 logger.info(f'No resource satisfying {resources} '

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1035,7 +1035,7 @@ def _fill_in_launchable_resources(
                     clouds_list[0])
                 num_node_str = ''
                 if task.num_nodes > 1:
-                    num_node_str = f'{task.num_nodes}x'
+                    num_node_str = f'{task.num_nodes}x '
                 logger.info(f'No resource satisfying {num_node_str}{resources} '
                             f'on {clouds_str}.')
                 if len(all_fuzzy_candidates) > 0:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1000,8 +1000,8 @@ def _fill_in_launchable_resources(
                                                      False)
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ResourcesUnavailableError(
-                    f'task_lib.Task {task} requires {resources.cloud} which is '
-                    'not enabled. To enable access, run '
+                    f'Task requires {resources.cloud} which is '
+                    f'not enabled: {task}.\nTo enable access, run '
                     f'{colorama.Style.BRIGHT}'
                     f'sky check {colorama.Style.RESET_ALL}, or change the '
                     'cloud requirement')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -299,8 +299,8 @@ class Resources:
         zone_str = ''
         if self.zone is not None:
             zone_str = f', zone={self.zone}'
-        repr_str = repr(self)
-        assert repr_str.endswith(')')
+        repr_str = str(self)
+        assert repr_str.endswith(')'), repr_str
 
         repr_str = repr_str[:-1] + f'{region_str}{zone_str})'
         return repr_str

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -290,6 +290,19 @@ class Resources:
             cloud_str = f'{self.cloud}'
 
         return f'{cloud_str}({hardware_str})'
+    
+    @property
+    def repr_with_region_zone(self) -> str:
+        region_str = ''
+        if self.region is not None:
+            region_str = f', region={self.region}'
+        zone_str = ''
+        if self.zone is not None:
+            zone_str = f', zone={self.zone}'
+        repr_str = repr(self)
+        repr_str = repr_str.replace(')', f'{region_str}{zone_str})')
+        return repr_str
+
 
     @property
     def cloud(self):

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -300,7 +300,9 @@ class Resources:
         if self.zone is not None:
             zone_str = f', zone={self.zone}'
         repr_str = repr(self)
-        repr_str = repr_str.replace(')', f'{region_str}{zone_str})')
+        assert repr_str.endswith(')')
+
+        repr_str = repr_str[:-1] + f'{region_str}{zone_str})'
         return repr_str
 
     @property

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -290,7 +290,7 @@ class Resources:
             cloud_str = f'{self.cloud}'
 
         return f'{cloud_str}({hardware_str})'
-    
+
     @property
     def repr_with_region_zone(self) -> str:
         region_str = ''
@@ -302,7 +302,6 @@ class Resources:
         repr_str = repr(self)
         repr_str = repr_str.replace(')', f'{region_str}{zone_str})')
         return repr_str
-
 
     @property
     def cloud(self):

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -300,9 +300,10 @@ class Resources:
         if self.zone is not None:
             zone_str = f', zone={self.zone}'
         repr_str = str(self)
-        assert repr_str.endswith(')'), repr_str
-
-        repr_str = repr_str[:-1] + f'{region_str}{zone_str})'
+        if repr_str.endswith(')'):
+            repr_str = repr_str[:-1] + f'{region_str}{zone_str})'
+        else:
+            repr_str += f'{region_str}{zone_str}'
         return repr_str
 
     @property

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -254,7 +254,7 @@ class Resources:
             if None in self.image_id:
                 image_id = f', image_id={self.image_id[None]}'
             else:
-                image_id = f', image_id={self.image_id!r}'
+                image_id = f', image_id={self.image_id}'
 
         disk_tier = ''
         if self.disk_tier is not None:

--- a/sky/task.py
+++ b/sky/task.py
@@ -1018,10 +1018,11 @@ class Task:
         if self.num_nodes > 1:
             s += f'\n  nodes: {self.num_nodes}'
         if len(self.resources) > 1:
-            s += f'\n  resources: {self.resources}'
+            resources_str_set = {r.repr_with_region_zone for r in self.resources}
+            s += f'\n  resources: {resources_str_set}'
         elif len(
                 self.resources) == 1 and not list(self.resources)[0].is_empty():
-            s += f'\n  resources: {list(self.resources)[0]}'
+            s += f'\n  resources: {list(self.resources)[0].repr_with_region_zone}'
         else:
             s += '\n  resources: default instances'
         return s

--- a/sky/task.py
+++ b/sky/task.py
@@ -1026,7 +1026,7 @@ class Task:
         elif len(
                 self.resources) == 1 and not list(self.resources)[0].is_empty():
             s += (f'\n  resources: '
-            f'{list(self.resources)[0].repr_with_region_zone}')
+                  f'{list(self.resources)[0].repr_with_region_zone}')
         else:
             s += '\n  resources: default instances'
         return s

--- a/sky/task.py
+++ b/sky/task.py
@@ -1005,6 +1005,7 @@ class Task:
                 run_msg = f'run=\'{run_msg[:20]}...\''
             else:
                 run_msg = f'run=\'{run_msg}\''
+
         elif self.run is None:
             run_msg = 'run=<empty>'
         else:
@@ -1018,11 +1019,14 @@ class Task:
         if self.num_nodes > 1:
             s += f'\n  nodes: {self.num_nodes}'
         if len(self.resources) > 1:
-            resources_str_set = {r.repr_with_region_zone for r in self.resources}
+            resources_str_set = {
+                r.repr_with_region_zone for r in self.resources
+            }
             s += f'\n  resources: {resources_str_set}'
         elif len(
                 self.resources) == 1 and not list(self.resources)[0].is_empty():
-            s += f'\n  resources: {list(self.resources)[0].repr_with_region_zone}'
+            s += (f'\n  resources: '
+            f'{list(self.resources)[0].repr_with_region_zone}')
         else:
             s += '\n  resources: default instances'
         return s

--- a/sky/task.py
+++ b/sky/task.py
@@ -997,8 +997,6 @@ class Task:
         sky.dag.get_current_dag().add_edge(self, b)
 
     def __repr__(self):
-        if self.name and self.name != 'sky-cmd':  # CLI launch with a command
-            return self.name
         if isinstance(self.run, str):
             run_msg = self.run.replace('\n', '\\n')
             if len(run_msg) > 20:
@@ -1010,7 +1008,10 @@ class Task:
         else:
             run_msg = 'run=<fn>'
 
-        s = f'Task({run_msg})'
+        name_str = ''
+        if self.name is not None:
+            name_str = f'<name={self.name}>'
+        s = f'Task{name_str}({run_msg})'
         if self.inputs is not None:
             s += f'\n  inputs: {self.inputs}'
         if self.outputs is not None:
@@ -1018,12 +1019,11 @@ class Task:
         if self.num_nodes > 1:
             s += f'\n  nodes: {self.num_nodes}'
         if len(self.resources) > 1:
-            resources_str_set = {
-                r.repr_with_region_zone for r in self.resources
-            }
-            s += f'\n  resources: {resources_str_set}'
-        elif len(
-                self.resources) == 1 and not list(self.resources)[0].is_empty():
+            resources_str = ('{' + ', '.join(
+                r.repr_with_region_zone for r in self.resources) + '}')
+            s += f'\n  resources: {resources_str}'
+        elif (len(self.resources) == 1 and
+              not list(self.resources)[0].is_empty()):
             s += (f'\n  resources: '
                   f'{list(self.resources)[0].repr_with_region_zone}')
         else:

--- a/sky/task.py
+++ b/sky/task.py
@@ -1005,7 +1005,6 @@ class Task:
                 run_msg = f'run=\'{run_msg[:20]}...\''
             else:
                 run_msg = f'run=\'{run_msg}\''
-
         elif self.run is None:
             run_msg = 'run=<empty>'
         else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously optimizer will fail when one of the multiple resources provided for the task is invalid. We now change it to allowing the optimization to continue as long as one of the resources is valid.

**The following issue was also the cause of the failure for `pytest tests/test_optimizer_random_dag.py::test_optimizer`.**

To reproduce:
```python
import sky

with sky.Dag() as d:
    task = sky.Task(name='task')
    task.set_resources({
        # This will fail as SCP does not support multiple nodes
        sky.Resources(sky.SCP(), instance_type='g1v32v4', accelerators='V100-32GB:4'), 
        # This will fail as SCP does not support multiple nodes
        sky.Resources(sky.SCP(), instance_type='g1v16v2', accelerators='V100-32GB:2'),
        sky.Resources(sky.GCP(), instance_type='g2-standard-16', accelerators='L4:1'),
        sky.Resources(sky.Lambda(), instance_type='gpu_8x_a100_80gb_sxm4', accelerators='A100-80GB:8'),
    })
    task.set_time_estimator(lambda _: 100)
    task.num_nodes = 3

sky.optimize(d)
```

Previously, it will fail with:

```
python test.py                                                                    ✱
I 10-03 23:16:35 optimizer.py:1044] No resource satisfying SCP(g1v32v4, {'V100-32GB': 4}) on SCP.
I 10-03 23:16:35 optimizer.py:1044] No resource satisfying SCP(g1v16v2, {'V100-32GB': 2}) on SCP.
sky.exceptions.ResourcesUnavailableError: Catalog does not contain any instances satisfying the request:
task.

To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
```

Now, it will proceed:
```
python test.py                                                                  ✭ ✱
I 10-03 23:15:38 optimizer.py:1035] No resource satisfying SCP(g1v16v2, {'V100-32GB': 2}) on SCP.
I 10-03 23:15:43 optimizer.py:1035] No resource satisfying SCP(g1v32v4, {'V100-32GB': 4}) on SCP.
I 10-03 23:15:48 optimizer.py:671] == Optimizer ==
I 10-03 23:15:48 optimizer.py:682] Target: minimizing cost
I 10-03 23:15:48 optimizer.py:697] Estimated total runtime: 0.0 hours
I 10-03 23:15:48 optimizer.py:697] Estimated total cost: $0.1
I 10-03 23:15:48 optimizer.py:697] 
I 10-03 23:15:48 optimizer.py:766] Considered resources (3 nodes):
I 10-03 23:15:48 optimizer.py:815] -----------------------------------------------------------------------------------------------------
I 10-03 23:15:48 optimizer.py:815]  CLOUD    INSTANCE                vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 10-03 23:15:48 optimizer.py:815] -----------------------------------------------------------------------------------------------------
I 10-03 23:15:48 optimizer.py:815]  GCP      g2-standard-16          16      64        L4:1           us-east4-a    0.10          ✔     
I 10-03 23:15:48 optimizer.py:815]  Lambda   gpu_8x_a100_80gb_sxm4   240     1800      A100-80GB:8    us-east-1     1.00                
I 10-03 23:15:48 optimizer.py:815] ----------------------------------------------------------------------------------------------------- 
```

An alternative way for this is to still fail for the resources that fail to find feasible launchable resources, but that seems contradicting with the meaning of `set` of resources in our task definition.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
