### PR TITLE
[k8s] Add netcat to dependency checks

### DIFF
--- a/docs/source/reference/kubernetes/index.rst
+++ b/docs/source/reference/kubernetes/index.rst
@@ -50,15 +50,15 @@ Submitting SkyPilot tasks to Kubernetes Clusters
 
 Once your cluster administrator has :ref:`setup a Kubernetes cluster <kubernetes-setup>` and provided you with a kubeconfig file:
 
-0. Make sure `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ and ``socat`` are installed on your local machine.
+0. Make sure `kubectl <https://kubernetes.io/docs/tasks/tools/>`_, ``socat`` and ``nc`` (netcat) are installed on your local machine.
 
    .. code-block:: console
 
      $ # MacOS
-     $ brew install kubectl socat
+     $ brew install kubectl socat netcat
 
      $ # Linux (may have socat already installed)
-     $ sudo apt-get install kubectl socat
+     $ sudo apt-get install kubectl socat netcat
 
 
 1. Place your kubeconfig file at ``~/.kube/config``.

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -7,6 +7,12 @@ if ! command -v socat > /dev/null; then
   exit
 fi
 
+# Checks if netcat is installed (may not be present in many docker images)
+if ! command -v nc > /dev/null; then
+  echo "Using 'port-forward' mode to run ssh session on Kubernetes instances requires 'nc' to be installed. Please install 'nc' (netcat)." >&2
+  exit
+fi
+
 # Establishes connection between local port and the ssh jump pod using kube port-forward
 # Instead of specifying a port, we let kubectl select a random port.
 # This is preferred because of socket re-use issues in kubectl port-forward,

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -994,10 +994,8 @@ def check_port_forward_mode_dependencies() -> None:
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.
-    # nc does not have a version flag and `nc -h` returns returncode 1,
-    # so we use `command -v` to check if it is installed.
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
-                       ['nc', ['command', '-v', 'nc'], 'netcat']]
+                       ['nc', ['nc', '-h'], 'netcat']]
     for name, check_cmd, install_cmd in dependency_list:
         try:
             subprocess.run(check_cmd,


### PR DESCRIPTION
Closes #2626. Adds preemptive check for netcat before trying provisioning.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky launch -c test --cloud kubernetes` on a docker container with a) Neither `socat` nor `nc` b) with `socat`, but without `nc` c) with all dependencies.
- [x] Rendered docs locally