### PR TITLE
[Setup] Not skipping `conda init`

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -76,7 +76,7 @@ CONDA_INSTALLATION_COMMANDS = (
     'bash Miniconda3-Linux-x86_64.sh -b && '
     'eval "$(~/miniconda3/bin/conda shell.bash hook)" && '
     'conda config --set auto_activate_base true); '
-    'grep "# >>> conda initialize >>>" ~/.bashrc || conda init > /dev/null;')
+    'grep "# >>> conda initialize >>>" ~/.bashrc || conda init;')
 
 # The name for the environment variable that stores SkyPilot user hash, which
 # is mainly used to make sure sky commands runs on a VM launched by SkyPilot

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -74,12 +74,9 @@ CONDA_INSTALLATION_COMMANDS = (
     'which conda > /dev/null 2>&1 || '
     '(wget -nc https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O Miniconda3-Linux-x86_64.sh && '  # pylint: disable=line-too-long
     'bash Miniconda3-Linux-x86_64.sh -b && '
-    'eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && '
+    'eval "$(~/miniconda3/bin/conda shell.bash hook)" && '
     'conda config --set auto_activate_base true); '
-    # Only run `conda init` if the conda is not installed under /opt/conda,
-    # which is the case for VMs created on GCP, and running `conda init` will
-    # cause error and waiting for the error to be reported: #2273.
-    'which conda | grep /opt/conda || conda init > /dev/null;')
+    'grep "# >>> conda initialize >>>" ~/.bashrc || conda init > /dev/null;')
 
 # The name for the environment variable that stores SkyPilot user hash, which
 # is mainly used to make sure sky commands runs on a VM launched by SkyPilot


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2908 

This reverts changes in #2277, due to the update of GCP image has resolved the `conda init` issue in #2273

(Confirmed that the problem exists with the older image we used: `sky launch -c test-old-image --cloud gcp --image-id skypilot:cpu-debian-10 'conda activate'`. Though it takes longer to launch for older image, but it is not critical for user job.)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-aws-conda-init --cloud aws --cpus 2 'conda create -n test -y python=3.8; conda activate test; python --version'`; `ssh test-aws-conda-init`; `conda activate; python --version'` (check provision.log that there is no error)
  - [x] `sky launch -c test-gcp-conda-init --cloud gcp --cpus 2 'conda create -n test -y python=3.8; conda activate test; python --version'`; `ssh test-gcp-conda-init`; `conda activate; python --version'` (check provision.log that there is no error)
  - [x] `sky launch -c test-azure-conda-init --cloud gcp --cpus 2 'conda create -n test -y python=3.8; conda activate test; python --version'`; `ssh test-azure-conda-init`; `conda activate; python --version'` (check provision.log that there is no error)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
