### PR TITLE
[BugFix] Fix modification of `sky/__init__.py` when building sky wheels

### DIFF
--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -69,7 +69,7 @@ def _build_sky_wheel():
             if item.name != '__init__.py':
                 # We do not symlink `sky/__init__.py` as we need to
                 # modify the commit hash in the file later.
-                # Symlink other files.
+                # Symlink other files/folders.
                 target.symlink_to(item, target_is_directory=item.is_dir())
         setup_files_dir = SKY_PACKAGE_PATH / 'setup_files'
 

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -62,7 +62,16 @@ def _build_sky_wheel():
     with tempfile.TemporaryDirectory() as tmp_dir:
         # prepare files
         tmp_dir = pathlib.Path(tmp_dir)
-        (tmp_dir / 'sky').symlink_to(SKY_PACKAGE_PATH, target_is_directory=True)
+        sky_tmp_dir = tmp_dir / 'sky'
+        sky_tmp_dir.mkdir()
+        for item in SKY_PACKAGE_PATH.iterdir():
+            target = sky_tmp_dir / item.name
+            if item.name == '__init__.py':
+                # Copy __init__.py since we need to modify it.
+                shutil.copy(item, target)
+            else:
+                # Symlink other files.
+                target.symlink_to(item, target_is_directory=item.is_dir())
         setup_files_dir = SKY_PACKAGE_PATH / 'setup_files'
 
         setup_content = (setup_files_dir / 'setup.py').read_text()
@@ -78,12 +87,11 @@ def _build_sky_wheel():
                 shutil.copy(str(f), str(tmp_dir))
 
         init_file_path = SKY_PACKAGE_PATH / '__init__.py'
-        original_init_file_content = init_file_path.read_text()
+        init_file_content = init_file_path.read_text()
         # Replace the commit hash with the current commit hash.
         init_file_content = re.sub(
             r'_SKYPILOT_COMMIT_SHA = [\'"](.*?)[\'"]',
-            f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'',
-            original_init_file_content)
+            f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'', init_file_content)
         (tmp_dir / 'sky' / '__init__.py').write_text(init_file_content)
 
         # It is important to normalize the path, otherwise 'pip wheel' would
@@ -122,7 +130,6 @@ def _build_sky_wheel():
         wheel_dir = WHEEL_DIR / hash_of_latest_wheel
         wheel_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(wheel_path), wheel_dir)
-        (tmp_dir / 'sky' / '__init__.py').write_text(original_init_file_content)
 
 
 def build_sky_wheel() -> Tuple[pathlib.Path, str]:

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -66,10 +66,9 @@ def _build_sky_wheel():
         sky_tmp_dir.mkdir()
         for item in SKY_PACKAGE_PATH.iterdir():
             target = sky_tmp_dir / item.name
-            if item.name == '__init__.py':
-                # Copy __init__.py since we need to modify it.
-                shutil.copy(item, target)
-            else:
+            if item.name != '__init__.py':
+                # We do not symlink `sky/__init__.py` as we need to
+                # modify the commit hash in the file later.
                 # Symlink other files.
                 target.symlink_to(item, target_is_directory=item.is_dir())
         setup_files_dir = SKY_PACKAGE_PATH / 'setup_files'

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -78,11 +78,12 @@ def _build_sky_wheel():
                 shutil.copy(str(f), str(tmp_dir))
 
         init_file_path = SKY_PACKAGE_PATH / '__init__.py'
-        init_file_content = init_file_path.read_text()
+        original_init_file_content = init_file_path.read_text()
         # Replace the commit hash with the current commit hash.
         init_file_content = re.sub(
             r'_SKYPILOT_COMMIT_SHA = [\'"](.*?)[\'"]',
-            f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'', init_file_content)
+            f'_SKYPILOT_COMMIT_SHA = \'{sky.__commit__}\'',
+            original_init_file_content)
         (tmp_dir / 'sky' / '__init__.py').write_text(init_file_content)
 
         # It is important to normalize the path, otherwise 'pip wheel' would
@@ -121,6 +122,7 @@ def _build_sky_wheel():
         wheel_dir = WHEEL_DIR / hash_of_latest_wheel
         wheel_dir.mkdir(parents=True, exist_ok=True)
         shutil.move(str(wheel_path), wheel_dir)
+        (tmp_dir / 'sky' / '__init__.py').write_text(original_init_file_content)
 
 
 def build_sky_wheel() -> Tuple[pathlib.Path, str]:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce:
```bash
python -c 'from sky.backends import wheel_utils; wheel_utils.build_sky_wheel()'
```

This will replace the `_SKYPILOT_COMMIT_SHA` in `sky/__init__.py` with the current commit. This PR fixed the problem.
<img width="555" alt="image" src="https://github.com/skypilot-org/skypilot/assets/74357442/b1dd622e-d3b6-42ed-8449-a938880f62ba">


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
