### PR TITLE
[k8s] Fix for spaces and equals signs in docker env vars

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -271,13 +271,15 @@ def _set_env_vars_in_pods(namespace: str, new_pods: List):
     shell sessions.
     """
     set_k8s_env_var_cmd = [
-        '/bin/sh', '-c',
-        ('prefix_cmd() '
-         '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
-         'printenv | while IFS=\'=\' read -r key value; do echo "export $key=\\\"$value\\\""; done > '  # pylint: disable=line-too-long
-         '~/k8s_env_var.sh && '
-         'mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh || '
-         '$(prefix_cmd) mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh')
+        '/bin/sh',
+        '-c',
+        (
+            'prefix_cmd() '
+            '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
+            'printenv | while IFS=\'=\' read -r key value; do echo "export $key=\\\"$value\\\""; done > '  # pylint: disable=line-too-long
+            '~/k8s_env_var.sh && '
+            'mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh || '
+            '$(prefix_cmd) mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh')
     ]
 
     for new_pod in new_pods:

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -274,7 +274,7 @@ def _set_env_vars_in_pods(namespace: str, new_pods: List):
         '/bin/sh', '-c',
         ('prefix_cmd() '
          '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
-         'printenv | awk -F "=" \'{print "export " $1 "=\\047" $2 "\\047"}\' > '
+         'printenv | awk -F "=" \'{var=$1; $1=""; value=substr($0, 2); printf "export %s=\"%s\"\n", var, value}\' > '  # pylint: disable=line-too-long
          '~/k8s_env_var.sh && '
          'mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh || '
          '$(prefix_cmd) mv ~/k8s_env_var.sh /etc/profile.d/k8s_env_var.sh')


### PR DESCRIPTION
Closes #3320. Our parsing for k8s envvars -> ssh envvars would break if the envvar value contained equals signs or spaces. This PR fixes it. 

Example, if the env is set as `ENV GIT_SSH_COMMAND="ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"`.

Before, our custom envs script would contain:
```
...
export GIT_SSH_COMMAND=ssh -o HostKeyAlgorithms
...
```

After (handles equals sign, adds quotes to handle spaces):
```
...
export GIT_SSH_COMMAND="ssh -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"
...
```

Tested (run the relevant ones):

- [x] Repro from #3320.