### PR TITLE
[k8s] Increase ssh timeout when calling `uptime`

### DIFF
--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -49,7 +49,8 @@ SSHCommandRunner.set_port = set_port
 
 def run_override_timeout(*args, **kwargs):
     # If command is `uptime`, change timeout to 10s
-    if args[1] == 'uptime':
+    command = args[1]
+    if command == 'uptime':
         kwargs['timeout'] = UPTIME_SSH_TIMEOUT
     return SSHCommandRunner._run(*args, **kwargs)
 

--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 MAX_TAG_RETRIES = 3
 DELAY_BEFORE_TAG_RETRY = 0.5
+UPTIME_SSH_TIMEOUT = 10
 
 RAY_COMPONENT_LABEL = 'cluster.ray.io/component'
 
@@ -29,6 +30,32 @@ def set_port(self, port):
 
 
 SSHCommandRunner.set_port = set_port
+
+
+# Monkey patch SSHCommandRunner to use a larger timeout when running uptime to
+# check cluster liveness. This is needed because the default timeout of 5s is
+# too short when the cluster is accessed from different geographical
+# locations over VPN.
+#
+# Ray autoscaler sets the timeout on a per-call basis (as an arg to
+# SSHCommandRunner.run). The 5s timeout is hardcoded in
+# NodeUpdater.wait_ready() in updater.py is hard to modify without
+# duplicating a large chunk of ray autoscaler code. Instead, we
+# monkey patch the run method to check if the command being run is 'uptime',
+# and if so change the timeout to 10s.
+#
+# Fortunately, Ray uses a timeout of 120s for running commands after the
+# cluster is ready, so we do not need to modify that.
+
+def run_override_timeout(*args, **kwargs):
+    # If command is `uptime`, change timeout to 10s
+    if args[1] == 'uptime':
+        kwargs['timeout'] = UPTIME_SSH_TIMEOUT
+    return SSHCommandRunner._run(*args, **kwargs)
+
+
+SSHCommandRunner._run = SSHCommandRunner.run
+SSHCommandRunner.run = run_override_timeout
 
 
 def head_service_selector(cluster_name: str) -> Dict[str, str]:

--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -31,7 +31,6 @@ def set_port(self, port):
 
 SSHCommandRunner.set_port = set_port
 
-
 # Monkey patch SSHCommandRunner to use a larger timeout when running uptime to
 # check cluster liveness. This is needed because the default timeout of 5s is
 # too short when the cluster is accessed from different geographical
@@ -46,6 +45,7 @@ SSHCommandRunner.set_port = set_port
 #
 # Fortunately, Ray uses a timeout of 120s for running commands after the
 # cluster is ready, so we do not need to modify that.
+
 
 def run_override_timeout(*args, **kwargs):
     # If command is `uptime`, change timeout to 10s


### PR DESCRIPTION
## Issue
When trying provisioning on a Kubernetes cluster on a high latency connection (e.g., different geographic region + VPN), SkyPilot would get stuck on launching. This is because the `uptime` call run by the ray autoscaler to check for cluster liveness uses a very short `ConnectTimeout=5s`. Using a larger SSH timeout fixes the issue. 

## Fix in this PR
This PR introduces a monkey patch to SSHCommandRunner in `kubernetes/node_provider.py`. It uses a larger timeout when running uptime to check cluster liveness. This monkeypatch to `SSHCommandRunner.run`is necessary since the ray autoscaler sets the timeout on a per-call basis (as an arg to `SSHCommandRunner.run`) and the 5s timeout is hardcoded in `updater.py::NodeUpdater.wait_ready()` is hard to modify without duplicating a large chunk of ray autoscaler code. 

Thus, we monkey patch the run method to check if the command being run is 'uptime', and if so change the timeout to 10s.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky launch -c test --cloud kubernetes` on GKE and EKS clusters on a high latency connection.