### PR TITLE
[SkyServe] Support `min_replicas = 0`

### DIFF
--- a/examples/serve/min_replicas_zero.yaml
+++ b/examples/serve/min_replicas_zero.yaml
@@ -1,5 +1,9 @@
 # SkyServe YAML to test min_replicas=0 with a simple http server.
-#
+# The service will be initialized with no replica (min_replicas = 0).
+# Any traffic to the service will trigger an immediate scale-up.
+# The service will be scaled down to 0 replica when there is no traffic
+# for a long time. 
+# 
 # Usage:
 #   sky serve up -n min_replicas examples/serve/min_replicas_zero.yaml
 # The endpoint will be printed in the console.

--- a/examples/serve/min_replicas_zero.yaml
+++ b/examples/serve/min_replicas_zero.yaml
@@ -1,0 +1,24 @@
+# SkyServe YAML to run a simple http server.
+#
+# Usage:
+#   sky serve up -n http examples/serve/http_server/task.yaml
+# The endpoint will be printed in the console. You
+# could also check the endpoint by running:
+#   sky serve status --endpoint http
+
+service:
+  readiness_probe:
+    path: /health
+    initial_delay_seconds: 20
+  replica_policy:
+    min_replicas: 0
+    max_replicas: 2
+    target_qps_per_replica: 1
+
+resources:
+  ports: 8081
+  cpus: 2+
+
+workdir: examples/serve/http_server
+
+run: python3 server.py

--- a/examples/serve/min_replicas_zero.yaml
+++ b/examples/serve/min_replicas_zero.yaml
@@ -1,10 +1,9 @@
-# SkyServe YAML to run a simple http server.
+# SkyServe YAML to test min_replicas=0 with a simple http server.
 #
 # Usage:
-#   sky serve up -n http examples/serve/http_server/task.yaml
-# The endpoint will be printed in the console. You
-# could also check the endpoint by running:
-#   sky serve status --endpoint http
+#   sky serve up -n min_replicas examples/serve/min_replicas_zero.yaml
+# The endpoint will be printed in the console.
+# Querying the endpoint will trigger a scale up.
 
 service:
   readiness_probe:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4387,7 +4387,7 @@ def serve_status(all: bool, endpoint: bool, service_names: List[str]):
       please login to the cloud console and double-check
 
     - ``NO_REPLICAS``: The service has no replicas. This usually happens when
-        min_replicas is set to 0.
+        min_replicas is set to 0 and there is no traffic to the system.
 
     Each replica can have one of the following statuses:
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4386,6 +4386,9 @@ def serve_status(all: bool, endpoint: bool, service_names: List[str]):
       down. This usually indicates resource leakages. If you see such status,
       please login to the cloud console and double-check
 
+    - ``NO_REPLICAS``: The service has no replicas. This usually happens when
+        min_replicas is set to 0.
+
     Each replica can have one of the following statuses:
 
     - ``PENDING``: The maximum number of simultaneous launches has been reached

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -154,7 +154,7 @@ class RequestRateAutoscaler(Autoscaler):
         logger.info(f'Requests per second: {num_requests_per_second}, '
                     f'Current target number of replicas: {target_num_replicas}')
 
-        if (not self.bootstrap_done or self.target_num_replicas == 0):
+        if not self.bootstrap_done or self.target_num_replicas == 0:
             self.bootstrap_done = True
             return target_num_replicas
         elif target_num_replicas > self.target_num_replicas:

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -173,6 +173,14 @@ class RequestRateAutoscaler(Autoscaler):
             self.upscale_counter = self.downscale_counter = 0
         return self.target_num_replicas
 
+    def return_autoscaler_decision_interval(self) -> int:
+        # Reduce autoscaler interval when target_num_replicas = 0.
+        # This will happen when min_replicas = 0 and no traffic.
+        if self.target_num_replicas == 0:
+            return constants.AUTOSCALER_NO_REPLICA_DECISION_INTERVAL_SECONDS
+        else:
+            return constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS
+
     def evaluate_scaling(
         self,
         replica_infos: List['replica_managers.ReplicaInfo'],

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -154,7 +154,7 @@ class RequestRateAutoscaler(Autoscaler):
         logger.info(f'Requests per second: {num_requests_per_second}, '
                     f'Current target number of replicas: {target_num_replicas}')
 
-        if not self.bootstrap_done:
+        if (not self.bootstrap_done or self.target_num_replicas == 0):
             self.bootstrap_done = True
             return target_num_replicas
         elif target_num_replicas > self.target_num_replicas:

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -173,7 +173,7 @@ class RequestRateAutoscaler(Autoscaler):
             self.upscale_counter = self.downscale_counter = 0
         return self.target_num_replicas
 
-    def return_autoscaler_decision_interval(self) -> int:
+    def get_decision_interval(self) -> int:
         # Reduce autoscaler interval when target_num_replicas = 0.
         # This will happen when min_replicas = 0 and no traffic.
         if self.target_num_replicas == 0:

--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -36,6 +36,8 @@ AUTOSCALER_QPS_WINDOW_SIZE_SECONDS = 60
 # Autoscaler scale decision interval in seconds.
 # We will try to scale up/down every `decision_interval`.
 AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS = 20
+# Autoscaler no replica decision interval in seconds.
+AUTOSCALER_NO_REPLICA_DECISION_INTERVAL_SECONDS = 5
 # Autoscaler default upscale delays in seconds.
 # We will upscale only if the target number of instances
 # is larger than the current launched instances for delay amount of time.

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -88,6 +88,8 @@ class SkyServeController:
                              f'{common_utils.format_exception(e)}')
                 with ux_utils.enable_traceback():
                     logger.error(f'  Traceback: {traceback.format_exc()}')
+            # Reduce autoscaler interval when target_num_replicas = 0.
+            # This will happen when min_replicas = 0 and no traffic.
             if self._autoscaler.target_num_replicas == 0:
                 time.sleep(
                     constants.AUTOSCALER_NO_REPLICA_DECISION_INTERVAL_SECONDS)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -88,7 +88,12 @@ class SkyServeController:
                              f'{common_utils.format_exception(e)}')
                 with ux_utils.enable_traceback():
                     logger.error(f'  Traceback: {traceback.format_exc()}')
-            time.sleep(constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS)
+            if self._autoscaler.target_num_replicas == 0:
+                time.sleep(
+                    constants.AUTOSCALER_NO_REPLICA_DECISION_INTERVAL_SECONDS)
+            else:
+                time.sleep(
+                    constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS)
 
     def run(self) -> None:
 

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -88,7 +88,7 @@ class SkyServeController:
                              f'{common_utils.format_exception(e)}')
                 with ux_utils.enable_traceback():
                     logger.error(f'  Traceback: {traceback.format_exc()}')
-            time.sleep(self._autoscaler.return_autoscaler_decision_interval())
+            time.sleep(self._autoscaler.get_decision_interval())
 
     def run(self) -> None:
 

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -88,14 +88,7 @@ class SkyServeController:
                              f'{common_utils.format_exception(e)}')
                 with ux_utils.enable_traceback():
                     logger.error(f'  Traceback: {traceback.format_exc()}')
-            # Reduce autoscaler interval when target_num_replicas = 0.
-            # This will happen when min_replicas = 0 and no traffic.
-            if self._autoscaler.target_num_replicas == 0:
-                time.sleep(
-                    constants.AUTOSCALER_NO_REPLICA_DECISION_INTERVAL_SECONDS)
-            else:
-                time.sleep(
-                    constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS)
+            time.sleep(self._autoscaler.return_autoscaler_decision_interval())
 
     def run(self) -> None:
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -179,9 +179,7 @@ class ServiceStatus(enum.Enum):
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
         # When min_replicas = 0, there is no (provisioning) replica.
-        if (len(replica_statuses) == sum(
-            [status2num[status] for status in ReplicaStatus.failed_statuses()
-            ])):
+        if len(replica_statuses) == 0:
             return cls.NO_REPLICA
         return cls.REPLICA_INIT
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -178,7 +178,8 @@ class ServiceStatus(enum.Enum):
         if sum(status2num[status]
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
-        if len(replica_statuses) == 0:
+        if (len(replica_statuses) - status2num[ReplicaStatus.FAILED] -
+                status2num[ReplicaStatus.FAILED_CLEANUP] == 0):
             return cls.NO_REPLICA
         return cls.REPLICA_INIT
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -178,6 +178,7 @@ class ServiceStatus(enum.Enum):
         if sum(status2num[status]
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
+        # When min_replicas = 0, there is no (provisioning) replica.
         if (len(replica_statuses) - status2num[ReplicaStatus.FAILED] -
                 status2num[ReplicaStatus.FAILED_CLEANUP] == 0):
             return cls.NO_REPLICA

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -179,9 +179,9 @@ class ServiceStatus(enum.Enum):
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
         # When min_replicas = 0, there is no (provisioning) replica.
-        if (len(replica_statuses) - sum(
+        if (len(replica_statuses) == sum(
             [status2num[status] for status in ReplicaStatus.failed_statuses()
-            ]) == 0):
+            ])):
             return cls.NO_REPLICA
         return cls.REPLICA_INIT
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -179,8 +179,9 @@ class ServiceStatus(enum.Enum):
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
         # When min_replicas = 0, there is no (provisioning) replica.
-        if (len(replica_statuses) - status2num[ReplicaStatus.FAILED] -
-                status2num[ReplicaStatus.FAILED_CLEANUP] == 0):
+        if (len(replica_statuses) - sum(
+            [status2num[status] for status in ReplicaStatus.failed_statuses()
+            ]) == 0):
             return cls.NO_REPLICA
         return cls.REPLICA_INIT
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -153,6 +153,9 @@ class ServiceStatus(enum.Enum):
     # Clean up failed
     FAILED_CLEANUP = 'FAILED_CLEANUP'
 
+    # No replica
+    NO_REPLICA = 'NO_REPLICA'
+
     @classmethod
     def failed_statuses(cls) -> List['ServiceStatus']:
         return [cls.CONTROLLER_FAILED, cls.FAILED_CLEANUP]
@@ -175,6 +178,8 @@ class ServiceStatus(enum.Enum):
         if sum(status2num[status]
                for status in ReplicaStatus.failed_statuses()) > 0:
             return cls.FAILED
+        if len(replica_statuses) == 0:
+            return cls.NO_REPLICA
         return cls.REPLICA_INIT
 
 
@@ -186,6 +191,7 @@ _SERVICE_STATUS_TO_COLOR = {
     ServiceStatus.SHUTTING_DOWN: colorama.Fore.YELLOW,
     ServiceStatus.FAILED: colorama.Fore.RED,
     ServiceStatus.FAILED_CLEANUP: colorama.Fore.RED,
+    ServiceStatus.NO_REPLICA: colorama.Fore.MAGENTA,
 }
 
 

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -33,9 +33,9 @@ class SkyServiceSpec:
         qps_upper_threshold: Optional[float] = None,
         qps_lower_threshold: Optional[float] = None,
     ) -> None:
-        if min_replicas <= 0:
+        if min_replicas < 0:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError('min_replicas must be greater than 0')
+                raise ValueError('min_replicas must be greater or equal to 0')
         if max_replicas is not None and max_replicas < min_replicas:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Related issue: https://github.com/skypilot-org/skypilot/issues/2893
Add a new status `NO_REPLICAS`.
Lower autoscaler decision interval when `target_num_replicas = 0`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky serve up examples/serve/min_replicas_zero.yaml`
