### PR TITLE
[Serve] Expose replica and controller urls on load balancer

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -114,7 +114,14 @@ User
     storage.objects.get
     storage.objects.list
 
-5. **Optional**: If the user needs to access TPU VMs, you can additionally add the following permissions (the following may not be exhaustive, please file an issue if you find any missing permissions):
+5. **Optional**: If :code:`--ports` or :ref:`SkyServe <sky-serve>` is used, you can additionally add the following permissions:
+
+.. code-block:: text
+
+    compute.firewalls.list
+    compute.networks.updatePolicy
+
+6. **Optional**: If the user needs to access TPU VMs, you can additionally add the following permissions (the following may not be exhaustive, please file an issue if you find any missing permissions):
 
 .. code-block:: text
 
@@ -125,7 +132,7 @@ User
     tpu.nodes.update
     tpu.operations.get
 
-6. **Optional**: To enable ``sky launch --clone-disk-from``, you need to have the following permissions for the role as well:
+7. **Optional**: To enable ``sky launch --clone-disk-from``, you need to have the following permissions for the role as well:
 
 .. code-block:: text
 
@@ -134,7 +141,7 @@ User
     compute.images.get
     compute.images.delete
 
-7. **Optional**: To enable opening ports on GCP cluster, you need to have the following permissions for the role as well:
+8. **Optional**: To enable opening ports on GCP cluster, you need to have the following permissions for the role as well:
 
 .. code-block:: text
 
@@ -142,7 +149,7 @@ User
     compute.firewalls.list
     compute.firewalls.update
 
-8. **Optional**: If the user needs to use custom machine images with ``sky launch --image-id``, you can additionally add the following permissions:
+9. **Optional**: If the user needs to use custom machine images with ``sky launch --image-id``, you can additionally add the following permissions:
 
 .. code-block:: text
     
@@ -151,15 +158,15 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
+10. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 
     compute.reservations.list
 
-9. Click **Create** to create the role.
-10. Go back to the "IAM" tab and click on **GRANT ACCESS**.
-11. Fill in the email address of the user in the “Add principals” section, and select ``minimal-skypilot-role`` in the “Assign roles” section. Click **Save**.
+11. Click **Create** to create the role.
+12. Go back to the "IAM" tab and click on **GRANT ACCESS**.
+13. Fill in the email address of the user in the “Add principals” section, and select ``minimal-skypilot-role`` in the “Assign roles” section. Click **Save**.
 
 
 .. image:: ../../images/screenshots/gcp/create-iam.png
@@ -167,7 +174,7 @@ User
     :align: center
     :alt: GCP Grant Access
 
-12. The user should receive an invitation to the project and should be able to setup SkyPilot by following the instructions in :ref:`Installation <installation-gcp>`.
+14. The user should receive an invitation to the project and should be able to setup SkyPilot by following the instructions in :ref:`Installation <installation-gcp>`.
 
 .. note::
 

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -99,11 +99,10 @@ class SkyServeLoadBalancer:
             if not ready_replica_url.startswith('http'):
                 ready_replica_url = 'http://' + ready_replica_url
             ready_replica_urls[i] = ready_replica_url
-        return fastapi.responses.JSONResponse(
-            content={
-                'controller': self._controller_url,
-                'replicas': ready_replica_urls
-            })
+        return fastapi.responses.JSONResponse(content={
+            'controller': self._controller_url,
+            'replicas': ready_replica_urls
+        })
 
     def run(self):
         self._app.add_api_route('/-/urls', self._get_urls, methods=['GET'])

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -91,7 +91,22 @@ class SkyServeLoadBalancer:
         logger.info(f'Redirecting request to {path}')
         return fastapi.responses.RedirectResponse(url=path)
 
+    async def _get_urls(self, request: fastapi.Request):
+        del request  # Unused
+
+        ready_replica_urls = self._load_balancing_policy.ready_replicas
+        for i, ready_replica_url in enumerate(ready_replica_urls):
+            if not ready_replica_url.startswith('http'):
+                ready_replica_url = 'http://' + ready_replica_url
+            ready_replica_urls[i] = ready_replica_url
+        return fastapi.responses.JSONResponse(
+            content={
+                'controller': self._controller_url,
+                'replicas': ready_replica_urls
+            })
+
     def run(self):
+        self._app.add_api_route('/-/urls', self._get_urls, methods=['GET'])
         self._app.add_api_route('/{path:path}',
                                 self._redirect_handler,
                                 methods=['GET', 'POST', 'PUT', 'DELETE'])

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -141,10 +141,12 @@ def _get_cloud_dependencies_installation_commands(
         controller_type: str) -> List[str]:
     commands = [
         # aws
+        'echo Installing AWS dependencies...; '
         'pip list | grep boto3 > /dev/null 2>&1 || '
         'pip install "urllib3<2" awscli>=1.27.10 botocore>=1.29.10 '
         'boto3>=1.26.1 > /dev/null 2>&1',
         # gcp
+        'echo Installing GCP dependencies...; '
         'pip list | grep google-api-python-client > /dev/null 2>&1 || '
         'pip install google-api-python-client>=2.69.0 google-cloud-storage '
         '> /dev/null 2>&1',
@@ -164,6 +166,7 @@ def _get_cloud_dependencies_installation_commands(
             cloud.is_same_cloud(clouds.Azure())
             for cloud in global_user_state.get_enabled_clouds()):
         commands.append(
+            'echo Installing Azure dependencies...; '
             'pip list | grep azure-cli > /dev/null 2>&1 || '
             'pip install azure-cli>=2.31.0 azure-core azure-identity>=1.13.0 '
             'azure-mgmt-network > /dev/null 2>&1')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now expose replica URLs from the load balancer for better metrics support.

```
curl http://lb_endpoint/-/urls

{
  'controller': 'http://endpoint:30001',
  'replicas': ['http://ip1:8080', 'http://ip2:8080']
}
```

Future TODO:
- Add prometheus example

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky serve up -n test examples/serve/http_server/task.yaml`
  - [x] `curl $(sky serve status --endpoint test)/-/urls`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
