### PR TITLE
GCP: Fix subnet filtering.

### DIFF
--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -818,9 +818,7 @@ def get_usable_vpc_and_subnet(
         if len(vpcnets_all) == 1:
             # Skip checking any firewall rules if the user has specified a VPC.
             logger.info(f"Using user-specified VPC {specific_vpc_to_use!r}.")
-            subnets = _list_subnets(
-                config, compute, network=specific_vpc_to_use
-            )
+            subnets = _list_subnets(config, compute, network=specific_vpc_to_use)
             if not subnets:
                 _skypilot_log_error_and_exit_for_failover(
                     f"No subnet for region {config['provider']['region']} found for specified VPC {specific_vpc_to_use!r}. "

--- a/sky/skylet/providers/gcp/config.py
+++ b/sky/skylet/providers/gcp/config.py
@@ -1006,10 +1006,16 @@ def _list_subnets(
     items = response["items"] if "items" in response else []
     if network is None:
         return items
+
+    # Filter by network (VPC) name.
+    #
+    # Note we do not directly use the filter (network=<...>) arg of the list()
+    # call above, because it'd involve constructing a long URL of the following
+    # format and passing it as the filter value:
+    # 'https://www.googleapis.com/compute/v1/projects/<project_id>/global/networks/<network_name>'
     matched_items = []
     for item in items:
-        # 'https://www.googleapis.com/compute/v1/projects/<project_id>/global/networks/<network_name>'
-        if network == item["network"].split("/")[-1]:
+        if network == _network_interface_to_vpc_name(item):
             matched_items.append(item)
     return matched_items
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously we were filtering by subnet name (`name`), but rather we should be filtering by vpc name (`network`). We did not hit this bug because our subnets were named the same as the VPC:

```
» gcloud compute networks subnets list --network="skypilot-vpc" 

NAME          REGION                   NETWORK       RANGE          STACK_TYPE  IPV6_ACCESS_TYPE  INTERNAL_IPV6_PREFIX  EXTERNAL_IPV6_PREFIX
skypilot-vpc  us-central1              skypilot-vpc  10.128.0.0/20  IPV4_ONLY
..
```
while a user hit this bug because they are named differently:
```
NAME           REGION    NETWORK   RANGE          STACK_TYPE  IPV6_ACCESS_TYPE  INTERNAL_IPV6_PREFIX  EXTERNAL_IPV6_PREFIX
priv-subnet-1  us-west1  skypilot  10.10.72.0/22  IPV4_ONLY
pub-subnet-1   us-west1  skypilot  10.10.68.0/22  IPV4_ONLY
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - No `gcp.vpc_name` config: `sky launch -c no-gcp-config --cpus 2 --use-spot --cloud gcp -i0 --down -y`
  - With `gcp.vpc_name` config: `sky launch -c skypilot-vpc-gcp-config --cpus 2 --use-spot --cloud gcp -i0 --down -y`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
