### PR TITLE
[SkyServe] Fix resource parse when multiple accelerators is used

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4289,9 +4289,10 @@ def serve_up(
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
             # For the case when the user specified a port range like 10000-10010
-            raise ValueError(f'Port {service_port_str!r} is not a valid port '
-                             'number. Please specify a single port instead. '
-                             f'Got: {service_port_str!r}')
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Port {service_port_str!r} is not a valid '
+                                 'port number. Please specify a single port '
+                                 f'instead. Got: {service_port_str!r}')
         # We request all the replicas using the same port for now, but it
         # should be fine to allow different replicas to use different ports
         # in the future.
@@ -4299,9 +4300,10 @@ def serve_up(
         if service_port is None:
             service_port = resource_port
         if service_port != resource_port:
-            raise ValueError(
-                f'Got multiple ports: {service_port} and {resource_port} '
-                'in different resources. Please specify single port instead.')
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Got multiple ports: {service_port} and '
+                                 f'{resource_port} in different resources. '
+                                 'Please specify single port instead.')
 
     click.secho('Service Spec:', fg='cyan')
     click.echo(task.service)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4288,6 +4288,7 @@ def serve_up(
                     'will use the port specified as application ingress port.')
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
+            # For the case when the user specified a port range like 10000-10010
             raise ValueError(f'Port {service_port_str!r} is not a valid port '
                              'number. Please specify a single port instead. '
                              f'Got: {service_port_str!r}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4291,8 +4291,9 @@ def serve_up(
             raise ValueError(f'Port {service_port_str!r} is not a valid port '
                              'number. Please specify a single port instead. '
                              f'Got: {service_port_str!r}')
-        # We request all the replicas using the same port for now, but it should be
-        # fine to allow different repilcas to use different ports in the future.
+        # We request all the replicas using the same port for now, but it
+        # should be fine to allow different replicas to use different ports
+        # in the future.
         resource_port = int(service_port_str)
         if service_port is None:
             service_port = resource_port

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4291,6 +4291,8 @@ def serve_up(
             raise ValueError(f'Port {service_port_str!r} is not a valid port '
                              'number. Please specify a single port instead. '
                              f'Got: {service_port_str!r}')
+        # We request all the replicas using the same port for now, but it should be
+        # fine to allow different repilcas to use different ports in the future.
         resource_port = int(service_port_str)
         if service_port is None:
             service_port = resource_port

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -71,6 +71,7 @@ def up(
                     'will use the port specified as application ingress port.')
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
+            # For the case when the user specified a port range like 10000-10010
             raise ValueError(f'Port {service_port_str!r} is not a valid port '
                              'number. Please specify a single port instead. '
                              f'Got: {service_port_str!r}')

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -83,6 +83,10 @@ def up(
                 'in different resources. Please specify single port instead.')
         if requested_cloud is None:
             requested_cloud = requested_resources.cloud
+        if requested_cloud != requested_resources.cloud:
+            raise ValueError(f'Got multiple clouds: {requested_cloud} and '
+                             f'{requested_resources.cloud} in different '
+                             'resources. Please specify single cloud instead.')
 
     controller_utils.maybe_translate_local_file_mounts_and_sync_up(task,
                                                                    path='serve')

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -149,7 +149,8 @@ def terminate_cluster(cluster_name: str, max_retry: int = 3) -> None:
 def _get_resources_ports(task_yaml: str) -> str:
     """Get the resources ports used by the task."""
     task = sky.Task.from_yaml(task_yaml)
-    assert len(task.resources) == 1, task
+    # Already checked all ports are the same in sky.serve.core.up
+    assert len(task.resources) >= 1, task
     task_resources = list(task.resources)[0]
     # Already checked the resources have and only have one port
     # before upload the task yaml.

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -47,6 +47,8 @@ def create_table(cursor: 'sqlite3.Cursor', conn: 'sqlite3.Connection') -> None:
 
 
 _DB = db_utils.SQLiteConn(_DB_PATH, create_table)
+db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services',
+                             'requested_resources_str', 'TEXT')
 
 _UNIQUE_CONSTRAINT_FAILED_ERROR_MSG = 'UNIQUE constraint failed: services.name'
 
@@ -178,7 +180,7 @@ _SERVICE_STATUS_TO_COLOR = {
 
 
 def add_service(name: str, controller_job_id: int, policy: str,
-                auto_restart: bool, requested_resources: 'sky.Resources',
+                auto_restart: bool, requested_resources_str: str,
                 status: ServiceStatus) -> bool:
     """Add a service in the database.
 
@@ -190,11 +192,11 @@ def add_service(name: str, controller_job_id: int, policy: str,
         _DB.cursor.execute(
             """\
             INSERT INTO services
-            (name, controller_job_id, status, policy,
-            auto_restart, requested_resources)
+            (name, controller_job_id, status, policy, auto_restart,
+            requested_resources, requested_resources_str)
             VALUES (?, ?, ?, ?, ?, ?)""",
             (name, controller_job_id, status.value, policy, int(auto_restart),
-             pickle.dumps(requested_resources)))
+             None, requested_resources_str))
         _DB.conn.commit()
     except sqlite3.IntegrityError as e:
         if str(e) != _UNIQUE_CONSTRAINT_FAILED_ERROR_MSG:
@@ -251,7 +253,8 @@ def set_service_load_balancer_port(service_name: str,
 
 def _get_service_from_row(row) -> Dict[str, Any]:
     (name, controller_job_id, controller_port, load_balancer_port, status,
-     uptime, policy, auto_restart, requested_resources) = row[:9]
+     uptime, policy, auto_restart, requested_resources,
+     requested_resources_str) = row[:10]
     return {
         'name': name,
         'controller_job_id': controller_job_id,
@@ -263,6 +266,7 @@ def _get_service_from_row(row) -> Dict[str, Any]:
         'auto_restart': bool(auto_restart),
         'requested_resources': pickle.loads(requested_resources)
                                if requested_resources is not None else None,
+        'requested_resources_str': requested_resources_str,
     }
 
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -194,7 +194,7 @@ def add_service(name: str, controller_job_id: int, policy: str,
             INSERT INTO services
             (name, controller_job_id, status, policy, auto_restart,
             requested_resources, requested_resources_str)
-            VALUES (?, ?, ?, ?, ?, ?)""",
+            VALUES (?, ?, ?, ?, ?, ?, ?)""",
             (name, controller_job_id, status.value, policy, int(auto_restart),
              None, requested_resources_str))
         _DB.conn.commit()

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -192,11 +192,11 @@ def add_service(name: str, controller_job_id: int, policy: str,
         _DB.cursor.execute(
             """\
             INSERT INTO services
-            (name, controller_job_id, status, policy, auto_restart,
-            requested_resources, requested_resources_str)
-            VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (name, controller_job_id, status, policy,
+            auto_restart, requested_resources_str)
+            VALUES (?, ?, ?, ?, ?, ?)""",
             (name, controller_job_id, status.value, policy, int(auto_restart),
-             None, requested_resources_str))
+             requested_resources_str))
         _DB.conn.commit()
     except sqlite3.IntegrityError as e:
         if str(e) != _UNIQUE_CONSTRAINT_FAILED_ERROR_MSG:
@@ -264,6 +264,8 @@ def _get_service_from_row(row) -> Dict[str, Any]:
         'uptime': uptime,
         'policy': policy,
         'auto_restart': bool(auto_restart),
+        # TODO(tian): Backward compatibility.
+        # Remove after 2 minor release, 0.6.0.
         'requested_resources': pickle.loads(requested_resources)
                                if requested_resources is not None else None,
         'requested_resources_str': requested_resources_str,

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -681,7 +681,7 @@ def format_service_table(service_records: List[Dict[str, Any]],
         endpoint = get_endpoint(record)
         policy = record['policy']
         # TODO(tian): Backward compatibility.
-        # Remove after 2 minor release, 0.6.0.
+        # Remove `requested_resources` field after 2 minor release, 0.6.0.
         if record.get('requested_resources_str') is None:
             requested_resources_str = str(record['requested_resources'])
         else:

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -680,7 +680,12 @@ def format_service_table(service_records: List[Dict[str, Any]],
         replicas = _get_replicas(record)
         endpoint = get_endpoint(record)
         policy = record['policy']
-        requested_resources = record['requested_resources']
+        # TODO(tian): Backward compatibility.
+        # Remove after 2 minor release, 0.6.0.
+        if record.get('requested_resources_str') is None:
+            requested_resources_str = str(record['requested_resources'])
+        else:
+            requested_resources_str = record['requested_resources_str']
 
         service_values = [
             service_name,
@@ -690,7 +695,7 @@ def format_service_table(service_records: List[Dict[str, Any]],
             endpoint,
         ]
         if show_all:
-            service_values.extend([policy, requested_resources])
+            service_values.extend([policy, requested_resources_str])
         service_table.add_row(service_values)
 
     replica_table = _format_replica_table(replica_infos, show_all)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -12,14 +12,12 @@ import traceback
 from typing import Dict, List
 
 import filelock
-import yaml
 
 from sky import authentication
 from sky import exceptions
-from sky import resources
-from sky import serve
 from sky import sky_logging
 from sky import task as task_lib
+from sky.backends import backend_utils
 from sky.backends import cloud_vm_ray_backend
 from sky.serve import constants
 from sky.serve import controller
@@ -129,13 +127,9 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     authentication.get_or_generate_keys()
 
     # Initialize database record for the service.
-    service_spec = serve.SkyServiceSpec.from_yaml(tmp_task_yaml)
-    with open(tmp_task_yaml, 'r') as f:
-        config = yaml.safe_load(f)
-    resources_config = None
-    if isinstance(config, dict):
-        resources_config = config.get('resources')
-    requested_resources = resources.Resources.from_yaml_config(resources_config)
+    task = task_lib.Task.from_yaml(tmp_task_yaml)
+    assert task.service is not None
+    service_spec = task.service
     if len(serve_state.get_services()) >= serve_utils.NUM_SERVICE_THRESHOLD:
         _cleanup_storage(tmp_task_yaml)
         with ux_utils.print_exception_no_traceback():
@@ -145,7 +139,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         controller_job_id=job_id,
         policy=service_spec.policy_str(),
         auto_restart=service_spec.auto_restart,
-        requested_resources=requested_resources,
+        requested_resources_str=backend_utils.get_task_resources_str(task),
         status=serve_state.ServiceStatus.CONTROLLER_INIT)
     # Directly throw an error here. See sky/serve/api.py::up
     # for more details.

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -128,7 +128,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
 
     # Initialize database record for the service.
     task = task_lib.Task.from_yaml(tmp_task_yaml)
-    assert task.service is not None
+    # Already checked before submit to controller.
+    assert task.service is not None, task
     service_spec = task.service
     if len(serve_state.get_services()) >= serve_utils.NUM_SERVICE_THRESHOLD:
         _cleanup_storage(tmp_task_yaml)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR changed the representation of the `request_resources` field in service status. Now it will store a string to represent multiple accelerators, just like implementation for SkySpot.

```yaml
service:
  readiness_probe: /
  replicas: 1

resources:
  accelerators: {L4:1, T4:1}
  ports: 8000

run: python3 -m http.server 8000

```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - Previous YAML
     - Backward compatibility test: launch a service on the old version, switch to this branch and launch a new service. Everything works fine.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
