### PR TITLE
[Core] Fix for `sky status --endpoints` when a range of ports is opened

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1979,7 +1979,8 @@ def status(all: bool, refresh: bool, ip: bool, endpoints: bool,
 
                 if endpoint is not None:
                     # If cluster had no ports to be exposed
-                    if str(endpoint) not in handle.launched_resources.ports:
+                    ports_set = resources_utils.port_ranges_to_set(handle.launched_resources.ports)
+                    if endpoint not in ports_set:
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(f'Port {endpoint} is not exposed '
                                              'on cluster '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1979,7 +1979,8 @@ def status(all: bool, refresh: bool, ip: bool, endpoints: bool,
 
                 if endpoint is not None:
                     # If cluster had no ports to be exposed
-                    ports_set = resources_utils.port_ranges_to_set(handle.launched_resources.ports)
+                    ports_set = resources_utils.port_ranges_to_set(
+                        handle.launched_resources.ports)
                     if endpoint not in ports_set:
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(f'Port {endpoint} is not exposed '


### PR DESCRIPTION
When multiple ports are opened, `sky status --endpoint 8888 <cluster>` would fail. This is because the `handle.launched_resources.ports` contains a str like `'8888-8889'`. We need to convert to a set of ints and then compare in our code.

Repro:
```
resources:
  cloud: kubernetes
  ports:
    - 8888
    - 8889

run: |
    python -m http.server 8888 & python -m http.server 8889;
```

```
# Before:
$ sky status --endpoint 8889 mycluster
ValueError: Port 8889 is not exposed on cluster 'test'.

# After fix:
$ sky status --endpoint 8889 mycluster
34.67.101.159:8889
```

FYI - code paths for endpoints are refactored out of cli.py in #3109.

- [x] Code formatting: `bash format.sh`
- [x] Tested manually for the above repro with a) no ports, b)1 port c) many ports
