### PR TITLE
[k8s] Install ray dashboard dependencies in CPU k8s image

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -28,7 +28,7 @@ USER sky
 # Install SkyPilot pip dependencies
 RUN pip install wheel Click colorama cryptography jinja2 jsonschema && \
     pip install networkx oauth2client pandas pendulum PrettyTable && \
-    pip install ray==2.4.0 rich tabulate filelock && \
+    pip install ray[default]==2.4.0 rich tabulate filelock && \
     pip install packaging 'protobuf<4.0.0' pulp && \
     pip install awscli boto3 pycryptodome==3.12.0 && \
     pip install docker kubernetes


### PR DESCRIPTION
Fresh builds of our k8s CPU image would fail during provisioning with:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/sky/.local/lib/python3.10/site-packages/sky/skylet/ray_patches/__init__.py", line 85, in patch
    from ray.dashboard.modules.job import job_head
  File "/home/sky/.local/lib/python3.10/site-packages/ray/dashboard/modules/job/job_head.py", line 9, in <module>
    import aiohttp.web
ModuleNotFoundError: No module named 'aiohttp'
```

This is because ray dashboard dependencies are not correct installed.

This PR changes ray installation in our Dockerfile to also install dashboard dependencies. 

GPU image does not need this change since the base image installs `ray[default]` anyway. 

cc @kbrgl