### PR TITLE
[Doc] Highlight debian-based image in docker as runtime env doc

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -98,7 +98,7 @@ When a container is used as the runtime environment, everything happens inside t
 - :code:`setup` and :code:`run` commands are executed in the container;
 - Any files created by the task will be stored inside the container.
 
-To use a Docker image as your runtime environment, set the :code:`image_id` field in the :code:`resources` section of your task YAML file to :code:`docker:<image_id>`. Only **Debian-based** images are supported for now.
+To use a Docker image as your runtime environment, set the :code:`image_id` field in the :code:`resources` section of your task YAML file to :code:`docker:<image_id>`. Only **Debian-based** images (e.g., Ubuntu) are supported for now.
 
 For example, to use the :code:`ubuntu:20.04` image from Docker Hub:
 

--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -98,7 +98,7 @@ When a container is used as the runtime environment, everything happens inside t
 - :code:`setup` and :code:`run` commands are executed in the container;
 - Any files created by the task will be stored inside the container.
 
-To use a Docker image as your runtime environment, set the :code:`image_id` field in the :code:`resources` section of your task YAML file to :code:`docker:<image_id>`.
+To use a Docker image as your runtime environment, set the :code:`image_id` field in the :code:`resources` section of your task YAML file to :code:`docker:<image_id>`. Only **Debian-based** images are supported for now.
 
 For example, to use the :code:`ubuntu:20.04` image from Docker Hub:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, our hint for only support Debian-based containers was hard to spot. This PR added a sentence for that.

<img width="1071" alt="image" src="https://github.com/skypilot-org/skypilot/assets/74357442/de6494d0-c6ef-4263-a266-5cbdc3b588ac">

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
