### PR TITLE
[k8s][docs] Add `containers` example to pod_config example

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -182,7 +182,8 @@ Available fields and semantics:
     #
     # Example use cases: adding custom labels to SkyPilot pods, specifying
     # imagePullSecrets for pulling images from private registries, overriding
-    # the default runtimeClassName etc.
+    # the default runtimeClassName, adding pod environment variables for
+    # setting up proxies, adding custom volume mounts etc.
     pod_config:
       metadata:
         labels:

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -180,23 +180,20 @@ Available fields and semantics:
     # in the Kubernetes API:
     # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#pod-v1-core
     #
-    # Example use cases: adding custom labels to SkyPilot pods, specifying
-    # imagePullSecrets for pulling images from private registries, overriding
-    # the default runtimeClassName, adding pod environment variables for
-    # setting up proxies, adding custom volume mounts etc.
+    # Some example use cases are shown below. All fields are optional.
     pod_config:
       metadata:
         labels:
-          my-label: my-value
+          my-label: my-value    # Custom labels to SkyPilot pods
       spec:
-        runtimeClassName: nvidia
+        runtimeClassName: nvidia    # Custom runtimeClassName for GPU pods. Required on K3s.
         imagePullSecrets:
-          - name: my-secret
+          - name: my-secret     # Pull images from a private registry using a secret
         containers:
-          - env:
+          - env:                # Custom environment variables for the pod, e.g., for proxy
             - name: HTTP_PROXY
               value: http://proxy-host:3128
-            volumeMounts:
+            volumeMounts:       # Custom volume mounts for the pod
               - mountPath: /foo
                 name: example-volume
                 readOnly: true

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -191,6 +191,19 @@ Available fields and semantics:
         runtimeClassName: nvidia
         imagePullSecrets:
           - name: my-secret
+        containers:
+          - env:
+            - name: HTTP_PROXY
+              value: http://proxy-host:3128
+            volumeMounts:
+              - mountPath: /foo
+                name: example-volume
+                readOnly: true
+        volumes:
+          - name: example-volume
+            hostPath:
+              path: /tmp
+              type: Directory
 
   # Advanced OCI configurations (optional).
   oci:

--- a/docs/source/reference/kubernetes/index.rst
+++ b/docs/source/reference/kubernetes/index.rst
@@ -177,6 +177,25 @@ FAQs
 
   For isolation, you can create separate Kubernetes namespaces and set them in the kubeconfig distributed to users. SkyPilot will use the namespace set in the kubeconfig for running all tasks.
 
+* **How can I specify custom configuration for the pods created by SkyPilot?**
+
+  You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/config.yaml`.
+  The value of :code:`pod_config` should be a dictionary that follows the `Kubernetes Pod API <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#pod-v1-core>`_.
+
+  For example, to set custom environment variables in the pod, you can add the following to your :code:`~/.sky/config.yaml` file:
+
+  .. code-block:: yaml
+
+      kubernetes:
+        pod_config:
+          spec:
+            containers:
+              - env:
+                - name: MY_ENV_VAR
+                  value: MY_ENV_VALUE
+
+  For more details refer to, :ref:`config-yaml`.
+
 Features and Roadmap
 --------------------
 

--- a/docs/source/reference/kubernetes/index.rst
+++ b/docs/source/reference/kubernetes/index.rst
@@ -194,7 +194,7 @@ FAQs
                 - name: MY_ENV_VAR
                   value: MY_ENV_VALUE
 
-  For more details refer to, :ref:`config-yaml`.
+  For more details refer to :ref:`config-yaml`.
 
 Features and Roadmap
 --------------------

--- a/examples/serve/http_server/task.yaml
+++ b/examples/serve/http_server/task.yaml
@@ -10,12 +10,16 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 20
-  replicas: 2
+  replicas: 1
 
 resources:
   ports: 8081
-  cpus: 2+
+  cpus: 1+
+  cloud: kubernetes
 
-workdir: examples/serve/http_server
+setup: |
+  git clone https://www.github.com/skypilot-org/skypilot.git
 
-run: python3 server.py
+run: |
+  cd skypilot/examples/serve/http_server
+  python3 server.py

--- a/examples/serve/http_server/task.yaml
+++ b/examples/serve/http_server/task.yaml
@@ -10,16 +10,12 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 20
-  replicas: 1
+  replicas: 2
 
 resources:
   ports: 8081
-  cpus: 1+
-  cloud: kubernetes
+  cpus: 2+
 
-setup: |
-  git clone https://www.github.com/skypilot-org/skypilot.git
+workdir: examples/serve/http_server
 
-run: |
-  cd skypilot/examples/serve/http_server
-  python3 server.py
+run: python3 server.py


### PR DESCRIPTION
Updates our config documentation for `pod_config` to include more common jobs-to-be-done - setting pod-wide environment variables and adding volume mounts. 

Adding these examples is important because users may often make errors while adding these fields, so something they can copy-paste is easier to use.