### PR TITLE
[Tests] Fix `_get_timeout` in smoke tests

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -102,6 +102,7 @@ _SPOT_CANCEL_WAIT = (
 
 DEFAULT_CMD_TIMEOUT = 15 * 60
 
+
 class Test(NamedTuple):
     name: str
     # Each command is executed serially.  If any failed, the remaining commands

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -100,6 +100,7 @@ _SPOT_CANCEL_WAIT = (
     'done; echo "$s"; echo; echo; echo "$s"')
 # TODO(zhwu): make the spot controller on GCP.
 
+DEFAULT_CMD_TIMEOUT = 15 * 60
 
 class Test(NamedTuple):
     name: str
@@ -108,7 +109,7 @@ class Test(NamedTuple):
     commands: List[str]
     teardown: Optional[str] = None
     # Timeout for each command in seconds.
-    timeout: int = 15 * 60
+    timeout: int = DEFAULT_CMD_TIMEOUT
 
     def echo(self, message: str):
         # pytest's xdist plugin captures stdout; print to stderr so that the
@@ -119,9 +120,10 @@ class Test(NamedTuple):
         print(message, file=sys.stderr, flush=True)
 
 
-def _get_timeout(generic_cloud: str, default_timeout: int = Test.timeout):
+def _get_timeout(generic_cloud: str,
+                 override_timeout: int = DEFAULT_CMD_TIMEOUT):
     timeouts = {'fluidstack': 60 * 60}  # file_mounts
-    return timeouts.get(generic_cloud, default_timeout)
+    return timeouts.get(generic_cloud, override_timeout)
 
 
 def _get_cluster_name() -> str:


### PR DESCRIPTION
Smoke tests seem broken on the current master:
```
$ pytest tests/test_smoke.py::test_minimal

_________________________________________________________________________________________________________________________________________________________________________________ test_minimal _________________________________________________________________________________________________________________________________________________________________________________
[gw0] darwin -- Python 3.9.13 /Users/romilb/tools/anaconda3/bin/python
tests/test_smoke.py:281: in test_minimal
    run_one_test(test)
tests/test_smoke.py:161: in run_one_test
    proc.wait(timeout=test.timeout)
../../../../tools/anaconda3/lib/python3.9/subprocess.py:1187: in wait
    endtime = _time() + timeout
E   TypeError: unsupported operand type(s) for +: 'float' and '_collections._tuplegetter'
=========================================================================================================================================================================== short test summary info ============================================================================================================================================================================
FAILED tests/test_smoke.py::test_minimal - TypeError: unsupported operand type(s) for +: 'float' and '_collections._tuplegetter'
1 failed, 2549 warnings in 6.66s
```

This PR fixes by using an int default value.