### PR TITLE
[Core] Return `job_id` and `handle` for `sky/execution.py::_execute`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,6 +17,7 @@ jobs:
         python-version: [3.8]
         test-path:
           - tests/unit_tests
+          - tests/test_api.py
           - tests/test_cli.py
           - tests/test_config.py
           - tests/test_global_user_state.py

--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -86,7 +86,12 @@ class Backend(Generic[_ResourceHandleType]):
                 handle: _ResourceHandleType,
                 task: 'task_lib.Task',
                 detach_run: bool,
-                dryrun: bool = False) -> None:
+                dryrun: bool = False) -> Optional[int]:
+        """Execute the task on the cluster.
+
+        Returns:
+            Job id if the task is submitted to the cluster, None otherwise.
+        """
         usage_lib.record_cluster_name_for_current_operation(
             handle.get_cluster_name())
         usage_lib.messages.usage.update_actual_task(task)
@@ -143,7 +148,7 @@ class Backend(Generic[_ResourceHandleType]):
                  handle: _ResourceHandleType,
                  task: 'task_lib.Task',
                  detach_run: bool,
-                 dryrun: bool = False) -> None:
+                 dryrun: bool = False) -> Optional[int]:
         raise NotImplementedError
 
     def _post_execute(self, handle: _ResourceHandleType, down: bool) -> None:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3474,10 +3474,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         task: task_lib.Task,
         detach_run: bool,
         dryrun: bool = False,
-    ) -> None:
+    ) -> Optional[int]:
+        """Executes the task on the cluster.
+
+        Returns:
+            Job id if the task is submitted to the cluster, None otherwise.
+        """
         if task.run is None:
             logger.info('Run commands not specified or empty.')
-            return
+            return None
         # Check the task resources vs the cluster resources. Since `sky exec`
         # will not run the provision and _check_existing_cluster
         # We need to check ports here since sky.exec shouldn't change resources
@@ -3487,7 +3492,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         if dryrun:
             logger.info(f'Dryrun complete. Would have run:\n{task}')
-            return
+            return None
 
         job_id = self._add_job(handle, task.name, resources_str)
 
@@ -3498,6 +3503,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         else:
             # Case: task_lib.Task(run, num_nodes=1)
             self._execute_task_one_node(handle, task, job_id, detach_run)
+
+        return job_id
 
     def _post_execute(self, handle: CloudVmRayResourceHandle,
                       down: bool) -> None:

--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -268,13 +268,8 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
                  handle: LocalDockerResourceHandle,
                  task: 'task_lib.Task',
                  detach_run: bool,
-                 dryrun: bool = False) -> Optional[int]:
-        """Launches the container.
-
-        Returns:
-            The job id of the launched job. Since LocalDockerBackend does not
-            have the concept of job id, it always returns None.
-        """
+                 dryrun: bool = False) -> None:
+        """ Launches the container."""
 
         if detach_run:
             raise NotImplementedError('detach_run=True is not supported in '
@@ -288,14 +283,13 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
         # Handle a basic task
         if task.run is None:
             logger.info(f'Nothing to run; run command not specified:\n{task}')
-            return None
+            return
 
         if dryrun:
             logger.info(f'Dryrun complete. Would have run:\n{task}')
-            return None
+            return
 
         self._execute_task_one_node(handle, task)
-        return None
 
     def _post_execute(self, handle: LocalDockerResourceHandle,
                       down: bool) -> None:

--- a/sky/backends/local_docker_backend.py
+++ b/sky/backends/local_docker_backend.py
@@ -268,8 +268,13 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
                  handle: LocalDockerResourceHandle,
                  task: 'task_lib.Task',
                  detach_run: bool,
-                 dryrun: bool = False) -> None:
-        """ Launches the container."""
+                 dryrun: bool = False) -> Optional[int]:
+        """Launches the container.
+
+        Returns:
+            The job id of the launched job. Since LocalDockerBackend does not
+            have the concept of job id, it always returns None.
+        """
 
         if detach_run:
             raise NotImplementedError('detach_run=True is not supported in '
@@ -283,13 +288,14 @@ class LocalDockerBackend(backends.Backend['LocalDockerResourceHandle']):
         # Handle a basic task
         if task.run is None:
             logger.info(f'Nothing to run; run command not specified:\n{task}')
-            return
+            return None
 
         if dryrun:
             logger.info(f'Dryrun complete. Would have run:\n{task}')
-            return
+            return None
 
         self._execute_task_one_node(handle, task)
+        return None
 
     def _post_execute(self, handle: LocalDockerResourceHandle,
                       down: bool) -> None:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2046,7 +2046,7 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
 @usage_lib.entrypoint
 def logs(
     cluster: str,
-    job_ids: Tuple[str],
+    job_ids: Tuple[str, ...],
     sync_down: bool,
     status: bool,  # pylint: disable=redefined-outer-name
     follow: bool,
@@ -2085,6 +2085,7 @@ def logs(
 
     assert job_ids is None or len(job_ids) <= 1, job_ids
     job_id = None
+    job_ids_to_query: Optional[List[int]] = None
     if job_ids:
         # Already check that len(job_ids) <= 1. This variable is used later
         # in core.tail_logs.
@@ -2094,7 +2095,8 @@ def logs(
                                    'Job ID must be integers.')
         job_ids_to_query = [int(job_id)]
     else:
-        job_ids_to_query = job_ids
+        # job_ids is either None or empty list, so it is safe to cast it here.
+        job_ids_to_query = typing.cast(Optional[List[int]], job_ids)
     if status:
         job_statuses = core.job_status(cluster, job_ids_to_query)
         job_id = list(job_statuses.keys())[0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import sky
 
 
-def test_sky_launch():
+def test_sky_launch(enable_all_clouds):
     task = sky.Task()
     job_id, handle = sky.launch(task, dryrun=True)
     assert job_id is None and handle is None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,7 @@
+import sky
+
+
+def test_sky_launch():
+    task = sky.Task()
+    job_id, handle = sky.launch(task, dryrun=True)
+    assert job_id is None and handle is None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -25,6 +25,7 @@
 import inspect
 import os
 import pathlib
+import shlex
 import shutil
 import subprocess
 import sys
@@ -2625,13 +2626,63 @@ def test_user_ray_cluster(generic_cloud: str):
     run_one_test(test)
 
 
+_CODE_PREFIX = ['import sky']
+
+
+def _build(code: List[str]) -> str:
+    code = _CODE_PREFIX + code
+    code = ';'.join(code)
+    return f'python3 -u -c {shlex.quote(code)}'
+
+
 # ------- Testing the core API --------
 # Most of the core APIs have been tested in the CLI tests.
 # These tests are for testing the return value of the APIs not fully used in CLI.
-def test_core_api():
+
+
+def test_core_api_sky_launch_dryrun():
+    code = [
+        'task = sky.Task()',
+        'job_id, handle = sky.launch(task, dryrun=True)',
+        'assert job_id is None and handle is None',
+    ]
+    cmd = _build(code)
+    test = Test(
+        'core-api-sky-launch-dryrun',
+        [cmd],
+    )
+    run_one_test(test)
+
+
+@pytest.mark.gcp
+def test_core_api_sky_launch_exec():
     name = _get_cluster_name()
-    sky.launch
-    # TODO(zhwu): Add a test for core api.
+    code = [
+        f'name = "{name}"',
+        'task = sky.Task(run="whoami")',
+        'task.set_resources(sky.Resources(cloud=sky.GCP()))',
+        'job_id, handle = sky.launch(task, cluster_name=name)',
+        'assert job_id == 1',
+        'assert handle is not None',
+        'assert handle.cluster_name == name',
+        'assert handle.launched_resources.cloud.is_same_cloud(sky.GCP())',
+        'job_id_exec, handle_exec = sky.exec(task, cluster_name=name)',
+        'assert job_id_exec == 2',
+        'assert handle_exec is not None',
+        'assert handle_exec.cluster_name == name',
+        'assert handle_exec.launched_resources.cloud.is_same_cloud(sky.GCP())',
+        # For dummy task (i.e. task.run is None), the job won't be submitted.
+        'dummy_task = sky.Task()',
+        'job_id_dummy, _ = sky.exec(dummy_task, cluster_name=name)',
+        'assert job_id_dummy is None',
+    ]
+    cmd = _build(code)
+    test = Test(
+        'core-api-sky-launch-exec',
+        [cmd],
+        f'sky down -y {name}',
+    )
+    run_one_test(test)
 
 
 # ---------- Testing Storage ----------

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2640,20 +2640,6 @@ def _build(code: List[str]) -> str:
 # These tests are for testing the return value of the APIs not fully used in CLI.
 
 
-def test_core_api_sky_launch_dryrun():
-    code = [
-        'task = sky.Task()',
-        'job_id, handle = sky.launch(task, dryrun=True)',
-        'assert job_id is None and handle is None',
-    ]
-    cmd = _build(code)
-    test = Test(
-        'core-api-sky-launch-dryrun',
-        [cmd],
-    )
-    run_one_test(test)
-
-
 @pytest.mark.gcp
 def test_core_api_sky_launch_exec():
     name = _get_cluster_name()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2643,32 +2643,23 @@ def _build(code: List[str]) -> str:
 @pytest.mark.gcp
 def test_core_api_sky_launch_exec():
     name = _get_cluster_name()
-    code = [
-        f'name = "{name}"',
-        'task = sky.Task(run="whoami")',
-        'task.set_resources(sky.Resources(cloud=sky.GCP()))',
-        'job_id, handle = sky.launch(task, cluster_name=name)',
-        'assert job_id == 1',
-        'assert handle is not None',
-        'assert handle.cluster_name == name',
-        'assert handle.launched_resources.cloud.is_same_cloud(sky.GCP())',
-        'job_id_exec, handle_exec = sky.exec(task, cluster_name=name)',
-        'assert job_id_exec == 2',
-        'assert handle_exec is not None',
-        'assert handle_exec.cluster_name == name',
-        'assert handle_exec.launched_resources.cloud.is_same_cloud(sky.GCP())',
-        # For dummy task (i.e. task.run is None), the job won't be submitted.
-        'dummy_task = sky.Task()',
-        'job_id_dummy, _ = sky.exec(dummy_task, cluster_name=name)',
-        'assert job_id_dummy is None',
-    ]
-    cmd = _build(code)
-    test = Test(
-        'core-api-sky-launch-exec',
-        [cmd],
-        f'sky down -y {name}',
-    )
-    run_one_test(test)
+    task = sky.Task(run="whoami")
+    task.set_resources(sky.Resources(cloud=sky.GCP()))
+    job_id, handle = sky.launch(task, cluster_name=name)
+    assert job_id == 1
+    assert handle is not None
+    assert handle.cluster_name == name
+    assert handle.launched_resources.cloud.is_same_cloud(sky.GCP())
+    job_id_exec, handle_exec = sky.exec(task, cluster_name=name)
+    assert job_id_exec == 2
+    assert handle_exec is not None
+    assert handle_exec.cluster_name == name
+    assert handle_exec.launched_resources.cloud.is_same_cloud(sky.GCP())
+    # For dummy task (i.e. task.run is None), the job won't be submitted.
+    dummy_task = sky.Task()
+    job_id_dummy, _ = sky.exec(dummy_task, cluster_name=name)
+    assert job_id_dummy is None
+    sky.down(name)
 
 
 # ---------- Testing Storage ----------


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR added return value for `sky/execution.py::_execute`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
