### PR TITLE
[Docs] Fix misaligned table; mention task logs.

### DIFF
--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -96,21 +96,21 @@ Environment variables for ``setup``
 
 
 .. list-table::
-  :widths: 20 70 10
-  :header-rows: 1
+   :widths: 20 70 10
+   :header-rows: 1
 
-  * - Name
-    - Definition
-    - Example
-  * - ``SKYPILOT_SETUP_NODE_RANK``
-    - Rank (an integer ID from 0 to :code:`num_nodes-1`) of the node being set up.
-    - 0
-  * - ``SKYPILOT_SETUP_NODE_IPS``
-    - A string of IP addresses of the nodes in the cluster with the same order as the node ranks, where each line contains one IP address.
-    - 1.2.3.4
-  * - ``SKYPILOT_SERVE_REPLICA_ID``
-    - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
-    - 1
+   * - Name
+     - Definition
+     - Example
+   * - ``SKYPILOT_SETUP_NODE_RANK``
+     - Rank (an integer ID from 0 to :code:`num_nodes-1`) of the node being set up.
+     - 0
+   * - ``SKYPILOT_SETUP_NODE_IPS``
+     - A string of IP addresses of the nodes in the cluster with the same order as the node ranks, where each line contains one IP address.
+     - 1.2.3.4
+   * - ``SKYPILOT_SERVE_REPLICA_ID``
+     - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
+     - 1
 
 Since setup commands always run on all nodes of a cluster, SkyPilot ensures both of these environment variables (the ranks and the IP list) never change across multiple setups on the same cluster.
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -121,30 +121,31 @@ Environment variables for ``run``
    :widths: 20 70 10
    :header-rows: 1
 
-  * - Name
-    - Definition
-    - Example
-  * - ``SKYPILOT_NODE_RANK``
-    - Rank (an integer ID from 0 to :code:`num_nodes-1`) of the node executing the task. Read more :ref:`here <dist-jobs>`.
-    - 0
-  * - ``SKYPILOT_NODE_IPS``
-    - A string of IP addresses of the nodes reserved to execute the task, where each line contains one IP address. Read more :ref:`here <dist-jobs>`.
-    - 1.2.3.4
-  * - ``SKYPILOT_NUM_GPUS_PER_NODE``
-    - Number of GPUs reserved on each node to execute the task; the same as the
-      count in ``accelerators: <name>:<count>`` (rounded up if a fraction). Read
-      more :ref:`here <dist-jobs>`.
-    - 0
-  * - ``SKYPILOT_TASK_ID``
-    - A unique ID assigned to each task.
-      Useful for logging purposes: e.g., use a unique output path on the cluster; pass to Weights & Biases; etc.
+   * - Name
+     - Definition
+     - Example
+   * - ``SKYPILOT_NODE_RANK``
+     - Rank (an integer ID from 0 to :code:`num_nodes-1`) of the node executing the task. Read more :ref:`here <dist-jobs>`.
+     - 0
+   * - ``SKYPILOT_NODE_IPS``
+     - A string of IP addresses of the nodes reserved to execute the task, where each line contains one IP address. Read more :ref:`here <dist-jobs>`.
+     - 1.2.3.4
+   * - ``SKYPILOT_NUM_GPUS_PER_NODE``
+     - Number of GPUs reserved on each node to execute the task; the same as the
+       count in ``accelerators: <name>:<count>`` (rounded up if a fraction). Read
+       more :ref:`here <dist-jobs>`.
+     - 0
+   * - ``SKYPILOT_TASK_ID``
+     - A unique ID assigned to each task.
+       Useful for logging purposes: e.g., use a unique output path on the cluster; pass to Weights & Biases; etc.
+       Each task's logs are stored on the cluster at ``~/sky_logs/${SKYPILOT_TASK_ID%%_*}/tasks/*.log``.
 
-      If a task is run as a :ref:`managed spot job <spot-jobs>`, then all
-      recoveries of that job will have the same ID value. Read more :ref:`here <spot-jobs-end-to-end>`.
-    - sky-2023-07-06-21-18-31-563597_myclus_id-1
-  * - ``SKYPILOT_SERVE_REPLICA_ID``
-    - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
-    - 1
+       If a task is run as a :ref:`managed spot job <spot-jobs>`, then all
+       recoveries of that job will have the same ID value. Read more :ref:`here <spot-jobs-end-to-end>`.
+     - sky-2023-07-06-21-18-31-563597_myclus_id-1
+   * - ``SKYPILOT_SERVE_REPLICA_ID``
+     - The ID of a replica within the service (starting from 1). Available only for a :ref:`service <sky-serve>`'s replica task.
+     - 1
 
 The values of these variables are filled in by SkyPilot at task execution time.
 


### PR DESCRIPTION
Was showing: `:widths: 20 70 10 :header-rows: 1` in https://skypilot.readthedocs.io/en/latest/running-jobs/environment-variables.html#environment-variables-for-run

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below): rendered
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
