### PR TITLE
[SkyServe] Fix `sky serve up` with docker login config

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -168,6 +168,11 @@ class DockerInitializer:
                       f'{docker_login_config.username} '
                       f'--password {docker_login_config.password} '
                       f'{docker_login_config.server}')
+            # We automatically add the server prefix to the image name if
+            # the user did not add it.
+            server_prefix = f'{docker_login_config.server}/'
+            if not specific_image.startswith(server_prefix):
+                specific_image = f'{server_prefix}{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -168,7 +168,6 @@ class DockerInitializer:
                       f'{docker_login_config.username} '
                       f'--password {docker_login_config.password} '
                       f'{docker_login_config.server}')
-            specific_image = f'{docker_login_config.server}/{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1257,7 +1257,6 @@ class Resources:
         add_if_not_none('image_id', self.image_id)
         add_if_not_none('disk_tier', self.disk_tier)
         add_if_not_none('ports', self.ports)
-        add_if_not_none('_docker_login_config', self._docker_login_config)
         if self._is_image_managed is not None:
             config['_is_image_managed'] = self._is_image_managed
         return config

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -127,6 +127,11 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 docker_login_config.password,
                 docker_login_config.server,
             ))
+            # We automatically add the server prefix to the image name if
+            # the user did not add it.
+            server_prefix = f'{docker_login_config.server}/'
+            if not specific_image.startswith(server_prefix):
+                specific_image = f'{server_prefix}{specific_image}'
 
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +

--- a/sky/task.py
+++ b/sky/task.py
@@ -149,11 +149,6 @@ def _with_docker_login_config(
         # Already checked in extract_docker_image
         assert len(resources.image_id) == 1, resources.image_id
         region = list(resources.image_id.keys())[0]
-        # We automatically add the server prefix to the image name if
-        # the user did not add it.
-        server_prefix = f'{docker_login_config.server}/'
-        if not docker_image.startswith(server_prefix):
-            docker_image = f'{server_prefix}{docker_image}'
         return resources.copy(image_id={region: 'docker:' + docker_image},
                               _docker_login_config=docker_login_config)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when we `sky serve up` a yaml w/ docker login config, it will throw an error saying `DockerLoginConfig is not JSON serializable`, which is because we accidentally added the docker login to resources' `to_yaml_config` function. This PR addressed the problem and fixed #2982 .

```yaml
# docker_login_service.yaml
service:
  readiness_probe: /
  replicas: 1

resources:
  cloud: aws
  cpus: 2
  image_id: docker:txia-test-ecr:latest
  ports: 5000

envs:
  SKYPILOT_DOCKER_USERNAME: AWS
  SKYPILOT_DOCKER_PASSWORD: <password here>
  SKYPILOT_DOCKER_SERVER: <uid>.dkr.ecr.us-east-1.amazonaws.com

run: |
  echo $SKYPILOT_DOCKER_USERNAME
  python -m http.server 5000
```

```bash
$ sky serve up docker_login_service.yaml
Service from YAML spec: docker_login_service.yaml
Service Spec:
Readiness probe method:           GET /v1/models
Readiness initial delay seconds:  1200
Replica autoscaling policy:       Fixed 1 replica        
Each replica will use the following resources (estimated):
I 01-13 22:07:14 optimizer.py:694] == Optimizer ==
I 01-13 22:07:14 optimizer.py:706] Target: minimizing cost
I 01-13 22:07:14 optimizer.py:717] Estimated cost: $0.7 / hour
I 01-13 22:07:14 optimizer.py:717] 
TypeError: Object of type DockerLoginConfig is not JSON serializable
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky serve up docker_login_service.yaml` and no error is thrown; also the service is working (one replica turns to READY).
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
