### PR TITLE
[k8s][docs] Clarify `nvidia` runtime is required for k8s

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -169,8 +169,18 @@ Setting up GPU support
 ~~~~~~~~~~~~~~~~~~~~~~
 If your Kubernetes cluster has Nvidia GPUs, ensure that:
 
-1. The Nvidia GPU operator is installed (i.e., ``nvidia.com/gpu`` resource is available on each node) and is ``nvidia`` is set as the default runtime for your container engine. See `Nvidia's installation guide <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#install-nvidia-gpu-operator>`_ for more details.
+1. The Nvidia GPU operator is installed (i.e., ``nvidia.com/gpu`` resource is available on each node) and ``nvidia`` is set as the default runtime for your container engine. See `Nvidia's installation guide <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#install-nvidia-gpu-operator>`_ for more details.
 2. Each node in your cluster is labelled with the GPU type. This labelling can be done by adding a label of the format ``skypilot.co/accelerators: <gpu_name>``, where the ``<gpu_name>`` is the lowercase name of the GPU. For example, a node with V100 GPUs must have a label :code:`skypilot.co/accelerators: v100`.
+
+.. tip::
+    You can check if GPU operator is installed and the ``nvidia`` runtime is set as default by running:
+
+    .. code-block:: console
+
+        $ kubectl apply -f https://raw.githubusercontent.com/skypilot-org/skypilot/master/tests/kubernetes/gpu_test_pod.yaml
+        $ watch kubectl get pods
+        # If the pod status changes to completed after a few minutes, your Kubernetes environment is set up correctly.
+
 
 .. note::
     If you are using RKE2, the GPU operator installation through helm requires extra flags to set ``nvidia`` as the default runtime for containerd. Refer to instructions on `Nvidia GPU Operator installation with Helm on RKE2 <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#custom-configuration-for-runtime-containerd>`_ for details.

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -169,8 +169,11 @@ Setting up GPU support
 ~~~~~~~~~~~~~~~~~~~~~~
 If your Kubernetes cluster has Nvidia GPUs, ensure that:
 
-1. The Nvidia device plugin is installed (i.e., ``nvidia.com/gpu`` resource is available on each node).
+1. The Nvidia GPU operator is installed (i.e., ``nvidia.com/gpu`` resource is available on each node) and is ``nvidia`` is set as the default runtime for your container engine. See `Nvidia's installation guide <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#install-nvidia-gpu-operator>`_ for more details.
 2. Each node in your cluster is labelled with the GPU type. This labelling can be done by adding a label of the format ``skypilot.co/accelerators: <gpu_name>``, where the ``<gpu_name>`` is the lowercase name of the GPU. For example, a node with V100 GPUs must have a label :code:`skypilot.co/accelerators: v100`.
+
+.. note::
+    If you are using RKE2, the GPU operator installation through helm requires extra flags to set ``nvidia`` as the default runtime for containerd. Refer to instructions on `Nvidia GPU Operator installation with Helm on RKE2 <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#custom-configuration-for-runtime-containerd>`_ for details.
 
 We provide a convenience script that automatically detects GPU types and labels each node. You can run it with:
 

--- a/tests/kubernetes/gpu_test_pod.yaml
+++ b/tests/kubernetes/gpu_test_pod.yaml
@@ -1,0 +1,15 @@
+# Runs nvidia-smi in a pod to test GPU operator and nvidia runtime are setup correctly
+# Run with kubectl apply -f gpu_pod_test.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nvidia-smi
+spec:
+  restartPolicy: Never
+  containers:
+  - name: nvidia-smi
+    image: nvidia/cuda:12.3.1-devel-ubuntu20.04
+    command: ["nvidia-smi"]
+    resources:
+      limits:
+         nvidia.com/gpu: "1"


### PR DESCRIPTION
Clarifies that `nvidia` must also be set as the default runtime for the container engine. This is a common gotcha on RKE2, since users may use the [nvidia's default instructions](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#install-nvidia-gpu-operator) instead of [their recommendation for RKE2](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html#custom-configuration-for-runtime-containerd). 

Tested (run the relevant ones):

- [x] Locally rendered docs
<img width="851" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/89fa970c-61ae-455d-81e3-443b956a703b">


- [x] Tested on RKE2 cluster
![image](https://github.com/skypilot-org/skypilot/assets/4416605/82385946-a152-4475-ad67-a9562463f596)
