### PR TITLE
[k8s] Kubernetes H100-80GB support

### DIFF
--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -79,10 +79,10 @@ def get_gke_accelerator_name(accelerator: str) -> str:
     """Returns the accelerator name for GKE clusters
 
     Uses the format - nvidia-tesla-<accelerator>.
-    A100-80GB and L4 are an exception - they use nvidia-<accelerator>.
+    A100-80GB, H100-80GB and L4 are an exception. They use nvidia-<accelerator>.
     """
     if accelerator in ('A100-80GB', 'L4', 'H100-80GB'):
-        # A100-80GB and L4 have a different name pattern.
+        # A100-80GB, L4 and H100-80GB have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
         return 'nvidia-tesla-{}'.format(accelerator.lower())

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -81,7 +81,7 @@ def get_gke_accelerator_name(accelerator: str) -> str:
     Uses the format - nvidia-tesla-<accelerator>.
     A100-80GB and L4 are an exception - they use nvidia-<accelerator>.
     """
-    if accelerator in ('A100-80GB', 'L4'):
+    if accelerator in ('A100-80GB', 'L4', 'H100-80GB'):
         # A100-80GB and L4 have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:


### PR DESCRIPTION
Quick fix to add support for `H100-80GB` - it also uses `cloud.google.com/gke-accelerator: nvidia-h100-80gb` naming convention.

- [x] Code formatting: `bash format.sh`