### PR TITLE
[Spot] Cleanup zombie controller processes for OOM corner cases

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -65,22 +65,12 @@ class JobSchedulerEvent(SkyletEvent):
 class SpotJobUpdateEvent(SkyletEvent):
     """Skylet event for updating spot job status."""
     EVENT_INTERVAL_SECONDS = 300  # 5 minutes
-    CLEANUP_INTERVAL_SECONDS = 3600  # 1 hour
-    CLEANUP_INTERVAL_CNT = CLEANUP_INTERVAL_SECONDS // EVENT_INTERVAL_SECONDS
-
-    def __init__(self):
-        super().__init__()
-        self._cnt = 0
 
     def _run(self):
-        self._cnt = (self._cnt + 1) % self.CLEANUP_INTERVAL_CNT
-        if self._cnt == 0:
-            # Update spot job status and cleanup abnormal spot jobs every
-            # CLEANUP_INTERVAL_SECONDS.
-            spot_utils.cleanup_zombie_spot_jobs()
-        else:
-            # Update spot job status every EVENT_INTERVAL_SECONDS.
-            spot_utils.update_spot_job_status()
+        # Update spot job status and cleanup abnormal spot jobs every
+        # CLEANUP_INTERVAL_SECONDS.
+        spot_utils.update_spot_job_status()
+        spot_utils.cleanup_zombie_spot_jobs()
 
 
 class AutostopEvent(SkyletEvent):

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -64,10 +64,23 @@ class JobSchedulerEvent(SkyletEvent):
 
 class SpotJobUpdateEvent(SkyletEvent):
     """Skylet event for updating spot job status."""
-    EVENT_INTERVAL_SECONDS = 300
+    EVENT_INTERVAL_SECONDS = 300  # 5 minutes
+    CLEANUP_INTERVAL_SECONDS = 3600  # 1 hour
+    CLEANUP_INTERVAL_CNT = CLEANUP_INTERVAL_SECONDS // EVENT_INTERVAL_SECONDS
+
+    def __init__(self):
+        super().__init__()
+        self._cnt = 0
 
     def _run(self):
-        spot_utils.update_spot_job_status()
+        self._cnt = (self._cnt + 1) % self.CLEANUP_INTERVAL_CNT
+        if self._cnt == 0:
+            # Update spot job status and cleanup abnormal spot jobs every
+            # CLEANUP_INTERVAL_SECONDS.
+            spot_utils.cleanup_zombie_spot_jobs()
+        else:
+            # Update spot job status every EVENT_INTERVAL_SECONDS.
+            spot_utils.update_spot_job_status()
 
 
 class AutostopEvent(SkyletEvent):

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -461,6 +461,7 @@ def _cleanup(job_id: int, dag_yaml: str):
 
 def start(job_id, dag_yaml, retry_until_up):
     """Start the controller."""
+    spot_state.set_controller_pid(job_id, os.getpid())
     controller_process = None
     cancelling = False
     try:

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -171,9 +171,6 @@ def cleanup_zombie_spot_jobs():
 
     Reference: https://github.com/skypilot-org/skypilot/issues/2668
     """
-    # Update the spot job status to find FAILED_CONTROLLER jobs.
-    update_spot_job_status()
-
     # Get all the FAILED_CONTROLLER jobs.
     spot_jobs = spot_state.get_spot_jobs()
     terminal_controller_jobs = []

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -226,6 +226,8 @@ def cleanup_zombie_spot_jobs():
                     f'No controller process found for abnormal spot job '
                     f'{job_id}.')
 
+        # controller_pid == 0 means the process is already killed, and the
+        # resources is already cleaned up.
         if controller_pid:
             logger.info(f'Found zombie controller process {controller_pid} '
                         f'for spot job {job_id} in status: {status}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes first TODO in #2668.
This ensures our spot job does not leak resources when ray job is finished, but the controller process is still running in the background. In that case, it is possible that a job supervisor for the controller job is killed, but the controller process itself is still running, causing a zombie spot job to run in the background while the user can only see `FAILED_CONTROLLER` for the spot job.

**We should be able to get rid of ray job in the future with the same design of recording pid in job table.**

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [ ] Manually kill the spot controller process's job supervisor, and wait until skylet cleans up the resources.
  - [ ] Launch > 50 spot jobs each with 16 nodes (can be finished), and check if the OOM happens, and our skylet should correctly handle the zombie controller.
- [ ] All smoke tests: `pytest tests/test_smoke.py --managed-spot` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
