### PR TITLE
fix: serve constants needs to be expanded with os.path.expanduser

### DIFF
--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -1,12 +1,14 @@
 """Constants used for SkyServe."""
 
+import os
+
 CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP = 10
 
 CONTROLLER_PREFIX = 'sky-serve-controller-'
 
 CONTROLLER_TEMPLATE = 'sky-serve-controller.yaml.j2'
 
-SERVE_PREFIX = '~/.sky/serve'
+SERVE_PREFIX = os.path.expanduser('~/.sky/serve')
 
 # This is the same with sky.skylet.constants.CLUSTER_NAME_VALID_REGEX
 # The service name will be used as:


### PR DESCRIPTION
On OSX, current serve branch generates a "~/.sky/serve/controller.lock" under current directory

<img width="174" alt="image" src="https://github.com/skypilot-org/skypilot/assets/388154/7789d174-a14c-492a-83cd-ee7509042260">
