### PR TITLE
[Cost Report] Store instance price in the history

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -149,10 +149,10 @@ def cost_report() -> List[Dict[str, Any]]:
 
     def get_total_cost(cluster_report: dict) -> float:
         duration = cluster_report['duration']
+        hourly_cost = cluster_report['hourly_cost']
         launched_nodes = cluster_report['num_nodes']
-        launched_resources = cluster_report['resources']
 
-        cost = (launched_resources.get_cost(duration) * launched_nodes)
+        cost = duration * (hourly_cost / 3600) * launched_nodes
         return cost
 
     for cluster_report in cluster_reports:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -281,7 +281,7 @@ def add_or_update_cluster(cluster_name: str,
 
     launched_nodes = getattr(cluster_handle, 'launched_nodes', None)
     launched_resources = getattr(cluster_handle, 'launched_resources', None)
-    #if cluster_hash is already present in cluster_history table
+    # if cluster_hash is already present in cluster_history table
     if _get_cluster_usage_intervals(cluster_hash):
         _DB.cursor.execute(
             'UPDATE cluster_history SET num_nodes=(?), '
@@ -294,7 +294,7 @@ def add_or_update_cluster(cluster_name: str,
                 cluster_hash,
             ))
     else:
-        #This will never be none as we are getting it from the handler
+        # This will never be none as we are getting it from the handler.
         assert launched_resources is not None
         launched_instance_hourly_cost = launched_resources.get_cost(
             seconds=3600)

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -122,7 +122,7 @@ _DB = db_utils.SQLiteConn(_DB_PATH, create_table)
 
 
 def _cluster_history_backward_compatibility():
-    """For backward compatibility. 
+    """For backward compatibility.
     This ensures that the cluster_history table has hourly_cost column.
     """
     cursor = _DB.cursor
@@ -286,8 +286,7 @@ def add_or_update_cluster(cluster_name: str,
         _DB.cursor.execute(
             'UPDATE cluster_history SET num_nodes=(?), '
             'launched_resources=(?), usage_intervals=(?), '
-            'requested_resources, WHERE cluster_hash=(?)',
-            (
+            'requested_resources, WHERE cluster_hash=(?)', (
                 launched_nodes,
                 pickle.dumps(launched_resources),
                 pickle.dumps(usage_intervals),
@@ -295,6 +294,8 @@ def add_or_update_cluster(cluster_name: str,
                 cluster_hash,
             ))
     else:
+        #This will never be none as we are getting it from the handler
+        assert launched_resources is not None
         launched_instance_hourly_cost = launched_resources.get_cost(
             seconds=3600)
         _DB.cursor.execute(
@@ -313,9 +314,9 @@ def add_or_update_cluster(cluster_name: str,
             # launched resources
             '?, '
             # usage intervals
-            '?)'
+            '?, '
             # hourly_cost
-            '?, ',
+            '?)',
             (
                 # hash
                 cluster_hash,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -610,7 +610,7 @@ def get_clusters() -> List[Dict[str, Any]]:
 
 def get_clusters_from_history() -> List[Dict[str, Any]]:
     rows = _DB.cursor.execute(
-        'SELECT ch.cluster_hash, ch.name, ch.num_nodes, ch.instance_cost, '
+        'SELECT ch.cluster_hash, ch.name, ch.num_nodes, ch.hourly_cost, '
         'ch.launched_resources, ch.usage_intervals, clusters.status  '
         'FROM cluster_history ch '
         'LEFT OUTER JOIN clusters '
@@ -627,7 +627,7 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
             cluster_hash,
             name,
             num_nodes,
-            instance_cost,
+            hourly_cost,
             launched_resources,
             usage_intervals,
             status,
@@ -641,7 +641,7 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
             'launched_at': _get_cluster_launch_time(cluster_hash),
             'duration': _get_cluster_duration(cluster_hash),
             'num_nodes': num_nodes,
-            'instance_cost': instance_cost,
+            'hourly_cost': hourly_cost,
             'resources': pickle.loads(launched_resources),
             'cluster_hash': cluster_hash,
             'usage_intervals': pickle.loads(usage_intervals),

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -130,7 +130,6 @@ def _cluster_history_backward_compatibility():
     # check if hourly_cost column exists in cluster_history table
     cursor.execute('SELECT * FROM cluster_history LIMIT 1')
     columns = [description[0] for description in cursor.description]
-    print(columns)
     if 'hourly_cost' not in columns:
         # add hourly_cost column to cluster_history table
         db_utils.add_column_to_table(cursor, conn, 'cluster_history',
@@ -658,7 +657,6 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
     # '(cluster_hash, name, num_nodes, requested_resources, '
     #         'launched_resources, usage_intervals) '
     records = []
-
     for row in rows:
         # TODO: use namedtuple instead of dict
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -402,7 +402,7 @@ def _get_price_for_cost_report(
     launched_nodes = cluster_cost_report_record['num_nodes']
     launched_resources = cluster_cost_report_record['resources']
 
-    hourly_cost = cluster_cost_report_record['instance_cost']
+    hourly_cost = cluster_cost_report_record['hourly_cost']
     price_str = f'$ {hourly_cost:.2f}'
     return price_str
 

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -399,9 +399,6 @@ def _get_resources_for_cost_report(
 
 def _get_price_for_cost_report(
         cluster_cost_report_record: _ClusterCostReportRecord) -> str:
-    launched_nodes = cluster_cost_report_record['num_nodes']
-    launched_resources = cluster_cost_report_record['resources']
-
     hourly_cost = cluster_cost_report_record['hourly_cost']
     price_str = f'$ {hourly_cost:.2f}'
     return price_str

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -402,7 +402,7 @@ def _get_price_for_cost_report(
     launched_nodes = cluster_cost_report_record['num_nodes']
     launched_resources = cluster_cost_report_record['resources']
 
-    hourly_cost = (launched_resources.get_cost(3600) * launched_nodes)
+    hourly_cost = cluster_cost_report_record['instance_cost']
     price_str = f'$ {hourly_cost:.2f}'
     return price_str
 


### PR DESCRIPTION
This is in relation to https://github.com/skypilot-org/skypilot/issues/2780

Now the `hourly_cost` at the time of launch is stored in cluster_history table. Also added backward compatibility for users.

Tests Ran: 

- [x] Launched a cluster on master and switched to the PR. Ran cost-report



