### PR TITLE
[UI] Now show-gpus shows the combined price for GCP GPU instance

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3543,11 +3543,6 @@ def show_gpus(
             yield 'to show available accelerators.'
             return
 
-        if cloud is None or cloud.lower() == 'gcp':
-            yield '*NOTE*: for most GCP accelerators, '
-            yield 'INSTANCE_TYPE == (attachable) means '
-            yield 'the host VM\'s cost is not included.\n\n'
-
         import pandas as pd  # pylint: disable=import-outside-toplevel
         for i, (gpu, items) in enumerate(result.items()):
             accelerator_table_headers = [

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -385,7 +385,7 @@ def list_accelerators(
             new_results[acc_name] = acc_info
     results = new_results
 
-    # If we can figure out which instances are to be used then we 
+    # If we can figure out which instances are to be used then we
     # can attach them here.
     accs = list(results.keys())
     acc_infos: List[common.InstanceTypeInfo] = sum(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -395,13 +395,11 @@ def list_accelerators(
         assert pd.isna(info.instance_type) and pd.isna(info.memory), acc_infos
         if info.accelerator_name.startswith('tpu'):
             new_infos[info.accelerator_name].append(
-                info._replace(
-                    instance_type='TPU-VM',
-                ))
+                info._replace(instance_type='TPU-VM',))
             continue
         vm_types, _ = get_instance_type_for_accelerator(info.accelerator_name,
                                                         info.accelerator_count,
-                                                        region=region_filter, 
+                                                        region=region_filter,
                                                         use_spot=True)
         #always has a vm type for GCP
         assert vm_types is not None

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -385,7 +385,8 @@ def list_accelerators(
             new_results[acc_name] = acc_info
     results = new_results
 
-    # If we can figure out which instances are to be used then we can attach them here.
+    # If we can figure out which instances are to be used then we 
+    # can attach them here.
     accs = list(results.keys())
     acc_infos: List[common.InstanceTypeInfo] = sum(
         [results.get(a, []) for a in accs], [])
@@ -397,6 +398,8 @@ def list_accelerators(
         assert pd.isna(info.instance_type) and pd.isna(info.memory), acc_infos
         vm_types, _ = get_instance_type_for_accelerator(info.accelerator_name,
                                                         info.accelerator_count)
+        if vm_types is None:
+            continue
         for vm_type in vm_types:
             df = _df[(_df['InstanceType'] == vm_type) &
                      (_df['Region'] == info.region)]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -387,14 +387,13 @@ def list_accelerators(
 
     # If we can figure out which instances are to be used then we
     # can attach them here.
-    acc_infos: List[common.InstanceTypeInfo] = sum(
-        results.values(), [])
+    acc_infos: List[common.InstanceTypeInfo] = sum(results.values(), [])
 
     new_infos = defaultdict(list)
     for info in acc_infos:
         assert pd.isna(info.instance_type) and pd.isna(info.memory), acc_infos
         vm_types, _ = get_instance_type_for_accelerator(info.accelerator_name,
-                                                        info.accelerator_count, 
+                                                        info.accelerator_count,
                                                         region=region_filter)
         for vm_type in vm_types:
             df = _df[(_df['InstanceType'] == vm_type)]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -386,11 +386,13 @@ def list_accelerators(
     results = new_results
 
     # Figure out which instance type to use.
-    acc_infos: List[common.InstanceTypeInfo] = sum(results.values(), [])
+    infos_with_instance_type: List[common.InstanceTypeInfo] = sum(
+        results.values(), [])
 
     new_infos = defaultdict(list)
-    for info in acc_infos:
-        assert pd.isna(info.instance_type) and pd.isna(info.memory), acc_infos
+    for info in infos_with_instance_type:
+        assert pd.isna(info.instance_type) and pd.isna(
+            info.memory), infos_with_instance_type
         if info.accelerator_name.startswith('tpu'):
             new_infos[info.accelerator_name].append(
                 info._replace(instance_type='TPU-VM',))

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -392,7 +392,8 @@ def list_accelerators(
     new_infos = defaultdict(list)
     for info in infos_with_instance_type:
         assert pd.isna(info.instance_type) and pd.isna(info.memory), info
-        #TPU-VM prices are shown here, so we don't ned to attach a VM to it.
+        # We show TPU-VM prices here, so no instance type is needed.
+        # Set it as `TPU-VM` to be shown in the table.
         if info.accelerator_name.startswith('tpu'):
             new_infos[info.accelerator_name].append(
                 info._replace(instance_type='TPU-VM'))

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -403,8 +403,8 @@ def list_accelerators(
         # The acc name & count in `info` are retrieved from the table so we
         # could definitely find a column in the original table
         # Additionally the way get_instance_type_for_accelerator works
-        # we will always get either a specialized instance type (L274 - L284)
-        # or a default instance type (L300). So we can safely assume that
+        # we will always get either a specialized instance type
+        # or a default instance type. So we can safely assume that
         # vm_types is not None.
         assert vm_types is not None
         for vm_type in vm_types:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -400,11 +400,12 @@ def list_accelerators(
                                                         info.accelerator_count,
                                                         region=region_filter,
                                                         use_spot=True)
-        # The acc name & count in `info` are retrieved from the table so
-        # we could definitely find a column in the original table
+        # The acc name & count in `info` are retrieved from the table so we
+        # could definitely find a column in the original table
         # Additionally the way get_instance_type_for_accelerator works
         # we will always get either a specialized instance type (L274 - L284)
-        # or a default instance type (L300).
+        # or a default instance type (L300). So we can safely assume that
+        # vm_types is not None.
         assert vm_types is not None
         for vm_type in vm_types:
             df = _df[_df['InstanceType'] == vm_type]

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -400,10 +400,10 @@ def list_accelerators(
                                                         info.accelerator_count,
                                                         region=region_filter,
                                                         use_spot=True)
-        # The acc name & count in `info` are retrieved from the table so 
+        # The acc name & count in `info` are retrieved from the table so
         # we could definitely find a column in the original table
-        # Additionally the way get_instance_type_for_accelerator works 
-        # we will always get either a specialized instance type (L274 - L284) 
+        # Additionally the way get_instance_type_for_accelerator works
+        # we will always get either a specialized instance type (L274 - L284)
         # or a default instance type (L300).
         assert vm_types is not None
         for vm_type in vm_types:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -402,12 +402,12 @@ def list_accelerators(
             vm_price = common.get_hourly_cost_impl(_df,
                                                    vm_type,
                                                    use_spot=False,
-                                                   region=None,
+                                                   region=region_filter,
                                                    zone=None)
             vm_spot_price = common.get_hourly_cost_impl(_df,
                                                         vm_type,
                                                         use_spot=True,
-                                                        region=None,
+                                                        region=region_filter,
                                                         zone=None)
             new_infos[info.accelerator_name].append(
                 info._replace(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -392,15 +392,14 @@ def list_accelerators(
     new_infos = defaultdict(list)
     for info in infos_with_instance_type:
         assert pd.isna(info.instance_type) and pd.isna(
-            info.memory), infos_with_instance_type
+            info.memory), infos
         if info.accelerator_name.startswith('tpu'):
             new_infos[info.accelerator_name].append(
-                info._replace(instance_type='TPU-VM',))
+                info._replace(instance_type='TPU-VM'))
             continue
         vm_types, _ = get_instance_type_for_accelerator(info.accelerator_name,
                                                         info.accelerator_count,
-                                                        region=region_filter,
-                                                        use_spot=True)
+                                                        region=region_filter)
         # The acc name & count in `info` are retrieved from the table so we
         # could definitely find a column in the original table
         # Additionally the way get_instance_type_for_accelerator works

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -385,8 +385,7 @@ def list_accelerators(
             new_results[acc_name] = acc_info
     results = new_results
 
-    # If we can figure out which instances are to be used then we
-    # can attach them here.
+    # Figure out which instance type to use.
     acc_infos: List[common.InstanceTypeInfo] = sum(results.values(), [])
 
     new_infos = defaultdict(list)

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -391,8 +391,8 @@ def list_accelerators(
 
     new_infos = defaultdict(list)
     for info in infos_with_instance_type:
-        assert pd.isna(info.instance_type) and pd.isna(
-            info.memory), infos
+        assert pd.isna(info.instance_type) and pd.isna(info.memory), info
+        #TPU-VM prices are shown here, so we don't ned to attach a VM to it.
         if info.accelerator_name.startswith('tpu'):
             new_infos[info.accelerator_name].append(
                 info._replace(instance_type='TPU-VM'))

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -378,7 +378,6 @@ def list_accelerators(
 
     # Remove GPUs that are unsupported by SkyPilot.
     new_results = {}
-    # print(acc_name)
     for acc_name, acc_info in results.items():
         if (acc_name.startswith('tpu') or
                 acc_name in _NUM_ACC_TO_MAX_CPU_AND_MEMORY or
@@ -401,7 +400,11 @@ def list_accelerators(
                                                         info.accelerator_count,
                                                         region=region_filter,
                                                         use_spot=True)
-        #always has a vm type for GCP
+        # The acc name & count in `info` are retrieved from the table so 
+        # we could definitely find a column in the original table
+        # Additionally the way get_instance_type_for_accelerator works 
+        # we will always get either a specialized instance type (L274 - L284) 
+        # or a default instance type (L300).
         assert vm_types is not None
         for vm_type in vm_types:
             df = _df[_df['InstanceType'] == vm_type]


### PR DESCRIPTION
This is in relation to https://github.com/skypilot-org/skypilot/issues/2039. 

Added functionality to show the combined price for GCP GPU instance. 

```
GPU   QTY  CLOUD   INSTANCE_TYPE       DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION
V100  1    AWS     p3.2xlarge          16GB        8      61GB      $ 3.060       $ 0.476            ap-northeast-1
V100  4    AWS     p3.8xlarge          16GB        32     244GB     $ 12.240      $ 1.596            ap-northeast-1
V100  8    AWS     p3.16xlarge         16GB        64     488GB     $ 24.480      $ 2.678            ap-northeast-1
V100  1    Azure   Standard_NC6s_v3    -           6      112GB     $ 3.060       $ 0.450            centralus
V100  2    Azure   Standard_NC12s_v3   -           12     224GB     $ 6.120       $ 0.899            centralus
V100  4    Azure   Standard_NC24rs_v3  -           24     448GB     $ 13.460      $ 1.978            centralus
V100  4    Azure   Standard_NC24s_v3   -           24     448GB     $ 12.240      $ 1.798            centralus
V100  1    GCP     n1-highmem-8        -           8      52GB      $ 2.953       $ 0.811            asia-east1
V100  2    GCP     n1-highmem-16       -           16     104GB     $ 5.906       $ 1.622            asia-east1
V100  4    GCP     n1-highmem-32       -           32     208GB     $ 11.813      $ 3.244            asia-east1
V100  8    GCP     n1-highmem-64       -           64     416GB     $ 23.626      $ 6.487            asia-east1
V100  1    IBM     gx2-8x64x1v100      -           8      64GB      $ 2.497       -                  au-syd
V100  8    Lambda  gpu_8x_v100         16GB        92     448GB     $ 4.400       -                  asia-northeast-1
V100  1    OCI     VM.GPU3.1           16GB        12     90GB      $ 2.950       -                  af-johannesburg-1
V100  2    OCI     VM.GPU3.2           16GB        24     180GB     $ 5.900       -                  af-johannesburg-1
V100  4    OCI     VM.GPU3.4           16GB        48     360GB     $ 11.800      -                  af-johannesburg-1
V100  8    OCI     BM.GPU3.8           16GB        104    768GB     $ 23.600      -                  af-johannesburg-1
```
To test: 

- [x] shows the correct added values for various gpus. (manually checked for 7 gpus)