### PR TITLE
[Provisioner] Fix cache for internal file mounts

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2904,8 +2904,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     provisioner.ClusterName(handle.cluster_name,
                                             handle.cluster_name_on_cloud),
                     handle.cluster_yaml,
-                    local_wheel_path=local_wheel_path,
-                    wheel_hash=wheel_hash,
                     provision_record=provision_record,
                     custom_resource=resources_vars.get('custom_resources'),
                     log_dir=self.log_dir)

--- a/sky/provision/metadata_utils.py
+++ b/sky/provision/metadata_utils.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import pathlib
 import shutil
+from typing import Optional
 
 from sky import sky_logging
 
@@ -30,7 +31,7 @@ def _get_instance_metadata_dir(cluster_name: str,
 
 
 def cache_func(cluster_name: str, instance_id: str, stage_name: str,
-               hash_str: str):
+               hash_str: Optional[str]):
     """A helper function for caching function execution."""
 
     def decorator(function):
@@ -51,8 +52,11 @@ def cache_func(cluster_name: str, instance_id: str, stage_name: str,
 
 @contextlib.contextmanager
 def check_cache_hash_or_update(cluster_name: str, instance_id: str,
-                               stage_name: str, hash_str: str):
+                               stage_name: str, hash_str: Optional[str]):
     """A decorator for 'cache_func'."""
+    if hash_str is None:
+        yield True
+        return
     path = get_instance_cache_dir(cluster_name, instance_id) / stage_name
     if path.exists():
         with open(path) as f:

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -3,7 +3,6 @@ import collections
 import dataclasses
 import json
 import os
-import pathlib
 import shlex
 import socket
 import subprocess
@@ -311,7 +310,6 @@ def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
 
 def _post_provision_setup(
         cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        local_wheel_path: pathlib.Path, wheel_hash: str,
         provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str]) -> provision_common.ClusterInfo:
     cluster_info = provision.get_cluster_info(cloud_name,
@@ -388,21 +386,15 @@ def _post_provision_setup(
         # (3) all instances need permission to mount storage for all clouds
         # It is possible to have a "smaller" permission model, but we leave that
         # for later.
-        file_mounts = {
-            backend_utils.SKY_REMOTE_PATH + '/' + wheel_hash:
-                str(local_wheel_path),
-            **config_from_yaml.get('file_mounts', {})
-        }
+        file_mounts = config_from_yaml.get('file_mounts', {})
 
         runtime_preparation_str = ('[bold cyan]Preparing SkyPilot '
                                    'runtime ({step}/3 - {step_name})')
         status.update(
             runtime_preparation_str.format(step=1, step_name='initializing'))
         instance_setup.internal_file_mounts(cluster_name.name_on_cloud,
-                                            file_mounts,
-                                            cluster_info,
-                                            ssh_credentials,
-                                            wheel_hash=wheel_hash)
+                                            file_mounts, cluster_info,
+                                            ssh_credentials)
 
         status.update(
             runtime_preparation_str.format(step=2, step_name='dependencies'))
@@ -464,7 +456,6 @@ def _post_provision_setup(
 
 def post_provision_runtime_setup(
         cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        local_wheel_path: pathlib.Path, wheel_hash: str,
         provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str],
         log_dir: str) -> provision_common.ClusterInfo:
@@ -483,8 +474,6 @@ def post_provision_runtime_setup(
             return _post_provision_setup(cloud_name,
                                          cluster_name,
                                          cluster_yaml=cluster_yaml,
-                                         local_wheel_path=local_wheel_path,
-                                         wheel_hash=wheel_hash,
                                          provision_record=provision_record,
                                          custom_resource=custom_resource)
         except Exception:  # pylint: disable=broad-except

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -2,6 +2,7 @@
 
 import time
 
+import sky
 from sky import sky_logging
 from sky.skylet import constants
 from sky.skylet import events
@@ -10,7 +11,8 @@ from sky.skylet import events
 # `sky.skylet.skylet` namespace when executed directly, so as
 # to inherit the setup from the `sky` logger.
 logger = sky_logging.init_logger('sky.skylet.skylet')
-logger.info(f'skylet started with version {constants.SKYLET_VERSION}.')
+logger.info(f'Skylet started with version {constants.SKYLET_VERSION}; '
+            f'SkyPilot v{sky.__version__} (commit: {sky.__commit__})')
 
 EVENTS = [
     events.AutostopEvent(),

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -3,13 +3,14 @@
 import time
 
 from sky import sky_logging
+from sky.skylet import constants
 from sky.skylet import events
 
 # Use the explicit logger name so that the logger is under the
 # `sky.skylet.skylet` namespace when executed directly, so as
 # to inherit the setup from the `sky` logger.
 logger = sky_logging.init_logger('sky.skylet.skylet')
-logger.info('skylet started')
+logger.info(f'skylet started with version {constants.SKYLET_VERSION}.')
 
 EVENTS = [
     events.AutostopEvent(),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2714

We should not cache the internal file mounts based on the wheel hash, as the cloud credential can be changed, and the cache will cause the credentials on the remote VM failed to udpate. 


On master
```
sky launch -c test-cloud-account --cpus 2
time sky launch -c test-cloud-account --cpus 2
28s
```

On the current PR
```
sky launch -c test-cloud-account --cpus 2
time sky launch -c test-cloud-account --cpus 2
28s
```

That said, this change will not affect the performance.


This PR fixes the following reproduction:
1. `sky spot launch --cloud aws echo hi` with only AWS credentials setup
2. `sky spot launch --cloud gcp echo hi` with GCP credential setup already

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Reproduciable script in #2714
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
