### PR TITLE
[Provisioner] Check ports for cloud not specified cases

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -261,9 +261,6 @@ def _execute(
         # NOTE: in general we may not have sufficiently specified info
         # (cloud/resource) to check STOP_SPOT_INSTANCE here. This is checked in
         # the backend.
-        if any(r.ports is not None for r in task.resources):
-            requested_features.add(
-                clouds.CloudImplementationFeatures.OPEN_PORTS)
 
     elif idle_minutes_to_autostop is not None:
         # TODO(zhwu): Autostop is not supported for non-CloudVmRayBackend.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -261,6 +261,9 @@ def _execute(
         # NOTE: in general we may not have sufficiently specified info
         # (cloud/resource) to check STOP_SPOT_INSTANCE here. This is checked in
         # the backend.
+        if any(r.ports is not None for r in task.resources):
+            requested_features.add(
+                clouds.CloudImplementationFeatures.OPEN_PORTS)
 
     elif idle_minutes_to_autostop is not None:
         # TODO(zhwu): Autostop is not supported for non-CloudVmRayBackend.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -869,19 +869,6 @@ class Resources:
         if self.cloud is not None:
             self.cloud.check_features_are_supported(
                 self, {clouds.CloudImplementationFeatures.OPEN_PORTS})
-        else:
-            at_least_one_cloud_supports_ports = False
-            for cloud in global_user_state.get_enabled_clouds():
-                try:
-                    cloud.check_features_are_supported(
-                        self, {clouds.CloudImplementationFeatures.OPEN_PORTS})
-                    at_least_one_cloud_supports_ports = True
-                except exceptions.NotSupportedError:
-                    pass
-            if not at_least_one_cloud_supports_ports:
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError('Cannot specify ports without enabling '
-                                     'a cloud that supports open ports.')
         # We don't need to check the ports format since we already done it
         # in resources_utils.simplify_ports
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -880,8 +880,7 @@ class Resources:
                     pass
             if not at_least_one_cloud_supports_ports:
                 with ux_utils.print_exception_no_traceback():
-                    raise ValueError('Cannot specify ports without enabling '
-                                     'a cloud that supports open ports.')
+                    raise ValueError('No enabled clouds support opening ports. To fix: do not specify resources.ports, or enable a cloud that does support this feature.')
         # We don't need to check the ports format since we already done it
         # in resources_utils.simplify_ports
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -869,6 +869,19 @@ class Resources:
         if self.cloud is not None:
             self.cloud.check_features_are_supported(
                 self, {clouds.CloudImplementationFeatures.OPEN_PORTS})
+        else:
+            at_least_one_cloud_supports_ports = False
+            for cloud in global_user_state.get_enabled_clouds():
+                try:
+                    cloud.check_features_are_supported(
+                        self, {clouds.CloudImplementationFeatures.OPEN_PORTS})
+                    at_least_one_cloud_supports_ports = True
+                except exceptions.NotSupportedError:
+                    pass
+            if not at_least_one_cloud_supports_ports:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError('Cannot specify ports without enabling '
+                                     'a cloud that supports open ports.')
         # We don't need to check the ports format since we already done it
         # in resources_utils.simplify_ports
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -880,7 +880,10 @@ class Resources:
                     pass
             if not at_least_one_cloud_supports_ports:
                 with ux_utils.print_exception_no_traceback():
-                    raise ValueError('No enabled clouds support opening ports. To fix: do not specify resources.ports, or enable a cloud that does support this feature.')
+                    raise ValueError(
+                        'No enabled clouds support opening ports. To fix: '
+                        'do not specify resources.ports, or enable a cloud '
+                        'that does support this feature.')
         # We don't need to check the ports format since we already done it
         # in resources_utils.simplify_ports
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

As mentioned in #3125, previously SkyPilot would not print correct ports not supported message if the resources has no cloud specified, and all enabled cloud has no ports support. This PR fixes the problem.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - [x] Start a new docker image; only setup runpod credentials; run `sky check`; then `sky serve up` the YAML described in #3125
```bash
(base) root@26a1fb705d3d:/sky_repo/skypilot# SKYPILOT_DEBUG=0 sky serve up ../a.yaml 
Service from YAML spec: ../a.yaml
ValueError: Cannot specify ports without enabling a cloud that supports open ports.
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
