### PR TITLE
[GCP] Use storage.admin permission for automatically created skypilot-v1 service account

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -463,7 +463,7 @@ def list_accelerators_impl(
     instance types offered by this cloud.
     """
     if gpus_only:
-        df = df[~df['AcceleratorName'].isna()]
+        df = df[~df['GpuInfo'].isna()]
     df = df.copy()  # avoid column assignment warning
 
     try:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -463,7 +463,7 @@ def list_accelerators_impl(
     instance types offered by this cloud.
     """
     if gpus_only:
-        df = df[~df['GpuInfo'].isna()]
+        df = df[~df['AcceleratorName'].isna()]
     df = df.copy()  # avoid column assignment warning
 
     try:

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -26,7 +26,7 @@ SKYPILOT_SERVICE_ACCOUNT_CONFIG = {
 # NOTE: `serviceAccountUser` allows the head node to create workers with
 # a serviceAccount. `roleViewer` allows the head node to run bootstrap_gcp.
 DEFAULT_SERVICE_ACCOUNT_ROLES = [
-    'roles/storage.objectAdmin',
+    'roles/storage.admin',
     'roles/compute.admin',
     'roles/iam.serviceAccountUser',
     'roles/iam.roleViewer',


### PR DESCRIPTION
This is to make sure the service account `skypilot-v1` automatically created by skypilot can access the user's bucket, to make it more convenient for the users.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
