### PR TITLE
[Storage] Storage tests cleanup and fixes

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -731,7 +731,7 @@ class Storage(object):
             # Following error is raised from _get_bucket and caught only when
             # an externally removed storage is attempted to be fetched.
             except exceptions.StorageExternalDeletionError:
-                logger.debug(f'Storage object {self.name} was attempted to '
+                logger.debug(f'Storage object {self.name!r} was attempted to '
                              'be reconstructed while the corresponding bucket'
                              ' was externally deleted.')
                 continue

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -731,7 +731,7 @@ class Storage(object):
             # Following error is raised from _get_bucket and caught only when
             # an externally removed storage is attempted to be fetched.
             except exceptions.StorageExternalDeletionError:
-                logger.debug(f'Storage object, {self.name}, was attempted to '
+                logger.debug(f'Storage object {self.name} was attempted to '
                              'be reconstructed while the corresponding bucket'
                              ' was externally deleted.')
                 continue

--- a/tests/kubernetes/eks_test_cluster.yaml
+++ b/tests/kubernetes/eks_test_cluster.yaml
@@ -5,17 +5,17 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: my-cluster
+  name: my-cluster2
   region: us-west-2
 
 managedNodeGroups:
-  - name: v100-nodes
-    instanceType: p3.2xlarge  # This instance type provides 1 NVIDIA V100 GPU.
-    desiredCapacity: 1
-
-  - name: t4-nodes
-    instanceType: g4dn.2xlarge  # This instance type provides 1 NVIDIA T4 GPU.
-    desiredCapacity: 1
+#  - name: v100-nodes
+#    instanceType: p3.2xlarge  # This instance type provides 1 NVIDIA V100 GPU.
+#    desiredCapacity: 1
+#
+#  - name: t4-nodes
+#    instanceType: g4dn.2xlarge  # This instance type provides 1 NVIDIA T4 GPU.
+#    desiredCapacity: 1
 
   - name: cpu-nodes # Creates 16 CPU nodes
     instanceType: m5.4xlarge

--- a/tests/kubernetes/eks_test_cluster.yaml
+++ b/tests/kubernetes/eks_test_cluster.yaml
@@ -5,17 +5,17 @@ apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 
 metadata:
-  name: my-cluster2
+  name: my-cluster
   region: us-west-2
 
 managedNodeGroups:
-#  - name: v100-nodes
-#    instanceType: p3.2xlarge  # This instance type provides 1 NVIDIA V100 GPU.
-#    desiredCapacity: 1
-#
-#  - name: t4-nodes
-#    instanceType: g4dn.2xlarge  # This instance type provides 1 NVIDIA T4 GPU.
-#    desiredCapacity: 1
+  - name: v100-nodes
+    instanceType: p3.2xlarge  # This instance type provides 1 NVIDIA V100 GPU.
+    desiredCapacity: 1
+
+  - name: t4-nodes
+    instanceType: g4dn.2xlarge  # This instance type provides 1 NVIDIA T4 GPU.
+    desiredCapacity: 1
 
   - name: cpu-nodes # Creates 16 CPU nodes
     instanceType: m5.4xlarge

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -824,7 +824,7 @@ def test_aws_storage_mounts():
         test = Test(
             'aws_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -851,7 +851,7 @@ def test_gcp_storage_mounts():
         test = Test(
             'gcp_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -881,7 +881,7 @@ def test_kubernetes_storage_mounts():
         test = Test(
             'kubernetes_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -910,7 +910,7 @@ def test_cloudflare_storage_mounts(generic_cloud: str):
         test = Test(
             'cloudflare_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -939,7 +939,7 @@ def test_ibm_storage_mounts():
         test = Test(
             'ibm_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -971,7 +971,7 @@ def test_aws_storage_mounts_with_stop():
         test = Test(
             'aws_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -1003,7 +1003,7 @@ def test_gcp_storage_mounts_with_stop():
         test = Test(
             'gcp_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -1038,7 +1038,7 @@ def test_kubernetes_storage_mounts_with_stop():
         test = Test(
             'kubernetes_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete {storage_name}',
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)


### PR DESCRIPTION
* Addresses #2773. Adds `-y` introduced by #2726
* Cleans up (removes commas) an error str when storage is externally deleted
* Removes invalid test `def test_kubernetes_storage_mounts_with_stop` since k8s does not support autostopping.
* Removes redundant `test_xxx_storage_mounts`. Superseded by `test_xxx_storage_mounts_with_stop`

Tested:
- [x] Tests edited here:`pytest tests/test_smoke.py::test_aws_storage_mounts_with_stop --aws; pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop; pytest tests/test_smoke.py::test_kubernetes_storage_mounts --kubernetes; pytest tests/test_smoke.py::test_cloudflare_storage_mounts --cloudflare; pytest tests/test_smoke.py::test_ibm_storage_mounts --ibm`