### PR TITLE
Docs: Add warning against installing Ray in base environment

### DIFF
--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -148,7 +148,6 @@ To execute a distributed Ray program on many VMs, you can use the following exam
   $ sky launch ray_train.yaml
 
 .. code-block:: yaml
-    :emphasize-lines: 6-6,21-22,24-25
   
     resources:
       accelerators: L4:2

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -137,3 +137,14 @@ This allows you directly to SSH into the worker nodes, if required.
   # Worker nodes.
   $ ssh mycluster-worker1
   $ ssh mycluster-worker2
+
+
+Executing a Distributed Ray Program
+------------------------------------
+.. warning:: 
+  **Avoid Installing Ray in Base Environment**
+
+  Before proceeding with the execution of a distributed Ray program, it is crucial to ensure that Ray is **not** installed in the base environment. Installing a different version of Ray in the base environment can lead to compatibility issues, conflicts, and unintended consequences.
+
+  To maintain a clean and stable environment for your distributed Ray program, it is highly recommended to **create a dedicated virtual environment** for Ray and its dependencies. This helps isolate the Ray installation and prevents interference with other packages in your base environment.
+

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -141,7 +141,7 @@ This allows you directly to SSH into the worker nodes, if required.
 
 Executing a Distributed Ray Program
 ------------------------------------
-To execute a distributed Ray program on many VMs, you can use the following example:
+To execute a distributed Ray program on many VMs, you can download the `training script <https://github.com/skypilot-org/skypilot/blob/master/examples/distributed_ray_train/train.py>`_ and launch the `task yaml <https://github.com/skypilot-org/skypilot/blob/master/examples/distributed_ray_train/ray_train.yaml>`_:
 
 .. code-block:: console
 

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -145,6 +145,7 @@ To execute a distributed Ray program on many VMs, you can download the `training
 
 .. code-block:: console
 
+  $ wget https://raw.githubusercontent.com/skypilot-org/skypilot/master/examples/distributed_ray_train/train.py
   $ sky launch ray_train.yaml
 
 .. code-block:: yaml

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -184,9 +184,7 @@ To execute a distributed Ray program on many VMs, you can download the `training
       fi
 
 .. warning:: 
-  **Avoid Installing Ray in Base Environment**
+  **Avoid Installing Ray in Base Environment**: Before proceeding with the execution of a distributed Ray program, it is crucial to ensure that Ray is **not** installed in the *base* environment. Installing a different version of Ray in the base environment can lead to abnormal cluster status.
 
-  Before proceeding with the execution of a distributed Ray program, it is crucial to ensure that Ray is **not** installed in the base environment. Installing a different version of Ray in the base environment can lead to compatibility issues, conflicts, and unintended consequences.
-
-  To maintain a clean and stable environment for your distributed Ray program, it is highly recommended to **create a dedicated virtual environment** for Ray and its dependencies. This helps isolate the Ray installation and prevents interference with other packages in your base environment.
+  It is highly recommended to **create a dedicated virtual environment** (as above) for Ray and its dependencies, and avoid calling `ray stop` as that will also cause issue with the cluster.
 

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -165,12 +165,6 @@ To execute a distributed Ray program on many VMs, you can download the `training
         conda activate ray
       fi
       
-      conda activate ray
-      if [ $? -ne 0 ]; then
-        conda create -n ray python=3.10 -y
-        conda activate ray
-      fi
-      
       pip install "ray[train]"
       pip install tqdm
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -165,6 +165,12 @@ To execute a distributed Ray program on many VMs, you can download the `training
         conda activate ray
       fi
       
+      conda activate ray
+      if [ $? -ne 0 ]; then
+        conda create -n ray python=3.10 -y
+        conda activate ray
+      fi
+      
       pip install "ray[train]"
       pip install tqdm
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -159,6 +159,12 @@ To execute a distributed Ray program on many VMs, you can download the `training
     workdir: .
 
     setup: |
+      conda activate ray
+      if [ $? -ne 0 ]; then
+        conda create -n ray python=3.10 -y
+        conda activate ray
+      fi
+      
       pip install "ray[train]"
       pip install tqdm
       pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -155,7 +155,9 @@ To execute a distributed Ray program on many VMs, you can download the `training
       memory: 64+
   
     num_nodes: 2
-  
+
+    workdir: .
+
     setup: |
       pip install "ray[train]"
       pip install tqdm

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -179,7 +179,6 @@ To execute a distributed Ray program on many VMs, you can download the `training
       sudo chmod 777 -R /var/tmp
       head_ip=`echo "$SKYPILOT_NODE_IPS" | head -n1`
       num_nodes=`echo "$SKYPILOT_NODE_IPS" | wc -l`
-      ray start --head  --disable-usage-stats --port 6379
       if [ "$SKYPILOT_NODE_RANK" == "0" ]; then
         ps aux | grep ray | grep 6379 &> /dev/null || ray start --head  --disable-usage-stats --port 6379
         sleep 5


### PR DESCRIPTION
Docs: Added warning in documentation against installing Ray in base environment

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
