### PR TITLE
[SkyServe] Minor hint wording change.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4359,7 +4359,7 @@ def serve_status(all: bool, endpoint: bool, service_names: List[str]):
     - ``CONTROLLER_INIT``: The controller is initializing.
 
     - ``REPLICA_INIT``: The controller has finished initializing, and there are
-      no available replicas for now. This also indicates that no replica failure
+      no ready replicas for now. This also indicates that no replica failure
       has been detected.
 
     - ``CONTROLLER_FAILED``: The controller failed to start or is in an abnormal

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -83,7 +83,7 @@ class SkyServeLoadBalancer:
 
         if ready_replica_url is None:
             raise fastapi.HTTPException(status_code=503,
-                                        detail='No available replicas. '
+                                        detail='No ready replicas. '
                                         'Use "sky serve status [SERVICE_NAME]" '
                                         'to check the replica status.')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I was curling a service with starting/provisioning replicas and got this message. "available replicas" in this case may be more misleading than "ready replicas".


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
