### PR TITLE
[AWS/LLM] Remove the conda channel that is not working on AWS and fix dependencies in LLMs

### DIFF
--- a/llm/codellama/endpoint.yaml
+++ b/llm/codellama/endpoint.yaml
@@ -27,8 +27,8 @@ setup: |
     conda activate codellama
   fi
 
-  pip list | grep vllm || pip install "git+https://github.com/vllm-project/vllm.git"
-  pip install git+https://github.com/huggingface/transformers
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
 
 run: |
   conda activate codellama

--- a/llm/mixtral/README.md
+++ b/llm/mixtral/README.md
@@ -59,6 +59,24 @@ curl -L http://$IP:8000/v1/completions \
   }'
 ```
 
+Chat API is also supported:
+```bash
+IP=$(sky status --ip mixtral)
+
+curl -L http://$IP:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+      "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hello! What is your name?"
+        }
+      ],
+      "max_tokens": 25
+  }'
+```
+
 ## 2. Serve with multiple instances
 
 When scaling up is required, [SkyServe](https://skypilot.readthedocs.io/en/latest/serving/sky-serve.html) is the library built on top of SkyPilot, which can help you scale up the serving with multiple instances, while still providing a single endpoint. To serve Mixtral with multiple instances, run the following command:
@@ -77,6 +95,7 @@ service:
       messages:
         - role: user
           content: Hello! What is your name?
+      max_tokens: 1
     initial_delay_seconds: 1200
   replica_policy:
     min_replicas: 1
@@ -102,6 +121,24 @@ curl -L http://$ENDPOINT/v1/completions \
   -d '{
       "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
       "prompt": "My favourite condiment is",
+      "max_tokens": 25
+  }'
+```
+
+Chat API is also supported:
+```bash
+ENDPOINT=$(sky serve status --endpoint mixtral)
+
+curl -L http://$ENDPOINT/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+      "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Hello! What is your name?"
+        }
+      ],
       "max_tokens": 25
   }'
 ```

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -26,11 +26,8 @@ setup: |
     conda create -n mixtral -y python=3.10
     conda activate mixtral
   fi
-  # We have to manually install Torch otherwise apex & xformers won't build
-  pip list | grep torch || pip install "torch>=2.0.0"
-
-  pip list | grep vllm || pip install "git+https://github.com/vllm-project/vllm.git"
-  pip install git+https://github.com/huggingface/transformers
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
   pip list | grep megablocks || pip install megablocks
 
 run: |

--- a/llm/mixtral/serve.yaml
+++ b/llm/mixtral/serve.yaml
@@ -11,6 +11,7 @@ service:
       messages:
         - role: user
           content: Hello! What is your name?
+      max_tokens: 1
     initial_delay_seconds: 1200
   replica_policy:
     min_replicas: 2

--- a/llm/vllm/serve-openai-api.yaml
+++ b/llm/vllm/serve-openai-api.yaml
@@ -14,8 +14,8 @@ setup: |
     conda activate vllm
   fi
 
-  pip list | grep vllm || pip install vllm==0.3.0
-  pip list | grep transformers || pip install transformers==4.37.2
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
 
   python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 

--- a/llm/vllm/serve.yaml
+++ b/llm/vllm/serve.yaml
@@ -13,8 +13,8 @@ setup: |
 
   # Install fschat and accelerate for chat completion
   git clone https://github.com/vllm-project/vllm.git || true
-  pip list | grep vllm || pip install vllm==0.3.0
-  pip list | grep transformers || pip install transformers==4.37.2
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
 
   pip install gradio
 

--- a/llm/vllm/service.yaml
+++ b/llm/vllm/service.yaml
@@ -23,8 +23,8 @@ setup: |
     conda activate vllm
   fi
 
-  pip list | grep vllm || pip install vllm==0.3.0
-  pip list | grep transformers || pip install transformers==4.37.2
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
 
   python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -94,6 +94,7 @@ def _fill_in_env_vars(
               messages:
                 - role: user
                   content: How to print hello world?
+              max_tokens: 1
 
     We simply dump yaml_field into a json string, and replace env vars using
     regex. This should be safe as yaml config has been schema-validated.

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -151,6 +151,7 @@ setup_commands:
   # We set auto_activate_base to be false for pre-installed conda.
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
   # Line "conda config --remove channels": remove the default channel set in the default AWS image as it cannot be accessed.
+  #    UnavailableInvalidChannel: HTTP 404 NOT FOUND for channel  <https://aws-ml-conda-ec2.s3.us-west-2.amazonaws.com>
   # Line 'sudo bash ..': set the ulimit as suggested by ray docs for performance. https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html#system-configuration
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -150,6 +150,7 @@ setup_commands:
   # Create ~/.ssh/config file in case the file does not exist in the custom image.
   # We set auto_activate_base to be false for pre-installed conda.
   # This also kills the service that is holding the lock on dpkg (problem only exists on aws/azure, not gcp)
+  # Line "conda config --remove channels": remove the default channel set in the default AWS image as it cannot be accessed.
   # Line 'sudo bash ..': set the ulimit as suggested by ray docs for performance. https://docs.ray.io/en/latest/cluster/vms/user-guides/large-cluster-best-practices.html#system-configuration
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
@@ -159,6 +160,7 @@ setup_commands:
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     source ~/.bashrc;
+    conda config --remove channels "https://aws-ml-conda-ec2.s3.us-west-2.amazonaws.com";
     mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;
     (pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U ray[default]=={{ray_version}});
     (pip3 list | grep "skypilot " && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[aws, remote]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);

--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -6,6 +6,7 @@ service:
       messages:
         - role: user
           content: How to print hello world?
+      max_tokens: 1
   replicas: 1
 
 envs:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`sky launch -c test-mixtral --use-spot ./llm/mixtral/serve.yaml`

It fail to work with our current master, due to the failure of accessing `"https://aws-ml-conda-ec2.s3.us-west-2.amazonaws.com"` when running `conda create`.

Fixes #3195

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-mixtral --cloud aws --use-spot ./llm/mixtral/serve.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
