### PR TITLE
[K8s] Use external-ip if configured on nginx ingress

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -361,7 +361,30 @@ This mode exposes ports by creating a Kubernetes `Ingress <https://kubernetes.io
 To use this mode:
 
 1. Install the Nginx Ingress Controller on your Kubernetes cluster. Refer to the `documentation <https://kubernetes.github.io/ingress-nginx/deploy/>`_ for installation instructions specific to your environment.
-2. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/config` to use the ingress mode.
+2. Verify that the ``ingress-nginx-controller`` service has a valid external IP:
+
+.. code-block:: bash
+
+    $ kubectl get service ingress-nginx-controller -n ingress-nginx
+
+    # Example output:
+    # NAME                             TYPE                CLUSTER-IP    EXTERNAL-IP     PORT(S)
+    # ingress-nginx-controller         LoadBalancer        10.24.4.254   35.202.58.117   80:31253/TCP,443:32699/TCP
+
+.. note::
+    If the ``EXTERNAL-IP`` field is ``<none>``, you must to manually assign a External IP.
+    This can be done by patching the service with an IP that can be accessed from outside the cluster.
+    If the service type is ``NodePort``, you can set the ``EXTERNAL-IP`` to any node's IP address:
+
+    .. code-block:: bash
+
+      # Patch the nginx ingress service with an external IP. Can be any node's IP if using NodePort service.
+      $ kubectl patch svc ingress-nginx-controller -n ingress-nginx -p '{"spec": {"externalIPs": ["<IP>"]}}'
+
+    If the ``EXTERNAL-IP`` field is left as ``<none>``, SkyPilot will use ``localhost`` as the external IP for the Ingress,
+    and the endpoint may not be accessible from outside the cluster.
+
+3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/config` to use the ingress mode.
 
 .. code-block:: yaml
 

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -182,11 +182,17 @@ def get_ingress_external_ip_and_ports(
 
     ingress_service = ingress_services[0]
     if ingress_service.status.load_balancer.ingress is None:
+        # Try to use assigned external IP if it exists,
+        # otherwise return 'localhost'
+        if ingress_service.spec.external_i_ps is not None:
+            ip = ingress_service.spec.external_i_ps[0]
+        else:
+            ip = 'localhost'
         ports = ingress_service.spec.ports
         http_port = [port for port in ports if port.name == 'http'][0].node_port
         https_port = [port for port in ports if port.name == 'https'
                      ][0].node_port
-        return 'localhost', (int(http_port), int(https_port))
+        return ip, (int(http_port), int(https_port))
 
     external_ip = ingress_service.status.load_balancer.ingress[
         0].ip or ingress_service.status.load_balancer.ingress[0].hostname


### PR DESCRIPTION
On some on-prem clusters, ingresses may be exposed through a NodePort service that is backed by a custom external-ip set by the cluster admin. We should return this ip when queries through `sky status --endpoints` instead of returning `localhost`.

This PR adds support for reading external-ip if it is set. Also updates docs for clarity on how to use nginx ingress.

```
# Before:
$ sky status --endpoints test
8888: http://localhost:30008/skypilot/test-2ea4/8888

# After:
# If external-ip is configured and backed by nodeport svc
$ sky status --endpoints test
8888: http://192.156.211.1:30008/skypilot/test-2ea4/8888 

# If external-ip is not configured and backed by nodeport svc
$ sky status --endpoints test
8888: http://localhost:30008/skypilot/test-2ea4/8888 
```

This is also helpful for skyserve on nginx ingress, since `localhost` is not accessible from the skyserve controller.

Cherry-picking this change from #3109 for v0.5 release.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual tests - `sky launch` a ports yaml on a) k3s cluster with this custom nodeport based ingress setup b) GKE cluster with regular loadbalancer based ingress.
