### PR TITLE
[Setup] Fix conda init

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -74,7 +74,7 @@ CONDA_INSTALLATION_COMMANDS = (
     'which conda > /dev/null 2>&1 || '
     '(wget -nc https://repo.anaconda.com/miniconda/Miniconda3-py310_23.5.2-0-Linux-x86_64.sh -O Miniconda3-Linux-x86_64.sh && '  # pylint: disable=line-too-long
     'bash Miniconda3-Linux-x86_64.sh -b && '
-    'eval "$(~/miniconda3/bin/conda shell.bash hook)" && '
+    'eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && '
     'conda config --set auto_activate_base true); '
     'grep "# >>> conda initialize >>>" ~/.bashrc || conda init;')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Revert part of the changes in #2909, as `conda init` requires conda to appear in the path.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-tpuvm test.yaml`
  ```
  resources: 
    accelerators: tpu-v2-8
    accelerator_args:
      tpu_vm: True
  
  run: |
    echo "Hello World"
  ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
