### PR TITLE
Core: Fix AWS/GCP autostop with new provisioner.

### DIFF
--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -44,7 +44,8 @@ if os.path.exists(VERSION_FILE):
 version_string = (f' (found version {found_version}, new version '
                   f'{constants.SKYLET_VERSION})')
 if not running:
-    print('Skylet is not running. Starting...')
+    print('Skylet is not running. Starting (version '
+          f'{constants.SKYLET_VERSION})...')
 elif not version_match:
     print(f'Skylet is stale{version_string}. Restarting...')
 else:

--- a/sky/skylet/attempt_skylet.py
+++ b/sky/skylet/attempt_skylet.py
@@ -34,17 +34,23 @@ proc = subprocess.run(
 running = (proc.returncode == 0)
 
 version_match = False
+found_version = None
 if os.path.exists(VERSION_FILE):
     with open(VERSION_FILE) as f:
-        if f.read().strip() == constants.SKYLET_VERSION:
+        found_version = f.read().strip()
+        if found_version == constants.SKYLET_VERSION:
             version_match = True
 
+version_string = (f' (found version {found_version}, new version '
+                  f'{constants.SKYLET_VERSION})')
 if not running:
     print('Skylet is not running. Starting...')
 elif not version_match:
-    print('Skylet is staled. Restarting...')
+    print(f'Skylet is stale{version_string}. Restarting...')
 else:
-    print('Skylet is running with the latest version.')
+    print(
+        f'Skylet is running with the latest version {constants.SKYLET_VERSION}.'
+    )
 
 if not running or not version_match:
     restart_skylet()

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -39,10 +39,12 @@ TASK_ID_ENV_VAR = 'SKYPILOT_TASK_ID'
 # lifetime of the job.
 TASK_ID_LIST_ENV_VAR = 'SKYPILOT_TASK_IDS'
 
-# The version of skylet. We should bump this version whenever we need the skylet
-# to be restarted on existing clusters updated with the new version of SkyPilot,
+# The version of skylet. MUST bump this version whenever we need the skylet to
+# be restarted on existing clusters updated with the new version of SkyPilot,
 # e.g., when we add new events to skylet, or we fix a bug in skylet.
-SKYLET_VERSION = '3'
+#
+# TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
+SKYLET_VERSION = '4'
 SKYLET_VERSION_FILE = '~/.sky/skylet_version'
 
 # `sky spot dashboard`-related

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -137,12 +137,12 @@ class AutostopEvent(SkyletEvent):
             assert provider_search is not None, config
             provider_name = provider_search.group(1).lower()
             if provider_name in ('aws', 'gcp'):
-                logger.debug('Using new provisioner to stop the cluster.')
+                logger.info('Using new provisioner to stop the cluster.')
                 self._stop_cluster_with_new_provisioner(autostop_config, config,
                                                         provider_name)
                 return
-            logger.debug('Not using new provisioner to stop the cluster. '
-                         f'Cloud found: {provider_name}')
+            logger.info('Not using new provisioner to stop the cluster. '
+                        f'Cloud of this cluster: {provider_name}')
 
             is_cluster_multinode = config['max_workers'] > 0
 

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -129,15 +129,20 @@ class AutostopEvent(SkyletEvent):
             config = common_utils.read_yaml(self._ray_yaml_path)
 
             provider_module = config['provider']['module']
-            provider_search = re.search(r'(?:providers|provision)\.(.*)(\.)?',
+            # Examples:
+            #   'sky.skylet.providers.aws.AWSNodeProviderV2' -> 'aws'
+            #   'sky.provision.aws' -> 'aws'
+            provider_search = re.search(r'(?:providers|provision)\.(\w+)\.?',
                                         provider_module)
             assert provider_search is not None, config
             provider_name = provider_search.group(1).lower()
-
-            if provider_name in ['aws', 'gcp']:
+            if provider_name in ('aws', 'gcp'):
+                logger.debug('Using new provisioner to stop the cluster.')
                 self._stop_cluster_with_new_provisioner(autostop_config, config,
                                                         provider_name)
                 return
+            logger.debug('Not using new provisioner to stop the cluster. '
+                         f'Cloud found: {provider_name}')
 
             is_cluster_multinode = config['max_workers'] > 0
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the regex used is incorrect, causing failures to autostop an AWS cluster that just got updated to use the new provisioner.

**Before**
```
git checkout b1d8c9d8
sky launch -c dbg --cloud aws --cpus 4+

git checkout bf336028  # master
sky launch -c dbg --cloud aws --cpus 4+ -i0
```
Observe failure to autostop in the VM's skylet.log:
```
..
KeyError: 'head_setup_commands'
E 10-18 05:07:42 events.py:51] AutostopEvent error: Command '['ray', 'down', '-y', '/home/ubuntu/.sky/sky_ray.yml']' returned non-zero exit status 1.
E 10-18 05:07:42 events.py:53] Traceback (most recent call last):
E 10-18 05:07:42 events.py:53]   File "/opt/conda/lib/python3.10/site-packages/sky/skylet/events.py", line 48, in run
E 10-18 05:07:42 events.py:53]     self._run()
E 10-18 05:07:42 events.py:53]   File "/opt/conda/lib/python3.10/site-packages/sky/skylet/events.py", line 122, in _run
E 10-18 05:07:42 events.py:53]     self._stop_cluster(autostop_config)
E 10-18 05:07:42 events.py:53]   File "/opt/conda/lib/python3.10/site-packages/sky/skylet/events.py", line 194, in _stop_cluster
E 10-18 05:07:42 events.py:53]     subprocess.run(
E 10-18 05:07:42 events.py:53]   File "/opt/conda/lib/python3.10/subprocess.py", line 524, in run
E 10-18 05:07:42 events.py:53]     raise CalledProcessError(retcode, process.args,
E 10-18 05:07:42 events.py:53] subprocess.CalledProcessError: Command '['ray', 'down', '-y', '/home/ubuntu/.sky/sky_ray.yml']' returned non-zero exit status 1.
E 10-18 05:07:42 events.py:53]
```

**With this PR**
- after running the above, switch to this branch and run
```
sky launch -c dbg --cloud aws --cpus 4+ -i0
```
- observe that autostop kicks in correctly

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py::test_autostop --aws`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
