### PR TITLE
[Config] Fix ssh proxy command to be null

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -323,7 +323,10 @@ def get_config_schema():
                             'type': 'object',
                             'required': [],
                             'additionalProperties': {
-                                'type': 'string',
+                                'anyOf': [
+                                    {'type': 'string'},
+                                    {'type': 'null'},
+                                ]
                             }
                         }]
                     },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -324,8 +324,12 @@ def get_config_schema():
                             'required': [],
                             'additionalProperties': {
                                 'anyOf': [
-                                    {'type': 'string'},
-                                    {'type': 'null'},
+                                    {
+                                        'type': 'string'
+                                    },
+                                    {
+                                        'type': 'null'
+                                    },
                                 ]
                             }
                         }]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,27 @@ def test_empty_config(monkeypatch, tmp_path) -> None:
     _reload_config()
     _check_empty_config()
 
+def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
+    """Test that the config is not loaded if the config file is empty."""
+    with open(tmp_path / 'valid.yaml', 'w') as f:
+        f.write(f"""\
+        aws:
+            instance_tags:
+                mytag: myvalue
+            ssh_proxy_command:
+                eu-west-1: null
+                us-east-1: null
+            use_internal_ips: true
+            vpc_name: abc
+
+        spot:
+            controller:
+                resources:
+                    disk_size: 256
+        """)
+    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'valid.yaml')
+    _reload_config()
+    _check_empty_config()
 
 def test_invalid_field_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file contains unknown field."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,7 @@ def test_empty_config(monkeypatch, tmp_path) -> None:
     _reload_config()
     _check_empty_config()
 
+
 def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'valid.yaml', 'w') as f:
@@ -78,6 +79,7 @@ def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'valid.yaml')
     _reload_config()
     _check_empty_config()
+
 
 def test_invalid_field_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file contains unknown field."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,9 @@ def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
         """)
     monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'valid.yaml')
     _reload_config()
-    _check_empty_config()
+    proxy_config = skypilot_config.get_nested(
+        ('aws', 'ssh_proxy_command', 'eu-west-1'), 'default')
+    assert proxy_config is None, proxy_config
 
 
 def test_invalid_field_config(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that the `sky launch` fails when the following `config.yaml` is provided:
```
aws:
      instance_tags:
          mytag: myvalue
      ssh_proxy_command:
          eu-west-1: null
          us-east-1: null
      use_internal_ips: true
      vpc_name: abc
```

This is due to our recent schema check for `config.yaml` in #2645


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test --cloud aws`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
