### PR TITLE
[GCP] Fix `--disk-size` for Custom Machine Images

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -134,9 +134,17 @@ User
     compute.firewalls.list
     compute.firewalls.update
 
-8. Click **Create** to create the role.
-9. Go back to the "IAM" tab and click on **GRANT ACCESS**.
-10. Fill in the email address of the user in the “Add principals” section, and select ``minimal-skypilot-role`` in the “Assign roles” section. Click **Save**.
+8. **Optional**: If the user needs to use custom machine images with ``sky launch --image-id``, you can additionally add the following permissions:
+
+.. code-block:: text
+    compute.disks.get
+    compute.disks.resize
+    compute.images.get
+    compute.images.useReadOnly
+
+9. Click **Create** to create the role.
+10. Go back to the "IAM" tab and click on **GRANT ACCESS**.
+11. Fill in the email address of the user in the “Add principals” section, and select ``minimal-skypilot-role`` in the “Assign roles” section. Click **Save**.
 
 
 .. image:: ../../images/screenshots/gcp/create-iam.png
@@ -144,7 +152,7 @@ User
     :align: center
     :alt: GCP Grant Access
 
-11. The user should receive an invitation to the project and should be able to setup SkyPilot by following the instructions in :ref:`Installation <installation-gcp>`.
+12. The user should receive an invitation to the project and should be able to setup SkyPilot by following the instructions in :ref:`Installation <installation-gcp>`.
 
 .. note::
 

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -137,6 +137,7 @@ User
 8. **Optional**: If the user needs to use custom machine images with ``sky launch --image-id``, you can additionally add the following permissions:
 
 .. code-block:: text
+    
     compute.disks.get
     compute.disks.resize
     compute.images.get

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -836,11 +836,11 @@ class Resources:
             image_size = self.cloud.get_image_size(image_id, region)
             if image_size >= self.disk_size:
                 with ux_utils.print_exception_no_traceback():
-                    size_compare = 'larger than' if image_size > self.disk_size \
+                    size_comp = 'larger than' if image_size > self.disk_size \
                         else 'equal to'
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
-                        f'{size_compare} the specified disk_size: '
+                        f'{size_comp} the specified disk_size: '
                         f'{self.disk_size} GB. Please specify a larger '
                         'disk_size to use this image.')
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -836,8 +836,8 @@ class Resources:
             image_size = self.cloud.get_image_size(image_id, region)
             if image_size >= self.disk_size:
                 with ux_utils.print_exception_no_traceback():
-                    size_comp = ('larger than' if image_size > self.disk_size
-                                 else 'equal to')
+                    size_comp = ('larger than'
+                                 if image_size > self.disk_size else 'equal to')
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
                         f'{size_comp} the specified disk_size: '

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -836,11 +836,13 @@ class Resources:
             image_size = self.cloud.get_image_size(image_id, region)
             if image_size >= self.disk_size:
                 with ux_utils.print_exception_no_traceback():
-                    size_comparison = "larger" if image_size > self.disk_size else "equal"
+                    size_compare = 'larger than' if image_size > self.disk_size \
+                        else 'equal to'
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
-                        f'{size_comparison} than the specified disk_size: {self.disk_size}'
-                        ' GB. Please specify a larger disk_size to use this image.')
+                        f'{size_compare} the specified disk_size: '
+                        f'{self.disk_size} GB. Please specify a larger '
+                        'disk_size to use this image.')
 
     def _try_validate_disk_tier(self) -> None:
         if self.disk_tier is None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -836,8 +836,8 @@ class Resources:
             image_size = self.cloud.get_image_size(image_id, region)
             if image_size >= self.disk_size:
                 with ux_utils.print_exception_no_traceback():
-                    size_comp = 'larger than' if image_size > self.disk_size \
-                        else 'equal to'
+                    size_comp = ('larger than' if image_size > self.disk_size
+                                 else 'equal to')
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
                         f'{size_comp} the specified disk_size: '

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -834,20 +834,13 @@ class Resources:
             # Check the image exists and get the image size.
             # It will raise ValueError if the image does not exist.
             image_size = self.cloud.get_image_size(image_id, region)
-            if image_size > self.disk_size:
+            if image_size >= self.disk_size:
                 with ux_utils.print_exception_no_traceback():
+                    size_comparison = "larger" if image_size > self.disk_size else "equal"
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
-                        f'larger than the specified disk_size: {self.disk_size}'
-                        ' GB. Please specify a larger disk_size to use this '
-                        'image.')
-            elif image_size == self.disk_size:
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError(
-                        f'Image {image_id!r} is {image_size}GB, which is '
-                        f'equal to the specified disk_size: {self.disk_size}'
-                        ' GB. Please specify a larger disk_size to use this '
-                        'image.')
+                        f'{size_comparison} than the specified disk_size: {self.disk_size}'
+                        ' GB. Please specify a larger disk_size to use this image.')
 
     def _try_validate_disk_tier(self) -> None:
         if self.disk_tier is None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -841,6 +841,13 @@ class Resources:
                         f'larger than the specified disk_size: {self.disk_size}'
                         ' GB. Please specify a larger disk_size to use this '
                         'image.')
+            elif image_size == self.disk_size:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'Image {image_id!r} is {image_size}GB, which is '
+                        f'equal to the specified disk_size: {self.disk_size}'
+                        ' GB. Please specify a larger disk_size to use this '
+                        'image.')
 
     def _try_validate_disk_tier(self) -> None:
         if self.disk_tier is None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -834,15 +834,13 @@ class Resources:
             # Check the image exists and get the image size.
             # It will raise ValueError if the image does not exist.
             image_size = self.cloud.get_image_size(image_id, region)
-            if image_size >= self.disk_size:
+            if image_size > self.disk_size:
                 with ux_utils.print_exception_no_traceback():
-                    size_comp = ('larger than'
-                                 if image_size > self.disk_size else 'equal to')
                     raise ValueError(
                         f'Image {image_id!r} is {image_size}GB, which is '
-                        f'{size_comp} the specified disk_size: '
-                        f'{self.disk_size} GB. Please specify a larger '
-                        'disk_size to use this image.')
+                        f'larger than the specified disk_size: {self.disk_size}'
+                        ' GB. Please specify a larger disk_size to use this '
+                        'image.')
 
     def _try_validate_disk_tier(self) -> None:
         if self.disk_tier is None:

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -650,26 +650,19 @@ class GCPCompute(GCPResource):
         )
         disk_name = response["disks"][0]["source"].split("/")[-1]
 
-        try:
-            # Execute the resize request and return the response
-            operation = (
-                self.resource.disks()
-                .resize(
-                    project=self.project_id,
-                    zone=self.availability_zone,
-                    disk=disk_name,
-                    body={
-                        "sizeGb": str(new_size_gb),
-                    },
-                )
-                .execute()
+        # Execute the resize request and return the response
+        operation = (
+            self.resource.disks()
+            .resize(
+                project=self.project_id,
+                zone=self.availability_zone,
+                disk=disk_name,
+                body={
+                    "sizeGb": str(new_size_gb),
+                },
             )
-        except HttpError as e:
-            # Catch HttpError when provided with invalid value for new disk size.
-            # Raises error when the new disk size is smaller than the exisiting
-            # disk size
-            logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
-            return {}
+            .execute()
+        )
 
         if wait_for_operation:
             result = self.wait_for_operation(operation)

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -905,4 +905,3 @@ class GCPTPU(GCPResource):
         to expand disk capacity. For more context on this requirement and its current status, refer to the related issue:
         #2387
         """
-        return {}

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -290,41 +290,14 @@ class GCPResource(metaclass=abc.ABCMeta):
         Returns a tuple of (result, node_name).
         """
         return
-
-    def resize_disk(self, base_config: dict, instance_name: str) -> Tuple[dict, str]:
-        """Resize a Google Cloud disk based on the provided configuration."""
-        # Build Compute Engine API
-        resource_v1 = discovery.build("compute", "v1")
-
-        # Extract the specified disk size from the configuration
-        new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
-
-        # Fetch the instance details to get the disk name
-        response = (
-            resource_v1.instances()
-            .get(
-                project=self.project_id,
-                zone=self.availability_zone,
-                instance=instance_name,
-            )
-            .execute()
-        )
-        disk_name = response["disks"][0]["source"].split("/")[-1]
-
-        # Execute the resize request and return the response
-        response = (
-            resource_v1.disks()
-            .resize(
-                project=self.project_id,
-                zone=self.availability_zone,
-                disk=disk_name,
-                body={
-                    "sizeGb": str(new_size_gb),
-                },
-            )
-            .execute()
-        )
-        return response
+    
+    @abc.abstractmethod
+    def resize_disk(self, base_config: dict, instance_name: str, wait_for_operation: bool = True) -> Tuple[dict, str]:
+        """Resize a Google Cloud disk based on the provided configuration.
+        
+        Returns the response of resize operation.
+        """
+        return 
 
     def create_instances(
         self,
@@ -656,6 +629,65 @@ class GCPCompute(GCPResource):
             result = operation
 
         return result
+
+    def resize_disk(self, base_config: dict, instance_name: str, wait_for_operation: bool = True) -> Tuple[dict, str]:
+        """Resize a Google Cloud disk based on the provided configuration."""
+        
+        # Extract the specified disk size from the configuration
+        new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
+
+        # Fetch the instance details to get the disk name and current disk size
+        response = (
+            self.resource.instances()
+            .get(
+                project=self.project_id,
+                zone=self.availability_zone,
+                instance=instance_name,
+            )
+            .execute()
+        )
+        disk_name = response["disks"][0]["source"].split("/")[-1]
+        cur_size_gb = response["disks"][0]['diskSizeGb']
+
+        # If the new disk size is the same as the existing disk size
+        # resizing is unnecessary
+        if int(new_size_gb) == int(cur_size_gb):
+            # Return empty list instead of raising exception to not break
+            # ray down.
+            return []
+        
+        elif int(new_size_gb) < int(cur_size_gb):
+            logger.warning("Disk resize operation aborted: Specified new disk size (%s GB) is smaller than the current disk size (%s GB)", new_size_gb, cur_size_gb)
+            return []
+
+        try:
+            # Execute the resize request and return the response
+            operation = (
+                self.resource.disks()
+                .resize(
+                    project=self.project_id,
+                    zone=self.availability_zone,
+                    disk=disk_name,
+                    body={
+                        "sizeGb": str(new_size_gb),
+                    },
+                )
+                .execute()
+            )
+        except HttpError as e:
+            # Catch HttpError when provided with invalid value for new disk size.
+            # Raises error when the new disk size is smaller than the exisiting 
+            # disk size
+            logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
+            return []
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+    
+        return result
+
 
 
 class GCPTPU(GCPResource):

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -290,14 +290,16 @@ class GCPResource(metaclass=abc.ABCMeta):
         Returns a tuple of (result, node_name).
         """
         return
-    
+
     @abc.abstractmethod
-    def resize_disk(self, base_config: dict, instance_name: str, wait_for_operation: bool = True) -> Tuple[dict, str]:
+    def resize_disk(
+        self, base_config: dict, instance_name: str, wait_for_operation: bool = True
+    ) -> Tuple[dict, str]:
         """Resize a Google Cloud disk based on the provided configuration.
-        
+
         Returns the response of resize operation.
         """
-        return 
+        return
 
     def create_instances(
         self,
@@ -527,7 +529,6 @@ class GCPCompute(GCPResource):
     def create_instance(
         self, base_config: dict, labels: dict, wait_for_operation: bool = True
     ) -> Tuple[dict, str]:
-
         config = self._convert_resources_to_urls(base_config)
         # removing TPU-specific default key set in config.py
         config.pop("networkConfig", None)
@@ -630,9 +631,11 @@ class GCPCompute(GCPResource):
 
         return result
 
-    def resize_disk(self, base_config: dict, instance_name: str, wait_for_operation: bool = True) -> Tuple[dict, str]:
+    def resize_disk(
+        self, base_config: dict, instance_name: str, wait_for_operation: bool = True
+    ) -> Tuple[dict, str]:
         """Resize a Google Cloud disk based on the provided configuration."""
-        
+
         # Extract the specified disk size from the configuration
         new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
 
@@ -647,7 +650,7 @@ class GCPCompute(GCPResource):
             .execute()
         )
         disk_name = response["disks"][0]["source"].split("/")[-1]
-        cur_size_gb = response["disks"][0]['diskSizeGb']
+        cur_size_gb = response["disks"][0]["diskSizeGb"]
 
         # If the new disk size is the same as the existing disk size
         # resizing is unnecessary
@@ -655,9 +658,13 @@ class GCPCompute(GCPResource):
             # Return empty list instead of raising exception to not break
             # ray down.
             return []
-        
+
         elif int(new_size_gb) < int(cur_size_gb):
-            logger.warning("Disk resize operation aborted: Specified new disk size (%s GB) is smaller than the current disk size (%s GB)", new_size_gb, cur_size_gb)
+            logger.warning(
+                "Disk resize operation aborted: Specified new disk size (%s GB) is smaller than the current disk size (%s GB)",
+                new_size_gb,
+                cur_size_gb,
+            )
             return []
 
         try:
@@ -676,7 +683,7 @@ class GCPCompute(GCPResource):
             )
         except HttpError as e:
             # Catch HttpError when provided with invalid value for new disk size.
-            # Raises error when the new disk size is smaller than the exisiting 
+            # Raises error when the new disk size is smaller than the exisiting
             # disk size
             logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
             return []
@@ -685,9 +692,8 @@ class GCPCompute(GCPResource):
             result = self.wait_for_operation(operation)
         else:
             result = operation
-    
-        return result
 
+        return result
 
 
 class GCPTPU(GCPResource):
@@ -766,7 +772,6 @@ class GCPTPU(GCPResource):
         label_filters[TAG_RAY_CLUSTER_NAME] = self.cluster_name
 
         def filter_instance(instance: GCPTPUNode) -> bool:
-
             labels = instance.get_labels()
             if label_filters:
                 for key, value in label_filters.items():

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -899,47 +899,10 @@ class GCPTPU(GCPResource):
     def resize_disk(
         self, base_config: dict, instance_name: str, wait_for_operation: bool = True
     ) -> dict:
-        """Resize a Google Cloud disk based on the provided configuration."""
-
-        # Extract the specified disk size from the configuration
-        new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
-
-        # Fetch the instance details to get the disk name and current disk size
-        response = (
-            self.resource.instances()
-            .get(
-                project=self.project_id,
-                zone=self.availability_zone,
-                instance=instance_name,
-            )
-            .execute()
-        )
-        disk_name = response["disks"][0]["source"].split("/")[-1]
-
-        try:
-            # Execute the resize request and return the response
-            operation = (
-                self.resource.disks()
-                .resize(
-                    project=self.project_id,
-                    zone=self.availability_zone,
-                    disk=disk_name,
-                    body={
-                        "sizeGb": str(new_size_gb),
-                    },
-                )
-                .execute()
-            )
-        except HttpError as e:
-            # Catch HttpError when provided with invalid value for new disk size.
-            # Raises error when the new disk size is smaller than the exisiting
-            # disk size
-            logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
-            return {}
-
-        if wait_for_operation:
-            result = self.wait_for_operation(operation)
-        else:
-            result = operation
-
-        return result
+        """
+        TODO: Implement the functionality to attach persistent disks for expanding local disk capacity in TPU VMs.
+        Currently, the boot disk of TPU VMs is not resizable, and users need to add a persistent disk
+        to expand disk capacity. For more context on this requirement and its current status, refer to the related issue:
+        https://github.com/skypilot-org/skypilot/issues/2387
+        """
+        return {}

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -289,8 +289,8 @@ class GCPResource(metaclass=abc.ABCMeta):
 
         Returns a tuple of (result, node_name).
         """
-        return 
-    
+        return
+
     def resize_disk(self, base_config: dict, instance_name: str) -> Tuple[dict, str]:
         """Resize a Google Cloud disk based on the provided configuration."""
         # Build Compute Engine API

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -291,11 +291,7 @@ class GCPResource(metaclass=abc.ABCMeta):
         """
         return
     
-    def resize_disk(
-        self, 
-        base_config: dict, 
-        instance_name: str
-    ) -> Tuple[dict, str]:
+    def resize_disk(self, base_config: dict, instance_name: str) -> Tuple[dict, str]:
         """Resize a Google Cloud disk based on the provided configuration."""
         # Build Compute Engine API
         resource_v1 = discovery.build("compute", "v1")

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -903,6 +903,6 @@ class GCPTPU(GCPResource):
         TODO: Implement the functionality to attach persistent disks for expanding local disk capacity in TPU VMs.
         Currently, the boot disk of TPU VMs is not resizable, and users need to add a persistent disk
         to expand disk capacity. For more context on this requirement and its current status, refer to the related issue:
-        https://github.com/skypilot-org/skypilot/issues/2387
+        #2387
         """
         return {}

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -895,3 +895,51 @@ class GCPTPU(GCPResource):
             result = operation
 
         return result
+
+    def resize_disk(
+        self, base_config: dict, instance_name: str, wait_for_operation: bool = True
+    ) -> dict:
+        """Resize a Google Cloud disk based on the provided configuration."""
+
+        # Extract the specified disk size from the configuration
+        new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
+
+        # Fetch the instance details to get the disk name and current disk size
+        response = (
+            self.resource.instances()
+            .get(
+                project=self.project_id,
+                zone=self.availability_zone,
+                instance=instance_name,
+            )
+            .execute()
+        )
+        disk_name = response["disks"][0]["source"].split("/")[-1]
+
+        try:
+            # Execute the resize request and return the response
+            operation = (
+                self.resource.disks()
+                .resize(
+                    project=self.project_id,
+                    zone=self.availability_zone,
+                    disk=disk_name,
+                    body={
+                        "sizeGb": str(new_size_gb),
+                    },
+                )
+                .execute()
+            )
+        except HttpError as e:
+            # Catch HttpError when provided with invalid value for new disk size.
+            # Raises error when the new disk size is smaller than the exisiting
+            # disk size
+            logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
+            return {}
+
+        if wait_for_operation:
+            result = self.wait_for_operation(operation)
+        else:
+            result = operation
+
+        return result

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -900,8 +900,7 @@ class GCPTPU(GCPResource):
         self, base_config: dict, instance_name: str, wait_for_operation: bool = True
     ) -> dict:
         """
-        TODO: Implement the functionality to attach persistent disks for expanding local disk capacity in TPU VMs.
-        Currently, the boot disk of TPU VMs is not resizable, and users need to add a persistent disk
-        to expand disk capacity. For more context on this requirement and its current status, refer to the related issue:
-        #2387
+        TODO: Implement the feature to attach persistent disks for TPU VMs.
+        The boot disk of TPU VMs is not resizable, and users need to add a
+        persistent disk to expand disk capacity. Related issue: #2387
         """

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -289,7 +289,7 @@ class GCPResource(metaclass=abc.ABCMeta):
 
         Returns a tuple of (result, node_name).
         """
-        return
+        return 
     
     def resize_disk(self, base_config: dict, instance_name: str) -> Tuple[dict, str]:
         """Resize a Google Cloud disk based on the provided configuration."""

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -304,25 +304,31 @@ class GCPResource(metaclass=abc.ABCMeta):
         new_size_gb = base_config["disks"][0]["initializeParams"]["diskSizeGb"]
 
         # Fetch the instance details to get the disk name
-        response = resource_v1.instances().get(
-            project=self.project_id,
-            zone=self.availability_zone,
-            instance=instance_name
-        ).execute()
+        response = (
+            resource_v1.instances()
+            .get(
+                project=self.project_id,
+                zone=self.availability_zone,
+                instance=instance_name,
+            )
+            .execute()
+        )
         disk_name = response["disks"][0]["source"].split("/")[-1]
 
         # Execute the resize request and return the response
-        response = resource_v1.disks().resize(
-            project=self.project_id,
-            zone=self.availability_zone,
-            disk=disk_name,
-            body={
-                "sizeGb": str(new_size_gb),
-            },
-        ).execute()
-
+        response = (
+            resource_v1.disks()
+            .resize(
+                project=self.project_id,
+                zone=self.availability_zone,
+                disk=disk_name,
+                body={
+                    "sizeGb": str(new_size_gb),
+                },
+            )
+            .execute()
+        )
         return response
-
 
     def create_instances(
         self,

--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -649,22 +649,6 @@ class GCPCompute(GCPResource):
             .execute()
         )
         disk_name = response["disks"][0]["source"].split("/")[-1]
-        cur_size_gb = response["disks"][0]["diskSizeGb"]
-
-        # If the new disk size is the same as the existing disk size
-        # resizing is unnecessary
-        if int(new_size_gb) == int(cur_size_gb):
-            # Return empty dict instead of raising exception to not break
-            # ray down.
-            return {}
-
-        elif int(new_size_gb) < int(cur_size_gb):
-            logger.warning(
-                "Disk resize operation aborted: Specified new disk size (%s GB) is smaller than the current disk size (%s GB)",
-                new_size_gb,
-                cur_size_gb,
-            )
-            return {}
 
         try:
             # Execute the resize request and return the response

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -280,6 +280,7 @@ class GCPNodeProvider(NodeProvider):
                     )
                     for node_id in reuse_node_ids:
                         result = resource.start_instance(node_id)
+                        resize_result = resource.resize_disk(base_config, node_id, self.resources)
                         result_dict[node_id] = {node_id: result}
                     for node_id in reuse_node_ids:
                         self.set_node_tags(node_id, tags)

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -280,15 +280,17 @@ class GCPNodeProvider(NodeProvider):
                     )
                     for node_id in reuse_node_ids:
                         result = resource.start_instance(node_id)
-                        resize_result = resource.resize_disk(base_config, node_id, self.resources)
+                        if 'sourceMachineImage' in base_config:
+                            resource.resize_disk(base_config, node_id)
                         result_dict[node_id] = {node_id: result}
                     for node_id in reuse_node_ids:
                         self.set_node_tags(node_id, tags)
                     count -= len(reuse_node_ids)
             if count:
                 results = resource.create_instances(base_config, labels, count)
-                for _, instance_id in results:
-                    resource.resize_disk(base_config, instance_id, self.resources)
+                if 'sourceMachineImage' in base_config:
+                    for _, instance_id in results:
+                        resource.resize_disk(base_config, instance_id)
                 result_dict.update(
                     {instance_id: result for result, instance_id in results}
                 )

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -280,7 +280,7 @@ class GCPNodeProvider(NodeProvider):
                     )
                     for node_id in reuse_node_ids:
                         result = resource.start_instance(node_id)
-                        if 'sourceMachineImage' in base_config:
+                        if "sourceMachineImage" in base_config:
                             resource.resize_disk(base_config, node_id)
                         result_dict[node_id] = {node_id: result}
                     for node_id in reuse_node_ids:
@@ -288,7 +288,7 @@ class GCPNodeProvider(NodeProvider):
                     count -= len(reuse_node_ids)
             if count:
                 results = resource.create_instances(base_config, labels, count)
-                if 'sourceMachineImage' in base_config:
+                if "sourceMachineImage" in base_config:
                     for _, instance_id in results:
                         resource.resize_disk(base_config, instance_id)
                 result_dict.update(

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -280,8 +280,6 @@ class GCPNodeProvider(NodeProvider):
                     )
                     for node_id in reuse_node_ids:
                         result = resource.start_instance(node_id)
-                        if "sourceMachineImage" in base_config:
-                            resource.resize_disk(base_config, node_id)
                         result_dict[node_id] = {node_id: result}
                     for node_id in reuse_node_ids:
                         self.set_node_tags(node_id, tags)

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -287,6 +287,8 @@ class GCPNodeProvider(NodeProvider):
                     count -= len(reuse_node_ids)
             if count:
                 results = resource.create_instances(base_config, labels, count)
+                for _, instance_id in results:
+                    resource.resize_disk(base_config, instance_id, self.resources)
                 result_dict.update(
                     {instance_id: result for result, instance_id in results}
                 )

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -18,7 +18,7 @@ docker:
 {%- endif %}
 
 provider:
-  # We use a custom node provider for GCP to support instance stop and reuse.
+  # We use a custom node provider for GCP to create, stop and reuse instances.
   type: external  # type: gcp
   module: sky.skylet.providers.gcp.GCPNodeProvider
   region: {{region}}


### PR DESCRIPTION
Issue Addressed: [#2488](https://github.com/skypilot-org/skypilot/issues/2488)

As reported in the issue, it's clear that when launching a GCP cluster with a machine image originating from a 150 GB disk, specifying the `--disk-size 200` parameter results in an instance retaining the original 150 GB size.

Based on [GCP's documentation](https://cloud.google.com/compute/docs/disks/resize-persistent-disk) on resizing persistent disks, when we create a custom Linux image, we have to manually increase the size of the boot and non-boot disks. To achieve this, I used the [Compute Engine API](https://cloud.google.com/python/docs/reference/compute/latest/google.cloud.compute_v1.services.disks.DisksClient#properties ) to modify disk sizes within our custom GCP node provider. Comments have been added to the code within the commits to provide additional context into the changes made. Please feel free to comment if further modifications are required.

**Custom Image Test:**
1. Launch the custom image with a specified disk size:
`sky launch -c custom-image --cloud gcp --image-id [image id path] --disk-size 200 `
`sky launch -c custom-image --cloud gcp --image-id [image id path] --disk-size 150 `

2. Confirmed the disk size has been increased to 200GB from the original 150GB for the first test, and ensured that users are able to create an instance with the image's original size.

**Multi-Node Test:**
1. Launch 8 nodes with a specified disk size:
`sky launch -c my-cluster --num-nodes 8 --image-id [image id path] --cloud gcp --disk-size 200`
2. Verified the disk of each node has been resized to 200GB.

**TPU Test:**
1. Launch the custom image with a specified TPU accelerator and disk size:
`sky launch tpu_node.yaml -c custom-image --cloud gcp --image-id [image id path] --disk-size 200`, where the YAML file is provided below:

    ```
    resources:
      instance_type: n1-highmem-8
      accelerators: tpu-v2-8
      accelerator_args:
        tpu_vm: False
    ```
2. Verified that the disk has been resized to 200GB for TPU node.

Note: TPU VMs include a 100GB boot disk that cannot be resized. Users have to add a Persistent Disk to expand their local disk capacity according to the [documentation](https://cloud.google.com/tpu/docs/setup-persistent-disk). This requirement may be associated with a feature request at: https://github.com/skypilot-org/skypilot/issues/2387