### PR TITLE
Added functionality in show_gpus to have an option to show all regions' pricing for an accelerator

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3395,7 +3395,8 @@ def check(verbose: bool):
     is_flag=True,
     default=False,
     help=
-    'Show pricing and instance details for a specified accelerator across all regions and clouds.'
+    'Show pricing and instance details for a specified accelerator across '
+    'all regions and clouds.'
 )
 @service_catalog.fallback_to_default_catalog
 @usage_lib.entrypoint
@@ -3440,7 +3441,8 @@ def show_gpus(
     # validation for the --all-regions flag
     if all_regions and accelerator_str is None:
         raise click.UsageError(
-            'The --all-regions flag is only valid when an accelerator is specified.'
+            'The --all-regions flag is only valid when an accelerator ' 
+            'is specified.'
         )
     if all_regions and region is not None:
         raise click.UsageError(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -795,7 +795,8 @@ def _launch_with_confirm(
 
     maybe_status, _ = backend_utils.refresh_cluster_status_handle(cluster)
     if maybe_status is None:
-        # Show the optimize log before the prompt if the cluster does not exist.
+        # Show the optimize log before the prompt if the cluster does not
+        # exist.
         try:
             backend_utils.check_public_cloud_enabled()
         except exceptions.NoCloudAccessError as e:
@@ -3415,7 +3416,7 @@ def show_gpus(
     To show all accelerators, including less common ones and their detailed
     information, use ``sky show-gpus --all``.
 
-    To show all regions for a specified accelerator, use 
+    To show all regions for a specified accelerator, use
     ``sky show-gpus <accelerator> --all-regions``.
 
     Definitions of certain fields:
@@ -4294,7 +4295,8 @@ def serve_up(
                     'will use the port specified as application ingress port.')
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
-            # For the case when the user specified a port range like 10000-10010
+            # For the case when the user specified a port range like
+            # 10000-10010
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Port {service_port_str!r} is not a valid '
                                  'port number. Please specify a single port '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -795,8 +795,7 @@ def _launch_with_confirm(
 
     maybe_status, _ = backend_utils.refresh_cluster_status_handle(cluster)
     if maybe_status is None:
-        # Show the optimize log before the prompt if the cluster does not
-        # exist.
+        # Show the optimize log before the prompt if the cluster does not exist.
         try:
             backend_utils.check_public_cloud_enabled()
         except exceptions.NoCloudAccessError as e:
@@ -3391,10 +3390,13 @@ def check(verbose: bool):
     ('The region to use. If not specified, shows accelerators from all regions.'
     ),
 )
-@click.option('--all-regions',
-              is_flag=True,
-              default=False,
-              help='Shows details for all regions.')
+@click.option(
+    '--all-regions',
+    is_flag=True,
+    default=False,
+    help=
+    'Show pricing and instance details for a specified accelerator across all regions and clouds.'
+)
 @service_catalog.fallback_to_default_catalog
 @usage_lib.entrypoint
 def show_gpus(
@@ -3426,19 +3428,24 @@ def show_gpus(
 
     * ``HOST_MEM``: Memory of the host instance (VM).
 
-    If ``--region`` is not specified, the price displayed for each instance
-    type is the lowest across all regions for both on-demand and spot
-    instances. There may be multiple regions with the same lowest price.
+    If ``--region`` or ``--all-regions`` is not specified, the price displayed 
+    for each instance type is the lowest across all regions for both on-demand 
+    and spotinstances. There may be multiple regions with the same lowest price.
     """
     # validation for the --region flag
     if region is not None and cloud is None:
         raise click.UsageError(
             'The --region flag is only valid when the --cloud flag is set.')
 
-    # validation for the --region flag
+    # validation for the --all-regions flag
     if all_regions and accelerator_str is None:
-        raise click.UsageError('The --all-region flag is only valid when an \
-            accelerator is specified.')
+        raise click.UsageError(
+            'The --all-regions flag is only valid when an accelerator is specified.'
+        )
+    if all_regions and region is not None:
+        raise click.UsageError(
+            'The --all-regions flag is incompatible with the --region flag.')
+
     # This will validate 'cloud' and raise if not found.
     clouds.CLOUD_REGISTRY.from_str(cloud)
     service_catalog.validate_region_zone(region, None, clouds=cloud)
@@ -4294,8 +4301,7 @@ def serve_up(
                     'will use the port specified as application ingress port.')
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
-            # For the case when the user specified a port range like
-            # 10000-10010
+            # For the case when the user specified a port range like 10000-10010
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Port {service_port_str!r} is not a valid '
                                  'port number. Please specify a single port '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3437,8 +3437,7 @@ def show_gpus(
 
     # validation for the --region flag
     if all_regions and accelerator_str is None:
-        raise click.UsageError(
-            'The --all-region flag is only valid when an \
+        raise click.UsageError('The --all-region flag is only valid when an \
             accelerator is specified.')
     # This will validate 'cloud' and raise if not found.
     clouds.CLOUD_REGISTRY.from_str(cloud)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3443,7 +3443,7 @@ def show_gpus(
             'is specified.')
     if all_regions and region is not None:
         raise click.UsageError(
-            'The --all-regions flag is incompatible with the --region flag.')
+            '--all-regions and --region flags cannot be used simultaneously.')
 
     # This will validate 'cloud' and raise if not found.
     clouds.CLOUD_REGISTRY.from_str(cloud)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3429,7 +3429,7 @@ def show_gpus(
 
     If ``--region`` or ``--all-regions`` is not specified, the price displayed
     for each instance type is the lowest across all regions for both on-demand
-    and spotinstances. There may be multiple regions with the same lowest price.
+    and spot instances. There may be multiple regions with the same lowest price.
     """
     # validation for the --region flag
     if region is not None and cloud is None:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3438,8 +3438,8 @@ def show_gpus(
     # validation for the --region flag
     if all_regions and accelerator_str is None:
         raise click.UsageError(
-            'The --all-region flag is only valid when an accelerator is specified.'
-        )
+            'The --all-region flag is only valid when an \
+            accelerator is specified.')
     # This will validate 'cloud' and raise if not found.
     clouds.CLOUD_REGISTRY.from_str(cloud)
     service_catalog.validate_region_zone(region, None, clouds=cloud)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3394,10 +3394,8 @@ def check(verbose: bool):
     '--all-regions',
     is_flag=True,
     default=False,
-    help=
-    'Show pricing and instance details for a specified accelerator across '
-    'all regions and clouds.'
-)
+    help='Show pricing and instance details for a specified accelerator across '
+    'all regions and clouds.')
 @service_catalog.fallback_to_default_catalog
 @usage_lib.entrypoint
 def show_gpus(
@@ -3441,9 +3439,8 @@ def show_gpus(
     # validation for the --all-regions flag
     if all_regions and accelerator_str is None:
         raise click.UsageError(
-            'The --all-regions flag is only valid when an accelerator ' 
-            'is specified.'
-        )
+            'The --all-regions flag is only valid when an accelerator '
+            'is specified.')
     if all_regions and region is not None:
         raise click.UsageError(
             'The --all-regions flag is incompatible with the --region flag.')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3390,13 +3390,18 @@ def check(verbose: bool):
     ('The region to use. If not specified, shows accelerators from all regions.'
     ),
 )
+@click.option('--all-regions',
+              is_flag=True,
+              default=False,
+              help='Shows details for all regions.')
 @service_catalog.fallback_to_default_catalog
 @usage_lib.entrypoint
 def show_gpus(
         accelerator_str: Optional[str],
         all: bool,  # pylint: disable=redefined-builtin
         cloud: Optional[str],
-        region: Optional[str]):
+        region: Optional[str],
+        all_regions: Optional[bool]):
     """Show supported GPU/TPU/accelerators and their prices.
 
     The names and counts shown can be set in the ``accelerators`` field in task
@@ -3409,6 +3414,9 @@ def show_gpus(
 
     To show all accelerators, including less common ones and their detailed
     information, use ``sky show-gpus --all``.
+
+    To show all regions for a specified accelerator, use 
+    ``sky show-gpus <accelerator> --all-regions``.
 
     Definitions of certain fields:
 
@@ -3425,6 +3433,12 @@ def show_gpus(
     if region is not None and cloud is None:
         raise click.UsageError(
             'The --region flag is only valid when the --cloud flag is set.')
+
+    # validation for the --region flag
+    if all_regions and accelerator_str is None:
+        raise click.UsageError(
+            'The --all-region flag is only valid when an accelerator is specified.'
+        )
     # This will validate 'cloud' and raise if not found.
     clouds.CLOUD_REGISTRY.from_str(cloud)
     service_catalog.validate_region_zone(region, None, clouds=cloud)
@@ -3509,7 +3523,8 @@ def show_gpus(
                                                    quantity_filter=quantity,
                                                    region_filter=region,
                                                    clouds=cloud,
-                                                   case_sensitive=False)
+                                                   case_sensitive=False,
+                                                   all_regions=all_regions)
 
         if len(result) == 0:
             if cloud == 'kubernetes':

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3427,8 +3427,8 @@ def show_gpus(
 
     * ``HOST_MEM``: Memory of the host instance (VM).
 
-    If ``--region`` or ``--all-regions`` is not specified, the price displayed 
-    for each instance type is the lowest across all regions for both on-demand 
+    If ``--region`` or ``--all-regions`` is not specified, the price displayed
+    for each instance type is the lowest across all regions for both on-demand
     and spotinstances. There may be multiple regions with the same lowest price.
     """
     # validation for the --region flag

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3429,7 +3429,8 @@ def show_gpus(
 
     If ``--region`` or ``--all-regions`` is not specified, the price displayed
     for each instance type is the lowest across all regions for both on-demand
-    and spot instances. There may be multiple regions with the same lowest price.
+    and spot instances. There may be multiple regions with the same lowest
+    price.
     """
     # validation for the --region flag
     if region is not None and cloud is None:

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -61,6 +61,7 @@ def list_accelerators(
     quantity_filter: Optional[int] = None,
     clouds: CloudFilter = None,
     case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> 'Dict[str, List[common.InstanceTypeInfo]]':
     """List the names of all accelerators offered by Sky.
 
@@ -72,7 +73,7 @@ def list_accelerators(
     """
     results = _map_clouds_catalog(clouds, 'list_accelerators', gpus_only,
                                   name_filter, region_filter, quantity_filter,
-                                  case_sensitive)
+                                  case_sensitive, all_regions)
     if not isinstance(results, list):
         results = [results]
     ret: Dict[str,

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -46,7 +46,7 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
             raise AttributeError(
                 f'Module "{cloud}_catalog" does not '
                 f'implement the "{method_name}" method') from None
-        if cloud == 'kubernetes':
+        if cloud == 'kubernetes' and method_name == 'list_accelerators':
             #remove the last argument (all_regions) for kubernetes
             results.append(method(*args[:-1], **kwargs))
         else:

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -48,7 +48,7 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
                 f'implement the "{method_name}" method') from None
         if cloud == 'kubernetes':
             #remove the last argument (all_regions) for kubernetes
-            results.append(method(*args[:-1]), **kwargs)
+            results.append(method(*args[:-1], **kwargs))
         else:
             results.append(method(*args, **kwargs))
     if single:

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -27,7 +27,6 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
         # kubernetes_catalog.py
         if method_name != 'list_accelerators':
             clouds.remove('kubernetes')
-
     single = isinstance(clouds, str)
     if single:
         clouds = [clouds]  # type: ignore
@@ -47,7 +46,11 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
             raise AttributeError(
                 f'Module "{cloud}_catalog" does not '
                 f'implement the "{method_name}" method') from None
-        results.append(method(*args, **kwargs))
+        if cloud == 'kubernetes':
+            #remove the last argument (all_regions) for kubernetes
+            results.append(method(*args[:-1]), **kwargs)
+        else:
+            results.append(method(*args, **kwargs))
     if single:
         return results[0]
     return results

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -46,11 +46,7 @@ def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
             raise AttributeError(
                 f'Module "{cloud}_catalog" does not '
                 f'implement the "{method_name}" method') from None
-        if cloud == 'kubernetes' and method_name == 'list_accelerators':
-            #remove the last argument (all_regions) for kubernetes
-            results.append(method(*args[:-1], **kwargs))
-        else:
-            results.append(method(*args, **kwargs))
+        results.append(method(*args, **kwargs))
     if single:
         return results[0]
     return results

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -291,12 +291,13 @@ def list_accelerators(
         name_filter: Optional[str],
         region_filter: Optional[str],
         quantity_filter: Optional[int],
-        case_sensitive: bool = True
-) -> Dict[str, List[common.InstanceTypeInfo]]:
+        case_sensitive: bool = True,
+        all_regions: bool = False) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in AWS offering accelerators."""
     return common.list_accelerators_impl('AWS', _get_df(), gpus_only,
                                          name_filter, region_filter,
-                                         quantity_filter, case_sensitive)
+                                         quantity_filter, case_sensitive,
+                                         all_regions)
 
 
 def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -169,8 +169,8 @@ def list_accelerators(
         name_filter: Optional[str],
         region_filter: Optional[str],
         quantity_filter: Optional[int],
-        case_sensitive: bool = True
-) -> Dict[str, List[common.InstanceTypeInfo]]:
+        case_sensitive: bool = True,
+        all_regions: bool = False) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Azure offering GPUs."""
     return common.list_accelerators_impl('Azure', _df, gpus_only, name_filter,
                                          region_filter, quantity_filter,

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -174,4 +174,4 @@ def list_accelerators(
     """Returns all instance types in Azure offering GPUs."""
     return common.list_accelerators_impl('Azure', _df, gpus_only, name_filter,
                                          region_filter, quantity_filter,
-                                         case_sensitive)
+                                         case_sensitive, all_regions)

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -452,6 +452,7 @@ def list_accelerators_impl(
     region_filter: Optional[str],
     quantity_filter: Optional[int],
     case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[InstanceTypeInfo]]:
     """Lists accelerators offered in a cloud service catalog.
 
@@ -500,12 +501,20 @@ def list_accelerators_impl(
     grouped = df.groupby('AcceleratorName')
 
     def make_list_from_df(rows):
-        # Only keep the lowest prices across regions.
-        rows = rows.groupby([
-            'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
-            'MemoryGiB'
-        ],
-                            dropna=False).aggregate('min').reset_index()
+        if all_regions:
+            # Keep all regions.
+            rows = rows.groupby([
+                'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
+                'MemoryGiB', 'Region'
+            ],
+                                dropna=False).aggregate('min').reset_index()
+        else:
+            # Only keep the lowest prices across regions.
+            rows = rows.groupby([
+                'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
+                'MemoryGiB'
+            ],
+                                dropna=False).aggregate('min').reset_index()
         ret = rows.apply(
             lambda row: InstanceTypeInfo(
                 cloud,

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -369,11 +369,12 @@ def list_accelerators(
     region_filter: Optional[str] = None,
     quantity_filter: Optional[int] = None,
     case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in GCP offering GPUs."""
     results = common.list_accelerators_impl('GCP', _df, gpus_only, name_filter,
                                             region_filter, quantity_filter,
-                                            case_sensitive)
+                                            case_sensitive, all_regions)
 
     # Remove GPUs that are unsupported by SkyPilot.
     new_results = {}

--- a/sky/clouds/service_catalog/ibm_catalog.py
+++ b/sky/clouds/service_catalog/ibm_catalog.py
@@ -85,16 +85,17 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def list_accelerators(
-        gpus_only: bool,
-        name_filter: Optional[str],
-        region_filter: Optional[str],
-        quantity_filter: Optional[int],
-        case_sensitive: bool = True
+    gpus_only: bool,
+    name_filter: Optional[str],
+    region_filter: Optional[str],
+    quantity_filter: Optional[int],
+    case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in IBM offering accelerators."""
     return common.list_accelerators_impl('IBM', _df, gpus_only, name_filter,
                                          region_filter, quantity_filter,
-                                         case_sensitive)
+                                         case_sensitive, all_regions)
 
 
 def get_default_instance_type(cpus: Optional[str] = None,

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -34,13 +34,15 @@ def is_image_tag_valid(tag: str, region: Optional[str]) -> bool:
 
 
 def list_accelerators(
-        gpus_only: bool,
-        name_filter: Optional[str],
-        region_filter: Optional[str],
-        quantity_filter: Optional[int],
-        case_sensitive: bool = True
+    gpus_only: bool,
+    name_filter: Optional[str],
+    region_filter: Optional[str],
+    quantity_filter: Optional[int],
+    case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     k8s_cloud = Kubernetes()
+    del all_regions  # unused
     if not any(
             map(k8s_cloud.is_same_cloud, global_user_state.get_enabled_clouds())
     ) or not kubernetes_utils.check_credentials()[0]:

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -34,11 +34,12 @@ def is_image_tag_valid(tag: str, region: Optional[str]) -> bool:
 
 
 def list_accelerators(
-        gpus_only: bool,
-        name_filter: Optional[str],
-        region_filter: Optional[str],
-        quantity_filter: Optional[int],
-        case_sensitive: bool = True
+    gpus_only: bool,
+    name_filter: Optional[str],
+    region_filter: Optional[str],
+    quantity_filter: Optional[int],
+    case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     k8s_cloud = Kubernetes()
     if not any(

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -34,12 +34,11 @@ def is_image_tag_valid(tag: str, region: Optional[str]) -> bool:
 
 
 def list_accelerators(
-    gpus_only: bool,
-    name_filter: Optional[str],
-    region_filter: Optional[str],
-    quantity_filter: Optional[int],
-    case_sensitive: bool = True,
-    all_regions: bool = False,
+        gpus_only: bool,
+        name_filter: Optional[str],
+        region_filter: Optional[str],
+        quantity_filter: Optional[int],
+        case_sensitive: bool = True
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     k8s_cloud = Kubernetes()
     if not any(

--- a/sky/clouds/service_catalog/lambda_catalog.py
+++ b/sky/clouds/service_catalog/lambda_catalog.py
@@ -126,13 +126,14 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def list_accelerators(
-        gpus_only: bool,
-        name_filter: Optional[str],
-        region_filter: Optional[str],
-        quantity_filter: Optional[int],
-        case_sensitive: bool = True
+    gpus_only: bool,
+    name_filter: Optional[str],
+    region_filter: Optional[str],
+    quantity_filter: Optional[int],
+    case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in Lambda offering GPUs."""
     return common.list_accelerators_impl('Lambda', _df, gpus_only, name_filter,
                                          region_filter, quantity_filter,
-                                         case_sensitive)
+                                         case_sensitive, all_regions)

--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -167,16 +167,18 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def list_accelerators(
-        gpus_only: bool,
-        name_filter: Optional[str],
-        region_filter: Optional[str],
-        quantity_filter: Optional[int],
-        case_sensitive: bool = True
+    gpus_only: bool,
+    name_filter: Optional[str],
+    region_filter: Optional[str],
+    quantity_filter: Optional[int],
+    case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in OCI offering GPUs."""
     return common.list_accelerators_impl('OCI', _get_df(), gpus_only,
                                          name_filter, region_filter,
-                                         quantity_filter, case_sensitive)
+                                         quantity_filter, case_sensitive,
+                                         all_regions)
 
 
 def get_vcpus_mem_from_instance_type(

--- a/sky/clouds/service_catalog/scp_catalog.py
+++ b/sky/clouds/service_catalog/scp_catalog.py
@@ -127,11 +127,12 @@ def list_accelerators(
     region_filter: Optional[str],
     quantity_filter: Optional[int],
     case_sensitive: bool = True,
+    all_regions: bool = False,
 ) -> Dict[str, List[common.InstanceTypeInfo]]:
     """Returns all instance types in SCP offering GPUs."""
     return common.list_accelerators_impl('scp', _df, gpus_only, name_filter,
                                          region_filter, quantity_filter,
-                                         case_sensitive)
+                                         case_sensitive, all_regions)
 
 
 def get_image_id_from_tag(tag: str, region: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This solves #2863 

show_gpus can now accept a new flag `--all-regions`, which displays all the regions for a given accelerator. It can be used as follows. 

`sky show-gpus <acclerator> --all-regions`

Additionally it can take a cloud argument as well. 

`sky show-gpus <acclerator> --cloud <cloud> --all-regions`

<!-- Describe the tests ran -->
I compared the outputs against the catalog. 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Checking all regions exist. 
