### PR TITLE
[UX/Catalog] Add DEVICE_MEM info to GCP GPUs.

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -308,10 +308,14 @@ def _get_gpus_for_zone(zone: str) -> pd.DataFrame:
                 continue
             if gpu_name.startswith('TPU-'):
                 continue
+            gpu_info = _gpu_info_from_name(gpu_name)
+            if gpu_info is None:
+                # Prevent `show-gpus` from not showing GPUs without GPU info.
+                gpu_info = gpu_name
             new_gpus.append({
                 'AcceleratorName': gpu_name,
                 'AcceleratorCount': count,
-                'GpuInfo': _gpu_info_from_name(gpu_name),
+                'GpuInfo': gpu_info,
                 'Region': zone.rpartition('-')[0],
                 'AvailabilityZone': zone,
             })
@@ -331,6 +335,7 @@ def _gpu_info_from_name(name: str) -> Optional[Dict[str, List[Dict[str, Any]]]]:
         'P4': 8 * 1024,
         'T4': 16 * 1024,
         'V100': 16 * 1024,
+        'P100': 16 * 1024,
         # End of life:
         'K80': 12 * 1024,
     }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Previously, `DEVICE_MEM` is missing in `sky show-gpus` GCP results. This was because GCP APIs didn't explicitly return such info.

Now:
```console
» sky show-gpus L4:1 --cloud gcp
GPU  QTY  CLOUD  INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION
L4   1    GCP    g2-standard-4  24GB        4      16GB      $ 0.705       $ 0.248            us-east4

» sky show-gpus A100:1 --cloud gcp
GPU   QTY  CLOUD  INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION
A100  1    GCP    a2-highgpu-1g  40GB        12     85GB      $ 3.673       $ 1.469            us-central1

GPU        QTY  CLOUD  INSTANCE_TYPE   DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION   
A100-80GB  1    GCP    a2-ultragpu-1g  80GB        12     170GB     $ 5.028       $ 2.011            us-central1
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
