### PR TITLE
[k8s][DO NOT MERGE] AMD support for k8s

### DIFF
--- a/examples/amd_opt.yaml
+++ b/examples/amd_opt.yaml
@@ -10,7 +10,9 @@
 resources:
   cloud: kubernetes
   image_id: docker:rocm/pytorch:rocm6.0.2_ubuntu22.04_py3.10_pytorch_2.1.2 # rocm/pytorch:latest does not work since it uses python 3.11, which fails with ray 2.4.0
-  accelerators: MI210:1
+  accelerators: MI210:32
+  cpus: 128
+  memory: 512+
 
 setup: |
   pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.0/
@@ -19,7 +21,7 @@ setup: |
   cd trl
   pip install .
   mkdir -p /root/.cache/huggingface/accelerate/
-  echo \"compute_environment: LOCAL_MACHINE\ndebug: false\ndistributed_type: MULTI_GPU\ndowncast_bf16: 'no'\ngpu_ids: all\nmachine_rank: 0\nmain_training_function: main\nmixed_precision: 'no'\nnum_machines: 1\nnum_processes: 32\nrdzv_backend: static\nsame_network: true\ntpu_env: []\ntpu_use_cluster: false\ntpu_use_sudo: false\nuse_cpu: false\" >/root/.cache/huggingface/accelerate/default_config.yaml
+  printf "compute_environment: LOCAL_MACHINE\ndebug: false\ndistributed_type: MULTI_GPU\ndowncast_bf16: 'no'\ngpu_ids: all\nmachine_rank: 0\nmain_training_function: main\nmixed_precision: 'no'\nnum_machines: 1\nnum_processes: 32\nrdzv_backend: static\nsame_network: true\ntpu_env: []\ntpu_use_cluster: false\ntpu_use_sudo: false\nuse_cpu: false\n" >/root/.cache/huggingface/accelerate/default_config.yaml
 
 run: |
   accelerate launch --num_processes 32 trl/examples/scripts/sft.py --model_name_or_path="facebook/opt-350m" --learning_rate=1.41e-5 --per_device_train_batch_size=64 --gradient_accumulation_steps=16 --output_dir="sft_openassistant-guanaco" --logging_steps=1 --num_train_epochs=3 --max_steps=-1 --gradient_checkpointing

--- a/examples/amd_opt.yaml
+++ b/examples/amd_opt.yaml
@@ -1,0 +1,25 @@
+# Example task using AMD GPUs.
+# Trains facebook/opt-350m
+
+# Make sure
+# Your nodes are labelled correctly:
+#   kubectl label node <node-name> skypilot.co/accelerator=mi210
+# There's no nvidia runtime on your cluster:
+#   kubectl delete runtimeclasses.node.k8s.io nvidia nvidia-experimental
+
+resources:
+  cloud: kubernetes
+  image_id: docker:rocm/pytorch:rocm6.0.2_ubuntu22.04_py3.10_pytorch_2.1.2 # rocm/pytorch:latest does not work since it uses python 3.11, which fails with ray 2.4.0
+  accelerators: MI210:1
+
+setup: |
+  pip install --upgrade --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/rocm6.0/
+  pip install trl numpy==1.22.4
+  git clone https://github.com/lvwerra/trl
+  cd trl
+  pip install .
+  mkdir -p /root/.cache/huggingface/accelerate/
+  echo \"compute_environment: LOCAL_MACHINE\ndebug: false\ndistributed_type: MULTI_GPU\ndowncast_bf16: 'no'\ngpu_ids: all\nmachine_rank: 0\nmain_training_function: main\nmixed_precision: 'no'\nnum_machines: 1\nnum_processes: 32\nrdzv_backend: static\nsame_network: true\ntpu_env: []\ntpu_use_cluster: false\ntpu_use_sudo: false\nuse_cpu: false\" >/root/.cache/huggingface/accelerate/default_config.yaml
+
+run: |
+  accelerate launch --num_processes 32 trl/examples/scripts/sft.py --model_name_or_path="facebook/opt-350m" --learning_rate=1.41e-5 --per_device_train_batch_size=64 --gradient_accumulation_steps=16 --output_dir="sft_openassistant-guanaco" --logging_steps=1 --num_train_epochs=3 --max_steps=-1 --gradient_checkpointing

--- a/examples/amd_task.yaml
+++ b/examples/amd_task.yaml
@@ -9,7 +9,7 @@
 
 resources:
   cloud: kubernetes
-  image_id: rocm/pytorch:latest
+  image_id: docker:rocm/pytorch:rocm6.0.2_ubuntu22.04_py3.10_pytorch_2.1.2 # rocm/pytorch:latest does not work since it uses python 3.11, which fails with ray 2.4.0
   accelerators: MI210:1
 
 run: |

--- a/examples/amd_task.yaml
+++ b/examples/amd_task.yaml
@@ -1,0 +1,16 @@
+# Example task using AMD GPUs.
+# Runs rocm-smi to get GPU information.
+
+# Make sure
+# Your nodes are labelled correctly:
+#   kubectl label node <node-name> skypilot.co/accelerator=mi210
+# There's no nvidia runtime on your cluster:
+#   kubectl delete runtimeclasses.node.k8s.io nvidia nvidia-experimental
+
+resources:
+  cloud: kubernetes
+  image_id: rocm/pytorch:latest
+  accelerators: MI210:1
+
+run: |
+  rocm-smi

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5479,7 +5479,7 @@ def local_up(gpus: bool):
                 gpu_type_str = ''
 
             # Get number of GPUs (sum of nvidia.com/gpu resources)
-            gpu_count_command = 'kubectl get nodes -o=jsonpath=\'{range .items[*]}{.status.allocatable.nvidia\\.com/gpu}{\"\\n\"}{end}\' | awk \'{sum += $1} END {print sum}\''  # pylint: disable=line-too-long
+            gpu_count_command = 'kubectl get nodes -o=jsonpath=\'{range .items[*]}{.status.allocatable.amd\\.com/gpu}{\"\\n\"}{end}\' | awk \'{sum += $1} END {print sum}\''  # pylint: disable=line-too-long
             try:
                 # Run the command and capture the output
                 gpu_count_output = subprocess.check_output(gpu_count_command,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -238,9 +238,6 @@ class Kubernetes(clouds.Cloud):
             # Get the container image ID from the service catalog.
             image_id = service_catalog.get_image_id_from_tag(
                 image_id, clouds='kubernetes')
-        logger.info('\n\n')
-        logger.info(f'Using image {image_id} for instance type. Had {resources.image_id}')
-        logger.info('\n\n')
         # TODO(romilb): Create a lightweight image for SSH jump host
         ssh_jump_image = service_catalog.get_image_id_from_tag(
             self.IMAGE_CPU, clouds='kubernetes')

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -228,13 +228,19 @@ class Kubernetes(clouds.Cloud):
         if resources.image_id is not None:
             # Use custom image specified in resources
             image_id_with_region = resources.image_id['kubernetes']
-            image_id = image_id_with_region.lstrip('docker:')
+            if image_id_with_region.startswith('docker:'):
+                image_id = image_id_with_region[len('docker:'):]
+            else:
+                image_id = image_id_with_region
         else:
             # Select image based on whether we are using GPUs or not.
             image_id = self.IMAGE_GPU if acc_count > 0 else self.IMAGE_CPU
             # Get the container image ID from the service catalog.
             image_id = service_catalog.get_image_id_from_tag(
                 image_id, clouds='kubernetes')
+        logger.info('\n\n')
+        logger.info(f'Using image {image_id} for instance type. Had {resources.image_id}')
+        logger.info('\n\n')
         # TODO(romilb): Create a lightweight image for SSH jump host
         ssh_jump_image = service_catalog.get_image_id_from_tag(
             self.IMAGE_CPU, clouds='kubernetes')

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -64,12 +64,11 @@ def list_accelerators(
             accelerator_name = label_formatter.get_accelerator_from_label_value(
                 node.metadata.labels.get(key))
             accelerator_count = int(
-                node.status.allocatable.get('nvidia.com/gpu', 0))
+                node.status.allocatable.get('amd.com/gpu', 0))
 
             if accelerator_name and accelerator_count > 0:
                 for count in range(1, accelerator_count + 1):
                     accelerators.add((accelerator_name, count))
-
     result = []
     for accelerator_name, accelerator_count in accelerators:
         result.append(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -142,7 +142,7 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
                             # TODO(romilb): We may have additional node
                             #  affinity selectors in the future - in that
                             #  case we will need to update this logic.
-                            if (('Insufficient nvidia.com/gpu'
+                            if (('Insufficient amd.com/gpu'
                                  in event_message) or
                                 ('didn\'t match Pod\'s node affinity/selector'
                                  in event_message)):

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -676,6 +676,7 @@ def get_cluster_info(
         custom_ray_options={
             'object-store-memory': 500000000,
             'num-cpus': cpu_request,
+            'num-gpus': 100, # FIXME - This is hack for AMD support. Ray does not auto detect number of GPUs. We should read from amd.com/gpu count if amd gpu is set.
         })
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -31,7 +31,7 @@ MEMORY_SIZE_UNITS = {
     'P': 2**50,
 }
 NO_GPU_ERROR_MESSAGE = 'No GPUs found in Kubernetes cluster. \
-If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on the nodes and the node labels for identifying GPUs \
+If your cluster contains GPUs, make sure amd.com/gpu resource is available on the nodes and the node labels for identifying GPUs \
 (e.g., skypilot.co/accelerators) are setup correctly. \
 To further debug, run: sky check.'
 
@@ -218,21 +218,21 @@ def detect_gpu_label_formatter(
 
 
 def detect_gpu_resource() -> Tuple[bool, Set[str]]:
-    """Checks if the Kubernetes cluster has nvidia.com/gpu resource.
+    """Checks if the Kubernetes cluster has amd.com/gpu resource.
 
-    If nvidia.com/gpu resource is missing, that typically means that the
+    If amd.com/gpu resource is missing, that typically means that the
     Kubernetes cluster does not have GPUs or the nvidia GPU operator and/or
     device drivers are not installed.
 
     Returns:
-        bool: True if the cluster has nvidia.com/gpu resource, False otherwise.
+        bool: True if the cluster has amd.com/gpu resource, False otherwise.
     """
     # Get the set of resources across all nodes
     cluster_resources: Set[str] = set()
     nodes = get_kubernetes_nodes()
     for node in nodes:
         cluster_resources.update(node.status.allocatable.keys())
-    has_gpu = 'nvidia.com/gpu' in cluster_resources
+    has_gpu = 'amd.com/gpu' in cluster_resources
 
     return has_gpu, cluster_resources
 
@@ -341,7 +341,7 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
         is True.
     Raises:
         ResourcesUnavailableError: Can be raised from the following conditions:
-            - The cluster does not have GPU resources (nvidia.com/gpu)
+            - The cluster does not have GPU resources (amd.com/gpu)
             - The cluster does not have GPU labels setup correctly
             - The cluster doesn't have any nodes with acc_type GPU
     """
@@ -428,11 +428,11 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
                 suffix = (' Available resources on the cluster: '
                           f'{cluster_resources}')
             raise exceptions.ResourcesUnavailableError(
-                'Could not detect GPU resources (`nvidia.com/gpu`) in '
+                'Could not detect GPU resources (`amd.com/gpu`) in '
                 'Kubernetes cluster. If this cluster contains GPUs, please '
                 'ensure GPU drivers are installed on the node. Check if the '
                 'GPUs are setup correctly by running `kubectl describe nodes` '
-                'and looking for the nvidia.com/gpu resource. '
+                'and looking for the amd.com/gpu resource. '
                 'Please refer to the documentation on how '
                 f'to set up GPUs.{suffix}')
 

--- a/sky/skylet/providers/kubernetes/config.py
+++ b/sky/skylet/providers/kubernetes/config.py
@@ -161,14 +161,14 @@ def _get_resource(container_resources: Dict[str, Any], resource_name: str,
         return float('inf')
     resources = container_resources[field_name]
     # Look for keys containing the resource_name. For example,
-    # the key 'nvidia.com/gpu' contains the key 'gpu'.
+    # the key 'amd.com/gpu' contains the key 'gpu'.
     matching_keys = [key for key in resources if resource_name in key.lower()]
     if len(matching_keys) == 0:
         return float('inf')
     if len(matching_keys) > 1:
         # Should have only one match -- mostly relevant for gpu.
         raise ValueError(f'Multiple {resource_name} types not supported.')
-    # E.g. 'nvidia.com/gpu' or 'cpu'.
+    # E.g. 'amd.com/gpu' or 'cpu'.
     resource_key = matching_keys.pop()
     resource_quantity = resources[resource_key]
     if resource_name == 'memory':

--- a/sky/skylet/providers/kubernetes/node_provider.py
+++ b/sky/skylet/providers/kubernetes/node_provider.py
@@ -288,7 +288,7 @@ class KubernetesNodeProvider(NodeProvider):
                                 # TODO(romilb): We may have additional node
                                 #  affinity selectors in the future - in that
                                 #  case we will need to update this logic.
-                                if ('Insufficient nvidia.com/gpu'
+                                if ('Insufficient amd.com/gpu'
                                         in event_message or
                                         'didn\'t match Pod\'s node affinity/selector'
                                         in event_message):

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -196,9 +196,9 @@ available_node_types:
             requests:
               cpu: {{cpus}}
               memory: {{memory}}G
-              nvidia.com/gpu: {{accelerator_count}}
+              amd.com/gpu: {{accelerator_count}}
             limits:
-              nvidia.com/gpu: {{accelerator_count}} # Limits need to be defined for GPU requests
+              amd.com/gpu: {{accelerator_count}} # Limits need to be defined for GPU requests
 
 setup_commands:
   # Disable `unattended-upgrades` to prevent apt-get from hanging. It should be called at the beginning before the process started to avoid being blocked. (This is a temporary fix.)
@@ -214,7 +214,7 @@ setup_commands:
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     source ~/.bashrc;
     mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && sudo touch ~/.sudo_as_admin_successful;
-    (pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U ray[default]=={{ray_version}});
+    (pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U async-timeout ray[default]=={{ray_version}});
     (pip3 list | grep "skypilot " && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[remote]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -207,12 +207,14 @@ setup_commands:
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
+  # FIXME: For some reason conda gets installed with python 3.11 on rocm which doesn't work with ray. Figure out why this is the case and remove the conda install -y python=3.10 line.
   - sudo DEBIAN_FRONTEND=noninteractive apt install gcc patch pciutils rsync fuse curl -y;
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
     (type -a python | grep -q python3) || echo 'alias python=python3' >> ~/.bashrc;
     (type -a pip | grep -q pip3) || echo 'alias pip=pip3' >> ~/.bashrc;
     source ~/.bashrc;
+    conda install -y python=3.10;
     mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app && sudo touch ~/.sudo_as_admin_successful;
     (pip3 list | grep "ray " | grep {{ray_version}} 2>&1 > /dev/null || pip3 install --exists-action w -U async-timeout ray[default]=={{ray_version}});
     (pip3 list | grep "skypilot " && [ "$(cat {{sky_remote_path}}/current_sky_wheel_hash)" == "{{sky_wheel_hash}}" ]) || (pip3 uninstall skypilot -y; pip3 install "$(echo {{sky_remote_path}}/{{sky_wheel_hash}}/skypilot-{{sky_version}}*.whl)[remote]" && echo "{{sky_wheel_hash}}" > {{sky_remote_path}}/current_sky_wheel_hash || exit 1);


### PR DESCRIPTION
POC for skypilot on amd k8s cluster. Changes nvidia.com/gpu to amd.com/gpu and uses custom image. Do not merge.

Includes a bunch of hacks that need to fixed.

<img width="1138" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/6d3cb704-cf5d-4392-a506-163909250c9e">


# Getting started

## Preparing your k8s cluster
1. Make sure `amd.com/gpu` is available on the cluster.
2. Make sure nvidia runtimeclass is not present on the cluster:
```
kubectl delete runtimeclasses.node.k8s.io nvidia nvidia-experimental
```
3. Make sure your nodes are labelled:
```
kubectl label node <node-name> skypilot.co/accelerator=mi210
```

## Install this branch of SkyPilot
```
conda create -y -n sky python=3.10
conda activate sky

git clone https://github.com/skypilot-org/skypilot.git
cd skypilot
git checkout amd_k8s

pip install -e ".[kubernetes]"
```

## Running training on AMD with SkyPilot
1. Run `sky check`
3. Run accelerate job `sky launch -c amd examples/amd_opt.yaml`

Example logs:
* [accelerate training facebook/opt-350](https://gist.github.com/romilbhardwaj/aa7568f1b92cb7a9170bb90065118858)
* [rocm-smi](https://gist.github.com/romilbhardwaj/59da3a617392867e88cab7c7acfe08da)

TODOs:
* Fix all fixmes. There's quite a few hacks in there. Goal is to make SkyPilot autodetect underlying GPU and use the right code paths.
* Multinode doesn't work yet.