### PR TITLE
Fix Issue 1175 - improve YAML error reporting with detailed debugging info

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1053,8 +1053,10 @@ def _check_yaml(entrypoint: str) -> Tuple[bool, Optional[Dict[str, Any]]]:
             except yaml.YAMLError as e:
                 if yaml_file_provided:
                     logger.debug(e)
-                    invalid_reason = ('contains an invalid configuration. '
-                                      ' Please check syntax.')
+                    detailed_error = (f"\nDetailed Error:\n"
+                                f"  Error: {e.problem}\n"
+                                f"  Location: {e.problem_mark.name}, Line {e.problem_mark.line + 1}, Column {e.problem_mark.column + 1}\n")
+                    invalid_reason = ('contains an invalid configuration. Please check syntax.\n'f"{detailed_error}")
                 is_yaml = False
     except OSError:
         if yaml_file_provided:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Added additional debug information to the YAML error reporting in `_check_yaml()` function `cli.py`. Formatted error reporting to be readable. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested detailed error reporting with a newly created test.yaml file that had syntax errors
