### PR TITLE
[Catalog] Add trainium accelerator in aws catalog

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -8,7 +8,7 @@ with resource specific information, these functions are called with the filled
 in ray yaml config as input,
 1. Replace the placeholders in the ray yaml file `skypilot:ssh_user` and
    `skypilot:ssh_public_key_content` with the actual username and public key
-   content, i.e., `_replace_ssh_info_in_config`.
+   content, i.e., `configure_ssh_info`.
 2. Setup the `authorized_keys` on the remote VM with the public key content,
    by cloud-init or directly using cloud provider's API.
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -294,7 +294,10 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
                 # the instance type name.
                 # https://aws.amazon.com/ec2/instance-types/trn1/
                 acc_name = 'Trainium'
-                num_in_name = re.search(r'(\d+)xlarge', row['InstanceType']).group(1)
+                find_num_in_name = re.search(r'(\d+)xlarge',
+                                             row['InstanceType'])
+                assert find_num_in_name is not None, row['InstanceType']
+                num_in_name = find_num_in_name.group(1)
                 acc_count = int(num_in_name) // 2
             return pd.Series({
                 'AcceleratorName': acc_name,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -7,6 +7,7 @@ import datetime
 import itertools
 from multiprocessing import pool as mp_pool
 import os
+import re
 import subprocess
 import sys
 import textwrap
@@ -287,6 +288,14 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
             if row['InstanceType'] == 'p4de.24xlarge':
                 acc_name = 'A100-80GB'
                 acc_count = 8
+            if row['InstanceType'].startswith('trn1'):
+                # Trainium instances does not have a field for information of
+                # the accelerators. We need to infer the accelerator info from
+                # the instance type name.
+                # https://aws.amazon.com/ec2/instance-types/trn1/
+                acc_name = 'Trainium'
+                num_in_name = re.search(r'(\d+)xlarge', row['InstanceType']).group(1)
+                acc_count = int(num_in_name) // 2
             return pd.Series({
                 'AcceleratorName': acc_name,
                 'AcceleratorCount': acc_count,

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -292,6 +292,7 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
                 # Trainium instances does not have a field for information of
                 # the accelerators. We need to infer the accelerator info from
                 # the instance type name.
+                # aws ec2 describe-instance-types --region us-east-1
                 # https://aws.amazon.com/ec2/instance-types/trn1/
                 acc_name = 'Trainium'
                 find_num_in_name = re.search(r'(\d+)xlarge',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to support #2690, adding Trainium in the catalog.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_aws`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
