### PR TITLE
[Spot/Storage] Supports empty spaces in source path for storages

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -243,7 +243,7 @@ def _group_files_by_dir(
     for source in source_list:
         source = os.path.abspath(os.path.expanduser(source))
         if os.path.isdir(source):
-            dirs.append(f'\'{source}\'')
+            dirs.append(source)
         else:
             base_path = os.path.dirname(source)
             file_name = os.path.basename(source)
@@ -292,7 +292,7 @@ def parallel_upload(source_path_list: List[str],
     # Generate dir upload commands
     for dir_path in dirs:
         if create_dirs:
-            dest_dir_name = os.path.basename(dir_path[1:-1])
+            dest_dir_name = os.path.basename(dir_path)
         else:
             dest_dir_name = ''
         sync_command = dirsync_command_generator(dir_path, dest_dir_name)

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1179,8 +1179,10 @@ class S3Store(AbstractStore):
         """
 
         def get_file_sync_command(base_dir_path, file_names):
-            includes = ' '.join(
-                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
+            includes = ' '.join([
+                f'--include {shlex.quote(file_name)}'
+                for file_name in file_names
+            ])
             base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
@@ -1192,8 +1194,10 @@ class S3Store(AbstractStore):
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
                 src_dir_path)
             excluded_list.append('.git/*')
-            excludes = ' '.join(
-                [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])
+            excludes = ' '.join([
+                f'--exclude {shlex.quote(file_name)}'
+                for file_name in excluded_list
+            ])
             src_dir_path = shlex.quote(src_dir_path)
             sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
                             f'{src_dir_path} '
@@ -1970,8 +1974,10 @@ class R2Store(AbstractStore):
         """
 
         def get_file_sync_command(base_dir_path, file_names):
-            includes = ' '.join(
-                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
+            includes = ' '.join([
+                f'--include {shlex.quote(file_name)}'
+                for file_name in file_names
+            ])
             endpoint_url = cloudflare.create_endpoint()
             base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
@@ -1988,8 +1994,10 @@ class R2Store(AbstractStore):
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
                 src_dir_path)
             excluded_list.append('.git/*')
-            excludes = ' '.join(
-                [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])
+            excludes = ' '.join([
+                f'--exclude {shlex.quote(file_name)}'
+                for file_name in excluded_list
+            ])
             endpoint_url = cloudflare.create_endpoint()
             src_dir_path = shlex.quote(src_dir_path)
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
@@ -2419,8 +2427,10 @@ class IBMCosStore(AbstractStore):
             """
 
             # wrapping file_name with "" to support spaces
-            includes = ' '.join(
-                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
+            includes = ' '.join([
+                f'--include {shlex.quote(file_name)}'
+                for file_name in file_names
+            ])
             base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('rclone copy '
                             f'{includes} {base_dir_path} '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1190,7 +1190,7 @@ class S3Store(AbstractStore):
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path[1:-1])
+                src_dir_path)
             excluded_list.append('.git/*')
             excludes = ' '.join(
                 [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])
@@ -1637,7 +1637,7 @@ class GcsStore(AbstractStore):
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path[1:-1])
+                src_dir_path)
             # we exclude .git directory from the sync
             excluded_list.append(r'^\.git/.*$')
             excludes = '|'.join(excluded_list)
@@ -1986,7 +1986,7 @@ class R2Store(AbstractStore):
         def get_dir_sync_command(src_dir_path, dest_dir_name):
             # we exclude .git directory from the sync
             excluded_list = storage_utils.get_excluded_files_from_gitignore(
-                src_dir_path[1:-1])
+                src_dir_path)
             excluded_list.append('.git/*')
             excludes = ' '.join(
                 [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2,6 +2,7 @@
 import enum
 import os
 import re
+import shlex
 import subprocess
 import time
 import typing
@@ -1179,7 +1180,8 @@ class S3Store(AbstractStore):
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join(
-                [f'--include "{file_name}"' for file_name in file_names])
+                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
+            base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name}')
@@ -1191,7 +1193,8 @@ class S3Store(AbstractStore):
                 src_dir_path)
             excluded_list.append('.git/*')
             excludes = ' '.join(
-                [f'--exclude "{file_name}"' for file_name in excluded_list])
+                [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])
+            src_dir_path = shlex.quote(src_dir_path)
             sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
                             f'{src_dir_path} '
                             f's3://{self.name}/{dest_dir_name}')
@@ -1626,6 +1629,7 @@ class GcsStore(AbstractStore):
         def get_file_sync_command(base_dir_path, file_names):
             sync_format = '|'.join(file_names)
             gsutil_alias, alias_gen = data_utils.get_gsutil_command()
+            base_dir_path = shlex.quote(base_dir_path)
             sync_command = (f'{alias_gen}; {gsutil_alias} '
                             f'rsync -e -x \'^(?!{sync_format}$).*\' '
                             f'{base_dir_path} gs://{self.name}')
@@ -1638,6 +1642,7 @@ class GcsStore(AbstractStore):
             excluded_list.append(r'^\.git/.*$')
             excludes = '|'.join(excluded_list)
             gsutil_alias, alias_gen = data_utils.get_gsutil_command()
+            src_dir_path = shlex.quote(src_dir_path)
             sync_command = (f'{alias_gen}; {gsutil_alias} '
                             f'rsync -e -r -x \'({excludes})\' {src_dir_path} '
                             f'gs://{self.name}/{dest_dir_name}')
@@ -1966,8 +1971,9 @@ class R2Store(AbstractStore):
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join(
-                [f'--include "{file_name}"' for file_name in file_names])
+                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
             endpoint_url = cloudflare.create_endpoint()
+            base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
                             f'{cloudflare.R2_CREDENTIALS_PATH} '
                             'aws s3 sync --no-follow-symlinks --exclude="*" '
@@ -1983,9 +1989,9 @@ class R2Store(AbstractStore):
                 src_dir_path)
             excluded_list.append('.git/*')
             excludes = ' '.join(
-                [f'--exclude "{file_name}"' for file_name in excluded_list])
+                [f'--exclude {shlex.quote(file_name)}' for file_name in excluded_list])
             endpoint_url = cloudflare.create_endpoint()
-
+            src_dir_path = shlex.quote(src_dir_path)
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
                             f'{cloudflare.R2_CREDENTIALS_PATH} '
                             f'aws s3 sync --no-follow-symlinks {excludes} '
@@ -2388,9 +2394,10 @@ class IBMCosStore(AbstractStore):
 
             # .git directory is excluded from the sync
             # wrapping src_dir_path with "" to support path with spaces
+            src_dir_path = shlex.quote(src_dir_path)
             sync_command = (
                 'rclone copy --exclude ".git/*" '
-                f'"{src_dir_path}" '
+                f'{src_dir_path} '
                 f'{self.bucket_rclone_profile}:{self.name}/{dest_dir_name}')
             return sync_command
 
@@ -2413,9 +2420,10 @@ class IBMCosStore(AbstractStore):
 
             # wrapping file_name with "" to support spaces
             includes = ' '.join(
-                [f'--include "{file_name}"' for file_name in file_names])
+                [f'--include {shlex.quote(file_name)}' for file_name in file_names])
+            base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('rclone copy '
-                            f'{includes} "{base_dir_path}" '
+                            f'{includes} {base_dir_path} '
                             f'{self.bucket_rclone_profile}:{self.name}')
             return sync_command
 

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -85,7 +85,8 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
 
     # This command outputs a list to be excluded according to .gitignore
     # and .git/info/exclude
-    filter_cmd = f'git -C {shlex.quote(expand_src_dir_path)} status --ignored --porcelain=v1'
+    filter_cmd = (f'git -C {shlex.quote(expand_src_dir_path)} '
+                  'status --ignored --porcelain=v1')
     excluded_list: List[str] = []
 
     if git_exclude_exists or gitignore_exists:

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for the storage module."""
 import os
+import shlex
 import subprocess
 from typing import Any, Dict, List
 
@@ -84,7 +85,7 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
 
     # This command outputs a list to be excluded according to .gitignore
     # and .git/info/exclude
-    filter_cmd = f'git -C {expand_src_dir_path} status --ignored --porcelain=v1'
+    filter_cmd = f'git -C {shlex.quote(expand_src_dir_path)} status --ignored --porcelain=v1'
     excluded_list: List[str] = []
 
     if git_exclude_exists or gitignore_exists:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3336,9 +3336,7 @@ class TestStorageWithCredentials:
         # Creates a list of storage objects with custom source names to
         # create multiple scratch storages.
         # Stores for each object in the list must be added in the test.
-        custom_source_names = [
-            '"path With Spaces"', 'path With Spaces'
-        ]
+        custom_source_names = ['"path With Spaces"', 'path With Spaces']
         storage_mult_obj = []
         for name in custom_source_names:
             src_path = os.path.expanduser(f'~/{name}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR resolves #2763 and #2243.

When a source path specified to `file_mounts` in task YAML had an empty space, Skypilot failed to upload the `source` to the cloud storages due to the limitation of CLIs used(#2243). This also prevented users from specifying `workdir` with empty spaces when running managed spot jobs as well since `workdir` is uploaded to the cloud storage first(#2763).

This PR supports the use of empty spaces in the file/directory names for `source` in `file_mounts` and `workdir` for managed spot jobs. And a test `test_upload_source_with_spaces` is added to check such cases.

Thanks to @aseriesof-tubes for the contribution.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Manually tested the case mentioned in #2763
- [ ] Manually tested the case mentioned in #2243 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [ ] Manual test with task YAML 1:
```
file_mounts:
  /doyoung-testing:
    name: doyoung-testing
    source: [~/yaml/doyoung-test.yaml, '/home/doyoung/path with spaces/file with spaces']
    store: gcs

```
- [ ] Manual test with task YAML 2:
```
file_mounts:
  /gcs-mount: 
    name: source-with-space
    source: /home/doyoung/source with space
    store: gcs
```
