### PR TITLE
[Core/AWS] Skip association with no subnetId and fix autodown for spot instances

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -218,7 +218,7 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
         rt for rt in all_route_tables
         # An RT can be associated with multiple subnets, i.e.,
         # rt['Associations'] is a list of associations.
-        # There may be no subnet associated in a association, we skip it.s
+        # There may be no subnet associated in an association.
         if any(
             assoc.get('SubnetId', '') == subnet_id
             for assoc in rt['Associations'])

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -218,7 +218,10 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
         rt for rt in all_route_tables
         # An RT can be associated with multiple subnets, i.e.,
         # rt['Associations'] is a list of associations.
-        if any(assoc['SubnetId'] == subnet_id for assoc in rt['Associations'])
+        # There may be no subnet associated in a association, we skip it.s
+        if any(
+            assoc.get('SubnetId', '') == subnet_id
+            for assoc in rt['Associations'])
     ]
 
     # Check each route table for an internet gateway route


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2920.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud aws --region us-west-2 -c test-west --cpus 2 echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
