### PR TITLE
[GCP] Fix machine image for cluster creation

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1057,6 +1057,15 @@ class FailoverCloudErrorHandlerV2:
                 _add_to_blocked_resources(
                     blocked_resources,
                     launchable_resources.copy(zone=zone.name))
+            elif code in ['RESOURCE_OPERATION_RATE_EXCEEDED']:
+                # This code can happen when the VM is being created with a
+                # machine image, and the VM and the machine image are on
+                # different zones. We already have the retry when calling the
+                # insert API, but if it still fails, we should block the zone
+                # to avoid infinite retry.
+                _add_to_blocked_resources(
+                    blocked_resources,
+                    launchable_resources.copy(zone=zone.name))
             elif code in [3, 8, 9]:
                 # Error code 3 means TPU is preempted during creation.
                 # Example:

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -745,7 +745,7 @@ class GCPComputeInstance(GCPInstance):
 
         for disk in config.get('disks', []):
             disk_type = disk.get('initializeParams', {}).get('diskType')
-            if disk_type:
+            if disk_type is not None:
                 disk['initializeParams']['diskType'] = selflink_to_name(
                     disk_type)
         config['machineType'] = selflink_to_name(config['machineType'])

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -724,7 +724,7 @@ class GCPComputeInstance(GCPInstance):
             # We need to retry the insert operation because it may fail with
             # RESOURCE_OPERATION_RATE_EXCEEDED error, which is normally caused
             # by creating VMs with machine images on different zones.
-            operation = request.execute(num_retries=GCP_CREATE_MAX_RETRIES)
+            operation = request.execute(num_retries=GCP_MAX_RETRIES)
             operations.append(operation)
 
         logger.debug('"insert" operation requested ...')

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -238,7 +238,12 @@ extras_require: Dict[str, List[str]] = {
     'runpod': ['runpod>=1.5.1'],
     'vsphere': [
         'pyvmomi==8.0.1.0.2',
-        'vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0'
+        # vsphere-automation-sdk is also required, but it does not have
+        # pypi release, which cause failure of our pypi release.
+        # https://peps.python.org/pep-0440/#direct-references
+        # We have the instruction for its installation in our
+        # docs instead.
+        # 'vsphere-automation-sdk @ git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.1.0'
     ],
 }
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1216,7 +1216,7 @@ def test_large_job_queue(generic_cloud: str):
             f'sky launch -y -c {name} --cpus 8 --cloud {generic_cloud}',
             f'for i in `seq 1 75`; do sky exec {name} -n {name}-$i -d "echo $i; sleep 100000000"; done',
             f'sky cancel -y {name} 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16',
-            'sleep 75',
+            'sleep 85',
             # Each job takes 0.5 CPU and the default VM has 8 CPUs, so there should be 8 / 0.5 = 16 jobs running.
             # The first 16 jobs are canceled, so there should be 75 - 32 = 43 jobs PENDING.
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep -v grep | grep PENDING | wc -l | grep 43',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3027

The `bulkInsert` API fails to create VMs using `machineImage` along with disk parameter override, as it does a check for the source of the disk, which should not be applied when `machineImage` is specified (bug of GCP API).
This PR makes it fallback to the regular `insert` API instead to support the creation of instances using machine image.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-machine-image2 --cloud gcp  --disk-size 256 --num-nodes 2 --gpus A100-80GB:8`; correctly failover through multiple regions
  - [x] `sky launch -c test-machine-image5 --cloud gcp --image-id p
rojects/skypilot-375900/global/machineImages/test-machine-image --disk-size 256 --cpus 2 --num-nodes 4`, successfully create the cluster
   - [x] `sky launch -c test-machine-image5 --cloud gcp --image-id projects/skypilot-375900/global/machineImages/test-machine-image --disk-size 256 --num-nodes 2 --gpus A100-80GB:8` successfuly failver through zones/regions.
- [x] All smoke tests: `pytest tests/test_smoke.py --gcp` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
