### PR TITLE
[Core] Relax cluster name restriction and transform cloud cluster name

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -93,7 +93,7 @@ USER_ENV_VAR = 'SKYPILOT_USER'
 
 # In most clouds, cluster names can only contain lowercase letters, numbers
 # and hyphens. We use this regex to validate the cluster name.
-CLUSTER_NAME_VALID_REGEX = '[a-z]([-a-z0-9]*[a-z0-9])?'
+CLUSTER_NAME_VALID_REGEX = '[a-zA-Z]([-_.a-zA-Z0-9]*[a-zA-Z0-9])?'
 
 # Used for translate local file mounts to cloud storage. Please refer to
 # sky/execution.py::_maybe_translate_local_file_mounts_and_sync_up for

--- a/tests/unit_tests/test_cloud.py
+++ b/tests/unit_tests/test_cloud.py
@@ -1,5 +1,6 @@
 import pytest
 
+from sky import exceptions
 from sky.clouds.cloud import Cloud
 
 
@@ -12,3 +13,23 @@ def test_cloud_get_reservations_available_resources(specific_reservations,
     available_resources = Cloud().get_reservations_available_resources(
         "instance_type", "region", "zone", specific_reservations)
     assert available_resources == expected
+
+
+class TestCheckClusterNameIsValid:
+
+    def test_simple_check(self):
+        Cloud.check_cluster_name_is_valid("lora")
+
+    def test_check_with_hyphen(self):
+        Cloud.check_cluster_name_is_valid("seed-1")
+
+    def test_check_with_characters_to_transform(self):
+        Cloud.check_cluster_name_is_valid("Cuda_11.8")
+
+    def test_check_when_starts_with_number(self):
+        with pytest.raises(exceptions.InvalidClusterNameError):
+            Cloud.check_cluster_name_is_valid("11.8cuda")
+
+    def test_check_with_invalid_characters(self):
+        with pytest.raises(exceptions.InvalidClusterNameError):
+            Cloud.check_cluster_name_is_valid("lor@")


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/2709
- Will close previous PR https://github.com/skypilot-org/skypilot/pull/2743 when this one gets merged
- Was easier to start new PR then work from PR started months ago

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
