### PR TITLE
[Core] Add option for down after idle for controllers

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -17,6 +17,7 @@ from sky import clouds
 from sky import global_user_state
 from sky import optimizer
 from sky import sky_logging
+from sky import skypilot_config
 from sky import spot
 from sky import task as task_lib
 from sky.backends import backend_utils
@@ -706,6 +707,8 @@ def spot_launch(
               f'Launching managed spot job {dag.name!r} from spot controller...'
               f'{colorama.Style.RESET_ALL}')
         print('Launching spot controller...')
+        down = skypilot_config.get_nested(
+            ('spot', 'controller', 'down_after_idle'), False)
         _execute(
             entrypoint=controller_task,
             stream_logs=stream_logs,
@@ -714,4 +717,5 @@ def spot_launch(
             idle_minutes_to_autostop=constants.
             CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
             retry_until_up=True,
+            down=down,
         )

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -10,6 +10,7 @@ from sky import backends
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky import skypilot_config
 from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.serve import constants as serve_constants
@@ -180,6 +181,8 @@ def up(
 
         print(f'{colorama.Fore.YELLOW}Launching controller for '
               f'{service_name!r}...{colorama.Style.RESET_ALL}')
+        down = skypilot_config.get_nested(
+            ('spot', 'controller', 'down_after_idle'), False)
         # We directly submit the request to the controller and let the
         # controller to check name conflict. Suppose we have multiple
         # sky.serve.up() with same service name, the first one will
@@ -197,6 +200,7 @@ def up(
             detach_run=True,
             idle_minutes_to_autostop=constants.
             CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
+            down=down,
             retry_until_up=True,
             _disable_controller_check=True,
         )

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -557,6 +557,9 @@ def get_config_schema():
                 'additionalProperties': False,
                 'properties': {
                     'resources': resources_schema,
+                    'down_after_idle': {
+                        'type': 'boolean',
+                    },
                 }
             },
         }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Per #3316, user would like to have a way to let the controller terminate after idle. This PR adds an option to terminate controllers after idle.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
