### PR TITLE
[GCP/Provisioner] Assign VMs launched on GCP with service account

### DIFF
--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -165,7 +165,7 @@ def bootstrap_instances(
 
     _configure_project(config.provider_config, crm)
     iam_role = _configure_iam_role(config, crm, iam)
-    config.provider_config['iam_role'] = iam_role  # temporary store
+    config.node_config.update(iam_role)
     config = _configure_subnet(region, cluster_name, config, compute)
 
     return config

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -288,7 +288,7 @@ def test_aws_region():
 
 
 @pytest.mark.gcp
-def test_gcp_region():
+def test_gcp_region_and_service_account():
     name = _get_cluster_name()
     test = Test(
         'gcp_region',
@@ -296,6 +296,8 @@ def test_gcp_region():
             f'sky launch -y -c {name} --region us-central1 --cloud gcp tests/test_yamls/minimal.yaml',
             f'sky exec {name} tests/test_yamls/minimal.yaml',
             f'sky logs {name} 1 --status',  # Ensure the job succeeded.
+            f'sky exec {name} \'curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=standard&audience=gcp"\'',
+            f'sky logs {name} 2 --status',  # Ensure the job succeeded.
             f'sky status --all | grep {name} | grep us-central1',  # Ensure the region is correct.
         ],
         f'sky down -y {name}',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2966
Assign the VMs laucnhed on GCP with service account. This is the original behavior which is missed in our new provisioner implementation.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] normal VM: `sky launch -c test-gcp-sa --cloud gcp --cpus 2 'curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=standard&audience=gcp"'`; check the VM on the console; `
  - [x] multiple nodes: `sky launch -c test-gcp-sa-mn --cloud gcp --num-nodes 4 --cpus 2 'curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=standard&audience=gcp"'`; check the VM on the console`
  - [x] TPU VM: `sky launch -c test-gcp-sa-tpu --cloud gcp --gpus tpu-v2-8 'curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=standard&audience=gcp"'`; check the VM on the console; `
  - [x] multi-node TPU VM: `sky launch -c test-gcp-sa-tpu --cloud gcp --gpus tpu-v2-8 --num-nodes 2 'curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?format=standard&audience=gcp"'`; check the VM on the console; `
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_gcp_region_and_service_account`
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
