### PR TITLE
Updates docs to clarify relative path evaluation for workdir

### DIFF
--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -19,6 +19,9 @@ Available fields:
     #
     # Commands in "setup" and "run" will be executed under it.
     #
+    # If a relative path is used, it's evaluated relative to the location from 
+    # which `sky launch` is called.
+    #
     # If a .gitignore file (or a .git/info/exclude file) exists in the working
     # directory, files and directories listed in it will be excluded from syncing.
     workdir: ~/my-task-code


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A minor update to the docs which clarifies that when a relative path is used as the `workdir`, it's evaluated with respect to the location from which `sky launch` is called, and not the location of the YAML file.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
