### PR TITLE
[examples] Update examples using deprecated `SKYPILOT_JOB_ID `

### DIFF
--- a/examples/tensorflow_distributed/tf_distributed.yaml
+++ b/examples/tensorflow_distributed/tf_distributed.yaml
@@ -53,12 +53,12 @@ run: |
               'index': node_rank
           }
       }
-  with open(f'/tmp/{os.environ.get("SKYPILOT_JOB_ID")}', 'w') as f:
+  with open(f'/tmp/{os.environ.get("SKYPILOT_TASK_ID")}', 'w') as f:
       json.dump(tf_config, f)
   EOF
   
   # Read and set TF_CONFIG from file
-  export TF_CONFIG=$(cat /tmp/$SKYPILOT_JOB_ID)
+  export TF_CONFIG=$(cat /tmp/$SKYPILOT_TASK_ID)
   echo $TF_CONFIG
   
   # ======== Run the training script ========

--- a/llm/vicuna/train.yaml
+++ b/llm/vicuna/train.yaml
@@ -100,7 +100,7 @@ run: |
     --fsdp_transformer_layer_cls_to_wrap 'LlamaDecoderLayer' \
     --tf32 True \
     --model_max_length ${SEQ_LEN} \
-    --run_name $SKYPILOT_JOB_ID \
+    --run_name $SKYPILOT_TASK_ID \
     --gradient_checkpointing True \
     --lazy_preprocess True
 


### PR DESCRIPTION
`SKYPILOT_JOB_ID` envvar was deprecated after v0.5. This PR updates examples in our repo to use the new `SKYPILOT_TASK_ID` envvar instead.

Tested:
- [x] `sky launch -c tfdistributed tf_distributed.yaml`
- [x] Couldn't test `llm/vicuna/train.yaml`, no GPU capacity for A100s.