### PR TITLE
GCP: upgrade GCSFuse to 1.3.0.

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1391,7 +1391,9 @@ class GcsStore(AbstractStore):
     """
 
     _ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
-    GCSFUSE_VERSION = '1.0.1'
+
+    # https://github.com/GoogleCloudPlatform/gcsfuse/releases
+    _GCSFUSE_VERSION = '1.3.0'
 
     def __init__(self,
                  name: str,
@@ -1743,8 +1745,8 @@ class GcsStore(AbstractStore):
           mount_path: str; Path to mount the bucket to.
         """
         install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
-                       f'/releases/download/v{self.GCSFUSE_VERSION}/'
-                       f'gcsfuse_{self.GCSFUSE_VERSION}_amd64.deb '
+                       f'/releases/download/v{self._GCSFUSE_VERSION}/'
+                       f'gcsfuse_{self._GCSFUSE_VERSION}_amd64.deb '
                        '-O /tmp/gcsfuse.deb && '
                        'sudo dpkg --install /tmp/gcsfuse.deb')
         mount_cmd = ('gcsfuse -o allow_other '
@@ -1755,7 +1757,7 @@ class GcsStore(AbstractStore):
                      f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
                      f'{self.bucket.name} {mount_path}')
         version_check_cmd = (
-            f'gcsfuse --version | grep -q {self.GCSFUSE_VERSION}')
+            f'gcsfuse --version | grep -q {self._GCSFUSE_VERSION}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop`
  - [x] `pytest tests/test_smoke.py::test_file_mounts --generic-cloud gcp`
- [x] Backward compatibility tests: 
  - [x] Old cluster UP (1.0.1); upgrade to this PR; `sky launch orig.yaml`, `ls -lthr /data`
    - 1.0.1 still in use & works
  - [x] Old cluster STOPPED (1.0.1); upgrade to this PR; `sky start`, `ls -lthr /data`
    - upgraded to 1.3.0 & works

