### PR TITLE
Example: Update vLLM example to use PyTorch <2.1 (CUDA 11.8)

### DIFF
--- a/llm/vllm/serve-openai-api.yaml
+++ b/llm/vllm/serve-openai-api.yaml
@@ -20,6 +20,11 @@ setup: |
   pip install accelerate
 
   cd vllm
+  # NOTE(skypilot): This is the last commit before the vLLM commit
+  # (06458a0b42449398aa2ba001d9dbaff256159448) that upgraded its requirements to
+  # PyTorch 2.1 which uses CUDA 12.1.  Since currently our default GCP image
+  # uses CUDA 11.8, we use this commit to avoid the CUDA version mismatch.
+  git checkout 1a2bbc930135cd3b94fbff2aafbdf5c568acc8bd
   pip list | grep vllm || pip install .
   python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Partially address #2692. Better fix is to update GCP default images to support CUDA 12.1?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `HF_TOKEN=xxx sky launch serve-openai-api.yaml -c vllm-dbg2 --env HF_TOKEN -i30 --down`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
