### PR TITLE
[LLM] Add example for Qwen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,8 @@ FROM continuumio/miniconda3:23.3.1-0
 # Install dependencies
 RUN conda install -c conda-forge google-cloud-sdk && \
     apt update -y && \
-    apt install rsync -y && \
+    apt install rsync vim -y && \
     rm -rf /var/lib/apt/lists/*
 
-COPY . /sky/
-
-WORKDIR /sky/
-
 # Install sky
-RUN cd /sky/ && \
-    pip install ".[all]"
+RUN pip install --no-cache-dir "skypilot[all]==0.5.0"

--- a/llm/qwen/README.md
+++ b/llm/qwen/README.md
@@ -1,6 +1,6 @@
 # Serving Qwen1.5 on Your Own Cloud
 
-[Qwen1.5](https://github.com/QwenLM/Qwen1.5) is one of the open LLMs.
+[Qwen1.5](https://github.com/QwenLM/Qwen1.5) is one of the top open LLMs.
 
 
 ## References

--- a/llm/qwen/README.md
+++ b/llm/qwen/README.md
@@ -86,7 +86,7 @@ As shown, the service is now backed by 2 replicas, one on Azure and one on GCP, 
 type is chosen to be **the cheapest available one** on the clouds. That said, it maximizes the
 availability of the service while minimizing the cost.
 
-3. To access the model, we use the same curl command to send the request to the endpoint:
+3. To access the model, we use a `curl -L` command (`-L` to follow redirect) to send the request to the endpoint:
 ```bash
 ENDPOINT=$(sky serve status --endpoint qwen)
 

--- a/llm/qwen/README.md
+++ b/llm/qwen/README.md
@@ -1,6 +1,7 @@
 # Serving Qwen1.5 on Your Own Cloud
 
 [Qwen1.5](https://github.com/QwenLM/Qwen1.5) is one of the top open LLMs.
+As of Feb 2024, Qwen1.5-72B-Chat is ranked higher than Mixtral-8x7b-Instruct-v0.1 on the LMSYS Chatbot Arena Leaderboard.
 
 
 ## References

--- a/llm/qwen/README.md
+++ b/llm/qwen/README.md
@@ -1,0 +1,128 @@
+# Serving Qwen1.5 on Your Own Cloud
+
+Qwen1.5 is an open model 
+
+The followings are the demos of Code Llama 70B hosted by SkyPilot Serve (aka SkyServe) (see more details about the setup in later sections):
+
+## References
+* [Qwen docs]
+
+## Why use SkyPilot to deploy over commercial hosted solutions?
+
+* Get the best GPU availability by utilizing multiple resources pools across multiple regions and clouds.
+* Pay absolute minimum — SkyPilot picks the cheapest resources across regions and clouds. No managed solution markups.
+* Scale up to multiple replicas across different locations and accelerators, all served with a single endpoint 
+* Everything stays in your cloud account (your VMs & buckets)
+* Completely private - no one else sees your chat history
+
+
+## Running your own Qwen with SkyPilot
+
+After [installing SkyPilot](https://skypilot.readthedocs.io/en/latest/getting-started/installation.html), run your own Qwen model on vLLM with SkyPilot in 1-click:
+
+1. Start serving Qwen 72B on a single instance with any available GPU in the list specified in [serve-72b.yaml](serve-72b.yaml) with a vLLM powered OpenAI-compatible endpoint (You can also switch to [serve-7b.yaml](serve-7b.yaml) for a smaller model):
+
+```console
+sky launch -c qwen serve-72b.yaml
+```
+2. Send a request to the endpoint for completion:
+```bash
+IP=$(sky status --ip qwen)
+
+curl -L http://$IP:8000/v1/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen/Qwen1.5-72B-Chat",
+      "prompt": "My favorite food is",
+      "max_tokens": 512
+  }' | jq -r '.choices[0].text'
+```
+
+3. Send a request for chat completion:
+```bash
+curl -L http://$IP:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen/Qwen1.5-72B-Chat",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful and honest chat expert."
+        },
+        {
+          "role": "user",
+          "content": "What is the best food?"
+        }
+      ],
+      "max_tokens": 512
+  }' | jq -r '.choices[0].message.content'
+```
+
+## Scale up the service with SkyServe
+
+1. With [SkyPilot Serving](https://skypilot.readthedocs.io/en/latest/serving/sky-serve.html), a serving library built on top of SkyPilot, scaling up the Qwen service is as simple as running:
+```bash
+sky serve up -n qwen ./serve-72b.yaml
+```
+This will start the service with multiple replicas on the cheapest available locations and accelerators. SkyServe will automatically manage the replicas, monitor their health, autoscale based on load, and restart them when needed.
+
+A single endpoint will be returned and any request sent to the endpoint will be routed to the ready replicas.
+
+2. To check the status of the service, run:
+```bash
+sky serve status qwen
+```
+After a while, you will see the following output:
+```console
+Services
+NAME        VERSION  UPTIME  STATUS        REPLICAS  ENDPOINT            
+Qwen  1        -       READY         2/2       3.85.107.228:30002  
+
+Service Replicas
+SERVICE_NAME  ID  VERSION  IP  LAUNCHED    RESOURCES                   STATUS REGION  
+Qwen          1   1        -   2 mins ago  1x Azure({'A100-80GB': 8}) READY  eastus  
+Qwen          2   1        -   2 mins ago  1x GCP({'L4': 8})          READY  us-east4-a 
+```
+As shown, the service is now backed by 2 replicas, one on Azure and one on GCP, and the accelerator
+type is chosen to be **the cheapest available one** on the clouds. That said, it maximizes the
+availability of the service while minimizing the cost.
+
+3. To access the model, we use the same curl command to send the request to the endpoint:
+```bash
+ENDPOINT=$(sky serve status --endpoint qwen)
+
+curl -L http://$ENDPOINT/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen/Qwen1.5-72B-Chat",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You are a helpful and honest code assistant expert in Python."
+        },
+        {
+          "role": "user",
+          "content": "Show me the python code for quick sorting a list of integers."
+        }
+      ],
+      "max_tokens": 512
+  }' | jq -r '.choices[0].message.content'
+```
+
+
+## **Optional:** Accessing Code Llama with Chat GUI
+
+It is also possible to access the Code Llama service with a GUI using [FastChat](https://github.com/lm-sys/FastChat).
+
+1. Start the chat web UI:
+```bash
+sky launch -c qwen-gui ./gui.yaml --env ENDPOINT=$(sky serve status --endpoint qwen)
+```
+
+2. Then, we can access the GUI at the returned gradio link:
+```
+| INFO | stdout | Running on public URL: https://6141e84201ce0bb4ed.gradio.live
+```
+
+Note that you may get better results to use a higher temperature and top_p value.
+

--- a/llm/qwen/README.md
+++ b/llm/qwen/README.md
@@ -1,11 +1,10 @@
 # Serving Qwen1.5 on Your Own Cloud
 
-Qwen1.5 is an open model 
+[Qwen1.5](https://github.com/QwenLM/Qwen1.5) is one of the open LLMs.
 
-The followings are the demos of Code Llama 70B hosted by SkyPilot Serve (aka SkyServe) (see more details about the setup in later sections):
 
 ## References
-* [Qwen docs]
+* [Qwen docs](https://qwen.readthedocs.io/en/latest/)
 
 ## Why use SkyPilot to deploy over commercial hosted solutions?
 

--- a/llm/qwen/gui.yaml
+++ b/llm/qwen/gui.yaml
@@ -1,11 +1,14 @@
 # Starts a GUI server that connects to the Qwen OpenAI API server.
-# This works with the endpoint.yaml, please refer to llm/qwen/README.md
-# for more details.
+#
+# Refer to llm/qwen/README.md for more details.
+#
 # Usage:
+#
 #  1. If you have a endpoint started on a cluster (sky launch):
 #     `sky launch -c qwen-gui ./gui.yaml --env ENDPOINT=$(sky status --ip qwen):8000`
 #  2. If you have a SkyPilot Service started (sky serve up) called qwen:
 #     `sky launch -c qwen-gui ./gui.yaml --env ENDPOINT=$(sky serve status --endpoint qwen)`
+#
 # After the GUI server is started, you will see a gradio link in the output and
 # you can click on it to open the GUI.
 

--- a/llm/qwen/gui.yaml
+++ b/llm/qwen/gui.yaml
@@ -1,0 +1,50 @@
+# Starts a GUI server that connects to the Qwen OpenAI API server.
+# This works with the endpoint.yaml, please refer to llm/qwen/README.md
+# for more details.
+# Usage:
+#  1. If you have a endpoint started on a cluster (sky launch):
+#     `sky launch -c qwen-gui ./gui.yaml --env ENDPOINT=$(sky status --ip qwen):8000`
+#  2. If you have a SkyPilot Service started (sky serve up) called qwen:
+#     `sky launch -c qwen-gui ./gui.yaml --env ENDPOINT=$(sky serve status --endpoint qwen)`
+# After the GUI server is started, you will see a gradio link in the output and
+# you can click on it to open the GUI.
+
+envs:
+  ENDPOINT: x.x.x.x:3031 # Address of the API server running qwen. 
+
+resources:
+  cpus: 2
+
+setup: |
+  conda activate qwen
+  if [ $? -ne 0 ]; then
+    conda create -n qwen python=3.10 -y
+    conda activate qwen
+  fi
+
+  pip install "fschat[model_worker,webui]"
+  pip install "openai<1"
+
+run: |
+  conda activate qwen
+  export PATH=$PATH:/sbin
+  WORKER_IP=$(hostname -I | cut -d' ' -f1)
+  CONTROLLER_PORT=21001
+  WORKER_PORT=21002
+
+  cat <<EOF > ~/model_info.json
+  {
+    "Qwen/Qwen1.5-72B-Chat": {
+      "model_name": "Qwen/Qwen1.5-72B-Chat",
+      "api_base": "http://${ENDPOINT}/v1",
+      "api_key": "empty",
+      "model_path": "Qwen/Qwen1.5-72B-Chat"
+    }
+  }
+  EOF
+
+  python3 -m fastchat.serve.controller --host 0.0.0.0 --port ${CONTROLLER_PORT} > ~/controller.log 2>&1 &
+
+  echo 'Starting gradio server...'
+  python -u -m fastchat.serve.gradio_web_server --share \
+    --register-openai-compatible-models ~/model_info.json | tee ~/gradio.log

--- a/llm/qwen/serve-72b.yaml
+++ b/llm/qwen/serve-72b.yaml
@@ -2,7 +2,7 @@ envs:
   MODEL_NAME: Qwen/Qwen1.5-72B-Chat
 
 service:
-  # Specifying the path to the endpoint to check the readiness of the service.
+  # Specifying the path to the endpoint to check the readiness of the replicas.
   readiness_probe:
     path: /v1/chat/completions
     post_data:

--- a/llm/qwen/serve-72b.yaml
+++ b/llm/qwen/serve-72b.yaml
@@ -39,5 +39,6 @@ run: |
     --host 0.0.0.0 \
     --model $MODEL_NAME \
     --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
-    --max-num-seqs 16 | tee ~/openai_api_server.log
+    --max-num-seqs 16 \
+    --max-model-len 4096 | tee ~/openai_api_server.log
 

--- a/llm/qwen/serve-72b.yaml
+++ b/llm/qwen/serve-72b.yaml
@@ -1,0 +1,43 @@
+envs:
+  MODEL_NAME: Qwen/Qwen1.5-72B-Chat
+
+service:
+  # Specifying the path to the endpoint to check the readiness of the service.
+  readiness_probe:
+    path: /v1/chat/completions
+    post_data:
+      model: $MODEL_NAME
+      messages:
+        - role: user
+          content: Hello! What is your name?
+      max_tokens: 1
+    initial_delay_seconds: 1200
+  # How many replicas to manage.
+  replicas: 2
+  
+
+resources:
+  accelerators: {A100:8, A100-80GB:4, A100-80GB:8}
+  disk_size: 1024
+  disk_tier: best
+  memory: 32+
+  ports: 8000
+
+setup: |
+  conda activate qwen
+  if [ $? -ne 0 ]; then
+    conda create -n qwen python=3.10 -y
+    conda activate qwen
+  fi
+  pip install -U vllm==0.3.2
+  pip install -U transformers==4.38.0
+
+run: |
+  conda activate qwen
+  export PATH=$PATH:/sbin
+  python -u -m vllm.entrypoints.openai.api_server \
+    --host 0.0.0.0 \
+    --model $MODEL_NAME \
+    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
+    --max-num-seqs 16 | tee ~/openai_api_server.log
+

--- a/llm/qwen/serve-72b.yaml
+++ b/llm/qwen/serve-72b.yaml
@@ -39,6 +39,5 @@ run: |
     --host 0.0.0.0 \
     --model $MODEL_NAME \
     --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
-    --max-num-seqs 16 \
-    --max-model-len 4096 | tee ~/openai_api_server.log
+    --max-num-seqs 16 | tee ~/openai_api_server.log
 

--- a/llm/qwen/serve-7b.yaml
+++ b/llm/qwen/serve-7b.yaml
@@ -33,7 +33,7 @@ setup: |
 run: |
   conda activate qwen
   export PATH=$PATH:/sbin
-  python -m vllm.entrypoints.api_server \
+  python -m vllm.entrypoints.openai.api_server \
     --host 0.0.0.0 \
     --model $MODEL_NAME \
     --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \

--- a/llm/qwen/serve-7b.yaml
+++ b/llm/qwen/serve-7b.yaml
@@ -1,0 +1,37 @@
+envs:
+  MODEL_NAME: Qwen/Qwen1.5-7B-Chat
+
+service:
+  # Specifying the path to the endpoint to check the readiness of the service.
+  readiness_probe:
+    path: /v1/chat/completions
+    post_data:
+      model: $MODEL_NAME
+      messages:
+        - role: user
+          content: Hello! What is your name?
+      max_tokens: 1
+    initial_delay_seconds: 1200
+  # How many replicas to manage.
+  replicas: 2
+  
+
+resources:
+  accelerators: {L4, A10g, A10, L40, A40, A100, A100-80GB}
+  disk_tier: best
+
+setup: |
+  conda activate qwen
+  if [ $? -ne 0 ]; then
+    conda create -n qwen python=3.10 -y
+    conda activate qwen
+  fi
+  pip install -U vllm==0.3.2
+  pip install -U transformers==4.38.0
+
+run: |
+  conda activate qwen
+  python -m vllm.entrypoints.api_server \
+    --host 0.0.0.0 \
+    --model $MODEL_NAME \
+    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE | tee ~/openai_api_server.log

--- a/llm/qwen/serve-7b.yaml
+++ b/llm/qwen/serve-7b.yaml
@@ -2,7 +2,7 @@ envs:
   MODEL_NAME: Qwen/Qwen1.5-7B-Chat
 
 service:
-  # Specifying the path to the endpoint to check the readiness of the service.
+  # Specifying the path to the endpoint to check the readiness of the replicas.
   readiness_probe:
     path: /v1/chat/completions
     post_data:

--- a/llm/qwen/serve-7b.yaml
+++ b/llm/qwen/serve-7b.yaml
@@ -34,4 +34,5 @@ run: |
   python -m vllm.entrypoints.api_server \
     --host 0.0.0.0 \
     --model $MODEL_NAME \
-    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE | tee ~/openai_api_server.log
+    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
+    --max-model-len 4096 | tee ~/openai_api_server.log

--- a/llm/qwen/serve-7b.yaml
+++ b/llm/qwen/serve-7b.yaml
@@ -19,6 +19,7 @@ service:
 resources:
   accelerators: {L4, A10g, A10, L40, A40, A100, A100-80GB}
   disk_tier: best
+  ports: 8000
 
 setup: |
   conda activate qwen
@@ -31,8 +32,9 @@ setup: |
 
 run: |
   conda activate qwen
+  export PATH=$PATH:/sbin
   python -m vllm.entrypoints.api_server \
     --host 0.0.0.0 \
     --model $MODEL_NAME \
     --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
-    --max-model-len 4096 | tee ~/openai_api_server.log
+    --max-model-len 1024 | tee ~/openai_api_server.log


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-qwen llm/qwen/serve-72b.yaml --cloud gcp`
  - [x] curl the model
    ```
    curl -L http://$IP:8000/v1/chat/completions     -H "Content-Type: application/json"     -d '{
          "model": "Qwen/Qwen1.5-72B-Chat",
          "messages": [
            {
              "role": "system",
              "content": "You are a helpful and honest chat expert."
            },
            {
              "role": "user",
              "content": "What is the best food?"
            }
          ],
          "max_tokens": 512
      }' | jq -r '.choices[0].message.content'
    ```
  - [x] `sky launch -c test-qwen llm/qwen/serve-7b.yaml --cloud gcp`
  - [x] `sky serve up -n test-qwen llm/qwen/serve-72b.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
