### PR TITLE
[Serve] Allow purging controller for identity mismatch

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3125,9 +3125,19 @@ def _down_or_stop_clusters(
                     controller_name)
                 assert controller is not None
                 hint_or_raise = _CONTROLLER_TO_HINT_OR_RAISE[controller]
-                hint_or_raise(controller_name)
+                try:
+                    hint_or_raise(controller_name)
+                except exceptions.ClusterOwnerIdentityMismatchError as e:
+                    if purge:
+                        click.echo(common_utils.format_exception(e))
+                    else:
+                        raise
                 confirm_str = 'delete'
+                input_prefix = ('Since --purge is set, errors will be ignored '
+                                'and controller will be removed from '
+                                'local state.\n') if purge else ''
                 user_input = click.prompt(
+                    f'{input_prefix}'
                     f'To proceed, please type {colorama.Style.BRIGHT}'
                     f'{confirm_str!r}{colorama.Style.RESET_ALL}',
                     type=str)


### PR DESCRIPTION
Closes #3061. Allows purging of serve controller if cluster identity mismatch happens (common on k8s).

Still shows the prompt and requires user to enter 'delete'. 

Blocked on #3093 and #3043 for full functionality on k8s. 

```
$ sky down sky-serve-controller-2ea485ea --purge
sky.exceptions.ClusterOwnerIdentityMismatchError: 'sky-serve-controller-2ea485ea' (Kubernetes) is owned by account ['gke_skypilot-375900_us-central1-c_gkeusc2_gke_skypilot-375900_us-central1-c_gkeusc2-skypilot-sa_default'], but the activated account is ['gke_skypilot-375900_us-central1-c_gkeusc2_gke_skypilot-375900_us-central1-c_gkeusc2_default'].
Since --purge is set, errors will be ignored and controller will be removed from local state.
To proceed, please type 'delete':
```

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR - tested manually with repro steps from the corresponding issues.