### PR TITLE
[SkyServe] Fix replica log not found when replica cluster not found

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -542,11 +542,6 @@ def stream_replica_logs(service_name: str,
 
     replica_cluster_name = generate_replica_cluster_name(
         service_name, replica_id)
-    handle = global_user_state.get_handle_from_cluster_name(
-        replica_cluster_name)
-    if handle is None:
-        return _FAILED_TO_FIND_REPLICA_MSG.format(replica_id=replica_id)
-    assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
 
     launch_log_file_name = generate_replica_launch_log_file_name(
         service_name, replica_id)
@@ -580,6 +575,11 @@ def stream_replica_logs(service_name: str,
           f'of replica {replica_id}...{colorama.Style.RESET_ALL}')
 
     backend = backends.CloudVmRayBackend()
+    handle = global_user_state.get_handle_from_cluster_name(
+        replica_cluster_name)
+    if handle is None:
+        return _FAILED_TO_FIND_REPLICA_MSG.format(replica_id=replica_id)
+    assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
     # Always tail the latest logs, which represent user setup & run.
     returncode = backend.tail_logs(handle, job_id=None, follow=follow)
     if returncode != 0:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previous SkyServe has a bug: when the replica cluster is not created yet, `sky serve logs` cannot correctly show the replica launch log. This PR fixes the problem.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky serve up` a cluster w/ OnDemand A100 and run `sky serve logs <service-name> 1`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
