### PR TITLE
AWS: make public / private subnet selection robust.

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -65,11 +65,11 @@ Available fields and semantics:
     # Set to true to use private IPs to communicate between the local client and
     # any SkyPilot nodes. This requires the networking stack be properly set up.
     #
-    # Specifically, setting this flag means SkyPilot will only use subnets that
-    # satisfy *both* of the following to launch nodes:
-    #   1. Subnets with name tags containing the substring "private"
-    #   2. Subnets that are configured to not assign public IPs (the
-    #      `map_public_ip_on_launch` attribute is False)
+    # When set to true, SkyPilot will only use private subnets to launch nodes.
+    # Private subnets are defined as those satisfying both of these properties:
+    #   1. Subnets whose route tables have no routes to an internet gateway (IGW);
+    #   2. Subnets that are configured to not assign public IPs by default
+    #       (the `map_public_ip_on_launch` attribute is False).
     #
     # This flag is typically set together with 'vpc_name' above and
     # 'ssh_proxy_command' below.

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -196,7 +196,7 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
     return {'Arn': profile.arn}
 
 
-@functools.lru_cache(maxsize=128)
+@functools.lru_cache(maxsize=128)  # Keep bounded.
 def _get_route_tables(ec2, vpc_id: Optional[str], main: bool) -> List[Any]:
     filters = [{'Name': 'association.main', 'Values': [str(main).lower()]}]
     if vpc_id is not None:

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -218,7 +218,7 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
         rt for rt in all_route_tables
         # An RT can be associated with multiple subnets, i.e.,
         # rt['Associations'] is a list of associations.
-        if any(assoc['SubnetId']  == subnet_id for assoc in rt['Associations'])
+        if any(assoc['SubnetId'] == subnet_id for assoc in rt['Associations'])
     ]
 
     # Check each route table for an internet gateway route

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -218,6 +218,7 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
         rt for rt in all_route_tables
         if rt['Associations'][0]['SubnetId'] == subnet_id
     ]
+
     # Check each route table for an internet gateway route
     def _has_igw_route(route_tables):
         for route_table in route_tables:

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -207,7 +207,12 @@ def _get_main_route_tables(ec2) -> List[Any]:
 
 
 def _is_subnet_public(ec2, subnet_id) -> bool:
-    """Checks if a subnet is public by existence of a route to an IGW."""
+    """Checks if a subnet is public by existence of a route to an IGW.
+
+    Conventionally, public subnets connect to a IGW, and private subnets to a
+    NAT. See ref:
+    https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html
+    """
     # Get the route table associated with the subnet
     route_tables = ec2.meta.client.describe_route_tables(Filters=[{
         'Name': 'association.subnet-id',

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -216,7 +216,9 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
     all_route_tables = _get_route_tables(ec2, vpc_id, main=False)
     route_tables = [
         rt for rt in all_route_tables
-        if rt['Associations'][0]['SubnetId'] == subnet_id
+        # An RT can be associated with multiple subnets, i.e.,
+        # rt['Associations'] is a list of associations.
+        if any(assoc['SubnetId']  == subnet_id for assoc in rt['Associations'])
     ]
 
     # Check each route table for an internet gateway route

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -164,16 +164,20 @@ def _create_instances(ec2_fail_fast, cluster_name: str,
         'MaxCount': count,
         'TagSpecifications': tag_specs
     })
+
     # We are adding 'NetworkInterfaces' in the inner loop and having both keys
     # is considered invalid by the create_instances API.
     security_group_ids = conf.pop('SecurityGroupIds', None)
+    # Guaranteed by config.py (the bootstrapping phase):
+    assert 'NetworkInterfaces' not in conf, conf
+    assert security_group_ids is not None, conf
+
     # NOTE: This ensures that we try ALL availability zones before
     # throwing an error.
     num_subnets = len(subnet_ids)
     max_tries = max(num_subnets * (BOTO_CREATE_MAX_RETRIES // num_subnets),
                     len(subnet_ids))
     per_subnet_tries = max_tries // num_subnets
-    assert 'NetworkInterfaces' not in conf, conf
     for i in range(max_tries):
         try:
             # Try each subnet for per_subnet_tries times.

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -173,6 +173,7 @@ def _create_instances(ec2_fail_fast, cluster_name: str,
     max_tries = max(num_subnets * (BOTO_CREATE_MAX_RETRIES // num_subnets),
                     len(subnet_ids))
     per_subnet_tries = max_tries // num_subnets
+    assert 'NetworkInterfaces' not in conf, conf
     for i in range(max_tries):
         try:
             # Try each subnet for per_subnet_tries times.

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -136,9 +136,9 @@ def _merge_tag_specs(tag_specs: List[Dict[str, Any]],
             tag_specs += [user_tag_spec]
 
 
-def _create_instances(ec2_fail_fast, cluster_name: str, node_config: Dict[str,
-                                                                          Any],
-                      tags: Dict[str, str], count: int) -> List:
+def _create_instances(ec2_fail_fast, cluster_name: str,
+                      node_config: Dict[str, Any], tags: Dict[str, str],
+                      count: int, associate_public_ip_address: bool) -> List:
     tags = {
         'Name': cluster_name,
         TAG_RAY_CLUSTER_NAME: cluster_name,
@@ -164,7 +164,9 @@ def _create_instances(ec2_fail_fast, cluster_name: str, node_config: Dict[str,
         'MaxCount': count,
         'TagSpecifications': tag_specs
     })
-
+    # We are adding 'NetworkInterfaces' in the inner loop and having both keys
+    # is considered invalid by the create_instances API.
+    security_group_ids = conf.pop('SecurityGroupIds', None)
     # NOTE: This ensures that we try ALL availability zones before
     # throwing an error.
     num_subnets = len(subnet_ids)
@@ -173,17 +175,17 @@ def _create_instances(ec2_fail_fast, cluster_name: str, node_config: Dict[str,
     per_subnet_tries = max_tries // num_subnets
     for i in range(max_tries):
         try:
-            if 'NetworkInterfaces' in conf:
-                logger.debug(
-                    'Attempting to create instances with NetworkInterfaces.'
-                    'Ignore SecurityGroupIds.')
-                # remove security group IDs previously copied from network
-                # interfaces (create_instances call fails otherwise)
-                conf.pop('SecurityGroupIds', None)
-            else:
-                # Try each subnet for per_subnet_tries times.
-                subnet_id = subnet_ids[i // per_subnet_tries]
-                conf['SubnetId'] = subnet_id
+            # Try each subnet for per_subnet_tries times.
+            subnet_id = subnet_ids[i // per_subnet_tries]
+
+            network_interfaces = [{
+                'SubnetId': subnet_id,
+                'DeviceIndex': 0,
+                # Whether the VM(s) should have a public IP.
+                'AssociatePublicIpAddress': associate_public_ip_address,
+                'Groups': security_group_ids,
+            }]
+            conf['NetworkInterfaces'] = network_interfaces
 
             # NOTE: We set retry=0 for fast failing when the resource is not
             # available. Here we have to handle 'RequestLimitExceeded'
@@ -383,10 +385,14 @@ def run_instances(region: str, cluster_name_on_cloud: str,
         #  This is a known issue before.
         ec2_fail_fast = aws.resource('ec2', region_name=region, max_attempts=0)
 
-        created_instances = _create_instances(ec2_fail_fast,
-                                              cluster_name_on_cloud,
-                                              config.node_config, tags,
-                                              to_start_count)
+        created_instances = _create_instances(
+            ec2_fail_fast,
+            cluster_name_on_cloud,
+            config.node_config,
+            tags,
+            to_start_count,
+            associate_public_ip_address=(
+                not config.provider_config['use_internal_ips']))
         created_instances.sort(key=lambda x: x.id)
 
         created_instance_ids = [n.id for n in created_instances]

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -120,8 +120,9 @@ def _bulk_provision(
             f'Instances of {cluster_name!r} are ready after {retry_cnt} '
             'retries.')
 
-    logger.debug(f'\nProvisioning {cluster_name!r} took {time.time() - start} '
-                 f'seconds.')
+    logger.debug(
+        f'\nProvisioning {cluster_name!r} took {time.time() - start:.2f} '
+        f'seconds.')
 
     return provision_record
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -342,17 +342,19 @@ def replace_skypilot_config_path_in_file_mounts(
     # is provisioned, e.g., we may need to decide which cloud to create a bucket
     # to be mounted to the cluster based on the cloud the cluster is actually
     # launched on (after failover).
-    if file_mounts is None or not skypilot_config.loaded():
+    if file_mounts is None:
         return
     replaced = False
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
-        new_skypilot_config = _setup_proxy_command_on_controller(cloud)
-        if new_skypilot_config is not None:
-            common_utils.dump_yaml(f.name, new_skypilot_config)
-            for remote_path, local_path in file_mounts.items():
-                if local_path == LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER:
-                    file_mounts[remote_path] = f.name
-                    replaced = True
+        if skypilot_config.loaded():
+            new_skypilot_config = _setup_proxy_command_on_controller(cloud)
+        else:
+            new_skypilot_config = {}
+        common_utils.dump_yaml(f.name, new_skypilot_config)
+        for remote_path, local_path in file_mounts.items():
+            if local_path == LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER:
+                file_mounts[remote_path] = f.name
+                replaced = True
     if replaced:
         logger.debug(f'Replaced {LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER} with '
                      f'the real path in file mounts: {file_mounts}')

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -345,16 +345,22 @@ def replace_skypilot_config_path_in_file_mounts(
     if file_mounts is None:
         return
     replaced = False
+    to_replace = True
     with tempfile.NamedTemporaryFile('w', delete=False) as f:
         if skypilot_config.loaded():
             new_skypilot_config = _setup_proxy_command_on_controller(cloud)
+            common_utils.dump_yaml(f.name, new_skypilot_config)
+            to_replace = True
         else:
-            new_skypilot_config = {}
-        common_utils.dump_yaml(f.name, new_skypilot_config)
+            # Empty config. Remove the placeholder below.
+            to_replace = False
         for remote_path, local_path in file_mounts.items():
             if local_path == LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER:
-                file_mounts[remote_path] = f.name
-                replaced = True
+                if to_replace:
+                    file_mounts[remote_path] = f.name
+                    replaced = True
+                else:
+                    del file_mounts[remote_path]
     if replaced:
         logger.debug(f'Replaced {LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER} with '
                      f'the real path in file mounts: {file_mounts}')

--- a/tests/backward_compatibility_tests.sh
+++ b/tests/backward_compatibility_tests.sh
@@ -1,6 +1,16 @@
-# This script is used to test backward compatibility of skypilot.
+# Script for testing backward compatibility of skypilot.
+#
 # To run this script, you need to uninstall the skypilot and ray in the base
 # conda environment, and run it in the base conda environment.
+#
+# It's recommended to use a smoke-test VM to run this.
+#
+# Usage:
+#
+#   cd skypilot-repo
+#   git checkout <feature branch>
+#   pip uninstall -y skypilot ray
+#   bash tests/backward_compatibility_tests.sh
 
 #!/bin/bash
 set -ev
@@ -8,7 +18,7 @@ set -ev
 need_launch=${1:-0}
 start_from=${2:-0}
 
-source ~/.bashrc 
+source ~/.bashrc
 CLUSTER_NAME="test-back-compat-$USER"
 source $(conda info --base 2> /dev/null)/etc/profile.d/conda.sh
 CLOUD="aws"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Removes two issues from before
- Previously, we test if a subnet is private by a hack (check if `private` is a substr in its name tag)
- Previously, SkyPilot does not allow launching VMs in a public subnet with `subnet.map_public_ip_on_launch` set to False. 
  - This PR now allows so -- and changes the underlying ec2.create_instances call to assign public IPs

This PR uses a more robust method to test if a subnet is public: 
- Check if its associated route tables have a route to an IGW (`igw-*`)
- If it has no explicitly associated route tables, check if any "main" route table has a route to an IGW (`igw-*`)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

-----

Tested:

- [x] smoke
  - [x] No VPC/private IP settings
  - [x] With `aws.vpc_name: skypilot-vpc` and corresponding `use_internal_ips,ssh_proxy_command`
- [x] back compat
  - [x] No VPC/private IP settings
  - [x] With `aws.vpc_name: skypilot-vpc` and corresponding `use_internal_ips,ssh_proxy_command`

Speed
- `for i in $(seq 3); do sky launch --cloud aws -i0 --down --use-spot --region us-east-1 -y >log-${i}; done`
  - Grepped for provisioner.log "Provisioning ... took"
  - Before (one region): 11.22, 11.47, 11.44 [median 11.44s]
  - This PR (one region): 11.47, 11.81, 11.58 [median 11.58s]

No VPC/private IP settings
- Region only has a default main route table (ap-northeast-3)
  - [x] `sky launch -c dbg --cloud aws -i0 --down --use-spot -y --region ap-northeast-3`
- Region has both two main route tables (only one of them is in effect + has an IGW route), and several `skypilot-vpc` route tables (us-east-2)
  - [x] `sky launch --cloud aws -i0 --down --use-spot -y --region us-east-2`
- Failover correctly
  - [x] `sky launch --gpus A100:8 --cloud aws -i0 --down --use-spot -y`

With `aws.vpc_name: skypilot-vpc` only
- Can now launch in a public subnet with `subnet.map_public_ip_on_launch` set to False. 
  - [x] `sky launch --cloud aws -i0 --down --use-spot -y --region us-east-2`

With `aws.vpc_name: skypilot-vpc` and corresponding `use_internal_ips,ssh_proxy_command`
  - [x] Can launch: `sky launch --cloud aws -i0 --down --use-spot -y --region us-east-2`
  - [x] Failover correctly: `sky launch --cloud aws -i0 --down --gpus A10G --use-spot -y`

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): see above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
