### PR TITLE
[Core] Unsupported features should fail with non-zero exit code #2775

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ sky/clouds/service_catalog/data_fetchers/*.csv
 .vscode/
 .idea/
 
+.venv/


### PR DESCRIPTION
Added non-zero exitcode on error for the `start`, `stop`, `autostop` and `down` commands. The logic for `stop`, `autostop` and `down`  with several clusters is like this: if any cluster fails, wait until the process finished for the other clusters, then return exit code 1. When running `down --purge`, exitcode 0 is always returned.

Tested (run the relevant ones):

- [v] Code formatting: `bash format.sh`
- [v] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

Manually tested `start`, `down` and `stop` with several clusters (local docker and kubernetes).