### PR TITLE
[Docs][k8s] Update GKE driver installation for L4 nodes

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -90,15 +90,21 @@ Deploying on Google Cloud GKE
 3. [If using GPUs] If your GKE nodes have GPUs, you may need to to
    `manually install <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_
    nvidia drivers. You can do so by deploying the daemonset
-   depending on the OS of your nodes:
+   depending on the GPU and OS on your nodes:
 
    .. code-block:: console
 
-     # For Container Optimized OS (COS) based nodes:
+     # For Container Optimized OS (COS) based nodes with GPUs other than Nvidia L4 (e.g., V100, A100, ...):
+     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+
+     # For Container Optimized OS (COS) based nodes with L4 GPUs:
      $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
 
-     # For Ubuntu based nodes:
+     # For Ubuntu based nodes with GPUs other than Nvidia L4 (e.g., V100, A100, ...):
      $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+
+     # For Ubuntu based nodes with L4 GPUs:
+     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded-R525.yaml
 
    To verify if GPU drivers are set up, run ``kubectl describe nodes`` and verify that ``nvidia.com/gpu`` is listed under the ``Capacity`` section.
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -95,10 +95,10 @@ Deploying on Google Cloud GKE
    .. code-block:: console
 
      # For Container Optimized OS (COS) based nodes with GPUs other than Nvidia L4 (e.g., V100, A100, ...):
-     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
+     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
 
      # For Container Optimized OS (COS) based nodes with L4 GPUs:
-     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+     $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded-latest.yaml
 
      # For Ubuntu based nodes with GPUs other than Nvidia L4 (e.g., V100, A100, ...):
      $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml


### PR DESCRIPTION
L4 uses a different driver installation YAML (see [gke docs](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#cos)). Updated our docs for users who may be running L4 GPUs.

Tested (run the relevant ones):

- [x] Rendered locally
