### PR TITLE
Revamped SSH Configuration Storage

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -478,6 +478,7 @@ class SSHConfigHelper(object):
         if docker_user is not None:
             username = docker_user
         key_path = os.path.expanduser(auth_config['ssh_private_key'])
+        host_name = cluster_name
         sky_autogen_comment = ('# Added by sky (use `sky stop/down '
                                f'{cluster_name}` to remove)')
         fix_stale_config = False

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -564,10 +564,10 @@ class SSHConfigHelper(object):
                 worker_name = cluster_name + f'-worker{i+1}'
                 #TODO update port numbers for workers in edge cases
                 codegen = cls._get_generated_config(sky_autogen_comment,
-                                                    worker_name, 
-                                                    ip, 
+                                                    worker_name,
+                                                    ip,
                                                     username,
-                                                    key_path, 
+                                                    key_path,
                                                     proxy_command,
                                                     ports[i + 1], #updated port numbers
                                                     docker_proxy_command)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -549,15 +549,15 @@ class SSHConfigHelper(object):
             head_port = constants.DEFAULT_DOCKER_PORT
 
         #Start generating the config with the head node
-        codegens += codegen(sky_autogen_comment, cluster_name, ip, username,
-                            key_path, proxy_command, head_port,
-                            docker_proxy_command) + '\n'
+        codegen = cls._get_generated_config(
+            sky_autogen_comment, cluster_name, ip, username, key_path,
+            proxy_command, head_port, docker_proxy_command) + '\n'
 
         #add the worker nodes if any exist
         for i, ip in enumerate(ips[1:]):
             worker_name = cluster_name + f'-worker{i+1}'
             #TODO update port numbers for workers in edge cases
-            codegen = cls._get_generated_config(
+            codegen += cls._get_generated_config(
                 sky_autogen_comment,
                 worker_name,
                 ip,
@@ -565,8 +565,7 @@ class SSHConfigHelper(object):
                 key_path,
                 proxy_command,
                 ports[i],  #updated port numbers
-                docker_proxy_command)
-            codegens += codegen + '\n'
+                docker_proxy_command) + '\n'
 
         # Remove the cluster from the old config if it exists.
         # We will add the config in ~/.sky/ssh/<cluster_name> instead.
@@ -578,7 +577,7 @@ class SSHConfigHelper(object):
             cls.ssh_cluster_path.format(cluster_name))
 
         with open(config_path, 'w') as f:
-            f.write(codegens)
+            f.write(codegen)
 
     @classmethod
     @timeline.FileLockEvent(ssh_conf_lock_path)

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -527,7 +527,7 @@ class SSHConfigHelper(object):
         if docker_user is not None:
             docker_proxy_command_generator = lambda ip, port: ' '.join(
                 ['ssh'] + command_runner.ssh_options_list(
-                    key_path, None, port=port) +
+                    key_path, ssh_control_name=None, port=port) +
                 ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
 
         codegen = ''
@@ -655,7 +655,7 @@ class SSHConfigHelper(object):
                 break
 
     @classmethod
-    # TODO: We can remve this after 0.6.0 and have a lock only per cluster.
+    # TODO: We can remove this after 0.6.0 and have a lock only per cluster.
     @timeline.FileLockEvent(ssh_conf_lock_path)
     def remove_cluster(
         cls,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -563,14 +563,15 @@ class SSHConfigHelper(object):
             for i, ip in enumerate(ips[1:]):
                 worker_name = cluster_name + f'-worker{i+1}'
                 #TODO update port numbers for workers in edge cases
-                codegen = cls._get_generated_config(sky_autogen_comment,
-                                                    worker_name,
-                                                    ip,
-                                                    username,
-                                                    key_path,
-                                                    proxy_command,
-                                                    ports[i + 1], #updated port numbers
-                                                    docker_proxy_command)
+                codegen = cls._get_generated_config(
+                    sky_autogen_comment,
+                    worker_name,
+                    ip,
+                    username,
+                    key_path,
+                    proxy_command,
+                    ports[i + 1],  #updated port numbers
+                    docker_proxy_command)
                 with open(cluster_config_path, 'a') as f:
                     f.write(codegen + '\n')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -475,7 +475,6 @@ class SSHConfigHelper(object):
             docker_user: If not None, use this user to ssh into the docker
         """
         username = auth_config['ssh_user']
-        print("In add cluster")
         if docker_user is not None:
             username = docker_user
         key_path = os.path.expanduser(auth_config['ssh_private_key'])

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -526,21 +526,20 @@ class SSHConfigHelper(object):
         docker_proxy_command = None
         head_port = ports[0]
         if docker_user is not None:
-            docker_proxy_command_generator = ' '.join(
+            docker_proxy_command_generator = lambda ip: ' '.join(
                 ['ssh'] + command_runner.ssh_options_list(key_path, None) +
-                ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ips}'])
+                ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
             head_port = constants.DEFAULT_DOCKER_PORT
 
         # Start generating the config with the head node
         codegen = cls._get_generated_config(
             sky_autogen_comment, host_name, ip, username, key_path,
-            proxy_command, head_port, docker_proxy_command) + '\n'
+            proxy_command, head_port, docker_proxy_command_generator(ip)) + '\n'
 
         # Add the worker nodes if any exist
         for i, ip in enumerate(ips[1:]):
             if docker_user is not None:
                 docker_proxy_command = docker_proxy_command_generator(ip)
-                ip = 'localhost'
             worker_name = cluster_name + f'-worker{i+1}'
             # TODO(romilb): Update port number when k8s supports multinode
             codegen += cls._get_generated_config(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -475,6 +475,7 @@ class SSHConfigHelper(object):
             docker_user: If not None, use this user to ssh into the docker
         """
         username = auth_config['ssh_user']
+        print("In add cluster")
         if docker_user is not None:
             username = docker_user
         key_path = os.path.expanduser(auth_config['ssh_private_key'])
@@ -525,8 +526,9 @@ class SSHConfigHelper(object):
 
         docker_proxy_command_generator = None
         if docker_user is not None:
-            docker_proxy_command_generator = lambda ip: ' '.join(
-                ['ssh'] + command_runner.ssh_options_list(key_path, None) +
+            docker_proxy_command_generator = lambda ip, port: ' '.join(
+                ['ssh'] + command_runner.ssh_options_list(
+                    key_path, None, port=port) +
                 ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
 
         codegen = ''
@@ -535,7 +537,7 @@ class SSHConfigHelper(object):
             docker_proxy_command = None
             port = ports[i]
             if docker_proxy_command_generator is not None:
-                docker_proxy_command = docker_proxy_command_generator(ip)
+                docker_proxy_command = docker_proxy_command_generator(ip, port)
                 ip = 'localhost'
                 port = constants.DEFAULT_DOCKER_PORT
             node_name = cluster_name if i == 0 else cluster_name + f'-worker{i}'

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -478,7 +478,6 @@ class SSHConfigHelper(object):
         if docker_user is not None:
             username = docker_user
         key_path = os.path.expanduser(auth_config['ssh_private_key'])
-        host_name = cluster_name
         sky_autogen_comment = ('# Added by sky (use `sky stop/down '
                                f'{cluster_name}` to remove)')
         ip = ips[0]
@@ -531,25 +530,19 @@ class SSHConfigHelper(object):
                 ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ip}'])
 
         codegen = ''
-        # Add the nodes to the codegen 
+        # Add the nodes to the codegen
         for i, ip in enumerate(ips):
             docker_proxy_command = None
             port = ports[i]
-            if docker_user is not None:
+            if docker_proxy_command_generator is not None:
                 docker_proxy_command = docker_proxy_command_generator(ip)
                 ip = 'localhost'
                 port = constants.DEFAULT_DOCKER_PORT
             node_name = cluster_name if i == 0 else cluster_name + f'-worker{i}'
             # TODO(romilb): Update port number when k8s supports multinode
             codegen += cls._get_generated_config(
-                sky_autogen_comment,
-                node_name,
-                ip,
-                username,
-                key_path,
-                proxy_command,
-                port,
-                docker_proxy_command) + '\n'
+                sky_autogen_comment, node_name, ip, username, key_path,
+                proxy_command, port, docker_proxy_command) + '\n'
 
         cluster_config_path = os.path.expanduser(
             cls.ssh_cluster_path.format(cluster_name))

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -482,7 +482,6 @@ class SSHConfigHelper(object):
         sky_autogen_comment = ('# Added by sky (use `sky stop/down '
                                f'{cluster_name}` to remove)')
         overwrite = False
-        overwrite_begin_idx = None
         ip = ips[0]
         if docker_user is not None:
             ip = 'localhost'
@@ -505,11 +504,11 @@ class SSHConfigHelper(object):
                     with open(config_path, 'w') as f:
                         config.insert(0, '\n')
                         config.insert(0, include_str + '\n')
-                        config.insert(0, "# Added by sky"+ '\n')
+                        config.insert(0, '# Added by sky' + '\n')
                         f.write(''.join(config).strip())
                         f.write('\n' * 2)
                     break
-        
+
         #For backward compatibility
         if os.path.exists(config_path):
             with open(config_path) as f:
@@ -551,9 +550,11 @@ class SSHConfigHelper(object):
 
         # Remove the old config if it exists.
         if overwrite:
-            SSHConfigHelper.remove_cluster(cluster_name)
+            SSHConfigHelper.remove_cluster(cluster_name, ip, auth_config,
+                                           docker_user)
 
-        cluster_config_path = os.path.expanduser(cls.ssh_cluster_path.format(cluster_name))
+        cluster_config_path = os.path.expanduser(
+            cls.ssh_cluster_path.format(cluster_name))
 
         with open(cluster_config_path, 'w') as f:
             f.write(codegen + '\n')
@@ -563,8 +564,11 @@ class SSHConfigHelper(object):
                 worker_name = cluster_name + f'-worker{i+1}'
                 #TODO update port numbers for workers in edge cases
                 codegen = cls._get_generated_config(sky_autogen_comment,
-                                                    worker_name, ip, username,
-                                                    key_path, proxy_command,
+                                                    worker_name, 
+                                                    ip, 
+                                                    username,
+                                                    key_path, 
+                                                    proxy_command,
                                                     ports[i + 1], #updated port numbers
                                                     docker_proxy_command)
                 with open(cluster_config_path, 'a') as f:
@@ -622,9 +626,9 @@ class SSHConfigHelper(object):
             if found:
                 start_line_idx = i - 1
                 break
-        
+
         # Ensures backward compatibility
-        if start_line_idx is not None: 
+        if start_line_idx is not None:
 
             # Scan for end of previous config.
             cursor = start_line_idx
@@ -651,7 +655,8 @@ class SSHConfigHelper(object):
                 f.write(''.join(config).strip())
                 f.write('\n' * 2)
 
-        cluster_config_path = os.path.expanduser(cls.ssh_cluster_path.format(cluster_name))
+        cluster_config_path = os.path.expanduser(
+            cls.ssh_cluster_path.format(cluster_name))
         if os.path.exists(cluster_config_path):
             os.remove(cluster_config_path)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -526,7 +526,7 @@ class SSHConfigHelper(object):
         docker_proxy_command = None
         head_port = ports[0]
         if docker_user is not None:
-            docker_proxy_command = ' '.join(
+            docker_proxy_command_generator = ' '.join(
                 ['ssh'] + command_runner.ssh_options_list(key_path, None) +
                 ['-W', '%h:%p', f'{auth_config["ssh_user"]}@{ips}'])
             head_port = constants.DEFAULT_DOCKER_PORT

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -550,7 +550,7 @@ class SSHConfigHelper(object):
 
         #Start generating the config with the head node
         codegen = cls._get_generated_config(
-            sky_autogen_comment, cluster_name, ip, username, key_path,
+            sky_autogen_comment, host_name, ip, username, key_path,
             proxy_command, head_port, docker_proxy_command) + '\n'
 
         #add the worker nodes if any exist
@@ -576,7 +576,7 @@ class SSHConfigHelper(object):
         cluster_config_path = os.path.expanduser(
             cls.ssh_cluster_path.format(cluster_name))
 
-        with open(config_path, 'w') as f:
+        with open(cluster_config_path, 'w') as f:
             f.write(codegen)
 
     @classmethod
@@ -692,7 +692,7 @@ class SSHConfigHelper(object):
         auth_config: Dict[str, str],
         docker_user: Optional[str] = None,
     ):
-        """Remove authentication information for cluster from local SSH config file 
+        """Remove authentication information for cluster from local SSH config file
         and ~/.sky/ssh/<cluster_name>.
 
         If no existing host matching the provided specification is found, then

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -556,7 +556,7 @@ class SSHConfigHelper(object):
         cluster_config_path = os.path.expanduser(cls.ssh_cluster_path.format(cluster_name))
 
         with open(cluster_config_path, 'w') as f:
-            f.write(codegen)
+            f.write(codegen + '\n')
 
         if len(ips) > 1:
             for i, ip in enumerate(ips[1:]):


### PR DESCRIPTION
### **Description**:

This is in relation to https://github.com/skypilot-org/skypilot/issues/1765

**Overview:**
This PR introduces a significant change to the SSHConfigHelper, where the configuration for cluster host details is now stored in a dedicated file within the .sky/generated/ssh folder. The user's primary configuration file now includes an Include statement to reference this folder.

**Backward Compatibility:**
For users adding existing clusters, the previous configuration for those clusters will be removed from the main configuration file, and a new configuration file will be created in the `.sky/generated/ssh folder.` This change ensures that removal of existing clusters performed prior to this update functions as expected.

**Testing:**
Extensive manual testing was conducted, as the existing tests were found to be inadequate for this specific use case. Testing primarily involved adding and removing clusters using sky launch and sky down commands, ensuring that a file is created and deleted for each cluster accordingly. To guarantee backward compatibility, clusters were added with the master and checked out on this branch to verify expected behavior.

**Please Review:**

- Ensure the revised SSHConfigHelper's compatibility with existing configurations.
- Confirm that new cluster configurations are correctly stored and referenced.
- Test backward compatibility, especially for clusters added prior to this update.
- Validate the behaviour of the sky launch and sky down commands in relation to configuration files.
- Your feedback and suggestions are highly appreciated. This change will significantly improve SSH configuration management and ensure smoother cluster management for users.