### PR TITLE
[Tests] Add CI test for doc build

### DIFF
--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -2,7 +2,7 @@ name: Documentation Build
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the main branch
+  # but only for the master branch
   push:
     branches:
       - master

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -1,0 +1,34 @@
+name: Documentation Build
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - master
+      - 'releases/**'
+  pull_request:
+    branches:
+      - master
+      - 'releases/**'
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        cd docs
+        pip install -r ./requirements-docs.txt
+    - name: Build documentation
+      run: |
+        ./build.sh

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -31,4 +31,5 @@ jobs:
         pip install -r ./requirements-docs.txt
     - name: Build documentation
       run: |
+        cd ./docs
         ./build.sh

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 rm -rf build docs
-make html
+script -q -c "make html" /tmp/build_docs.txt
+
+# Check if the output contains "ERROR:" or "WARNING:"
+if grep -q -E "ERROR:|WARNING:" /tmp/build_docs.txt; then
+  echo "Errors or warnings detected, exiting..."
+  exit 1
+fi

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,4 +105,5 @@ html_static_path = ['_static']
 html_js_files = ['custom.js']
 html_css_files = ['custom.css']
 
+# Allowing cross references in markdown files to be parsed
 myst_heading_anchors = 3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,3 +104,5 @@ html_favicon = '_static/favicon.ico'
 html_static_path = ['_static']
 html_js_files = ['custom.js']
 html_css_files = ['custom.css']
+
+myst_heading_anchors = 3


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add CI test for documentation build failure. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] Render locally
  - [x] CI
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
