### PR TITLE
[k8s] Optimize ingress creation to avoid nginx hot-reloads

### DIFF
--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -69,7 +69,8 @@ def _open_ports_using_ingress(
     service_details = [
         (f'{cluster_name_on_cloud}-skypilot-service--{port}', port,
          _PATH_PREFIX.format(cluster_name_on_cloud=cluster_name_on_cloud,
-                             port=port)) for port in ports
+                             port=port).rstrip('/').lstrip('/'))
+        for port in ports
     ]
 
     # Generate ingress and services specs

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -82,12 +82,8 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
     )
     content = yaml.safe_load(cont)
 
-    # Separate the ingress_spec and services_spec from the content
-    ingress_spec = content['ingress_spec']
-    services_spec = {k: v for k, v in content.items() if k != 'ingress_spec'}
-
     # Return a dictionary containing both specs
-    return {'ingress_spec': ingress_spec, 'services_spec': services_spec}
+    return {'ingress_spec': content['ingress_spec'], 'services_spec': content['services_spec']}
 
 
 def create_or_replace_namespaced_ingress(

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -57,9 +57,10 @@ def fill_loadbalancer_template(namespace: str, service_name: str,
     return content
 
 
-def fill_ingress_template(namespace: str, path_prefix: str, service_name: str,
-                          service_port: int, ingress_name: str,
-                          selector_key: str, selector_value: str) -> Dict:
+def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
+                                                                      str]],
+                          ingress_name: str, selector_key: str,
+                          selector_value: str) -> Dict:
     template_path = os.path.join(sky.__root_dir__, 'templates',
                                  _INGRESS_TEMPLATE_NAME)
     if not os.path.exists(template_path):
@@ -70,15 +71,23 @@ def fill_ingress_template(namespace: str, path_prefix: str, service_name: str,
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
-        path_prefix=path_prefix.rstrip('/').lstrip('/'),
-        service_name=service_name,
-        service_port=service_port,
+        service_names_and_ports=[{
+            'service_name': name,
+            'service_port': port,
+            'path_prefix': path_prefix
+        } for name, port, path_prefix in service_details],
         ingress_name=ingress_name,
         selector_key=selector_key,
         selector_value=selector_value,
     )
     content = yaml.safe_load(cont)
-    return content
+
+    # Separate the ingress_spec and services_spec from the content
+    ingress_spec = content['ingress_spec']
+    services_spec = {k: v for k, v in content.items() if k != 'ingress_spec'}
+
+    # Return a dictionary containing both specs
+    return {'ingress_spec': ingress_spec, 'services_spec': services_spec}
 
 
 def create_or_replace_namespaced_ingress(

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -83,7 +83,10 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
     content = yaml.safe_load(cont)
 
     # Return a dictionary containing both specs
-    return {'ingress_spec': content['ingress_spec'], 'services_spec': content['services_spec']}
+    return {
+        'ingress_spec': content['ingress_spec'],
+        'services_spec': content['services_spec']
+    }
 
 
 def create_or_replace_namespaced_ingress(

--- a/sky/templates/kubernetes-ingress.yml.j2
+++ b/sky/templates/kubernetes-ingress.yml.j2
@@ -12,24 +12,29 @@ ingress_spec:
     rules:
     - http:
         paths:
-        - path: /{{ path_prefix }}(/|$)(.*)
+        {% for service in service_names_and_ports %}
+        - path: /{{ service.path_prefix }}(/|$)(.*)
           pathType: ImplementationSpecific
           backend:
             service:
-              name: {{ service_name }}
+              name: {{ service.service_name }}
               port:
-                number: {{ service_port }}
-service_spec:
-  apiVersion: v1
-  kind: Service
-  metadata:
-    name: {{ service_name }}
-    labels:
-      parent: skypilot
-  spec:
-    type: ClusterIP
-    selector:
-      {{ selector_key }}: {{ selector_value }}
-    ports:
-    - port: {{ service_port }}
-      targetPort: {{ service_port }}
+                number: {{ service.service_port }}
+        {% endfor %}
+services_spec:
+  {% for service in service_names_and_ports %}
+  {{ service.service_name }}:
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ service.service_name }}
+      labels:
+        parent: skypilot
+    spec:
+      type: ClusterIP
+      selector:
+        {{ selector_key }}: {{ selector_value }}
+      ports:
+      - port: {{ service.service_port }}
+        targetPort: {{ service.service_port }}
+  {% endfor %}


### PR DESCRIPTION
Each ingress rule creation triggers a hot reload of the nginx controller. Since previously SkyPilot generates the listed ingresses sequentially, this could lead to multiple reloads of the Nginx-Ingress-Controller within a brief period. 

Consequently, the Nginx-Controller pod might spawn an excessive number of sub-processes. This surge triggers Kubernetes to kill and restart the Nginx due to the `podPidsLimit` parameter, which is typically set to a default value like 1024, and thus disrupts normal request handling.

This PR fixes this issue by batching ingress creation into one object containing multiple rules. 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested: `sky launch -c test --ports 8888-8899`
