### PR TITLE
[docker] Add /dev/fuse for mounting containers in docker

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -94,6 +94,10 @@ def docker_start_cmds(
         env_flags,
         user_options_str,
         '--net=host',
+        # SkyPilot: Add following options to enable fuse.
+        '--cap-add=SYS_ADMIN',
+        '--device=/dev/fuse',
+        '--security-opt=apparmor:unconfined',
         image,
         'bash',
     ]

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -250,8 +250,12 @@ class DockerInitializer:
             run_env='docker')
         # Install dependencies.
         self._run(
-            'sudo apt-get update; sudo apt-get install -y rsync curl wget '
-            'patch openssh-server python3-pip;',
+            'sudo apt-get update; '
+            # Our mount script will install gcsfuse without fuse package.
+            # We need to install fuse package first to enable storage mount.
+            # The dpkg option is to suppress the prompt for fuse installation.
+            'sudo apt-get -o DPkg::Options::="--force-confnew" install -y '
+            'rsync curl wget patch openssh-server python3-pip fuse;',
             run_env='docker')
 
         # Copy local authorized_keys to docker container.


### PR DESCRIPTION
Storage mounting was not working when running inside a docker container on the new provisioner. This PR fixes it and adds smoke tests.

Minimal repro:
```
resources:
  cloud: gcp
  image_id: docker:ubuntu:latest

file_mounts:
  /mymnt:
    source: s3://fah-public-data-covid19-cryptic-pockets #romileubucket2
    mode: MOUNT
  /mynotebooks:
    source: gs://romilb-notebooks/ #romileubucket2
    mode: MOUNT

setup: |
  echo hi

run: |
  ls -l /mynotebooks
  ls -l /mymnt
  echo run > /mynotebooks/hellotest.txt
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Smoke - `pytest tests/test_smoke.py::test_docker_storage_mounts`
