### PR TITLE
[GCP] Skip checking for `iam.serviceAccounts.actAs`

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -98,6 +98,10 @@ User
     
     For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/config.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
 
+.. note::
+
+    For users who want extreme minimal permissions, you can also remove ``iam.serviceAccounts.actAs`` from the list above, but you will need to grant the user the ability to use the service account ``skypilot-v1`` created by the admin (see :ref:`Service Account <gcp-service-account-creation>`). That can be done by going to ``IAM & Admin console -> Service Accounts -> skypilot-v1 -> Permissions -> GRANT ACCESS`` and adding the user with the role ``roles/iam.serviceAccountUser``. This only permits the user to use ``skypilot-v1`` service account required by SkyPilot.
+
 4. **Optional**: If the user needs to access GCS buckets, you can additionally add the following permissions:
 
 .. code-block:: text

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -743,12 +743,12 @@ class GCP(clouds.Cloud):
 
         # This takes user's credential info from "~/.config/gcloud/application_default_credentials.json".  # pylint: disable=line-too-long
         credentials, project = google.auth.default()
-        service = googleapiclient.discovery.build('cloudresourcemanager',
+        crm = googleapiclient.discovery.build('cloudresourcemanager',
                                                   'v1',
                                                   credentials=credentials)
         gcp_minimal_permissions = gcp_utils.get_minimal_permissions()
         permissions = {'permissions': gcp_minimal_permissions}
-        request = service.projects().testIamPermissions(resource=project,
+        request = crm.projects().testIamPermissions(resource=project,
                                                         body=permissions)
         ret_permissions = request.execute().get('permissions', [])
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -744,12 +744,12 @@ class GCP(clouds.Cloud):
         # This takes user's credential info from "~/.config/gcloud/application_default_credentials.json".  # pylint: disable=line-too-long
         credentials, project = google.auth.default()
         crm = googleapiclient.discovery.build('cloudresourcemanager',
-                                                  'v1',
-                                                  credentials=credentials)
+                                              'v1',
+                                              credentials=credentials)
         gcp_minimal_permissions = gcp_utils.get_minimal_permissions()
         permissions = {'permissions': gcp_minimal_permissions}
         request = crm.projects().testIamPermissions(resource=project,
-                                                        body=permissions)
+                                                    body=permissions)
         ret_permissions = request.execute().get('permissions', [])
 
         diffs = set(gcp_minimal_permissions).difference(set(ret_permissions))

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -243,7 +243,9 @@ def _is_permission_satisfied(service_account, crm, iam, required_permissions,
         # roles, so only call setIamPolicy if needed.
         return True, policy
 
-    logger.debug(f'_configure_iam_role: policy {json.dumps(original_policy, indent=2)}...')
+    logger.debug('_configure_iam_role: policy '
+                 f'{json.dumps(original_policy, indent=2)}...')
+
     # TODO(zhwu): It is possible that the permission is only granted at the
     # service-account level, not at the project level. We should check the
     # permission at both levels.
@@ -264,10 +266,12 @@ def _is_permission_satisfied(service_account, crm, iam, required_permissions,
                         name=role).execute()
                 except TypeError as e:
                     if 'does not match the pattern' in str(e):
-                        logger.info('_configure_iam_role: fail to check permission '
-                                    f'for built-in role {role}. Fallback to '
-                                    'predefined permission list.')
-                        permissions = constants.DEFAULT_ROLE_TO_PERMISSIONS.get(role, [])
+                        logger.info(
+                            '_configure_iam_role: fail to check permission '
+                            f'for built-in role {role}. Fallback to predefined '
+                            'permission list.')
+                        permissions = constants.DEFAULT_ROLE_TO_PERMISSIONS.get(
+                            role, [])
                     else:
                         raise
                 else:
@@ -278,8 +282,10 @@ def _is_permission_satisfied(service_account, crm, iam, required_permissions,
             if not required_permissions:
                 break
         return required_permissions
-    # Check the permissions 
-    required_permissions = check_permissions(original_policy, required_permissions)
+
+    # Check the permissions
+    required_permissions = check_permissions(original_policy,
+                                             required_permissions)
     if not required_permissions:
         # All required permissions are already granted.
         return True, policy

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -1,6 +1,5 @@
 """GCP configuration bootstrapping."""
 import copy
-import json
 import logging
 import time
 import typing
@@ -243,9 +242,6 @@ def _is_permission_satisfied(service_account, crm, iam, required_permissions,
         # roles, so only call setIamPolicy if needed.
         return True, policy
 
-    logger.debug('_configure_iam_role: policy '
-                 f'{json.dumps(original_policy, indent=2)}...')
-
     # TODO(zhwu): It is possible that the permission is only granted at the
     # service-account level, not at the project level. We should check the
     # permission at both levels.
@@ -270,7 +266,10 @@ def _is_permission_satisfied(service_account, crm, iam, required_permissions,
                             '_configure_iam_role: fail to check permission '
                             f'for built-in role {role}. Fallback to predefined '
                             'permission list.')
-                        permissions = constants.DEFAULT_ROLE_TO_PERMISSIONS.get(
+                        # Built-in roles cannot be checked for permissions with
+                        # the current API, so we fallback to predefined list
+                        # to find the implied permissions.
+                        permissions = constants.BUILTIN_ROLE_TO_PERMISSIONS.get(
                             role, [])
                     else:
                         raise

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -165,7 +165,10 @@ VM_MINIMAL_PERMISSIONS = [
     'compute.projects.get',
     'compute.zoneOperations.get',
     'iam.roles.get',
-    'iam.serviceAccounts.actAs',
+    # We now skip the check for `iam.serviceAccounts.actAs` permission for
+    # simplicity as it can be granted at the service-account level.
+    # Check: sky.provision.gcp.config::_is_permission_satisfied
+    # 'iam.serviceAccounts.actAs',
     'iam.serviceAccounts.get',
     'serviceusage.services.enable',
     'serviceusage.services.list',
@@ -177,6 +180,7 @@ VM_MINIMAL_PERMISSIONS = [
 DEFAULT_ROLE_TO_PERMISSIONS = {
     'roles/iam.serviceAccountUser': ['iam.serviceAccounts.actAs'],
     'roles/iam.serviceAccountViewer': ['iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'],
+    # TODO(zhwu): Add more default roles to make the permission check more robust.
 }
 
 FIREWALL_PERMISSIONS = [

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -174,6 +174,11 @@ VM_MINIMAL_PERMISSIONS = [
     'resourcemanager.projects.getIamPolicy',
 ]
 
+DEFAULT_ROLE_TO_PERMISSIONS = {
+    'roles/iam.serviceAccountUser': ['iam.serviceAccounts.actAs'],
+    'roles/iam.serviceAccountViewer': ['iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'],
+}
+
 FIREWALL_PERMISSIONS = [
     'compute.firewalls.create',
     'compute.firewalls.delete',

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -187,7 +187,8 @@ BUILTIN_ROLE_TO_PERMISSIONS = {
     'roles/iam.serviceAccountViewer': [
         'iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'
     ],
-    # TODO(zhwu): Add more default roles to make the permission check more robust.
+    # TODO(zhwu): Add more built-in roles to make the permission check more
+    # robust.
 }
 
 FIREWALL_PERMISSIONS = [

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -179,7 +179,9 @@ VM_MINIMAL_PERMISSIONS = [
 
 DEFAULT_ROLE_TO_PERMISSIONS = {
     'roles/iam.serviceAccountUser': ['iam.serviceAccounts.actAs'],
-    'roles/iam.serviceAccountViewer': ['iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'],
+    'roles/iam.serviceAccountViewer': [
+        'iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'
+    ],
     # TODO(zhwu): Add more default roles to make the permission check more robust.
 }
 

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -177,7 +177,12 @@ VM_MINIMAL_PERMISSIONS = [
     'resourcemanager.projects.getIamPolicy',
 ]
 
-DEFAULT_ROLE_TO_PERMISSIONS = {
+# Permissions implied by GCP built-in roles. We hardcode these here, as we
+# cannot get the permissions of built-in role from the GCP Python API.
+# The lists are not exhaustive, but should cover the permissions listed in
+# VM_MINIMAL_PERMISSIONS.
+# Check: sky.provision.gcp.config::_is_permission_satisfied
+BUILTIN_ROLE_TO_PERMISSIONS = {
     'roles/iam.serviceAccountUser': ['iam.serviceAccounts.actAs'],
     'roles/iam.serviceAccountViewer': [
         'iam.serviceAccounts.get', 'iam.serviceAccounts.getIamPolicy'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now skip the check for `iam.serviceAccounts.actAs` to make sure a user with more fine grained permission setup (only allowing the user to use `skypilot-v1` permission) could work.

This is requested by an organization user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-no-actas --cloud gcp --cpus 2 echo hi` with a user accourt and a service account without `actAs` permission (assigned the permission in permission tab)
  - [x] Rendered locally
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
