### PR TITLE
[UX] Hint user when changing `spot.controller.resources` in skypilot config

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -205,6 +205,11 @@ def _execute(
       idle_minutes_to_autostop: int; if provided, the cluster will be set to
         autostop after this many minutes of idleness.
       no_setup: bool; whether to skip setup commands or not when (re-)launching.
+
+    Raises:
+      sky.exceptions.ResourcesMismatchError: if an existing cluster is given,
+      and the requested resources in the task is more demanding than the
+      existing cluster.
     """
     dag = _convert_to_dag(entrypoint)
     assert len(dag) == 1, f'We support 1 task for now. {dag}'
@@ -758,10 +763,11 @@ def spot_launch(
         except exceptions.ResourcesMismatchError as e:
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(
-                    'Modifying spot controller resources is not supported. '
-                    'Please change the spot.controller.resources in '
-                    '~/.sky/config.yaml file to the original values or '
-                    'remove it instead.') from e
+                    'Found existing spot controller but ~/.sky/config.yaml '
+                    'specifies a different spot.controller.resources field.\n'
+                    'To change the spot controller\'s resources, `sky down` '
+                    'it first and redo `sky spot launch` for the configured '
+                    'resources to take effect.') from e
 
 
 def _maybe_translate_local_file_mounts_and_sync_up(task: task_lib.Task):

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -755,13 +755,13 @@ def spot_launch(
                 SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
                 retry_until_up=True,
             )
-        except exceptions.ResourcesMismatchError:
+        except exceptions.ResourcesMismatchError as e:
             with ux_utils.print_exception_no_traceback():
-                raise exceptions.ResourcesMismatchError(
+                raise RuntimeError(
                     'Modifying spot controller resources is not supported. '
                     'Please change the spot.controller.resources in '
-                    '~/.sky/config.yaml file to the original values or remove '
-                    'it instead.') from None
+                    '~/.sky/config.yaml file to the original values or '
+                    'remove it instead.') from e
 
 
 def _maybe_translate_local_file_mounts_and_sync_up(task: task_lib.Task):

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -745,15 +745,23 @@ def spot_launch(
               f'Launching managed spot job {dag.name!r} from spot controller...'
               f'{colorama.Style.RESET_ALL}')
         print('Launching spot controller...')
-        _execute(
-            entrypoint=controller_task,
-            stream_logs=stream_logs,
-            cluster_name=controller_name,
-            detach_run=detach_run,
-            idle_minutes_to_autostop=spot.
-            SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
-            retry_until_up=True,
-        )
+        try:
+            _execute(
+                entrypoint=controller_task,
+                stream_logs=stream_logs,
+                cluster_name=controller_name,
+                detach_run=detach_run,
+                idle_minutes_to_autostop=spot.
+                SPOT_CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
+                retry_until_up=True,
+            )
+        except exceptions.ResourcesMismatchError:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ResourcesMismatchError(
+                    'Modifying spot controller resources is not supported. '
+                    'Please change the spot.controller.resources in '
+                    '~/.sky/config.yaml file to the original values or remove '
+                    'it instead.') from None
 
 
 def _maybe_translate_local_file_mounts_and_sync_up(task: task_lib.Task):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Current spot implementation doesn't support modifying spot controller resources once the controller is launched. This PR adds a user hint for such cases.

Previously:
```bash
Traceback (most recent call last):
  File "/home/memory/install/miniconda3/envs/sky-dev/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 311, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/cli.py", line 1162, in invoke
    return super().invoke(ctx)
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 311, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/cli.py", line 1162, in invoke
    return super().invoke(ctx)
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/memory/install/miniconda3/envs/sky-dev/lib/python3.7/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 332, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 332, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/cli.py", line 3740, in spot_launch
    retry_until_up=retry_until_up)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 332, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/execution.py", line 755, in spot_launch
    retry_until_up=True,
  File "/home/memory/skypilot/sky/execution.py", line 320, in _execute
    retry_until_up=retry_until_up)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 332, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 311, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/backends/backend.py", line 57, in provision
    cluster_name, retry_until_up)
  File "/home/memory/skypilot/sky/backends/cloud_vm_ray_backend.py", line 2804, in _provision
    task, to_provision, cluster_name, dryrun)
  File "/home/memory/skypilot/sky/utils/common_utils.py", line 332, in _record
    return f(*args, **kwargs)
  File "/home/memory/skypilot/sky/backends/cloud_vm_ray_backend.py", line 4323, in _check_existing_cluster
    self.check_resources_fit_cluster(handle, task)
  File "/home/memory/skypilot/sky/backends/cloud_vm_ray_backend.py", line 2757, in check_resources_fit_cluster
    'Requested resources do not match the existing cluster.\n'
sky.exceptions.ResourcesMismatchError: Requested resources do not match the existing cluster.
  Requested:    1x AWS(cpus=4, disk_size=50) 
  Existing:     1x GCP(n2-standard-4, disk_size=50)
To fix: specify a new cluster name, or down the existing cluster first: sky down sky-spot-controller-402b1bba
```
Now:
```bash
sky.exceptions.ResourcesMismatchError: Requested resources do not match the existing cluster.
  Requested:    1x AWS(cpus=4, disk_size=50) 
  Existing:     1x GCP(n2-standard-4, disk_size=50)
To fix: specify a new cluster name, or down the existing cluster first: sky down sky-spot-controller-402b1bba

The above exception was the direct cause of the following exception:

RuntimeError: Modifying spot controller resources is not supported. Please change the spot.controller.resources in ~/.sky/config.yaml file to the original values or remove it instead.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - launch a spot controller with `cloud: gcp`; specify `cloud: aws` and `sky spot launch` again
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
