### PR TITLE
Release 0.5.0

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -33,7 +33,7 @@ def get_git_commit():
 
 
 __commit__ = get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.5.0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 # Keep this order to avoid cyclic imports


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- [x] `pytest tests/test_smoke.py` (commit: 92b2e118a589f24b82a28)
- [x] `pytest tests/test_smoke.py --aws` (~~except for `test_aws_custom_image` being fixed in #3215~~)
- [x] `pytest tests/test_smoke.py --gcp`
- [x] `pytest tests/test_smoke.py --azure` (~~except for `test_job_queue_with_docker` being fixed in #3218~~)
- [x] `pytest tests/test_smoke.py --kubernetes`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] `backward_compatibility_tests.sh` run against 0.4.1 on aws
- [x] `backward_compatibility_tests.sh` run against 0.4.1 on gcp
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky spot launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky spot logs --controller
        ```
  - [x] following script (skipped, not enough quotas)
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot 
    sky down dbg
    ```
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud gcp -y`
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud aws -y`
