### PR TITLE
[GCP] Support private IPs for GCP

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -267,3 +267,52 @@ See details in :ref:`config-yaml`.  Example use cases include using a private VP
 VPC with fine-grained constraints, typically created via Terraform or manually.
 
 The custom VPC should contain the :ref:`required firewall rules <gcp-minimum-firewall-rules>`.
+
+
+.. _gcp-use-internal-ips:
+
+
+Using Internal IPs
+-----------------------
+For security reason, users may only want to use internal IPs for SkyPilot instances.
+To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` field (to see the detailed syntax, see :ref:`config-yaml`):
+
+.. code-block:: yaml
+
+    gcp:
+      use_internal_ips: true
+      # VPC with NAT setup, see below
+      vpc_name: my-vpc-name
+      ssh_proxy_command: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.proxy      
+
+The ``gcp.ssh_proxy_command`` field is optional. If SkyPilot is run on a machine that can directly access the internal IPs of the instances, it can be omitted. Otherwise, it should be set to a command that can be used to proxy SSH connections to the internal IPs of the instances.
+
+
+Cloud NAT Setup
+~~~~~~~~~~~~~~~~
+
+Instances created with internal IPs only on GCP cannot access public internet by default. To make sure SkyPilot can install the dependencies correctly on the instances,
+cloud NAT needs to be setup for the VPC (see `GCP's documentation <https://cloud.google.com/nat/docs/overview>`__ for details).
+
+
+Cloud NAT is a regional resource, so it will need to be created in each region that SkyPilot will be used in. To limit SkyPilot to use some specific regions only, you can specify the ``gcp.ssh_proxy_command`` to be a dict mapping from region to the SSH proxy command for that region (see :ref:`config-yaml` for details):
+
+.. code-block:: yaml
+
+    gcp:
+      use_internal_ips: true
+      vpc_name: my-vpc-name
+      ssh_proxy_command:
+        us-west1: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.us-west1.proxy
+        us-east1: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.us-west2.proxy
+
+If proxy is not needed, but the regions need to be limited, you can set the ``gcp.ssh_proxy_command`` to be a dict mapping from region to ``null``:
+
+.. code-block:: yaml
+
+    gcp:
+      use_internal_ips: true
+      vpc_name: my-vpc-name
+      ssh_proxy_command:
+        us-west1: null
+        us-east1: null

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -121,6 +121,31 @@ Available fields and semantics:
     # will be added.
     vpc_name: skypilot-vpc
 
+    # Should instances be assigned private IPs only? (optional)
+    #
+    # Set to true to use private IPs to communicate between the local client and
+    # any SkyPilot nodes. This requires the networking stack be properly set up.
+    #
+    # This flag is typically set together with 'vpc_name' above and
+    # 'ssh_proxy_command' below.
+    #
+    # Default: false.
+    use_internal_ips: true
+    # SSH proxy command (optional).
+    #
+    # Please refer to the aws.ssh_proxy_command section above for more details.
+    ### Format 1 ###
+    # A string; the same proxy command is used for all regions.
+    ssh_proxy_command: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@<jump server public ip>
+    ### Format 2 ###
+    # A dict mapping region names to region-specific proxy commands.
+    # NOTE: This restricts SkyPilot's search space for this cloud to only use
+    # the specified regions and not any other regions in this cloud.
+    ssh_proxy_command:
+      us-east-1: ssh -W %h:%p -p 1234 -o StrictHostKeyChecking=no myself@my.us-east-1.proxy
+      us-east-2: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@<jump server public ip>
+
+
     # Reserved capacity (optional).
     #
     # The specific reservation to be considered when provisioning clusters on GCP.

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -28,6 +28,7 @@ from sky.serve import replica_managers
 from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.utils import common_utils
+from sky.utils import controller_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
@@ -252,4 +253,5 @@ if __name__ == '__main__':
     # We start process with 'spawn', because 'fork' could result in weird
     # behaviors; 'spawn' is also cross-platform.
     multiprocessing.set_start_method('spawn', force=True)
+    controller_utils.setup_proxy_command_on_controller()
     _start(args.service_name, args.task_yaml, args.job_id)

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -11,12 +11,12 @@ import psutil
 import yaml
 
 from sky import sky_logging
-from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.serve import serve_utils
 from sky.skylet import autostop_lib
 from sky.skylet import job_lib
 from sky.spot import spot_utils
+from sky.utils import cluster_yaml_utils
 from sky.utils import common_utils
 from sky.utils import ux_utils
 
@@ -104,8 +104,8 @@ class AutostopEvent(SkyletEvent):
     def __init__(self):
         super().__init__()
         autostop_lib.set_last_active_time_to_now()
-        self._ray_yaml_path = os.path.abspath(
-            os.path.expanduser(backend_utils.SKY_RAY_YAML_REMOTE_PATH))
+        self._ray_yaml_path = cluster_yaml_utils.get_cluster_yaml_absolute_path(
+        )
 
     def _run(self):
         autostop_config = autostop_lib.get_autostop_config()
@@ -139,16 +139,8 @@ class AutostopEvent(SkyletEvent):
                 cloud_vm_ray_backend.CloudVmRayBackend.NAME):
             autostop_lib.set_autostopping_started()
 
+            provider_name = cluster_yaml_utils.get_provider_name()
             config = common_utils.read_yaml(self._ray_yaml_path)
-
-            provider_module = config['provider']['module']
-            # Examples:
-            #   'sky.skylet.providers.aws.AWSNodeProviderV2' -> 'aws'
-            #   'sky.provision.aws' -> 'aws'
-            provider_search = re.search(r'(?:providers|provision)\.(\w+)\.?',
-                                        provider_module)
-            assert provider_search is not None, config
-            provider_name = provider_search.group(1).lower()
             if provider_name in ('aws', 'gcp'):
                 logger.info('Using new provisioner to stop the cluster.')
                 self._stop_cluster_with_new_provisioner(autostop_config, config,

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -910,6 +910,8 @@ def _configure_subnet(config, compute):
             ],
         }
     ]
+    if config["provider"].get("use_internal_ips", False):
+        default_interfaces[0].pop("accessConfigs")
 
     for node_config in node_configs:
         # The not applicable key will be removed during node creation
@@ -920,7 +922,7 @@ def _configure_subnet(config, compute):
         # TPU
         if "networkConfig" not in node_config:
             node_config["networkConfig"] = copy.deepcopy(default_interfaces)[0]
-            node_config["networkConfig"].pop("accessConfigs")
+            node_config["networkConfig"].pop("accessConfigs", None)
 
     return config
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -49,7 +49,6 @@ from typing import Any, Dict, Iterable
 import yaml
 
 from sky import sky_logging
-from sky.clouds import cloud_registry
 from sky.utils import common_utils
 from sky.utils import schemas
 
@@ -74,6 +73,7 @@ logger = sky_logging.init_logger(__name__)
 
 # The loaded config.
 _dict = None
+_loaded_config_path = None
 
 
 def get_nested(keys: Iterable[str], default_value: Any) -> Any:
@@ -119,6 +119,19 @@ def set_nested(keys: Iterable[str], value: Any) -> Dict[str, Any]:
     return to_return
 
 
+def overwrite_config_file(config: dict) -> None:
+    """Overwrites the config file with the current config."""
+    global _dict, _loaded_config_path
+    if _loaded_config_path is None:
+        raise RuntimeError('No config file loaded.')
+    common_utils.validate_schema(config,
+                                 schemas.get_config_schema(),
+                                 f'Invalid config YAML: {config!r}',
+                                 skip_none=False)
+    common_utils.write_yaml(_loaded_config_path, config)
+    _dict = config
+
+
 def to_dict() -> Dict[str, Any]:
     """Returns a deep-copied version of the current config."""
     global _dict
@@ -127,27 +140,8 @@ def to_dict() -> Dict[str, Any]:
     return {}
 
 
-def _syntax_check_for_ssh_proxy_command(cloud: str) -> None:
-    ssh_proxy_command_config = get_nested((cloud.lower(), 'ssh_proxy_command'),
-                                          None)
-    if ssh_proxy_command_config is None or isinstance(ssh_proxy_command_config,
-                                                      str):
-        return
-
-    if isinstance(ssh_proxy_command_config, dict):
-        for region, cmd in ssh_proxy_command_config.items():
-            if cmd and not isinstance(cmd, str):
-                raise ValueError(
-                    f'Invalid ssh_proxy_command config for region {region!r} '
-                    f'(expected a str): {cmd!r}')
-        return
-    raise ValueError(
-        'Invalid ssh_proxy_command config (expected a str or a dict with '
-        f'region names as keys): {ssh_proxy_command_config!r}')
-
-
 def _try_load_config() -> None:
-    global _dict
+    global _dict, _loaded_config_path
     config_path_via_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
     if config_path_via_env_var is not None:
         config_path = config_path_via_env_var
@@ -156,6 +150,7 @@ def _try_load_config() -> None:
     config_path = os.path.expanduser(config_path)
     if os.path.exists(config_path):
         logger.debug(f'Using config path: {config_path}')
+        _loaded_config_path = config_path
         try:
             _dict = common_utils.read_yaml(config_path)
             logger.debug(f'Config loaded:\n{pprint.pformat(_dict)}')
@@ -168,8 +163,6 @@ def _try_load_config() -> None:
                 f'Invalid config YAML ({config_path}): ',
                 skip_none=False)
 
-        for cloud in cloud_registry.CLOUD_REGISTRY:
-            _syntax_check_for_ssh_proxy_command(cloud)
         logger.debug('Config syntax check passed.')
 
 

--- a/sky/spot/controller.py
+++ b/sky/spot/controller.py
@@ -523,4 +523,5 @@ if __name__ == '__main__':
     # We start process with 'spawn', because 'fork' could result in weird
     # behaviors; 'spawn' is also cross-platform.
     multiprocessing.set_start_method('spawn', force=True)
+    controller_utils.setup_proxy_command_on_controller()
     start(args.job_id, args.dag_yaml, args.retry_until_up)

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -46,6 +46,7 @@ provider:
     password: {{docker_login_config.password}}
     server: {{docker_login_config.server}}
 {%- endif %}
+  use_internal_ips: {{use_internal_ips}}
 {%- if tpu_vm %}
   _has_tpus: True
 {%- endif %}
@@ -59,6 +60,9 @@ provider:
 auth:
   ssh_user: gcpuser
   ssh_private_key: {{ssh_private_key}}
+{% if ssh_proxy_command is not none %}
+  ssh_proxy_command: {{ssh_proxy_command}}
+{% endif %}
 
 available_node_types:
   ray_head_default:

--- a/sky/templates/spot-controller.yaml.j2
+++ b/sky/templates/spot-controller.yaml.j2
@@ -33,6 +33,7 @@ setup: |
   ((ps aux | grep -v nohup | grep -v grep | grep -q -- "python3 -m sky.spot.dashboard.dashboard") || (nohup python3 -m sky.spot.dashboard.dashboard >> ~/.sky/spot-dashboard.log 2>&1 &));
 
 run: |
+  # Start the controller for the current spot job.
   python -u -m sky.spot.controller {{remote_user_yaml_path}} \
     --job-id $SKYPILOT_INTERNAL_JOB_ID {% if retry_until_up %}--retry-until-up{% endif %}
 

--- a/sky/utils/cluster_yaml_utils.py
+++ b/sky/utils/cluster_yaml_utils.py
@@ -1,0 +1,31 @@
+"""Utility functions for cluster yaml file."""
+
+import os
+import re
+
+from sky.utils import common_utils
+
+SKY_CLUSTER_YAML_REMOTE_PATH = '~/.sky/sky_ray.yml'
+
+
+def get_cluster_yaml_absolute_path() -> str:
+    """Return the absolute path of the cluster yaml file.
+
+    This function should be called on the remote machine.
+    """
+    return os.path.abspath(os.path.expanduser(SKY_CLUSTER_YAML_REMOTE_PATH))
+
+
+def get_provider_name() -> str:
+    """Return the name of the provider."""
+    config = common_utils.read_yaml(get_cluster_yaml_absolute_path())
+
+    provider_module = config['provider']['module']
+    # Examples:
+    #   'sky.skylet.providers.aws.AWSNodeProviderV2' -> 'aws'
+    #   'sky.provision.aws' -> 'aws'
+    provider_search = re.search(r'(?:providers|provision)\.(\w+)\.?',
+                                provider_module)
+    assert provider_search is not None, config
+    provider_name = provider_search.group(1).lower()
+    return provider_name

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -457,6 +457,38 @@ def get_cluster_schema():
         }
     }
 
+_NETWORK_CONFIG_SCHEMA = {
+    'vpc_name': {
+        'oneOf': [{
+            'type': 'string',
+        }, {
+            'type': 'null',
+        }],
+    },
+    'use_internal_ips': {
+        'type': 'boolean',
+    },
+    'ssh_proxy_command': {
+        'oneOf': [{
+            'type': 'string',
+        }, {
+            'type': 'null',
+        }, {
+            'type': 'object',
+            'required': [],
+            'additionalProperties': {
+                'anyOf': [
+                    {
+                        'type': 'string'
+                    },
+                    {
+                        'type': 'null'
+                    },
+                ]
+            }
+        }]
+    },
+}
 
 def get_config_schema():
     # pylint: disable=import-outside-toplevel
@@ -505,36 +537,7 @@ def get_config_schema():
                             'type': 'string',
                         },
                     },
-                    'vpc_name': {
-                        'oneOf': [{
-                            'type': 'string',
-                        }, {
-                            'type': 'null',
-                        }],
-                    },
-                    'use_internal_ips': {
-                        'type': 'boolean',
-                    },
-                    'ssh_proxy_command': {
-                        'oneOf': [{
-                            'type': 'string',
-                        }, {
-                            'type': 'null',
-                        }, {
-                            'type': 'object',
-                            'required': [],
-                            'additionalProperties': {
-                                'anyOf': [
-                                    {
-                                        'type': 'string'
-                                    },
-                                    {
-                                        'type': 'null'
-                                    },
-                                ]
-                            }
-                        }]
-                    },
+                    **_NETWORK_CONFIG_SCHEMA,
                 }
             },
             'gcp': {
@@ -550,16 +553,7 @@ def get_config_schema():
                         'minItems': 1,
                         'maxItems': 1,
                     },
-                    'vpc_name': {
-                        'oneOf': [{
-                            'type': 'string',
-                        }, {
-                            'type': 'null',
-                        }],
-                    },
-                    'use_internal_ips': {
-                        'type': 'boolean',
-                    },
+                    **_NETWORK_CONFIG_SCHEMA,
                 }
             },
             'kubernetes': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -557,6 +557,9 @@ def get_config_schema():
                             'type': 'null',
                         }],
                     },
+                    'use_internal_ips': {
+                        'type': 'boolean',
+                    },
                 }
             },
             'kubernetes': {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ def _create_config_file(config_file_path: pathlib.Path) -> None:
 
             gcp:
                 vpc_name: {VPC_NAME}
+                use_internal_ips: true
 
             kubernetes:
                 networking: {NODEPORT_MODE_NAME}
@@ -195,6 +196,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     assert skypilot_config.get_nested(
         ('aws', 'ssh_proxy_command'), None) is None
     assert skypilot_config.get_nested(('gcp', 'vpc_name'), None) == VPC_NAME
+    assert skypilot_config.get_nested(('gcp', 'use_internal_ips'), None)
 
     # Check config with only partial keys still works
     new_config3 = copy.copy(new_config2)
@@ -230,3 +232,4 @@ def test_config_with_env(monkeypatch, tmp_path) -> None:
     assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
                                       None) == PROXY_COMMAND
     assert skypilot_config.get_nested(('gcp', 'vpc_name'), None) == VPC_NAME
+    assert skypilot_config.get_nested(('gcp', 'use_internal_ips'), None)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2818.

In GCP, we can create instances with internal IPs only. This PR adds the support for creating cluster with internal IPs only. A user can specify the `~/.sky/config.yaml` for this:

```yaml
gcp:
  use_internal_ips: true
  vpc_name: skypilot-vpc
  ssh_proxy_command: 
    us-west1: ssh -W %h:%p -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes jump
    us-east1: ssh -W %h:%p -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes jump
```

The normal VPC created by SkyPilot can support internal IPs with an extra step. 

## Cloud NAT Setup

The instances with internal IPs only cannot access internet by default. The cloud NAT needs to be setup for the VPC for the internet connection, which can be created through the GCP console:
1. Go the the page for Cloud NAT: https://console.cloud.google.com/net-services/nat
2. Click `Create Cloud NAT gateway`
3. Fill in a random name, select the `skypilot-vpc` (or any VPC that will be used by the cluster created)
4. Select the region that will be used for the cluster (NAT needs to be created for each region separately)
5. Create the `Cloud Router` with any name.
6. Click `Create`

With the setup above, we should be able to create clusters with internal IPs only using SkyPilot and the `~/.sky/config.yaml` above.
`sky launch -c test-private --cloud gcp --cpus 2`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] Creating a cluster in a region with internal IPs only: `sky launch -c test-private --cloud gcp --cpus 2`
  - [ ] `sky launch -c test-private --cloud gcp --cpus 2 --num-nodes 2`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
