### PR TITLE
[CLI] Disable `--ip` with `--refresh` when calling `sky status` to avoid additional empty lines in output

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1757,7 +1757,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
         if ip:
             if refresh:
                 raise click.UsageError(
-                    'Using --ip with --refresh is not supported for now.')
+                    'Using --ip with --refresh is not supported for now. To fix, refresh first, then query the IP.')
             if len(clusters) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(clusters) > 1 else ''

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1757,7 +1757,8 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
         if ip:
             if refresh:
                 raise click.UsageError(
-                    'Using --ip with --refresh is not supported for now. To fix, refresh first, then query the IP.')
+                    'Using --ip with --refresh is not supported for now. '
+                    'To fix, refresh first, then query the IP.')
             if len(clusters) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(clusters) > 1 else ''

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1757,7 +1757,7 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
         if ip:
             if refresh:
                 raise click.UsageError(
-                    f'Using --ip with --refresh is not supported for now.')
+                    'Using --ip with --refresh is not supported for now.')
             if len(clusters) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(clusters) > 1 else ''

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1691,6 +1691,10 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
 
     If CLUSTERS is given, show those clusters. Otherwise, show all clusters.
 
+    If --ip is specified, show the IP address of the head node of the cluster.
+    Only available when CLUSTERS contains exactly one cluster, e.g.
+    ``sky status --ip mycluster``.
+
     The following fields for each cluster are recorded: cluster name, time
     since last launch, resources, region, zone, hourly price, status, autostop,
     command.
@@ -1751,6 +1755,9 @@ def status(all: bool, refresh: bool, ip: bool, show_spot_jobs: bool,
                           limit_num_jobs_to_show=not all,
                           is_called_by_user=False))
         if ip:
+            if refresh:
+                raise click.UsageError(
+                    f'Using --ip with --refresh is not supported for now.')
             if len(clusters) != 1:
                 with ux_utils.print_exception_no_traceback():
                     plural = 's' if len(clusters) > 1 else ''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

If `--ip` is used with `--refresh`, there will be an additional new line in the output (which is caused by the rich progress bar. It will make commands like `curl $(sky status --ip <cluster> -r)` to report illegal format (`curl: (3) URL using bad/illegal format or missing URL`). To reproduce:

```bash
$ echo "a$(sky status cluster-0 --ip)b"
a33.127.121.7b
$ echo "a$(sky status cluster-0 -r --ip)b"
a
33.127.121.7b
$ ip=$(sky status --ip cluster-0 -r); echo "a$ip b"; curl $ip
a
33.127.121.7 b
curl: (3) URL using bad/illegal format or missing URL
```

This PR disabled such option.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
