### PR TITLE
[Serve/Spot] Allow spot queue/cancel/logs during controller INIT state

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,7 @@ jobs:
           - tests/test_optimizer_random_dag.py
           - tests/test_storage.py
           - tests/test_wheels.py
-          - tests/test_spot.py
+          - tests/test_spot_serve.py
           - tests/test_yaml_parser.py
     runs-on: ubuntu-latest
     steps:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2282,7 +2282,7 @@ def is_controller_accessible(
         # callers will get the requested information from the controller by ssh
         # with best effort.
         controller_status, handle = refresh_cluster_status_handle(
-            cluster_name, force_refresh_statuses=None, acquire_lock_timeout=0)
+            cluster_name, force_refresh_statuses=None, acquire_per_cluster_status_lock_timeout=0)
     except exceptions.ClusterStatusFetchingError as e:
         # We do not catch the exceptions related to the cluster owner identity
         # mismatch, please refer to the comment in

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2290,8 +2290,6 @@ def is_controller_up(
                f'is {controller_status.value}.')
         if controller_status == status_lib.ClusterStatus.STOPPED:
             msg += f'\n{stopped_message}'
-        if controller_status == status_lib.ClusterStatus.INIT:
-            msg += '\nPlease wait for the controller to be ready.'
         sky_logging.print(msg)
     return controller_status, handle
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2282,7 +2282,9 @@ def is_controller_accessible(
         # callers will get the requested information from the controller by ssh
         # with best effort.
         controller_status, handle = refresh_cluster_status_handle(
-            cluster_name, force_refresh_statuses=None, acquire_per_cluster_status_lock_timeout=0)
+            cluster_name,
+            force_refresh_statuses=None,
+            acquire_per_cluster_status_lock_timeout=0)
     except exceptions.ClusterStatusFetchingError as e:
         # We do not catch the exceptions related to the cluster owner identity
         # mismatch, please refer to the comment in

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2004,7 +2004,7 @@ def refresh_cluster_record(
     *,
     force_refresh_statuses: Optional[Set[status_lib.ClusterStatus]] = None,
     acquire_per_cluster_status_lock: bool = True,
-    acquire_lock_timeout: int = CLUSTER_FILE_MOUNTS_LOCK_TIMEOUT_SECONDS
+    acquire_lock_timeout: int = CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS
 ) -> Optional[Dict[str, Any]]:
     """Refresh the cluster, and return the possibly updated record.
 
@@ -2264,9 +2264,10 @@ def is_controller_up(
         # unnecessary costly refresh when the controller is already stopped.
         # This optimization is based on the assumption that the user will not
         # start the controller manually from the cloud console.
-        # The acquire_lock_timeout is set to 1 second to avoid hanging the
-        # command when multiple spot_launch commands are running at the same
-        # time. It should be safe to set it to 0 (try once to get the lock).
+        #
+        # The acquire_lock_timeout is set to 0 to avoid hanging the command when
+        # multiple spot_launch commands are running at the same time. It should
+        # be safe to set it to 0 (try once to get the lock).
         controller_status, handle = refresh_cluster_status_handle(
             cluster_name, force_refresh_statuses=None, acquire_lock_timeout=0)
     except exceptions.ClusterStatusFetchingError as e:
@@ -2287,6 +2288,7 @@ def is_controller_up(
         sky_logging.print(non_existent_message)
     elif controller_status == status_lib.ClusterStatus.STOPPED:
         sky_logging.print(stopped_message)
+        handle = None
     return controller_status, handle
 
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1737,6 +1737,7 @@ def _update_cluster_status_no_lock(
     all_nodes_up = (all(
         status == status_lib.ClusterStatus.UP for status in node_statuses) and
                     len(node_statuses) == handle.launched_nodes)
+
     def run_ray_status_to_check_ray_cluster_healthy() -> bool:
         try:
             # TODO(zhwu): This function cannot distinguish transient network
@@ -1951,9 +1952,10 @@ def _update_cluster_status_no_lock(
 
 
 def _update_cluster_status(
-        cluster_name: str,
-        acquire_per_cluster_status_lock: bool,
-        acquire_lock_timeout: int = CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS) -> Optional[Dict[str, Any]]:
+    cluster_name: str,
+    acquire_per_cluster_status_lock: bool,
+    acquire_lock_timeout: int = CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS
+) -> Optional[Dict[str, Any]]:
     """Update the cluster status.
 
     The cluster status is updated by checking ray cluster and real status from
@@ -1998,11 +2000,11 @@ def _update_cluster_status(
 
 
 def refresh_cluster_record(
-        cluster_name: str,
-        *,
-        force_refresh_statuses: Optional[Set[status_lib.ClusterStatus]] = None,
-        acquire_per_cluster_status_lock: bool = True,
-        acquire_lock_timeout: Optional[int] = None
+    cluster_name: str,
+    *,
+    force_refresh_statuses: Optional[Set[status_lib.ClusterStatus]] = None,
+    acquire_per_cluster_status_lock: bool = True,
+    acquire_lock_timeout: int = CLUSTER_FILE_MOUNTS_LOCK_TIMEOUT_SECONDS
 ) -> Optional[Dict[str, Any]]:
     """Refresh the cluster, and return the possibly updated record.
 
@@ -2264,10 +2266,9 @@ def is_controller_up(
         # start the controller manually from the cloud console.
         # The acquire_lock_timeout is set to 1 second to avoid hanging the
         # command when multiple spot_launch commands are running at the same
-        # time. It should be safe to set it to a small value as the controller
-        # will not be autostopped in that cases.
+        # time. It should be safe to set it to 0 (try once to get the lock).
         controller_status, handle = refresh_cluster_status_handle(
-            cluster_name, force_refresh_statuses=None, acquire_lock_timeout=1)
+            cluster_name, force_refresh_statuses=None, acquire_lock_timeout=0)
     except exceptions.ClusterStatusFetchingError as e:
         # We do not catch the exceptions related to the cluster owner identity
         # mismatch, please refer to the comment in

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2068,7 +2068,8 @@ def refresh_cluster_status_handle(
     *,
     force_refresh_statuses: Optional[Set[status_lib.ClusterStatus]] = None,
     acquire_per_cluster_status_lock: bool = True,
-    acquire_lock_timeout: int = CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS
+    acquire_per_cluster_status_lock_timeout:
+    int = CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS
 ) -> Tuple[Optional[status_lib.ClusterStatus],
            Optional[backends.ResourceHandle]]:
     """Refresh the cluster, and return the possibly updated status and handle.
@@ -2081,7 +2082,8 @@ def refresh_cluster_status_handle(
         cluster_name,
         force_refresh_statuses=force_refresh_statuses,
         acquire_per_cluster_status_lock=acquire_per_cluster_status_lock,
-        acquire_per_cluster_status_lock_timeout=acquire_lock_timeout)
+        acquire_per_cluster_status_lock_timeout=
+        acquire_per_cluster_status_lock_timeout)
     if record is None:
         return None, None
     return record['status'], record['handle']

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2285,12 +2285,8 @@ def is_controller_up(
 
     if controller_status is None:
         sky_logging.print(non_existent_message)
-    elif controller_status != status_lib.ClusterStatus.UP:
-        msg = (f'{controller_name.capitalize()} controller {cluster_name} '
-               f'is {controller_status.value}.')
-        if controller_status == status_lib.ClusterStatus.STOPPED:
-            msg += f'\n{stopped_message}'
-        sky_logging.print(msg)
+    elif controller_status == status_lib.ClusterStatus.STOPPED:
+        sky_logging.print(stopped_message)
     return controller_status, handle
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1700,7 +1700,7 @@ def _get_services(service_names: Optional[List[str]],
         controller_status = e.cluster_status
         msg = str(e)
         if controller_status is None:
-            msg += (f'(See: {colorama.Style.BRIGHT}sky serve -h'
+            msg += (f' (See: {colorama.Style.BRIGHT}sky serve -h'
                     f'{colorama.Style.RESET_ALL})')
     except RuntimeError as e:
         msg = ('Failed to fetch service statuses due to connection issues. '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4081,10 +4081,10 @@ def spot_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool):
       # Cancel managed spot jobs with IDs 1, 2, 3
       $ sky spot cancel 1 2 3
     """
-    _, handle = backend_utils.is_controller_up(
+    controller_status, _ = backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
         stopped_message='All managed spot jobs should have finished.')
-    if handle is None:
+    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         # Hint messages already printed by the call above.
         sys.exit(1)
 
@@ -4166,11 +4166,11 @@ def spot_dashboard(port: Optional[int]):
     hint = (
         'Dashboard is not available if spot controller is not up. Run a spot '
         'job first.')
-    _, handle = backend_utils.is_controller_up(
+    controller_status, _ = backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
         stopped_message=hint,
         non_existent_message=hint)
-    if handle is None:
+    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         sys.exit(1)
     # SSH forward a free local port to remote's dashboard port.
     remote_port = constants.SPOT_DASHBOARD_REMOTE_PORT
@@ -4674,10 +4674,10 @@ def serve_down(service_names: List[str], all: bool, purge: bool, yes: bool):
             'Can only specify one of SERVICE_NAMES or --all. '
             f'Provided {argument_str!r}.')
 
-    _, handle = backend_utils.is_controller_up(
+    controller_status, _ = backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message='All services should have been terminated.')
-    if handle is None:
+    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         # Hint messages already printed by the call above.
         sys.exit(1)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4084,6 +4084,9 @@ def spot_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool):
     controller_status, _ = backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
         stopped_message='All managed spot jobs should have finished.')
+    # Allow the access to the spot controller even if it is INIT, as the
+    # controller can be temporarily in INIT mode when submitting multiple spot
+    # jobs.
     if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         # Hint messages already printed by the call above.
         sys.exit(1)
@@ -4170,6 +4173,9 @@ def spot_dashboard(port: Optional[int]):
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
         stopped_message=hint,
         non_existent_message=hint)
+    # Allow the access to the spot controller even if it is INIT, as the
+    # controller can be temporarily in INIT mode when submitting multiple spot
+    # jobs.
     if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         sys.exit(1)
     # SSH forward a free local port to remote's dashboard port.
@@ -4677,6 +4683,9 @@ def serve_down(service_names: List[str], all: bool, purge: bool, yes: bool):
     controller_status, _ = backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message='All services should have been terminated.')
+    # Allow the access to the spot controller even if it is INIT, as the
+    # controller can be temporarily in INIT mode when submitting multiple spot
+    # jobs.
     if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
         # Hint messages already printed by the call above.
         sys.exit(1)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4081,15 +4081,10 @@ def spot_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool):
       # Cancel managed spot jobs with IDs 1, 2, 3
       $ sky spot cancel 1 2 3
     """
-    controller_status, _ = backend_utils.is_controller_up(
+    backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
-        stopped_message='All managed spot jobs should have finished.')
-    # Allow the access to the spot controller even if it is INIT, as the
-    # controller can be temporarily in INIT mode when submitting multiple spot
-    # jobs.
-    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
-        # Hint messages already printed by the call above.
-        sys.exit(1)
+        stopped_message='All managed spot jobs should have finished.',
+        exit_on_error=True)
 
     job_id_str = ','.join(map(str, job_ids))
     if sum([len(job_ids) > 0, name is not None, all]) != 1:
@@ -4169,15 +4164,12 @@ def spot_dashboard(port: Optional[int]):
     hint = (
         'Dashboard is not available if spot controller is not up. Run a spot '
         'job first.')
-    controller_status, _ = backend_utils.is_controller_up(
+    backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
         stopped_message=hint,
-        non_existent_message=hint)
-    # Allow the access to the spot controller even if it is INIT, as the
-    # controller can be temporarily in INIT mode when submitting multiple spot
-    # jobs.
-    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
-        sys.exit(1)
+        non_existent_message=hint,
+        exit_on_error=True)
+
     # SSH forward a free local port to remote's dashboard port.
     remote_port = constants.SPOT_DASHBOARD_REMOTE_PORT
     if port is None:
@@ -4680,15 +4672,10 @@ def serve_down(service_names: List[str], all: bool, purge: bool, yes: bool):
             'Can only specify one of SERVICE_NAMES or --all. '
             f'Provided {argument_str!r}.')
 
-    controller_status, _ = backend_utils.is_controller_up(
+    backend_utils.is_controller_up(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-        stopped_message='All services should have been terminated.')
-    # Allow the access to the spot controller even if it is INIT, as the
-    # controller can be temporarily in INIT mode when submitting multiple spot
-    # jobs.
-    if controller_status in [status_lib.ClusterStatus.STOPPED, None]:
-        # Hint messages already printed by the call above.
-        sys.exit(1)
+        stopped_message='All services should have been terminated.',
+        exit_on_error=True)
 
     if not yes:
         quoted_service_names = [f'{name!r}' for name in service_names]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1652,6 +1652,10 @@ def _get_spot_jobs(
         if controller_status is None:
             msg += (f' (See: {colorama.Style.BRIGHT}sky spot -h'
                     f'{colorama.Style.RESET_ALL})')
+        elif (controller_status == status_lib.ClusterStatus.STOPPED and
+              is_called_by_user):
+            msg += (f' (See finished jobs: {colorama.Style.BRIGHT}'
+                    f'sky spot queue --refresh{colorama.Style.RESET_ALL})')
     except RuntimeError as e:
         msg = ('Failed to query spot jobs due to connection '
                'issues. Try again later. '

--- a/sky/core.py
+++ b/sky/core.py
@@ -796,14 +796,15 @@ def spot_queue(refresh: bool,
             does not exist.
         RuntimeError: if failed to get the spot jobs with ssh.
     """
-    stop_msg = ''
+    stopped_message = ''
     if not refresh:
-        stop_msg = ('No in-progress spot jobs.\nTo view the latest job table: '
-                    'sky spot queue --refresh')
+        stopped_message = (
+            'No in-progress spot jobs.\nTo view the latest job table: '
+            'sky spot queue --refresh')
     try:
         handle = backend_utils.is_controller_accessible(
             controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
-            stopped_message=stop_msg)
+            stopped_message=stopped_message)
     except exceptions.ClusterNotUpError as e:
         if not refresh:
             raise

--- a/sky/core.py
+++ b/sky/core.py
@@ -841,10 +841,10 @@ def spot_queue(refresh: bool,
         subprocess_utils.handle_returncode(returncode,
                                            code,
                                            'Failed to fetch managed spot jobs',
-                                           stderr,
+                                           job_table_payload + stderr,
                                            stream_logs=False)
     except exceptions.CommandError as e:
-        raise RuntimeError(e.error_msg) from e
+        raise RuntimeError(str(e)) from e
 
     jobs = spot.load_spot_job_queue(job_table_payload)
     if skip_finished:

--- a/sky/core.py
+++ b/sky/core.py
@@ -796,10 +796,10 @@ def spot_queue(refresh: bool,
             does not exist.
         RuntimeError: if failed to get the spot jobs with ssh.
     """
-
     stop_msg = ''
     if not refresh:
-        stop_msg = 'To view the latest job table: sky spot queue --refresh'
+        stop_msg = ('No in-progress spot jobs.\nTo view the latest job table: '
+                    'sky spot queue --refresh')
     try:
         handle = backend_utils.is_controller_accessible(
             controller_type=controller_utils.Controllers.SPOT_CONTROLLER,
@@ -833,6 +833,7 @@ def spot_queue(refresh: bool,
         require_outputs=True,
         stream_logs=False,
         separate_stderr=True)
+
     try:
         subprocess_utils.handle_returncode(returncode,
                                            code,

--- a/sky/core.py
+++ b/sky/core.py
@@ -798,9 +798,7 @@ def spot_queue(refresh: bool,
     """
     stopped_message = ''
     if not refresh:
-        stopped_message = (
-            'No in-progress spot jobs.\nTo view the latest job table: '
-            'sky spot queue --refresh')
+        stopped_message = ('No in-progress spot jobs.')
     try:
         handle = backend_utils.is_controller_accessible(
             controller_type=controller_utils.Controllers.SPOT_CONTROLLER,

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -305,7 +305,7 @@ def update(task: 'sky.Task', service_name: str) -> None:
         service_name: Name of the service.
     """
     _validate_service_task(task)
-    handle = backend_utils.is_controller_up(
+    handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message=
         'Service controller is stopped. There is no service to update. '
@@ -448,7 +448,7 @@ def down(
         service_names = []
     if isinstance(service_names, str):
         service_names = [service_names]
-    handle = backend_utils.is_controller_up(
+    handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message='All services should have terminated.')
 
@@ -553,7 +553,7 @@ def status(
             raise RuntimeError(
                 'Failed to refresh service status due to network error.') from e
 
-    handle = backend_utils.is_controller_up(
+    handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message='No service is found.')
 
@@ -637,7 +637,7 @@ def tail_logs(
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('`replica_id` must be None when using '
                                  'target=CONTROLLER/LOAD_BALANCER.')
-    handle = backend_utils.is_controller_up(
+    handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message='No service is found.')
 

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -640,7 +640,8 @@ def tail_logs(
                                  'target=CONTROLLER/LOAD_BALANCER.')
     handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-   stopped_message=controller_utils.Controllers.SKY_SERVE_CONTROLLER.default_hint_if_non_existent)
+        stopped_message=(controller_utils.Controllers.SKY_SERVE_CONTROLLER.
+                         value.default_hint_if_non_existent))
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend), backend

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -553,9 +553,10 @@ def status(
             raise RuntimeError(
                 'Failed to refresh service status due to network error.') from e
 
+    controller_type = controller_utils.Controllers.SKY_SERVE_CONTROLLER
     handle = backend_utils.is_controller_accessible(
-        controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-        stopped_message='No in-progress services.')
+        controller_type=controller_type,
+        stopped_message=controller_type.value.default_hint_if_non_existent)
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
@@ -639,7 +640,7 @@ def tail_logs(
                                  'target=CONTROLLER/LOAD_BALANCER.')
     handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-        stopped_message='No in-progress services.')
+        stopped_message='No live services.')
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend), backend

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -555,7 +555,7 @@ def status(
 
     handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-        stopped_message='No service is found.')
+        stopped_message='No in-progress services.')
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
@@ -639,7 +639,7 @@ def tail_logs(
                                  'target=CONTROLLER/LOAD_BALANCER.')
     handle = backend_utils.is_controller_accessible(
         controller_type=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
-        stopped_message='No service is found.')
+        stopped_message='No in-progress services.')
 
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend), backend

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -111,12 +111,13 @@ def silent():
     _root_logger.setLevel(logging.ERROR)
     _logging_config.is_silent = True
     print = lambda *args, **kwargs: None
-    yield
-
-    # Restore logger
-    print = previous_print
-    _root_logger.setLevel(previous_level)
-    _logging_config.is_silent = previous_is_silent
+    try:
+        yield
+    finally:
+        # Restore logger
+        print = previous_print
+        _root_logger.setLevel(previous_level)
+        _logging_config.is_silent = previous_is_silent
 
 
 def is_silent():

--- a/sky/spot/spot_utils.py
+++ b/sky/spot/spot_utils.py
@@ -657,7 +657,7 @@ def format_job_table(
     if status_str:
         status_str = f'In progress tasks: {status_str}'
     else:
-        status_str = 'No in progress tasks.'
+        status_str = 'No in-progress spot jobs.'
     output = status_str
     if str(job_table):
         output += f'\n{job_table}'

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -47,7 +47,7 @@ def ssh_options_list(
     *,
     ssh_proxy_command: Optional[str] = None,
     docker_ssh_proxy_command: Optional[str] = None,
-    connect_timeout: Optional[int] = 30,
+    connect_timeout: Optional[int] = None,
     port: int = 22,
     disable_control_master: Optional[bool] = False,
 ) -> List[str]:

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -459,7 +459,7 @@ class SSHCommandRunner:
 
     def check_connection(self) -> bool:
         """Check if the connection to the remote machine is successful."""
-        returncode = self.run('true', connect_timeout=5)
+        returncode = self.run('true', connect_timeout=5, stream_logs=False)
         if returncode:
             return False
         return True

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -123,3 +123,6 @@ class SSHCommandRunner:
               log_path: str = ...,
               stream_logs: bool = ...) -> None:
         ...
+
+    def check_connection(self) -> bool:
+        ...

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -48,10 +48,11 @@ LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER = 'skypilot:local_skypilot_config_path'
 class _ControllerSpec:
     """Spec for skypilot controllers."""
     name: str
+    managing_name: str
     cluster_name: str
     in_progress_hint: str
     decline_cancel_hint: str
-    decline_down_in_init_status_hint: str
+    decline_down_in_when_failed_to_fetch_hint: str
     decline_down_for_dirty_controller_hint: str
     check_cluster_name_hint: str
     default_hint_if_non_existent: str
@@ -64,6 +65,7 @@ class Controllers(enum.Enum):
     # sky/cli.py::_CONTROLLER_TO_HINT_OR_RAISE
     SPOT_CONTROLLER = _ControllerSpec(
         name='managed spot controller',
+        managing_name='spot jobs',
         cluster_name=spot_utils.SPOT_CONTROLLER_NAME,
         in_progress_hint=(
             '* {job_info}To see all spot jobs: '
@@ -72,7 +74,7 @@ class Controllers(enum.Enum):
             'Cancelling the spot controller\'s jobs is not allowed.\nTo cancel '
             f'spot jobs, use: {colorama.Style.BRIGHT}sky spot cancel <spot '
             f'job IDs> [--all]{colorama.Style.RESET_ALL}'),
-        decline_down_in_init_status_hint=(
+        decline_down_in_when_failed_to_fetch_hint=(
             f'{colorama.Fore.RED}Tearing down the spot controller while '
             'it is in INIT state is not supported (this means a spot launch '
             'is in progress or the previous launch failed), as we cannot '
@@ -86,19 +88,20 @@ class Controllers(enum.Enum):
             f'sky spot cancel -a{colorama.Style.RESET_ALL}\n'),
         check_cluster_name_hint=(
             f'Cluster {spot_utils.SPOT_CONTROLLER_NAME} is reserved for '
-            'managed spot controller. '),
-        default_hint_if_non_existent='No managed spot jobs are found.',
+            'managed spot controller.'),
+        default_hint_if_non_existent='No in-progress spot jobs.',
         hint_for_connection_error=(
-            'Failed to connect to spot controller, please try again later'))
+            'Failed to connect to spot controller, please try again later.'))
     SKY_SERVE_CONTROLLER = _ControllerSpec(
-        name='sky serve controller',
+        name='serve controller',
+        managing_name='services',
         cluster_name=serve_utils.SKY_SERVE_CONTROLLER_NAME,
         in_progress_hint=(
             f'* To see detailed service status: {colorama.Style.BRIGHT}'
             f'sky serve status -a{colorama.Style.RESET_ALL}'),
         decline_cancel_hint=(
             'Cancelling the sky serve controller\'s jobs is not allowed.'),
-        decline_down_in_init_status_hint=(
+        decline_down_in_when_failed_to_fetch_hint=(
             f'{colorama.Fore.RED}Tearing down the sky serve controller '
             'while it is in INIT state is not supported (this means a sky '
             'serve up is in progress or the previous launch failed), as we '
@@ -115,10 +118,10 @@ class Controllers(enum.Enum):
             f'{colorama.Style.RESET_ALL}.'),
         check_cluster_name_hint=(
             f'Cluster {serve_utils.SKY_SERVE_CONTROLLER_NAME} is reserved for '
-            'sky serve controller. '),
-        default_hint_if_non_existent='No service is found.',
+            'sky serve controller.'),
+        default_hint_if_non_existent='No in-progress services.',
         hint_for_connection_error=(
-            'Failed to connect to spot controller, please try again later'))
+            'Failed to connect to serve controller, please try again later.'))
 
     @classmethod
     def from_name(cls, name: Optional[str]) -> Optional['Controllers']:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -48,15 +48,14 @@ LOCAL_SKYPILOT_CONFIG_PATH_PLACEHOLDER = 'skypilot:local_skypilot_config_path'
 class _ControllerSpec:
     """Spec for skypilot controllers."""
     name: str
-    managing_name: str
     cluster_name: str
     in_progress_hint: str
     decline_cancel_hint: str
-    decline_down_in_when_failed_to_fetch_hint: str
+    decline_down_when_failed_to_fetch_status_hint: str
     decline_down_for_dirty_controller_hint: str
     check_cluster_name_hint: str
     default_hint_if_non_existent: str
-    hint_for_connection_error: str
+    connection_error_hint: str
 
 
 class Controllers(enum.Enum):
@@ -65,7 +64,6 @@ class Controllers(enum.Enum):
     # sky/cli.py::_CONTROLLER_TO_HINT_OR_RAISE
     SPOT_CONTROLLER = _ControllerSpec(
         name='managed spot controller',
-        managing_name='spot jobs',
         cluster_name=spot_utils.SPOT_CONTROLLER_NAME,
         in_progress_hint=(
             '* {job_info}To see all spot jobs: '
@@ -74,7 +72,7 @@ class Controllers(enum.Enum):
             'Cancelling the spot controller\'s jobs is not allowed.\nTo cancel '
             f'spot jobs, use: {colorama.Style.BRIGHT}sky spot cancel <spot '
             f'job IDs> [--all]{colorama.Style.RESET_ALL}'),
-        decline_down_in_when_failed_to_fetch_hint=(
+        decline_down_when_failed_to_fetch_status_hint=(
             f'{colorama.Fore.RED}Tearing down the spot controller while '
             'it is in INIT state is not supported (this means a spot launch '
             'is in progress or the previous launch failed), as we cannot '
@@ -90,18 +88,17 @@ class Controllers(enum.Enum):
             f'Cluster {spot_utils.SPOT_CONTROLLER_NAME} is reserved for '
             'managed spot controller.'),
         default_hint_if_non_existent='No in-progress spot jobs.',
-        hint_for_connection_error=(
+        connection_error_hint=(
             'Failed to connect to spot controller, please try again later.'))
     SKY_SERVE_CONTROLLER = _ControllerSpec(
         name='serve controller',
-        managing_name='services',
         cluster_name=serve_utils.SKY_SERVE_CONTROLLER_NAME,
         in_progress_hint=(
             f'* To see detailed service status: {colorama.Style.BRIGHT}'
             f'sky serve status -a{colorama.Style.RESET_ALL}'),
         decline_cancel_hint=(
             'Cancelling the sky serve controller\'s jobs is not allowed.'),
-        decline_down_in_when_failed_to_fetch_hint=(
+        decline_down_when_failed_to_fetch_status_hint=(
             f'{colorama.Fore.RED}Tearing down the sky serve controller '
             'while it is in INIT state is not supported (this means a sky '
             'serve up is in progress or the previous launch failed), as we '
@@ -119,8 +116,8 @@ class Controllers(enum.Enum):
         check_cluster_name_hint=(
             f'Cluster {serve_utils.SKY_SERVE_CONTROLLER_NAME} is reserved for '
             'sky serve controller.'),
-        default_hint_if_non_existent='No in-progress services.',
-        hint_for_connection_error=(
+        default_hint_if_non_existent='No live services.',
+        connection_error_hint=(
             'Failed to connect to serve controller, please try again later.'))
 
     @classmethod

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -55,6 +55,7 @@ class _ControllerSpec:
     decline_down_for_dirty_controller_hint: str
     check_cluster_name_hint: str
     default_hint_if_non_existent: str
+    hint_for_connection_error: str
 
 
 class Controllers(enum.Enum):
@@ -86,7 +87,9 @@ class Controllers(enum.Enum):
         check_cluster_name_hint=(
             f'Cluster {spot_utils.SPOT_CONTROLLER_NAME} is reserved for '
             'managed spot controller. '),
-        default_hint_if_non_existent='No managed spot jobs are found.')
+        default_hint_if_non_existent='No managed spot jobs are found.',
+        hint_for_connection_error=(
+            'Failed to connect to spot controller, please try again later'))
     SKY_SERVE_CONTROLLER = _ControllerSpec(
         name='sky serve controller',
         cluster_name=serve_utils.SKY_SERVE_CONTROLLER_NAME,
@@ -113,7 +116,9 @@ class Controllers(enum.Enum):
         check_cluster_name_hint=(
             f'Cluster {serve_utils.SKY_SERVE_CONTROLLER_NAME} is reserved for '
             'sky serve controller. '),
-        default_hint_if_non_existent='No service is found.')
+        default_hint_if_non_existent='No service is found.',
+        hint_for_connection_error=(
+            'Failed to connect to spot controller, please try again later'))
 
     @classmethod
     def from_name(cls, name: Optional[str]) -> Optional['Controllers']:

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -122,7 +122,7 @@ class TestControllerOperations:
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME],
                                    input='n')
-        assert 'WARNING: Tearing down the managed spot controller (UP).' in result.output
+        assert 'WARNING: Tearing down the managed spot controller.' in result.output
         assert isinstance(result.exception,
                           SystemExit), (result.exception, result.output)
 

--- a/tests/test_spot.py
+++ b/tests/test_spot.py
@@ -1,5 +1,7 @@
 import tempfile
 import textwrap
+import time
+from typing import Optional, Tuple
 
 import click
 from click import testing as cli_testing
@@ -8,8 +10,12 @@ import pytest
 import sky
 from sky import backends
 from sky import cli
+from sky import exceptions
 from sky import global_user_state
 from sky import spot
+from sky.spot import spot_state
+from sky.utils import common_utils
+from sky.utils import controller_utils
 from sky.utils import db_utils
 
 
@@ -29,102 +35,148 @@ def test_spot_nonexist_strategy():
             sky.Task.from_yaml(f.name)
 
 
+@pytest.fixture
+def _mock_db_conn(monkeypatch, tmp_path):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    db_path = tmp_path / 'state_testing.db'
+    monkeypatch.setattr(
+        global_user_state, '_DB',
+        db_utils.SQLiteConn(str(db_path), global_user_state.create_table))
+
+
+@pytest.fixture
+def _mock_cluster_state(_mock_db_conn):
+    assert 'state.db' not in global_user_state._DB.db_path
+    handle = backends.CloudVmRayResourceHandle(
+        cluster_name='test-cluster1',
+        cluster_name_on_cloud='test-cluster1',
+        cluster_yaml='/tmp/cluster1.yaml',
+        launched_nodes=2,
+        launched_resources=sky.Resources(sky.AWS(),
+                                         instance_type='p3.2xlarge',
+                                         region='us-east-1'),
+    )
+    global_user_state.add_or_update_cluster(
+        'test-cluster1',
+        handle,
+        requested_resources={handle.launched_resources},
+        ready=True)
+    handle = backends.CloudVmRayResourceHandle(
+        cluster_name='test-cluster2',
+        cluster_name_on_cloud='test-cluster2',
+        cluster_yaml='/tmp/cluster2.yaml',
+        launched_nodes=1,
+        launched_resources=sky.Resources(sky.GCP(),
+                                         instance_type='a2-highgpu-4g',
+                                         accelerators={'A100': 4},
+                                         region='us-west1'),
+    )
+    global_user_state.add_or_update_cluster(
+        'test-cluster2',
+        handle,
+        requested_resources={handle.launched_resources},
+        ready=True)
+    handle = backends.CloudVmRayResourceHandle(
+        cluster_name='test-cluster3',
+        cluster_name_on_cloud='test-cluster3',
+        cluster_yaml='/tmp/cluster3.yaml',
+        launched_nodes=4,
+        launched_resources=sky.Resources(sky.Azure(),
+                                         instance_type='Standard_D4s_v3',
+                                         region='eastus'),
+    )
+    global_user_state.add_or_update_cluster(
+        'test-cluster3',
+        handle,
+        requested_resources={handle.launched_resources},
+        ready=False)
+
+
+@pytest.fixture
+def _mock_spot_controller(_mock_db_conn):
+    handle = backends.CloudVmRayResourceHandle(
+        cluster_name=spot.SPOT_CONTROLLER_NAME,
+        cluster_name_on_cloud=spot.SPOT_CONTROLLER_NAME,
+        cluster_yaml='/tmp/spot_controller.yaml',
+        launched_nodes=1,
+        launched_resources=sky.Resources(sky.AWS(),
+                                         instance_type='m4.2xlarge',
+                                         region='us-west-1'),
+    )
+    global_user_state.add_or_update_cluster(
+        spot.SPOT_CONTROLLER_NAME,
+        handle,
+        requested_resources={handle.launched_resources},
+        ready=True)
+
+
 class TestControllerOperations:
     """Test operations on controllers."""
 
-    @pytest.fixture
-    def _mock_db_conn(self, monkeypatch, tmp_path):
-        tmp_path.mkdir(parents=True, exist_ok=True)
-        db_path = tmp_path / 'state_testing.db'
-        monkeypatch.setattr(
-            global_user_state, '_DB',
-            db_utils.SQLiteConn(str(db_path), global_user_state.create_table))
-
-    @pytest.fixture
-    def _mock_cluster_state(self, _mock_db_conn):
-        assert 'state.db' not in global_user_state._DB.db_path
-        handle = backends.CloudVmRayResourceHandle(
-            cluster_name='test-cluster1',
-            cluster_name_on_cloud='test-cluster1',
-            cluster_yaml='/tmp/cluster1.yaml',
-            launched_nodes=2,
-            launched_resources=sky.Resources(sky.AWS(),
-                                             instance_type='p3.2xlarge',
-                                             region='us-east-1'),
-        )
-        global_user_state.add_or_update_cluster(
-            'test-cluster1',
-            handle,
-            requested_resources={handle.launched_resources},
-            ready=True)
-        handle = backends.CloudVmRayResourceHandle(
-            cluster_name='test-cluster2',
-            cluster_name_on_cloud='test-cluster2',
-            cluster_yaml='/tmp/cluster2.yaml',
-            launched_nodes=1,
-            launched_resources=sky.Resources(sky.GCP(),
-                                             instance_type='a2-highgpu-4g',
-                                             accelerators={'A100': 4},
-                                             region='us-west1'),
-        )
-        global_user_state.add_or_update_cluster(
-            'test-cluster2',
-            handle,
-            requested_resources={handle.launched_resources},
-            ready=True)
-        handle = backends.CloudVmRayResourceHandle(
-            cluster_name='test-cluster3',
-            cluster_name_on_cloud='test-cluster3',
-            cluster_yaml='/tmp/cluster3.yaml',
-            launched_nodes=4,
-            launched_resources=sky.Resources(sky.Azure(),
-                                             instance_type='Standard_D4s_v3',
-                                             region='eastus'),
-        )
-        global_user_state.add_or_update_cluster(
-            'test-cluster3',
-            handle,
-            requested_resources={handle.launched_resources},
-            ready=False)
-        handle = backends.CloudVmRayResourceHandle(
-            cluster_name=spot.SPOT_CONTROLLER_NAME,
-            cluster_name_on_cloud=spot.SPOT_CONTROLLER_NAME,
-            cluster_yaml='/tmp/spot_controller.yaml',
-            launched_nodes=1,
-            launched_resources=sky.Resources(sky.AWS(),
-                                             instance_type='m4.2xlarge',
-                                             region='us-west-1'),
-        )
-        global_user_state.add_or_update_cluster(
-            spot.SPOT_CONTROLLER_NAME,
-            handle,
-            requested_resources={handle.launched_resources},
-            ready=True)
-
     @pytest.mark.timeout(60)
-    def test_down_spot_controller(self, _mock_cluster_state, monkeypatch):
+    def test_down_spot_controller(self, _mock_cluster_state,
+                                  _mock_spot_controller, monkeypatch):
 
-        def mock_cluster_refresh_up(
-            cluster_name: str,
-            *,
-            force_refresh_statuses: bool = False,
-            acquire_per_cluster_status_lock: bool = True,
+        def mock_is_controller_accessible(
+            controller_type: controller_utils.Controllers,
+            stopped_message: str,
+            non_existent_message: Optional[str] = None,
+            exit_on_error: bool = False,
         ):
-            record = global_user_state.get_cluster_from_name(cluster_name)
-            return record['status'], record['handle']
+            record = global_user_state.get_cluster_from_name(
+                spot.SPOT_CONTROLLER_NAME)
+            return record['handle']
+
+        def mock_get_job_table_no_job(cls, handle, code, require_outputs,
+                                      stream_logs,
+                                      separate_stderr) -> Tuple[int, str, str]:
+            return 0, common_utils.encode_payload([]), ''
+
+        def mock_get_job_table_one_job(cls, handle, code, require_outputs,
+                                       stream_logs,
+                                       separate_stderr) -> Tuple[int, str, str]:
+            return 0, common_utils.encode_payload([{
+                'job_id': '1',
+                'job_name': 'test_job',
+                'resources': 'test',
+                'status': 'RUNNING',
+                'submitted_at': time.time(),
+                'run_timestamp': str(time.time()),
+                'start_at': time.time(),
+                'end_at': time.time(),
+                'last_recovered_at': None,
+                'recovery_count': 0,
+                'failure_reason': '',
+                'spot_job_id': '1',
+                'task_id': 0,
+                'task_name': 'test_task',
+                'job_duration': 20,
+            }]), ''
 
         monkeypatch.setattr(
-            'sky.backends.backend_utils.refresh_cluster_status_handle',
-            mock_cluster_refresh_up)
+            'sky.backends.backend_utils.is_controller_accessible',
+            mock_is_controller_accessible)
 
-        monkeypatch.setattr('sky.core.spot_queue', lambda refresh: [])
+        monkeypatch.setattr(
+            'sky.backends.cloud_vm_ray_backend.CloudVmRayBackend.run_on_head',
+            mock_get_job_table_no_job)
 
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME],
                                    input='n')
-        assert 'WARNING: Tearing down the managed spot controller.' in result.output
+        assert 'WARNING: Tearing down the managed spot controller.' in result.output, (
+            result.exception, result.output, result.exc_info)
         assert isinstance(result.exception,
                           SystemExit), (result.exception, result.output)
+
+        monkeypatch.setattr(
+            'sky.backends.cloud_vm_ray_backend.CloudVmRayBackend.run_on_head',
+            mock_get_job_table_one_job)
+        result = cli_runner.invoke(cli.down, [spot.SPOT_CONTROLLER_NAME],
+                                   input='n')
+        assert 'WARNING: Tearing down the managed spot controller.' in result.output, (
+            result.exception, result.output, result.exc_info)
+        assert isinstance(result.exception, exceptions.NotSupportedError)
 
         result = cli_runner.invoke(cli.down, ['sky-spot-con*'])
         assert not result.exception
@@ -143,7 +195,8 @@ class TestControllerOperations:
         assert 'Aborted' in result.output
 
     @pytest.mark.timeout(60)
-    def test_stop_spot_controller(self, _mock_cluster_state):
+    def test_stop_spot_controller(self, _mock_cluster_state,
+                                  _mock_spot_controller):
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.stop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
@@ -159,7 +212,8 @@ class TestControllerOperations:
         assert 'Aborted' in result.output
 
     @pytest.mark.timeout(60)
-    def test_autostop_spot_controller(self, _mock_cluster_state):
+    def test_autostop_spot_controller(self, _mock_cluster_state,
+                                      _mock_spot_controller):
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.autostop, [spot.SPOT_CONTROLLER_NAME])
         assert result.exit_code == click.UsageError.exit_code
@@ -175,10 +229,40 @@ class TestControllerOperations:
         assert isinstance(result.exception, SystemExit)
         assert 'Aborted' in result.output
 
-    def test_cancel_on_spot_controller(self, _mock_cluster_state):
+    def test_cancel_on_spot_controller(self, _mock_cluster_state,
+                                       _mock_spot_controller):
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.cancel,
                                    [spot.SPOT_CONTROLLER_NAME, '-a'])
         assert result.exit_code == 1
         assert 'Cancelling the spot controller\'s jobs is not allowed.' in str(
             result.output)
+
+
+class TestSpotJobOperationsWithoutController:
+
+    @pytest.mark.timeout(60)
+    def test_cancel(self):
+        cli_runner = cli_testing.CliRunner()
+        result = cli_runner.invoke(cli.spot_cancel, ['-a'])
+        assert result.exit_code == 1
+        assert 'All managed spot jobs should have finished.' in str(
+            result.output), (result.exception, result.output, result.exc_info)
+
+    @pytest.mark.timeout(60)
+    def test_logs(self):
+        cli_runner = cli_testing.CliRunner()
+        result = cli_runner.invoke(cli.spot_logs, ['1'])
+        assert result.exit_code == 1
+        assert 'Please restart the spot controller with' in str(
+            result.output), (result.exception, result.output, result.exc_info)
+
+    @pytest.mark.timeout(60)
+    def test_queue(self):
+        cli_runner = cli_testing.CliRunner()
+        result = cli_runner.invoke(cli.spot_queue)
+        assert result.exit_code == 0
+        assert controller_utils.Controllers.SPOT_CONTROLLER.value.default_hint_if_non_existent in str(
+            result.output), (result.exception, result.output, result.exc_info)
+        assert 'To view the latest job table' in str(
+            result.output), (result.exception, result.output, result.exc_info)

--- a/tests/test_spot_serve.py
+++ b/tests/test_spot_serve.py
@@ -407,8 +407,10 @@ class TestServeOperations:
         cli_runner = cli_testing.CliRunner()
         result = cli_runner.invoke(cli.serve_down, ['-a'])
         assert result.exit_code == 1
-        assert (controller_utils.Controllers.SKY_SERVE_CONTROLLER.value.default_hint_if_non_existent in str(
-            result.output)), (result.exception, result.output, result.exc_info)
+        assert (controller_utils.Controllers.SKY_SERVE_CONTROLLER.value.
+                default_hint_if_non_existent
+                in str(result.output)), (result.exception, result.output,
+                                         result.exc_info)
 
     @pytest.mark.timeout(60)
     def test_logs(self, _mock_db_conn):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #1592, #3285

TODO:
- [x] Handle the case, when the controller is actually abnormal (autostopped or manually terminated)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - ```for i in `seq 1 100`; do sky spot launch -n test-$i --cloud gcp --cpus 2 -y -d "echo hi; sleep 120"; done```; during the submission
  - [x] `sky spot queue`
  - [x] `sky spot logs 10`
  - [x] `sky spot cancel 4 5 6`
- [x] All smoke tests: `pytest tests/test_smoke.py --managed-spot`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
