### PR TITLE
[k8s] Surface docker permission error for `sky local up`

### DIFF
--- a/sky/utils/kubernetes/create_cluster.sh
+++ b/sky/utils/kubernetes/create_cluster.sh
@@ -8,9 +8,20 @@ set -e
 PORT_RANGE_START=30000
 PORT_RANGE_END=30100
 
-# Check if docker is running
-if ! docker info > /dev/null 2>&1; then
-    >&2 echo "Docker is not running. Please start Docker and try again."
+# Temporarily disable 'exit on error' to capture docker info output
+set +e
+docker_output=$(docker info 2>&1)
+exit_status=$?
+set -e
+
+# Check if docker info command was successful
+if [ $exit_status -ne 0 ]; then
+    # Check for 'permission denied' in docker output
+    if echo "$docker_output" | grep -q "permission denied"; then
+        >&2 echo "Permission denied while trying to connect to the Docker daemon socket. Please ensure your user is added to the docker group or has appropriate permissions."
+    else
+        >&2 echo "Docker is not running. Please start Docker and try again."
+    fi
     exit 1
 fi
 

--- a/sky/utils/kubernetes/create_cluster.sh
+++ b/sky/utils/kubernetes/create_cluster.sh
@@ -18,7 +18,7 @@ set -e
 if [ $exit_status -ne 0 ]; then
     # Check for 'permission denied' in docker output
     if echo "$docker_output" | grep -q "permission denied"; then
-        >&2 echo "Permission denied while trying to connect to the Docker daemon socket. Please ensure your user is added to the docker group or has appropriate permissions."
+        >&2 echo "Permission denied while trying to connect to the Docker daemon socket. Make sure your user is added to the docker group or has appropriate permissions. Instructions: https://docs.docker.com/engine/install/linux-postinstall/"
     else
         >&2 echo "Docker is not running. Please start Docker and try again."
     fi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #2592. 

This pull request updates create_cluster.sh to enhance the handling of Docker permission errors. The revised script captures the output and error messages from `docker info`. It identifies and distinguishes between 'permission denied' errors and scenarios where Docker is not running, and alerts the user with an error message accordingly. 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Created test user without docker permission (not in docker group) and verified that a permission error was reported instead of the standard "Docker is not running" error.
- [x] Added test user to docker group and ran `sky local up` to ensure that permission error/docker error did not prevail after docker permissions were granted.
