### PR TITLE
[UX][Serve] More comprehensive `target_qps_per_replica` check

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -217,6 +217,8 @@ class RequestRateAutoscaler(Autoscaler):
         index = bisect.bisect_left(self.request_timestamps,
                                    current_time - self.qps_window_size)
         self.request_timestamps = self.request_timestamps[index:]
+        logger.info(f'Num of requests in the last {self.qps_window_size} '
+                    f'seconds: {len(self.request_timestamps)}')
 
     def _set_target_num_replica_with_hysteresis(self) -> None:
         """Set target_num_replicas based on request rate with hysteresis."""

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -58,7 +58,7 @@ class SkyServiceSpec:
             if max_replicas is not None and max_replicas != min_replicas:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        'Detect different min_replicas and max_replicas '
+                        'Detected different min_replicas and max_replicas '
                         'while target_qps_per_replica is not set. To enable '
                         'autoscaling, please set target_qps_per_replica.')
 
@@ -258,8 +258,7 @@ class SkyServiceSpec:
         # TODO(tian): Refactor to contain more information
         max_plural = '' if self.max_replicas == 1 else 's'
         return (f'Autoscaling from {self.min_replicas} to {self.max_replicas} '
-                f'replica{max_plural} with Target {self.target_qps_per_replica}'
-                ' QPS/replica')
+                f'replica{max_plural} (target QPS per replica: {self.target_qps_per_replica})')
 
     def __repr__(self) -> str:
         return textwrap.dedent(f"""\

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -37,27 +37,44 @@ class SkyServiceSpec:
     ) -> None:
         if max_replicas is not None and max_replicas < min_replicas:
             with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'max_replicas must be greater than or equal to min_replicas'
-                )
+                raise ValueError('max_replicas must be greater than or '
+                                 'equal to min_replicas. Found: '
+                                 f'min_replicas={min_replicas}, '
+                                 f'max_replicas={max_replicas}')
 
-        if target_qps_per_replica is not None and max_replicas is None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError('max_replicas must be set where '
-                                 'target_qps_per_replica is set.')
+        if target_qps_per_replica is not None:
+            if max_replicas is None:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError('max_replicas must be set where '
+                                     'target_qps_per_replica is set.')
+            if max_replicas == min_replicas:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        'Detect min_replicas equal to max_replicas while '
+                        'target_qps_per_replica is set. No autoscaling will '
+                        'be performed. Please set different min_replicas and '
+                        'max_replicas to enable autoscaling.')
+        else:
+            if max_replicas is not None and max_replicas != min_replicas:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        'Detect different min_replicas and max_replicas '
+                        'while target_qps_per_replica is not set. To enable '
+                        'autoscaling, please set target_qps_per_replica.')
 
         if not readiness_path.startswith('/'):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('readiness_path must start with a slash (/). '
                                  f'Got: {readiness_path}')
 
+        # TODO(tian): Following field are deprecated. Remove after 2 minor
+        # release, i.e. 0.6.0.
         if qps_upper_threshold is not None or qps_lower_threshold is not None:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Field `qps_upper_threshold` and `qps_lower_threshold`'
                     'under `replica_policy` are deprecated. '
                     'Please use target_qps_per_replica instead.')
-
         if auto_restart is not None:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
@@ -236,10 +253,13 @@ class SkyServiceSpec:
         min_plural = '' if self.min_replicas == 1 else 's'
         if self.max_replicas == self.min_replicas or self.max_replicas is None:
             return f'Fixed {self.min_replicas} replica{min_plural}'
+        # Already checked in __init__.
+        assert self.target_qps_per_replica is not None
         # TODO(tian): Refactor to contain more information
         max_plural = '' if self.max_replicas == 1 else 's'
-        return (f'Autoscaling from {self.min_replicas} to '
-                f'{self.max_replicas} replica{max_plural}')
+        return (f'Autoscaling from {self.min_replicas} to {self.max_replicas} '
+                f'replica{max_plural} with Target {self.target_qps_per_replica}'
+                ' QPS/replica')
 
     def __repr__(self) -> str:
         return textwrap.dedent(f"""\

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -47,13 +47,6 @@ class SkyServiceSpec:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError('max_replicas must be set where '
                                      'target_qps_per_replica is set.')
-            if max_replicas == min_replicas:
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError(
-                        'Detect min_replicas equal to max_replicas while '
-                        'target_qps_per_replica is set. No autoscaling will '
-                        'be performed. Please set different min_replicas and '
-                        'max_replicas to enable autoscaling.')
         else:
             if max_replicas is not None and max_replicas != min_replicas:
                 with ux_utils.print_exception_no_traceback():
@@ -258,7 +251,8 @@ class SkyServiceSpec:
         # TODO(tian): Refactor to contain more information
         max_plural = '' if self.max_replicas == 1 else 's'
         return (f'Autoscaling from {self.min_replicas} to {self.max_replicas} '
-                f'replica{max_plural} (target QPS per replica: {self.target_qps_per_replica})')
+                f'replica{max_plural} (target QPS per replica: '
+                f'{self.target_qps_per_replica})')
 
     def __repr__(self) -> str:
         return textwrap.dedent(f"""\


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3359

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
1. Autoscaling enabled
```yaml
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 20
  replica_policy:
    min_replicas: 1
    max_replicas: 2
    target_qps_per_replica: 1
```
```bash
$ sky serve up -n http @temp/svc.yaml
Service from YAML spec: @temp/svc.yaml
Service Spec:
Readiness probe method:           GET /health
Readiness initial delay seconds:  20
Replica autoscaling policy:       Autoscaling from 1 to 2 replicas with Target 1 QPS/replica
Spot Policy:                      No spot policy
```
2. Error (`target_qps_per_replica` not set)
```yaml
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 20
  replica_policy:
    min_replicas: 1
    max_replicas: 2
```
```bash
$ sky serve up -n http @temp/svc.yaml
Service from YAML spec: @temp/svc.yaml
ValueError: Detect different min_replicas and max_replicas while target_qps_per_replica is not set. To enable autoscaling, please set target_qps_per_replica.
```
3. Fixed replicas when min==max
```yaml
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 20
  replica_policy:
    min_replicas: 1
    max_replicas: 1
    target_qps_per_replica: 1
```
```bash
$ sky serve up -n http @temp/svc.yaml
Service from YAML spec: @temp/svc.yaml
Service Spec:
Readiness probe method:           GET /health
Readiness initial delay seconds:  20
Replica autoscaling policy:       Fixed 1 replica
Spot Policy:                      No spot policy
```
4. Autoscaling disabled
```bash
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 20
  replica_policy:
    min_replicas: 1
    max_replicas: 1
```
```bash
$ sky serve up -n http @temp/svc.yaml
Service from YAML spec: @temp/svc.yaml
Service Spec:
Readiness probe method:           GET /health
Readiness initial delay seconds:  20
Replica autoscaling policy:       Fixed 1 replica
Spot Policy:                      No spot policy
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
