### PR TITLE
[Examples] Fix Vicuna serve example and add OpenAI Example for Vicuna

### DIFF
--- a/llm/vicuna/README.md
+++ b/llm/vicuna/README.md
@@ -41,6 +41,11 @@ sky launch -c vicuna-serve-v100 -s serve.yaml --gpus V100
 sky launch -c vicuna-serve -s serve.yaml --env MODEL_SIZE=13
 ```
 
+5. [Optional] Serve the OpenAI API Compatible Endpoint:
+```bash
+sky launch -c vicuna-openai-api -s serve-openai-api-endpoint.yaml
+```
+
 
 ## Training Vicuna with SkyPilot
 Currently, training requires GPUs with 80GB memory.  See `sky show-gpus --all` for supported GPUs.

--- a/llm/vicuna/serve-openai-api-endpoint.yaml
+++ b/llm/vicuna/serve-openai-api-endpoint.yaml
@@ -1,4 +1,5 @@
 resources:
+  ports: 8080
   accelerators: A100:1
   disk_size: 1024
   disk_tier: high
@@ -14,7 +15,6 @@ setup: |
   pip install "fschat[model_worker,webui]==0.2.24"
   pip install protobuf
 
-
 run: |
   conda activate chatbot
   
@@ -29,8 +29,8 @@ run: |
   echo 'Waiting for model worker to start...'
   while ! `cat model_worker.log | grep -q 'Uvicorn running on'`; do sleep 1; done
 
-  echo 'Starting gradio server...'
-  python -u -m fastchat.serve.gradio_web_server --share | tee ~/gradio.log
+  echo 'Starting openai api server...'
+  python -u -m fastchat.serve.openai_api_server --host 0.0.0.0 --port 8080 | tee ~/openai_api_server.log
 
 envs:
-  MODEL_SIZE: 7
+  MODEL_SIZE: 13


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds an OpenAI Compatible Endpoint for Vicuna. It also fixed a version issue in our Vicuna example.

This is required for our SkyServe User Doc; I feel like if we could start from an existing example, it would make the understanding easier.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
     - [ ] `sky launch` those two YAMLs and make sure them works
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
