### PR TITLE
[UX] Add commit hash

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -8,7 +8,12 @@ _SKYPILOT_COMMIT_SHA = '{{SKYPILOT_COMMIT_SHA}}'
 
 def get_git_commit():
     if 'SKYPILOT_COMMIT_SHA' not in _SKYPILOT_COMMIT_SHA:
+        # This is a release build, so we don't need to get the commit hash from
+        # git, as it's already been set.
         return _SKYPILOT_COMMIT_SHA
+
+    # This is a development build (pip install -e .), so we need to get the
+    # commit hash from git.
     try:
         cwd = os.path.dirname(__file__)
         commit_hash = subprocess.check_output(

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -11,12 +11,15 @@ def get_git_commit():
         return _SKYPILOT_COMMIT_SHA
     try:
         cwd = os.path.dirname(__file__)
-        commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
-                                              cwd=cwd,
-                                              universal_newlines=True).strip()
+        commit_hash = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=cwd,
+            universal_newlines=True,
+            stderr=subprocess.DEVNULL).strip()
         changes = subprocess.check_output(['git', 'status', '--porcelain'],
                                           cwd=cwd,
-                                          universal_newlines=True).strip()
+                                          universal_newlines=True,
+                                          stderr=subprocess.DEVNULL).strip()
         if changes:
             commit_hash += '-dirty'
         return commit_hash

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -11,14 +11,14 @@ def get_git_commit():
         return _SKYPILOT_COMMIT_SHA
     try:
         cwd = os.path.dirname(__file__)
-        commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
+        commit_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                               cwd=cwd,
                                               universal_newlines=True).strip()
-        changes = subprocess.check_output(["git", "status", "--porcelain"],
+        changes = subprocess.check_output(['git', 'status', '--porcelain'],
                                           cwd=cwd,
                                           universal_newlines=True).strip()
         if changes:
-            commit_hash += "-dirty"
+            commit_hash += '-dirty'
         return commit_hash
     except Exception:
         return _SKYPILOT_COMMIT_SHA
@@ -29,6 +29,7 @@ __version__ = '1.0.0-dev0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 # Keep this order to avoid cyclic imports
+# pylint: disable=wrong-import-position
 from sky import backends
 from sky import benchmark
 from sky import clouds

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -20,7 +20,7 @@ def get_git_commit():
         if changes:
             commit_hash += '-dirty'
         return commit_hash
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return _SKYPILOT_COMMIT_SHA
 
 

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -1,8 +1,30 @@
 """The SkyPilot package."""
 import os
+import subprocess
 
 # Replaced with the current commit when building the wheels.
-__commit__ = '{{SKYPILOT_COMMIT_SHA}}'
+_SKYPILOT_COMMIT_SHA = '{{SKYPILOT_COMMIT_SHA}}'
+
+
+def get_git_commit():
+    if 'SKYPILOT_COMMIT_SHA' not in _SKYPILOT_COMMIT_SHA:
+        return _SKYPILOT_COMMIT_SHA
+    try:
+        cwd = os.path.dirname(__file__)
+        commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"],
+                                              cwd=cwd,
+                                              universal_newlines=True).strip()
+        changes = subprocess.check_output(["git", "status", "--porcelain"],
+                                          cwd=cwd,
+                                          universal_newlines=True).strip()
+        if changes:
+            commit_hash += "-dirty"
+        return commit_hash
+    except Exception:
+        return _SKYPILOT_COMMIT_SHA
+
+
+__commit__ = get_git_commit()
 __version__ = '1.0.0-dev0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -73,7 +73,6 @@ def _build_sky_wheel():
                                setup_content)
         (tmp_dir / 'setup.py').write_text(setup_content)
 
-
         for f in setup_files_dir.iterdir():
             if f.is_file() and f.name != 'setup.py':
                 shutil.copy(str(f), str(tmp_dir))
@@ -81,9 +80,9 @@ def _build_sky_wheel():
         init_file_path = SKY_PACKAGE_PATH / '__init__.py'
         init_file_content = init_file_path.read_text()
         # Replace the commit hash with the current commit hash.
-        init_file_content = re.sub(r'_SKYPILOT_COMMIT_SHA = [\'"](.*?)[\'"]',
-                                   f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'',
-                                   init_file_content)
+        init_file_content = re.sub(
+            r'_SKYPILOT_COMMIT_SHA = [\'"](.*?)[\'"]',
+            f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'', init_file_content)
         (tmp_dir / 'sky' / '__init__.py').write_text(init_file_content)
 
         # It is important to normalize the path, otherwise 'pip wheel' would

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -73,9 +73,18 @@ def _build_sky_wheel():
                                setup_content)
         (tmp_dir / 'setup.py').write_text(setup_content)
 
+
         for f in setup_files_dir.iterdir():
             if f.is_file() and f.name != 'setup.py':
                 shutil.copy(str(f), str(tmp_dir))
+
+        init_file_path = SKY_PACKAGE_PATH / '__init__.py'
+        init_file_content = init_file_path.read_text()
+        # Replace the commit hash with the current commit hash.
+        init_file_content = re.sub(r'_SKYPILOT_COMMIT_SHA = [\'"](.*?)[\'"]',
+                                   f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'',
+                                   init_file_content)
+        (tmp_dir / 'sky' / '__init__.py').write_text(init_file_content)
 
         # It is important to normalize the path, otherwise 'pip wheel' would
         # treat the directory as a file and generate an empty wheel.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1214,6 +1214,12 @@ def _add_command_alias_to_group(group, command, name, hidden):
               is_eager=True,
               help='Uninstall shell completion for the specified shell.')
 @click.version_option(sky.__version__, '--version', '-v', prog_name='skypilot')
+@click.version_option(sky.__commit__,
+                      '--commit',
+                      '-c',
+                      prog_name='skypilot',
+                      message='%(prog)s, commit %(version)s',
+                      help='Show the commit hash and exit')
 def cli():
     pass
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -13,30 +13,81 @@ please join us in [this
 discussion](https://github.com/skypilot-org/skypilot/discussions/1016)
 """
 
+import atexit
 import io
 import os
 import platform
 import re
+import subprocess
 from typing import Dict, List
-import warnings
 
 import setuptools
 
 ROOT_DIR = os.path.dirname(__file__)
+INIT_FILE_PATH = os.path.join(ROOT_DIR, 'sky', '__init__.py')
 
 system = platform.system()
 
 
-def find_version(*filepath):
+def find_version():
     # Extract version information from filepath
     # Adapted from:
     #  https://github.com/ray-project/ray/blob/master/python/setup.py
-    with open(os.path.join(ROOT_DIR, *filepath)) as fp:
+    with open(INIT_FILE_PATH, 'r') as fp:
         version_match = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]',
                                   fp.read(), re.M)
         if version_match:
             return version_match.group(1)
         raise RuntimeError('Unable to find version string.')
+
+
+def get_commit_hash():
+    with open(INIT_FILE_PATH, 'r') as fp:
+        commit_match = re.search(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
+                                 fp.read(), re.M)
+        if commit_match:
+            commit_hash = commit_match.group(1)
+        else:
+            raise RuntimeError('Unable to find commit string.')
+
+    if 'SKYPILOT_COMMIT_SHA' not in commit_hash:
+        return commit_hash
+    try:
+        cwd = os.path.dirname(__file__)
+        commit_hash = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'],
+            cwd=cwd,
+            universal_newlines=True,
+            stderr=subprocess.DEVNULL).strip()
+        changes = subprocess.check_output(['git', 'status', '--porcelain'],
+                                          cwd=cwd,
+                                          universal_newlines=True,
+                                          stderr=subprocess.DEVNULL).strip()
+        if changes:
+            commit_hash += '-dirty'
+        return commit_hash
+    except Exception:  # pylint: disable=broad-except
+        return commit_hash
+
+
+def replace_commit_hash():
+    with open(INIT_FILE_PATH, 'r') as fp:
+        content = fp.read()
+        content = re.sub(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
+                         f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
+                         content,
+                         flags=re.M)
+    with open(INIT_FILE_PATH, 'w') as fp:
+        fp.write(content)
+
+
+def revert_commit_hash():
+    try:
+        subprocess.check_call(['git', 'checkout', INIT_FILE_PATH],
+                              cwd=ROOT_DIR,
+                              stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        pass
 
 
 def parse_readme(readme: str) -> str:
@@ -173,12 +224,15 @@ if os.path.exists(readme_filepath):
     long_description = io.open(readme_filepath, 'r', encoding='utf-8').read()
     long_description = parse_readme(long_description)
 
+atexit.register(revert_commit_hash)
+replace_commit_hash()
+
 setuptools.setup(
     # NOTE: this affects the package.whl wheel name. When changing this (if
     # ever), you must grep for '.whl' and change all corresponding wheel paths
     # (templates/*.j2 and wheel_utils.py).
     name='skypilot',
-    version=find_version('sky', '__init__.py'),
+    version=find_version(),
     packages=setuptools.find_packages(),
     author='SkyPilot Team',
     license='Apache 2.0',

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -25,6 +25,7 @@ import setuptools
 
 ROOT_DIR = os.path.dirname(__file__)
 INIT_FILE_PATH = os.path.join(ROOT_DIR, 'sky', '__init__.py')
+original_init_content = None
 
 system = platform.system()
 
@@ -71,8 +72,11 @@ def get_commit_hash():
 
 
 def replace_commit_hash():
+    """Fill in the commit hash in the __init__.py file."""
     with open(INIT_FILE_PATH, 'r') as fp:
         content = fp.read()
+        global original_init_content
+        original_init_content = content
         content = re.sub(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
                          f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
                          content,
@@ -83,7 +87,11 @@ def replace_commit_hash():
 
 def revert_commit_hash():
     try:
-        subprocess.check_call(['git', 'checkout', INIT_FILE_PATH],
+        if original_init_content is not None:
+            with open(INIT_FILE_PATH, 'w') as fp:
+                fp.write(original_init_content)
+        else:
+            subprocess.check_call(['git', 'checkout', INIT_FILE_PATH],
                               cwd=ROOT_DIR,
                               stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError:

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -92,8 +92,8 @@ def revert_commit_hash():
                 fp.write(original_init_content)
         else:
             subprocess.check_call(['git', 'checkout', INIT_FILE_PATH],
-                              cwd=ROOT_DIR,
-                              stderr=subprocess.DEVNULL)
+                                  cwd=ROOT_DIR,
+                                  stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
         pass
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -54,6 +54,9 @@ def get_commit_hash():
     if 'SKYPILOT_COMMIT_SHA' not in commit_hash:
         return commit_hash
     try:
+        # Getting the commit hash from git, and check if there are any
+        # uncommitted changes.
+        # TODO: keep this in sync with sky/__init__.py
         cwd = os.path.dirname(__file__)
         commit_hash = subprocess.check_output(
             ['git', 'rev-parse', 'HEAD'],
@@ -86,16 +89,9 @@ def replace_commit_hash():
 
 
 def revert_commit_hash():
-    try:
-        if original_init_content is not None:
-            with open(INIT_FILE_PATH, 'w') as fp:
-                fp.write(original_init_content)
-        else:
-            subprocess.check_call(['git', 'checkout', INIT_FILE_PATH],
-                                  cwd=ROOT_DIR,
-                                  stderr=subprocess.DEVNULL)
-    except subprocess.CalledProcessError:
-        pass
+    if original_init_content is not None:
+        with open(INIT_FILE_PATH, 'w') as fp:
+            fp.write(original_init_content)
 
 
 def parse_readme(readme: str) -> str:

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -129,7 +129,7 @@ class AutostopEvent(SkyletEvent):
             config = common_utils.read_yaml(self._ray_yaml_path)
 
             provider_module = config['provider']['module']
-            provider_search = re.search(r'(?:providers|provision)\.(.*)(\.)?',
+            provider_search = re.search(r'(?:providers|provision)\.(.*)($|\.)',
                                         provider_module)
             assert provider_search is not None, config
             provider_name = provider_search.group(1).lower()

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -72,6 +72,7 @@ class UsageMessageToReport(MessageToReport):
         self.user: str = common_utils.get_user_hash()
         self.run_id: str = common_utils.get_usage_run_id()
         self.sky_version: str = sky.__version__
+        self.sky_commit: str = sky.__commit__
 
         # Entry
         self.cmd: str = common_utils.get_pretty_entry_point()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Make it possible to get commit hash of the current SkyPilot for both installed from pypi and source code.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `pip install -e .; cd ~; sky --commit; sky launch -c test --cpus 2+; sky spot launch -n test-aws --cpus 2 --cloud aws`
  - [x] `pip install .; cd ~; sky --commit; sky launch -c test --cpus 2+ echo hi; sky down sky-spot-controller-xxx`
  - [x] Upload to test pypi with the building script in nightly build script, `pip install -i https://test.pypi.org/simple/ skypilot==1.0.0.dev20231020; sky --commit`
  - [x] `pip install -e .; sky launch -c test-commit --cpus 2 echo hi; ssh test-commit; sky -c`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
