### PR TITLE
[Docker] Add retry for docker pull due to daemon not ready

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -136,7 +136,7 @@ _RAY_YAML_KEYS_TO_RESTORE_FOR_BACK_COMPATIBILITY = {
 #   should take the latest security group name.
 _RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS = [
     ('provider', 'availability_zone'),
-    # AWS with new provisioner has docker_login_config in the
+    # Clouds with new provisioner has docker_login_config in the
     # docker field, instead of the provider field.
     ('docker', 'docker_login_config'),
     # Other clouds

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1837,6 +1837,8 @@ class RetryingVmProvisioner(object):
                 logger.info(
                     'Retrying launching in {:.1f} seconds.'.format(sleep))
                 time.sleep(sleep)
+            # TODO(zhwu): when we retry ray up, it is possible that the ray
+            # cluster fail to start because --no-restart flag is used.
             ray_up_return_value = ray_up()
 
         assert ray_up_return_value is not None

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -15,8 +15,8 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_DOCKER_PERMISSION_DENIED_STR = ('permission denied while trying to connect to '
-                                 'the Docker daemon socket')
+DOCKER_PERMISSION_DENIED_STR = ('permission denied while trying to connect to '
+                                'the Docker daemon socket')
 
 
 @dataclasses.dataclass
@@ -147,7 +147,7 @@ class DockerInitializer:
                                                  require_outputs=True,
                                                  stream_logs=False,
                                                  log_path=self.log_path)
-            if rc == 0 or _DOCKER_PERMISSION_DENIED_STR not in stdout:
+            if DOCKER_PERMISSION_DENIED_STR not in stdout + stderr:
                 break
             if not wait_for_docker_daemon:
                 break

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -147,9 +147,8 @@ class DockerInitializer:
                                                  require_outputs=True,
                                                  stream_logs=False,
                                                  log_path=self.log_path)
-            if DOCKER_PERMISSION_DENIED_STR not in stdout + stderr:
-                break
-            if not wait_for_docker_daemon:
+            if (not wait_for_docker_daemon or
+                    DOCKER_PERMISSION_DENIED_STR not in stdout + stderr):
                 break
 
             cnt += 1

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import shlex
+import time
 import typing
 from typing import Any, Dict, List
 
@@ -13,6 +14,9 @@ if typing.TYPE_CHECKING:
     from sky.utils import command_runner
 
 logger = sky_logging.init_logger(__name__)
+
+_DOCKER_PERMISSION_DENIED_STR = ('permission denied while trying to connect to '
+                                 'the Docker daemon socket')
 
 
 @dataclasses.dataclass
@@ -120,7 +124,11 @@ class DockerInitializer:
         self.docker_cmd = 'podman' if use_podman else 'docker'
         self.log_path = log_path
 
-    def _run(self, cmd, run_env='host') -> str:
+    def _run(self,
+             cmd,
+             run_env='host',
+             wait_for_docker_daemon: bool = False) -> str:
+
         if run_env == 'docker':
             cmd = self._docker_expand_user(cmd, any_char=True)
             cmd = ' '.join(_with_interactive(cmd))
@@ -132,10 +140,25 @@ class DockerInitializer:
                    f' {shlex.quote(cmd)} ')
 
         logger.debug(f'+ {cmd}')
-        rc, stdout, stderr = self.runner.run(cmd,
-                                             require_outputs=True,
-                                             stream_logs=False,
-                                             log_path=self.log_path)
+        cnt = 0
+        retry = 3
+        while True:
+            rc, stdout, stderr = self.runner.run(cmd,
+                                                 require_outputs=True,
+                                                 stream_logs=False,
+                                                 log_path=self.log_path)
+            if rc == 0 or _DOCKER_PERMISSION_DENIED_STR not in stdout:
+                break
+            if not wait_for_docker_daemon:
+                break
+
+            cnt += 1
+            if cnt > retry:
+                break
+            logger.info(
+                'Failed to run docker command, retrying in 10 seconds... '
+                f'({cnt}/{retry})')
+            time.sleep(10)
         subprocess_utils.handle_returncode(
             rc,
             cmd,
@@ -164,10 +187,12 @@ class DockerInitializer:
             # TODO(tian): Maybe support a command to get the login password?
             docker_login_config = DockerLoginConfig(
                 **self.docker_config['docker_login_config'])
-            self._run(f'{self.docker_cmd} login --username '
-                      f'{docker_login_config.username} '
-                      f'--password {docker_login_config.password} '
-                      f'{docker_login_config.server}')
+            self._run(
+                f'{self.docker_cmd} login --username '
+                f'{docker_login_config.username} '
+                f'--password {docker_login_config.password} '
+                f'{docker_login_config.server}',
+                wait_for_docker_daemon=True)
             # We automatically add the server prefix to the image name if
             # the user did not add it.
             server_prefix = f'{docker_login_config.server}/'
@@ -177,11 +202,14 @@ class DockerInitializer:
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if ' +
                                     'pull_before_run is specified')
-            self._run(f'{self.docker_cmd} pull {specific_image}')
+            self._run(f'{self.docker_cmd} pull {specific_image}',
+                      wait_for_docker_daemon=True)
         else:
-            self._run(f'{self.docker_cmd} image inspect {specific_image} '
-                      '1> /dev/null  2>&1 || '
-                      f'{self.docker_cmd} pull {specific_image}')
+            self._run(
+                f'{self.docker_cmd} image inspect {specific_image} '
+                '1> /dev/null  2>&1 || '
+                f'{self.docker_cmd} pull {specific_image}',
+                wait_for_docker_daemon=True)
 
         logger.info(f'Starting container {self.container_name} with image '
                     f'{specific_image}')
@@ -347,7 +375,8 @@ class DockerInitializer:
     def _check_container_exited(self) -> bool:
         if self.initialized:
             return True
-        output = (self._run(
-            check_docker_running_cmd(self.container_name, self.docker_cmd)))
+        output = (self._run(check_docker_running_cmd(self.container_name,
+                                                     self.docker_cmd),
+                            wait_for_docker_daemon=True))
         return 'false' in output.lower(
         ) and 'no such object' not in output.lower()

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -93,6 +93,8 @@ class SkyDockerCommandRunner(DockerCommandRunner):
             except click.ClickException as e:
                 # We retry the command if it fails, because docker commands can
                 # fail due to the docker daemon not being ready yet.
+                # Ray command runner raise ClickException when the command
+                # fails.
                 cnt += 1
                 if cnt >= max_retry:
                     raise e

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -86,7 +86,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
     def _run_with_retry(self, cmd, **kwargs):
         """Run a command with retries for docker."""
         cnt = 0
-        max_retry = 5
+        max_retry = 10
         while True:
             try:
                 return self.run(cmd, **kwargs)

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -161,7 +161,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                     raise e
                 cli_logger.warning(f'Failed to get image {specific_image}. '
                                    f'Retrying in 3 seconds. Retry count: {cnt}')
-                time.sleep(3)
+                time.sleep(10)
 
         # Bootstrap files cannot be bind mounted because docker opens the
         # underlying inode. When the file is switched, docker becomes outdated.

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -86,7 +86,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
     def _run_with_retry(self, cmd, **kwargs):
         """Run a command with retries for docker."""
         cnt = 0
-        max_retry = 10
+        max_retry = 3
         while True:
             try:
                 return self.run(cmd, **kwargs)
@@ -97,8 +97,8 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 if cnt >= max_retry:
                     raise e
                 cli_logger.warning(f'Failed to run command {cmd}. '
-                                   f'Retrying in 3 seconds. Retry count: {cnt}')
-                time.sleep(3)
+                                   f'Retrying in 10 seconds. Retry count: {cnt}')
+                time.sleep(10)
 
     # SkyPilot: New function to check whether a container is exited
     # (but not removed). This is due to previous `sky stop` command,

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -160,8 +160,8 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                     cli_logger.error(f'Failed to get image {specific_image}.')
                     raise e
                 cli_logger.warning(f'Failed to get image {specific_image}. '
-                                   f'Retrying in 1 seconds. Retry count: {cnt}')
-                time.sleep(1)
+                                   f'Retrying in 3 seconds. Retry count: {cnt}')
+                time.sleep(3)
 
         # Bootstrap files cannot be bind mounted because docker opens the
         # underlying inode. When the file is switched, docker becomes outdated.

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -99,7 +99,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 if cnt >= max_retry:
                     raise e
                 cli_logger.warning(
-                    f'Failed to run command {cmd}. '
+                    f'Failed to run command {cmd!r}. '
                     f'Retrying in 10 seconds. Retry count: {cnt}')
                 time.sleep(10)
 
@@ -147,12 +147,9 @@ class SkyDockerCommandRunner(DockerCommandRunner):
             docker_login_config: docker_utils.DockerLoginConfig = self.docker_config[
                 "docker_login_config"]
             self._run_with_retry(
-                '{} login --username {} --password {} {}'.format(
-                    self.docker_cmd,
-                    docker_login_config.username,
-                    docker_login_config.password,
-                    docker_login_config.server,
-                ))
+                f'{self.docker_cmd} login --username '
+                f'{docker_login_config.username} --password '
+                f'{docker_login_config.password} {docker_login_config.server}')
             # We automatically add the server prefix to the image name if
             # the user did not add it.
             server_prefix = f'{docker_login_config.server}/'
@@ -162,8 +159,7 @@ class SkyDockerCommandRunner(DockerCommandRunner):
         if self.docker_config.get('pull_before_run', True):
             assert specific_image, ('Image must be included in config if '
                                     'pull_before_run is specified')
-            self._run_with_retry('{} pull {}'.format(self.docker_cmd,
-                                                     specific_image),
+            self._run_with_retry(f'{self.docker_cmd} pull {specific_image}',
                                  run_env='host')
         else:
             self._run_with_retry(

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -96,8 +96,9 @@ class SkyDockerCommandRunner(DockerCommandRunner):
                 cnt += 1
                 if cnt >= max_retry:
                     raise e
-                cli_logger.warning(f'Failed to run command {cmd}. '
-                                   f'Retrying in 10 seconds. Retry count: {cnt}')
+                cli_logger.warning(
+                    f'Failed to run command {cmd}. '
+                    f'Retrying in 10 seconds. Retry count: {cnt}')
                 time.sleep(10)
 
     # SkyPilot: New function to check whether a container is exited

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -40,15 +40,6 @@ provider:
   # NOTE: This is a new field added by SkyPilot to force use a specific VPC.
   vpc_name: {{vpc_name}}
 {% endif %}
-{%- if docker_login_config is not none %}
-  # We put docker login config in provider section because ray's schema disabled
-  # additionalProperties for docker config.
-  # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
-  docker_login_config:
-    username: {{docker_login_config.username}}
-    password: {{docker_login_config.password}}
-    server: {{docker_login_config.server}}
-{%- endif %}
   use_internal_ips: {{use_internal_ips}}
   # Disable launch config check for worker nodes as it can cause resource
   # leakage.

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -17,14 +17,14 @@ docker:
 {%- endif %}
 
 provider:
-    type: external
-    module: sky.skylet.providers.azure.AzureNodeProvider
-    location: {{region}}
-    # Ref: https://github.com/ray-project/ray/blob/2367a2cb9033913b68b1230316496ae273c25b54/python/ray/autoscaler/_private/_azure/node_provider.py#L87
-    # For Azure, ray distinguishes different instances by the resource_group,
-    # instead of the cluster_name. This ensures that ray creates new instances
-    # for different cluster_name.
-    resource_group: {{resource_group}}
+  type: external
+  module: sky.skylet.providers.azure.AzureNodeProvider
+  location: {{region}}
+  # Ref: https://github.com/ray-project/ray/blob/2367a2cb9033913b68b1230316496ae273c25b54/python/ray/autoscaler/_private/_azure/node_provider.py#L87
+  # For Azure, ray distinguishes different instances by the resource_group,
+  # instead of the cluster_name. This ensures that ray creates new instances
+  # for different cluster_name.
+  resource_group: {{resource_group}}
 {%- if docker_login_config is not none %}
   # We put docker login config in provider section because ray's schema disabled
   # additionalProperties for docker config.
@@ -34,17 +34,17 @@ provider:
     password: {{docker_login_config.password}}
     server: {{docker_login_config.server}}
 {%- endif %}
-    # Keep (otherwise cannot reuse when re-provisioning).
-    # teardown(terminate=True) will override this.
-    cache_stopped_nodes: True
-    # subscription id of the azure user
-    subscription_id: {{azure_subscription_id}}
-    # Disable launch config check for worker nodes as it can cause resource
-    # leakage.
-    # Reference: https://github.com/ray-project/ray/blob/cd1ba65e239360c8a7b130f991ed414eccc063ce/python/ray/autoscaler/_private/autoscaler.py#L1115
-    # The upper-level SkyPilot code has make sure there will not be resource
-    # leakage.
-    disable_launch_config_check: true
+  # Keep (otherwise cannot reuse when re-provisioning).
+  # teardown(terminate=True) will override this.
+  cache_stopped_nodes: True
+  # subscription id of the azure user
+  subscription_id: {{azure_subscription_id}}
+  # Disable launch config check for worker nodes as it can cause resource
+  # leakage.
+  # Reference: https://github.com/ray-project/ray/blob/cd1ba65e239360c8a7b130f991ed414eccc063ce/python/ray/autoscaler/_private/autoscaler.py#L1115
+  # The upper-level SkyPilot code has make sure there will not be resource
+  # leakage.
+  disable_launch_config_check: true
 
 
 auth:

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -17,9 +17,12 @@ docker:
     {%- endif %}
 {%- if docker_login_config is not none %}
   docker_login_config:
-    username: {{docker_login_config.username}}
-    password: {{docker_login_config.password}}
-    server: {{docker_login_config.server}}
+    username: |-
+      {{docker_login_config.username}}
+    password: |-
+      {{docker_login_config.password}}
+    server: |-
+      {{docker_login_config.server}}
 {%- endif %}
 {%- endif %}
 

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -15,6 +15,12 @@ docker:
     {%- if gpu is not none %}
       --gpus all
     {%- endif %}
+{%- if docker_login_config is not none %}
+  docker_login_config:
+    username: {{docker_login_config.username}}
+    password: {{docker_login_config.password}}
+    server: {{docker_login_config.server}}
+{%- endif %}
 {%- endif %}
 
 provider:
@@ -37,15 +43,6 @@ provider:
 {% if firewall_rule is not none %}
   firewall_rule: {{firewall_rule}}
 {% endif %}
-{%- if docker_login_config is not none %}
-  # We put docker login config in provider section because ray's schema disabled
-  # additionalProperties for docker config.
-  # See: https://github.com/ray-project/ray/blob/d2fc4823126927b2c54f89ec72fa3d24b442e6a3/python/ray/autoscaler/ray-schema.json#L227
-  docker_login_config:
-    username: {{docker_login_config.username}}
-    password: {{docker_login_config.password}}
-    server: {{docker_login_config.server}}
-{%- endif %}
   use_internal_ips: {{use_internal_ips}}
 {%- if tpu_vm %}
   _has_tpus: True

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1100,6 +1100,14 @@ def test_job_queue_with_docker(generic_cloud: str):
             'sleep 5',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-3 | grep RUNNING',
             f'sky cancel -y {name} 3',
+            f'sky stop -y {name}',
+            # Make sure the job status preserve after stop and start the
+            # cluster. This is also a test for the docker container to be
+            # preserved after stop and start.
+            f'sky start -y {name}',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-1 | grep FAILED',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-2 | grep CANCLLED',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-3 | grep CANCLLED',
             f'sky exec {name} --gpus T4:0.2 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
             f'sky exec {name} --gpus T4:1 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
             f'sky logs {name} 4 --status',

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1106,8 +1106,8 @@ def test_job_queue_with_docker(generic_cloud: str):
             # preserved after stop and start.
             f'sky start -y {name}',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-1 | grep FAILED',
-            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-2 | grep CANCLLED',
-            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-3 | grep CANCLLED',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-2 | grep CANCELLED',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-3 | grep CANCELLED',
             f'sky exec {name} --gpus T4:0.2 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
             f'sky exec {name} --gpus T4:1 "[[ \$SKYPILOT_NUM_GPUS_PER_NODE -eq 1 ]] || exit 1"',
             f'sky logs {name} 4 --status',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`pytest tests/test_smoke.py::test_job_queue_with_docker --azure` fails because `ray cluster` fail to start on the remote machine. Logs: https://gist.github.com/Michaelvll/4528e47faa9a008e1b204ea8b6873947

The main reason is that the `docker pull` fails due to the docker daemon not ready when the cluster is just up, and our retry in cloud_vm_ray_backend tries `ray up` again with `--no-restart` passed, which causes the ray cluster fail to start due to some bug in ray.
https://github.com/skypilot-org/skypilot/blob/ad755dfa7e96d4d049a301440c0ffefe8f7b2eb4/sky/backends/cloud_vm_ray_backend.py#L1832-L1843

In this PR, we retry the `docker pull` when the cluster is just up, so it does not error out and trigger that retry.

Future TODO:
- [ ] We should make the retry of ray up more robust and make sure the ray cluster is started on the cluster.
- [ ] A more useful way is to move all the cloud implementation to new provisioner API

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_job_queue_with_docker --azure` for three times and checked that there is no retry
  - [x] `pytest tests/test_smoke.py::test_job_queue_with_docker --aws`
  - [x] `pytest tests/test_smoke.py::test_job_queue_with_docker --gcp`
  - [x] `sky launch -c test-docker --cloud azure --cpus 2 ./test.yaml` with private docker image on aws
  - [x] `sky launch -c test-docker --cloud gcp --cpus 2 ./test.yaml` with private docker image on aws
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
