### PR TITLE
[UX] Rephrase service initialization timeout

### DIFF
--- a/sky/serve/constants.py
+++ b/sky/serve/constants.py
@@ -12,8 +12,8 @@ PORT_SELECTION_FILE_LOCK_PATH = f'{SKYSERVE_METADATA_DIR}/port_selection.lock'
 # Signal file path for controller to handle signals.
 SIGNAL_FILE_PATH = '/tmp/sky_serve_controller_signal_{}'
 
-# Time to wait in seconds for service to initialize.
-INITIALIZATION_TIMEOUT_SECONDS = 60
+# Time to wait in seconds for service to register on the controller.
+SERVICE_REGISTER_TIMEOUT_SECONDS = 60
 
 # The time interval in seconds for load balancer to sync with controller. Every
 # time the load balancer syncs with controller, it will update all available

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -181,7 +181,7 @@ def up(
             # This function will check the controller job id in the database
             # and return the endpoint if the job id matches. Otherwise it will
             # return None.
-            code = serve_utils.ServeCodeGen.wait_service_initialization(
+            code = serve_utils.ServeCodeGen.wait_service_registration(
                 service_name, controller_job_id)
             backend = backend_utils.get_backend_from_handle(controller_handle)
             assert isinstance(backend, backends.CloudVmRayBackend)

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -177,7 +177,7 @@ def up(
         # TODO(tian): Cache endpoint locally to speedup. Endpoint won't
         # change after the first time, so there is no consistency issue.
         with rich_utils.safe_status(
-                '[cyan]Waiting for the service to initialize[/]'):
+                '[cyan]Waiting for the service to register[/]'):
             # This function will check the controller job id in the database
             # and return the endpoint if the job id matches. Otherwise it will
             # return None.

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -465,10 +465,15 @@ def wait_service_initialization(service_name: str, job_id: int) -> str:
                 raise RuntimeError('Max number of services reached. '
                                    'To spin up more services, please '
                                    'tear down some existing services.')
-        if time.time() - start_time > constants.INITIALIZATION_TIMEOUT_SECONDS:
+        elapsed = time.time() - start_time
+        if elapsed > constants.SERVICE_REGISTER_TIMEOUT_SECONDS:
             controller_log_path = (
                 generate_remote_controller_log_file_name(service_name))
-            with open(os.path.expanduser(controller_log_path), 'r') as f:
+            with open(
+                    os.path.expanduser(controller_log_path),
+                    'r',
+                    encoding='utf-8',
+            ) as f:
                 log_content = f.read()
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Failed to register service {service_name!r} '

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -466,9 +466,14 @@ def wait_service_initialization(service_name: str, job_id: int) -> str:
                                    'To spin up more services, please '
                                    'tear down some existing services.')
         if time.time() - start_time > constants.INITIALIZATION_TIMEOUT_SECONDS:
+            controller_log_path = (
+                generate_remote_controller_log_file_name(service_name))
+            with open(os.path.expanduser(controller_log_path), 'r') as f:
+                log_content = f.read()
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    f'Initialization of service {service_name!r} timeout.')
+                raise ValueError(f'Failed to register service {service_name!r} '
+                                 'on the SkyServe controller. Reason:\n'
+                                 f'{log_content}Please try again later.')
         time.sleep(1)
 
 

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -432,7 +432,7 @@ def terminate_services(service_names: Optional[List[str]], purge: bool) -> str:
     return '\n'.join(messages)
 
 
-def wait_service_initialization(service_name: str, job_id: int) -> str:
+def wait_service_registration(service_name: str, job_id: int) -> str:
     """Util function to call at the end of `sky.serve.up()`.
 
     This function will:
@@ -467,18 +467,17 @@ def wait_service_initialization(service_name: str, job_id: int) -> str:
                                    'tear down some existing services.')
         elapsed = time.time() - start_time
         if elapsed > constants.SERVICE_REGISTER_TIMEOUT_SECONDS:
+            # Print the controller log to help user debug.
             controller_log_path = (
                 generate_remote_controller_log_file_name(service_name))
-            with open(
-                    os.path.expanduser(controller_log_path),
-                    'r',
-                    encoding='utf-8',
-            ) as f:
+            with open(os.path.expanduser(controller_log_path),
+                      'r',
+                      encoding='utf-8') as f:
                 log_content = f.read()
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Failed to register service {service_name!r} '
-                                 'on the SkyServe controller. Reason:\n'
-                                 f'{log_content}')
+                                 'on the SkyServe controller. '
+                                 f'Reason:\n{log_content}')
         time.sleep(1)
 
 
@@ -846,9 +845,9 @@ class ServeCodeGen:
         return cls._build(code)
 
     @classmethod
-    def wait_service_initialization(cls, service_name: str, job_id: int) -> str:
+    def wait_service_registration(cls, service_name: str, job_id: int) -> str:
         code = [
-            'msg = serve_utils.wait_service_initialization('
+            'msg = serve_utils.wait_service_registration('
             f'{service_name!r}, {job_id})', 'print(msg, end="", flush=True)'
         ]
         return cls._build(code)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The service initialization timeout is confusing with `initial_delay_seconds`. This PR rephrased to `failed to register service` to avoid such confusion.

```bash
$ sky serve up @temp/serve.yaml 
Service from YAML spec: @temp/serve.yaml
Service Spec:
Readiness probe method:           GET /
Readiness initial delay seconds:  1200
Replica autoscaling policy:       Fixed 1 replica        
Each replica will use the following resources (estimated):
I 02-17 07:55:20 optimizer.py:691] == Optimizer ==
I 02-17 07:55:20 optimizer.py:702] Target: minimizing cost
I 02-17 07:55:20 optimizer.py:714] Estimated cost: $0.4 / hour
I 02-17 07:55:20 optimizer.py:714] 
I 02-17 07:55:20 optimizer.py:837] Considered resources (1 node):
I 02-17 07:55:20 optimizer.py:907] ------------------------------------------------------------------------------------------------
I 02-17 07:55:20 optimizer.py:907]  CLOUD   INSTANCE          vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN   
I 02-17 07:55:20 optimizer.py:907] ------------------------------------------------------------------------------------------------
I 02-17 07:55:20 optimizer.py:907]  AWS     m6i.2xlarge       8       32        -              us-east-1       0.38          ✔     
I 02-17 07:55:20 optimizer.py:907]  Azure   Standard_D8s_v5   8       32        -              eastus          0.38                
I 02-17 07:55:20 optimizer.py:907]  GCP     n2-standard-8     8       32        -              us-central1-a   0.39                
I 02-17 07:55:20 optimizer.py:907] ------------------------------------------------------------------------------------------------
I 02-17 07:55:20 optimizer.py:907] 
Launching a new service 'sky-service-8a75'. Proceed? [Y/n]: 
Launching controller for 'sky-service-8a75'...
I 02-17 07:55:30 cloud_vm_ray_backend.py:1421] To view detailed progress: tail -n100 -f /home/txia/sky_logs/sky-2024-02-17-07-55-21-715729/provision.log
I 02-17 07:55:30 cloud_vm_ray_backend.py:1332] Cluster 'sky-serve-controller-4a0782e9' (status: INIT) was previously launched in AWS us-east-1. Relaunching in that region.
I 02-17 07:55:31 provisioner.py:79] Launching on AWS us-east-1 (us-east-1a)
I 02-17 07:55:49 provisioner.py:454] Successfully provisioned or found existing instance.
I 02-17 07:56:15 provisioner.py:556] Successfully provisioned cluster: sky-serve-controller-4a0782e9
I 02-17 07:56:17 cloud_vm_ray_backend.py:4469] Processing file mounts.
I 02-17 07:56:17 cloud_vm_ray_backend.py:4501] To view detailed progress: tail -n100 -f ~/sky_logs/sky-2024-02-17-07-55-21-715729/file_mounts.log
I 02-17 07:56:17 backend_utils.py:1288] Syncing (to 1 node): /tmp/service-task-sky-service-8a75-jj4ckwaz -> ~/.sky/serve/sky_service_8a75/task.yaml.tmp
I 02-17 07:56:20 backend_utils.py:1288] Syncing (to 1 node): /tmp/tmp4hzxbl51 -> ~/.sky/serve/sky_service_8a75/config.yaml
I 02-17 07:56:22 cloud_vm_ray_backend.py:3209] Running setup on 1 node.
I 02-17 07:56:33 cloud_vm_ray_backend.py:3222] Setup completed.
I 02-17 07:56:42 cloud_vm_ray_backend.py:3319] Job submitted with Job ID: 1

E 02-17 07:57:45 subprocess_utils.py:84] ValueError: Failed to register service 'sky-service-8a75' on the SkyServe controller. Reason:
E 02-17 07:57:45 subprocess_utils.py:84] ValueError: No enabled clouds support opening ports. To fix: do not specify resources.ports, or enable a cloud that does support this feature.
E 02-17 07:57:45 subprocess_utils.py:84] Please try again later.
E 02-17 07:57:45 subprocess_utils.py:84] 
RuntimeError: Failed to spin up the service. Please check the logs above for more details.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
