### PR TITLE
Remove Exponential Backoff for Retry Until Up

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,7 +2859,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
-            backoff = common_utils.Backoff(_RETRY_UNTIL_UP_INIT_GAP_SECONDS)
             attempt_cnt = 1
             while True:
                 # For on-demand instances, RetryingVmProvisioner will retry
@@ -2907,13 +2906,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     if retry_until_up:
                         logger.error(error_message)
                         # Sleep and retry.
-                        gap_seconds = backoff.current_backoff()
+                        gap_seconds = _RETRY_UNTIL_UP_INIT_GAP_SECONDS
                         plural = 's' if attempt_cnt > 1 else ''
                         logger.info(
                             f'{colorama.Style.BRIGHT}=== Retry until up ==='
                             f'{colorama.Style.RESET_ALL}\n'
                             f'Retrying provisioning after {gap_seconds:.0f}s '
-                            '(exponential backoff with random jittering). '
                             f'Already tried {attempt_cnt} attempt{plural}.')
                         attempt_cnt += 1
                         time.sleep(gap_seconds)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,9 +2859,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
-                # The most frequent reason for the failure of a provision request is
-                # resource unavailability instead of rate limiting; to make users
-                # wait shorter, we do not make backoffs exponential.
+                # The most frequent reason for the failure of a provision
+                # request is resource unavailability instead of rate 
+                # limiting; to make users wait shorter, we do not make 
+                # backoffs exponential.
                 backoff = common_utils.Backoff(
                     initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,
                     max_backoff_factor=1)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,8 +2859,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
-                # The most frequent reason for the failure of a provision request is 
-                # resource unavailability instead of rate limiting; to make users 
+                # The most frequent reason for the failure of a provision request is
+                # resource unavailability instead of rate limiting; to make users
                 # wait shorter, we do not make backoffs exponential.
                 backoff = common_utils.Backoff(
                     initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2861,7 +2861,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
                 # The most frequent reason for the failure of a provision request is 
                 # resource unavailability instead of rate limiting; to make users 
-                # wait shorter, we do not make the backoffs exponential.
+                # wait shorter, we do not make backoffs exponential.
                 backoff = common_utils.Backoff(
                     initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,
                     max_backoff_factor=1)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,6 +2859,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
+                jitter = common_utils.Jitter(_RETRY_UNTIL_UP_INIT_GAP_SECONDS)
             attempt_cnt = 1
             while True:
                 # For on-demand instances, RetryingVmProvisioner will retry
@@ -2906,12 +2907,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     if retry_until_up:
                         logger.error(error_message)
                         # Sleep and retry.
-                        gap_seconds = _RETRY_UNTIL_UP_INIT_GAP_SECONDS
+                        gap_seconds = jitter.current_delay()
                         plural = 's' if attempt_cnt > 1 else ''
                         logger.info(
                             f'{colorama.Style.BRIGHT}=== Retry until up ==='
                             f'{colorama.Style.RESET_ALL}\n'
                             f'Retrying provisioning after {gap_seconds:.0f}s '
+                            '(random jittering). '
                             f'Already tried {attempt_cnt} attempt{plural}.')
                         attempt_cnt += 1
                         time.sleep(gap_seconds)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,6 +2859,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
+                # The most frequent reason for the failure of a provision request is 
+                # resource unavailability instead of rate limiting; to make users 
+                # wait shorter, we do not make the backoffs exponential.
                 backoff = common_utils.Backoff(
                     initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,
                     max_backoff_factor=1)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2859,8 +2859,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # TODO(suquark): once we have sky on PyPI, we should directly
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
-                backoff = common_utils.Backoff(initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,
-                                               max_backoff_factor=1)
+                backoff = common_utils.Backoff(
+                    initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,
+                    max_backoff_factor=1)
             attempt_cnt = 1
             while True:
                 # For on-demand instances, RetryingVmProvisioner will retry

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2860,8 +2860,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # install sky from PyPI.
                 local_wheel_path, wheel_hash = wheel_utils.build_sky_wheel()
                 # The most frequent reason for the failure of a provision
-                # request is resource unavailability instead of rate 
-                # limiting; to make users wait shorter, we do not make 
+                # request is resource unavailability instead of rate
+                # limiting; to make users wait shorter, we do not make
                 # backoffs exponential.
                 backoff = common_utils.Backoff(
                     initial_backoff=_RETRY_UNTIL_UP_INIT_GAP_SECONDS,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -88,7 +88,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = {
 
 # Time gap between retries after failing to provision in all possible places.
 # Used only if --retry-until-up is set.
-_RETRY_UNTIL_UP_INIT_GAP_SECONDS = 60
+_RETRY_UNTIL_UP_INIT_GAP_SECONDS = 30
 
 # The maximum retry count for fetching IP address.
 _FETCH_IP_MAX_ATTEMPTS = 3

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -201,7 +201,8 @@ class Backoff:
         self._backoff += random.uniform(-self.JITTER * self._backoff,
                                         self.JITTER * self._backoff)
         return self._backoff
-    
+
+
 class Jitter:
     """Random jittering."""
     JITTER = 0.4

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -201,6 +201,19 @@ class Backoff:
         self._backoff += random.uniform(-self.JITTER * self._backoff,
                                         self.JITTER * self._backoff)
         return self._backoff
+    
+class Jitter:
+    """Random jittering."""
+    JITTER = 0.4
+
+    def __init__(self, initial: int = 5):
+        self._initial = initial
+
+    def current_delay(self) -> float:
+        """Returns the current delay in seconds with random jitter."""
+        jitter = self._initial + random.uniform(-self.JITTER * self._initial,
+                                                self.JITTER * self._initial)
+        return jitter
 
 
 def get_pretty_entry_point() -> str:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -203,20 +203,6 @@ class Backoff:
         return self._backoff
 
 
-class Jitter:
-    """Random jittering."""
-    JITTER = 0.4
-
-    def __init__(self, initial: int = 5):
-        self._initial = initial
-
-    def current_delay(self) -> float:
-        """Returns the current delay in seconds with random jitter."""
-        jitter = self._initial + random.uniform(-self.JITTER * self._initial,
-                                                self.JITTER * self._initial)
-        return jitter
-
-
 def get_pretty_entry_point() -> str:
     """Returns the prettified entry point of this process (sys.argv).
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Looks to resolve #2805
Replaces the use of exponential backoff with the static initial value each retry
Tested:
- [x] Code formatting: `bash format.sh`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
