### PR TITLE
Clean the username on mounts directory.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1014,7 +1014,7 @@ def write_cluster_config(
                 # calling user which should've been passed in as the
                 # SKYPILOT_USER env var (see
                 # controller_utils.shared_controller_vars_to_fill().
-                'user': get_cleaned_username(
+                'user': common_utils.get_cleaned_username(
                     os.environ.get(constants.USER_ENV_VAR, '')),
 
                 # Networking configs
@@ -1489,30 +1489,7 @@ def check_local_gpus() -> bool:
 def generate_cluster_name():
     # TODO: change this ID formatting to something more pleasant.
     # User name is helpful in non-isolated accounts, e.g., GCP, Azure.
-    return f'sky-{uuid.uuid4().hex[:4]}-{get_cleaned_username()}'
-
-
-def get_cleaned_username(username: str = '') -> str:
-    """Cleans the username to be used as part of a cluster name.
-
-    Clean up includes:
-     1. Making all characters lowercase
-     2. Removing any non-alphanumeric characters (excluding hyphens)
-     3. Removing any numbers and/or hyphens at the start of the username.
-     4. Removing any hyphens at the end of the username
-
-    e.g. 1SkY-PiLot2- becomes sky-pilot2.
-
-    Returns:
-      A cleaned username that will pass the regex in
-      check_cluster_name_is_valid().
-    """
-    username = username or getpass.getuser()
-    username = username.lower()
-    username = re.sub(r'[^a-z0-9-]', '', username)
-    username = re.sub(r'^[0-9-]+', '', username)
-    username = re.sub(r'-$', '', username)
-    return username
+    return f'sky-{uuid.uuid4().hex[:4]}-{common_utils.get_cleaned_username()}'
 
 
 def _query_head_ip_with_retries(cluster_yaml: str,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1,7 +1,6 @@
 """Util constants/functions for the backends."""
 from datetime import datetime
 import enum
-import getpass
 import json
 import os
 import pathlib

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -709,7 +709,7 @@ def _default_interactive_node_name(node_type: str):
     # same-username user.  E.g., sky-gpunode-ubuntu.  Not a problem on AWS
     # which is the current cloud for interactive nodes.
     assert node_type in _INTERACTIVE_NODE_TYPES, node_type
-    return f'sky-{node_type}-{backend_utils.get_cleaned_username()}'
+    return f'sky-{node_type}-{common_utils.get_cleaned_username()}'
 
 
 def _infer_interactive_node_type(resources: sky.Resources):

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -547,3 +547,26 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
     if err_msg:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(err_msg)
+
+
+def get_cleaned_username(username: str = '') -> str:
+    """Cleans the username as some cloud provider have limitation on 
+    characters usage such as dot (.) is not allowed in GCP.
+
+    Clean up includes:
+     1. Making all characters lowercase
+     2. Removing any non-alphanumeric characters (excluding hyphens)
+     3. Removing any numbers and/or hyphens at the start of the username.
+     4. Removing any hyphens at the end of the username
+
+    e.g. 1SkY-PiLot2- becomes sky-pilot2
+
+    Returns:
+      A cleaned username.
+    """
+    username = username or getpass.getuser()
+    username = username.lower()
+    username = re.sub(r'[^a-z0-9-]', '', username)
+    username = re.sub(r'^[0-9-]+', '', username)
+    username = re.sub(r'-$', '', username)
+    return username

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -550,7 +550,7 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
 
 
 def get_cleaned_username(username: str = '') -> str:
-    """Cleans the username as some cloud provider have limitation on 
+    """Cleans the username as some cloud provider have limitation on
     characters usage such as dot (.) is not allowed in GCP.
 
     Clean up includes:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -398,7 +398,7 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
     new_storage_mounts = {}
     if task.workdir is not None:
         bucket_name = constants.WORKDIR_BUCKET_NAME.format(
-            username=getpass.getuser(), id=run_id)
+            username=common_utils.get_cleaned_username(), id=run_id)
         workdir = task.workdir
         task.workdir = None
         if (constants.SKY_REMOTE_WORKDIR in original_file_mounts or
@@ -432,7 +432,7 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
             copy_mounts_with_file_in_src[dst] = src
             continue
         bucket_name = constants.FILE_MOUNTS_BUCKET_NAME.format(
-            username=getpass.getuser(),
+            username=common_utils.get_cleaned_username(),
             id=f'{run_id}-{i}',
         )
         new_storage_mounts[dst] = storage_lib.Storage.from_yaml_config({
@@ -452,7 +452,7 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
         constants.FILE_MOUNTS_LOCAL_TMP_DIR.format(id=run_id))
     os.makedirs(local_fm_path, exist_ok=True)
     file_bucket_name = constants.FILE_MOUNTS_FILE_ONLY_BUCKET_NAME.format(
-        username=getpass.getuser(), id=run_id)
+        username=common_utils.get_cleaned_username(), id=run_id)
     file_mount_remote_tmp_dir = constants.FILE_MOUNTS_REMOTE_TMP_DIR.format(
         path)
     if copy_mounts_with_file_in_src:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When running, the `sky spot launch hello_sky.yaml` failed due to the username (used as bucket name) containing the invalid characters (.) allowed by the Google Cloud Platform.
The [hello_sky.yaml](https://skypilot.readthedocs.io/en/latest/getting-started/quickstart.html) is the configuration used in the Quickstart tutorial.

```bash
Launching the spot job 'sky-f3d9-saihtaungkham'. Proceed? [Y/n]: Y
I 12-06 16:18:20 controller_utils.py:394] Translating workdir to SkyPilot Storage...
I 12-06 16:18:20 controller_utils.py:419] Workdir '.' will be synced to cloud storage 'skypilot-workdir-sai.htaungkham-75ee1a2f'.
I 12-06 16:18:20 controller_utils.py:492] Uploading sources to cloud storage. See: sky storage ls
E 12-06 16:18:32 storage.py:808] Could not create StoreType.GCS store with name skypilot-workdir-sai.htaungkham-75ee1a2f.
google.api_core.exceptions.NotFound: 404 GET https://storage.googleapis.com/storage/v1/b/skypilot-workdir-sai.htaungkham-75ee1a2f?projection=noAcl&prettyPrint=false: The specified bucket does not exist.

During handling of the above exception, another exception occurred:

google.api_core.exceptions.BadRequest: 400 POST https://storage.googleapis.com/storage/v1/b?project=<your-project>&prettyPrint=false: The specified bucket contains a '.' but is not under a currently recognized top-level domain.

The above exception was the direct cause of the following exception:

sky.exceptions.StorageBucketCreateError: Attempted to create a bucket skypilot-workdir-sai.htaungkham-75ee1a2f but failed.

During handling of the above exception, another exception occurred:

ValueError: Storage skypilot-workdir-sai.htaungkham-75ee1a2f not found.
```

- Also move the `get_cleaned_username` function under `common_utils`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
