### PR TITLE
[SkyServe] Check positive for `target_qps_per_replica`

### DIFF
--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -41,6 +41,10 @@ class SkyServiceSpec:
                 raise ValueError(
                     'max_replicas must be greater than or equal to min_replicas'
                 )
+        if target_qps_per_replica is not None and target_qps_per_replica <= 0:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    'target_qps_per_replica must be greater than 0')
         if not readiness_path.startswith('/'):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('readiness_path must start with a slash (/). '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our autoscaling metric `target_qps_per_replica` should be a positive number. This PR adds a check on the constraint.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```yaml
# neg-tar-qps.yaml
service:
  readiness_probe: /
  replica_policy:
    min_replicas: 2
    max_replicas: 10
    target_qps_per_replica: -2.5 # also tested with 0

resources:
  ports: 5000
```
```bash
$ sky serve up neg-tar-qps.yaml
Service from YAML spec: neg-tar-qps.yaml
ValueError: target_qps_per_replica must be greater than 0
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
