### PR TITLE
[Azure] Fix empty string for status query

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -652,6 +652,8 @@ class Azure(clouds.Cloud):
 
         original_statuses_list = json.loads(stdout.strip())
         if not original_statuses_list:
+            # No nodes found. The original_statuses_list will be empty string.
+            # Return empty list.
             return []
         if not isinstance(original_statuses_list, list):
             original_statuses_list = [original_statuses_list]

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -651,6 +651,8 @@ class Azure(clouds.Cloud):
         assert stdout.strip(), f'No status returned for {name!r}'
 
         original_statuses_list = json.loads(stdout.strip())
+        if not original_statuses_list:
+            return []
         if not isinstance(original_statuses_list, list):
             original_statuses_list = [original_statuses_list]
         statuses = []


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce:
1. `sky launch -c test --gpus A100-80GB:2`; ctrl-c immediately after the cluster is INIT.
2. `sky launch -c test` again.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
