### PR TITLE
[Storage] Use task's region for initializing new stores

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -90,7 +90,7 @@ def split_cos_path(s3_path: str) -> Tuple[str, str, str]:
     return bucket_name, data_path, region
 
 
-def create_s3_client(region: Optional[str] = 'us-east-1') -> Client:
+def create_s3_client(region: Optional[str] = None) -> Client:
     """Helper method that connects to Boto3 client for S3 Bucket
 
     Args:

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -90,12 +90,16 @@ def split_cos_path(s3_path: str) -> Tuple[str, str, str]:
     return bucket_name, data_path, region
 
 
-def create_s3_client(region: str = 'us-east-2') -> Client:
+def create_s3_client(region: Optional[str] = 'us-east-2') -> Client:
     """Helper method that connects to Boto3 client for S3 Bucket
 
     Args:
-      region: str; Region name, e.g. us-west-1, us-east-2
+      region: str; Region name, e.g. us-west-1, us-east-2. If None, default
+        region us-east-2 is used.
     """
+    if region is None:
+        # If region is None, default to us-east-2 since
+        region = 'us-east-2'
     return aws.client('s3', region_name=region)
 
 

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -90,16 +90,15 @@ def split_cos_path(s3_path: str) -> Tuple[str, str, str]:
     return bucket_name, data_path, region
 
 
-def create_s3_client(region: Optional[str] = 'us-east-2') -> Client:
+def create_s3_client(region: Optional[str] = 'us-east-1') -> Client:
     """Helper method that connects to Boto3 client for S3 Bucket
 
     Args:
       region: str; Region name, e.g. us-west-1, us-east-2. If None, default
-        region us-east-2 is used.
+        region us-east-1 is used.
     """
     if region is None:
-        # If region is None, default to us-east-2 since
-        region = 'us-east-2'
+        region = 'us-east-1'
     return aws.client('s3', region_name=region)
 
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1386,7 +1386,9 @@ class S3Store(AbstractStore):
                 s3_client.create_bucket(Bucket=bucket_name)
             else:
                 if region == 'us-east-1':
-                    # If default us-east-1 region is used, the LocationConstraint must not be specified. https://stackoverflow.com/a/51912090
+                    # If default us-east-1 region is used, the
+                    # LocationConstraint must not be specified.
+                    # https://stackoverflow.com/a/51912090
                     s3_client.create_bucket(Bucket=bucket_name)
                 else:
                     location = {'LocationConstraint': region}

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -791,7 +791,9 @@ class Storage(object):
 
         return storage_obj
 
-    def add_store(self, store_type: Union[str, StoreType]) -> AbstractStore:
+    def add_store(self,
+                  store_type: Union[str, StoreType],
+                  region: Optional[str] = None) -> AbstractStore:
         """Initializes and adds a new store to the storage.
 
         Invoked by the optimizer after it has selected a store to
@@ -799,6 +801,8 @@ class Storage(object):
 
         Args:
           store_type: StoreType; Type of the storage [S3, GCS, AZURE, R2, IBM]
+          region: str; Region to place the bucket in. Caller must ensure that
+            the region is valid for the chosen store_type.
         """
         if isinstance(store_type, str):
             store_type = StoreType(store_type)
@@ -826,6 +830,7 @@ class Storage(object):
             store = store_cls(
                 name=self.name,
                 source=self.source,
+                region=region,
                 sync_on_reconstruction=self.sync_on_reconstruction)
         except exceptions.StorageBucketCreateError:
             # Creation failed, so this must be sky managed store. Add failure
@@ -1310,7 +1315,7 @@ class S3Store(AbstractStore):
         # Store object is being reconstructed for deletion or re-mount with
         # sky start, and error is raised instead.
         if self.sync_on_reconstruction:
-            bucket = self._create_s3_bucket(self.name)
+            bucket = self._create_s3_bucket(self.name, self.region)
             return bucket, True
         else:
             # Raised when Storage object is reconstructed for sky storage
@@ -1360,9 +1365,13 @@ class S3Store(AbstractStore):
             if region is None:
                 s3_client.create_bucket(Bucket=bucket_name)
             else:
-                location = {'LocationConstraint': region}
-                s3_client.create_bucket(Bucket=bucket_name,
-                                        CreateBucketConfiguration=location)
+                if region == 'us-east-1':
+                    # If default us-east-1 region is used, the LocationConstraint must not be specified. https://stackoverflow.com/a/51912090
+                    s3_client.create_bucket(Bucket=bucket_name)
+                else:
+                    location = {'LocationConstraint': region}
+                    s3_client.create_bucket(Bucket=bucket_name,
+                                            CreateBucketConfiguration=location)
                 logger.info(f'Created S3 bucket {bucket_name} in {region}')
         except aws.botocore_exceptions().ClientError as e:
             with ux_utils.print_exception_no_traceback():
@@ -1736,7 +1745,7 @@ class GcsStore(AbstractStore):
                 # is being reconstructed for deletion or re-mount with
                 # sky start, and error is raised instead.
                 if self.sync_on_reconstruction:
-                    bucket = self._create_gcs_bucket(self.name)
+                    bucket = self._create_gcs_bucket(self.name, self.region)
                     return bucket, True
                 else:
                     # This is raised when Storage object is reconstructed for

--- a/sky/task.py
+++ b/sky/task.py
@@ -857,15 +857,16 @@ class Task:
         task_storage_mounts.update(storage_mounts)
         return self.set_storage_mounts(task_storage_mounts)
 
-    def get_preferred_store_type(self) -> storage_lib.StoreType:
+    def get_preferred_store(self) -> Tuple[storage_lib.StoreType, Optional[str]]:
+        """Returns the preferred store type and region for this task."""
         # TODO(zhwu, romilb): The optimizer should look at the source and
         #  destination to figure out the right stores to use. For now, we
         #  use a heuristic solution to find the store type by the following
         #  order:
-        #  1. cloud decided in best_resources.
-        #  2. cloud specified in the task resources.
+        #  1. cloud/region decided in best_resources.
+        #  2. cloud/region specified in the task resources.
         #  3. if not specified or the task's cloud does not support storage,
-        #     use the first enabled storage cloud.
+        #     use the first enabled storage cloud with default region.
         # This should be refactored and moved to the optimizer.
 
         # This check is not needed to support multiple accelerators;
@@ -880,9 +881,11 @@ class Task:
 
         if self.best_resources is not None:
             storage_cloud = self.best_resources.cloud
+            storage_region = self.best_resources.region
         else:
             resources = list(self.resources)[0]
             storage_cloud = resources.cloud
+            storage_region = resources.region
         if storage_cloud is not None:
             if str(storage_cloud) not in enabled_storage_clouds:
                 storage_cloud = None
@@ -891,9 +894,10 @@ class Task:
             storage_cloud = clouds.CLOUD_REGISTRY.from_str(
                 enabled_storage_clouds[0])
             assert storage_cloud is not None, enabled_storage_clouds[0]
+            storage_region = None   # Use default region in the Store class
 
         store_type = storage_lib.get_storetype_from_cloud(storage_cloud)
-        return store_type
+        return store_type, storage_region
 
     def sync_storage_mounts(self) -> None:
         """(INTERNAL) Eagerly syncs storage mounts to cloud storage.
@@ -904,9 +908,9 @@ class Task:
         """
         for storage in self.storage_mounts.values():
             if len(storage.stores) == 0:
-                store_type = self.get_preferred_store_type()
+                store_type, store_region = self.get_preferred_store()
                 self.storage_plans[storage] = store_type
-                storage.add_store(store_type)
+                storage.add_store(store_type, store_region)
             else:
                 # We will download the first store that is added to remote.
                 self.storage_plans[storage] = list(storage.stores.keys())[0]

--- a/sky/task.py
+++ b/sky/task.py
@@ -855,7 +855,8 @@ class Task:
         task_storage_mounts.update(storage_mounts)
         return self.set_storage_mounts(task_storage_mounts)
 
-    def get_preferred_store(self) -> Tuple[storage_lib.StoreType, Optional[str]]:
+    def get_preferred_store(
+            self) -> Tuple[storage_lib.StoreType, Optional[str]]:
         """Returns the preferred store type and region for this task."""
         # TODO(zhwu, romilb): The optimizer should look at the source and
         #  destination to figure out the right stores to use. For now, we
@@ -891,7 +892,7 @@ class Task:
             storage_cloud = clouds.CLOUD_REGISTRY.from_str(
                 enabled_storage_clouds[0])
             assert storage_cloud is not None, enabled_storage_clouds[0]
-            storage_region = None   # Use default region in the Store class
+            storage_region = None  # Use default region in the Store class
 
         store_type = storage_lib.get_storetype_from_cloud(storage_cloud)
         return store_type, storage_region

--- a/sky/task.py
+++ b/sky/task.py
@@ -855,7 +855,7 @@ class Task:
         task_storage_mounts.update(storage_mounts)
         return self.set_storage_mounts(task_storage_mounts)
 
-    def get_preferred_store(
+    def _get_preferred_store(
             self) -> Tuple[storage_lib.StoreType, Optional[str]]:
         """Returns the preferred store type and region for this task."""
         # TODO(zhwu, romilb): The optimizer should look at the source and
@@ -906,7 +906,7 @@ class Task:
         """
         for storage in self.storage_mounts.values():
             if len(storage.stores) == 0:
-                store_type, store_region = self.get_preferred_store()
+                store_type, store_region = self._get_preferred_store()
                 self.storage_plans[storage] = store_type
                 storage.add_store(store_type, store_region)
             else:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2625,8 +2625,8 @@ def test_spot_storage(generic_cloud: str):
             [
                 *storage_setup_commands,
                 f'sky spot launch -n {name} --cloud {generic_cloud}{region_flag} {file_path} -y',
-                'sleep 60',  # Wait the spot queue to be updated
                 region_validation_cmd,  # Check if the bucket is created in the correct region
+                'sleep 60',  # Wait the spot queue to be updated
                 f'{_SPOT_QUEUE_WAIT}| grep {name} | grep SUCCEEDED',
                 f'[ $(aws s3api list-buckets --query "Buckets[?contains(Name, \'{storage_name}\')].Name" --output text | wc -l) -eq 0 ]'
             ],

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2603,16 +2603,16 @@ def test_spot_storage(generic_cloud: str):
     region_flag = ''
     region_validation_cmd = 'true'
     if generic_cloud == 'aws':
-        region = 'us-west-2'
+        region = 'eu-central-1'
         region_flag = f' --region {region}'
-        region_cmd = TestStorageWithCredentials.cli_region_cmd(storage_lib.StoreType.S3,
-                                                               storage_name)
+        region_cmd = TestStorageWithCredentials.cli_region_cmd(
+            storage_lib.StoreType.S3, storage_name)
         region_validation_cmd = f'{region_cmd} | grep {region}'
     elif generic_cloud == 'gcp':
         region = 'us-west2'
         region_flag = f' --region {region}'
-        region_cmd = TestStorageWithCredentials.cli_region_cmd(storage_lib.StoreType.GCS,
-                                                               storage_name)
+        region_cmd = TestStorageWithCredentials.cli_region_cmd(
+            storage_lib.StoreType.GCS, storage_name)
         region_validation_cmd = f'{region_cmd} | grep {region}'
 
     yaml_str = yaml_str.replace('sky-workdir-zhwu', storage_name)
@@ -4440,13 +4440,12 @@ class TestStorageWithCredentials:
             storage_obj.delete()
 
     @pytest.mark.no_fluidstack
-    @pytest.mark.parametrize('region',
-                             ['ap-northeast-1', 'ap-northeast-2',
-                              'ap-northeast-3', 'ap-south-1', 'ap-southeast-1',
-                              'ap-southeast-2', 'eu-central-1',
-                              'eu-north-1', 'eu-west-1', 'eu-west-2',
-                              'eu-west-3', 'sa-east-1', 'us-east-1',
-                              'us-east-2', 'us-west-1', 'us-west-2'])
+    @pytest.mark.parametrize('region', [
+        'ap-northeast-1', 'ap-northeast-2', 'ap-northeast-3', 'ap-south-1',
+        'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-north-1',
+        'eu-west-1', 'eu-west-2', 'eu-west-3', 'sa-east-1', 'us-east-1',
+        'us-east-2', 'us-west-1', 'us-west-2'
+    ])
     def test_aws_regions(self, tmp_local_storage_obj, region):
         # This tests creation and upload to bucket in all AWS s3 regions
         # To test full functionality, use test_spot_storage above.
@@ -4460,7 +4459,7 @@ class TestStorageWithCredentials:
         output = out.decode('utf-8')
         expected_output_region = region
         if region == 'us-east-1':
-            expected_output_region = 'None' # us-east-1 is the default region
+            expected_output_region = 'None'  # us-east-1 is the default region
         assert expected_output_region in out.decode('utf-8'), (
             f'Bucket was not found in region {region} - '
             f'output of {region_cmd} was: {output}')
@@ -4473,23 +4472,18 @@ class TestStorageWithCredentials:
             f'tmp-file not found in bucket - output of {ls_cmd} was: {output}')
 
     @pytest.mark.no_fluidstack
-    @pytest.mark.parametrize('region',
-                             ['northamerica-northeast1',
-                              'northamerica-northeast2', 'us-central1',
-                              'us-east1', 'us-east4', 'us-east5', 'us-south1',
-                              'us-west1', 'us-west2', 'us-west3', 'us-west4',
-                              'southamerica-east1', 'southamerica-west1',
-                              'europe-central2', 'europe-north1',
-                              'europe-southwest1', 'europe-west1',
-                              'europe-west2', 'europe-west3', 'europe-west4',
-                              'europe-west6', 'europe-west8', 'europe-west9',
-                              'europe-west10', 'europe-west12', 'asia-east1',
-                              'asia-east2', 'asia-northeast1',
-                              'asia-northeast2', 'asia-northeast3',
-                              'asia-southeast1', 'asia-south1', 'asia-south2',
-                              'asia-southeast2', 'me-central1', 'me-central2',
-                              'me-west1', 'australia-southeast1',
-                              'australia-southeast2', 'africa-south1'])
+    @pytest.mark.parametrize('region', [
+        'northamerica-northeast1', 'northamerica-northeast2', 'us-central1',
+        'us-east1', 'us-east4', 'us-east5', 'us-south1', 'us-west1', 'us-west2',
+        'us-west3', 'us-west4', 'southamerica-east1', 'southamerica-west1',
+        'europe-central2', 'europe-north1', 'europe-southwest1', 'europe-west1',
+        'europe-west2', 'europe-west3', 'europe-west4', 'europe-west6',
+        'europe-west8', 'europe-west9', 'europe-west10', 'europe-west12',
+        'asia-east1', 'asia-east2', 'asia-northeast1', 'asia-northeast2',
+        'asia-northeast3', 'asia-southeast1', 'asia-south1', 'asia-south2',
+        'asia-southeast2', 'me-central1', 'me-central2', 'me-west1',
+        'australia-southeast1', 'australia-southeast2', 'africa-south1'
+    ])
     def test_gcs_regions(self, tmp_local_storage_obj, region):
         # This tests creation and upload to bucket in all GCS regions
         # To test full functionality, use test_spot_storage above.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2598,7 +2598,7 @@ def test_spot_storage(generic_cloud: str):
 
     # Also perform region testing for bucket creation to validate if buckets are
     # created in the correct region and correctly mounted in spot jobs.
-    # However, we inject this testing for AWS and GCP since they are the
+    # However, we inject this testing only for AWS and GCP since they are the
     # supported object storage providers in SkyPilot.
     region_flag = ''
     region_validation_cmd = 'true'

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3783,14 +3783,13 @@ class TestStorageWithCredentials:
         if store_type == storage_lib.StoreType.S3:
             return ('aws s3api get-bucket-location '
                     f'--bucket {bucket_name} --output text')
-        if store_type == storage_lib.StoreType.GCS:
+        elif store_type == storage_lib.StoreType.GCS:
             return (f'gsutil ls -L -b gs://{bucket_name}/ | '
                     'grep "Location constraint" | '
                     'awk \'{print tolower($NF)}\'')
-        if store_type == storage_lib.StoreType.R2:
-            raise NotImplementedError
-        if store_type == storage_lib.StoreType.IBM:
-            raise NotImplementedError
+        else:
+            raise NotImplementedError(f'Region command not implemented for '
+                                      f'{store_type}')
 
     @staticmethod
     def cli_count_name_in_bucket(store_type, bucket_name, file_name, suffix=''):


### PR DESCRIPTION
Closes #3114. Uses the optimizer's `best_resources` or the the tasks' resource spec to infer the region for the bucket, if available.

Note that currently the bucket is eagerly provisioned in the first region that will be tried by the provisioner. If failover is trigerred, the bucket and compute may lie in a different region. A better fix could have been to make store init lazy and create the bucket in the region where the VM actually gets provisioned, but that requires deeper changes + considerations on wasted VM time while data is uploaded to the object store.

TODO:
- [x] Testing across StoreTypes and regions

Tested:
- [x] YAML with and without region specified in `task.resources` on GCP and AWS. Also tested that the same buckets can be successfully mounted by goofys/gcsfuse on tasks in other regions.
- [x] `pytest tests/test_smoke.py::TestStorageWithCredentials` for gcs and s3
- [x] `pytest tests/test_smoke.py::test_spot_storage --gcp`
- [x] `pytest tests/test_smoke.py::test_spot_storage --aws`
- [x] `pytest tests/test_smoke.py --aws` (Unrelated failures in `spot_recovery_aws` and `test-skyserve-new-autoscaler-update`)
- [x] `pytest tests/test_smoke.py --gcp` (Unrelated failures in `sky-bench`, `test_spot_tpu` )