### PR TITLE
[GCP] Ignore missing gcp credentials

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -752,9 +752,14 @@ class GCP(clouds.Cloud):
         # Excluding the symlink to the python executable created by the gcp
         # credential, which causes problem for ray up multiple nodes, tracked
         # in #494, #496, #483.
+        # We only add the existing credential files. It should be safe to ignore
+        # the missing files, as we successfully created the VM at this point,
+        # meaning the authentication is successful.
         credentials = {
             f'~/.config/gcloud/{filename}': f'~/.config/gcloud/{filename}'
             for filename in _CREDENTIAL_FILES
+            if os.path.exists(os.path.expanduser(
+                f'~/.config/gcloud/{filename}'))
         }
         # Upload the application key path to the default path, so that
         # autostop and GCS can be accessed on the remote cluster.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3026 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test --cloud gcp --cpus 2` with legacy_credentials removed.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
