### PR TITLE
[kubernetes] Add curl and other dependencies in k8s image

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3:23.3.1-0
 
 # Initialize conda for root user, install ssh and other local dependencies
 RUN apt update -y && \
-    apt install gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat -y && \
+    apt install gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat curl -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt remove -y python3 && \
     conda init
@@ -31,7 +31,8 @@ RUN pip install wheel Click colorama cryptography jinja2 jsonschema && \
     pip install ray[default]==2.9.3 rich tabulate filelock && \
     pip install packaging 'protobuf<4.0.0' pulp && \
     pip install pycryptodome==3.12.0 && \
-    pip install docker kubernetes==28.1.0
+    pip install docker kubernetes==28.1.0 && \
+    pip install grpcio==1.51.3 python-dotenv==1.0.1
 
 # Add /home/sky/.local/bin/ to PATH
 RUN echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -7,7 +7,7 @@ FROM rayproject/ray:2.9.3-py310-gpu
 # We remove cuda lists to avoid conflicts with the cuda version installed by ray
 RUN sudo rm -rf /etc/apt/sources.list.d/cuda* && \
     sudo apt update -y && \
-    sudo apt install gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat -y && \
+    sudo apt install gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat curl -y && \
     sudo rm -rf /var/lib/apt/lists/* && \
     sudo apt remove -y python3 && \
     conda init
@@ -39,7 +39,8 @@ RUN pip install wheel Click colorama cryptography jinja2 jsonschema && \
     pip install rich tabulate filelock && \
     pip install packaging 'protobuf<4.0.0' pulp && \
     pip install pycryptodome==3.12.0 && \
-    pip install docker kubernetes==28.1.0
+    pip install docker kubernetes==28.1.0 && \
+    pip install grpcio==1.51.3 python-dotenv==1.0.1
 
 # Add /home/sky/.local/bin/ to PATH
 RUN echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to improve the dependency installation by pinning the version of the dependencies.

master: `for i in `seq 1 5`; do sky launch -y -c test-dep-$i --cloud kubernetes --cpus 1 echo hi; done`
```
1m21s
1m19s
1m22s
1m22s
1m24s
```
avg: 1m21.6s

this PR: `for i in `seq 1 5`; do sky launch -y -c test-dep-$i --cloud kubernetes --cpus 1 echo hi; done`
```
1m20s
1m27s
1m18s
1m20s
1m17s
```
avg: 1m20.4s



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
