### PR TITLE
[Serve] Use versions in database for autoscaler and replica_manager (#3301)

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -294,8 +294,7 @@ class RequestRateAutoscaler(Autoscaler):
         if self.update_mode == serve_utils.UpdateMode.ROLLING:
             latest_ready_replicas = []
             old_nonterminal_replicas = []
-            latest_version = serve_state.get_latest_version(
-                self._service_name)
+            latest_version = serve_state.get_latest_version(self._service_name)
             for info in replica_infos:
                 if info.version == latest_version:
                     if info.is_ready:
@@ -493,9 +492,10 @@ class FallbackRequestRateAutoscaler(RequestRateAutoscaler):
         replica_infos: List['replica_managers.ReplicaInfo'],
     ) -> List[AutoscalerDecision]:
 
+        latest_version = serve_state.get_latest_version(self._service_name)
         latest_nonterminal_replicas = list(
             filter(
-                lambda info: not info.is_terminal and info.version == self.
+                lambda info: not info.is_terminal and info.version ==
                 latest_version, replica_infos))
 
         self._set_target_num_replica_with_hysteresis()

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -169,9 +169,9 @@ class RequestRateAutoscaler(Autoscaler):
         return max(self.min_replicas, min(self.max_replicas,
                                           target_num_replicas))
 
-    def update_version(self, version: int, spec: 'service_spec.SkyServiceSpec',
+    def update_version(self, spec: 'service_spec.SkyServiceSpec',
                        update_mode: serve_utils.UpdateMode) -> None:
-        super().update_version(version, spec, update_mode)
+        super().update_version(spec, update_mode)
         self.target_qps_per_replica = spec.target_qps_per_replica
         upscale_delay_seconds = (
             spec.upscale_delay_seconds if spec.upscale_delay_seconds is not None
@@ -468,9 +468,9 @@ class FallbackRequestRateAutoscaler(RequestRateAutoscaler):
             spec.dynamic_ondemand_fallback
             if spec.dynamic_ondemand_fallback is not None else False)
 
-    def update_version(self, version: int, spec: 'service_spec.SkyServiceSpec',
+    def update_version(self, spec: 'service_spec.SkyServiceSpec',
                        update_mode: serve_utils.UpdateMode) -> None:
-        super().update_version(version, spec, update_mode=update_mode)
+        super().update_version(spec, update_mode=update_mode)
         self.base_ondemand_fallback_replicas = (
             spec.base_ondemand_fallback_replicas
             if spec.base_ondemand_fallback_replicas is not None else 0)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -120,10 +120,11 @@ class SkyServeController:
                 logger.info(
                     f'Update to new version version {version}: {service}')
 
-                # TODO(Xuanlin Jiang): This assertion is disabled because of
-                # possibility of race condition.
-                # assert version == self._replica_manager.get_latest_version(
-                #    self._service_name)
+                latest_version = serve_state.get_latest_version()
+                if version != latest_version:
+                    logger.error(f'Invalid version {version}, '
+                                 f'latest version: {latest_version}.')
+                    return
 
                 self._replica_manager.update_version(service,
                                                      update_mode=update_mode)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -120,8 +120,12 @@ class SkyServeController:
                 logger.info(
                     f'Update to new version version {version}: {service}')
 
-                self._replica_manager.update_version(version,
-                                                     service,
+                # TODO(Xuanlin Jiang): This assertion is disabled because of 
+                # possibility of race condition.
+                # assert version == self._replica_manager.get_latest_version(
+                #    self._service_name)
+                
+                self._replica_manager.update_version(service,
                                                      update_mode=update_mode)
                 new_autoscaler = autoscalers.Autoscaler.from_spec(
                     self._service_name, service)
@@ -132,8 +136,7 @@ class SkyServeController:
                     self._autoscaler = new_autoscaler
                     self._autoscaler.load_dynamic_states(
                         old_autoscaler.dump_dynamic_states())
-                self._autoscaler.update_version(version,
-                                                service,
+                self._autoscaler.update_version(service,
                                                 update_mode=update_mode)
                 return {'message': 'Success'}
             except Exception as e:  # pylint: disable=broad-except

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -120,7 +120,8 @@ class SkyServeController:
                 logger.info(
                     f'Update to new version version {version}: {service}')
 
-                latest_version = serve_state.get_latest_version()
+                latest_version = serve_state.get_latest_version(
+                    self._service_name)
                 if version != latest_version:
                     logger.error(f'Invalid version {version}, '
                                  f'latest version: {latest_version}.')

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -120,11 +120,11 @@ class SkyServeController:
                 logger.info(
                     f'Update to new version version {version}: {service}')
 
-                # TODO(Xuanlin Jiang): This assertion is disabled because of 
+                # TODO(Xuanlin Jiang): This assertion is disabled because of
                 # possibility of race condition.
                 # assert version == self._replica_manager.get_latest_version(
                 #    self._service_name)
-                
+
                 self._replica_manager.update_version(service,
                                                      update_mode=update_mode)
                 new_autoscaler = autoscalers.Autoscaler.from_spec(

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -556,7 +556,7 @@ class ReplicaManager:
         """Scale down replica with replica_id."""
         raise NotImplementedError
 
-    def update_version(self, version: int, spec: 'service_spec.SkyServiceSpec',
+    def update_version(self, spec: 'service_spec.SkyServiceSpec',
                        update_mode: serve_utils.UpdateMode) -> None:
         raise NotImplementedError
 

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -882,21 +882,23 @@ class SkyPilotReplicaManager(ReplicaManager):
                     serve_state.remove_replica(self._service_name, replica_id)
                     logger.info(f'Replica {replica_id} removed from the '
                                 f'replica table {removal_reason}.')
-                    
+
                     removed_version = info.version
-                    replica_infos = serve_state.get_replica_infos(self._service_name)
+                    replica_infos = serve_state.get_replica_infos(
+                        self._service_name)
                     no_replica_of_removed_version = all([
-                        info.version != removed_version for info in replica_infos
+                        info.version != removed_version
+                        for info in replica_infos
                     ])
-                    if (no_replica_of_removed_version and 
-                        removed_version != latest_version):
+                    if (no_replica_of_removed_version and
+                            removed_version != latest_version):
                         task_yaml = serve_utils.generate_task_yaml_file_name(
                             self._service_name, removed_version)
                         # Delete old version metadata.
-                        serve_state.delete_version(self._service_name, removed_version)
+                        serve_state.delete_version(self._service_name,
+                                                   removed_version)
                         # Delete storage buckets of older versions.
                         service.cleanup_storage(task_yaml)
-
 
     def _process_pool_refresher(self) -> None:
         """Periodically refresh the launch/down process pool."""

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -515,6 +515,17 @@ def get_latest_version(service_name: str) -> int:
         return row[0]
     raise ValueError(f'No version found for service {service_name}')
 
+def get_least_recent_version(service_name: str) -> int:
+    """Gets the least recent version of a service."""
+    with db_utils.safe_cursor(_DB_PATH) as cursor:
+        rows = cursor.execute(
+            """\
+            SELECT MIN(version) FROM version_specs
+            WHERE service_name=(?)""", (service_name,)).fetchall()
+    for row in rows:
+        return row[0]
+    raise ValueError(f'No version found for service {service_name}')
+
 
 def delete_version(service_name: str, version: int) -> None:
     """Deletes a version from the database."""

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -504,7 +504,7 @@ def get_spec(service_name: str,
     return None
 
 
-def get_latest_version(service_name: str) -> Optional[int]:
+def get_latest_version(service_name: str) -> int:
     """Gets the latest version of a service."""
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute(
@@ -513,7 +513,7 @@ def get_latest_version(service_name: str) -> Optional[int]:
             WHERE service_name=(?)""", (service_name,)).fetchall()
     for row in rows:
         return row[0]
-    return None
+    raise ValueError(f'No version found for service {service_name}')
 
 
 def delete_version(service_name: str, version: int) -> None:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -515,6 +515,7 @@ def get_latest_version(service_name: str) -> int:
         return row[0]
     raise ValueError(f'No version found for service {service_name}')
 
+
 def get_least_recent_version(service_name: str) -> int:
     """Gets the least recent version of a service."""
     with db_utils.safe_cursor(_DB_PATH) as cursor:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -504,6 +504,18 @@ def get_spec(service_name: str,
     return None
 
 
+def get_latest_version(service_name: str) -> Optional[int]:
+    """Gets the latest version of a service."""
+    with db_utils.safe_cursor(_DB_PATH) as cursor:
+        rows = cursor.execute(
+            """\
+            SELECT MAX(version) FROM version_specs
+            WHERE service_name=(?)""", (service_name,)).fetchall()
+    for row in rows:
+        return row[0]
+    return None
+
+
 def delete_version(service_name: str, version: int) -> None:
     """Deletes a version from the database."""
     with db_utils.safe_cursor(_DB_PATH) as cursor:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Remove `latest_version` field in `AutoScaler` class

* Remove `latest_version` and `least_recent_version` fields in `ReplicaManager` class

* Add a function in `serve_state.py` to retrieve version information from database

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
(Run on AWS) `pytest tests/test_smoke.py::test_skyserve_update`  `pytest tests/test_smoke.py::test_skyserve_rolling_update` `pytest tests/test_smoke.py::test_skyserve_fast_update` `pytest tests/test_smoke.py::test_skyserve_update_autoscale` `pytest tests/test_smoke.py::test_skyserve_new_autoscaler_update` 

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`