### PR TITLE
[SkyServe] Not add default value of `{up,down}scale_delay_seconds` in service spec

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -109,11 +109,18 @@ class RequestRateAutoscaler(Autoscaler):
         self.request_timestamps: List[float] = []
         self.upscale_counter: int = 0
         self.downscale_counter: int = 0
+        upscale_delay_seconds = (
+            spec.upscale_delay_seconds if spec.upscale_delay_seconds is not None
+            else constants.AUTOSCALER_DEFAULT_UPSCALE_DELAY_SECONDS)
         self.scale_up_consecutive_periods: int = int(
-            spec.upscale_delay_seconds /
+            upscale_delay_seconds /
             constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS)
+        downscale_delay_seconds = (
+            spec.downscale_delay_seconds
+            if spec.downscale_delay_seconds is not None else
+            constants.AUTOSCALER_DEFAULT_DOWNSCALE_DELAY_SECONDS)
         self.scale_down_consecutive_periods: int = int(
-            spec.downscale_delay_seconds /
+            downscale_delay_seconds /
             constants.AUTOSCALER_DEFAULT_DECISION_INTERVAL_SECONDS)
         # Target number of replicas is initialized to min replicas.
         # TODO(MaoZiming): add init replica numbers in SkyServe spec.

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -66,13 +66,8 @@ class SkyServiceSpec:
         self._max_replicas = max_replicas
         self._target_qps_per_replica = target_qps_per_replica
         self._post_data = post_data
-
-        self._upscale_delay_seconds = (
-            upscale_delay_seconds if upscale_delay_seconds is not None else
-            constants.AUTOSCALER_DEFAULT_UPSCALE_DELAY_SECONDS)
-        self._downscale_delay_seconds = (
-            downscale_delay_seconds if downscale_delay_seconds is not None else
-            constants.AUTOSCALER_DEFAULT_DOWNSCALE_DELAY_SECONDS)
+        self._upscale_delay_seconds = upscale_delay_seconds
+        self._downscale_delay_seconds = downscale_delay_seconds
 
     @staticmethod
     def from_yaml_config(config: Dict[str, Any]) -> 'SkyServiceSpec':
@@ -238,9 +233,9 @@ class SkyServiceSpec:
         return self._post_data
 
     @property
-    def upscale_delay_seconds(self) -> int:
+    def upscale_delay_seconds(self) -> Optional[int]:
         return self._upscale_delay_seconds
 
     @property
-    def downscale_delay_seconds(self) -> int:
+    def downscale_delay_seconds(self) -> Optional[int]:
         return self._downscale_delay_seconds


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, the `SkyServiceSpec` will add the fields `{up,down}scale_delay_seconds` even if there are no autoscaling enabled. This PR fixed the issue.

To reproduce:

```python
>>> import sky
>>> sky.serve.SkyServiceSpec.from_yaml_config({'readiness_probe': '/', 'replicas': 1}).to_yaml_config()
{'readiness_probe': {'path': '/', 'initial_delay_seconds': 1200}, 'replica_policy': {'min_replicas': 1, 'upscale_delay_seconds': 300, 'downscale_delay_seconds': 1200}}
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] The reproducible script shown above; now returning
```python
>>> import sky
>>> sky.serve.SkyServiceSpec.from_yaml_config({'readiness_probe': '/', 'replicas': 1}).to_yaml_config()
{'readiness_probe': {'path': '/', 'initial_delay_seconds': 1200}, 'replica_policy': {'min_replicas': 1}}
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
