### PR TITLE
[Serve] Order replicas by version and `READY` status when using `sky serve status`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1756,7 +1756,7 @@ def _get_services(service_names: Optional[List[str]],
                                if len(service_records) > 0 else 'No')
                 raise click.UsageError(
                     f'{service_num} service{plural} found. Please specify '
-                    'an existing service to show its endpoint. Usage: '
+                    'only one existing service to show its endpoint. Usage: '
                     'sky serve status --endpoint <service-name>')
             msg = serve_lib.get_endpoint(service_records[0])
         else:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1756,8 +1756,9 @@ def _get_services(service_names: Optional[List[str]],
                                if len(service_records) > 0 else 'No')
                 raise click.UsageError(
                     f'{service_num} service{plural} found. Please specify '
-                    'only one existing service to show its endpoint. Usage: '
-                    'sky serve status --endpoint <service-name>')
+                    'one and only only one existing service to show its '
+                    'endpoint. Usage: sky serve status --endpoint '
+                    '<service-name>')
             msg = serve_lib.get_endpoint(service_records[0])
         else:
             msg = serve_lib.format_service_table(service_records, show_all)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1756,7 +1756,7 @@ def _get_services(service_names: Optional[List[str]],
                                if len(service_records) > 0 else 'No')
                 raise click.UsageError(
                     f'{service_num} service{plural} found. Please specify '
-                    'one and only only one existing service to show its '
+                    'one and only one existing service to show its '
                     'endpoint. Usage: sky serve status --endpoint '
                     '<service-name>')
             msg = serve_lib.get_endpoint(service_records[0])

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1,13 +1,13 @@
 """User interface with the SkyServe."""
 import base64
 import enum
-import math
 import os
 import pathlib
 import pickle
 import re
 import shlex
 import shutil
+import sys
 import threading
 import time
 import typing
@@ -737,7 +737,7 @@ def _sort_replica_records(
 
     def _sort_key(record: Dict[str, Any]) -> Tuple[int, int, int]:
         # If no version, then position replica at the end.
-        version = int(record.get('version', -math.inf))
+        version = int(record.get('version', -sys.maxsize))
         status_priority = 0 if record['status'] == 'READY' else 1
         replica_id = int(record['replica_id'])
         return -version, status_priority, replica_id

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -11,7 +11,7 @@ import threading
 import time
 import typing
 from typing import (Any, Callable, Dict, Generic, Iterator, List, Optional,
-                    TextIO, Type, TypeVar)
+                    TextIO, Tuple, Type, TypeVar)
 import uuid
 
 import colorama
@@ -731,10 +731,22 @@ def format_service_table(service_records: List[Dict[str, Any]],
             f'{replica_table}')
 
 
+def _sort_replica_records(
+        replica_records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+
+    def sort_key(record) -> Tuple[int, int]:
+        status_priority = 0 if record['status'] == 'READY' else 1
+        return -int(record['version']), status_priority
+
+    sorted_records = sorted(replica_records, key=sort_key)
+    return sorted_records
+
+
 def _format_replica_table(replica_records: List[Dict[str, Any]],
                           show_all: bool) -> str:
     if not replica_records:
         return 'No existing replicas.'
+    replica_records = _sort_replica_records(replica_records)
 
     replica_columns = [
         'SERVICE_NAME', 'ID', 'VERSION', 'IP', 'LAUNCHED', 'RESOURCES',

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -1,6 +1,7 @@
 """User interface with the SkyServe."""
 import base64
 import enum
+import math
 import os
 import pathlib
 import pickle
@@ -734,11 +735,14 @@ def format_service_table(service_records: List[Dict[str, Any]],
 def _sort_replica_records(
         replica_records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
-    def sort_key(record: Dict[str, Any]) -> Tuple[int, int]:
+    def _sort_key(record: Dict[str, Any]) -> Tuple[int, int, int]:
+        # If no version, then position replica at the end.
+        version = int(record.get('version', -math.inf))
         status_priority = 0 if record['status'] == 'READY' else 1
-        return -int(record['version']), status_priority
+        replica_id = int(record['replica_id'])
+        return -version, status_priority, replica_id
 
-    sorted_records = sorted(replica_records, key=sort_key)
+    sorted_records = sorted(replica_records, key=_sort_key)
     return sorted_records
 
 

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -734,7 +734,7 @@ def format_service_table(service_records: List[Dict[str, Any]],
 def _sort_replica_records(
         replica_records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
-    def sort_key(record) -> Tuple[int, int]:
+    def sort_key(record: Dict[str, Any]) -> Tuple[int, int]:
         status_priority = 0 if record['status'] == 'READY' else 1
         return -int(record['version']), status_priority
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes https://github.com/skypilot-org/skypilot/issues/3052

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky serve status sky-service-65a6 `
```
Service Replicas
SERVICE_NAME      ID  VERSION  IP              LAUNCHED     RESOURCES       STATUS    REGION     
sky-service-65a6  3   2        54.146.217.39   39 secs ago  1x AWS(vCPU=2)  READY     us-east-1  
sky-service-65a6  4   2        3.95.34.252     38 secs ago  1x AWS(vCPU=2)  READY     us-east-1  
sky-service-65a6  5   2        34.238.126.234  26 secs ago  1x AWS(vCPU=2)  STARTING  us-east-1  
sky-service-65a6  1   1        44.211.224.67   7 mins ago   1x AWS(vCPU=2)  READY     us-east-1  
sky-service-65a6  2   1        44.201.246.191  7 mins ago   1x AWS(vCPU=2)  READY     us-east-1
``` 
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
