### PR TITLE
[Core] Add L4 to accelerator_registry

### DIFF
--- a/sky/utils/accelerator_registry.py
+++ b/sky/utils/accelerator_registry.py
@@ -12,7 +12,10 @@ from sky.utils import ux_utils
 # The list is simply an optimization to short-circuit the search in the catalog.
 # If the name is not found in the list, it will be searched in the catalog
 # with its case being ignored. If a match is found, the name will be
-# canonicalized to that in the catalog.
+# canonicalized to that in the catalog. Note that this lookup can be an
+# expensive operation, as it requires reading the catalog or making external
+# API calls (such as for Kubernetes). Thus it is desirable to keep this list
+# up-to-date with commonly used accelerators.
 # 3. (For SkyPilot dev) What to do if I want to add a new accelerator?
 # Append its case-sensitive canonical name to this list. The name must match
 # `AcceleratorName` in the service catalog, or what we define in

--- a/sky/utils/accelerator_registry.py
+++ b/sky/utils/accelerator_registry.py
@@ -37,6 +37,7 @@ _ACCELERATORS = [
     'P40',
     'Radeon MI25',
     'P4',
+    'L4',
 ]
 
 


### PR DESCRIPTION
Adds L4 to accelerator registry. This allows us to bypass unnecessary calls to `service_catalog.list_accelerators` every time `resource.copy()` is called.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested `sky launch --gpus L4:1` 