### PR TITLE
Azure: allow spot instances.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1413,15 +1413,6 @@ def launch(
     if backend_name is None:
         backend_name = backends.CloudVmRayBackend.NAME
 
-    # A basic check. Programmatic calls will have a proper (but less
-    # informative) error from optimizer.
-    if (cloud is not None and cloud.lower() == 'azure' and
-            use_spot is not None and use_spot):
-        raise click.UsageError(
-            'SkyPilot currently has not implemented '
-            'support for spot instances on Azure. Please file '
-            'an issue if you need this feature.')
-
     task_or_dag = _make_task_or_dag_from_entrypoint_with_overrides(
         entrypoint=entrypoint,
         name=name,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -64,10 +64,8 @@ class Azure(clouds.Cloud):
     def _cloud_unsupported_features(
             cls) -> Dict[clouds.CloudImplementationFeatures, str]:
         return {
-            clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER: f'Migrating disk is not supported in {cls._REPR}.',
-            # TODO(zhwu): our azure subscription offer ID does not support spot.
-            # Need to support it.
-            clouds.CloudImplementationFeatures.SPOT_INSTANCE: f'Spot instances are not supported in {cls._REPR}.',
+            clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:
+                (f'Migrating disk is not supported in {cls._REPR}.'),
         }
 
     @classmethod
@@ -244,8 +242,6 @@ class Azure(clouds.Cloud):
         region_name = region.name
 
         r = resources
-        assert not r.use_spot, \
-            'Our subscription offer ID does not support spot instances.'
         # r.accelerators is cleared but .instance_type encodes the info.
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         if acc_dict is not None:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -68,7 +68,6 @@ def get_hourly_cost(instance_type: str,
                     region: Optional[str] = None,
                     zone: Optional[str] = None) -> float:
     # Ref: https://azure.microsoft.com/en-us/support/legal/offer-details/
-    assert not use_spot, 'Current Azure subscription does not support spot.'
     if zone is not None:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Azure does not support zones.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Removes the artificial restriction that was added due to our subscription not support spot instances. However, users' subscriptions have access so should be allowed.

Tested:
- `sky launch --cloud azure --use-spot --gpus A100-80GB` no longer shows our asserts, but rather proper errors from Azure 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
