### PR TITLE
[UX] Resources representation for Image ID

### DIFF
--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -216,7 +216,7 @@ class IBM(clouds.Cloud):
         elif None in r.image_id:
             image_id = r.image_id[None]
         else:
-            image_id = r.image_id[region.name]  
+            image_id = r.image_id[region.name]
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -211,8 +211,12 @@ class IBM(clouds.Cloud):
                                                    r.instance_type)
         worker_instance_resources = _get_profile_resources(worker_instance_type)
         # r.image_id: {clouds.Region:image_id} - property of Resources class
-        image_id = r.image_id[
-            region.name] if r.image_id else self.get_default_image(region_name)
+        if r.image_id is None:
+            image_id = self.get_default_image(region_name)
+        elif None in r.image_id:
+            image_id = r.image_id[None]
+        else:
+            image_id = r.image_id[region.name]  
 
         return {
             'instance_type': r.instance_type,

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -833,6 +833,9 @@ class Resources:
 
         # Validate the image exists and the size is smaller than the disk size.
         for region, image_id in self._image_id.items():
+            # For None, narrow down to self._region.
+            if region is None:
+                region = self._region
             # Check the image exists and get the image size.
             # It will raise ValueError if the image does not exist.
             image_size = self.cloud.get_image_size(image_id, region)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -160,7 +160,7 @@ class Resources:
         # The key is None if the same image_id applies for all regions.
         self._image_id = image_id
         if isinstance(image_id, str):
-            self._image_id = {self._region: image_id.strip()}
+            self._image_id = {None: image_id.strip()}
         elif isinstance(image_id, dict):
             if None in image_id:
                 self._image_id = {None: image_id[None].strip()}
@@ -810,10 +810,14 @@ class Resources:
                     raise ValueError(
                         f'image_id {self._image_id} should contain the image '
                         f'for the specified region {self._region} or None.')
+            # Narrow down the image_id to the specified region, if multiple
+            # regions are specified.
+            if len(self._image_id) > 1:
+                self._image_id = {self._region: self._image_id[self._region]}
 
         # Check the image_id's are valid.
         for region, image_id in self._image_id.items():
-            # For None, narrow down to self._region.
+            # For None, narrow down to self._region to check.
             if region is None:
                 region = self._region
             if (image_id.startswith('skypilot:') and
@@ -833,7 +837,7 @@ class Resources:
 
         # Validate the image exists and the size is smaller than the disk size.
         for region, image_id in self._image_id.items():
-            # For None, narrow down to self._region.
+            # For None, narrow down to self._region to check.
             if region is None:
                 region = self._region
             # Check the image exists and get the image size.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -160,10 +160,10 @@ class Resources:
         # The key is None if the same image_id applies for all regions.
         self._image_id = image_id
         if isinstance(image_id, str):
-            self._image_id = {self._region: image_id.strip()}
+            self._image_id = {None: image_id.strip()}
         elif isinstance(image_id, dict):
             if None in image_id:
-                self._image_id = {self._region: image_id[None].strip()}
+                self._image_id = {None: image_id[None].strip()}
             else:
                 self._image_id = {
                     k.strip(): v.strip() for k, v in image_id.items()
@@ -804,7 +804,7 @@ class Resources:
                     'explicitly specify the cloud.')
 
         if self._region is not None:
-            if self._region not in self._image_id:
+            if self._region not in self._image_id and None not in self._image_id:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'image_id {self._image_id} should contain the image '

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -764,10 +764,15 @@ class Resources:
     def extract_docker_image(self) -> Optional[str]:
         if self.image_id is None:
             return None
-        if len(self.image_id) == 1 and self.region in self.image_id:
-            image_id = self.image_id[self.region]
-            if image_id.startswith('docker:'):
-                return image_id[len('docker:'):]
+        if len(self.image_id) == 1:
+            image_id = None
+            if self.region in self.image_id:
+                image_id = self.image_id[self.region]
+            elif None in self.image_id:
+                image_id = self.image_id[None]
+            if image_id is not None:
+                if image_id.startswith('docker:'):
+                    return image_id[len('docker:'):]
         return None
 
     def _try_validate_image_id(self) -> None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -160,7 +160,7 @@ class Resources:
         # The key is None if the same image_id applies for all regions.
         self._image_id = image_id
         if isinstance(image_id, str):
-            self._image_id = {None: image_id.strip()}
+            self._image_id = {self._region: image_id.strip()}
         elif isinstance(image_id, dict):
             if None in image_id:
                 self._image_id = {None: image_id[None].strip()}

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -804,19 +804,21 @@ class Resources:
                     'explicitly specify the cloud.')
 
         if self._region is not None:
-            if self._region not in self._image_id and None not in self._image_id:
+            if (self._region not in self._image_id and
+                    None not in self._image_id):
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'image_id {self._image_id} should contain the image '
-                        f'for the specified region {self._region}.')
-            # Narrow down the image_id to the specified region.
-            self._image_id = {self._region: self._image_id[self._region]}
+                        f'for the specified region {self._region} or None.')
 
         # Check the image_id's are valid.
         for region, image_id in self._image_id.items():
+            # For None, narrow down to self._region.
+            if region is None:
+                region = self._region
             if (image_id.startswith('skypilot:') and
                     not self._cloud.is_image_tag_valid(image_id, region)):
-                region_str = f' ({region})' if region else ''
+                region_str = f' ({region})' if region is not None else ''
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'Image tag {image_id!r} is not valid, please make sure'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolves #2750 .

Only tested in AWS and GCP.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```yaml
resources:
  cloud: gcp
  image_id: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
# output: GCP(n2-standard-8, image_id=projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310)
```
```yaml
resources:
  cloud: gcp
  region: us-central1
  image_id: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
# output: GCP(n2-standard-8, image_id=projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310)
```
```yaml
resources:
  cloud: gcp
  region: us-central1
  image_id:
    us-west1: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
    us-east1: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
# output: failed
```
```yaml
resources:
  cloud: gcp
  image_id:
    us-west1: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
    us-east1: projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310
# output: GCP(n2-standard-8, image_id={'us-east1': 'projects/deeplearning-platform-release/global/images/common-cpu-v20230615-debian-11-py310'})
```
```yaml
resources:
  cloud: aws
  region: us-east-1
  image_id: ami-0729d913a335efca7
# output: AWS(m6i.2xlarge, image_id=ami-0729d913a335efca7)
```
```yaml
resources:
  cloud: aws
  image_id: ami-0729d913a335efca7
# output: failed
```
```yaml
resources:
  cloud: aws
  image_id:
    us-east-1: ami-0729d913a335efca7
    us-west-2: ami-050814f384259894c
# output: AWS(m6i.2xlarge, image_id={'us-east-1': 'ami-0729d913a335efca7'})
```
```yaml
resources:
  cloud: aws
  region: us-west-2
  image_id:
    us-east-1: ami-0729d913a335efca7
    us-west-2: ami-050814f384259894c
# output: AWS(m6i.2xlarge, image_id={'us-west-2': 'ami-050814f384259894c'})
```
- [x] All smoke tests: `pytest tests/test_smoke.py`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
