### PR TITLE
[SkyServe] Fix FastAPI

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -3,7 +3,6 @@
 Responsible for autoscaling and replica management.
 """
 import argparse
-import asyncio
 import base64
 import logging
 import pickle
@@ -52,9 +51,9 @@ class SkyServeController:
     def run(self) -> None:
 
         @self.app.post('/controller/update_num_requests')
-        def update_num_requests(request: fastapi.Request):
+        async def update_num_requests(request: fastapi.Request):
             # await request
-            request_data = asyncio.run(request.json())
+            request_data = await request.json()
             # get request data
             num_requests = request_data['num_requests']
             logger.info(f'Received request: {request_data}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The current implementation will cause the controller FastAPI to hang after ~1mo. This PR fixed the issue.

Reference: https://github.com/tiangolo/fastapi/issues/1728#issuecomment-1255675198

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
