### PR TITLE
[Spot] Speedup and handle failure when cleanup

### DIFF
--- a/sky/spot/spot_state.py
+++ b/sky/spot/spot_state.py
@@ -197,6 +197,9 @@ class SpotStatus(enum.Enum):
     # FAILED_CONTROLLER: The job is finished with failure because of unexpected
     # error in the controller process.
     FAILED_CONTROLLER = 'FAILED_CONTROLLER'
+    # FAILED_CLEANUP: The job is finished with failure because of unexpected
+    # error in the cleanup process.
+    FAILED_CLEANUP = 'FAILED_CLEANUP'
 
     def is_terminal(self) -> bool:
         return self in self.terminal_statuses()
@@ -220,6 +223,7 @@ class SpotStatus(enum.Enum):
             cls.FAILED_PRECHECKS,
             cls.FAILED_NO_RESOURCE,
             cls.FAILED_CONTROLLER,
+            cls.FAILED_CLEANUP,
             cls.CANCELLING,
             cls.CANCELLED,
         ]
@@ -228,7 +232,7 @@ class SpotStatus(enum.Enum):
     def failure_statuses(cls) -> List['SpotStatus']:
         return [
             cls.FAILED, cls.FAILED_SETUP, cls.FAILED_PRECHECKS,
-            cls.FAILED_NO_RESOURCE, cls.FAILED_CONTROLLER
+            cls.FAILED_NO_RESOURCE, cls.FAILED_CONTROLLER, cls.FAILED_CLEANUP
         ]
 
 
@@ -244,6 +248,7 @@ _SPOT_STATUS_TO_COLOR = {
     SpotStatus.FAILED_SETUP: colorama.Fore.RED,
     SpotStatus.FAILED_NO_RESOURCE: colorama.Fore.RED,
     SpotStatus.FAILED_CONTROLLER: colorama.Fore.RED,
+    SpotStatus.FAILED_CLEANUP: colorama.Fore.RED,
     SpotStatus.CANCELLING: colorama.Fore.YELLOW,
     SpotStatus.CANCELLED: colorama.Fore.YELLOW,
 }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR uses `multiprocessing.Process` to speedup spot cluster termination speed when spot pipeline is used. This also enables error handling for cleanup failure.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - `sky spot launch whoami --cloud gcp --cpus 2` and check the sport cluster is correctly tear down.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
