### PR TITLE
[BugFix] Fix SCP error raised in `sky check`

### DIFF
--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -310,7 +310,8 @@ class SCP(clouds.Cloud):
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         try:
             scp_utils.SCPClient().list_instances()
-        except (AssertionError, KeyError, scp_utils.SCPClientError):
+        except (AssertionError, KeyError, scp_utils.SCPClientError,
+                scp_utils.SCPCreationFailError):
             return False, (
                 'Failed to access SCP with credentials. '
                 'To configure credentials, see: '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce: in an environment that does not have scp credentials, run `sky check`:

```bash
$ sky check
Checking SCP...Traceback (most recent call last):
  File "/home/txia/miniconda3/envs/skyserve/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/home/txia/miniconda3/envs/skyserve/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/txia/miniconda3/envs/skyserve/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/txia/skypilot/sky/utils/common_utils.py", line 315, in _record
    return f(*args, **kwargs)
  File "/home/txia/skypilot/sky/cli.py", line 1219, in invoke
    return super().invoke(ctx)
  File "/home/txia/miniconda3/envs/skyserve/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/txia/miniconda3/envs/skyserve/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/txia/miniconda3/envs/skyserve/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/txia/skypilot/sky/utils/common_utils.py", line 336, in _record
    return f(*args, **kwargs)
  File "/home/txia/skypilot/sky/cli.py", line 3519, in check
    sky_check.check(verbose=verbose)
  File "/home/txia/skypilot/sky/check.py", line 20, in check
    ok, reason = cloud.check_credentials()
  File "/home/txia/skypilot/sky/clouds/scp.py", line 312, in check_credentials
    scp_utils.SCPClient().list_instances()
  File "/home/txia/skypilot/sky/clouds/utils/scp_utils.py", line 318, in list_instances
    return self._get(url)
  File "/home/txia/skypilot/sky/clouds/utils/scp_utils.py", line 140, in method_with_retries
    return method(self, *args, **kwargs)
  File "/home/txia/skypilot/sky/clouds/utils/scp_utils.py", line 191, in _get
    raise_scp_error(response)
  File "/home/txia/skypilot/sky/clouds/utils/scp_utils.py", line 114, in raise_scp_error
    raise SCPCreationFailError(f'{status_code}: {message}')
sky.clouds.utils.scp_utils.SCPCreationFailError: 404: Access key not found
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky check`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
