### PR TITLE
[Serve] Print out the yaml on update in the controller log

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -19,6 +19,7 @@ from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.utils import common_utils
 from sky.utils import env_options
+from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -117,6 +118,7 @@ class SkyServeController:
                 service = serve.SkyServiceSpec.from_yaml(latest_task_yaml)
                 logger.info(
                     f'Update to new version version {version}: {service}')
+                subprocess_utils.log_command_output(f'cat {latest_task_yaml}')
 
                 self._replica_manager.update_version(version, service)
                 self._autoscaler.update_version(version, service)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -10,6 +10,7 @@ import traceback
 
 import fastapi
 import uvicorn
+import yaml
 
 from sky import serve
 from sky import sky_logging
@@ -19,7 +20,6 @@ from sky.serve import serve_state
 from sky.serve import serve_utils
 from sky.utils import common_utils
 from sky.utils import env_options
-from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
@@ -118,8 +118,9 @@ class SkyServeController:
                 service = serve.SkyServiceSpec.from_yaml(latest_task_yaml)
                 logger.info(
                     f'Update to new version version {version}: {service}')
-                subprocess_utils.log_command_output(f'cat {latest_task_yaml}')
-
+                with open(latest_task_yaml, 'r', encoding='utf-8') as f:
+                    data = yaml.safe_load(f)
+                    logger.info(yaml.dump(data, sort_keys=False))
                 self._replica_manager.update_version(version, service)
                 self._autoscaler.update_version(version, service)
                 return {'message': 'Success'}

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -185,3 +185,22 @@ def run_with_retries(
                 continue
         break
     return returncode, stdout, stderr
+
+
+def log_command_output(command: str) -> None:
+    """Log output of a command.
+
+    Args:
+        command: The command to run.
+    """
+    try:
+        result = subprocess.run(command,
+                                shell=True,
+                                check=True,
+                                text=True,
+                                capture_output=True)
+        logger.info(result.stdout)
+        if result.stderr:
+            logger.error(result.stderr)
+    except subprocess.CalledProcessError as e:
+        logger.error(f'Command "{command}" failed with error: {e}')

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -185,22 +185,3 @@ def run_with_retries(
                 continue
         break
     return returncode, stdout, stderr
-
-
-def log_command_output(command: str) -> None:
-    """Log output of a command.
-
-    Args:
-        command: The command to run.
-    """
-    try:
-        result = subprocess.run(command,
-                                shell=True,
-                                check=True,
-                                text=True,
-                                capture_output=True)
-        logger.info(result.stdout)
-        if result.stderr:
-            logger.error(result.stderr)
-    except subprocess.CalledProcessError as e:
-        logger.error(f'Command "{command}" failed with error: {e}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/3056


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
   - [x]  Getting output on `sky serve update` commands. Output for multiline strings can be a little off though. For example, with yaml
```yaml
service:
  readiness_probe: /
  replicas: 3

resources:
  cloud: aws
  ports: 8080
  cpus: 2

setup: |
  echo "hello world"
  echo "foo bar"

workdir: .

run: python -m http.server 8080
```
can see the output look like
```yaml
I 02-26 05:16:43 subprocess_utils.py:204] name: sky-service-39a9
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] resources:
I 02-26 05:16:43 subprocess_utils.py:204]   cloud: AWS
I 02-26 05:16:43 subprocess_utils.py:204]   cpus: '2'
I 02-26 05:16:43 subprocess_utils.py:204]   disk_size: 256
I 02-26 05:16:43 subprocess_utils.py:204]   ports:
I 02-26 05:16:43 subprocess_utils.py:204]   - '8080'
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] service:
I 02-26 05:16:43 subprocess_utils.py:204]   readiness_probe:
I 02-26 05:16:43 subprocess_utils.py:204]     path: /
I 02-26 05:16:43 subprocess_utils.py:204]     initial_delay_seconds: 1200
I 02-26 05:16:43 subprocess_utils.py:204]   replica_policy:
I 02-26 05:16:43 subprocess_utils.py:204]     min_replicas: 3
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] num_nodes: 1
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] setup: 'echo "hello world"
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204]   echo "foo bar"
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204]   '
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] run: python -m http.server 8080
I 02-26 05:16:43 subprocess_utils.py:204] 
I 02-26 05:16:43 subprocess_utils.py:204] file_mounts:
I 02-26 05:16:43 subprocess_utils.py:204]   ~/sky_workdir:
I 02-26 05:16:43 subprocess_utils.py:204]     source: s3://skypilot-workdir-davidtran-fabe0f23
I 02-26 05:16:43 subprocess_utils.py:204]     store: S3
I 02-26 05:16:43 subprocess_utils.py:204]     persistent: false
I 02-26 05:16:43 subprocess_utils.py:204]     mode: COPY
I 02-26 05:16:43 subprocess_utils.py:204]     _force_delete: true
```
Clearly better than previous state (i.e. no logging), but currently not sure why some unnecessary single quotes and new lines are showing up
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
