### PR TITLE
[Storage] Add CloudImplementationFeature for Storage Mounting

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 import click
 import colorama
 import rich
+import traceback
 
 from sky import clouds
 from sky import exceptions
@@ -22,7 +23,12 @@ def check(quiet: bool = False, verbose: bool = False) -> None:
     def check_one_cloud(cloud_tuple: Tuple[str, clouds.Cloud]) -> None:
         cloud_repr, cloud = cloud_tuple
         echo(f'  Checking {cloud_repr}...', nl=False)
-        ok, reason = cloud.check_credentials()
+        try:
+            ok, reason = cloud.check_credentials()
+        except Exception as e:  # pylint: disable=broad-except
+            # Catch all exceptions to prevent a single cloud from blocking the
+            # check for other clouds.
+            ok, reason = False, str(traceback.format_exc())
         echo('\r', nl=False)
         status_msg = 'enabled' if ok else 'disabled'
         styles = {'fg': 'green', 'bold': False} if ok else {'dim': True}

--- a/sky/check.py
+++ b/sky/check.py
@@ -1,10 +1,10 @@
 """Credential checks: check cloud credentials and enable clouds."""
+import traceback
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import click
 import colorama
 import rich
-import traceback
 
 from sky import clouds
 from sky import exceptions

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -41,6 +41,7 @@ class CloudImplementationFeatures(enum.Enum):
     SPOT_INSTANCE = 'spot_instance'
     CUSTOM_DISK_TIER = 'custom_disk_tier'
     OPEN_PORTS = 'open_ports'
+    STORAGE_MOUNTING = 'storage_mounting'
 
 
 class Region(collections.namedtuple('Region', ['name'])):

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -41,8 +41,8 @@ class RunPod(clouds.Cloud):
             ('Customizing disk tier is not supported yet on RunPod.'),
         clouds.CloudImplementationFeatures.STORAGE_MOUNTING:
             ('Mounting object stores is not supported on RunPod. To read data '
-             'from object stores, use `mode: COPY` to copy the data to '
-             'local disk.'),
+             'from object stores on RunPod, use `mode: COPY` to copy the data '
+             'to local disk.'),
     }
     _MAX_CLUSTER_NAME_LEN_LIMIT = 120
     _regions: List[clouds.Region] = []

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -38,7 +38,11 @@ class RunPod(clouds.Cloud):
         clouds.CloudImplementationFeatures.DOCKER_IMAGE:
             (f'Docker image is currently not supported on {_REPR}.'),
         clouds.CloudImplementationFeatures.CUSTOM_DISK_TIER:
-            ('Customizing disk tier is not supported yet on RunPod.')
+            ('Customizing disk tier is not supported yet on RunPod.'),
+        clouds.CloudImplementationFeatures.STORAGE_MOUNTING:
+            ('Mounting object stores is not supported on RunPod. To read data '
+             'from object stores, use `mode: COPY` to copy the data to '
+             'local disk.'),
     }
     _MAX_CLUSTER_NAME_LEN_LIMIT = 120
     _regions: List[clouds.Region] = []

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -234,8 +234,8 @@ def _execute(
     # Requested features that some clouds support and others don't.
     requested_features = set()
 
-    if task.num_nodes > 1:
-        requested_features.add(clouds.CloudImplementationFeatures.MULTI_NODE)
+    # Add requested features from the task
+    requested_features |= task.get_requested_features()
 
     backend = backend if backend is not None else backends.CloudVmRayBackend()
     if isinstance(backend, backends.CloudVmRayBackend):

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -235,7 +235,7 @@ def _execute(
     requested_features = set()
 
     # Add requested features from the task
-    requested_features |= task.get_requested_features()
+    requested_features |= task.get_required_cloud_features()
 
     backend = backend if backend is not None else backends.CloudVmRayBackend()
     if isinstance(backend, backends.CloudVmRayBackend):

--- a/sky/task.py
+++ b/sky/task.py
@@ -1066,6 +1066,26 @@ class Task:
             })
         return config
 
+    def get_requested_features(self) -> Set[str]:
+        """Returns the requested features for this task.
+
+        INTERNAL: this method is internal-facing.
+        """
+        requested_features = set()
+
+        # Multi-node
+        if self.num_nodes > 1:
+            requested_features.add(clouds.CloudImplementationFeatures.MULTI_NODE)
+
+        # Storage mounting
+        for path, storage_mount in self.storage_mounts.items():
+            if storage_mount.mode == storage_lib.StorageMode.MOUNT:
+                requested_features.add(
+                    clouds.CloudImplementationFeatures.STORAGE_MOUNTING)
+                break
+
+        return requested_features
+
     def __rshift__(self, b):
         sky.dag.get_current_dag().add_edge(self, b)
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -1066,7 +1066,8 @@ class Task:
             })
         return config
 
-    def get_required_cloud_features(self) -> Set[clouds.CloudImplementationFeatures]:
+    def get_required_cloud_features(
+            self) -> Set[clouds.CloudImplementationFeatures]:
         """Returns the required features for this task (but not for resources).
 
         Features required by the resources are checked separately in
@@ -1078,8 +1079,7 @@ class Task:
 
         # Multi-node
         if self.num_nodes > 1:
-            required_features.add(
-                clouds.CloudImplementationFeatures.MULTI_NODE)
+            required_features.add(clouds.CloudImplementationFeatures.MULTI_NODE)
 
         # Storage mounting
         for _, storage_mount in self.storage_mounts.items():

--- a/sky/task.py
+++ b/sky/task.py
@@ -1067,7 +1067,10 @@ class Task:
         return config
 
     def get_required_cloud_features(self) -> Set[clouds.CloudImplementationFeatures]:
-        """Returns the required features for this task.
+        """Returns the required features for this task (but not for resources).
+
+        Features required by the resources are checked separately in
+        cloud.get_feasible_launchable_resources().
 
         INTERNAL: this method is internal-facing.
         """

--- a/sky/task.py
+++ b/sky/task.py
@@ -1066,26 +1066,26 @@ class Task:
             })
         return config
 
-    def get_requested_features(self) -> Set[clouds.CloudImplementationFeatures]:
-        """Returns the requested features for this task.
+    def get_required_cloud_features(self) -> Set[clouds.CloudImplementationFeatures]:
+        """Returns the required features for this task.
 
         INTERNAL: this method is internal-facing.
         """
-        requested_features = set()
+        required_features = set()
 
         # Multi-node
         if self.num_nodes > 1:
-            requested_features.add(
+            required_features.add(
                 clouds.CloudImplementationFeatures.MULTI_NODE)
 
         # Storage mounting
         for _, storage_mount in self.storage_mounts.items():
             if storage_mount.mode == storage_lib.StorageMode.MOUNT:
-                requested_features.add(
+                required_features.add(
                     clouds.CloudImplementationFeatures.STORAGE_MOUNTING)
                 break
 
-        return requested_features
+        return required_features
 
     def __rshift__(self, b):
         sky.dag.get_current_dag().add_edge(self, b)

--- a/sky/task.py
+++ b/sky/task.py
@@ -1066,7 +1066,7 @@ class Task:
             })
         return config
 
-    def get_requested_features(self) -> Set[str]:
+    def get_requested_features(self) -> Set[clouds.CloudImplementationFeatures]:
         """Returns the requested features for this task.
 
         INTERNAL: this method is internal-facing.
@@ -1075,10 +1075,11 @@ class Task:
 
         # Multi-node
         if self.num_nodes > 1:
-            requested_features.add(clouds.CloudImplementationFeatures.MULTI_NODE)
+            requested_features.add(
+                clouds.CloudImplementationFeatures.MULTI_NODE)
 
         # Storage mounting
-        for path, storage_mount in self.storage_mounts.items():
+        for _, storage_mount in self.storage_mounts.items():
             if storage_mount.mode == storage_lib.StorageMode.MOUNT:
                 requested_features.add(
                     clouds.CloudImplementationFeatures.STORAGE_MOUNTING)


### PR DESCRIPTION
RunPod does not support storage mounting since the container is not run in privileged mode (or with CAP_SYS_ADMIN). As a result, `/dev/fuse` is not available inside the container and goofys/gcsfuse cannot function.

For a user, this reflects very late into their workflow when mounting fails after provisioning.

This PR adds `CloudImplementationFeatures.STORAGE_MOUNTING` to provide early failover for clouds which don't support mounting.

```
I 03-28 15:25:27 optimizer.py:690] == Optimizer ==
I 03-28 15:25:27 optimizer.py:701] Target: minimizing cost
I 03-28 15:25:27 optimizer.py:713] Estimated cost: $0.3 / hour
I 03-28 15:25:27 optimizer.py:713] 
I 03-28 15:25:27 optimizer.py:836] Considered resources (1 node):
I 03-28 15:25:27 optimizer.py:906] --------------------------------------------------------------------------------------------------
I 03-28 15:25:27 optimizer.py:906]  CLOUD    INSTANCE             vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 03-28 15:25:27 optimizer.py:906] --------------------------------------------------------------------------------------------------
I 03-28 15:25:27 optimizer.py:906]  RunPod   1x_RTXA4000_SECURE   6       16        RTXA4000:1     CA            0.34          ✔     
I 03-28 15:25:27 optimizer.py:906] --------------------------------------------------------------------------------------------------
I 03-28 15:25:27 optimizer.py:906] 
Launching a new cluster 'runpod'. Proceed? [Y/n]: 
I 03-28 15:25:28 cloud_vm_ray_backend.py:4238] Creating a new cluster: 'runpod' [1x RunPod(1x_RTXA4000_SECURE, {'RTXA4000': 1})].
I 03-28 15:25:28 cloud_vm_ray_backend.py:4238] Tip: to reuse an existing cluster, specify --cluster (-c). Run `sky status` to see existing clusters.
W 03-28 15:25:28 cloud_vm_ray_backend.py:2013] sky.exceptions.NotSupportedError: The following features are not supported by RunPod:
W 03-28 15:25:28 cloud_vm_ray_backend.py:2013]  Feature           Reason                                                                                                                                          
W 03-28 15:25:28 cloud_vm_ray_backend.py:2013]  storage_mounting  Mounting object stores is not supported on RunPod. To read data from object stores on RunPod, use `mode: COPY` to copy the data to local disk.  
W 03-28 15:25:28 cloud_vm_ray_backend.py:2039] 
W 03-28 15:25:28 cloud_vm_ray_backend.py:2039] Provision failed for 1x RunPod(1x_RTXA4000_SECURE, {'RTXA4000': 1}) in CA. Trying other locations (if any).
```


Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested manually by launching a storage mounting task on RunPod and GCP