### PR TITLE
Adds an env_overrides to  the Task().from_yaml().

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -348,7 +348,8 @@ class Task:
     @staticmethod
     def from_yaml_config(
         config: Dict[str, Any],
-        env_overrides: Optional[List[Tuple[str, str]]] = None,
+        env_overrides: Optional[Union[Dict[str, str], List[Tuple[str,
+                                                                 str]]]] = None,
     ) -> 'Task':
         if env_overrides is not None:
             # We must override env vars before constructing the Task, because
@@ -458,7 +459,11 @@ class Task:
         return task
 
     @staticmethod
-    def from_yaml(yaml_path: str) -> 'Task':
+    def from_yaml(
+        yaml_path: str,
+        env_overrides: Optional[Union[Dict[str, str], List[Tuple[str,
+                                                                 str]]]] = None
+    ) -> 'Task':
         """Initializes a task from a task YAML.
 
         Example:
@@ -468,6 +473,8 @@ class Task:
 
         Args:
           yaml_path: file path to a valid task yaml file.
+          env_overrides: Environment variables to override when creating the
+            task. Equivalent to the `--env` flag when calling `sky launch`.
 
         Raises:
           ValueError: if the path gets loaded into a str instead of a dict; or
@@ -486,7 +493,7 @@ class Task:
 
         if config is None:
             config = {}
-        return Task.from_yaml_config(config)
+        return Task.from_yaml_config(config, env_overrides)
 
     @property
     def num_nodes(self) -> int:


### PR DESCRIPTION


<!-- Describe the changes in this PR -->

* Adds an env_overrides to  the Task().from_yaml().
* Also updates the env_overrides type hint for the `from_yaml` and `from_yaml_config` methods to allow a dictionary.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
