### PR TITLE
Raykoaza/issue/3009 shuf depen

### DIFF
--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -45,8 +45,11 @@ done
 # To avoid errors when many concurrent requests are sent (see https://github.com/skypilot-org/skypilot/issues/2628),
 # we add a random delay before establishing the socat connection.
 # Empirically, this needs to be at least 1 second. We set this to be random between 1 and 2 seconds.
-sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
-
+if which shuf > /dev/null; then
+  sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
+elif which gshuf > /dev/null; then
+  sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
+fi
 # Establishes two directional byte streams to handle stdin/stdout between
 # terminal and the jump pod.
 # socat process terminates when port-forward terminates.

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -14,23 +14,14 @@ if ! command -v nc > /dev/null; then
 fi
 
 # Checks if shuf is installed(Linux/macos)
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # Check if gshuf is installed
-    if [[ $(command -v gshuf) == "" ]]; then
-        echo "gshuf is not installed. Please install gshuf first."
-        exit 1
-    else
-        shufcommand=$(command -v gshuf)
-    fi
+if [[ $(command -v gshuf) != "" ]]; then
+  shufcommand=$(command -v gshuf)
+elif [[ $(command -v shuf) != "" ]]; then
+  shufcommand=$(command -v shuf)
 else
-    # Check if shuf is installed
-    if [[ $(command -v shuf) == "" ]]; then
-        echo "shuf is not installed. Please install shuf first."
-        exit 1
-    else
-        shufcommand=$(command -v shuf)
-    fi
+  echo "shuf is not installed. Please install shuf(coreutils) first."
 fi
+
 
 # Establishes connection between local port and the ssh jump pod using kube port-forward
 # Instead of specifying a port, we let kubectl select a random port.

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -34,7 +34,7 @@ local_port=$(awk -F: '/Forwarding from 127.0.0.1/{print $2}' "${KUBECTL_OUTPUT}"
 # Clean up the temporary file
 rm -f "${KUBECTL_OUTPUT}"
 
-# Add handler to terminate the port-forward process when this script exits.
+Added shuf/gshuf(macos) dependency check# Add handler to terminate the port-forward process when this script exits.
 trap "[[ -e /proc/$K8S_PORT_FWD_PID ]] && kill $K8S_PORT_FWD_PID" EXIT
 
 # Checks if a connection to local_port of 127.0.0.1:[local_port] is established
@@ -49,6 +49,21 @@ if which shuf > /dev/null; then
   sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
 elif which gshuf > /dev/null; then
   sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
+else 
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+      # Check if gshuf is installed
+      if [[ $(command -v gshuf) == "" ]]; then
+          echo "gshuf is not installed. Please install gshuf first."
+          exit 1
+      fi
+  else
+      # Check if shuf is installed
+      if [[ $(command -v shuf) == "" ]]; then
+          echo "shuf is not installed. Please install shuf first."
+          exit 1
+      fi
+      echo "shuf is installed."
+  fi
 fi
 # Establishes two directional byte streams to handle stdin/stdout between
 # terminal and the jump pod.

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -13,6 +13,25 @@ if ! command -v nc > /dev/null; then
   exit
 fi
 
+# Checks if shuf is installed(Linux/macos)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Check if gshuf is installed
+    if [[ $(command -v gshuf) == "" ]]; then
+        echo "gshuf is not installed. Please install gshuf first."
+        exit 1
+    else
+        shufcommand=$(command -v gshuf)
+    fi
+else
+    # Check if shuf is installed
+    if [[ $(command -v shuf) == "" ]]; then
+        echo "shuf is not installed. Please install shuf first."
+        exit 1
+    else
+        shufcommand=$(command -v shuf)
+    fi
+fi
+
 # Establishes connection between local port and the ssh jump pod using kube port-forward
 # Instead of specifying a port, we let kubectl select a random port.
 # This is preferred because of socket re-use issues in kubectl port-forward,
@@ -34,7 +53,7 @@ local_port=$(awk -F: '/Forwarding from 127.0.0.1/{print $2}' "${KUBECTL_OUTPUT}"
 # Clean up the temporary file
 rm -f "${KUBECTL_OUTPUT}"
 
-Added shuf/gshuf(macos) dependency check# Add handler to terminate the port-forward process when this script exits.
+# Add handler to terminate the port-forward process when this script exits.
 trap "[[ -e /proc/$K8S_PORT_FWD_PID ]] && kill $K8S_PORT_FWD_PID" EXIT
 
 # Checks if a connection to local_port of 127.0.0.1:[local_port] is established
@@ -45,26 +64,9 @@ done
 # To avoid errors when many concurrent requests are sent (see https://github.com/skypilot-org/skypilot/issues/2628),
 # we add a random delay before establishing the socat connection.
 # Empirically, this needs to be at least 1 second. We set this to be random between 1 and 2 seconds.
-if which shuf > /dev/null; then
-  sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
-elif which gshuf > /dev/null; then
-  sleep $(shuf -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
-else 
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-      # Check if gshuf is installed
-      if [[ $(command -v gshuf) == "" ]]; then
-          echo "gshuf is not installed. Please install gshuf first."
-          exit 1
-      fi
-  else
-      # Check if shuf is installed
-      if [[ $(command -v shuf) == "" ]]; then
-          echo "shuf is not installed. Please install shuf first."
-          exit 1
-      fi
-      echo "shuf is installed."
-  fi
-fi
+
+sleep $($shufcommand -i 10-20 -n 1 | awk '{printf "%f", $1/10}')
+
 # Establishes two directional byte streams to handle stdin/stdout between
 # terminal and the jump pod.
 # socat process terminates when port-forward terminates.

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import jinja2
 import yaml
+from platform import system as pltsys
 
 import sky
 from sky import exceptions
@@ -1020,8 +1021,17 @@ def check_port_forward_mode_dependencies() -> None:
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.
+    _osused = pltsys()
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
                        ['nc', ['nc', '-h'], 'netcat']]
+    if _osused == "Darwin":
+
+        dependency_list.append(["gshuf", ["gshuf", "--version"], "coreutils"])
+
+    elif _osused == "Linux":
+
+        dependency_list.append(["shuf", ["shuf", "--version"], "coreutils"])
+    
     for name, check_cmd, install_cmd in dependency_list:
         try:
             subprocess.run(check_cmd,

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1,6 +1,7 @@
 """Kubernetes utilities for SkyPilot."""
 import math
 import os
+from platform import system as pltsys
 import re
 import subprocess
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -8,7 +9,7 @@ from urllib.parse import urlparse
 
 import jinja2
 import yaml
-from platform import system as pltsys
+
 
 import sky
 from sky import exceptions

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1025,13 +1025,9 @@ def check_port_forward_mode_dependencies() -> None:
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
                        ['nc', ['nc', '-h'], 'netcat']]
     if _osused == "Darwin":
-
         dependency_list.append(["gshuf", ["gshuf", "--version"], "coreutils"])
-
     elif _osused == "Linux":
-
         dependency_list.append(["shuf", ["shuf", "--version"], "coreutils"])
-    
     for name, check_cmd, install_cmd in dependency_list:
         try:
             subprocess.run(check_cmd,

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1024,10 +1024,10 @@ def check_port_forward_mode_dependencies() -> None:
     osused = pltsys()
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
                        ['nc', ['nc', '-h'], 'netcat']]
-    if osused == "Darwin":
-        dependency_list.append(["gshuf", ["gshuf", "--version"], "coreutils"])
-    elif osused == "Linux":
-        dependency_list.append(["shuf", ["shuf", "--version"], "coreutils"])
+    if osused == 'Darwin':
+        dependency_list.append(['gshuf', ['gshuf', '--version'], 'coreutils'])
+    elif osused == 'Linux':
+        dependency_list.append(['shuf', ['shuf', '--version'], 'coreutils'])
     for name, check_cmd, install_cmd in dependency_list:
         try:
             subprocess.run(check_cmd,

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -10,7 +10,6 @@ from urllib.parse import urlparse
 import jinja2
 import yaml
 
-
 import sky
 from sky import exceptions
 from sky import sky_logging

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1017,7 +1017,7 @@ def fill_ssh_jump_template(ssh_key_secret: str, ssh_jump_image: str,
 
 
 def check_port_forward_mode_dependencies() -> None:
-    """Checks if 'socat' is installed"""
+    """Checks if 'socat', 'netcat', 'shuf(coreutils)' are installed"""
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1021,12 +1021,12 @@ def check_port_forward_mode_dependencies() -> None:
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.
-    _osused = pltsys()
+    osused = pltsys()
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
                        ['nc', ['nc', '-h'], 'netcat']]
-    if _osused == "Darwin":
+    if osused == "Darwin":
         dependency_list.append(["gshuf", ["gshuf", "--version"], "coreutils"])
-    elif _osused == "Linux":
+    elif osused == "Linux":
         dependency_list.append(["shuf", ["shuf", "--version"], "coreutils"])
     for name, check_cmd, install_cmd in dependency_list:
         try:

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1,7 +1,6 @@
 """Kubernetes utilities for SkyPilot."""
 import math
 import os
-from platform import system as pltsys
 import re
 import subprocess
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -1021,13 +1020,9 @@ def check_port_forward_mode_dependencies() -> None:
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.
-    osused = pltsys()
     dependency_list = [['socat', ['socat', '-V'], 'socat'],
-                       ['nc', ['nc', '-h'], 'netcat']]
-    if osused == 'Darwin':
-        dependency_list.append(['gshuf', ['gshuf', '--version'], 'coreutils'])
-    elif osused == 'Linux':
-        dependency_list.append(['shuf', ['shuf', '--version'], 'coreutils'])
+                       ['nc', ['nc', '-h'], 'netcat'],
+                       ['shuf', ['shuf', '--version'], 'coreutils']]
     for name, check_cmd, install_cmd in dependency_list:
         try:
             subprocess.run(check_cmd,

--- a/sky/utils/kubernetes_utils.py
+++ b/sky/utils/kubernetes_utils.py
@@ -1016,7 +1016,7 @@ def fill_ssh_jump_template(ssh_key_secret: str, ssh_jump_image: str,
 
 
 def check_port_forward_mode_dependencies() -> None:
-    """Checks if 'socat', 'netcat', 'shuf(coreutils)' are installed"""
+    """Checks if 'socat', 'netcat', 'shuf' are installed"""
     # We store the dependency list as a list of lists. Each inner list
     # contains the name of the dependency, the command to check if it is
     # installed, and the package name to install it.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Added shuf/gshuf(macos) dependency check for shuf package on Linux (gshuf on mac).

https://github.com/skypilot-org/skypilot/issues/3009

<!-- Describe the tests ran -->

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

Built and executed the code, now it's exiting if the command is not installed rather than failing with "command not found error"