### PR TITLE
Core: Fix syncing workdir with spaces in .git/info/exclude path.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import pprint
 import re
+import shlex
 import subprocess
 import tempfile
 import textwrap
@@ -292,8 +293,12 @@ def path_size_megabytes(path: str) -> int:
     git_exclude_filter = ''
     if (resolved_path / command_runner.GIT_EXCLUDE).exists():
         # Ensure file exists; otherwise, rsync will error out.
+        #
+        # We shlex.quote() because the path may contain spaces:
+        #   'my dir/.git/info/exclude'
+        # Without quoting rsync fails.
         git_exclude_filter = command_runner.RSYNC_EXCLUDE_OPTION.format(
-            str(resolved_path / command_runner.GIT_EXCLUDE))
+            shlex.quote(str(resolved_path / command_runner.GIT_EXCLUDE)))
     rsync_command = (f'rsync {command_runner.RSYNC_DISPLAY_OPTION} '
                      f'{command_runner.RSYNC_FILTER_OPTION} '
                      f'{git_exclude_filter} --dry-run {path!r}')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -852,8 +852,8 @@ class Storage(object):
                         warn_for_git_dir(source)
             store.upload()
         except exceptions.StorageUploadError:
-            logger.error(f'Could not upload {self.source} to store '
-                         f'name {store.name}.')
+            logger.error(f'Could not upload {self.source!r} to store '
+                         f'name {store.name!r}.')
             if store.is_sky_managed:
                 global_user_state.set_storage_status(
                     self.name, StorageStatus.UPLOAD_FAILED)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -391,9 +391,13 @@ class SSHCommandRunner:
             resolved_source = pathlib.Path(source).expanduser().resolve()
             if (resolved_source / GIT_EXCLUDE).exists():
                 # Ensure file exists; otherwise, rsync will error out.
+                #
+                # We shlex.quote() because the path may contain spaces:
+                #   'my dir/.git/info/exclude'
+                # Without quoting rsync fails.
                 rsync_command.append(
                     RSYNC_EXCLUDE_OPTION.format(
-                        str(resolved_source / GIT_EXCLUDE)))
+                        shlex.quote(str(resolved_source / GIT_EXCLUDE))))
 
         if self._docker_ssh_proxy_command is not None:
             docker_ssh_proxy_command = self._docker_ssh_proxy_command(['ssh'])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
A user reported the following error:

Repro
```
mkdir 'test dir with space'
cd 'test dir with space'
git init  # creates a .git/info/exclude
cd ..
sky launch --use-spot --cpus 2+ -i30 --down --workdir='test dir with space' -- ls -lthr
```

Before this PR, errors are thrown due to `--exclude-from=<path with spaces>`
```
...
I 11-07 09:46:32 log_utils.py:45] Head node is up.
I 11-07 09:47:09 cloud_vm_ray_backend.py:1692] Successfully provisioned or found existing VM.
rsync: failed to open exclude file /Users/zongheng/Dropbox/workspace/riselab/sky-computing/test: No such file or directory (2)
rsync error: error in file IO (code 11) at /AppleInternal/Library/BuildRoots/a0876c02-1788-11ed-b9c4-96898e02b808/Library/Caches/com.apple.xbs/Sources/rsync/rsync/exclude.c(1005) [client=2.6.9]
I 11-07 09:47:11 cloud_vm_ray_backend.py:3146] Syncing workdir (to 1 node): test dir with space -> ~/sky_workdir
I 11-07 09:47:11 cloud_vm_ray_backend.py:3153] To view detailed progress: tail -n100 -f ~/sky_logs/sky-2023-11-07-09-45-55-876372/workdir_sync.log
Clusters
NAME               LAUNCHED     RESOURCES                    STATUS  AUTOSTOP    COMMAND
sky-be42-zongheng  14 secs ago  1x GCP(n2-standard-2[Spot])  UP      30m (down)  sky launch --use-spot --c...

* 1 cluster has auto{stop,down} scheduled. Refresh statuses with: sky status --refresh

sky.exceptions.CommandError: Command rsync -Pavz --filter='dir-merge,- .gitignore' --exclude-from=/Users/zongheng/Dropbox/workspace/riselab/sky-computing/test dir with space/.git/info/exclude -e "ssh -i ~/.ssh/sky-key -o Port=22 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=5 -o ServerAliveCountMax=3 -o ConnectTimeout=30s -o ForwardAgent=yes -o ControlMaster=auto -o ControlPath=/tmp/skypilot_ssh_zongheng/cc4bb0d529/%C -o ControlPersist=300s" '/Users/zongheng/Dropbox/workspace/riselab/sky-computing/test dir with space/' gcpuser@34.130.132.10:'~/sky_workdir' failed with return code 11.
Failed to rsync up: test dir with space -> ~/sky_workdir. Ensure that the network is stable, then retry.
```

With this PR, errors are fixed due to the above being quoted.

---

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
