### PR TITLE
[Core] Fix the NoOp for rich status

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -564,7 +564,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         ctx.exit()
 
     try:
-        subprocess.run(cmd, shell=True, check=True)
+        subprocess.run(cmd, shell=True, check=True, executable='/bin/bash')
         click.secho(f'Shell completion installed for {value}', fg='green')
         click.echo(
             'Completion will take effect once you restart the terminal: ' +

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -69,7 +69,7 @@ install_requires = [
     'jinja2 >= 3.0',
     'jsonschema',
     'networkx',
-    'pandas',
+    'pandas>=1.3.0',
     'pendulum',
     # PrettyTable with version >=2.0.0 is required for the support of
     # `add_rows` method.

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -69,7 +69,7 @@ install_requires = [
     'jinja2 >= 3.0',
     'jsonschema',
     'networkx',
-    'pandas>=1.3.0',
+    'pandas',
     'pendulum',
     # PrettyTable with version >=2.0.0 is required for the support of
     # `add_rows` method.

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -15,7 +15,7 @@ class _NoOpConsoleStatus:
     """An empty class for multi-threaded console.status."""
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2665

Previously, when `NoOp` is returned, `with rich_utils.safe_status() as status:`, the `status` is actually the return value of `__enter__` (None for the `NoOp`), causing failure if `status` is used later.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] reproducible code in #2665.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
