### PR TITLE
[GCP] Fix spot with machine image

### DIFF
--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -133,6 +133,7 @@ available_node_types:
   {%- if use_spot or gpu is not none %}
       scheduling:
   {%- if use_spot %}
+        preemptible: true
         provisioningModel: SPOT
   {%- endif %}
   {%- if gpu is not none %}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -134,6 +134,7 @@ available_node_types:
       scheduling:
   {%- if use_spot %}
         preemptible: true
+        automaticRestart: false
         provisioningModel: SPOT
   {%- endif %}
   {%- if gpu is not none %}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -133,9 +133,11 @@ available_node_types:
   {%- if use_spot or gpu is not none %}
       scheduling:
   {%- if use_spot %}
-        preemptible: true
         automaticRestart: false
+        instanceTerminationAction: DELETE
+        onHostMaintenance: TERMINATE
         provisioningModel: SPOT
+        preemptible: true
   {%- endif %}
   {%- if gpu is not none %}
         onHostMaintenance: TERMINATE  # Required for GPU-attached VMs.

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -133,7 +133,7 @@ available_node_types:
   {%- if use_spot or gpu is not none %}
       scheduling:
   {%- if use_spot %}
-        preemptible: true
+        provisioningModel: SPOT
   {%- endif %}
   {%- if gpu is not none %}
         onHostMaintenance: TERMINATE  # Required for GPU-attached VMs.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3235 

We have some missing configurations for launching spot instances on GCP with machine image, which seems caused by the API update of GCP.

Note: all the configs added are required to make spot work with machine image.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-machine-image  test.yaml`
    ```yaml
    resources:
      cloud: gcp
      region: us-west1
      image_id: projects/skypilot-xxxx/global/machineImages/test-machine-image
      cpus: 2+
      memory: 4+
      disk_size: 256
      use_spot: true
    
    num_nodes: 2
    ```
  - [x] `sky launch -c test-normal  test.yaml`
    ```yaml
    resources:
      cloud: gcp
      region: us-west1
      cpus: 2+
      memory: 4+
      disk_size: 256
      use_spot: true
    
    num_nodes: 2
    ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
