### PR TITLE
[VPC] Fix config yaml env var for spot/serve controller

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -677,8 +677,10 @@ def spot_launch(
             'dag_name': dag.name,
             'retry_until_up': retry_until_up,
             'remote_user_config_path': remote_user_config_path,
-            **controller_utils.shared_controller_vars_to_fill('spot',
-                                                              remote_user_config_path=remote_user_config_path),
+            **controller_utils.shared_controller_vars_to_fill(
+                'spot',
+                remote_user_config_path=remote_user_config_path,
+            ),
         }
 
         yaml_path = os.path.join(spot.SPOT_CONTROLLER_YAML_PREFIX,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -677,7 +677,8 @@ def spot_launch(
             'dag_name': dag.name,
             'retry_until_up': retry_until_up,
             'remote_user_config_path': remote_user_config_path,
-            **controller_utils.shared_controller_vars_to_fill('spot'),
+            **controller_utils.shared_controller_vars_to_fill('spot',
+                                                              remote_user_config_path=remote_user_config_path),
         }
 
         yaml_path = os.path.join(spot.SPOT_CONTROLLER_YAML_PREFIX,

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -118,8 +118,10 @@ def up(
             'service_name': service_name,
             'controller_log_file': controller_log_file,
             'remote_user_config_path': remote_config_yaml_path,
-            **controller_utils.shared_controller_vars_to_fill('serve',
-                                                              remote_user_config_path=remote_config_yaml_path),
+            **controller_utils.shared_controller_vars_to_fill(
+                'serve',
+                remote_user_config_path=remote_config_yaml_path,
+            ),
         }
         backend_utils.fill_template(serve_constants.CONTROLLER_TEMPLATE,
                                     vars_to_fill,

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -118,7 +118,8 @@ def up(
             'service_name': service_name,
             'controller_log_file': controller_log_file,
             'remote_user_config_path': remote_config_yaml_path,
-            **controller_utils.shared_controller_vars_to_fill('serve'),
+            **controller_utils.shared_controller_vars_to_fill('serve',
+                                                              remote_user_config_path=remote_config_yaml_path),
         }
         backend_utils.fill_template(serve_constants.CONTROLLER_TEMPLATE,
                                     vars_to_fill,

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -225,7 +225,8 @@ def download_and_stream_latest_job_log(
     return log_file
 
 
-def shared_controller_vars_to_fill(controller_type: str) -> Dict[str, str]:
+def shared_controller_vars_to_fill(controller_type: str,
+                                   remote_user_config_path) -> Dict[str, str]:
     vars_to_fill: Dict[str, Any] = {
         'cloud_dependencies_installation_commands':
             _get_cloud_dependencies_installation_commands(controller_type)
@@ -241,6 +242,9 @@ def shared_controller_vars_to_fill(controller_type: str) -> Dict[str, str]:
         # Skip cloud identity check to avoid the overhead.
         env_options.Options.SKIP_CLOUD_IDENTITY_CHECK.value: '1',
     })
+    if (remote_user_config_path is not None and skypilot_config.loaded()):
+        env_vars[
+            skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = remote_user_config_path
     vars_to_fill['controller_envs'] = env_vars
     return vars_to_fill
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -225,8 +225,8 @@ def download_and_stream_latest_job_log(
     return log_file
 
 
-def shared_controller_vars_to_fill(controller_type: str,
-                                   remote_user_config_path) -> Dict[str, str]:
+def shared_controller_vars_to_fill(
+        controller_type: str, remote_user_config_path: str) -> Dict[str, str]:
     vars_to_fill: Dict[str, Any] = {
         'cloud_dependencies_installation_commands':
             _get_cloud_dependencies_installation_commands(controller_type)
@@ -242,7 +242,8 @@ def shared_controller_vars_to_fill(controller_type: str,
         # Skip cloud identity check to avoid the overhead.
         env_options.Options.SKIP_CLOUD_IDENTITY_CHECK.value: '1',
     })
-    if (remote_user_config_path is not None and skypilot_config.loaded()):
+    if skypilot_config.loaded():
+        # Only set the SKYPILOT_CONFIG env var if the user has a config file.
         env_vars[
             skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = remote_user_config_path
     vars_to_fill['controller_envs'] = env_vars


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We left out the env var of the path for config yaml in #2819. This is problemetic as the spot job and service replica will fail to respect the settings in user config yaml

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch -n test-private "echo hi; sleep 1000"` with `~/.sky/config.yaml`: the spot cluster should not have public IP.
    ```yaml. 
    spot:
      controller:
        resources:
          cloud: aws

    aws:
      use_internal_ips: true
      vpc_name: skypilot-test-vpc
      ssh_proxy_command:
        us-east-1: ssh -W %h:%p -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sky-key ec2-user@xx.xxx.xxx.xxx
    ```
  - [x] `sky spot launch -n test-private "echo hi; sleep 1000"` with `~/.sky/config.yaml` with #2867 merged: the spot cluster should not have public IP.
    ```yaml. 
    spot:
      controller:
        resources:
          cloud: aws

    aws:
      use_internal_ips: true
      vpc_name: skypilot-test-vpc
      ssh_proxy_command:
        us-east-1: ssh -W %h:%p -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i ~/.ssh/sky-key ec2-user@xx.xxx.xxx.xxx
    ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
