### PR TITLE
[UX] Make retry clean up security group silent

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -698,7 +698,7 @@ def cleanup_ports(
             sg.delete()
         except aws.botocore_exceptions().ClientError as e:
             if _DEPENDENCY_VIOLATION_PATTERN.findall(str(e)):
-                logger.info(f'Security group {sg_name} is still in use. Retry.')
+                logger.debug(f'Security group {sg_name} is still in use. Retry.')
                 time.sleep(backoff.current_backoff())
                 continue
             raise

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -698,7 +698,8 @@ def cleanup_ports(
             sg.delete()
         except aws.botocore_exceptions().ClientError as e:
             if _DEPENDENCY_VIOLATION_PATTERN.findall(str(e)):
-                logger.debug(f'Security group {sg_name} is still in use. Retry.')
+                logger.debug(
+                    f'Security group {sg_name} is still in use. Retry.')
                 time.sleep(backoff.current_backoff())
                 continue
             raise


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

There will be some output that interrupts the progress bar when clean-up SG fails:

```bash
» sky down sky-serve-controller-8a3968f2-0
Tearing down sky serve controller: sky-serve-controller-8a3968f2-0.
To proceed, please check the information above and type 'delete': delete
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--I 10-19 21:52:21 instance.py:697] Security group sky-sg-sky-serve-controller-8a3968f2-0-8a39 is still in use. Retry.
Terminating cluster sky-serve-controller-8a3968f2-0...done.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
```

This PR makes the log silent by changing it to debug. See https://github.com/skypilot-org/skypilot/pull/2458#pullrequestreview-1689120059 for more information.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
