### PR TITLE
[Setup] Make setup more robust when there is no permission to get/write commit hash

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -72,9 +72,10 @@ def get_commit_hash():
             commit_hash += '-dirty'
         return commit_hash
     except Exception as e:  # pylint: disable=broad-except
-        print('WARNING: SkyPilot fail to get the commit hash in '
-              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-              file=sys.stderr)
+        print(
+            'WARNING: SkyPilot fail to get the commit hash in '
+            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+            file=sys.stderr)
         return commit_hash
 
 
@@ -86,17 +87,18 @@ def replace_commit_hash():
             global original_init_content
             original_init_content = content
             content = re.sub(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
-                            f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
-                            content,
-                            flags=re.M)
+                             f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
+                             content,
+                             flags=re.M)
         with open(INIT_FILE_PATH, 'w') as fp:
             fp.write(content)
-    except Exception as e: # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         # Avoid breaking the installation when there is no permission to write
         # the file.
-        print('WARNING: SkyPilot fail to replace the commit hash in '
-              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-              file=sys.stderr)
+        print(
+            'WARNING: SkyPilot fail to replace the commit hash in '
+            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+            file=sys.stderr)
         pass
 
 
@@ -105,12 +107,13 @@ def revert_commit_hash():
         if original_init_content is not None:
             with open(INIT_FILE_PATH, 'w') as fp:
                 fp.write(original_init_content)
-    except Exception: # pylint: disable=broad-except
+    except Exception:  # pylint: disable=broad-except
         # Avoid breaking the installation when there is no permission to write
         # the file.
-        print('WARNING: SkyPilot fail to replace the commit hash in '
-              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-              file=sys.stderr)
+        print(
+            'WARNING: SkyPilot fail to replace the commit hash in '
+            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+            file=sys.stderr)
         pass
 
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -19,6 +19,7 @@ import os
 import platform
 import re
 import subprocess
+import sys
 from typing import Dict, List
 
 import setuptools
@@ -70,7 +71,10 @@ def get_commit_hash():
         if changes:
             commit_hash += '-dirty'
         return commit_hash
-    except Exception:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
+        print('WARNING: SkyPilot fail to get the commit hash in '
+              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+              file=sys.stderr)
         return commit_hash
 
 
@@ -87,8 +91,12 @@ def replace_commit_hash():
                             flags=re.M)
         with open(INIT_FILE_PATH, 'w') as fp:
             fp.write(content)
-    except Exception: # pylint: disable=broad-except
-        # Avoid breaking the installation.
+    except Exception as e: # pylint: disable=broad-except
+        # Avoid breaking the installation when there is no permission to write
+        # the file.
+        print('WARNING: SkyPilot fail to replace the commit hash in '
+              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+              file=sys.stderr)
         pass
 
 
@@ -98,7 +106,11 @@ def revert_commit_hash():
             with open(INIT_FILE_PATH, 'w') as fp:
                 fp.write(original_init_content)
     except Exception: # pylint: disable=broad-except
-        # Avoid breaking the installation.
+        # Avoid breaking the installation when there is no permission to write
+        # the file.
+        print('WARNING: SkyPilot fail to replace the commit hash in '
+              f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
+              file=sys.stderr)
         pass
 
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -76,22 +76,30 @@ def get_commit_hash():
 
 def replace_commit_hash():
     """Fill in the commit hash in the __init__.py file."""
-    with open(INIT_FILE_PATH, 'r') as fp:
-        content = fp.read()
-        global original_init_content
-        original_init_content = content
-        content = re.sub(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
-                         f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
-                         content,
-                         flags=re.M)
-    with open(INIT_FILE_PATH, 'w') as fp:
-        fp.write(content)
+    try:
+        with open(INIT_FILE_PATH, 'r') as fp:
+            content = fp.read()
+            global original_init_content
+            original_init_content = content
+            content = re.sub(r'^_SKYPILOT_COMMIT_SHA = [\'"]([^\'"]*)[\'"]',
+                            f'_SKYPILOT_COMMIT_SHA = \'{get_commit_hash()}\'',
+                            content,
+                            flags=re.M)
+        with open(INIT_FILE_PATH, 'w') as fp:
+            fp.write(content)
+    except Exception: # pylint: disable=broad-except
+        # Avoid breaking the installation.
+        pass
 
 
 def revert_commit_hash():
-    if original_init_content is not None:
-        with open(INIT_FILE_PATH, 'w') as fp:
-            fp.write(original_init_content)
+    try:
+        if original_init_content is not None:
+            with open(INIT_FILE_PATH, 'w') as fp:
+                fp.write(original_init_content)
+    except Exception: # pylint: disable=broad-except
+        # Avoid breaking the installation.
+        pass
 
 
 def parse_readme(readme: str) -> str:

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -26,6 +26,11 @@ import setuptools
 
 ROOT_DIR = os.path.dirname(__file__)
 INIT_FILE_PATH = os.path.join(ROOT_DIR, 'sky', '__init__.py')
+_COMMIT_FAILURE_MESSAGE = (
+    'WARNING: SkyPilot fail to {verb} the commit hash in '
+    f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): '
+    '{error}')
+
 original_init_content = None
 
 system = platform.system()
@@ -72,10 +77,8 @@ def get_commit_hash():
             commit_hash += '-dirty'
         return commit_hash
     except Exception as e:  # pylint: disable=broad-except
-        print(
-            'WARNING: SkyPilot fail to get the commit hash in '
-            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-            file=sys.stderr)
+        print(_COMMIT_FAILURE_MESSAGE.format(verb='get', error=str(e)),
+              file=sys.stderr)
         return commit_hash
 
 
@@ -95,10 +98,8 @@ def replace_commit_hash():
     except Exception as e:  # pylint: disable=broad-except
         # Avoid breaking the installation when there is no permission to write
         # the file.
-        print(
-            'WARNING: SkyPilot fail to replace the commit hash in '
-            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-            file=sys.stderr)
+        print(_COMMIT_FAILURE_MESSAGE.format(verb='replace', error=str(e)),
+              file=sys.stderr)
         pass
 
 
@@ -107,14 +108,11 @@ def revert_commit_hash():
         if original_init_content is not None:
             with open(INIT_FILE_PATH, 'w') as fp:
                 fp.write(original_init_content)
-    except Exception:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         # Avoid breaking the installation when there is no permission to write
         # the file.
-        print(
-            'WARNING: SkyPilot fail to replace the commit hash in '
-            f'{INIT_FILE_PATH!r} (SkyPilot can still be normally used): {e}',
-            file=sys.stderr)
-        pass
+        print(_COMMIT_FAILURE_MESSAGE.format(verb='replace', error=str(e)),
+              file=sys.stderr)
 
 
 def parse_readme(readme: str) -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This fixes an issue introduced by #2720: a permission error can be raised when there is no permission to write the `__init__` file during `sky launch`
```
PermissionError: [Errno 13] Permission denied: '/var/folders/cc/xxxxxx/T/tmp40gtc6r1/sky/__init__.py'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
