### PR TITLE
[Catalog] Fix gcp fetch for tpu with none price

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -473,7 +473,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             if not hidden_tpu.empty:
                 price_str = 'SpotPrice' if spot else 'Price'
                 tpu_price = hidden_tpu[price_str].values[0]
-        assert tpu_price is not None, row
+        assert tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
         return tpu_price
 
     df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -472,6 +472,10 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             if not hidden_tpu.empty:
                 price_str = 'SpotPrice' if spot else 'Price'
                 tpu_price = hidden_tpu[price_str].values[0]
+        if tpu_price is None:
+            spot_str = 'spot ' if spot else ''
+            print(f'The {spot_str}price of {tpu_name} in {tpu_region} is '
+                    'not found in SKUs or hidden TPU price DF.')
         assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
         return tpu_price
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -473,7 +473,6 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             if not hidden_tpu.empty:
                 price_str = 'SpotPrice' if spot else 'Price'
                 tpu_price = hidden_tpu[price_str].values[0]
-        assert tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
         return tpu_price
 
     df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -475,7 +475,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
         if tpu_price is None:
             spot_str = 'spot ' if spot else ''
             print(f'The {spot_str}price of {tpu_name} in {tpu_region} is '
-                    'not found in SKUs or hidden TPU price DF.')
+                  'not found in SKUs or hidden TPU price DF.')
         assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
         return tpu_price
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -464,12 +464,12 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             break
         
         if tpu_price is None:
-            # Find the line with the same accelerator name, count and region in
+            # Find the line with the same accelerator name, region, zone in
             # the hidden TPU dataframe for the row.
             hidden_tpu = HIDDEN_TPU_DF[
                 (HIDDEN_TPU_DF['AcceleratorName'] == row['AcceleratorName']) &
-                (HIDDEN_TPU_DF['AcceleratorCount'] == row['AcceleratorCount']) &
-                (HIDDEN_TPU_DF['Region'] == row['Region'])]
+                (HIDDEN_TPU_DF['Region'] == row['Region']) &
+                (HIDDEN_TPU_DF['AvailabilityZone'] == row['AvailabilityZone'])]
             if not hidden_tpu.empty:
                 price_str = 'SpotPrice' if spot else 'Price'
                 tpu_price = hidden_tpu[price_str].values[0]

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -421,7 +421,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
     if df.empty:
         return df
 
-    def get_tpu_price(row: pd.Series, spot: bool) -> float:
+    def get_tpu_price(row: pd.Series, spot: bool) -> Optional[float]:
         assert row['AcceleratorCount'] == 1, row
         tpu_price = None
         tpu_region = row['Region']
@@ -447,7 +447,6 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
                 if 'Preemptible' in description:
                     continue
 
-
             if f'Tpu-{tpu_version}' not in description:
                 continue
             if is_pod:
@@ -462,7 +461,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             tpu_core_price = tpu_device_price / 8
             tpu_price = num_cores * tpu_core_price
             break
-        
+
         if tpu_price is None:
             # Find the line with the same accelerator name, region, zone in
             # the hidden TPU dataframe for the row.

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -473,6 +473,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
             if not hidden_tpu.empty:
                 price_str = 'SpotPrice' if spot else 'Price'
                 tpu_price = hidden_tpu[price_str].values[0]
+        assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
         return tpu_price
 
     df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3136

GCP recently added the on-demand price for the hidden TPUs in us-east1-d  in their SKU, but not spot prices, which causes the failure of our fetching fail due to the assertion we have in the fetcher.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `python -m sky.clouds.service_catalog.data_fetchers.fetch_gcp --all-regions`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
