### PR TITLE
[Core] Avoid race condition for key generation

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -111,7 +111,10 @@ def get_or_generate_keys() -> Tuple[str, str]:
 
     key_file_lock = os.path.expanduser(_SSH_KEY_GENERATION_LOCK)
     lock_dir = os.path.dirname(key_file_lock)
-    os.makedirs(lock_dir, exist_ok=True)
+    # We should have the folder ~/.sky/generated/ssh to have 0o700 permission,
+    # as the ssh configs will be written to this folder as well in
+    # backend_utils.SSHConfigHelper
+    os.makedirs(lock_dir, exist_ok=True, mode=0o700)
     with filelock.FileLock(key_file_lock, timeout=10):
         if not os.path.exists(private_key_path):
             public_key, private_key = _generate_rsa_key_pair()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to avoid the racing condition when multiple spot, services or launch run concurrently on a new environemnt. Previously, it is possible that two process generates the public key and private key concurrently causing unmatched keys. For example,
1. process 1 writes private key
2. process 2 writes private key
3. process 2 writes public key
4. process 1 writes public key

This PR adds a lock for the key generation to avoid this race condition

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
