### PR TITLE
[RunPod] Fix multi-gpu provisioning.

### DIFF
--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -108,6 +108,7 @@ def launch(name: str, instance_type: str, region: str, disk_size: int) -> str:
         container_disk_in_gb=disk_size,
         min_vcpu_count=4 * gpu_quantity,
         min_memory_in_gb=gpu_specs['memoryInGb'] * gpu_quantity,
+        gpu_count=gpu_quantity,
         country_code=region,
         ports=(f'22/tcp,'
                f'{constants.SKY_REMOTE_RAY_DASHBOARD_PORT}/http,'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3146, #3289.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --gpus RTXA6000:2 --cloud runpod --down -- nvidia-smi`
  - [x] `sky launch --gpus RTXA6000 --cloud runpod --down -- nvidia-smi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
