### PR TITLE
[k8s] Kubernetes realtime availability

### DIFF
--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -110,6 +110,22 @@ def list_accelerator_counts(
         ret[gpu] = sorted(counts)
     return ret
 
+def list_accelerators_realtime(
+    clouds: CloudFilter = None,
+) -> Dict[str, str]:
+    """List available and total number of accelerators offered by Sky.
+
+    Returns: A dictionary of canonical accelerator names mapped to a 
+    string available/total counts in fraction form. See usage in cli.py.
+    """
+    total_accelerator_available, total_accelerator_count = _map_clouds_catalog(clouds, 'list_accelerators_realtime', False)
+    # if not isinstance(results, list): # unsure if needed
+    #     results = [results]
+    ret: Dict[str, str] = {}
+    for gpu in total_accelerator_available:
+        ret[gpu] = f"{total_accelerator_available[gpu]}/{total_accelerator_count[gpu]}"
+    return ret
+
 
 def instance_type_exists(instance_type: str,
                          clouds: CloudFilter = None) -> bool:

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -242,6 +242,16 @@ def get_kubernetes_nodes() -> List[Any]:
             'Please check if the cluster is healthy and retry.') from None
     return nodes
 
+def get_kubernetes_pods() -> List[Any]:
+    try:
+        ns = get_current_kube_config_context_namespace()
+        pods = kubernetes.core_api().list_namespaced_pod(ns, _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.max_retry_error():
+        raise exceptions.ResourcesUnavailableError(
+            'Timed out when trying to get pod info from Kubernetes cluster. '
+            'Please check if the cluster is healthy and retry.') from None
+    return pods
+
 
 def check_instance_fits(instance: str) -> Tuple[bool, Optional[str]]:
     """Checks if the instance fits on the Kubernetes cluster.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Working on addressing issue [#2839](https://github.com/skypilot-org/skypilot/issues/2839). 

When users run `sky show-gpus --cloud kubernetes`, there is an additional column showing how many GPUs have jobs scheduled on them out of the total, preview below.

<img width="701" alt="image" src="https://github.com/skypilot-org/skypilot/assets/32891260/51b31367-e4f7-4f76-90b6-d7008cfd70ea">

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
