### PR TITLE
[GCP] Add retry for transient error during launching GCP clusters

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1945,9 +1945,8 @@ class RetryingVmProvisioner(object):
                 result = re.search(pattern, stderr)
                 if result is not None:
                     # Retry. Unlikely will succeed if it's due to no capacity.
-                    logger.info(
-                        'Retrying due to the possibly flaky RESOURCE_NOT_FOUND '
-                        'error.')
+                    logger.info('Retrying due to the possibly transient '
+                                'RESOURCE_NOT_FOUND error.')
                     logger.debug(f'-- Stderr --\n{stderr}\n ----')
                     return True
 
@@ -1956,9 +1955,8 @@ class RetryingVmProvisioner(object):
                 result = re.search(pattern, stderr)
                 if result is not None:
                     # Retry. Unlikely will succeed if it's due to no capacity.
-                    logger.info(
-                        'Retrying due to the possibly flaky resourceNotReady '
-                        f'error.')
+                    logger.info('Retrying due to the possibly transient '
+                                'resourceNotReady error.')
                     logger.debug(f'-- Stderr --\n{stderr}\n ----')
                     return True
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -787,7 +787,7 @@ class RetryingVmProvisioner(object):
             if 'Head node fetch timed out' in stderr:
                 # Example: click.exceptions.ClickException: Head node fetch
                 # timed out. Failed to create head node.
-                # This is a transient error, but we have retried in `need_ray_up`
+                # This is a transient error, but we have retried in need_ray_up
                 # and failed.  So we skip this zone.
                 logger.info('Got \'Head node fetch timed out\' in '
                             f'{zone.name}.')
@@ -903,7 +903,7 @@ class RetryingVmProvisioner(object):
             if 'Head node fetch timed out' in stderr:
                 # Example: click.exceptions.ClickException: Head node fetch
                 # timed out. Failed to create head node.
-                # This is a transient error, but we have retried in `need_ray_up`
+                # This is a transient error, but we have retried in need_ray_up
                 # and failed.  So we skip this region.
                 logger.info('Got \'Head node fetch timed out\' in '
                             f'{region.name}.')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1947,7 +1947,8 @@ class RetryingVmProvisioner(object):
                     # Retry. Unlikely will succeed if it's due to no capacity.
                     logger.info(
                         'Retrying due to the possibly flaky RESOURCE_NOT_FOUND '
-                        f'error: {stderr}')
+                        'error.')
+                    logger.debug(f'-- Stderr --\n{stderr}\n ----')
                     return True
 
                 # "The resource 'projects/skypilot-375900/regions/us-central1/subnetworks/default' is not ready". Details: "[{'message': "The resource 'projects/xxx/regions/us-central1/subnetworks/default' is not ready", 'domain': 'global', 'reason': 'resourceNotReady'}]"> # pylint: disable=line-too-long
@@ -1957,7 +1958,8 @@ class RetryingVmProvisioner(object):
                     # Retry. Unlikely will succeed if it's due to no capacity.
                     logger.info(
                         'Retrying due to the possibly flaky resourceNotReady '
-                        f'error: {stderr}')
+                        f'error.')
+                    logger.debug(f'-- Stderr --\n{stderr}\n ----')
                     return True
 
             if isinstance(to_provision_cloud, clouds.Lambda):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -694,7 +694,10 @@ class GCP(clouds.Cloud):
         )
         returncode, stdout, stderr = subprocess_utils.run_with_retries(
             list_reservations_cmd,
-            retry_returncode=[255],
+            # 1: means connection aborted (although it shows 22 in the error,
+            # but the actual error code is 1)
+            # Example: ERROR: gcloud crashed (ConnectionError): ('Connection aborted.', OSError(22, 'Invalid argument')) # pylint: disable=line-too-long
+            retry_returncode=[255, 22],
         )
         subprocess_utils.handle_returncode(
             returncode,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -697,7 +697,7 @@ class GCP(clouds.Cloud):
             # 1: means connection aborted (although it shows 22 in the error,
             # but the actual error code is 1)
             # Example: ERROR: gcloud crashed (ConnectionError): ('Connection aborted.', OSError(22, 'Invalid argument')) # pylint: disable=line-too-long
-            retry_returncode=[255, 22],
+            retry_returncode=[255, 1],
         )
         subprocess_utils.handle_returncode(
             returncode,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

GCP generats some flaky error while launching causing #2666. We should add retry for the `ray up` during launching as well as the blocklist update for errors.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud gcp --gpus A100:8 --image-id projects/deeplearning-platform-release/global/images/pytorch-2-0-gpu-v20230822-ubuntu-2004-py310 --down --retry-until-up`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
