### PR TITLE
Fix creation of `~/sky_logging/{timestamp}` under dir running `sky` commands

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2872,7 +2872,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     wheel_hash=wheel_hash,
                     provision_record=provision_record,
                     custom_resource=resources_vars.get('custom_resources'),
-                    log_dir=self.log_dir)
+                    log_dir=os.path.expanduser(self.log_dir))
                 # We must query the IPs from the cloud provider, when the
                 # provisioning is done, to make sure the cluster IPs are
                 # up-to-date.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2872,7 +2872,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     wheel_hash=wheel_hash,
                     provision_record=provision_record,
                     custom_resource=resources_vars.get('custom_resources'),
-                    log_dir=os.path.expanduser(self.log_dir))
+                    log_dir=self.log_dir)
                 # We must query the IPs from the cloud provider, when the
                 # provisioning is done, to make sure the cluster IPs are
                 # up-to-date.

--- a/sky/provision/logging.py
+++ b/sky/provision/logging.py
@@ -23,7 +23,7 @@ config = _LoggingConfig()
 def setup_provision_logging(log_dir: str):
     try:
         # Redirect underlying provision logs to file.
-        log_path = os.path.join(log_dir, 'provision.log')
+        log_path = os.path.expanduser(os.path.join(log_dir, 'provision.log'))
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         log_abs_path = pathlib.Path(log_path).expanduser().absolute()
         fh = logging.FileHandler(log_abs_path)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Current master will create a log dir `~/sky_logging/{timestamp}` under the dir you run `sky` commands:
<img width="558" alt="image" src="https://github.com/skypilot-org/skypilot/assets/74357442/94b422b9-6e83-484c-9f44-6978cbaf6633">
This is because of one absent of `os.path.expanduser` introduced by the new provisioner. This PR fixed the bug.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `sky launch --cloud aws` and check there is no extra dirs created
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
