### PR TITLE
[k8s] Fix custom image parsing 

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -227,8 +227,9 @@ class Kubernetes(clouds.Cloud):
 
         if resources.image_id is not None:
             # Use custom image specified in resources
-            image_id_with_region = resources.image_id['kubernetes']
-            image_id = image_id_with_region.lstrip('docker:')
+            image_id = resources.image_id['kubernetes']
+            if image_id.startswith('docker:'):
+                image_id = image_id[len('docker:'):]
         else:
             # Select image based on whether we are using GPUs or not.
             image_id = self.IMAGE_GPU if acc_count > 0 else self.IMAGE_CPU


### PR DESCRIPTION
Our current custom image text parsing for k8s uses `lstrip` incorrectly. The arg to lstrip specifies a set of characters, not a string. As a result, any image starting with the letters d,o,c,k,e,r or a permutation of docker gets parsed incorrectly:

```
>>> "rayproject/ray".lstrip('docker:')
'ayproject/ray'
```

Tested with the `sky launch` this YAML:
```
resources:
  cloud: kubernetes
  image_id: docker:rayproject/ray:2.4.0-py310-cpu
```