### PR TITLE
[Core] Set file permission when writing the ssh config file

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -92,7 +92,9 @@ def _save_key_pair(private_key_path: str, public_key_path: str,
     ) as f:
         f.write(private_key)
 
-    with open(public_key_path, 'w') as f:
+    with open(public_key_path,
+              'w',
+              opener=functools.partial(os.open, mode=0o644)) as f:
         f.write(public_key)
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -490,7 +490,6 @@ class SSHConfigHelper(object):
             config = f.readlines()
 
         ssh_dir = cls.ssh_cluster_path.format('')
-        os.makedirs(os.path.expanduser(ssh_dir), exist_ok=True, mode=0o700)
 
         # Handle Include on top of Config file
         include_str = f'Include {cls.ssh_cluster_path.format("*")}'
@@ -541,7 +540,6 @@ class SSHConfigHelper(object):
 
         with open(cluster_config_path, 'w') as f:
             f.write(codegen)
-        os.chmod(cluster_config_path, 0o644)
 
     @classmethod
     def _remove_stale_cluster_config_for_backward_compatibility(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1,6 +1,7 @@
 """Util constants/functions for the backends."""
 from datetime import datetime
 import enum
+import functools
 import os
 import pathlib
 import pprint
@@ -482,14 +483,16 @@ class SSHConfigHelper(object):
 
         if not os.path.exists(config_path):
             config = ['\n']
-            with open(config_path, 'w') as f:
+            with open(config_path,
+                      'w',
+                      opener=functools.partial(os.open, mode=0o644)) as f:
                 f.writelines(config)
-            os.chmod(config_path, 0o644)
 
         with open(config_path, 'r') as f:
             config = f.readlines()
 
         ssh_dir = cls.ssh_cluster_path.format('')
+        os.makedirs(os.path.expanduser(ssh_dir), exist_ok=True, mode=0o700)
 
         # Handle Include on top of Config file
         include_str = f'Include {cls.ssh_cluster_path.format("*")}'
@@ -538,7 +541,9 @@ class SSHConfigHelper(object):
         cluster_config_path = os.path.expanduser(
             cls.ssh_cluster_path.format(cluster_name))
 
-        with open(cluster_config_path, 'w') as f:
+        with open(cluster_config_path,
+                  'w',
+                  opener=functools.partial(os.open, mode=0o644)) as f:
             f.write(codegen)
 
     @classmethod

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -490,7 +490,7 @@ class SSHConfigHelper(object):
             config = f.readlines()
 
         ssh_dir = cls.ssh_cluster_path.format('')
-        os.makedirs(os.path.expanduser(ssh_dir), exist_ok=True)
+        os.makedirs(os.path.expanduser(ssh_dir), exist_ok=True, mode=0o700)
 
         # Handle Include on top of Config file
         include_str = f'Include {cls.ssh_cluster_path.format("*")}'
@@ -541,6 +541,7 @@ class SSHConfigHelper(object):
 
         with open(cluster_config_path, 'w') as f:
             f.write(codegen)
+        os.chmod(cluster_config_path, 0o644)
 
     @classmethod
     def _remove_stale_cluster_config_for_backward_compatibility(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -240,6 +240,20 @@ def _wait_for_pods_to_run(namespace, new_nodes):
         time.sleep(1)
 
 
+def _run_command_on_pods(node_name, node_namespace, command):
+    cmd_output = kubernetes.stream()(
+        kubernetes.core_api().connect_get_namespaced_pod_exec,
+        node_name,
+        node_namespace,
+        command=command,
+        stderr=True,
+        stdin=False,
+        stdout=True,
+        tty=False,
+        _request_timeout=kubernetes.API_TIMEOUT)
+    return cmd_output
+
+
 def _set_env_vars_in_pods(namespace: str, new_pods: List):
     """Setting environment variables in pods.
 
@@ -267,30 +281,8 @@ def _set_env_vars_in_pods(namespace: str, new_pods: List):
     ]
 
     for new_pod in new_pods:
-        kubernetes.stream()(
-            kubernetes.core_api().connect_get_namespaced_pod_exec,
-            new_pod.metadata.name,
-            namespace,
-            command=set_k8s_env_var_cmd,
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
-            _request_timeout=kubernetes.API_TIMEOUT)
-
-
-def run_command_on_pods(node_name, node_namespace, command):
-    cmd_output = kubernetes.stream()(
-        kubernetes.core_api().connect_get_namespaced_pod_exec,
-        node_name,
-        node_namespace,
-        command=command,
-        stderr=True,
-        stdin=False,
-        stdout=True,
-        tty=False,
-        _request_timeout=kubernetes.API_TIMEOUT)
-    return cmd_output
+        _run_command_on_pods(new_pod.metadata.name, namespace,
+                             set_k8s_env_var_cmd)
 
 
 def _check_user_privilege(namespace: str, new_nodes: List) -> None:
@@ -314,8 +306,9 @@ def _check_user_privilege(namespace: str, new_nodes: List) -> None:
     ]
 
     for new_node in new_nodes:
-        privilege_check = run_command_on_pods(new_node.metadata.name, namespace,
-                                              check_k8s_user_sudo_cmd)
+        privilege_check = _run_command_on_pods(new_node.metadata.name,
+                                               namespace,
+                                               check_k8s_user_sudo_cmd)
         if privilege_check == str(exceptions.INSUFFICIENT_PRIVILEGES_CODE):
             raise config_lib.KubernetesError(
                 'Insufficient system privileges detected. '
@@ -358,7 +351,7 @@ def _setup_ssh_in_pods(namespace: str, new_nodes: List) -> None:
     ]
     # TODO(romilb): We need logging and surface errors here.
     for new_node in new_nodes:
-        run_command_on_pods(new_node.metadata.name, namespace, set_k8s_ssh_cmd)
+        _run_command_on_pods(new_node.metadata.name, namespace, set_k8s_ssh_cmd)
 
 
 def _label_pod(namespace: str, pod_name: str, label: Dict[str, str]) -> None:
@@ -651,8 +644,8 @@ def get_cluster_info(
     ssh_user = 'sky'
     get_k8s_ssh_user_cmd = ['/bin/sh', '-c', ('echo $(whoami)')]
     assert head_pod_name is not None
-    ssh_user = run_command_on_pods(head_pod_name, namespace,
-                                   get_k8s_ssh_user_cmd)
+    ssh_user = _run_command_on_pods(head_pod_name, namespace,
+                                    get_k8s_ssh_user_cmd)
     ssh_user = ssh_user.strip()
     logger.debug(
         f'Using ssh user {ssh_user} for cluster {cluster_name_on_cloud}')

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -342,7 +342,7 @@ def _setup_ssh_in_pods(namespace: str, new_nodes: List) -> None:
             '~/.ssh/authorized_keys; '
             '$(prefix_cmd) chown -R $(whoami) ~/.ssh;'
             '$(prefix_cmd) chmod 700 ~/.ssh; '
-            '$(prefix_cmd) chmod 600 ~/.ssh/authorized_keys; '
+            '$(prefix_cmd) chmod 644 ~/.ssh/authorized_keys; '
             '$(prefix_cmd) service ssh restart; '
             # Eliminate the error
             # `mesg: ttyname failed: inappropriate ioctl for device`.

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -295,6 +295,16 @@ def _wait_ssh_connection_direct(ip: str,
                                 ssh_control_name: Optional[str] = None,
                                 ssh_proxy_command: Optional[str] = None,
                                 **kwargs) -> Tuple[bool, str]:
+    """Wait for SSH connection using raw sockets, and a direct connection.
+
+    Using raw socket is more efficient than using SSH command to probe the
+    connection, before the SSH connection is ready. We use a actual SSH command
+    connection to test the connection, after the raw socket connection is ready
+    to make sure the SSH connection is actually ready.
+
+    Returns:
+        A tuple of (success, stderr).
+    """
     del kwargs  # unused
     assert ssh_proxy_command is None, 'SSH proxy command is not supported.'
     try:
@@ -331,6 +341,11 @@ def _wait_ssh_connection_indirect(ip: str,
                                   ssh_control_name: Optional[str] = None,
                                   ssh_proxy_command: Optional[str] = None,
                                   **kwargs) -> Tuple[bool, str]:
+    """Wait for SSH connection using SSH command.
+    
+    Returns:
+        A tuple of (success, stderr).
+    """
     del ssh_control_name, kwargs  # unused
     command = _ssh_probe_command(ip, ssh_port, ssh_user, ssh_private_key,
                                  ssh_proxy_command)

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -357,9 +357,10 @@ def _wait_ssh_connection_indirect(ip: str,
                           stderr=subprocess.PIPE)
     if proc.returncode != 0:
         stderr = proc.stderr.decode('utf-8')
+        stderr = f'Error: {stderr}'
         logger.debug(
             f'Waiting for SSH to {ip} with command: {_shlex_join(command)}\n'
-            f'Error: {stderr}')
+            f'{stderr}')
         return False, stderr
     return True, ''
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -295,7 +295,7 @@ def _wait_ssh_connection_direct(ip: str,
                                 ssh_control_name: Optional[str] = None,
                                 ssh_proxy_command: Optional[str] = None,
                                 **kwargs) -> Tuple[bool, str]:
-    """Wait for SSH connection using raw sockets, and a direct connection.
+    """Wait for SSH connection using raw sockets, and a SSH connection.
 
     Using raw socket is more efficient than using SSH command to probe the
     connection, before the SSH connection is ready. We use a actual SSH command

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -342,7 +342,7 @@ def _wait_ssh_connection_indirect(ip: str,
                                   ssh_proxy_command: Optional[str] = None,
                                   **kwargs) -> Tuple[bool, str]:
     """Wait for SSH connection using SSH command.
-    
+
     Returns:
         A tuple of (success, stderr).
     """

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -356,10 +356,12 @@ def _wait_ssh_connection_indirect(ip: str,
                           stdout=subprocess.DEVNULL,
                           stderr=subprocess.PIPE)
     if proc.returncode != 0:
+        stderr = proc.stderr.decode('utf-8')
         logger.debug(
             f'Waiting for SSH to {ip} with command: {_shlex_join(command)}\n'
-            f'Error: {proc.stderr.decode("utf-8")}')
-    return proc.returncode == 0, proc.stderr.decode('utf-8')
+            f'Error: {stderr}')
+        return False, stderr
+    return True, ''
 
 
 def wait_for_ssh(cluster_info: provision_common.ClusterInfo,

--- a/sky/provision/vsphere/common/custom_script.py
+++ b/sky/provision/vsphere/common/custom_script.py
@@ -6,5 +6,5 @@ if [ x$1 = x"precustomization" ]; then
     sudo mkdir -p /home/user_placeholder/.ssh/pre
     sudo chown -R user_placeholder:user_placeholder /home/user_placeholder/.ssh
     sudo chmod 700 /home/user_placeholder/.ssh
-    sudo chmod 600 /home/user_placeholder/.ssh/authorized_keys
+    sudo chmod 644 /home/user_placeholder/.ssh/authorized_keys
 fi"""

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -65,7 +65,7 @@ def _handle_io_stream(io_stream, out_stream, args: _ProcessingArgs):
                       if args.line_processor is None else args.line_processor)
 
     out = []
-    with open(args.log_path, 'a') as fout:
+    with open(args.log_path, 'a', encoding='utf-8') as fout:
         with line_processor:
             while True:
                 line = out_io.readline()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now explicitly set the permission for the ssh config file writen by SkyPilot, because sometimes if the user changed the username of their local machine, and still use the conda environment with skypilot installed under the old `/home/old-user` folder. In this case, the files writen to `~/.sky/generated/ssh` can have a permssion `dwxr-rw-rw--` which violates the permission required for ssh, causing all `ssh` fails.

This is one of the potential reasons for #2689. This PR also prints out the output of the last ssh command if the wait ssh timeout.

Reproducible steps:
1. `docker run -it --rm centos:centos7 /bin/bash`
2. `adduser -m test-original; adduser -m test-new`
3. `passwd test-original; passwd test-new`
4. `sermod -aG wheel test-new; sermod -aG wheel test-original`
5. `su test-original; # setup miniconda`
6. `setfacl -R -m u:test-new:rwx /home/test-original/`
7. `su test-new; /home/test-original/miniconda3/bin/conda init; # install skypilot`
8. `sky launch --cloud gcp --cpus 2 echo hi; # task submission fails due to ssh permission issue with the folder`
```
Bad owner or permissions on /home/test-new/.sky/generated/ssh/test-new-user
```
By deleting `~/.sky/generated/ssh` and switch to this PR, the problem goes away.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
