### PR TITLE
Docs: Minor updates to Llama-2 example and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SkyPilot **maximizes GPU availability for your jobs**:
 
 SkyPilot **cuts your cloud costs**:
 * [Managed Spot](https://skypilot.readthedocs.io/en/latest/examples/spot-jobs.html): 3-6x cost savings using spot VMs, with auto-recovery from preemptions
-* Optimizer: 2x cost savings by auto-picking the cheapest VM/zone/region/cloud
+* [Optimizer](https://skypilot.readthedocs.io/en/latest/examples/auto-failover.html): 2x cost savings by auto-picking the cheapest VM/zone/region/cloud
 * [Autostop](https://skypilot.readthedocs.io/en/latest/reference/auto-stop.html): hands-free cleanup of idle clusters
 
 SkyPilot supports your existing GPU, TPU, and CPU workloads, with no code changes.
@@ -112,7 +112,7 @@ Prepare the workdir by cloning:
 git clone https://github.com/pytorch/examples.git ~/torch_examples
 ```
 
-Launch with `sky launch` (note: [access to GPU instances](https://skypilot.readthedocs.io/en/latest/reference/quota.html) is needed for this example):
+Launch with `sky launch` (note: [access to GPU instances](https://skypilot.readthedocs.io/en/latest/cloud-setup/quota.html) is needed for this example):
 ```bash
 sky launch my_task.yaml
 ```

--- a/llm/llama-2/chatbot-hf.yaml
+++ b/llm/llama-2/chatbot-hf.yaml
@@ -16,9 +16,7 @@ setup: |
   fi
 
   # Install dependencies
-  pip install git+https://github.com/lm-sys/FastChat.git
-  # Need the latest transformers to support 70B model
-  pip install git+https://github.com/huggingface/transformers.git
+  pip install "fschat[model_worker,webui]"
 
   python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 


### PR DESCRIPTION
Fixes the issue #2680 around Llama-2 example with requisite dependencies and a broken link in README.md

Below are a few issues deploying Llama-2 7B/70B models on GCP (with GPU config; A100-80GB:2 and L4:8), and the additional dependencies are based upon recursively fixing the dependency one-by-one (issues in case of Llama-2 70B deployment is given👇).
```
(setup pid=16754) Token will not been saved to git credential helper. Pass `add_to_git_credential=True` if you want to set the git credential as well.
(setup pid=16754) Token is valid (permission: read).
(setup pid=16754) Your token has been saved to /home/gcpuser/.cache/huggingface/token
(setup pid=16754) Login successful
(task, pid=16754) Starting controller...
(task, pid=16754) Starting model worker...
(task, pid=16754) Waiting for model worker to start...
(task, pid=16754) cat: model_worker.log: No such file or directory
(task, pid=16754) Traceback (most recent call last):
(task, pid=16754)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 197, in _run_module_as_main
(task, pid=16754)     return _run_code(code, main_globals, None,
(task, pid=16754)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 87, in _run_code
(task, pid=16754)     exec(code, run_globals)
(task, pid=16754)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/serve/model_worker.py", line 12, in <module>
(task, pid=16754)     import torch
(task, pid=16754) ModuleNotFoundError: No module named 'torch'
```
```
(setup pid=16830) Successfully built transformers
(setup pid=16830) Installing collected packages: tqdm, safetensors, packaging, fsspec, filelock, huggingface-hub, tokenizers, transformers
(setup pid=16830) Successfully installed filelock-3.13.1 fsspec-2023.10.0 huggingface-hub-0.19.4 packaging-23.2 safetensors-0.4.0 tokenizers-0.15.0 tqdm-4.66.1 transformers-4.36.0.dev0
(setup pid=16830) Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cu113
(setup pid=16830) Collecting torch==1.12.1+cu113
(setup pid=16830)   Downloading https://download.pytorch.org/whl/cu113/torch-1.12.1%2Bcu113-cp39-cp39-linux_x86_64.whl (1837.7 MB)
(setup pid=16830)      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.8/1.8 GB 1.8 MB/s eta 0:00:00
(setup pid=16830) Requirement already satisfied: typing-extensions in /opt/conda/envs/chatbot/lib/python3.9/site-packages (from torch==1.12.1+cu113) (4.8.0)
(setup pid=16830) Installing collected packages: torch
(setup pid=16830) Successfully installed torch-1.12.1+cu113
(setup pid=16830) Token will not been saved to git credential helper. Pass `add_to_git_credential=True` if you want to set the git credential as well.
(setup pid=16830) Token is valid (permission: read).
(setup pid=16830) Your token has been saved to /home/gcpuser/.cache/huggingface/token
(setup pid=16830) Login successful
INFO: Reserved IPs: ['10.140.0.4']
(task, pid=16830) Starting controller...
(task, pid=16830) Starting model worker...
(task, pid=16830) Waiting for model worker to start...
(task, pid=16830) cat: model_worker.log: No such file or directory
(task, pid=16830) Traceback (most recent call last):
(task, pid=16830)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 197, in _run_module_as_main
(task, pid=16830)     return _run_code(code, main_globals, None,
(task, pid=16830)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 87, in _run_code
(task, pid=16830)     exec(code, run_globals)
(task, pid=16830)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/serve/model_worker.py", line 18, in <module>
(task, pid=16830)     from fastchat.model.model_adapter import (
(task, pid=16830)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/model/__init__.py", line 1, in <module>
(task, pid=16830)     from fastchat.model.model_adapter import (
(task, pid=16830)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/model/model_adapter.py", line 15, in <module>
(task, pid=16830)     import accelerate
(task, pid=16830) ModuleNotFoundError: No module named 'accelerate'
```
Afterwards, I found just using the latest gradio version still encounters a similar issue, as given below
```
(task, pid=16835) 2023-11-26 20:27:18 | ERROR | stderr | 
Downloading shards: 100%|██████████| 15/15 [07:19<00:00, 21.77s/it]
Downloading shards: 100%|██████████| 15/15 [07:19<00:00, 29.30s/it]
(task, pid=16835) 2023-11-26 20:27:18 | ERROR | stderr | 
Loading checkpoint shards:   0%|          | 0/15 [00:00<?, ?it/s]
Loading checkpoint shards:   7%|▋         | 1/15 [00:05<01:13,  5.25s/it]
Loading checkpoint shards:  13%|█▎        | 2/15 [00:10<01:04,  4.97s/it]
Loading checkpoint shards:  20%|██        | 3/15 [00:12<00:48,  4.03s/it]
Loading checkpoint shards:  27%|██▋       | 4/15 [00:17<00:47,  4.36s/it]
Loading checkpoint shards:  33%|███▎      | 5/15 [00:20<00:38,  3.81s/it]
Loading checkpoint shards:  40%|████      | 6/15 [00:25<00:37,  4.11s/it]
Loading checkpoint shards:  47%|████▋     | 7/15 [00:28<00:29,  3.70s/it]
Loading checkpoint shards:  53%|█████▎    | 8/15 [00:32<00:28,  4.03s/it]
Loading checkpoint shards:  60%|██████    | 9/15 [00:35<00:21,  3.63s/it]
Loading checkpoint shards:  67%|██████▋   | 10/15 [00:40<00:19,  3.96s/it]
Loading checkpoint shards:  73%|███████▎  | 11/15 [00:43<00:14,  3.59s/it]
Loading checkpoint shards:  80%|████████  | 12/15 [00:47<00:11,  3.93s/it]
Loading checkpoint shards:  87%|████████▋ | 13/15 [00:50<00:07,  3.57s/it]
Loading checkpoint shards:  93%|█████████▎| 14/15 [00:55<00:03,  3.87s/it]
Loading checkpoint shards: 100%|██████████| 15/15 [00:55<00:00,  2.75s/it]
Loading checkpoint shards: 100%|██████████| 15/15 [00:55<00:00,  3.69s/it]
(task, pid=16835) 2023-11-26 20:28:14 | ERROR | stderr | 
generation_config.json:   0%|          | 0.00/188 [00:00<?, ?B/s]
generation_config.json: 100%|██████████| 188/188 [00:00<00:00, 51.4kB/s]
(task, pid=16835) 2023-11-26 20:28:14 | ERROR | stderr | 
(task, pid=16835) 2023-11-26 20:28:15 | INFO | model_worker | Register to controller
(task, pid=16835) 2023-11-26 20:28:15 | ERROR | stderr | INFO:     Started server process [18162]
(task, pid=16835) 2023-11-26 20:28:15 | ERROR | stderr | INFO:     Waiting for application startup.
(task, pid=16835) 2023-11-26 20:28:15 | ERROR | stderr | INFO:     Application startup complete.
(task, pid=16835) 2023-11-26 20:28:15 | ERROR | stderr | INFO:     Uvicorn running on http://localhost:21002 (Press CTRL+C to quit)
(task, pid=16835) Starting gradio server...
(task, pid=16835) Traceback (most recent call last):
(task, pid=16835)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 197, in _run_module_as_main
(task, pid=16835)     return _run_code(code, main_globals, None,
(task, pid=16835)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 87, in _run_code
(task, pid=16835)     exec(code, run_globals)
(task, pid=16835)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/serve/gradio_web_server.py", line 14, in <module>
(task, pid=16835)     import gradio as gr
(task, pid=16835) ModuleNotFoundError: No module named 'gradio'
```
```
(task, pid=16973) 2023-11-26 21:46:05 | ERROR | stderr | 
generation_config.json:   0%|          | 0.00/188 [00:00<?, ?B/s]
generation_config.json: 100%|██████████| 188/188 [00:00<00:00, 51.2kB/s]
(task, pid=16973) 2023-11-26 21:46:05 | ERROR | stderr | 
(task, pid=16973) 2023-11-26 21:46:06 | INFO | model_worker | Register to controller
(task, pid=16973) 2023-11-26 21:46:06 | ERROR | stderr | INFO:     Started server process [18466]
(task, pid=16973) 2023-11-26 21:46:06 | ERROR | stderr | INFO:     Waiting for application startup.
(task, pid=16973) 2023-11-26 21:46:06 | ERROR | stderr | INFO:     Application startup complete.
(task, pid=16973) 2023-11-26 21:46:06 | ERROR | stderr | INFO:     Uvicorn running on http://localhost:21002 (Press CTRL+C to quit)
(task, pid=16973) Starting gradio server...
(task, pid=16973) Traceback (most recent call last):
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 197, in _run_module_as_main
(task, pid=16973)     return _run_code(code, main_globals, None,
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/runpy.py", line 87, in _run_code
(task, pid=16973)     exec(code, run_globals)
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/fastchat/serve/gradio_web_server.py", line 14, in <module>
(task, pid=16973)     import gradio as gr
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/__init__.py", line 3, in <module>
(task, pid=16973)     import gradio._simple_templates
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/_simple_templates/__init__.py", line 1, in <module>
(task, pid=16973)     from .simpledropdown import SimpleDropdown
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/_simple_templates/simpledropdown.py", line 6, in <module>
(task, pid=16973)     from gradio.components.base import FormComponent
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/components/__init__.py", line 1, in <module>
(task, pid=16973)     from gradio.components.annotated_image import AnnotatedImage
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/components/annotated_image.py", line 11, in <module>
(task, pid=16973)     from gradio import processing_utils, utils
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/processing_utils.py", line 22, in <module>
(task, pid=16973)     from gradio.data_classes import FileData, GradioModel, GradioRootModel
(task, pid=16973)   File "/opt/conda/envs/chatbot/lib/python3.9/site-packages/gradio/data_classes.py", line 14, in <module>
(task, pid=16973)     from pydantic import BaseModel, RootModel, ValidationError
(task, pid=16973) ImportError: cannot import name 'RootModel' from 'pydantic' (/opt/conda/envs/chatbot/lib/python3.9/site-packages/pydantic/__init__.cpython-39-x86_64-linux-gnu.so)
(task, pid=16973) 2023-11-26 21:46:51 | INFO | model_worker | Send heart beat. Models: ['Llama-2-70b-chat-hf']. Semaphore: None. call_ct: 0. worker_id: 511ab813. 
(task, pid=16973) 2023-11-26 21:47:36 | INFO | model_worker | Send heart beat. Models: ['Llama-2-70b-chat-hf']. Semaphore: None. call_ct: 0. worker_id: 511ab813. 
```
Also, a minor fix to broken links for GPU instances in README.md file
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
