### PR TITLE
[Storage] Mount command construction refactor

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -6,31 +6,17 @@ from typing import Optional
 from sky import exceptions
 
 
-def get_mounting_command(
+def get_mounting_script(
     mount_path: str,
-    install_cmd: str,
     mount_cmd: str,
+    install_cmd: str,
     version_check_cmd: Optional[str] = None,
 ) -> str:
-    """Generates the mounting command for a given bucket.
-
-    Generated script first unmounts any existing mount at the mount path, checks
-    and installs the mounting utility if required, creates the mount path and
-    finally mounts the bucket.
-
-    Args:
-        mount_path: Path to mount the bucket at.
-        install_cmd: Command to install the mounting utility. Should be
-          single line.
-        mount_cmd: Command to mount the bucket. Should be single line.
-
-    Returns:
-        str: Mounting command with the mounting script as a heredoc.
-    """
     mount_binary = mount_cmd.split()[0]
     installed_check = f'[ -x "$(command -v {mount_binary})" ]'
     if version_check_cmd is not None:
         installed_check += f' && {version_check_cmd}'
+
     script = textwrap.dedent(f"""
         #!/usr/bin/env bash
         set -e
@@ -69,6 +55,32 @@ def get_mounting_command(
         {mount_cmd}
         echo "Mounting done."
     """)
+
+    return script
+
+def get_mounting_command(
+    mount_path: str,
+    install_cmd: str,
+    mount_cmd: str,
+    version_check_cmd: Optional[str] = None,
+) -> str:
+    """Generates the mounting command for a given bucket.
+
+    Generated script first unmounts any existing mount at the mount path, checks
+    and installs the mounting utility if required, creates the mount path and
+    finally mounts the bucket.
+
+    Args:
+        mount_path: Path to mount the bucket at.
+        install_cmd: Command to install the mounting utility. Should be
+          single line.
+        mount_cmd: Command to mount the bucket. Should be single line.
+
+    Returns:
+        str: Mounting command with the mounting script as a heredoc.
+    """
+    script = get_mounting_script(mount_path, mount_cmd, install_cmd,
+                                 version_check_cmd)
 
     # TODO(romilb): Get direct bash script to work like so:
     # command = f'bash <<-\EOL' \

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -5,6 +5,95 @@ from typing import Optional
 
 from sky import exceptions
 
+# Values used to construct mounting commands
+_STAT_CACHE_TTL = '5s'
+_STAT_CACHE_CAPACITY = 4096
+_TYPE_CACHE_TTL = '5s'
+_RENAME_DIR_LIMIT = 10000
+# https://github.com/GoogleCloudPlatform/gcsfuse/releases
+GCSFUSE_VERSION = '1.3.0'
+
+def get_s3_mount_install_cmd() -> str:
+    """Returns a command to install S3 mount utility, 'goofys'."""
+    install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
+                   'releases/download/0.24.0-romilb-upstream/goofys '
+                   '-O /usr/local/bin/goofys && '
+                   'sudo chmod +x /usr/local/bin/goofys')
+    return install_cmd
+
+
+def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    """Returns a command to mount an S3 bucket using 'goofys'."""
+    mount_cmd = ('goofys -o allow_other '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_gcs_mount_install_cmd() -> str:
+    """Returns a command to install GCS mount utility, 'gcsfuse'."""
+    install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
+                   f'/releases/download/v{GCSFUSE_VERSION}/'
+                   f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
+                   '-O /tmp/gcsfuse.deb && '
+                   'sudo dpkg --install /tmp/gcsfuse.deb')
+    return install_cmd
+
+
+def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    """Returns a command to mount a GCS bucket using 'gcsfuse'."""
+    mount_cmd = ('gcsfuse -o allow_other '
+                 '--implicit-dirs '
+                 f'--stat-cache-capacity {_STAT_CACHE_CAPACITY} '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'--rename-dir-limit {_RENAME_DIR_LIMIT} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
+                     endpoint_url: str, bucket_name: str,
+                     mount_path: str) -> str:
+    """Returns a command to install R2 mount utility, 'goofys'."""
+    mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
+                 f'AWS_PROFILE={r2_profile_name} goofys -o allow_other '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'--endpoint {endpoint_url} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_cos_mount_install_cmd() -> str:
+    """Returns a command to install IBM COS mount utility, 'rclone'."""
+    install_cmd = ('rclone version >/dev/null 2>&1 || '
+                   '(curl https://rclone.org/install.sh | '
+                   'sudo bash)')
+    return install_cmd
+
+
+def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
+                      bucket_rclone_profile: str, bucket_name: str,
+                      mount_path: str) -> str:
+    """Returns a command to mount an IBM COS bucket using 'rclone'."""
+    # creates a fusermount soft link on older (<22) Ubuntu systems for
+    # rclone's mount utility.
+    set_fuser3_soft_link = ('[ ! -f /bin/fusermount3 ] && '
+                            'sudo ln -s /bin/fusermount /bin/fusermount3 || '
+                            'true')
+    # stores bucket profile in rclone config file at the cluster's nodes.
+    configure_rclone_profile = (f'{set_fuser3_soft_link}; '
+                                'mkdir -p ~/.config/rclone/ && '
+                                f'echo "{rclone_config_data}" >> '
+                                f'{rclone_config_path}')
+    # --daemon will keep the mounting process running in the background.
+    mount_cmd = (f'{configure_rclone_profile} && '
+                 'rclone mount '
+                 f'{bucket_rclone_profile}:{bucket_name} {mount_path} '
+                 '--daemon')
+    return mount_cmd
 
 def get_mounting_script(
     mount_path: str,

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -12,7 +12,21 @@ def get_mounting_script(
     install_cmd: str,
     version_check_cmd: Optional[str] = None,
 ) -> str:
-    """Generates the mounting script."""
+    """Generates the mounting script.
+
+    Generated script first unmounts any existing mount at the mount path,
+    checks and installs the mounting utility if required, creates the mount
+    path and finally mounts the bucket.
+    
+    Args:
+        mount_path: Path to mount the bucket at.
+        install_cmd: Command to install the mounting utility. Should be
+          single line.
+        mount_cmd: Command to mount the bucket. Should be single line.
+
+    Returns:
+        str: Mounting script as a heredoc.
+    """
 
     mount_binary = mount_cmd.split()[0]
     installed_check = f'[ -x "$(command -v {mount_binary})" ]'
@@ -68,9 +82,9 @@ def get_mounting_command(
 ) -> str:
     """Generates the mounting command for a given bucket.
 
-    Generated script first unmounts any existing mount at the mount path, checks
-    and installs the mounting utility if required, creates the mount path and
-    finally mounts the bucket.
+    The generated mounting script is written to a temporary file, which is then
+    executed and subsequently deleted, ensuring that these operations are
+    encapsulated within a single, executable command sequence.
 
     Args:
         mount_path: Path to mount the bucket at.

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -15,7 +15,7 @@ GCSFUSE_VERSION = '1.3.0'
 
 
 def get_s3_mount_install_cmd() -> str:
-    """Returns a command to install S3 mount utility, 'goofys'."""
+    """Returns a command to install S3 mount utility goofys."""
     install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
                    'releases/download/0.24.0-romilb-upstream/goofys '
                    '-O /usr/local/bin/goofys && '
@@ -24,7 +24,7 @@ def get_s3_mount_install_cmd() -> str:
 
 
 def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
-    """Returns a command to mount an S3 bucket using 'goofys'."""
+    """Returns a command to mount an S3 bucket using goofys."""
     mount_cmd = ('goofys -o allow_other '
                  f'--stat-cache-ttl {_STAT_CACHE_TTL} '
                  f'--type-cache-ttl {_TYPE_CACHE_TTL} '
@@ -33,7 +33,7 @@ def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
 
 
 def get_gcs_mount_install_cmd() -> str:
-    """Returns a command to install GCS mount utility, 'gcsfuse'."""
+    """Returns a command to install GCS mount utility gcsfuse."""
     install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
                    f'/releases/download/v{GCSFUSE_VERSION}/'
                    f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
@@ -43,7 +43,7 @@ def get_gcs_mount_install_cmd() -> str:
 
 
 def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
-    """Returns a command to mount a GCS bucket using 'gcsfuse'."""
+    """Returns a command to mount a GCS bucket using gcsfuse."""
     mount_cmd = ('gcsfuse -o allow_other '
                  '--implicit-dirs '
                  f'--stat-cache-capacity {_STAT_CACHE_CAPACITY} '
@@ -57,7 +57,7 @@ def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
 def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
                      endpoint_url: str, bucket_name: str,
                      mount_path: str) -> str:
-    """Returns a command to install R2 mount utility, 'goofys'."""
+    """Returns a command to install R2 mount utility goofys."""
     mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
                  f'AWS_PROFILE={r2_profile_name} goofys -o allow_other '
                  f'--stat-cache-ttl {_STAT_CACHE_TTL} '
@@ -68,7 +68,7 @@ def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
 
 
 def get_cos_mount_install_cmd() -> str:
-    """Returns a command to install IBM COS mount utility, 'rclone'."""
+    """Returns a command to install IBM COS mount utility rclone."""
     install_cmd = ('rclone version >/dev/null 2>&1 || '
                    '(curl https://rclone.org/install.sh | '
                    'sudo bash)')
@@ -78,7 +78,7 @@ def get_cos_mount_install_cmd() -> str:
 def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
                       bucket_rclone_profile: str, bucket_name: str,
                       mount_path: str) -> str:
-    """Returns a command to mount an IBM COS bucket using 'rclone'."""
+    """Returns a command to mount an IBM COS bucket using rclone."""
     # creates a fusermount soft link on older (<22) Ubuntu systems for
     # rclone's mount utility.
     set_fuser3_soft_link = ('[ ! -f /bin/fusermount3 ] && '
@@ -118,7 +118,7 @@ def get_mounting_script(
           mounting util.
 
     Returns:
-        str: Mounting script as a heredoc.
+        str: Mounting script as a str.
     """
 
     mount_binary = mount_cmd.split()[0]

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -13,6 +13,7 @@ _RENAME_DIR_LIMIT = 10000
 # https://github.com/GoogleCloudPlatform/gcsfuse/releases
 GCSFUSE_VERSION = '1.3.0'
 
+
 def get_s3_mount_install_cmd() -> str:
     """Returns a command to install S3 mount utility, 'goofys'."""
     install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
@@ -95,6 +96,7 @@ def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
                  '--daemon')
     return mount_cmd
 
+
 def get_mounting_script(
     mount_path: str,
     mount_cmd: str,
@@ -106,12 +108,14 @@ def get_mounting_script(
     Generated script first unmounts any existing mount at the mount path,
     checks and installs the mounting utility if required, creates the mount
     path and finally mounts the bucket.
-    
+
     Args:
         mount_path: Path to mount the bucket at.
         install_cmd: Command to install the mounting utility. Should be
           single line.
         mount_cmd: Command to mount the bucket. Should be single line.
+        version_check_cmd: Command to check the version of already installed
+          mounting util.
 
     Returns:
         str: Mounting script as a heredoc.
@@ -163,6 +167,7 @@ def get_mounting_script(
 
     return script
 
+
 def get_mounting_command(
     mount_path: str,
     install_cmd: str,
@@ -180,6 +185,8 @@ def get_mounting_command(
         install_cmd: Command to install the mounting utility. Should be
           single line.
         mount_cmd: Command to mount the bucket. Should be single line.
+        version_check_cmd: Command to check the version of already installed
+          mounting util.
 
     Returns:
         str: Mounting command with the mounting script as a heredoc.

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -12,6 +12,8 @@ def get_mounting_script(
     install_cmd: str,
     version_check_cmd: Optional[str] = None,
 ) -> str:
+    """Generates the mounting script."""
+
     mount_binary = mount_cmd.split()[0]
     installed_check = f'[ -x "$(command -v {mount_binary})" ]'
     if version_check_cmd is not None:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -169,10 +169,6 @@ class AbstractStore:
     present in a cloud.
     """
 
-    _STAT_CACHE_TTL = '5s'
-    _STAT_CACHE_CAPACITY = 4096
-    _TYPE_CACHE_TTL = '5s'
-    _RENAME_DIR_LIMIT = 10000
 
     class StoreMetadata:
         """A pickle-able representation of Store
@@ -1307,14 +1303,8 @@ class S3Store(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
-                       'releases/download/0.24.0-romilb-upstream/goofys '
-                       '-O /usr/local/bin/goofys && '
-                       'sudo chmod +x /usr/local/bin/goofys')
-        mount_cmd = ('goofys -o allow_other '
-                     f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
-                     f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
-                     f'{self.bucket.name} {mount_path}')
+        install_cmd = storage_utils.get_s3_mount_install_cmd()
+        mount_cmd = storage_utils.get_s3_mount_cmd(self.bucket.name, mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
@@ -1391,9 +1381,6 @@ class GcsStore(AbstractStore):
     """
 
     _ACCESS_DENIED_MESSAGE = 'AccessDeniedException'
-
-    # https://github.com/GoogleCloudPlatform/gcsfuse/releases
-    _GCSFUSE_VERSION = '1.3.0'
 
     def __init__(self,
                  name: str,
@@ -1744,20 +1731,11 @@ class GcsStore(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
-                       f'/releases/download/v{self._GCSFUSE_VERSION}/'
-                       f'gcsfuse_{self._GCSFUSE_VERSION}_amd64.deb '
-                       '-O /tmp/gcsfuse.deb && '
-                       'sudo dpkg --install /tmp/gcsfuse.deb')
-        mount_cmd = ('gcsfuse -o allow_other '
-                     '--implicit-dirs '
-                     f'--stat-cache-capacity {self._STAT_CACHE_CAPACITY} '
-                     f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
-                     f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
-                     f'--rename-dir-limit {self._RENAME_DIR_LIMIT} '
-                     f'{self.bucket.name} {mount_path}')
+        install_cmd = storage_utils.get_gcs_mount_install_cmd()
+        mount_cmd = storage_utils.get_gcs_mount_cmd(self.bucket.name,
+                                                    mount_path)
         version_check_cmd = (
-            f'gcsfuse --version | grep -q {self._GCSFUSE_VERSION}')
+            f'gcsfuse --version | grep -q {storage_utils.GCSFUSE_VERSION}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)
 
@@ -2123,18 +2101,14 @@ class R2Store(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
-                       'releases/download/0.24.0-romilb-upstream/goofys '
-                       '-O /usr/local/bin/goofys && '
-                       'sudo chmod +x /usr/local/bin/goofys')
+        install_cmd = storage_utils.get_s3_mount_install_cmd()
         endpoint_url = cloudflare.create_endpoint()
-        mount_cmd = (
-            f'AWS_SHARED_CREDENTIALS_FILE={cloudflare.R2_CREDENTIALS_PATH} '
-            f'AWS_PROFILE={cloudflare.R2_PROFILE_NAME} goofys -o allow_other '
-            f'--stat-cache-ttl {self._STAT_CACHE_TTL} '
-            f'--type-cache-ttl {self._TYPE_CACHE_TTL} '
-            f'--endpoint {endpoint_url} '
-            f'{self.bucket.name} {mount_path}')
+        r2_credential_path = cloudflare.R2_CREDENTIALS_PATH
+        r2_profile_name = cloudflare.R2_PROFILE_NAME
+        mount_cmd = storage_utils.get_r2_mount_cmd(r2_credential_path,
+                                                   r2_profile_name,
+                                                   endpoint_url,
+                                                   self.bucket.name, mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
@@ -2546,22 +2520,18 @@ class IBMCosStore(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
+        # install rclone if not installed.
+        install_cmd = storage_utils.get_cos_mount_install_cmd()
         rclone_config_data = Rclone.get_rclone_config(
             self.bucket.name,
             Rclone.RcloneClouds.IBM,
             self.region,  # type: ignore
         )
-        # pylint: disable=line-too-long
-        # creates a fusermount soft link on older (<22) Ubuntu systems for rclone's mount utility.
-        create_fuser3_soft_link = '[ ! -f /bin/fusermount3 ] && sudo ln -s /bin/fusermount /bin/fusermount3 || true'
-        # stores bucket profile in rclone config file at the cluster's nodes.
-        configure_rclone_profile = (
-            f'{create_fuser3_soft_link}; mkdir -p ~/.config/rclone/ && echo "{rclone_config_data}">> {Rclone.RCLONE_CONFIG_PATH}'
-        )
-        # install rclone if not installed.
-        install_cmd = 'rclone version >/dev/null 2>&1 || (curl https://rclone.org/install.sh | sudo bash)'
-        # --daemon will keep the mounting process running in the background.
-        mount_cmd = f'{configure_rclone_profile} && rclone mount {self.bucket_rclone_profile}:{self.bucket.name} {mount_path} --daemon'
+        mount_cmd = storage_utils.get_cos_mount_cmd(rclone_config_data,
+                                                    Rclone.RCLONE_CONFIG_PATH,
+                                                    self.bucket_rclone_profile,
+                                                    self.bucket.name,
+                                                    mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -169,7 +169,6 @@ class AbstractStore:
     present in a cloud.
     """
 
-
     class StoreMetadata:
         """A pickle-able representation of Store
 
@@ -1304,7 +1303,8 @@ class S3Store(AbstractStore):
           mount_path: str; Path to mount the bucket to.
         """
         install_cmd = mounting_utils.get_s3_mount_install_cmd()
-        mount_cmd = mounting_utils.get_s3_mount_cmd(self.bucket.name, mount_path)
+        mount_cmd = mounting_utils.get_s3_mount_cmd(self.bucket.name,
+                                                    mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
@@ -1733,7 +1733,7 @@ class GcsStore(AbstractStore):
         """
         install_cmd = mounting_utils.get_gcs_mount_install_cmd()
         mount_cmd = mounting_utils.get_gcs_mount_cmd(self.bucket.name,
-                                                    mount_path)
+                                                     mount_path)
         version_check_cmd = (
             f'gcsfuse --version | grep -q {mounting_utils.GCSFUSE_VERSION}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
@@ -2106,9 +2106,10 @@ class R2Store(AbstractStore):
         r2_credential_path = cloudflare.R2_CREDENTIALS_PATH
         r2_profile_name = cloudflare.R2_PROFILE_NAME
         mount_cmd = mounting_utils.get_r2_mount_cmd(r2_credential_path,
-                                                   r2_profile_name,
-                                                   endpoint_url,
-                                                   self.bucket.name, mount_path)
+                                                    r2_profile_name,
+                                                    endpoint_url,
+                                                    self.bucket.name,
+                                                    mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
@@ -2528,10 +2529,10 @@ class IBMCosStore(AbstractStore):
             self.region,  # type: ignore
         )
         mount_cmd = mounting_utils.get_cos_mount_cmd(rclone_config_data,
-                                                    Rclone.RCLONE_CONFIG_PATH,
-                                                    self.bucket_rclone_profile,
-                                                    self.bucket.name,
-                                                    mount_path)
+                                                     Rclone.RCLONE_CONFIG_PATH,
+                                                     self.bucket_rclone_profile,
+                                                     self.bucket.name,
+                                                     mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1303,8 +1303,8 @@ class S3Store(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = storage_utils.get_s3_mount_install_cmd()
-        mount_cmd = storage_utils.get_s3_mount_cmd(self.bucket.name, mount_path)
+        install_cmd = mounting_utils.get_s3_mount_install_cmd()
+        mount_cmd = mounting_utils.get_s3_mount_cmd(self.bucket.name, mount_path)
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd)
 
@@ -1731,11 +1731,11 @@ class GcsStore(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = storage_utils.get_gcs_mount_install_cmd()
-        mount_cmd = storage_utils.get_gcs_mount_cmd(self.bucket.name,
+        install_cmd = mounting_utils.get_gcs_mount_install_cmd()
+        mount_cmd = mounting_utils.get_gcs_mount_cmd(self.bucket.name,
                                                     mount_path)
         version_check_cmd = (
-            f'gcsfuse --version | grep -q {storage_utils.GCSFUSE_VERSION}')
+            f'gcsfuse --version | grep -q {mounting_utils.GCSFUSE_VERSION}')
         return mounting_utils.get_mounting_command(mount_path, install_cmd,
                                                    mount_cmd, version_check_cmd)
 
@@ -2101,11 +2101,11 @@ class R2Store(AbstractStore):
         Args:
           mount_path: str; Path to mount the bucket to.
         """
-        install_cmd = storage_utils.get_s3_mount_install_cmd()
+        install_cmd = mounting_utils.get_s3_mount_install_cmd()
         endpoint_url = cloudflare.create_endpoint()
         r2_credential_path = cloudflare.R2_CREDENTIALS_PATH
         r2_profile_name = cloudflare.R2_PROFILE_NAME
-        mount_cmd = storage_utils.get_r2_mount_cmd(r2_credential_path,
+        mount_cmd = mounting_utils.get_r2_mount_cmd(r2_credential_path,
                                                    r2_profile_name,
                                                    endpoint_url,
                                                    self.bucket.name, mount_path)
@@ -2521,13 +2521,13 @@ class IBMCosStore(AbstractStore):
           mount_path: str; Path to mount the bucket to.
         """
         # install rclone if not installed.
-        install_cmd = storage_utils.get_cos_mount_install_cmd()
+        install_cmd = mounting_utils.get_cos_mount_install_cmd()
         rclone_config_data = Rclone.get_rclone_config(
             self.bucket.name,
             Rclone.RcloneClouds.IBM,
             self.region,  # type: ignore
         )
-        mount_cmd = storage_utils.get_cos_mount_cmd(rclone_config_data,
+        mount_cmd = mounting_utils.get_cos_mount_cmd(rclone_config_data,
                                                     Rclone.RCLONE_CONFIG_PATH,
                                                     self.bucket_rclone_profile,
                                                     self.bucket.name,

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -13,14 +13,6 @@ from sky.utils.cli_utils import status_utils
 
 logger = sky_logging.init_logger(__name__)
 
-# Values used to construct mounting commands
-_STAT_CACHE_TTL = '5s'
-_STAT_CACHE_CAPACITY = 4096
-_TYPE_CACHE_TTL = '5s'
-_RENAME_DIR_LIMIT = 10000
-# https://github.com/GoogleCloudPlatform/gcsfuse/releases
-GCSFUSE_VERSION = '1.3.0'
-
 _FILE_EXCLUSION_FROM_GITIGNORE_FAILURE_MSG = (
     f'{colorama.Fore.YELLOW}Warning: Files/dirs '
     'specified in .gitignore will be uploaded '
@@ -170,86 +162,3 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
                     to_be_excluded += '*'
                 excluded_list.append(to_be_excluded)
     return excluded_list
-
-
-def get_s3_mount_install_cmd() -> str:
-    """Returns a command to install S3 mount utility, 'goofys'."""
-    install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
-                   'releases/download/0.24.0-romilb-upstream/goofys '
-                   '-O /usr/local/bin/goofys && '
-                   'sudo chmod +x /usr/local/bin/goofys')
-    return install_cmd
-
-
-def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
-    """Returns a command to mount an S3 bucket using 'goofys'."""
-    mount_cmd = ('goofys -o allow_other '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'{bucket_name} {mount_path}')
-    return mount_cmd
-
-
-def get_gcs_mount_install_cmd() -> str:
-    """Returns a command to install GCS mount utility, 'gcsfuse'."""
-    install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
-                   f'/releases/download/v{GCSFUSE_VERSION}/'
-                   f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
-                   '-O /tmp/gcsfuse.deb && '
-                   'sudo dpkg --install /tmp/gcsfuse.deb')
-    return install_cmd
-
-
-def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
-    """Returns a command to mount a GCS bucket using 'gcsfuse'."""
-    mount_cmd = ('gcsfuse -o allow_other '
-                 '--implicit-dirs '
-                 f'--stat-cache-capacity {_STAT_CACHE_CAPACITY} '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'--rename-dir-limit {_RENAME_DIR_LIMIT} '
-                 f'{bucket_name} {mount_path}')
-    return mount_cmd
-
-
-def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
-                     endpoint_url: str, bucket_name: str,
-                     mount_path: str) -> str:
-    """Returns a command to install R2 mount utility, 'goofys'."""
-    mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
-                 f'AWS_PROFILE={r2_profile_name} goofys -o allow_other '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'--endpoint {endpoint_url} '
-                 f'{bucket_name} {mount_path}')
-    return mount_cmd
-
-
-def get_cos_mount_install_cmd() -> str:
-    """Returns a command to install IBM COS mount utility, 'rclone'."""
-    install_cmd = ('rclone version >/dev/null 2>&1 || '
-                   '(curl https://rclone.org/install.sh | '
-                   'sudo bash)')
-    return install_cmd
-
-
-def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
-                      bucket_rclone_profile: str, bucket_name: str,
-                      mount_path: str) -> str:
-    """Returns a command to mount an IBM COS bucket using 'rclone'."""
-    # creates a fusermount soft link on older (<22) Ubuntu systems for
-    # rclone's mount utility.
-    set_fuser3_soft_link = ('[ ! -f /bin/fusermount3 ] && '
-                            'sudo ln -s /bin/fusermount /bin/fusermount3 || '
-                            'true')
-    # stores bucket profile in rclone config file at the cluster's nodes.
-    configure_rclone_profile = (f'{set_fuser3_soft_link}; '
-                                'mkdir -p ~/.config/rclone/ && '
-                                f'echo "{rclone_config_data}" >> '
-                                f'{rclone_config_path}')
-    # --daemon will keep the mounting process running in the background.
-    mount_cmd = (f'{configure_rclone_profile} && '
-                 'rclone mount '
-                 f'{bucket_rclone_profile}:{bucket_name} {mount_path} '
-                 '--daemon')
-    return mount_cmd

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -13,6 +13,14 @@ from sky.utils.cli_utils import status_utils
 
 logger = sky_logging.init_logger(__name__)
 
+# Values used to construct mounting commands
+_STAT_CACHE_TTL = '5s'
+_STAT_CACHE_CAPACITY = 4096
+_TYPE_CACHE_TTL = '5s'
+_RENAME_DIR_LIMIT = 10000
+# https://github.com/GoogleCloudPlatform/gcsfuse/releases
+GCSFUSE_VERSION = '1.3.0'
+
 _FILE_EXCLUSION_FROM_GITIGNORE_FAILURE_MSG = (
     f'{colorama.Fore.YELLOW}Warning: Files/dirs '
     'specified in .gitignore will be uploaded '
@@ -162,3 +170,79 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
                     to_be_excluded += '*'
                 excluded_list.append(to_be_excluded)
     return excluded_list
+
+
+def get_s3_mount_install_cmd() -> str:
+    install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
+                   'releases/download/0.24.0-romilb-upstream/goofys '
+                   '-O /usr/local/bin/goofys && '
+                   'sudo chmod +x /usr/local/bin/goofys')
+    return install_cmd
+
+
+def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    mount_cmd = ('goofys -o allow_other '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_gcs_mount_install_cmd() -> str:
+    install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
+                   f'/releases/download/v{GCSFUSE_VERSION}/'
+                   f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
+                   '-O /tmp/gcsfuse.deb && '
+                   'sudo dpkg --install /tmp/gcsfuse.deb')
+    return install_cmd
+
+
+def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    mount_cmd = ('gcsfuse -o allow_other '
+                 '--implicit-dirs '
+                 f'--stat-cache-capacity {_STAT_CACHE_CAPACITY} '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'--rename-dir-limit {_RENAME_DIR_LIMIT} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
+                     endpoint_url: str, bucket_name: str,
+                     mount_path: str) -> str:
+    mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
+                 f'AWS_PROFILE={r2_profile_name} goofys -o allow_other '
+                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                 f'--endpoint {endpoint_url} '
+                 f'{bucket_name} {mount_path}')
+    return mount_cmd
+
+
+def get_cos_mount_install_cmd() -> str:
+    install_cmd = ('rclone version >/dev/null 2>&1 || '
+                   '(curl https://rclone.org/install.sh | '
+                   'sudo bash)')
+    return install_cmd
+
+
+def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
+                      bucket_rclone_profile: str, bucket_name: str,
+                      mount_path: str) -> str:
+    # creates a fusermount soft link on older (<22) Ubuntu systems for
+    # rclone's mount utility.
+    set_fuser3_soft_link = ('[ ! -f /bin/fusermount3 ] && '
+                            'sudo ln -s /bin/fusermount /bin/fusermount3 || '
+                            'true')
+    # stores bucket profile in rclone config file at the cluster's nodes.
+    configure_rclone_profile = (f'{set_fuser3_soft_link}; '
+                                'mkdir -p ~/.config/rclone/ && '
+                                f'echo "{rclone_config_data}" >> '
+                                f'{rclone_config_path}')
+    # --daemon will keep the mounting process running in the background.
+    mount_cmd = (f'{configure_rclone_profile} && '
+                 'rclone mount '
+                 f'{bucket_rclone_profile}:{bucket_name} {mount_path} '
+                 '--daemon')
+    return mount_cmd

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -173,6 +173,7 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
 
 
 def get_s3_mount_install_cmd() -> str:
+    """Returns a command to install S3 mount utility, 'goofys'."""
     install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
                    'releases/download/0.24.0-romilb-upstream/goofys '
                    '-O /usr/local/bin/goofys && '
@@ -181,6 +182,7 @@ def get_s3_mount_install_cmd() -> str:
 
 
 def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    """Returns a command to mount an S3 bucket using 'goofys'."""
     mount_cmd = ('goofys -o allow_other '
                  f'--stat-cache-ttl {_STAT_CACHE_TTL} '
                  f'--type-cache-ttl {_TYPE_CACHE_TTL} '
@@ -189,6 +191,7 @@ def get_s3_mount_cmd(bucket_name: str, mount_path: str) -> str:
 
 
 def get_gcs_mount_install_cmd() -> str:
+    """Returns a command to install GCS mount utility, 'gcsfuse'."""
     install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
                    f'/releases/download/v{GCSFUSE_VERSION}/'
                    f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
@@ -198,6 +201,7 @@ def get_gcs_mount_install_cmd() -> str:
 
 
 def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
+    """Returns a command to mount a GCS bucket using 'gcsfuse'."""
     mount_cmd = ('gcsfuse -o allow_other '
                  '--implicit-dirs '
                  f'--stat-cache-capacity {_STAT_CACHE_CAPACITY} '
@@ -211,6 +215,7 @@ def get_gcs_mount_cmd(bucket_name: str, mount_path: str) -> str:
 def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
                      endpoint_url: str, bucket_name: str,
                      mount_path: str) -> str:
+    """Returns a command to install R2 mount utility, 'goofys'."""
     mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
                  f'AWS_PROFILE={r2_profile_name} goofys -o allow_other '
                  f'--stat-cache-ttl {_STAT_CACHE_TTL} '
@@ -221,6 +226,7 @@ def get_r2_mount_cmd(r2_credentials_path: str, r2_profile_name: str,
 
 
 def get_cos_mount_install_cmd() -> str:
+    """Returns a command to install IBM COS mount utility, 'rclone'."""
     install_cmd = ('rclone version >/dev/null 2>&1 || '
                    '(curl https://rclone.org/install.sh | '
                    'sudo bash)')
@@ -230,6 +236,7 @@ def get_cos_mount_install_cmd() -> str:
 def get_cos_mount_cmd(rclone_config_data: str, rclone_config_path: str,
                       bucket_rclone_profile: str, bucket_name: str,
                       mount_path: str) -> str:
+    """Returns a command to mount an IBM COS bucket using 'rclone'."""
     # creates a fusermount soft link on older (<22) Ubuntu systems for
     # rclone's mount utility.
     set_fuser3_soft_link = ('[ ! -f /bin/fusermount3 ] && '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Until now, the mounting script(heredoc) from `mounting_utils.py` were only used from `storage.py`. But now, our new `CSYNC` design, #2336, requires to run cloud storage mounting command(`gcsfuse`, `goofys`) as well. To reuse scripts from `mounting_utils.py` for `CSYNC`(`sky_csync.py` from #2336), this modularization is necessary. 

`CSYNC` module will be utilizing:
- `storage_utils.get_*_install_cmd()`
- `storage_utils.get_*_mount_cmd()`
- `mounting_utils.get_mounting_script()
`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] pytest tests/test_smoke.py::test_aws_storage_mounts_with_stop --aws
- [x] pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop --gcp
- [x] pytest tests/test_smoke.py::test_ibm_storage_mounts --ibm
- [x] All smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
