### PR TITLE
[Minor] Fix mixtral eample for other accelerators

### DIFF
--- a/llm/mixtral/README.md
+++ b/llm/mixtral/README.md
@@ -29,7 +29,7 @@ IP=$(sky status --ip mixtral)
 curl -L http://$IP:8000/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
-      "model": "mistralai/Mistral-7B-v0.1",
+      "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
       "prompt": "My favourite condiment is",
       "max_tokens": 25
   }'

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -14,7 +14,6 @@ service:
     initial_delay_seconds: 1200
   replica_policy:
     min_replicas: 2
-    auto_restart: true
 
 resources: 
   accelerators: {A100:4, A100:8, A100-80GB:2, A100-80GB:4, A100-80GB:8}
@@ -40,5 +39,5 @@ run: |
   python -u -m vllm.entrypoints.openai.api_server \
                 --host 0.0.0.0 \
                 --model mistralai/Mixtral-8x7B-Instruct-v0.1 \
-                --tensor-parallel-size 2 | tee ~/openai_api_server.log
+                --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE | tee ~/openai_api_server.log
 

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -14,7 +14,6 @@ service:
     initial_delay_seconds: 1200
   replica_policy:
     min_replicas: 2
-    auto_restart: true
 
 resources: 
   accelerators: {L4:8, A10g:8, A10:8, A100:4, A100:8, A100-80GB:2, A100-80GB:4, A100-80GB:8}

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -14,9 +14,10 @@ service:
     initial_delay_seconds: 1200
   replica_policy:
     min_replicas: 2
+    auto_restart: true
 
 resources: 
-  accelerators: {A100:4, A100:8, A100-80GB:2, A100-80GB:4, A100-80GB:8}
+  accelerators: {L4:8, A10g:8, A10:8, A100:4, A100:8, A100-80GB:2, A100-80GB:4, A100-80GB:8}
   ports: 8000
   disk_tier: high
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We should change the tensor parallel value for different number of accelerators.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Tested with `A100:4` and `--tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE`
  - [x] Tested with `L4:8` and `--tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
