### PR TITLE
[Serve] Retry when fetching cluster status

### DIFF
--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -42,9 +42,6 @@ SIGNAL_FILE_PREFIX = '/tmp/sky_spot_controller_signal_{}'
 # Controller checks its job's status every this many seconds.
 JOB_STATUS_CHECK_GAP_SECONDS = 20
 
-# Controller checks if its job has started every this many seconds.
-JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
-
 _SPOT_STATUS_CACHE = '~/.sky/spot_status_cache.txt'
 
 _LOG_STREAM_CHECK_CONTROLLER_GAP_SECONDS = 5

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -43,6 +43,13 @@ CONTROLLER_RESOURCES_NOT_VALID_MESSAGE = (
 # The placeholder for the local skypilot config path in file mounts.
 LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER = 'skypilot:local_skypilot_config_path'
 
+# Controller checks if its job has started every this many seconds.
+JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5
+
+# Waiting time for job from INIT/PENDING to RUNNING
+# 10 * JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 10 * 5 = 50 seconds
+MAX_STATUS_CHECKING_RETRY = 10
+
 
 @dataclasses.dataclass
 class _ControllerSpec:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our status refresh for the spot clusters in skyserve did not have retries. The refresh may not be that stable if some clouds (like azure) do not have a stable api call. This PR adds retry and refactor the preemption handling.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
