### PR TITLE
[Provisioner] Fix open ports on Azure

### DIFF
--- a/sky/skylet/providers/azure/config.py
+++ b/sky/skylet/providers/azure/config.py
@@ -3,12 +3,16 @@ import logging
 import random
 from hashlib import sha256
 from pathlib import Path
+import time
 from typing import Any, Callable
 
 from azure.common.credentials import get_cli_profile
 from azure.identity import AzureCliCredential
+from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
+
+from sky.utils import common_utils
 
 UNIQUE_ID_LEN = 4
 
@@ -50,9 +54,8 @@ def _configure_resource_group(config):
     # Increase the timeout to fix the Azure get-access-token (used by ray azure
     # node_provider) timeout issue.
     # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
-    resource_client = ResourceManagementClient(
-        AzureCliCredential(process_timeout=30), subscription_id
-    )
+    credentials = AzureCliCredential(process_timeout=30)
+    resource_client = ResourceManagementClient(credentials, subscription_id)
     config["provider"]["subscription_id"] = subscription_id
     logger.info("Using subscription id: %s", subscription_id)
 
@@ -126,9 +129,21 @@ def _configure_resource_group(config):
         .properties.outputs
     )
 
+    # We should wait for the NSG to be created before opening any ports
+    # to avoid overriding the newly-added NSG rules.
+    nsg_id = outputs["nsg"]["value"]
+    nsg_name = nsg_id.split("/")[-1]
+    network_client = NetworkManagementClient(credentials, subscription_id)
+    backoff = common_utils.Backoff()
+    while True:
+        nsg = network_client.network_security_groups.get(resource_group, nsg_name)
+        if nsg.provisioning_state == "Succeeded":
+            break
+        time.sleep(backoff.current_backoff())
+
     # append output resource ids to be used with vm creation
     config["provider"]["msi"] = outputs["msi"]["value"]
-    config["provider"]["nsg"] = outputs["nsg"]["value"]
+    config["provider"]["nsg"] = nsg_id
     config["provider"]["subnet"] = outputs["subnet"]["value"]
 
     return config


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes the bug when opening ports in Azure sometimes.

The problem is when SkyPilot created the security group, it didn’t wait for the group to be created; Instead, it just returned and continued to open ports. If the open ports (add security rule) are finished earlier than the security group creation (the creation consists of multiple phases), it might get overridden.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky launch --cloud azure --ports 8080 --cpus 2 'python -m http.server 8080' --detach-run` and curl for 40 clusters
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
    - [x] `pytest tests/test_smoke.py::test_skyserve_azure_http`
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
