### PR TITLE
[Test] Fix multi-node fail test

### DIFF
--- a/tests/test_yamls/failed_worker_run.yaml
+++ b/tests/test_yamls/failed_worker_run.yaml
@@ -5,6 +5,7 @@ num_nodes: 3
 
 run: |
   if [ "$SKYPILOT_NODE_RANK" == "1" ]; then
+      sleep 2
       exit 1
   fi
   echo My hostname: $(hostname)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix smoke test for multi-node fail fast.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_multi_node_failure`
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
