### PR TITLE
[AWS] More logging for restarting an instance in STOPPING state and fail fast for the restart

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -372,11 +372,12 @@ def run_instances(region: str, cluster_name_on_cloud: str,
         timeout = 480
         per_instance_timeout = 120
         if stopping_instances:
-            verb = 'is' if len(stopping_instances) == 1 else 'are'
+            plural = 's' if len(stopping_instances) > 1 else ''
+            verb = 'are' if len(stopping_instances) > 1 else 'is'
             logger.warning(
-                f'Instances {stopping_instances} {verb} still in stopping '
-                'state on AWS. It can only be resumed after it is fully '
-                'stopped. Waiting ...')
+                f'Instance{plural} {stopping_instances} {verb} still in '
+                'STOPPING state on AWS. It can only be resumed after it is '
+                'fully STOPPED. Waiting ...')
         while (stopping_instances and
                to_start_count > len(stopped_instances) and
                time.time() - time_start < timeout):

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -371,11 +371,12 @@ def run_instances(region: str, cluster_name_on_cloud: str,
         time_start = time.time()
         timeout = 480
         per_instance_timeout = 120
-        verb = 'is' if len(stopping_instances) == 1 else 'are'
-        logger.warning(
-            f'Instances {stopping_instances} {verb} still in stopping state on '
-            'AWS. It can only be resumed after it is fully stopped. '
-            'Waiting ...')
+        if stopping_instances:
+            verb = 'is' if len(stopping_instances) == 1 else 'are'
+            logger.warning(
+                f'Instances {stopping_instances} {verb} still in stopping '
+                'state on AWS. It can only be resumed after it is fully '
+                'stopped. Waiting ...')
         while (stopping_instances and
                to_start_count > len(stopped_instances) and
                time.time() - time_start < timeout):

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -395,8 +395,8 @@ def run_instances(region: str, cluster_name_on_cloud: str,
                     time.sleep(1)
                 else:
                     logger.warning(
-                        f'Instance {inst.id} is still in stopping state.'
-                        'Retrying ...')
+                        f'Instance {inst.id} is still in stopping state '
+                        f'(Timeout: {per_instance_timeout}). Retrying ...')
                     stopping_instances.append(inst)
                     continue
             stopped_instances.append(inst)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -109,8 +109,7 @@ def _ec2_call_with_retry_on_server_error(ec2_fail_fast_fn: Callable[..., _T],
                                          log_level=logging.DEBUG,
                                          **kwargs) -> _T:
     # Here we have to handle 'RequestLimitExceeded' error, so the provision
-    # would not fail due to request limit
-    # issues.
+    # would not fail due to request limit issues.
     # Here the backoff config (5, 12) is picked at random and does not
     # have any special meaning.
     backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=12)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -399,10 +399,11 @@ def run_instances(region: str, cluster_name_on_cloud: str,
                     continue
             stopped_instances.append(inst)
         if stopping_instances and to_start_count > len(stopped_instances):
-            raise RuntimeError(
-                'Timeout for waiting for existing instances '
+            msg = ('Timeout for waiting for existing instances '
                 f'{stopping_instances} in STOPPING state to '
                 'be STOPPED before restarting them. Please try again later.')
+            logger.error(msg)
+            raise RuntimeError(msg)
 
         resumed_instances = stopped_instances[:to_start_count]
         resumed_instances.sort(key=lambda x: x.id)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -129,8 +129,8 @@ def _ec2_call_with_retry_on_rate_limit(ec2_fail_fast_fn: Callable[..., _T],
             raise
     if ret is None:
         raise RuntimeError(
-            f'Failed to call ec2 function {ec2_fail_fast_fn} due to RequestLimitExceeded.'
-            ' Max attempts exceeded.')
+            f'Failed to call ec2 function {ec2_fail_fast_fn} due to '
+            'RequestLimitExceeded. Max attempts exceeded.')
     return ret
 
 
@@ -266,7 +266,7 @@ def run_instances(region: str, cluster_name_on_cloud: str,
     """See sky/provision/__init__.py"""
     ec2 = _default_ec2_resource(region)
     # NOTE: We set retry=0 for fast failing when the resource is not
-    # available (although the doc says it will only retry for network 
+    # available (although the doc says it will only retry for network
     # issues, practically, it retries for capacity errors, etc as well).
     ec2_fail_fast = aws.resource('ec2', region_name=region, max_attempts=0)
 

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -113,7 +113,7 @@ def _ec2_call_with_retry_on_server_error(ec2_fail_fast_fn: Callable[..., _T],
     # issues.
     # Here the backoff config (5, 12) is picked at random and does not
     # have any special meaning.
-    backoff = common_utils.Backoff(5, 12)
+    backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=12)
     ret = None
     for _ in range(utils.BOTO_MAX_RETRIES):
         try:

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -371,14 +371,15 @@ def run_instances(region: str, cluster_name_on_cloud: str,
         time_start = time.time()
         timeout = 480
         per_instance_timeout = 120
+        verb = 'is' if len(stopping_instances) == 1 else 'are'
+        logger.warning(
+            f'Instances {stopping_instances} {verb} still in stopping state on '
+            'AWS. It can only be resumed after it is fully stopped. '
+            'Waiting ...')
         while (stopping_instances and
                to_start_count > len(stopped_instances) and
                time.time() - time_start < timeout):
             inst = stopping_instances.pop(0)
-            logger.warning(
-                f'Instance {inst.id} is still in stopping state on AWS.'
-                ' It can only be resumed after it is fully stopped. '
-                'Waiting ...')
             with pool.ThreadPool(processes=1) as pool_:
                 # wait_until_stopped() is a blocking call, and sometimes it can
                 # take significant time to return due to AWS keeping the

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -270,7 +270,7 @@ def run_instances(region: str, cluster_name_on_cloud: str,
                   config: common.ProvisionConfig) -> common.ProvisionRecord:
     """See sky/provision/__init__.py"""
     ec2 = _default_ec2_resource(region)
-    # NOTE: We set retry=0 for fast failing when the resource is not
+    # NOTE: We set max_attempts=0 for fast failing when the resource is not
     # available (although the doc says it will only retry for network
     # issues, practically, it retries for capacity errors, etc as well).
     ec2_fail_fast = aws.resource('ec2', region_name=region, max_attempts=0)

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -41,8 +41,8 @@ _DEPENDENCY_VIOLATION_PATTERN = re.compile(
     r'An error occurred \(DependencyViolation\) when calling the '
     r'DeleteSecurityGroup operation(.*): (.*)')
 
-_RESUME_INSTANCE_TIMEOUT = 480 # 8 minutes
-_RESUME_PER_INSTANCE_TIMEOUT = 120 # 2 minutes
+_RESUME_INSTANCE_TIMEOUT = 480  # 8 minutes
+_RESUME_PER_INSTANCE_TIMEOUT = 120  # 2 minutes
 
 # ======================== About AWS subnet/VPC ========================
 # https://stackoverflow.com/questions/37407492/are-there-differences-in-networking-performance-if-ec2-instances-are-in-differen


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user encountered an issue where the AWS cluster takes a long time (>40 mins) to raise the no capacity issue when restarting a STOPPED cluster. This PR mitigates the problem by adding more logs when we are waiting an instance that is in STOPPING state and fail fast for the restart with capacity issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud aws --gpus V100:8 -i 0 echo hi; sky stop sky-8919-gcpuser`
  - [x] During the stopping of the instance: `sky start sky-8919-gcpuser`. We show more logging and error out if timeout
    <img width="839" alt="image" src="https://github.com/skypilot-org/skypilot/assets/6753189/3b3ae769-f469-40de-bf6d-e2446d896b65">
  - [x] When the instance is stopped: `sky start sky-8919-gcpuser`. Show the capacity issue quickly.
- [ ] All smoke tests: `pytest tests/test_smoke.py --aws` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
