### PR TITLE
[Provisioner] Reduce parallelism for file mounts based on fd limit

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -7,8 +7,6 @@ import resource
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-import psutil
-
 from sky import sky_logging
 from sky.provision import common
 from sky.provision import docker_utils
@@ -51,11 +49,6 @@ RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (
 
 # Restart skylet when the version does not match to keep the skylet up-to-date.
 _MAYBE_SKYLET_RESTART_CMD = 'python3 -m sky.skylet.attempt_skylet'
-
-
-def _get_idle_cpu_count() -> int:
-    """Returns the number of idle CPUs."""
-    return max(8, int((1 - psutil.cpu_percent() / 100) * psutil.cpu_count()))
 
 
 def _auto_retry(func):
@@ -114,7 +107,7 @@ def _parallel_ssh_with_cache(func,
     if max_workers is None:
         # Not using the default value of `max_workers` in ThreadPoolExecutor,
         # as 32 is too large for some machines.
-        max_workers = _get_idle_cpu_count()
+        max_workers = subprocess_utils.get_cpu_count()
     with futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         results = []
         for instance_id, metadatas in cluster_info.instances.items():
@@ -418,7 +411,7 @@ def _max_workers_for_file_mounts(common_file_mounts: Dict[str, str]) -> int:
 
     max_workers = (fd_limit - fd_reserve) // fd_per_rsync
     # At least 1 worker, and avoid too many workers overloading the system.
-    max_workers = min(max(max_workers, 1), _get_idle_cpu_count())
+    max_workers = min(max(max_workers, 1), subprocess_utils.get_cpu_count())
     logger.debug(f'Using {max_workers} workers for file mounts.')
     return max_workers
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -103,7 +103,7 @@ def _parallel_ssh_with_cache(func,
                              digest: Optional[str],
                              cluster_info: common.ClusterInfo,
                              ssh_credentials: Dict[str, Any],
-                             max_workers: int = 32) -> List[Any]:
+                             max_workers: Optional[int] = None) -> List[Any]:
     with futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         results = []
         for instance_id, metadatas in cluster_info.instances.items():

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -411,7 +411,8 @@ def _max_workers_for_file_mounts(common_file_mounts: Dict[str, str]) -> int:
 
     max_workers = (fd_limit - fd_reserve) // fd_per_rsync
     # At least 1 worker, and avoid too many workers overloading the system.
-    max_workers = min(max(max_workers, 1), subprocess_utils.get_parallel_threads())
+    max_workers = min(max(max_workers, 1),
+                      subprocess_utils.get_parallel_threads())
     logger.debug(f'Using {max_workers} workers for file mounts.')
     return max_workers
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -107,7 +107,7 @@ def _parallel_ssh_with_cache(func,
     if max_workers is None:
         # Not using the default value of `max_workers` in ThreadPoolExecutor,
         # as 32 is too large for some machines.
-        max_workers = subprocess_utils.get_cpu_count()
+        max_workers = subprocess_utils.get_parallel_threads()
     with futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         results = []
         for instance_id, metadatas in cluster_info.instances.items():
@@ -411,7 +411,7 @@ def _max_workers_for_file_mounts(common_file_mounts: Dict[str, str]) -> int:
 
     max_workers = (fd_limit - fd_reserve) // fd_per_rsync
     # At least 1 worker, and avoid too many workers overloading the system.
-    max_workers = min(max(max_workers, 1), subprocess_utils.get_cpu_count())
+    max_workers = min(max(max_workers, 1), subprocess_utils.get_parallel_threads())
     logger.debug(f'Using {max_workers} workers for file mounts.')
     return max_workers
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -403,7 +403,9 @@ def _max_workers_for_file_mounts(common_file_mounts: Dict[str, str]) -> int:
 
     max_workers = (fd_limit - fd_reserve) // fd_per_rsync
     # At least 1 worker, and avoid too many workers overloading the system.
-    return min(max(max_workers, 1), 32)
+    max_workers = min(max(max_workers, 1), 32)
+    logger.debug(f'Using {max_workers} workers for file mounts.')
+    return max_workers
 
 
 @_log_start_end

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -3,10 +3,11 @@ from concurrent import futures
 import functools
 import hashlib
 import os
-import psutil
 import resource
 import time
 from typing import Any, Dict, List, Optional, Tuple
+
+import psutil
 
 from sky import sky_logging
 from sky.provision import common
@@ -50,6 +51,7 @@ RAY_STATUS_WITH_SKY_RAY_PORT_COMMAND = (
 
 # Restart skylet when the version does not match to keep the skylet up-to-date.
 _MAYBE_SKYLET_RESTART_CMD = 'python3 -m sky.skylet.attempt_skylet'
+
 
 def _get_idle_cpu_count() -> int:
     """Returns the number of idle CPUs."""

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -246,16 +246,19 @@ def _wait_ssh_connection_direct(
         ssh_proxy_command: Optional[str] = None) -> bool:
     assert ssh_proxy_command is None, 'SSH proxy command is not supported.'
     try:
-        with socket.create_connection((ip, ssh_port), timeout=1) as s:
+        success = False
+        with socket.create_connection((ip, ssh_port), timeout=10) as s:
             if s.recv(100).startswith(b'SSH'):
                 # Wait for SSH being actually ready, otherwise we may get the
                 # following error:
                 # "System is booting up. Unprivileged users are not permitted to
                 # log in yet".
-                return _wait_ssh_connection_indirect(ip, ssh_port, ssh_user,
-                                                     ssh_private_key,
-                                                     ssh_control_name,
-                                                     ssh_proxy_command)
+                success = True
+        if success:
+            return _wait_ssh_connection_indirect(ip, ssh_port, ssh_user,
+                                                 ssh_private_key,
+                                                 ssh_control_name,
+                                                 ssh_proxy_command)
     except socket.timeout:  # this is the most expected exception
         pass
     except Exception:  # pylint: disable=broad-except

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -247,7 +247,7 @@ def _wait_ssh_connection_direct(
     assert ssh_proxy_command is None, 'SSH proxy command is not supported.'
     try:
         success = False
-        with socket.create_connection((ip, ssh_port), timeout=10) as s:
+        with socket.create_connection((ip, ssh_port), timeout=1) as s:
             if s.recv(100).startswith(b'SSH'):
                 # Wait for SSH being actually ready, otherwise we may get the
                 # following error:

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -42,7 +42,7 @@ def run_no_outputs(cmd, **kwargs):
                **kwargs)
 
 
-def get_cpu_count() -> int:
+def get_parallel_threads() -> int:
     """Returns the number of idle CPUs."""
     cpu_count = os.cpu_count()
     if cpu_count is None:
@@ -58,7 +58,7 @@ def run_in_parallel(func: Callable, args: List[Any]) -> List[Any]:
     as the arguments.
     """
     # Reference: https://stackoverflow.com/questions/25790279/python-multiprocessing-early-termination # pylint: disable=line-too-long
-    with pool.ThreadPool(processes=get_cpu_count()) as p:
+    with pool.ThreadPool(processes=get_parallel_threads()) as p:
         # Run the function in parallel on the arguments, keeping the order.
         return list(p.imap(func, args))
 

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -1,5 +1,6 @@
 """Utility functions for subprocesses."""
 from multiprocessing import pool
+import os
 import random
 import subprocess
 import time
@@ -41,6 +42,14 @@ def run_no_outputs(cmd, **kwargs):
                **kwargs)
 
 
+def get_cpu_count() -> int:
+    """Returns the number of idle CPUs."""
+    cpu_count = os.cpu_count()
+    if cpu_count is None:
+        cpu_count = 1
+    return max(4, cpu_count - 1)
+
+
 def run_in_parallel(func: Callable, args: List[Any]) -> List[Any]:
     """Run a function in parallel on a list of arguments.
 
@@ -49,7 +58,7 @@ def run_in_parallel(func: Callable, args: List[Any]) -> List[Any]:
     as the arguments.
     """
     # Reference: https://stackoverflow.com/questions/25790279/python-multiprocessing-early-termination # pylint: disable=line-too-long
-    with pool.ThreadPool() as p:
+    with pool.ThreadPool(processes=get_cpu_count()) as p:
         # Run the function in parallel on the arguments, keeping the order.
         return list(p.imap(func, args))
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3002. This should be compatible with #3004.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-100-nodes --cloud aws --num-nodes 100 --cpus 2 echo hi`
  - [x] `sky down test-100-nodes`
  - [x] `sky status -r test-100-nodes` (tried again)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
