### PR TITLE
[Storage] Storage mounting tool permissions fix

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -19,7 +19,7 @@ def get_s3_mount_install_cmd() -> str:
     install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
                    'releases/download/0.24.0-romilb-upstream/goofys '
                    '-O /usr/local/bin/goofys && '
-                   'sudo chmod +rx /usr/local/bin/goofys')
+                   'sudo chmod 755 /usr/local/bin/goofys')
     return install_cmd
 
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -19,7 +19,7 @@ def get_s3_mount_install_cmd() -> str:
     install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
                    'releases/download/0.24.0-romilb-upstream/goofys '
                    '-O /usr/local/bin/goofys && '
-                   'sudo chmod +x /usr/local/bin/goofys')
+                   'sudo chmod +rx /usr/local/bin/goofys')
     return install_cmd
 
 


### PR DESCRIPTION
Fixes `test_aws_custom_image` for #3211.
 
On certain images, chmod +x on `/usr` doesn't work:

e.g. on [ami-062ddd90fb6f8267a](https://aws.amazon.com/marketplace/pp/prodview-rf7na2b2ttvdg)
```
(base) ubuntu@ip-172-31-4-126:~/.sky$ sudo chmod 700 /usr/local/bin/goofys
(base) ubuntu@ip-172-31-4-126:~/.sky$ ls -lah /usr/local/bin/goofys
-rwx------ 1 root root 28M Apr  6  2022 /usr/local/bin/goofys

(base) ubuntu@ip-172-31-4-126:~/.sky$ sudo chmod +x /usr/local/bin/goofys
(base) ubuntu@ip-172-31-4-126:~/.sky$ ls -lah /usr/local/bin/goofys
-rwx------ 1 root root 28M Apr  6  2022 /usr/local/bin/goofys # Didn't work

(base) ubuntu@ip-172-31-4-126:~/.sky$ sudo chmod 755 /usr/local/bin/goofys
(base) ubuntu@ip-172-31-4-126:~/.sky$ ls -lah /usr/local/bin/goofys
-rwxr-xr-x 1 root root 28M Apr  6  2022 /usr/local/bin/goofys # chmod 755 works
```

same on gcp debian image and aws ubuntu image:
```
(base) gcpuser@mymntgcp-2ea4-head-arrpfaio-compute:/$ sudo chmod 700 /usr/local/bin/goofys
(base) gcpuser@mymntgcp-2ea4-head-arrpfaio-compute:/$ ls -lah /usr/local/bin/goofys
-rwx------ 1 root root 28M Apr  6  2022 /usr/local/bin/goofys

(base) gcpuser@mymntgcp-2ea4-head-arrpfaio-compute:/$ sudo chmod +x /usr/local/bin/goofys
(base) gcpuser@mymntgcp-2ea4-head-arrpfaio-compute:/$ ls -lah /usr/local/bin/goofys
-rwx--x--x 1 root root 28M Apr  6  2022 /usr/local/bin/goofys # Works!
```

This PR changes to use chmod 755.

Tested:
- [x] `pytest tests/test_smoke.py::test_aws_custom_image --aws`
- [x] `pytest tests/test_smoke.py -k "test_aws_storage_mounts_with_stop" --aws`
- [x]  `pytest tests/test_smoke.py -k "test_gcp_storage_mounts_with_stop"` 
