### PR TITLE
[LLM] Fix mixtral example for Azure

### DIFF
--- a/llm/mixtral/README.md
+++ b/llm/mixtral/README.md
@@ -19,6 +19,30 @@ resources:
   accelerators: {A100:4, A100:8, A100-80GB:2, A100-80GB:4, A100-80GB:8}
 ```
 
+The following is the example output of the optimizer:
+
+```
+Considered resources (1 node):
+----------------------------------------------------------------------------------------------------------
+ CLOUD   INSTANCE                    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN   
+----------------------------------------------------------------------------------------------------------
+ Azure   Standard_NC48ads_A100_v4    48      440       A100-80GB:2    eastus          7.35          ✔     
+ GCP     g2-standard-96              96      384       L4:8           us-east4-a      7.98                
+ GCP     a2-ultragpu-2g              24      340       A100-80GB:2    us-central1-a   10.06               
+ Azure   Standard_NC96ads_A100_v4    96      880       A100-80GB:4    eastus          14.69               
+ GCP     a2-highgpu-4g               48      340       A100:4         us-central1-a   14.69               
+ AWS     g5.48xlarge                 192     768       A10G:8         us-east-1       16.29               
+ GCP     a2-ultragpu-4g              48      680       A100-80GB:4    us-central1-a   20.11               
+ Azure   Standard_ND96asr_v4         96      900       A100:8         eastus          27.20               
+ GCP     a2-highgpu-8g               96      680       A100:8         us-central1-a   29.39               
+ Azure   Standard_ND96amsr_A100_v4   96      1924      A100-80GB:8    eastus          32.77               
+ AWS     p4d.24xlarge                96      1152      A100:8         us-east-1       32.77               
+ GCP     a2-ultragpu-8g              96      1360      A100-80GB:8    us-central1-a   40.22               
+ AWS     p4de.24xlarge               96      1152      A100-80GB:8    us-east-1       40.97               
+----------------------------------------------------------------------------------------------------------
+```
+
+
 ### Accessing the model
 
 We can now access the model through the OpenAI API with the IP and port:

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -34,6 +34,9 @@ setup: |
   pip list | grep megablocks || pip install megablocks
 
 run: |
+  # Remove the default nccl.conf which causes failure on Azure
+  sudo mv /etc/nccl.conf /etc/nccl.conf.bak || true
+
   conda activate mixtral
   export PATH=$PATH:/sbin
   python -u -m vllm.entrypoints.openai.api_server \

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -34,9 +34,6 @@ setup: |
   pip list | grep megablocks || pip install megablocks
 
 run: |
-  # Remove the default nccl.conf which causes failure on Azure
-  sudo mv /etc/nccl.conf /etc/nccl.conf.bak || true
-
   conda activate mixtral
   export PATH=$PATH:/sbin
   python -u -m vllm.entrypoints.openai.api_server \

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -138,6 +138,7 @@ setup_commands:
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
+  # Line 'sudo mv /etc/nccl.conf /etc/nccl.conf.bak' removes the default nccl.conf which is wrongly configured on many multi-GPU Azure VM, causing failure for multi-GPU workloads using NCCL.
   - mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
@@ -157,6 +158,7 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     python3 -c "from sky.skylet.ray_patches import patch; patch()" || exit 1;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf');
+    sudo mv /etc/nccl.conf /etc/nccl.conf.bak || true;
 
 # Command to start ray on the head node. You don't need to change this.
 # NOTE: these are very performance-sensitive. Each new item opens/closes an SSH

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -192,7 +192,7 @@ setup_commands:
     grep "export TPU_NAME=" ~/.bashrc && echo "TPU_NAME already set" || echo "export TPU_NAME={{tpu_node_name}}" >> ~/.bashrc;
   {%- endif %}
     mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
-    (pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U ray[default]=={{ray_version}});
+    pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U ray[default]=={{ray_version}};
     (pip3 list | grep "skypilot " && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[gcp, remote]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     {%- if docker_image is none %}

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3983,6 +3983,7 @@ def test_multiple_resources():
 
 
 # ---------- Sky Benchmark ----------
+@pytest.mark.no_kubernetes
 def test_sky_bench(generic_cloud: str):
     name = _get_cluster_name()
     test = Test(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #2905
Fix mixtral example for Azure by removing the problemetic nccl config file on Azure.

With this PR, after #2434 is merged, we should be able to change the examples to `disk_tier: best`, so that Azure is allowed to be part of the candidates.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --disk-tier none -c test-mixtral --cloud azure llm/mixtral/serve.yaml`
  - [x] `sky launch -c test-gcp-mixtral --cloud gcp --use-spot llm/mixtral/serve.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
