### PR TITLE
[core] Prevent clouds from blocking `sky check`

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -28,7 +28,7 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
         except Exception:  # pylint: disable=broad-except
             # Catch all exceptions to prevent a single cloud from blocking the
             # check for other clouds.
-            ok, reason = False, str(traceback.format_exc())
+            ok, reason = False, traceback.format_exc()
         echo('\r', nl=False)
         status_msg = 'enabled' if ok else 'disabled'
         styles = {'fg': 'green', 'bold': False} if ok else {'dim': True}

--- a/sky/check.py
+++ b/sky/check.py
@@ -1,10 +1,10 @@
 """Credential checks: check cloud credentials and enable clouds."""
+import traceback
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 import colorama
 import rich
-import traceback
 
 from sky import clouds
 from sky import exceptions
@@ -25,7 +25,7 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
         echo(f'  Checking {cloud_repr}...', nl=False)
         try:
             ok, reason = cloud.check_credentials()
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             # Catch all exceptions to prevent a single cloud from blocking the
             # check for other clouds.
             ok, reason = False, str(traceback.format_exc())

--- a/sky/check.py
+++ b/sky/check.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 import click
 import colorama
 import rich
+import traceback
 
 from sky import clouds
 from sky import exceptions
@@ -22,7 +23,12 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
     def check_one_cloud(cloud_tuple: Tuple[str, clouds.Cloud]) -> None:
         cloud_repr, cloud = cloud_tuple
         echo(f'  Checking {cloud_repr}...', nl=False)
-        ok, reason = cloud.check_credentials()
+        try:
+            ok, reason = cloud.check_credentials()
+        except Exception as e:  # pylint: disable=broad-except
+            # Catch all exceptions to prevent a single cloud from blocking the
+            # check for other clouds.
+            ok, reason = False, str(traceback.format_exc())
         echo('\r', nl=False)
         status_msg = 'enabled' if ok else 'disabled'
         styles = {'fg': 'green', 'bold': False} if ok else {'dim': True}


### PR DESCRIPTION
Cloud implementations may misbehave and throw exceptions up to `check.check()`. This blocks `sky check` from running on other clouds, and can often be hard to fix without disabling the cloud by moving files around/uninstalling dependencies. Examples:

* #3385
* OCI - if the path specified in `key_file` in `~/.oci/config` does not exist
* ...

This PR adds a broad exception catch to sky check to catch unexpected failures and gracefully fail by show the traceback as the reason for cloud disable.

Example:

```
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled
  Azure: enabled
  Cloudflare, for R2 object store: disabled
    Reason: [r2] profile is not set in ~/.cloudflare/r2.credentials. Additionally, Account ID from R2 dashboard is not set. Run the following commands:
      $ pip install boto3
      $ AWS_SHARED_CREDENTIALS_FILE=~/.cloudflare/r2.credentials aws configure --profile r2
      $ mkdir -p ~/.cloudflare
      $ echo <YOUR_ACCOUNT_ID_HERE> > ~/.cloudflare/accountid
    For more info: https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#cloudflare-r2
  Cudo: disabled
    Reason: Traceback (most recent call last):
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/check.py", line 27, in check_one_cloud
    ok, reason = cloud.check_credentials()
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/clouds/cudo.py", line 293, in check_credentials
    project_id, error = cudo_api.get_project_id()
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/cudo_compute/cudo_api.py", line 34, in get_project_id
    return context_config['project'], None
KeyError: 'project'

  Fluidstack: enabled
  Checking GCP...INFO:googleapiclient.discovery_cache:file_cache is only supported with oauth2client<4.0.0
  GCP: enabled
  IBM: enabled
  Kubernetes: enabled
  Lambda: enabled
  OCI: enabled
  Paperspace: enabled
  RunPod: enabled
  SCP: disabled
    Reason: Failed to access SCP with credentials. To configure credentials, see: https://cloud.samsungsds.com/openapiguide
    Generate API key and add the following line to ~/.scp/scp_credential:
      access_key = [YOUR API ACCESS KEY]
      secret_key = [YOUR API SECRET KEY]
      project_id = [YOUR PROJECT ID]
  vSphere: disabled
    Reason: vSphere dependencies are not installed. Run the following commands:
      $ pip install skypilot[vSphere]
    Credentials may also need to be set. For more details. See https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#vmware-vsphere[ModuleNotFoundError] No module named 'pyVmomi'
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`