### PR TITLE
[Fluidstack] Support opening ports and service

### DIFF
--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -50,9 +50,6 @@ class Fluidstack(clouds.Cloud):
         clouds.CloudImplementationFeatures.CUSTOM_DISK_TIER:
             'Custom disk tiers'
             f' is not supported in {_REPR}.',
-        clouds.CloudImplementationFeatures.OPEN_PORTS:
-            'Opening ports'
-            f'is not supported in {_REPR}.',
     }
     # Using the latest SkyPilot provisioner API to provision and check status.
     PROVISIONER_VERSION = clouds.ProvisionerVersion.SKYPILOT

--- a/sky/provision/fluidstack/__init__.py
+++ b/sky/provision/fluidstack/__init__.py
@@ -2,8 +2,8 @@
 
 from sky.provision.fluidstack.config import bootstrap_instances
 from sky.provision.fluidstack.instance import cleanup_ports
-from sky.provision.fluidstack.instance import open_ports
 from sky.provision.fluidstack.instance import get_cluster_info
+from sky.provision.fluidstack.instance import open_ports
 from sky.provision.fluidstack.instance import query_instances
 from sky.provision.fluidstack.instance import run_instances
 from sky.provision.fluidstack.instance import stop_instances

--- a/sky/provision/fluidstack/__init__.py
+++ b/sky/provision/fluidstack/__init__.py
@@ -2,6 +2,7 @@
 
 from sky.provision.fluidstack.config import bootstrap_instances
 from sky.provision.fluidstack.instance import cleanup_ports
+from sky.provision.fluidstack.instance import open_ports
 from sky.provision.fluidstack.instance import get_cluster_info
 from sky.provision.fluidstack.instance import query_instances
 from sky.provision.fluidstack.instance import run_instances

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -345,3 +345,13 @@ def cleanup_ports(
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
     del cluster_name_on_cloud, provider_config
+
+
+def open_ports(
+    cluster_name_on_cloud: str,
+    ports: List[str],
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> None:
+    del cluster_name_on_cloud, ports, provider_config
+    logger.debug(f'Skip opening ports {ports} for Fluidstack instances, as all '
+                  'ports are open by default.')

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -342,9 +342,10 @@ def query_instances(
 
 def cleanup_ports(
     cluster_name_on_cloud: str,
+    ports: List[str],
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
-    del cluster_name_on_cloud, provider_config
+    del cluster_name_on_cloud, ports, provider_config
 
 
 def open_ports(

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -353,6 +353,6 @@ def open_ports(
     ports: List[str],
     provider_config: Optional[Dict[str, Any]] = None,
 ) -> None:
-    del cluster_name_on_cloud, ports, provider_config
+    del cluster_name_on_cloud, provider_config
     logger.debug(f'Skip opening ports {ports} for Fluidstack instances, as all '
-                  'ports are open by default.')
+                 'ports are open by default.')

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -144,6 +144,7 @@ def _get_cloud_dependencies_installation_commands(
         'pip install google-api-python-client>=2.69.0 google-cloud-storage '
         '> /dev/null 2>&1',
         f'{gcp.GOOGLE_SDK_INSTALLATION_COMMAND}',
+        # fluidstack does not need to install any cloud dependencies.
     ]
     # k8s and ibm doesn't support open port and spot instance yet, so we don't
     # install them for either controller.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3293

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-fluid --ports 8000 --cloud fluidstack "pip install jupyterlab; jupyter lab --ip 0.0.0.0 --port 8000"`
  - [x] `sky serve up -n http tests/skyserve/update/new.yaml --cloud fluidstack` (with 2 replicas)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
