### PR TITLE
[AWS] Add security_group_name back

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -100,6 +100,12 @@ Available fields and semantics:
       us-east-1: ssh -W %h:%p -p 1234 -o StrictHostKeyChecking=no myself@my.us-east-1.proxy
       us-east-2: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no ec2-user@<jump server public ip>
 
+    # Security group (optional).
+    #
+    # The name of the security group to use for all instances. If not specified,
+    # SkyPilot will use the default name for the security group: sky-sg-<hash>
+    security_group_name: my-security-group
+
   # Advanced GCP configurations (optional).
   # Apply to all new instances but not existing ones.
   gcp:

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -104,6 +104,9 @@ Available fields and semantics:
     #
     # The name of the security group to use for all instances. If not specified,
     # SkyPilot will use the default name for the security group: sky-sg-<hash>
+    # Note: please ensure the security group name specified exists in the
+    # regions the instances are going to be launched or the AWS account has the
+    # permission to create a security group.
     security_group_name: my-security-group
 
   # Advanced GCP configurations (optional).

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -555,6 +555,9 @@ def get_config_schema():
                             'type': 'string',
                         },
                     },
+                    'security_group_name': {
+                        'type': 'string',
+                    },
                     **_NETWORK_CONFIG_SCHEMA,
                 }
             },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `security_group_name` feature was accidentally removed when we added the schema check for `~/.sky/schemas.py`. This PR is to add it back and fixes user requests in #1354.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-aws --cloud aws --cpus 2` with the following config yaml:
```yaml
aws:
  security_group_name: launch-wizard-7
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
