### PR TITLE
[fluidstack] Fix norway_2_eu username for fluidstack

### DIFF
--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -304,7 +304,7 @@ class Fluidstack(clouds.Cloud):
     @classmethod
     def default_username(cls, region: str) -> str:
         return {
-            'norway_2_eu': 'fsuser',
+            'norway_2_eu': 'ubuntu',
             'calgary_1_canada': 'ubuntu',
             'norway_3_eu': 'ubuntu',
             'norway_4_eu': 'ubuntu',


### PR DESCRIPTION
`norway_2_eu` VMs on fluidstack seem to use `ubuntu` username instead of `fsuser`.

Tested:

- [ ]`sky launch -c test --cloud fluidstack --gpus A6000:1 --region norway_2_eu`. Previously would stay stuck on SSH, now works.

March 2 9:20a PT - Unable to test as fluidstack seems to be having issues provisioning on norway_2_eu (stuck on `customizing`). Was working as of 9a. Will test when it's back up.

<img width="400" alt="image" src="https://github.com/skypilot-org/skypilot/assets/4416605/52df7fcc-2782-428f-9780-ff65ad8de3ae">
