### PR TITLE
[Docs] Clarify `--purge` in `sky down`, `sky.down`, `sky.stop`

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3330,7 +3330,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                   handle: CloudVmRayResourceHandle,
                   terminate: bool,
                   purge: bool = False):
-        """Tear down/ Stop the cluster.
+        """Tear down or stop the cluster.
 
         Args:
             handle: The handle to the cluster.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2845,13 +2845,18 @@ def start(
               default=False,
               required=False,
               help='Skip confirmation prompt.')
-@click.option('--purge',
-              '-p',
-              is_flag=True,
-              default=False,
-              required=False,
-              help='Ignore cloud provider errors (if any). '
-              'Useful for cleaning up manually deleted cluster(s).')
+@click.option(
+    '--purge',
+    '-p',
+    is_flag=True,
+    default=False,
+    required=False,
+    help=('(Advanced) Forcefully remove the cluster(s) from '
+          'SkyPilot\'s cluster table, even if the actual cluster termination '
+          'failed on the cloud. WARNING: This flag should only be set sparingly'
+          ' in certain manual troubleshooting scenarios; with it set, it is the'
+          ' user\'s responsibility to ensure there are no leaked instances and '
+          'related resources.'))
 @usage_lib.entrypoint
 def down(
     clusters: List[str],

--- a/sky/core.py
+++ b/sky/core.py
@@ -310,7 +310,12 @@ def stop(cluster_name: str, purge: bool = False) -> None:
 
     Args:
         cluster_name: name of the cluster to stop.
-        purge: whether to ignore cloud provider errors (if any).
+        purge: (Advanced) Forcefully mark the cluster as stopped in SkyPilot's
+            cluster table, even if the actual cluster stop operation failed on
+            the cloud. WARNING: This flag should only be set sparingly in
+            certain manual troubleshooting scenarios; with it set, it is the
+            user's responsibility to ensure there are no leaked instances and
+            related resources.
 
     Raises:
         ValueError: the specified cluster does not exist.
@@ -360,7 +365,12 @@ def down(cluster_name: str, purge: bool = False) -> None:
 
     Args:
         cluster_name: name of the cluster to down.
-        purge: whether to ignore cloud provider errors (if any).
+        purge: (Advanced) Forcefully remove the cluster from SkyPilot's cluster
+            table, even if the actual cluster termination failed on the cloud.
+            WARNING: This flag should only be set sparingly in certain manual
+            troubleshooting scenarios; with it set, it is the user's
+            responsibility to ensure there are no leaked instances and related
+            resources.
 
     Raises:
         ValueError: the specified cluster does not exist.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User found the previous docstr confusing

> When calling sky.down, do you recommend setting purse=True? Since these clusters are running on ephemeral cloud machines, I want to make sure that all clusters are killed at the end of the task, no matter what.

Semantics of `--purge` does not mean "no matter what". This PR updates the docstr.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): rendered
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
