### PR TITLE
Replace name variable by common_utils.get_user_hash()

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -37,7 +37,7 @@ def _ssh_control_path(ssh_control_filename: Optional[str]) -> Optional[str]:
     if ssh_control_filename is None:
         return None
     username = getpass.getuser()
-    path = (f'/tmp/skypilot_ssh_{username}/{ssh_control_filename}')
+    path = (f'/tmp/skypilot_ssh_{common_utils.get_user_hash()}/{ssh_control_filename}')
     os.makedirs(path, exist_ok=True)
     return path
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Replace the name variable by common_utils.get_user_hash() to resolve an issue where the SSH control path was too long, which caused problems with Unix domain sockets.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
