### PR TITLE
[Refactor] Remove part of clouds.Local related code to avoid errors for jobs

### DIFF
--- a/sky/backends/onprem_utils.py
+++ b/sky/backends/onprem_utils.py
@@ -139,15 +139,6 @@ def get_python_executable(cluster_name: str) -> str:
     return config['python']
 
 
-def get_job_owner(cluster_yaml: str, docker_user: Optional[str] = None) -> str:
-    """Get the owner of the job."""
-    if docker_user is not None:
-        return docker_user
-    cluster_config = common_utils.read_yaml(os.path.expanduser(cluster_yaml))
-    # User name is guaranteed to exist (on all jinja files)
-    return cluster_config['auth']['ssh_user']
-
-
 def get_local_cluster_config_or_error(cluster_name: str) -> Dict[str, Any]:
     """Gets the local cluster config in ~/.sky/local/."""
     local_file = os.path.expanduser(

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -140,8 +140,6 @@ def run_with_log(
     process_stream: bool = True,
     line_processor: Optional[log_utils.LineProcessor] = None,
     streaming_prefix: Optional[str] = None,
-    ray_job_id: Optional[str] = None,
-    use_sudo: bool = False,
     **kwargs,
 ) -> Union[int, Tuple[int, str, str]]:
     """Runs a command and logs its output to a file.
@@ -155,7 +153,6 @@ def run_with_log(
             command, such as replacing or skipping lines on the fly. If
             enabled, lines are printed only when '\r' or '\n' is found.
         ray_job_id: The id for a ray job.
-        use_sudo: Whether to use sudo to create log_path.
 
     Returns the returncode or returncode, stdout and stderr of the command.
       Note that the stdout and stderr is already decoded.
@@ -166,19 +163,7 @@ def run_with_log(
 
     log_path = os.path.expanduser(log_path)
     dirname = os.path.dirname(log_path)
-    if use_sudo:
-        # Sudo case is encountered when submitting
-        # a job for Sky on-prem, when a non-admin user submits a job.
-        subprocess.run(f'sudo mkdir -p {dirname}', shell=True, check=True)
-        subprocess.run(f'sudo touch {log_path}; sudo chmod a+rwx {log_path}',
-                       shell=True,
-                       check=True)
-        # Hack: Subprocess Popen does not accept sudo.
-        # subprocess.Popen in local mode with shell=True does not work,
-        # as it does not understand what -H means for sudo.
-        shell = False
-    else:
-        os.makedirs(dirname, exist_ok=True)
+    os.makedirs(dirname, exist_ok=True)
     # Redirect stderr to stdout when using ray, to preserve the order of
     # stdout and stderr.
     stdout_arg = stderr_arg = None
@@ -208,14 +193,7 @@ def run_with_log(
                 '--proc-pid',
                 str(proc.pid),
             ]
-            # Bool use_sudo is true in the Sky On-prem case.
-            # In this case, subprocess_daemon.py should run on the root user
-            # and the Ray job id should be passed for daemon to poll for
-            # job status (as `ray job stop` does not work in the
-            # multitenant case).
-            if use_sudo:
-                daemon_cmd.insert(0, 'sudo')
-                daemon_cmd.extend(['--local-ray-job-id', str(ray_job_id)])
+
             subprocess.Popen(
                 daemon_cmd,
                 start_new_session=True,
@@ -311,16 +289,12 @@ def add_ray_env_vars(
 
 def run_bash_command_with_log(bash_command: str,
                               log_path: str,
-                              job_owner: Optional[str] = None,
                               job_id: Optional[int] = None,
                               env_vars: Optional[Dict[str, str]] = None,
                               stream_logs: bool = False,
-                              with_ray: bool = False,
-                              use_sudo: bool = False):
+                              with_ray: bool = False):
     with tempfile.NamedTemporaryFile('w', prefix='sky_app_',
                                      delete=False) as fp:
-        if use_sudo:
-            env_vars = add_ray_env_vars(env_vars)
         bash_command = make_task_bash_script(bash_command, env_vars=env_vars)
         fp.write(bash_command)
         fp.flush()
@@ -330,22 +304,15 @@ def run_bash_command_with_log(bash_command: str,
         inner_command = f'/bin/bash -i {script_path}'
 
         subprocess_cmd: Union[str, List[str]]
-        if use_sudo and job_owner is not None:
-            subprocess.run(f'chmod a+rwx {script_path}', shell=True, check=True)
-            subprocess_cmd = job_lib.make_job_command_with_user_switching(
-                job_owner, inner_command)
-        else:
-            subprocess_cmd = inner_command
+        subprocess_cmd = inner_command
 
-        ray_job_id = job_lib.make_ray_job_id(job_id,
-                                             job_owner) if job_id else None
+        ray_job_id = job_lib.make_ray_job_id(job_id) if job_id else None
         return run_with_log(
             subprocess_cmd,
             log_path,
             ray_job_id=ray_job_id,
             stream_logs=stream_logs,
             with_ray=with_ray,
-            use_sudo=use_sudo,
             # Disable input to avoid blocking.
             stdin=subprocess.DEVNULL,
             shell=True)
@@ -399,15 +366,13 @@ def _follow_job_logs(file,
             status = job_lib.get_status_no_lock(job_id)
 
 
-def tail_logs(job_owner: str,
-              job_id: Optional[int],
+def tail_logs(job_id: Optional[int],
               log_dir: Optional[str],
               spot_job_id: Optional[int] = None,
               follow: bool = True) -> None:
     """Tail the logs of a job.
 
     Args:
-        job_owner: The owner username of the job.
         job_id: The job id.
         log_dir: The log directory of the job.
         spot_job_id: The spot job id (for logging info only to avoid confusion).
@@ -433,7 +398,7 @@ def tail_logs(job_owner: str,
     log_path = os.path.join(log_dir, 'run.log')
     log_path = os.path.expanduser(log_path)
 
-    status = job_lib.update_job_status(job_owner, [job_id], silent=True)[0]
+    status = job_lib.update_job_status([job_id], silent=True)[0]
 
     # Wait for the log to be written. This is needed due to the `ray submit`
     # will take some time to start the job and write the log.
@@ -451,7 +416,7 @@ def tail_logs(job_owner: str,
         print(f'INFO: Waiting {_SKY_LOG_WAITING_GAP_SECONDS}s for the logs '
               'to be written...')
         time.sleep(_SKY_LOG_WAITING_GAP_SECONDS)
-        status = job_lib.update_job_status(job_owner, [job_id], silent=True)[0]
+        status = job_lib.update_job_status([job_id], silent=True)[0]
 
     start_stream_at = 'INFO: Tip: use Ctrl-C to exit log'
     if follow and status in [

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -152,7 +152,6 @@ def run_with_log(
         process_stream: Whether to post-process the stdout/stderr of the
             command, such as replacing or skipping lines on the fly. If
             enabled, lines are printed only when '\r' or '\n' is found.
-        ray_job_id: The id for a ray job.
 
     Returns the returncode or returncode, stdout and stderr of the command.
       Note that the stdout and stderr is already decoded.
@@ -289,7 +288,6 @@ def add_ray_env_vars(
 
 def run_bash_command_with_log(bash_command: str,
                               log_path: str,
-                              job_id: Optional[int] = None,
                               env_vars: Optional[Dict[str, str]] = None,
                               stream_logs: bool = False,
                               with_ray: bool = False):
@@ -306,11 +304,9 @@ def run_bash_command_with_log(bash_command: str,
         subprocess_cmd: Union[str, List[str]]
         subprocess_cmd = inner_command
 
-        ray_job_id = job_lib.make_ray_job_id(job_id) if job_id else None
         return run_with_log(
             subprocess_cmd,
             log_path,
-            ray_job_id=ray_job_id,
             stream_logs=stream_logs,
             with_ray=with_ray,
             # Disable input to avoid blocking.

--- a/sky/skylet/log_lib.pyi
+++ b/sky/skylet/log_lib.pyi
@@ -58,7 +58,6 @@ def run_with_log(cmd: Union[List[str], str],
                  line_processor: Optional[log_utils.LineProcessor] = ...,
                  streaming_prefix: Optional[str] = ...,
                  ray_job_id: Optional[str] = ...,
-                 use_sudo: bool = ...,
                  **kwargs) -> int:
     ...
 
@@ -78,7 +77,6 @@ def run_with_log(cmd: Union[List[str], str],
                  line_processor: Optional[log_utils.LineProcessor] = ...,
                  streaming_prefix: Optional[str] = ...,
                  ray_job_id: Optional[str] = ...,
-                 use_sudo: bool = ...,
                  **kwargs) -> Tuple[int, str, str]:
     ...
 
@@ -98,7 +96,6 @@ def run_with_log(cmd: Union[List[str], str],
                  line_processor: Optional[log_utils.LineProcessor] = ...,
                  streaming_prefix: Optional[str] = ...,
                  ray_job_id: Optional[str] = ...,
-                 use_sudo: bool = ...,
                  **kwargs) -> Union[int, Tuple[int, str, str]]:
     ...
 
@@ -115,17 +112,14 @@ def add_ray_env_vars(
 
 def run_bash_command_with_log(bash_command: str,
                               log_path: str,
-                              job_owner: Optional[str] = ...,
                               job_id: Optional[int] = ...,
                               env_vars: Optional[Dict[str, str]] = ...,
                               stream_logs: bool = ...,
-                              with_ray: bool = ...,
-                              use_sudo: bool = ...):
+                              with_ray: bool = ...):
     ...
 
 
-def tail_logs(job_owner: str,
-              job_id: int,
+def tail_logs(job_id: int,
               log_dir: Optional[str],
               spot_job_id: Optional[int] = ...,
               follow: bool = ...) -> None:

--- a/sky/skylet/log_lib.pyi
+++ b/sky/skylet/log_lib.pyi
@@ -112,7 +112,6 @@ def add_ray_env_vars(
 
 def run_bash_command_with_log(bash_command: str,
                               log_path: str,
-                              job_id: Optional[int] = ...,
                               env_vars: Optional[Dict[str, str]] = ...,
                               stream_logs: bool = ...,
                               with_ray: bool = ...):

--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -9,20 +9,13 @@ import sys
 import time
 
 import psutil
-from ray.dashboard.modules.job import common as job_common
-from ray.dashboard.modules.job import sdk as job_sdk
-import requests
-
-from sky.skylet import job_lib
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--parent-pid', type=int, required=True)
     parser.add_argument('--proc-pid', type=int, required=True)
-    parser.add_argument('--local-ray-job-id', type=str, required=False)
     args = parser.parse_args()
-    local_ray_job_id = args.local_ray_job_id
 
     process = None
     parent_process = None
@@ -35,32 +28,7 @@ if __name__ == '__main__':
     if process is None:
         sys.exit()
 
-    wait_for_process = False
-    # Local Ray Job ID is only used in the Sky On-prem case.
-    # If Local Ray job id is passed in, wait until the job
-    # is done/cancelled/failed.
-    if local_ray_job_id is None:
-        wait_for_process = True
-    else:
-        try:
-            # Polls the Job submission client to check job status.
-            port = job_lib.get_job_submission_port()
-            client = job_sdk.JobSubmissionClient(f'http://127.0.0.1:{port}')
-            while True:
-                status_info = client.get_job_status(local_ray_job_id)
-                status = status_info.status
-                if status in {
-                        job_common.JobStatus.SUCCEEDED,
-                        job_common.JobStatus.STOPPED,
-                        job_common.JobStatus.FAILED
-                }:
-                    break
-                time.sleep(1)
-        except (requests.exceptions.ConnectionError, RuntimeError) as e:
-            print(e)
-            wait_for_process = True
-
-    if wait_for_process and parent_process is not None:
+    if parent_process is not None:
         # Wait for either parent or target process to exit.
         while process.is_running() and parent_process.is_running():
             time.sleep(1)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR removes the job_owner for jobs submitted to skypilot cluster, which has caused a bunch of bugs (https://github.com/skypilot-org/skypilot/pull/3019/commits/cd5e68924b8d0fb779110b30cca274c3e66b19ac) and making the part error-prone. Since we have deprecated the local mode (clouds.Local), we are safe to remove those.

TODO:
- [ ] backward compatibility.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
