### PR TITLE
Minor update to sort by price in show-gpus

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -530,9 +530,8 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count, info.
-                                   price, info.spot_price
-                                   if info.cpu_count is not None else 0))
+        ret.sort(key=lambda info:
+                 (info.accelerator_count, info.price, info.spot_price))
         return ret
 
     return {k: make_list_from_df(v) for k, v in grouped}

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -501,23 +501,17 @@ def list_accelerators_impl(
     grouped = df.groupby('AcceleratorName')
 
     def make_list_from_df(rows):
+        
+        sort_key = ['Price', 'SpotPrice']
+        subset = ['InstanceType', 'AcceleratorName', 'AcceleratorCount',
+                        'vCPUs', 'MemoryGiB']
         if all_regions:
-            # Keep all regions.
-            rows = rows.sort_values(
-                by=['Price', 'SpotPrice', 'Region']).drop_duplicates(
-                    subset=[
-                        'InstanceType', 'AcceleratorName', 'AcceleratorCount',
-                        'vCPUs', 'MemoryGiB', 'Region'
-                    ],
+            sort_key.append('Region')
+            subset.append('Region')
+
+        rows = rows.sort_values(by=sort_key).drop_duplicates(
+                    subset=subset,
                     keep='first')
-        else:
-            # Only keep the lowest prices across regions.
-            rows = rows.sort_values(by=['Price', 'SpotPrice']).drop_duplicates(
-                subset=[
-                    'InstanceType', 'AcceleratorName', 'AcceleratorCount',
-                    'vCPUs', 'MemoryGiB'
-                ],
-                keep='first')
         ret = rows.apply(
             lambda row: InstanceTypeInfo(
                 cloud,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -501,17 +501,18 @@ def list_accelerators_impl(
     grouped = df.groupby('AcceleratorName')
 
     def make_list_from_df(rows):
-        
+
         sort_key = ['Price', 'SpotPrice']
-        subset = ['InstanceType', 'AcceleratorName', 'AcceleratorCount',
-                        'vCPUs', 'MemoryGiB']
+        subset = [
+            'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs',
+            'MemoryGiB'
+        ]
         if all_regions:
             sort_key.append('Region')
             subset.append('Region')
 
-        rows = rows.sort_values(by=sort_key).drop_duplicates(
-                    subset=subset,
-                    keep='first')
+        rows = rows.sort_values(by=sort_key).drop_duplicates(subset=subset,
+                                                             keep='first')
         ret = rows.apply(
             lambda row: InstanceTypeInfo(
                 cloud,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -530,8 +530,8 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        ret.sort(key=lambda info:
-                 (info.accelerator_count, info.price, info.spot_price))
+        ret.sort(key=lambda info: (info.accelerator_count, info.price, info.
+                                   spot_price, info.region))
         return ret
 
     return {k: make_list_from_df(v) for k, v in grouped}

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -530,8 +530,9 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        ret.sort(key=lambda info: (info.accelerator_count, info.price, info.
-                                   spot_price, info.region))
+        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count
+                                   if not pd.isna(info.cpu_count) else 0, info.
+                                   price, info.spot_price, info.region))
         return ret
 
     return {k: make_list_from_df(v) for k, v in grouped}

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -530,7 +530,8 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count
+        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count,
+                                   info.price, info.spot_price
                                    if info.cpu_count is not None else 0))
         return ret
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -530,8 +530,8 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count,
-                                   info.price, info.spot_price
+        ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count, info.
+                                   price, info.spot_price
                                    if info.cpu_count is not None else 0))
         return ret
 

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -533,16 +533,11 @@ def list_accelerators_impl(
             ),
             axis='columns',
         ).tolist()
-        if all_regions:
-            # Sort by price and region as well.
-            ret.sort(
-                key=lambda info: (info.accelerator_count, info.cpu_count
-                                  if not pd.isna(info.cpu_count) else 0, info.
-                                  price, info.spot_price, info.region))
-        else:
-            #Sort only by accelerator count and cpu count
-            ret.sort(key=lambda info: (info.accelerator_count, info.cpu_count
-                                       if not pd.isna(info.cpu_count) else 0))
+        # Sort by price and region as well.
+        ret.sort(
+            key=lambda info: (info.accelerator_count, info.instance_type, info.
+                              cpu_count if not pd.isna(info.cpu_count) else 0,
+                              info.price, info.spot_price, info.region))
         return ret
 
     return {k: make_list_from_df(v) for k, v in grouped}


### PR DESCRIPTION
This pertains to https://github.com/skypilot-org/skypilot/issues/2863, and updates previous PR https://github.com/skypilot-org/skypilot/pull/2892

Minor update to fix the sorting issue mentioned by @concretevitamin  https://github.com/skypilot-org/skypilot/pull/2892#issuecomment-1872572086
```
sky show-gpus V100 --all-regions                                                                                             ─╯
*NOTE*: for most GCP accelerators, INSTANCE_TYPE == (attachable) means the host VM's cost is not included.

GPU   QTY  CLOUD   INSTANCE_TYPE       DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.060       $ 1.024            us-west-2
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.060       $ 1.139            us-east-2
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.060       $ 1.467            us-east-1
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.305       $ 1.229            eu-west-1
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.366       $ 0.726            ca-central-1
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.589       $ 0.687            eu-west-2
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.823       $ 0.971            eu-central-1
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 4.194       $ 1.043            ap-northeast-1
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 4.234       $ 0.469            ap-northeast-2
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 4.234       $ 1.209            ap-southeast-2
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 4.234       $ 1.255            ap-southeast-1
V100  4    AWS     p3.8xlarge          16GB        32     244GB     $ 12.240      $ 3.544            us-west-2
V100  4    AWS     p3.8xlarge          16GB        32     244GB     $ 12.240      $ 4.008            us-east-2
V100  4    AWS     p3.8xlarge          16GB        32     244GB     $ 12.240      $ 4.221            us-east-1
V100  4    AWS     p3.8xlarge          16GB        32     244GB     $ 13.220      $ 4.781            eu-west-1
```