### PR TITLE
[TPU VM] Attaching Persistent Disks

### DIFF
--- a/sky/skylet/providers/gcp/node.py
+++ b/sky/skylet/providers/gcp/node.py
@@ -903,3 +903,61 @@ class GCPTPU(GCPResource):
         The boot disk of TPU VMs is not resizable, and users need to add a
         persistent disk to expand disk capacity. Related issue: #2387
         """
+        from sky.skylet import log_lib
+        import os
+        from googleapiclient import discovery
+
+        resource = discovery.build("compute", "v1")
+
+        # TODO: Update the CLI to prompt the for disk mode and size
+        disk_size_gb = 200
+        disk_mode = "read-write"
+        tpu_name = instance_name.split("/")[-1]
+
+        # Create a new disk
+        disk_body = {
+            "name": f"{tpu_name}-extra-disk",
+            "sizeGb": str(disk_size_gb),
+            "type": f"zones/{self.availability_zone}/diskTypes/pd-standard",  # or pd-ssd
+        }
+
+        try:
+            create_operation = (
+                resource.disks()
+                .insert(
+                    project=self.project_id, zone=self.availability_zone, body=disk_body
+                )
+                .execute()
+            )
+            time.sleep(3)
+
+        except HttpError as e:
+            # Catch HttpError for issues during disk creation or attachment
+            logger.warning(f"googleapiclient.errors.HttpError: {e.reason}")
+
+        # Attach the disk to TPUVMs with gcloud alpha
+        attach_to_tpus = (
+            f"gcloud alpha compute tpus tpu-vm attach-disk {tpu_name} "
+            f"--zone {self.availability_zone} --disk {disk_body['name']} "
+            f"--mode {disk_mode}"
+        )
+
+        rcode, stdout, stderr = log_lib.run_with_log(
+            attach_to_tpus,
+            os.devnull,
+            shell=True,
+            stream_logs=False,
+            require_outputs=True,
+        )
+
+        if rcode != 0:
+            failure_massage = (
+                "Failed to attach disk to TPU VMs.\n"
+                "**** STDOUT ****\n"
+                "{stdout}\n"
+                "**** STDERR ****\n"
+                "{stderr}"
+            )
+            logger.warning(failure_massage)
+
+        return {}

--- a/sky/skylet/providers/gcp/node_provider.py
+++ b/sky/skylet/providers/gcp/node_provider.py
@@ -280,6 +280,7 @@ class GCPNodeProvider(NodeProvider):
                     )
                     for node_id in reuse_node_ids:
                         result = resource.start_instance(node_id)
+                        resource.resize_disk(base_config, node_id)
                         result_dict[node_id] = {node_id: result}
                     for node_id in reuse_node_ids:
                         self.set_node_tags(node_id, tags)


### PR DESCRIPTION
**Issue** 
Reference: [#2778](https://github.com/skypilot-org/skypilot/issues/2778)

When launching a TPU VM with ```sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 300```, the resulting VM is still initialized with a disk size of 100 GB (default size). Users have to add a persistent disk to expand their local disk capacity as the boot disk of TPU VMs is not resizable. 

**Solution**
We currently use the [Cloud TPU API](https://cloud.google.com/tpu/docs/reference/rest/v1/projects.locations.nodes) for managing TPUVMs (e.g. `create_instance, set_labels, and delete_instance`). However, this API lacks functionality for disk attachment.

Two approaches for attaching a persistent disk to TPUVMs:
1.	**Google Cloud CLI**: The initial commit includes using the GCP CLI to attach a persistent disk to the TPU node. [Detailed Instructions](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/tpus/tpu-vm/attach-disk).
2.	**TpuClient**: An alternative solution is to use the TpuClient. More information on this method can be found at [TpuClient Documentation](https://cloud.google.com/python/docs/reference/tpu/latest/google.cloud.tpu_v2alpha1.services.tpu.TpuClient#google_cloud_tpu_v2alpha1_services_tpu_TpuClient_create_queued_resource).


**Test**:
1.	Launch the TPUVM with a specified disk size:
`sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 200`
`sky stop mucluster`

2.	Restart the TPUVM with a specified disk size:
`sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 200`
3.	Verified that a new disk with size 200GB has been created and attached to the TPUVM

**Note**:
This PR is currently in draft status. The disk size and mode is configured manually, and it only takes effect when the cluster is restarted.

**Questions**:
- How should we structure our CLI to prompt the users to select a disk mode (like read-write) and specify the size/type for the new disk?

- Would it be more better to use TpuClient in place of Cloud TPU, considering that TpuClient appears to offer more functionalities for handling TPUVMs?
