### PR TITLE
[Docs] Minor: fix header levels

### DIFF
--- a/docs/source/serving/autoscaling.rst
+++ b/docs/source/serving/autoscaling.rst
@@ -100,7 +100,7 @@ change the scaling delay by specifying the :code:`upscale_delay_seconds` and
 If you want more aggressive scaling, set those values to a lower number and vice versa.
 
 Scale-to-Zero
-===============
+~~~~~~~~~~~~~
 
 SkyServe supports scale-to-zero.
 

--- a/docs/source/serving/update.rst
+++ b/docs/source/serving/update.rst
@@ -48,7 +48,7 @@ new-versioned replicas.  :code:`sky serve status` shows the latest service
 version and each replica's version.
 
 Example
-===========
+~~~~~~~
 
 We first launch a `simple HTTP service <https://github.com/skypilot-org/skypilot/blob/master/examples/serve/http_server/task.yaml>`_:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Before
```
SkyServe: Model Serving

[Serving Models](https://skypilot.readthedocs.io/en/latest/serving/sky-serve.html)
[Service YAML](https://skypilot.readthedocs.io/en/latest/serving/service-yaml-spec.html)
[Autoscaling](https://skypilot.readthedocs.io/en/latest/serving/autoscaling.html)
[Scale-to-Zero](https://skypilot.readthedocs.io/en/latest/serving/autoscaling.html#scale-to-zero)
[Updating a Service](https://skypilot.readthedocs.io/en/latest/serving/update.html)
[Example](https://skypilot.readthedocs.io/en/latest/serving/update.html#example)
```

Now
```
SkyServe: Model Serving

[Serving Models](https://github.com/skypilot-org/skypilot/compare/serving/sky-serve.html)
[Service YAML](https://github.com/skypilot-org/skypilot/compare/serving/service-yaml-spec.html)
[Autoscaling](https://github.com/skypilot-org/skypilot/compare/serving/autoscaling.html)
[Updating a Service](https://github.com/skypilot-org/skypilot/compare/serving/update.html)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): rendered
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
