### PR TITLE
[pypi] Allow existing file on pypi

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -57,8 +57,10 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When the nightly build experience a temporary failure (eg network issue), and we retry the CI/CD, it could fail as the file could already exist on testpypi (though not exists on pypi). 

This PR adds `skip-existing: true` to ignore the error for existing file on the remote repo.

Reference:
First attempt: https://github.com/skypilot-org/skypilot/actions/runs/8466029811/attempts/1
second attempt: https://github.com/skypilot-org/skypilot/actions/runs/8466029811/attempts/2

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
