### PR TITLE
Fixes error when source path has spaces in them 

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -243,7 +243,7 @@ def _group_files_by_dir(
     for source in source_list:
         source = os.path.abspath(os.path.expanduser(source))
         if os.path.isdir(source):
-            dirs.append(source)
+            dirs.append(f'\'{source}\'')
         else:
             base_path = os.path.dirname(source)
             file_name = os.path.basename(source)
@@ -292,7 +292,7 @@ def parallel_upload(source_path_list: List[str],
     # Generate dir upload commands
     for dir_path in dirs:
         if create_dirs:
-            dest_dir_name = os.path.basename(dir_path)
+            dest_dir_name = os.path.basename(dir_path[1:-1])
         else:
             dest_dir_name = ''
         sync_command = dirsync_command_generator(dir_path, dest_dir_name)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1135,7 +1135,7 @@ class S3Store(AbstractStore):
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path)
+                src_dir_path[1:-1])
             excluded_list.append('.git/*')
             excludes = ' '.join(
                 [f'--exclude "{file_name}"' for file_name in excluded_list])
@@ -1571,7 +1571,7 @@ class GcsStore(AbstractStore):
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path)
+                src_dir_path[1:-1])
             # we exclude .git directory from the sync
             excluded_list.append(r'^\.git/.*$')
             excludes = '|'.join(excluded_list)
@@ -1910,7 +1910,7 @@ class R2Store(AbstractStore):
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path)
+                src_dir_path[1:-1])
             excluded_list.append('.git/*')
             excludes = ' '.join(
                 [f'--exclude "{file_name}"' for file_name in excluded_list])

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2933,7 +2933,8 @@ class TestStorageWithCredentials:
                 storage_obj.delete()
 
     @pytest.fixture
-    def tmp_multiple_custom_source_storage_obj(self, tmp_source):
+    def tmp_multiple_custom_source_storage_obj(self):
+        # List of four different source paths that should be tested
         custom_source_names = [
             'pathWithoutSpaces', '\"path With Spaces\"',
             '\"pathWithoutSpaces\"', 'path With Spaces'
@@ -2941,6 +2942,10 @@ class TestStorageWithCredentials:
         # Creates a list of 4 storage objects with custom source names to
         # create multiple scratch storages.
         # Stores for each object in the list must be added in the test.
+
+        # Adds paths to home directory in order to test if uploaded properly.
+        # Specifies source in new storage object.
+        # Otherwise, mostly identical to tmp_multiple_scratch_storage_obj.
         storage_mult_obj = []
         for name in custom_source_names:
             pathlib.Path(f'~/{name}').expanduser().mkdir(exist_ok=True)
@@ -3141,9 +3146,9 @@ class TestStorageWithCredentials:
         pytest.param(storage_lib.StoreType.IBM, marks=pytest.mark.ibm),
         pytest.param(storage_lib.StoreType.R2, marks=pytest.mark.cloudflare)
     ])
-    def test_upload_with_custom_source_name(
-            self, store_type, tmp_multiple_custom_source_storage_obj):
-
+    def test_upload_source_with_spaces(self, store_type,
+                                       tmp_multiple_custom_source_storage_obj):
+        # Creates four buckets with specified local source paths and deletes them
         storage_obj_name = []
         for store_obj in tmp_multiple_custom_source_storage_obj:
             store_obj.add_store(store_type)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR resolves issue #2243. 

The changes made mostly have to do with adding wrapping the source directories in quotes. This resolves the issue where directories that have spaces in their names do not work with `aws s3 sync` or `gsutil rsync`. 

Also added a new smoke test, specified below. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- Created a new smoke test `test_upload_source_with_spaces`. Almost identical to `test_multiple_buckets_creation_and_deletion`.
- Created a new fixture `tmp_multiple_custom_source_storage_obj` for the new smoke test, that is almost identical to `tmp_multiple_scratch_storage_obj`, except path name is specified in the creation of new storage objects to test sources with spaces. 
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
