### PR TITLE
Allow --disk-tier to be None to remove the disk_tier setup in yaml

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -235,11 +235,12 @@ def _interactive_node_cli_command(cli_func):
                              help=('OS disk size in GBs.'))
     disk_tier = click.option('--disk-tier',
                              default=None,
-                             type=click.Choice(['low', 'medium', 'high'],
+                             type=click.Choice(['low', 'medium', 'high', 'none'],
                                                case_sensitive=False),
                              required=False,
-                             help=('OS disk tier. Could be one of "low", '
-                                   '"medium", "high". Default: medium'))
+    help=(
+        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
+    ))
     ports = click.option(
         '--ports',
         required=False,
@@ -697,7 +698,10 @@ def _parse_override_params(
     if disk_size is not None:
         override_params['disk_size'] = disk_size
     if disk_tier is not None:
-        override_params['disk_tier'] = disk_tier
+        if disk_tier.lower() == 'none':
+            override_params['disk_tier'] = None
+        else:
+            override_params['disk_tier'] = disk_tier
     if ports:
         override_params['ports'] = ports
     return override_params
@@ -1303,10 +1307,10 @@ def cli():
 @click.option(
     '--disk-tier',
     default=None,
-    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
+    type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
     help=(
-        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
     ))
 @click.option(
     '--idle-minutes-to-autostop',
@@ -3797,10 +3801,10 @@ def spot():
 @click.option(
     '--disk-tier',
     default=None,
-    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
+    type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
     help=(
-        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
     ))
 @click.option(
     '--detach-run',
@@ -4651,10 +4655,10 @@ def _get_candidate_configs(yaml_path: str) -> Optional[List[Dict[str, str]]]:
 @click.option(
     '--disk-tier',
     default=None,
-    type=click.Choice(['low', 'medium', 'high'], case_sensitive=False),
+    type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
     help=(
-        'OS disk tier. Could be one of "low", "medium", "high". Default: medium'
+        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
     ))
 @click.option(
     '--idle-minutes-to-autostop',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -233,14 +233,14 @@ def _interactive_node_cli_command(cli_func):
                              type=int,
                              required=False,
                              help=('OS disk size in GBs.'))
-    disk_tier = click.option('--disk-tier',
-                             default=None,
-                             type=click.Choice(['low', 'medium', 'high', 'none'],
-                                               case_sensitive=False),
-                             required=False,
-    help=(
-        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
-    ))
+    disk_tier = click.option(
+        '--disk-tier',
+        default=None,
+        type=click.Choice(['low', 'medium', 'high', 'none'],
+                          case_sensitive=False),
+        required=False,
+        help=('OS disk tier. Could be one of "low", "medium", "high" or "none" '
+              '("none" for using the default value). Default: medium'))
     ports = click.option(
         '--ports',
         required=False,
@@ -1309,9 +1309,8 @@ def cli():
     default=None,
     type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
-    help=(
-        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
-    ))
+    help=('OS disk tier. Could be one of "low", "medium", "high" or "none" '
+          '("none" for using the default value). Default: medium'))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',
@@ -3803,9 +3802,8 @@ def spot():
     default=None,
     type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
-    help=(
-        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
-    ))
+    help=('OS disk tier. Could be one of "low", "medium", "high" or "none" '
+          '("none" for using the default value). Default: medium'))
 @click.option(
     '--detach-run',
     '-d',
@@ -4657,9 +4655,8 @@ def _get_candidate_configs(yaml_path: str) -> Optional[List[Dict[str, str]]]:
     default=None,
     type=click.Choice(['low', 'medium', 'high', 'none'], case_sensitive=False),
     required=False,
-    help=(
-        'OS disk tier. Could be one of "low", "medium", "high" or "none" ("none" for using the default value). Default: medium'
-    ))
+    help=('OS disk tier. Could be one of "low", "medium", "high" or "none" '
+          '("none" for using the default value). Default: medium'))
 @click.option(
     '--idle-minutes-to-autostop',
     '-i',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to enable `sky launch --disk-tier none -c test-mixtral --cloud azure llm/mixtral/serve.yaml`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
