### PR TITLE
[Dependency] Remove direct reference for sphere

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -238,7 +238,12 @@ extras_require: Dict[str, List[str]] = {
     'runpod': ['runpod>=1.5.1'],
     'vsphere': [
         'pyvmomi==8.0.1.0.2',
-        'vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0'
+        # vsphere-automation-sdk is also required, but it does not have
+        # pypi release, which cause failure of our pypi release.
+        # https://peps.python.org/pep-0440/#direct-references
+        # We have the instruction for installation in our
+        # docs instead.
+        # 'vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0'
     ],
 }
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -241,7 +241,7 @@ extras_require: Dict[str, List[str]] = {
         # vsphere-automation-sdk is also required, but it does not have
         # pypi release, which cause failure of our pypi release.
         # https://peps.python.org/pep-0440/#direct-references
-        # We have the instruction for installation in our
+        # We have the instruction for its installation in our
         # docs instead.
         # 'vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0'
     ],


### PR DESCRIPTION
The direct reference causes error in our pypi release: https://github.com/skypilot-org/skypilot/actions/runs/7638977430

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
