### PR TITLE
[k8s] Fix GPU labelling nomenclature

### DIFF
--- a/sky/utils/kubernetes/k8s_gpu_labeler_setup.yaml
+++ b/sky/utils/kubernetes/k8s_gpu_labeler_setup.yaml
@@ -59,7 +59,7 @@ data:
     
     canonical_gpu_names = [
         'A100-80GB', 'A100', 'A10G', 'H100', 'K80', 'M60', 'T4g', 'T4', 'V100', 
-        'A10', 'P100', 'P40', 'P4', 'L4', 'A6000'
+        'A10', 'P100', 'P40', 'P4', 'L4'
     ]
     
     
@@ -108,9 +108,13 @@ data:
                     labelled = True
                     break
             if not labelled:
-                # If we didn't find a canonical name, just use the GPU name
-                # with spaces replaced by dashes
-                gpu_label = gpu_name.lower().replace(' ', '-')
+                # If we didn't find a canonical name:
+                # 1. remove 'NVIDIA ' if present (e.g., 'NVIDIA RTX A6000' -> 'RTX A6000')
+                # 2. remove 'GeForce ' if present (e.g., 'NVIDIA GeForce RTX 3070' -> 'RTX 3070')
+                # 3. replace 'RTX ' with 'RTX' (without spaces) (e.g., 'RTX 6000' -> 'RTX6000')
+                # 4. replace any other spaces with dashes (e.g. 'RTX 2080 Ti' -> 'RTX2080-Ti')
+                gpu_name = gpu_name.lower().replace('nvidia ', '').replace('geforce ', '').replace('rtx ', 'rtx').replace(' ', '-')
+                gpu_label = gpu_name
                 label_node(gpu_label)
                 labelled = True
         else:


### PR DESCRIPTION
Currently, a `RTX A6000` gets labelled as `A6000`, which is a different card. This further causes confusion when the user tries to run `sky launch --gpus a6000` as prompted by `sky local up` output:

```
...
Local Kubernetes cluster created successfully with 8 CPUs and 1 a6000 GPUs. `sky launch` can now run tasks locally.

$ sky launch --gpus a6000
ValueError: Accelerator name 'a6000' is ambiguous. Please choose one of ['A6000', 'RTXA6000'].
```

with this PR, the naming for RTX series card is aligned with runpod, fluidstack and other clouds' catalogs. 

* RTX A6000 - `RTXA6000`
* Nvidia Geforce RTX 4090 - `RTX4090`
etc.


- [x] Manual tests - `sky local up` (which also invokes labelling) on A6000 and A100 machines from fluidstack.