### PR TITLE
[Core] Fix aws dependency check

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -478,8 +478,9 @@ class AWS(clouds.Cloud):
             return False, dependency_installation_hints
         try:
             # Checks if aws boto is installed properly
-            import boto3 as _boto3
-            import botocore as _botocore
+            # pylint: disable=import-outside-toplevel
+            import boto3
+            import botocore
         except ImportError:
             return False, dependency_installation_hints
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -478,7 +478,7 @@ class AWS(clouds.Cloud):
             return False, dependency_installation_hints
         try:
             # Checks if aws boto is installed properly
-            # pylint: disable=import-outside-toplevel
+            # pylint: disable=import-outside-toplevel, unused-import
             import boto3
             import botocore
         except ImportError:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -461,6 +461,13 @@ class AWS(clouds.Cloud):
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud."""
 
+        dependency_installation_hints = (
+            'AWS dependency is not installed properly. '
+            'Run the following commands:'
+            f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[aws]'
+            f'\n{cls._INDENT_PREFIX}Credentials may also need to be set. '
+            f'{cls._STATIC_CREDENTIAL_HELP_STR}')
+
         # Checks if the AWS CLI is installed properly
         proc = subprocess.run('aws --version',
                               shell=True,
@@ -468,12 +475,13 @@ class AWS(clouds.Cloud):
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
         if proc.returncode != 0:
-            return False, (
-                'AWS CLI is not installed properly. '
-                'Run the following commands:'
-                f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[aws]'
-                f'\n{cls._INDENT_PREFIX}Credentials may also need to be set. '
-                f'{cls._STATIC_CREDENTIAL_HELP_STR}')
+            return False, dependency_installation_hints
+        try:
+            # Checks if aws boto is installed properly
+            import boto3 as _boto3
+            import botocore as _botocore
+        except ImportError:
+            return False, dependency_installation_hints
 
         # Checks if AWS credentials 1) exist and 2) are valid.
         # https://stackoverflow.com/questions/53548737/verify-aws-credentials-with-boto3

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -462,7 +462,7 @@ class AWS(clouds.Cloud):
         """Checks if the user has access credentials to this cloud."""
 
         dependency_installation_hints = (
-            'AWS dependency is not installed properly. '
+            'AWS dependencies are not installed properly. '
             'Run the following commands:'
             f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[aws]'
             f'\n{cls._INDENT_PREFIX}Credentials may also need to be set. '

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -462,7 +462,7 @@ class AWS(clouds.Cloud):
         """Checks if the user has access credentials to this cloud."""
 
         dependency_installation_hints = (
-            'AWS dependencies are not installed properly. '
+            'AWS dependencies are not installed. '
             'Run the following commands:'
             f'\n{cls._INDENT_PREFIX}  $ pip install skypilot[aws]'
             f'\n{cls._INDENT_PREFIX}Credentials may also need to be set. '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Since we remove the aws dependency from the `pip install skypilot`, we need to check the installation of the AWS dependency in `sky check`.

To reproduce this:
```
pip install .
pip install awscli
sky check
```
Error:
```
...
  File "/home/gcpuser/skypilot/sky/clouds/service_catalog/aws_catalog.py", line 197, in validate_region_zone
    return common.validate_region_zone_impl('aws', _get_df(), region, zone)
  File "/home/gcpuser/skypilot/sky/clouds/service_catalog/aws_catalog.py", line 158, in _get_df
    _user_df = _fetch_and_apply_az_mapping(_default_df)
  File "/home/gcpuser/skypilot/sky/clouds/service_catalog/aws_catalog.py", line 114, in _fetch_and_apply_az_mapping
    user_identity_list = aws.AWS.get_current_user_identity()
  File "/home/gcpuser/skypilot/sky/clouds/aws.py", line 626, in get_current_user_identity
    except aws.botocore_exceptions().NoCredentialsError as e:
  File "/home/gcpuser/skypilot/sky/adaptors/aws.py", line 88, in wrapper
    raise ImportError('Fail to import dependencies for AWS. '
ImportError: Fail to import dependencies for AWS. Try pip install "skypilot[aws]"
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] The reproducible code above.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
