### PR TITLE
Release 0.4.1

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 # Replaced with the current commit when building the wheels.
-_SKYPILOT_COMMIT_SHA = 'acd5ab70f5ac0249e0f18a05855164091fba796a'
+_SKYPILOT_COMMIT_SHA = '4d6e455fcc002356fbcb298b051021d21166f3a2'
 
 
 def get_git_commit():

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 # Replaced with the current commit when building the wheels.
-_SKYPILOT_COMMIT_SHA = '{{SKYPILOT_COMMIT_SHA}}'
+_SKYPILOT_COMMIT_SHA = 'acd5ab70f5ac0249e0f18a05855164091fba796a'
 
 
 def get_git_commit():
@@ -33,7 +33,7 @@ def get_git_commit():
 
 
 __commit__ = get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.4.1'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 # Keep this order to avoid cyclic imports

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2904,8 +2904,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     provisioner.ClusterName(handle.cluster_name,
                                             handle.cluster_name_on_cloud),
                     handle.cluster_yaml,
-                    local_wheel_path=local_wheel_path,
-                    wheel_hash=wheel_hash,
                     provision_record=provision_record,
                     custom_resource=resources_vars.get('custom_resources'),
                     log_dir=self.log_dir)

--- a/sky/provision/metadata_utils.py
+++ b/sky/provision/metadata_utils.py
@@ -4,6 +4,7 @@ import contextlib
 import functools
 import pathlib
 import shutil
+from typing import Optional
 
 from sky import sky_logging
 
@@ -30,7 +31,7 @@ def _get_instance_metadata_dir(cluster_name: str,
 
 
 def cache_func(cluster_name: str, instance_id: str, stage_name: str,
-               hash_str: str):
+               hash_str: Optional[str]):
     """A helper function for caching function execution."""
 
     def decorator(function):
@@ -51,8 +52,11 @@ def cache_func(cluster_name: str, instance_id: str, stage_name: str,
 
 @contextlib.contextmanager
 def check_cache_hash_or_update(cluster_name: str, instance_id: str,
-                               stage_name: str, hash_str: str):
+                               stage_name: str, hash_str: Optional[str]):
     """A decorator for 'cache_func'."""
+    if hash_str is None:
+        yield True
+        return
     path = get_instance_cache_dir(cluster_name, instance_id) / stage_name
     if path.exists():
         with open(path) as f:

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -3,7 +3,6 @@ import collections
 import dataclasses
 import json
 import os
-import pathlib
 import shlex
 import socket
 import subprocess
@@ -311,7 +310,6 @@ def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
 
 def _post_provision_setup(
         cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        local_wheel_path: pathlib.Path, wheel_hash: str,
         provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str]) -> provision_common.ClusterInfo:
     cluster_info = provision.get_cluster_info(cloud_name,
@@ -388,21 +386,15 @@ def _post_provision_setup(
         # (3) all instances need permission to mount storage for all clouds
         # It is possible to have a "smaller" permission model, but we leave that
         # for later.
-        file_mounts = {
-            backend_utils.SKY_REMOTE_PATH + '/' + wheel_hash:
-                str(local_wheel_path),
-            **config_from_yaml.get('file_mounts', {})
-        }
+        file_mounts = config_from_yaml.get('file_mounts', {})
 
         runtime_preparation_str = ('[bold cyan]Preparing SkyPilot '
                                    'runtime ({step}/3 - {step_name})')
         status.update(
             runtime_preparation_str.format(step=1, step_name='initializing'))
         instance_setup.internal_file_mounts(cluster_name.name_on_cloud,
-                                            file_mounts,
-                                            cluster_info,
-                                            ssh_credentials,
-                                            wheel_hash=wheel_hash)
+                                            file_mounts, cluster_info,
+                                            ssh_credentials)
 
         status.update(
             runtime_preparation_str.format(step=2, step_name='dependencies'))
@@ -464,7 +456,6 @@ def _post_provision_setup(
 
 def post_provision_runtime_setup(
         cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        local_wheel_path: pathlib.Path, wheel_hash: str,
         provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str],
         log_dir: str) -> provision_common.ClusterInfo:
@@ -483,8 +474,6 @@ def post_provision_runtime_setup(
             return _post_provision_setup(cloud_name,
                                          cluster_name,
                                          cluster_yaml=cluster_yaml,
-                                         local_wheel_path=local_wheel_path,
-                                         wheel_hash=wheel_hash,
                                          provision_record=provision_record,
                                          custom_resource=custom_resource)
         except Exception:  # pylint: disable=broad-except

--- a/sky/skylet/skylet.py
+++ b/sky/skylet/skylet.py
@@ -2,14 +2,17 @@
 
 import time
 
+import sky
 from sky import sky_logging
+from sky.skylet import constants
 from sky.skylet import events
 
 # Use the explicit logger name so that the logger is under the
 # `sky.skylet.skylet` namespace when executed directly, so as
 # to inherit the setup from the `sky` logger.
 logger = sky_logging.init_logger('sky.skylet.skylet')
-logger.info('skylet started')
+logger.info(f'Skylet started with version {constants.SKYLET_VERSION}; '
+            f'SkyPilot v{sky.__version__} (commit: {sky.__commit__})')
 
 EVENTS = [
     events.AutostopEvent(),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- [x] `pytest tests/test_smoke.py`
- [x] `pytest tests/test_smoke.py --aws`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] `backward_compatibility_tests.sh` run against 0.4.0.
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky spot launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky spot logs --controller
        ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --cpus 2+ --down echo hi  # without timeout bump
    sky down dbg  
    ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot echo hi
    sky down dbg
    ```
  - [x] following script (16 nodes do not work with GCP due to the autoscaler bug of ray)
    ```
    sky launch -c dbg --cloud gcp --num-nodes 8 --cpus 2+ --down  echo hi# with or without timeout bump
    sky down dbg  
    ```
  - [x] following script
    ```
    # Run a 24-hour+ spot job and ensure it doesn’t OOM
    # https://github.com/skypilot-org/skypilot/pull/2675
    sky spot launch -n test-oom --cloud aws --cpus 2 sleep 86400
    ```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
