### PR TITLE
[GCP] Docs for GCP reservation permission and fix auto reservation

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -79,7 +79,6 @@ User
     compute.networks.list
     compute.networks.getEffectiveFirewalls
     compute.globalOperations.get
-    compute.reservations.list
     compute.subnetworks.use
     compute.subnetworks.list
     compute.subnetworks.useExternalIp
@@ -152,11 +151,10 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If the user sets ``gcp.prioritize_reservations`` or ```gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
+9. **Optional**: If the user sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 
-    compute.reservations.get
     compute.reservations.list
 
 9. Click **Create** to create the role.

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -151,7 +151,7 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If the user sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
+9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -152,6 +152,13 @@ User
     compute.images.get
     compute.images.useReadOnly
 
+9. **Optional**: If the user sets ``gcp.prioritize_reservations`` or ```gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
+
+.. code-block:: text
+
+    compute.reservations.get
+    compute.reservations.list
+
 9. Click **Create** to create the role.
 10. Go back to the "IAM" tab and click on **GRANT ACCESS**.
 11. Fill in the email address of the user in the “Add principals” section, and select ``minimal-skypilot-role`` in the “Assign roles” section. Click **Save**.

--- a/sky/clouds/utils/gcp_utils.py
+++ b/sky/clouds/utils/gcp_utils.py
@@ -178,8 +178,10 @@ def get_minimal_permissions() -> List[str]:
         # required to ensure SkyPilot to be able to setup the network, and
         # allow opening ports (e.g., via `resources.ports`).
         permissions += constants.FIREWALL_PERMISSIONS
-    
-    if skypilot_config.get_nested(('gcp', 'prioritize_reservations'), False) or skypilot_config.get_nested(('gcp', 'specific_reservations'), []):
+
+    if skypilot_config.get_nested(('gcp', 'prioritize_reservations'),
+                                  False) or skypilot_config.get_nested(
+                                      ('gcp', 'specific_reservations'), []):
         permissions += constants.RESERVATION_PERMISSIONS
 
     return permissions

--- a/sky/clouds/utils/gcp_utils.py
+++ b/sky/clouds/utils/gcp_utils.py
@@ -179,9 +179,8 @@ def get_minimal_permissions() -> List[str]:
         # allow opening ports (e.g., via `resources.ports`).
         permissions += constants.FIREWALL_PERMISSIONS
 
-    if skypilot_config.get_nested(('gcp', 'prioritize_reservations'),
-                                  False) or skypilot_config.get_nested(
-                                      ('gcp', 'specific_reservations'), []):
+    if (skypilot_config.get_nested(('gcp', 'prioritize_reservations'), False) or
+            skypilot_config.get_nested(('gcp', 'specific_reservations'), [])):
         permissions += constants.RESERVATION_PERMISSIONS
 
     return permissions

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -196,7 +196,7 @@ FIREWALL_PERMISSIONS = [
     'compute.firewalls.delete',
 ]
 
-RESERVATIONS_PERMISSIONS = [
+RESERVATION_PERMISSIONS = [
     'compute.reservations.get',
     'compute.reservations.list',
 ]

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -197,7 +197,6 @@ FIREWALL_PERMISSIONS = [
 ]
 
 RESERVATION_PERMISSIONS = [
-    'compute.reservations.get',
     'compute.reservations.list',
 ]
 

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -196,6 +196,11 @@ FIREWALL_PERMISSIONS = [
     'compute.firewalls.delete',
 ]
 
+RESERVATIONS_PERMISSIONS = [
+    'compute.reservations.get',
+    'compute.reservations.list',
+]
+
 TPU_MINIMAL_PERMISSIONS = [
     'tpu.nodes.create',
     'tpu.nodes.delete',

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -650,7 +650,6 @@ class GCPComputeInstance(GCPInstance):
 
         all_names = []
         if 'reservationAffinity' in config:
-            print(set(config['reservationAffinity']['values']))
             specific_reservations = set(config['reservationAffinity']['values'])
             reservations = gcp_cloud.GCP().get_reservations_available_resources(
                 config['machineType'],
@@ -683,7 +682,6 @@ class GCPComputeInstance(GCPInstance):
                 logger.debug(f'Creating {reservation_count} instances '
                              f'with reservation {reservation}')
                 config['reservationAffinity']['values'] = [reservation]
-                print(config)
                 created_names = names[:reservation_count]
                 errors = cls._create_instances(
                     created_names, project_id, zone, config,

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -657,7 +657,7 @@ class GCPComputeInstance(GCPInstance):
                 zone=zone,
                 specific_reservations=specific_reservations)
             # Filter the reservations by the user-specified ones, because
-            # reservations contains auto reservations as well, which does not
+            # reservations contain auto reservations as well, which do not
             # need to explicitly specify in the config for creating instances.
             specific_reservations_to_count = {
                 reservation: count


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR moves the reservation permission into the optional list, as users without the reservations set in `config.yaml` will not need to have the reservation permissions.

It also fixes #3327.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] having a auto and a specific reservation setup, and launch an instance with the same resource: correctly created the instance, with only the `compute.reservations.list` permission
  - [x] create an instance without reservation requirement and the permission
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
