### PR TITLE
[Provisioner] Additional check to make sure ssh works

### DIFF
--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -245,10 +245,14 @@ def _wait_ssh_connection_direct(
     try:
         with socket.create_connection((ip, 22), timeout=1) as s:
             if s.recv(100).startswith(b'SSH'):
-                # Wait for SSH actually ready, otherwise we may get "System
-                # is booting up. Unprivileged users are not permitted to log in
-                # yet".
-                return _wait_ssh_connection_indirect(ip, ssh_user, ssh_private_key, ssh_control_name, ssh_proxy_command)
+                # Wait for SSH being actually ready, otherwise we may get the
+                # following error:
+                # "System is booting up. Unprivileged users are not permitted to
+                # log in yet".
+                return _wait_ssh_connection_indirect(ip, ssh_user,
+                                                     ssh_private_key,
+                                                     ssh_control_name,
+                                                     ssh_proxy_command)
     except socket.timeout:  # this is the most expected exception
         pass
     except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2796

The additional check for the ssh does not affect the provisioning speed significantly.
Tested with `sky launch -c test-launch --cloud aws --cpus 2`
Original: 3m20s, 2m53s
New: 2m39s, 2m36s

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-launch --cloud aws --cpus 2`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
