### PR TITLE
Added confirmation prompt for sky storage delete, and --yes flag to skip it

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3443,8 +3443,14 @@ def storage_ls(all: bool):
               is_flag=True,
               required=False,
               help='Delete all storage objects.')
+@click.option('--yes',
+              '-y',
+              default=False,
+              is_flag=True,
+              required=False,
+              help='Skip confirmation prompt.')
 @usage_lib.entrypoint
-def storage_delete(names: List[str], all: bool):  # pylint: disable=redefined-builtin
+def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=redefined-builtin
     """Delete storage objects.
 
     Examples:
@@ -3460,8 +3466,35 @@ def storage_delete(names: List[str], all: bool):  # pylint: disable=redefined-bu
         # Delete all storage objects.
         sky storage delete -a
     """
+
     if sum([len(names) > 0, all]) != 1:
         raise click.UsageError('Either --all or a name must be specified.')
+    if not yes:
+        if all:
+            storages = sky.storage_ls()
+            storage_list = [s['name'] for s in storages]
+            storage_names = ', '.join(storage_list)
+            click.confirm(
+                f'Deleting {len(storage_list)} storages: '
+                f'{storage_names}. Proceed?',
+                default=True,
+                abort=True,
+                show_default=True)
+        else:
+            if len(names) > 1:
+                click.confirm(
+                    f'Deleting {len(names)} storages: '
+                    f'{", ".join(names)}. Proceed?',
+                    default=True,
+                    abort=True,
+                    show_default=True)
+            else:
+                storage_name = names[0]
+                click.confirm(
+                    f'Deleting storage: {storage_name}. Proceed?',
+                    default=True,
+                    abort=True,
+                    show_default=True)
     if all:
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3479,8 +3479,7 @@ def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=r
                 f'{storage_names}. Proceed?',
                 default=True,
                 abort=True,
-                show_default=True
-            )
+                show_default=True)
         else:
             if len(names) > 1:
                 click.confirm(
@@ -3488,16 +3487,13 @@ def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=r
                     f'{", ".join(names)}. Proceed?',
                     default=True,
                     abort=True,
-                    show_default=True
-                )
+                    show_default=True)
             else:
                 storage_name = names[0]
-                click.confirm(
-                    f'Deleting storage: {storage_name}. Proceed?',
-                    default=True,
-                    abort=True,
-                    show_default=True
-                )
+                click.confirm(f'Deleting storage: {storage_name}. Proceed?',
+                              default=True,
+                              abort=True,
+                              show_default=True)
     if all:
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3475,23 +3475,23 @@ def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=r
             storage_list = [s['name'] for s in storages]
             storage_names = ', '.join(storage_list)
             click.confirm(f'Deleting {len(storage_list)} storages: '
-                         f'{storage_names}. Proceed?',
-                         default=True,
-                         abort=True,
-                         show_default=True)
+                          f'{storage_names}. Proceed?',
+                          default=True,
+                          abort=True,
+                          show_default=True)
         else:
             if len(names) > 1:
-                click.confirm(f'Deleting {len(names)} storages: ' 
-                             f'{", ".join(names)}. Proceed?',
-                             default=True,
-                             abort=True,
-                             show_default=True)
+                click.confirm(f'Deleting {len(names)} storages: '
+                              f'{", ".join(names)}. Proceed?',
+                              default=True,
+                              abort=True,
+                              show_default=True)
             else:
                 storage_name = names[0]
                 click.confirm(f'Deleting storage: {storage_name}. Proceed?', 
-                             default=True, 
-                             abort=True, 
-                             show_default=True)
+                              default=True, 
+                              abort=True, 
+                              show_default=True)
     if all:
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3474,24 +3474,30 @@ def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=r
             storages = sky.storage_ls()
             storage_list = [s['name'] for s in storages]
             storage_names = ', '.join(storage_list)
-            click.confirm(f'Deleting {len(storage_list)} storages: '
-                          f'{storage_names}. Proceed?',
-                          default=True,
-                          abort=True,
-                          show_default=True)
+            click.confirm(
+                f'Deleting {len(storage_list)} storages: '
+                f'{storage_names}. Proceed?',
+                default=True,
+                abort=True,
+                show_default=True
+            )
         else:
             if len(names) > 1:
-                click.confirm(f'Deleting {len(names)} storages: '
-                              f'{", ".join(names)}. Proceed?',
-                              default=True,
-                              abort=True,
-                              show_default=True)
+                click.confirm(
+                    f'Deleting {len(names)} storages: '
+                    f'{", ".join(names)}. Proceed?',
+                    default=True,
+                    abort=True,
+                    show_default=True
+                )
             else:
                 storage_name = names[0]
-                click.confirm(f'Deleting storage: {storage_name}. Proceed?', 
-                              default=True, 
-                              abort=True, 
-                              show_default=True)
+                click.confirm(
+                    f'Deleting storage: {storage_name}. Proceed?',
+                    default=True,
+                    abort=True,
+                    show_default=True
+                )
     if all:
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3474,27 +3474,24 @@ def storage_delete(names: List[str], all: bool, yes: bool):  # pylint: disable=r
             storages = sky.storage_ls()
             storage_list = [s['name'] for s in storages]
             storage_names = ', '.join(storage_list)
-            click.confirm(
-                f'Deleting {len(storage_list)} storages: '
-                f'{storage_names}. Proceed?',
-                default=True,
-                abort=True,
-                show_default=True)
+            click.confirm(f'Deleting {len(storage_list)} storages: '
+                         f'{storage_names}. Proceed?',
+                         default=True,
+                         abort=True,
+                         show_default=True)
         else:
             if len(names) > 1:
-                click.confirm(
-                    f'Deleting {len(names)} storages: '
-                    f'{", ".join(names)}. Proceed?',
-                    default=True,
-                    abort=True,
-                    show_default=True)
+                click.confirm(f'Deleting {len(names)} storages: ' 
+                             f'{", ".join(names)}. Proceed?',
+                             default=True,
+                             abort=True,
+                             show_default=True)
             else:
                 storage_name = names[0]
-                click.confirm(
-                    f'Deleting storage: {storage_name}. Proceed?',
-                    default=True,
-                    abort=True,
-                    show_default=True)
+                click.confirm(f'Deleting storage: {storage_name}. Proceed?', 
+                             default=True, 
+                             abort=True, 
+                             show_default=True)
     if all:
         click.echo('Deleting all storage objects.')
         storages = sky.storage_ls()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3149,8 +3149,8 @@ class TestStorageWithCredentials:
         tmp_bulk_del_storage_obj.add_store(store_type)
 
         subprocess.check_output(
-            ['sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'])
-
+            ['sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'
+        ])
         output = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_bulk_del_storage_obj.name not in output.decode('utf-8')
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3148,8 +3148,8 @@ class TestStorageWithCredentials:
         # files and folders to a new bucket, then delete bucket.
         tmp_bulk_del_storage_obj.add_store(store_type)
 
-        subprocess.check_output(
-            ['sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'
+        subprocess.check_output([
+            'sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'
         ])
         output = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_bulk_del_storage_obj.name not in output.decode('utf-8')

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3062,7 +3062,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage delete to delete the storage object
         subprocess.check_output(
-            ['sky', 'storage', 'delete', tmp_local_storage_obj.name])
+            ['sky', 'storage', 'delete', tmp_local_storage_obj.name, '--yes'])
 
         # Run sky storage ls to check if storage object is deleted
         out = subprocess.check_output(['sky', 'storage', 'ls'])
@@ -3096,6 +3096,7 @@ class TestStorageWithCredentials:
         # Run sky storage delete all to delete all storage objects
         delete_cmd = ['sky', 'storage', 'delete']
         delete_cmd += storage_obj_name
+        delete_cmd.append('--yes')
         subprocess.check_output(delete_cmd)
 
         # Run sky storage ls to check if all storage objects filtered by store
@@ -3129,7 +3130,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage delete to delete the storage object
         out = subprocess.check_output(
-            ['sky', 'storage', 'delete', tmp_scratch_storage_obj.name])
+            ['sky', 'storage', 'delete', tmp_scratch_storage_obj.name, '--yes'])
         # Make sure bucket was not created during deletion (see issue #1322)
         assert 'created' not in out.decode('utf-8').lower()
 
@@ -3148,7 +3149,7 @@ class TestStorageWithCredentials:
         tmp_bulk_del_storage_obj.add_store(store_type)
 
         subprocess.check_output(
-            ['sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name])
+            ['sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'])
 
         output = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_bulk_del_storage_obj.name not in output.decode('utf-8')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This is for issue #2635 

Added a feature for `sky storage delete` where by default it shows a confirmation prompt before deleting, like in `sky down` or `sky stop`. Like those commands, users can add a `--yes` flag to skip the confirmation prompt. Also changed some tests in test_smoke for TestStorageWithCredentials for the tests to automatically use the --yes flag. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
Changed some `check_output` commands to include the `--yes` flag, so previously if it was `check_output(['sky', 'storage', 'delete', [storage_name])`, now it's `check_output(['sky', 'storage', 'delete', [storage_name], '--yes')`   
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
