### PR TITLE
[Serve] Enable multiple cloud in resources

### DIFF
--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -60,10 +60,9 @@ def up(
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError('Service section not found.')
 
-    # Pickup the cloud if all resources are from the same cloud. This is to
-    # select the cloud for the controller if it does not exist yet. If the
-    # controller and all replicas are from the same cloud, it should provide
-    # better connectivity.
+    # If all resources are from the same cloud, set the cloud of the controller
+    # to be that cloud if it does not exist yet. If the controller and all replicas 
+    # are from the same cloud, it should provide better connectivity.
     requested_cloud: Optional['clouds.Cloud'] = None
     requested_multiple_clouds = False
     service_port: Optional[int] = None

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -64,7 +64,7 @@ def up(
     # to be that cloud if it does not exist yet. If the controller and all replicas 
     # are from the same cloud, it should provide better connectivity.
     requested_cloud: Optional['clouds.Cloud'] = None
-    requested_multiple_clouds = False
+    requested_multiple_clouds: bool = False
     service_port: Optional[int] = None
     for requested_resources in task.resources:
         if requested_resources.ports is None or len(

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -61,8 +61,8 @@ def up(
             raise RuntimeError('Service section not found.')
 
     # If all resources are from the same cloud, set the cloud of the controller
-    # to be that cloud if it does not exist yet. If the controller and all replicas 
-    # are from the same cloud, it should provide better connectivity.
+    # to be that cloud if it does not exist yet. If the controller and all
+    #replicas  are from the same cloud, it should provide better connectivity.
     requested_cloud: Optional['clouds.Cloud'] = None
     requested_multiple_clouds: bool = False
     service_port: Optional[int] = None

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -62,7 +62,7 @@ def up(
 
     # If all resources are from the same cloud, set the cloud of the controller
     # to be that cloud if it does not exist yet. If the controller and all
-    #replicas  are from the same cloud, it should provide better connectivity.
+    # replicas are from the same cloud, it should provide better connectivity.
     requested_cloud: Optional['clouds.Cloud'] = None
     requested_multiple_clouds: bool = False
     service_port: Optional[int] = None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Originally the SkyServe does not allow multiple resources using different cloud. This PR fixed the issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
