### PR TITLE
[UX] Suppress azure logs when opening ports

### DIFF
--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -11,7 +11,7 @@ logger = sky_logging.init_logger(__name__)
 
 # Suppress noisy logs from Azure SDK. Reference:
 # https://github.com/Azure/azure-sdk-for-python/issues/9422
-azure_logger = logging.getLogger("azure")
+azure_logger = logging.getLogger('azure')
 azure_logger.setLevel(logging.WARNING)
 
 # Tag uniquely identifying all nodes of a cluster

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -1,4 +1,5 @@
 """Azure instance provisioning."""
+import logging
 from typing import Any, Callable, Dict, List, Optional
 
 from sky import sky_logging
@@ -7,6 +8,11 @@ from sky.provision import common
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
+
+# Suppress noisy logs from Azure SDK. Reference:
+# https://github.com/Azure/azure-sdk-for-python/issues/9422
+azure_logger = logging.getLogger("azure")
+azure_logger.setLevel(logging.WARNING)
 
 # Tag uniquely identifying all nodes of a cluster
 TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

On the latest master branch when we provisioned an Azure cluster w/ ports, it printed out a lots of logs and corrupted the CLI. This PR fixed the issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] `sky launch --cloud azure --ports 8000` and no extra logs printed
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
