### PR TITLE
[Core] Reduce import time with lazy imports and exec time by avoiding script rsync

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -37,13 +37,14 @@ from typing import Any, Callable
 from sky.adaptors import common
 from sky.utils import common_utils
 
-logger = logging.getLogger(__name__)
-
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for AWS. '
                          'Try pip install "skypilot[aws]"')
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',
                              import_error_message=_IMPORT_ERROR_MESSAGE)
+_LAZY_MODULES = (boto3, botocore)
+
+logger = logging.getLogger(__name__)
 _session_creation_lock = threading.RLock()
 
 version = 1
@@ -171,11 +172,15 @@ def client(service_name: str, **kwargs):
                               'client')
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def botocore_exceptions():
     """AWS botocore exception."""
-    return botocore.exceptions
+    from botocore import exceptions
+    return exceptions
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def botocore_config():
     """AWS botocore exception."""
-    return botocore.config
+    from botocore import config
+    return config

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -173,11 +173,9 @@ def client(service_name: str, **kwargs):
 
 def botocore_exceptions():
     """AWS botocore exception."""
-    from botocore import exceptions
-    return exceptions
+    return botocore.exceptions
 
 
 def botocore_config():
     """AWS botocore exception."""
-    from botocore import config
-    return config
+    return botocore.config

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -34,12 +34,16 @@ import threading
 import time
 from typing import Any, Callable
 
+from sky.adaptors import common
 from sky.utils import common_utils
 
 logger = logging.getLogger(__name__)
 
-boto3 = None
-botocore = None
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for AWS. '
+                         'Try pip install "skypilot[aws]"')
+boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
+botocore = common.LazyImport('botocore',
+                             import_error_message=_IMPORT_ERROR_MESSAGE)
 _session_creation_lock = threading.RLock()
 
 version = 1
@@ -71,25 +75,6 @@ def _thread_local_lru_cache(maxsize=32):
         return wrapper
 
     return decorator
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global boto3, botocore
-        if boto3 is None or botocore is None:
-            try:
-                import boto3 as _boto3
-                import botocore as _botocore
-                boto3 = _boto3
-                botocore = _botocore
-            except ImportError:
-                raise ImportError('Fail to import dependencies for AWS. '
-                                  'Try pip install "skypilot[aws]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 def _assert_kwargs_builtin_type(kwargs):
@@ -131,7 +116,6 @@ def _create_aws_object(creation_fn_or_cls: Callable[[], Any],
                         f'{common_utils.format_exception(e)}.')
 
 
-@import_package
 # The LRU cache needs to be thread-local to avoid multiple threads sharing the
 # same session object, which is not guaranteed to be thread-safe.
 @_thread_local_lru_cache()
@@ -140,7 +124,6 @@ def session():
     return _create_aws_object(boto3.session.Session, 'session')
 
 
-@import_package
 # Avoid caching the resource/client objects. If we are using the assumed role,
 # the credentials will be automatically rotated, but the cached resource/client
 # object will only refresh the credentials with a fixed 15 minutes interval,
@@ -172,7 +155,6 @@ def resource(service_name: str, **kwargs):
         lambda: session().resource(service_name, **kwargs), 'resource')
 
 
-@import_package
 def client(service_name: str, **kwargs):
     """Create an AWS client of a certain service.
 
@@ -189,14 +171,12 @@ def client(service_name: str, **kwargs):
                               'client')
 
 
-@import_package
 def botocore_exceptions():
     """AWS botocore exception."""
     from botocore import exceptions
     return exceptions
 
 
-@import_package
 def botocore_config():
     """AWS botocore exception."""
     from botocore import config

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -39,7 +39,7 @@ from sky.utils import common_utils
 
 logger = logging.getLogger(__name__)
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for AWS. '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for AWS. '
                          'Try pip install "skypilot[aws]"')
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -14,6 +14,7 @@ _LAZY_MODULES = (azure,)
 
 _session_creation_lock = threading.RLock()
 
+
 @common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_subscription_id() -> str:
     """Get the default subscription id."""
@@ -47,12 +48,10 @@ def get_client(name: str, subscription_id: str):
         credential = AzureCliCredential(process_timeout=30)
         if name == 'compute':
             from azure.mgmt.compute import ComputeManagementClient
-            return ComputeManagementClient(
-                credential, subscription_id)
+            return ComputeManagementClient(credential, subscription_id)
         elif name == 'network':
             from azure.mgmt.network import NetworkManagementClient
-            return NetworkManagementClient(
-                credential, subscription_id)
+            return NetworkManagementClient(credential, subscription_id)
         elif name == 'resource':
             from azure.mgmt.resource import ResourceManagementClient
             return ResourceManagementClient(credential, subscription_id)

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -8,7 +8,7 @@ from sky.adaptors import common
 
 azure = common.LazyImport(
     'azure',
-    import_error_message=('Fail to import dependencies for Azure.'
+    import_error_message=('Failed to import dependencies for Azure.'
                           'Try pip install "skypilot[azure]"'))
 _session_creation_lock = threading.RLock()
 

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -31,8 +31,8 @@ def get_current_account_user() -> str:
 @common.load_lazy_modules(modules=_LAZY_MODULES)
 def exceptions():
     """Azure exceptions."""
-    from azure.common import credentials
-    return credentials.get_cli_profile().get_current_account_user()
+    from azure.core import exceptions as azure_exceptions
+    return azure_exceptions
 
 
 @functools.lru_cache()

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -15,20 +15,17 @@ _session_creation_lock = threading.RLock()
 
 def get_subscription_id() -> str:
     """Get the default subscription id."""
-    from azure.common import credentials
-    return credentials.get_cli_profile().get_subscription_id()
+    return azure.common.credentials.get_cli_profile().get_subscription_id()
 
 
 def get_current_account_user() -> str:
     """Get the default account user."""
-    from azure.common import credentials
-    return credentials.get_cli_profile().get_current_account_user()
+    return azure.common.credentials.get_cli_profile().get_current_account_user()
 
 
 def exceptions():
     """Azure exceptions."""
-    from azure.core import exceptions as azure_exceptions
-    return azure_exceptions
+    return azure.core.exceptions
 
 
 @functools.lru_cache()
@@ -37,22 +34,20 @@ def get_client(name: str, subscription_id: str):
     # Increase the timeout to fix the Azure get-access-token timeout issue.
     # Tracked in
     # https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
-    from azure.identity import AzureCliCredential
-    from azure.mgmt.network import NetworkManagementClient
-    from azure.mgmt.resource import ResourceManagementClient
     with _session_creation_lock:
-        credential = AzureCliCredential(process_timeout=30)
+        credential = azure.identity.AzureCliCredential(process_timeout=30)
         if name == 'compute':
-            from azure.mgmt.compute import ComputeManagementClient
-            return ComputeManagementClient(credential, subscription_id)
+            return azure.mgmt.compute.ComputeManagementClient(
+                credential, subscription_id)
         elif name == 'network':
-            return NetworkManagementClient(credential, subscription_id)
+            return azure.mgmt.network.NetworkManagementClient(
+                credential, subscription_id)
         elif name == 'resource':
-            return ResourceManagementClient(credential, subscription_id)
+            return azure.mgmt.resource.ResourceManagementClient(
+                credential, subscription_id)
         else:
             raise ValueError(f'Client not supported: "{name}"')
 
 
 def create_security_rule(**kwargs):
-    from azure.mgmt.network.models import SecurityRule
-    return SecurityRule(**kwargs)
+    return azure.mgmt.network.models.SecurityRule(**kwargs)

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -10,44 +10,57 @@ azure = common.LazyImport(
     'azure',
     import_error_message=('Failed to import dependencies for Azure.'
                           'Try pip install "skypilot[azure]"'))
+_LAZY_MODULES = (azure,)
+
 _session_creation_lock = threading.RLock()
 
-
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_subscription_id() -> str:
     """Get the default subscription id."""
-    return azure.common.credentials.get_cli_profile().get_subscription_id()
+    from azure.common import credentials
+    return credentials.get_cli_profile().get_subscription_id()
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_current_account_user() -> str:
     """Get the default account user."""
-    return azure.common.credentials.get_cli_profile().get_current_account_user()
+    from azure.common import credentials
+    return credentials.get_cli_profile().get_current_account_user()
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def exceptions():
     """Azure exceptions."""
-    return azure.core.exceptions
+    from azure.common import credentials
+    return credentials.get_cli_profile().get_current_account_user()
 
 
 @functools.lru_cache()
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_client(name: str, subscription_id: str):
     # Sky only supports Azure CLI credential for now.
     # Increase the timeout to fix the Azure get-access-token timeout issue.
     # Tracked in
     # https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
+    from azure.identity import AzureCliCredential
     with _session_creation_lock:
-        credential = azure.identity.AzureCliCredential(process_timeout=30)
+        credential = AzureCliCredential(process_timeout=30)
         if name == 'compute':
-            return azure.mgmt.compute.ComputeManagementClient(
+            from azure.mgmt.compute import ComputeManagementClient
+            return ComputeManagementClient(
                 credential, subscription_id)
         elif name == 'network':
-            return azure.mgmt.network.NetworkManagementClient(
+            from azure.mgmt.network import NetworkManagementClient
+            return NetworkManagementClient(
                 credential, subscription_id)
         elif name == 'resource':
-            return azure.mgmt.resource.ResourceManagementClient(
-                credential, subscription_id)
+            from azure.mgmt.resource import ResourceManagementClient
+            return ResourceManagementClient(credential, subscription_id)
         else:
             raise ValueError(f'Client not supported: "{name}"')
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def create_security_rule(**kwargs):
-    return azure.mgmt.network.models.SecurityRule(**kwargs)
+    from azure.mgmt.network.models import SecurityRule
+    return SecurityRule(**kwargs)

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -15,6 +15,8 @@ _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Cloudflare.'
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',
                              import_error_message=_IMPORT_ERROR_MESSAGE)
+_LAZY_MODULES = (boto3, botocore)
+
 _session_creation_lock = threading.RLock()
 ACCOUNT_ID_PATH = '~/.cloudflare/accountid'
 R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
@@ -124,6 +126,7 @@ def client(service_name: str, region):
         region_name=region)
 
 
+@common.load_lazy_modules(_LAZY_MODULES)
 def botocore_exceptions():
     """AWS botocore exception."""
     from botocore import exceptions

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional, Tuple
 from sky.adaptors import common
 from sky.utils import ux_utils
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for Cloudflare.'
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Cloudflare.'
                          'Try pip install "skypilot[cloudflare]"')
 boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
 botocore = common.LazyImport('botocore',

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -7,35 +7,20 @@ import os
 import threading
 from typing import Dict, Optional, Tuple
 
+from sky.adaptors import common
 from sky.utils import ux_utils
 
-boto3 = None
-botocore = None
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for Cloudflare.'
+                         'Try pip install "skypilot[cloudflare]"')
+boto3 = common.LazyImport('boto3', import_error_message=_IMPORT_ERROR_MESSAGE)
+botocore = common.LazyImport('botocore',
+                             import_error_message=_IMPORT_ERROR_MESSAGE)
 _session_creation_lock = threading.RLock()
 ACCOUNT_ID_PATH = '~/.cloudflare/accountid'
 R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 NAME = 'Cloudflare'
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global boto3, botocore
-        if boto3 is None or botocore is None:
-            try:
-                import boto3 as _boto3
-                import botocore as _botocore
-                boto3 = _boto3
-                botocore = _botocore
-            except ImportError:
-                raise ImportError('Fail to import dependencies for Cloudflare.'
-                                  'Try pip install "skypilot[aws]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 @contextlib.contextmanager
@@ -75,7 +60,6 @@ def get_r2_credentials(boto3_session):
 # for different threads.
 # Reference: https://docs.python.org/3/library/functools.html#functools.lru_cache # pylint: disable=line-too-long
 @functools.lru_cache()
-@import_package
 def session():
     """Create an AWS session."""
     # Creating the session object is not thread-safe for boto3,
@@ -90,7 +74,6 @@ def session():
 
 
 @functools.lru_cache()
-@import_package
 def resource(resource_name: str, **kwargs):
     """Create a Cloudflare resource.
 
@@ -141,7 +124,6 @@ def client(service_name: str, region):
         region_name=region)
 
 
-@import_package
 def botocore_exceptions():
     """AWS botocore exception."""
     from botocore import exceptions

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -1,7 +1,7 @@
 """Lazy import for modules to avoid import error when not used."""
 import functools
 import importlib
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 
 class LazyImport:
@@ -9,7 +9,7 @@ class LazyImport:
 
     We use this for pandas and networkx, as they can be time-consuming to import
     (0.1-0.2 seconds). With this class, we can avoid the unnecessary import time
-    when the module is not used (e.g., `networkx` should not be imported for 
+    when the module is not used (e.g., `networkx` should not be imported for
     `sky status and `pandas` should not be imported for `sky exec`).
 
     We also use this for cloud adaptors, because we do not want to import the
@@ -61,5 +61,5 @@ def load_lazy_modules(modules: Tuple[LazyImport, ...]):
             return func(*args, **kwargs)
 
         return wrapper
-    
+
     return decorator

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 class LazyImport:
     """Lazy importer for heavy modules or cloud modules only when enabled.
-    
+
     We use this for pandas and networkx in SkyPilot module, as they can be time-
     consuming to import (0.1-0.2 seconds). With this module, we can avoid the
     unnecessary import time when the module is not used.

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -9,7 +9,8 @@ class LazyImport:
 
     We use this for pandas and networkx, as they can be time-consuming to import
     (0.1-0.2 seconds). With this class, we can avoid the unnecessary import time
-    when the module is not used.
+    when the module is not used (e.g., `networkx` should not be imported for 
+    `sky status and `pandas` should not be imported for `sky exec`).
 
     We also use this for cloud adaptors, because we do not want to import the
     cloud dependencies when it is not enabled.

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -6,7 +6,9 @@ from typing import Optional
 class LazyImport:
     """Lazy importer for heavy modules or cloud modules only when enabled."""
 
-    def __init__(self, module_name: str, import_error_message: Optional[str] = None):
+    def __init__(self,
+                 module_name: str,
+                 import_error_message: Optional[str] = None):
         self._module_name = module_name
         self._module = None
         self._import_error_message = import_error_message

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -27,10 +27,13 @@ class LazyImport:
         # Attempt to access the attribute, if it fails, assume it's a submodule
         # and lazily import it
         try:
+            if name in self.__dict__:
+                return self.__dict__[name]
             return getattr(self.load_module(), name)
         except AttributeError:
             # Dynamically create a new LazyImport instance for the submodule
             submodule_name = f'{self._module_name}.{name}'
-            setattr(self, name,
-                    LazyImport(submodule_name, self._import_error_message))
-            return getattr(self, name)
+            lazy_submodule = LazyImport(submodule_name,
+                                        self._import_error_message)
+            setattr(self, name, lazy_submodule)
+            return lazy_submodule

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -4,7 +4,15 @@ from typing import Optional
 
 
 class LazyImport:
-    """Lazy importer for heavy modules or cloud modules only when enabled."""
+    """Lazy importer for heavy modules or cloud modules only when enabled.
+    
+    We use this for pandas and networkx in SkyPilot module, as they can be time-
+    consuming to import (0.1-0.2 seconds). With this module, we can avoid the
+    unnecessary import time when the module is not used.
+
+    We also use this for cloud adaptors, because we do not want to import the
+    cloud dependencies when it is not enabled.
+    """
 
     def __init__(self,
                  module_name: str,

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -1,0 +1,24 @@
+"""Lazy import for modules to avoid import error when not used."""
+from typing import Optional
+
+
+class LazyImport:
+    """Lazy importer for heavy modules."""
+
+    def __init__(self, module_name, import_error_message: Optional[str] = None):
+        self.module_name = module_name
+        self.module = None
+        self._import_error_message = import_error_message
+
+    def load_module(self):
+        if self.module is None:
+            try:
+                self.module = __import__(self.module_name)
+            except ImportError as e:
+                if self._import_error_message is not None:
+                    raise ImportError(self._import_error_message) from e
+                raise
+        return self.module
+
+    def __getattr__(self, name):
+        return getattr(self.load_module(), name)

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -33,7 +33,7 @@ class LazyImport:
                 raise
         return self._module
 
-    def __getattr__(self, name) -> Any:
+    def __getattr__(self, name: str) -> Any:
         # Attempt to access the attribute, if it fails, assume it's a submodule
         # and lazily import it
         try:

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -1,7 +1,7 @@
 """Lazy import for modules to avoid import error when not used."""
 import functools
 import importlib
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 
 class LazyImport:
@@ -33,7 +33,7 @@ class LazyImport:
                 raise
         return self._module
 
-    def __getattr__(self, name):
+    def __getattr__(self, name) -> Any:
         # Attempt to access the attribute, if it fails, assume it's a submodule
         # and lazily import it
         try:

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -50,7 +50,7 @@ class LazyImport:
 
 
 def load_lazy_modules(modules: Tuple[LazyImport, ...]):
-    """Load lazy modules to before entering a function to error out quickly."""
+    """Load lazy modules before entering a function to error out quickly."""
 
     def decorator(func):
 

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -4,22 +4,22 @@ from typing import Optional
 
 
 class LazyImport:
-    """Lazy importer for heavy modules."""
+    """Lazy importer for heavy modules or cloud modules only when enabled."""
 
-    def __init__(self, module_name, import_error_message: Optional[str] = None):
-        self.module_name = module_name
-        self.module = None
+    def __init__(self, module_name: str, import_error_message: Optional[str] = None):
+        self._module_name = module_name
+        self._module = None
         self._import_error_message = import_error_message
 
     def load_module(self):
-        if self.module is None:
+        if self._module is None:
             try:
-                self.module = importlib.import_module(self.module_name)
+                self._module = importlib.import_module(self._module_name)
             except ImportError as e:
                 if self._import_error_message is not None:
                     raise ImportError(self._import_error_message) from e
                 raise
-        return self.module
+        return self._module
 
     def __getattr__(self, name):
         # Attempt to access the attribute, if it fails, assume it's a submodule
@@ -28,7 +28,7 @@ class LazyImport:
             return getattr(self.load_module(), name)
         except AttributeError:
             # Dynamically create a new LazyImport instance for the submodule
-            submodule_name = f'{self.module_name}.{name}'
+            submodule_name = f'{self._module_name}.{name}'
             setattr(self, name,
                     LazyImport(submodule_name, self._import_error_message))
             return getattr(self, name)

--- a/sky/adaptors/cudo.py
+++ b/sky/adaptors/cudo.py
@@ -1,29 +1,13 @@
 """Cudo Compute cloud adaptor."""
 
-import functools
+from sky.adaptors import common
 
-_cudo_sdk = None
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global _cudo_sdk
-        if _cudo_sdk is None:
-            try:
-                import cudo_compute as _cudo  # pylint: disable=import-outside-toplevel
-                _cudo_sdk = _cudo
-            except ImportError:
-                raise ImportError(
-                    'Fail to import dependencies for Cudo Compute.'
-                    'Try pip install "skypilot[cudo]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
+cudo_sdk = common.LazyImport(
+    'cudo_compute',
+    import_error_message='Fail to import dependencies for Cudo Compute.'
+    'Try pip install "skypilot[cudo]"')
 
 
-@import_package
 def cudo():
     """Return the Cudo Compute package."""
-    return _cudo_sdk
+    return cudo_sdk.load_module()

--- a/sky/adaptors/cudo.py
+++ b/sky/adaptors/cudo.py
@@ -4,7 +4,7 @@ from sky.adaptors import common
 
 cudo_sdk = common.LazyImport(
     'cudo_compute',
-    import_error_message='Fail to import dependencies for Cudo Compute.'
+    import_error_message='Failed to import dependencies for Cudo Compute.'
     'Try pip install "skypilot[cudo]"')
 
 

--- a/sky/adaptors/cudo.py
+++ b/sky/adaptors/cudo.py
@@ -6,4 +6,3 @@ cudo = common.LazyImport(
     'cudo_compute',
     import_error_message='Failed to import dependencies for Cudo Compute. '
     'Try running: pip install "skypilot[cudo]"')
-

--- a/sky/adaptors/cudo.py
+++ b/sky/adaptors/cudo.py
@@ -2,12 +2,8 @@
 
 from sky.adaptors import common
 
-cudo_sdk = common.LazyImport(
+cudo = common.LazyImport(
     'cudo_compute',
-    import_error_message='Failed to import dependencies for Cudo Compute.'
-    'Try pip install "skypilot[cudo]"')
+    import_error_message='Failed to import dependencies for Cudo Compute. '
+    'Try running: pip install "skypilot[cudo]"')
 
-
-def cudo():
-    """Return the Cudo Compute package."""
-    return cudo_sdk

--- a/sky/adaptors/cudo.py
+++ b/sky/adaptors/cudo.py
@@ -10,4 +10,4 @@ cudo_sdk = common.LazyImport(
 
 def cudo():
     """Return the Cudo Compute package."""
-    return cudo_sdk.load_module()
+    return cudo_sdk

--- a/sky/adaptors/docker.py
+++ b/sky/adaptors/docker.py
@@ -2,43 +2,25 @@
 
 # pylint: disable=import-outside-toplevel
 
-from functools import wraps
+from sky.adaptors import common
 
-docker = None
-
-
-def import_package(func):
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        global docker
-        if docker is None:
-            try:
-                import docker as _docker
-            except ImportError:
-                raise ImportError('Fail to import dependencies for Docker. '
-                                  'See README for how to install it.') from None
-            docker = _docker
-        return func(*args, **kwargs)
-
-    return wrapper
+docker = common.LazyImport(
+    'docker',
+    import_error_message='Fail to import dependencies for Docker. '
+    'See README for how to install it.')
 
 
-@import_package
 def from_env():
     return docker.from_env()
 
 
-@import_package
 def build_error():
     return docker.errors.BuildError
 
 
-@import_package
 def not_found_error():
     return docker.errors.NotFound
 
 
-@import_package
 def api_error():
     return docker.errors.APIError

--- a/sky/adaptors/docker.py
+++ b/sky/adaptors/docker.py
@@ -6,7 +6,7 @@ from sky.adaptors import common
 
 docker = common.LazyImport(
     'docker',
-    import_error_message='Fail to import dependencies for Docker. '
+    import_error_message='Failed to import dependencies for Docker. '
     'See README for how to install it.')
 
 

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -11,27 +11,10 @@ _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for GCP. '
 googleapiclient = common.LazyImport('googleapiclient',
                                     import_error_message=_IMPORT_ERROR_MESSAGE)
 google = common.LazyImport('google', import_error_message=_IMPORT_ERROR_MESSAGE)
+_LAZY_MODULES = (google, googleapiclient)
 
 
-def import_package(func):
-    # import_package decorator is to check the dependencies and output user-
-    # friendly error messages if the dependencies are not installed before any
-    # function is called.
-
-    # We cannot use LazyImport for the underlying google.cloud.storage, because
-    # google.cloud can be imported but google.cloud.storage cannot be retrieved
-    # with getattr(google.cloud, 'storage').
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        google.load_module()
-        googleapiclient.load_module()
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def build(service_name: str, version: str, *args, **kwargs):
     """Build a GCP service.
 
@@ -43,7 +26,7 @@ def build(service_name: str, version: str, *args, **kwargs):
     return discovery.build(service_name, version, *args, **kwargs)
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def storage_client():
     """Helper method that connects to GCS Storage Client for
     GCS Bucket
@@ -52,7 +35,7 @@ def storage_client():
     return storage.Client()
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def anonymous_storage_client():
     """Helper method that connects to GCS Storage Client for
     Public GCS Buckets
@@ -61,35 +44,35 @@ def anonymous_storage_client():
     return storage.Client.create_anonymous_client()
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def not_found_exception():
     """NotFound exception."""
     from google.api_core import exceptions as gcs_exceptions
     return gcs_exceptions.NotFound
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def forbidden_exception():
     """Forbidden exception."""
     from google.api_core import exceptions as gcs_exceptions
     return gcs_exceptions.Forbidden
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def http_error_exception():
     """HttpError exception."""
     from googleapiclient import errors
     return errors.HttpError
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def credential_error_exception():
     """CredentialError exception."""
     from google.auth import exceptions
     return exceptions.DefaultCredentialsError
 
 
-@import_package
+@common.load_lazy_modules(_LAZY_MODULES)
 def get_credentials(cred_type: str, credentials_field: str):
     """Get GCP credentials."""
     from google.oauth2 import service_account

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -1,6 +1,7 @@
 """GCP cloud adaptors"""
 
 # pylint: disable=import-outside-toplevel
+import functools
 import json
 
 from sky.adaptors import common
@@ -12,6 +13,25 @@ googleapiclient = common.LazyImport('googleapiclient',
 google = common.LazyImport('google', import_error_message=_IMPORT_ERROR_MESSAGE)
 
 
+def import_package(func):
+    # import_package decorator is to check the dependencies and output user-
+    # friendly error messages if the dependencies are not installed before any
+    # function is called.
+
+    # We cannot use LazyImport for the underlying google.cloud.storage, because
+    # google.cloud can be imported but google.cloud.storage cannot be retrieved
+    # with getattr(google.cloud, 'storage').
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        google.load_module()
+        googleapiclient.load_module()
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@import_package
 def build(service_name: str, version: str, *args, **kwargs):
     """Build a GCP service.
 
@@ -19,42 +39,62 @@ def build(service_name: str, version: str, *args, **kwargs):
         service_name: GCP service name (e.g., 'compute', 'storagetransfer').
         version: Service version (e.g., 'v1').
     """
-    return googleapiclient.discovery.build(service_name, version, *args,
-                                           **kwargs)
+    from googleapiclient import discovery
+    return discovery.build(service_name, version, *args, **kwargs)
 
 
+@import_package
 def storage_client():
-    """Connects to GCS Storage Client for GCS Bucket"""
-    return google.cloud.storage.Client()
+    """Helper method that connects to GCS Storage Client for
+    GCS Bucket
+    """
+    from google.cloud import storage
+    return storage.Client()
 
 
+@import_package
 def anonymous_storage_client():
-    """Connects to GCS Storage Client for Public GCS Buckets"""
-    return google.cloud.storage.Client.create_anonymous_client()
+    """Helper method that connects to GCS Storage Client for
+    Public GCS Buckets
+    """
+    from google.cloud import storage
+    return storage.Client.create_anonymous_client()
 
 
+@import_package
 def not_found_exception():
     """NotFound exception."""
-    return google.api_core.exceptions.NotFound
+    from google.api_core import exceptions as gcs_exceptions
+    return gcs_exceptions.NotFound
 
 
+@import_package
 def forbidden_exception():
     """Forbidden exception."""
-    return google.api_core.exceptions.Forbidden
+    from google.api_core import exceptions as gcs_exceptions
+    return gcs_exceptions.Forbidden
 
 
+@import_package
 def http_error_exception():
     """HttpError exception."""
-    return googleapiclient.errors.HttpError
+    from googleapiclient import errors
+    return errors.HttpError
 
 
+@import_package
 def credential_error_exception():
     """CredentialError exception."""
-    return google.auth.exceptions.DefaultCredentialsError
+    from google.auth import exceptions
+    return exceptions.DefaultCredentialsError
 
 
+@import_package
 def get_credentials(cred_type: str, credentials_field: str):
     """Get GCP credentials."""
+    from google.oauth2 import service_account
+    from google.oauth2.credentials import Credentials as OAuthCredentials
+
     if cred_type == 'service_account':
         # If parsing the gcp_credentials failed, then the user likely made a
         # mistake in copying the credentials into the config yaml.
@@ -63,9 +103,9 @@ def get_credentials(cred_type: str, credentials_field: str):
         except json.decoder.JSONDecodeError as e:
             raise RuntimeError('gcp_credentials found in cluster yaml file but '
                                'formatted improperly.') from e
-        credentials = (google.oauth2.service_account.Credentials.
-                       from_service_account_info(service_account_info))
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info)
     elif cred_type == 'credentials_token':
         # Otherwise the credentials type must be credentials_token.
-        credentials = google.oauth2.credentials.Credentials(credentials_field)
+        credentials = OAuthCredentials(credentials_field)
     return credentials

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -5,7 +5,7 @@ import json
 
 from sky.adaptors import common
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for GCP. '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for GCP. '
                          'Try pip install "skypilot[gcp]"')
 googleapiclient = common.LazyImport('googleapiclient',
                                     import_error_message=_IMPORT_ERROR_MESSAGE)

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -1,33 +1,17 @@
 """GCP cloud adaptors"""
 
 # pylint: disable=import-outside-toplevel
-import functools
 import json
 
-googleapiclient = None
-google = None
+from sky.adaptors import common
+
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for GCP. '
+                         'Try pip install "skypilot[gcp]"')
+googleapiclient = common.LazyImport('googleapiclient',
+                                    import_error_message=_IMPORT_ERROR_MESSAGE)
+google = common.LazyImport('google', import_error_message=_IMPORT_ERROR_MESSAGE)
 
 
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global googleapiclient, google
-        if googleapiclient is None or google is None:
-            try:
-                import google as _google
-                import googleapiclient as _googleapiclient
-                googleapiclient = _googleapiclient
-                google = _google
-            except ImportError:
-                raise ImportError('Failed to import dependencies for GCP. '
-                                  'Try: pip install "skypilot[gcp]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-@import_package
 def build(service_name: str, version: str, *args, **kwargs):
     """Build a GCP service.
 
@@ -35,62 +19,46 @@ def build(service_name: str, version: str, *args, **kwargs):
         service_name: GCP service name (e.g., 'compute', 'storagetransfer').
         version: Service version (e.g., 'v1').
     """
-    from googleapiclient import discovery
-    return discovery.build(service_name, version, *args, **kwargs)
+    return googleapiclient.discovery.build(service_name, version, *args,
+                                           **kwargs)
 
 
-@import_package
 def storage_client():
     """Helper method that connects to GCS Storage Client for
     GCS Bucket
     """
-    from google.cloud import storage
-    return storage.Client()
+    return google.cloud.storage.Client()
 
 
-@import_package
 def anonymous_storage_client():
     """Helper method that connects to GCS Storage Client for
     Public GCS Buckets
     """
-    from google.cloud import storage
-    return storage.Client.create_anonymous_client()
+    return google.cloud.storage.Client.create_anonymous_client()
 
 
-@import_package
 def not_found_exception():
     """NotFound exception."""
-    from google.api_core import exceptions as gcs_exceptions
-    return gcs_exceptions.NotFound
+    return google.api_core.exceptions.NotFound
 
 
-@import_package
 def forbidden_exception():
     """Forbidden exception."""
-    from google.api_core import exceptions as gcs_exceptions
-    return gcs_exceptions.Forbidden
+    return google.api_core.exceptions.Forbidden
 
 
-@import_package
 def http_error_exception():
     """HttpError exception."""
-    from googleapiclient import errors
-    return errors.HttpError
+    return googleapiclient.errors.HttpError
 
 
-@import_package
 def credential_error_exception():
     """CredentialError exception."""
-    from google.auth import exceptions
-    return exceptions.DefaultCredentialsError
+    return google.auth.exceptions.DefaultCredentialsError
 
 
-@import_package
 def get_credentials(cred_type: str, credentials_field: str):
     """Get GCP credentials."""
-    from google.oauth2 import service_account
-    from google.oauth2.credentials import Credentials as OAuthCredentials
-
     if cred_type == 'service_account':
         # If parsing the gcp_credentials failed, then the user likely made a
         # mistake in copying the credentials into the config yaml.
@@ -99,9 +67,9 @@ def get_credentials(cred_type: str, credentials_field: str):
         except json.decoder.JSONDecodeError as e:
             raise RuntimeError('gcp_credentials found in cluster yaml file but '
                                'formatted improperly.') from e
-        credentials = service_account.Credentials.from_service_account_info(
-            service_account_info)
+        credentials = (google.oauth2.service_account.Credentials.
+                       from_service_account_info(service_account_info))
     elif cred_type == 'credentials_token':
         # Otherwise the credentials type must be credentials_token.
-        credentials = OAuthCredentials(credentials_field)
+        credentials = google.oauth2.credentials.Credentials(credentials_field)
     return credentials

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -1,7 +1,6 @@
 """GCP cloud adaptors"""
 
 # pylint: disable=import-outside-toplevel
-import functools
 import json
 
 from sky.adaptors import common

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -27,18 +27,14 @@ def build(service_name: str, version: str, *args, **kwargs):
 
 @common.load_lazy_modules(_LAZY_MODULES)
 def storage_client():
-    """Helper method that connects to GCS Storage Client for
-    GCS Bucket
-    """
+    """Helper that connects to GCS Storage Client for GCS Bucket"""
     from google.cloud import storage
     return storage.Client()
 
 
 @common.load_lazy_modules(_LAZY_MODULES)
 def anonymous_storage_client():
-    """Helper method that connects to GCS Storage Client for
-    Public GCS Buckets
-    """
+    """Helper that connects to GCS Storage Client for Public GCS Buckets"""
     from google.cloud import storage
     return storage.Client.create_anonymous_client()
 

--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -24,16 +24,12 @@ def build(service_name: str, version: str, *args, **kwargs):
 
 
 def storage_client():
-    """Helper method that connects to GCS Storage Client for
-    GCS Bucket
-    """
+    """Connects to GCS Storage Client for GCS Bucket"""
     return google.cloud.storage.Client()
 
 
 def anonymous_storage_client():
-    """Helper method that connects to GCS Storage Client for
-    Public GCS Buckets
-    """
+    """Connects to GCS Storage Client for Public GCS Buckets"""
     return google.cloud.storage.Client.create_anonymous_client()
 
 

--- a/sky/adaptors/ibm.py
+++ b/sky/adaptors/ibm.py
@@ -35,7 +35,7 @@ def read_credential_file():
                   encoding='utf-8') as f:
             return yaml.safe_load(f)
     except FileNotFoundError:
-        return False
+        return {}
 
 
 def get_api_key():

--- a/sky/adaptors/ibm.py
+++ b/sky/adaptors/ibm.py
@@ -15,7 +15,7 @@ from sky.adaptors import common
 CREDENTIAL_FILE = '~/.ibm/credentials.yaml'
 logger = sky_logging.init_logger(__name__)
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for IBM. '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for IBM. '
                          'Try running: pip install "skypilot[ibm]".\n')
 ibm_vpc = common.LazyImport('ibm_vpc',
                             import_error_message=_IMPORT_ERROR_MESSAGE)

--- a/sky/adaptors/ibm.py
+++ b/sky/adaptors/ibm.py
@@ -2,7 +2,6 @@
 
 # pylint: disable=import-outside-toplevel
 
-import functools
 import json
 import multiprocessing
 import os
@@ -11,42 +10,23 @@ import requests
 import yaml
 
 from sky import sky_logging
+from sky.adaptors import common
 
 CREDENTIAL_FILE = '~/.ibm/credentials.yaml'
 logger = sky_logging.init_logger(__name__)
 
-ibm_vpc = None
-ibm_cloud_sdk_core = None
-ibm_platform_services = None
-ibm_boto3 = None
-ibm_botocore = None
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global ibm_vpc, ibm_cloud_sdk_core, ibm_platform_services
-        global ibm_boto3, ibm_botocore
-        if None in [ibm_vpc, ibm_cloud_sdk_core, ibm_platform_services]:
-            try:
-                import ibm_boto3 as _ibm_boto3
-                import ibm_botocore as _ibm_botocore
-                import ibm_cloud_sdk_core as _ibm_cloud_sdk_core
-                import ibm_platform_services as _ibm_platform_services
-                import ibm_vpc as _ibm_vpc
-                ibm_vpc = _ibm_vpc
-                ibm_cloud_sdk_core = _ibm_cloud_sdk_core
-                ibm_platform_services = _ibm_platform_services
-                ibm_boto3 = _ibm_boto3
-                ibm_botocore = _ibm_botocore
-            except ImportError:
-                raise ImportError(
-                    'Failed to import dependencies for IBM. '
-                    'Try running: pip install "skypilot[ibm]".\n') from None
-        return func(*args, **kwargs)
-
-    return wrapper
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for IBM. '
+                         'Try running: pip install "skypilot[ibm]".\n')
+ibm_vpc = common.LazyImport('ibm_vpc',
+                            import_error_message=_IMPORT_ERROR_MESSAGE)
+ibm_cloud_sdk_core = common.LazyImport(
+    'ibm_cloud_sdk_core', import_error_message=_IMPORT_ERROR_MESSAGE)
+ibm_platform_services = common.LazyImport(
+    'ibm_platform_services', import_error_message=_IMPORT_ERROR_MESSAGE)
+ibm_boto3 = common.LazyImport('ibm_boto3',
+                              import_error_message=_IMPORT_ERROR_MESSAGE)
+ibm_botocore = common.LazyImport('ibm_botocore',
+                                 import_error_message=_IMPORT_ERROR_MESSAGE)
 
 
 def read_credential_file():
@@ -67,7 +47,6 @@ def get_hmac_keys():
     return cred_file['access_key_id'], cred_file['secret_access_key']
 
 
-@import_package
 def _get_authenticator():
     return ibm_cloud_sdk_core.authenticators.IAMAuthenticator(get_api_key())
 
@@ -87,7 +66,6 @@ def get_oauth_token():
     return json.loads(res.text)['access_token']
 
 
-@import_package
 def client(**kwargs):
     """Create an ibm vpc client.
 
@@ -114,19 +92,16 @@ def client(**kwargs):
     return vpc_client  # returns either formerly or newly created client
 
 
-@import_package
 def search_client():
     return ibm_platform_services.GlobalSearchV2(
         authenticator=_get_authenticator())
 
 
-@import_package
 def tagging_client():
     return ibm_platform_services.GlobalTaggingV1(
         authenticator=_get_authenticator())
 
 
-@import_package
 def get_cos_client(region: str = 'us-east'):
     """Returns an IBM COS client object.
       Using process lock to protect not multi process
@@ -149,7 +124,6 @@ def get_cos_client(region: str = 'us-east'):
             f'https://s3.{region}.cloud-object-storage.appdomain.cloud')
 
 
-@import_package
 def get_cos_resource(region: str = 'us-east'):
     """Returns an IBM COS Resource object.
       Using process lock to protect not multi process safe

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -2,14 +2,18 @@
 
 # pylint: disable=import-outside-toplevel
 
-import functools
 import os
 
+from sky.adaptors import common
 from sky.utils import env_options
 from sky.utils import ux_utils
 
-kubernetes = None
-urllib3 = None
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for Kubernetes. '
+                         'Try running: pip install "skypilot[kubernetes]"')
+kubernetes = common.LazyImport('kubernetes',
+                               import_error_message=_IMPORT_ERROR_MESSAGE)
+urllib3 = common.LazyImport('urllib3',
+                            import_error_message=_IMPORT_ERROR_MESSAGE)
 
 _configured = False
 _core_api = None
@@ -22,35 +26,6 @@ _node_api = None
 API_TIMEOUT = 5
 
 
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global kubernetes
-        global urllib3
-        if kubernetes is None:
-            try:
-                import kubernetes as _kubernetes
-                import urllib3 as _urllib3
-            except ImportError:
-                # TODO(romilb): Update this message to point to installation
-                #  docs when they are ready.
-                raise ImportError('Fail to import dependencies for Kubernetes. '
-                                  'Run `pip install kubernetes` to '
-                                  'install them.') from None
-            kubernetes = _kubernetes
-            urllib3 = _urllib3
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-@import_package
-def get_kubernetes():
-    return kubernetes
-
-
-@import_package
 def _load_config():
     global _configured
     if _configured:
@@ -88,7 +63,6 @@ def _load_config():
     _configured = True
 
 
-@import_package
 def core_api():
     global _core_api
     if _core_api is None:
@@ -98,7 +72,6 @@ def core_api():
     return _core_api
 
 
-@import_package
 def auth_api():
     global _auth_api
     if _auth_api is None:
@@ -108,7 +81,6 @@ def auth_api():
     return _auth_api
 
 
-@import_package
 def networking_api():
     global _networking_api
     if _networking_api is None:
@@ -118,7 +90,6 @@ def networking_api():
     return _networking_api
 
 
-@import_package
 def custom_objects_api():
     global _custom_objects_api
     if _custom_objects_api is None:
@@ -128,7 +99,6 @@ def custom_objects_api():
     return _custom_objects_api
 
 
-@import_package
 def node_api():
     global _node_api
     if _node_api is None:
@@ -138,21 +108,17 @@ def node_api():
     return _node_api
 
 
-@import_package
 def api_exception():
     return kubernetes.client.rest.ApiException
 
 
-@import_package
 def config_exception():
     return kubernetes.config.config_exception.ConfigException
 
 
-@import_package
 def max_retry_error():
     return urllib3.exceptions.MaxRetryError
 
 
-@import_package
 def stream():
     return kubernetes.stream.stream

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -8,7 +8,7 @@ from sky.adaptors import common
 from sky.utils import env_options
 from sky.utils import ux_utils
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for Kubernetes. '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Kubernetes. '
                          'Try running: pip install "skypilot[kubernetes]"')
 kubernetes = common.LazyImport('kubernetes',
                                import_error_message=_IMPORT_ERROR_MESSAGE)

--- a/sky/adaptors/oci.py
+++ b/sky/adaptors/oci.py
@@ -1,30 +1,16 @@
 """Oracle OCI cloud adaptor"""
 
-import functools
 import os
+
+from sky.adaptors import common
 
 CONFIG_PATH = '~/.oci/config'
 ENV_VAR_OCI_CONFIG = 'OCI_CONFIG'
 
-oci = None
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global oci
-        if oci is None:
-            try:
-                # pylint: disable=import-outside-toplevel
-                import oci as _oci
-                oci = _oci
-            except ImportError:
-                raise ImportError('Fail to import dependencies for OCI.'
-                                  'Try pip install "skypilot[oci]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
+oci = common.LazyImport(
+    'oci',
+    import_error_message='Fail to import dependencies for OCI. '
+    'Try running: pip install "skypilot[oci]"')
 
 
 def get_config_file() -> str:
@@ -35,12 +21,6 @@ def get_config_file() -> str:
     return conf_file_path
 
 
-@import_package
-def get_oci():
-    return oci
-
-
-@import_package
 def get_oci_config(region=None, profile='DEFAULT'):
     conf_file_path = get_config_file()
     oci_config = oci.config.from_file(file_location=conf_file_path,
@@ -50,30 +30,23 @@ def get_oci_config(region=None, profile='DEFAULT'):
     return oci_config
 
 
-@import_package
 def get_core_client(region=None, profile='DEFAULT'):
     return oci.core.ComputeClient(get_oci_config(region, profile))
 
 
-@import_package
 def get_net_client(region=None, profile='DEFAULT'):
     return oci.core.VirtualNetworkClient(get_oci_config(region, profile))
 
 
-@import_package
 def get_search_client(region=None, profile='DEFAULT'):
     return oci.resource_search.ResourceSearchClient(
         get_oci_config(region, profile))
 
 
-@import_package
 def get_identity_client(region=None, profile='DEFAULT'):
     return oci.identity.IdentityClient(get_oci_config(region, profile))
 
 
-@import_package
 def service_exception():
     """OCI service exception."""
-    # pylint: disable=import-outside-toplevel
-    from oci.exceptions import ServiceError
-    return ServiceError
+    return oci.exceptions.ServiceError

--- a/sky/adaptors/oci.py
+++ b/sky/adaptors/oci.py
@@ -9,7 +9,7 @@ ENV_VAR_OCI_CONFIG = 'OCI_CONFIG'
 
 oci = common.LazyImport(
     'oci',
-    import_error_message='Fail to import dependencies for OCI. '
+    import_error_message='Failed to import dependencies for OCI. '
     'Try running: pip install "skypilot[oci]"')
 
 

--- a/sky/adaptors/runpod.py
+++ b/sky/adaptors/runpod.py
@@ -1,29 +1,8 @@
 """RunPod cloud adaptor."""
 
-import functools
+from sky.adaptors import common
 
-_runpod_sdk = None
-
-
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global _runpod_sdk
-        if _runpod_sdk is None:
-            try:
-                import runpod as _runpod  # pylint: disable=import-outside-toplevel
-                _runpod_sdk = _runpod
-            except ImportError:
-                raise ImportError(
-                    'Fail to import dependencies for runpod.'
-                    'Try pip install "skypilot[runpod]"') from None
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-@import_package
-def runpod():
-    """Return the runpod package."""
-    return _runpod_sdk
+runpod = common.LazyImport(
+    'runpod',
+    import_error_message='Fail to import dependencies for RunPod. '
+    'Try running: pip install "skypilot[runpod]"')

--- a/sky/adaptors/runpod.py
+++ b/sky/adaptors/runpod.py
@@ -4,5 +4,5 @@ from sky.adaptors import common
 
 runpod = common.LazyImport(
     'runpod',
-    import_error_message='Fail to import dependencies for RunPod. '
+    import_error_message='Failed to import dependencies for RunPod. '
     'Try running: pip install "skypilot[runpod]"')

--- a/sky/adaptors/vsphere.py
+++ b/sky/adaptors/vsphere.py
@@ -1,216 +1,105 @@
 """vSphere cloud adaptor"""
 
-import functools
+from sky.adaptors import common
 
-tagging_client = None
-vapi_connect = None
-security_session = None
-user_password = None
-factories = None
-cis_client = None
-pyvim_connect = None
-std_client = None
-downloadsession_client = None
-updatesession_client = None
-item_client = None
-content_client = None
-iso_client = None
-ovf_client = None
-library_items_client = None
-vm_template_client = None
-vcenter_client = None
-library_client = None
-content_client = None
-vim = None
-vmodl = None
-pyvmomi = None
-pbm = None
-vmomi_support = None
+_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for vSphere. '
+                         'Try running: pip install "skypilot[vsphere]"')
+vmware_vapi = common.LazyImport('vmware.vapi',
+                                import_error_message=_IMPORT_ERROR_MESSAGE)
+com_vmware = common.LazyImport('com.vmware',
+                               import_error_message=_IMPORT_ERROR_MESSAGE)
+pyVim = common.LazyImport('pyVim', import_error_message=_IMPORT_ERROR_MESSAGE)
+pyVmomi = common.LazyImport('pyVmomi',
+                            import_error_message=_IMPORT_ERROR_MESSAGE)
 
 
-def import_package(func):
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        global tagging_client, vapi_connect, security_session, user_password, \
-            factories, cis_client, pyvim_connect, std_client, \
-            downloadsession_client, updatesession_client, item_client, \
-            content_client, iso_client, ovf_client, library_items_client, \
-            vm_template_client, vcenter_client, library_client, \
-            content_client, vim, vmodl, pyvmomi, pbm, vmomi_support
-        if tagging_client is None:
-            try:
-                # pylint: disable=import-outside-toplevel
-                from com.vmware import cis_client as _cis_client
-                from com.vmware import content_client as _content_client
-                from com.vmware import vcenter_client as _vcenter_client
-                from com.vmware.cis import tagging_client as _tagging_client
-                from com.vmware.content import library_client as _library_client
-                from com.vmware.content.library.item import (
-                    downloadsession_client as _downloadsession_client)
-                from com.vmware.content.library.item import (
-                    updatesession_client as _updatesession_client)
-                import com.vmware.content.library.item_client as _item_client
-                from com.vmware.vapi import std_client as _std_client
-                from com.vmware.vcenter import iso_client as _iso_client
-                from com.vmware.vcenter import ovf_client as _ovf_client
-                from com.vmware.vcenter.vm_template import (
-                    library_items_client as _library_items_client)
-                import com.vmware.vcenter.vm_template_client as _vm_template_client
-                from pyVim import connect as _pyvim_connect
-                from pyVmomi import pbm as _pbm
-                from pyVmomi import vim as _vim
-                from pyVmomi import vmodl as _vmodl
-                from pyVmomi import VmomiSupport as _vmomi_support
-                import pyVmomi as _pyvmomi
-                from vmware.vapi.lib import connect as _vapi_connect
-                from vmware.vapi.security import session as _security_session
-                from vmware.vapi.security import user_password as _user_password
-                from vmware.vapi.stdlib.client import factories as _factories
-
-                tagging_client = _tagging_client
-                vapi_connect = _vapi_connect
-                security_session = _security_session
-                user_password = _user_password
-                factories = _factories
-                cis_client = _cis_client
-                pyvim_connect = _pyvim_connect
-                std_client = _std_client
-                downloadsession_client = _downloadsession_client
-                updatesession_client = _updatesession_client
-                item_client = _item_client
-                content_client = _content_client
-                iso_client = _iso_client
-                ovf_client = _ovf_client
-                library_items_client = _library_items_client
-                vm_template_client = _vm_template_client
-                vcenter_client = _vcenter_client
-                library_client = _library_client
-                vim = _vim
-                vmodl = _vmodl
-                pyvmomi = _pyvmomi
-                pbm = _pbm
-                vmomi_support = _vmomi_support
-
-            except ImportError as e:
-                raise ImportError('Fail to import dependencies for vSphere.'
-                                  'Try pip install "skypilot[vsphere]"'
-                                  f'{e}') from None
-        return func(*args, **kwargs)
-
-    return wrapper
-
-
-@import_package
 def get_tagging_client():
-    return tagging_client
+    return com_vmware.cis.tagging_client
 
 
-@import_package
 def get_vapi_connect():
-    return vapi_connect
+    return vmware_vapi.lib.connect
 
 
-@import_package
 def get_security_session():
-    return security_session
+    return vmware_vapi.security
 
 
-@import_package
 def get_user_password():
-    return user_password
+    return vmware_vapi.security
 
 
-@import_package
 def get_factories():
-    return factories
+    return vmware_vapi.stdlib.client.factories
 
 
-@import_package
 def get_cis_client():
-    return cis_client
+    return com_vmware.cis_client
 
 
-@import_package
 def get_pyvim_connect():
-    return pyvim_connect
+    return pyVim.connect
 
 
-@import_package
 def get_std_client():
-    return std_client
+    return com_vmware.vapi
 
 
-@import_package
 def get_downloadsession_client():
-    return downloadsession_client
+    return com_vmware.content.library.item.downloadsession_client
 
 
-@import_package
 def get_updatesession_client():
-    return updatesession_client
+    return com_vmware.content.library.item.updatesession_client
 
 
-@import_package
 def get_item_client():
-    return item_client
+    return com_vmware.content.library.item_client
 
 
-@import_package
 def get_content_client():
-    return content_client
+    return com_vmware.content_client
 
 
-@import_package
 def get_iso_client():
-    return iso_client
+    return com_vmware.vcenter.iso_client
 
 
-@import_package
 def get_ovf_client():
-    return ovf_client
+    return com_vmware.vcenter.ovf_client
 
 
-@import_package
 def get_library_items_client():
-    return library_items_client
+    return com_vmware.vcenter.vm_template.library_items_client
 
 
-@import_package
 def get_vm_template_client():
-    return vm_template_client
+    return com_vmware.vcenter.vm_template_client
 
 
-@import_package
 def get_vcenter_client():
-    return vcenter_client
+    return com_vmware.vcenter_client
 
 
-@import_package
 def get_library_client():
-    return library_client
+    return com_vmware.content.library_client
 
 
-@import_package
 def get_vim():
-    return vim
+    return pyVmomi.vim
 
 
-@import_package
 def get_vmodl():
-    return vmodl
+    return pyVmomi.vmodl
 
 
-@import_package
 def get_pyvmomi():
-    return pyvmomi
+    return pyVmomi
 
 
-@import_package
 def get_pbm():
-    return pbm
+    return pyVmomi.pbm
 
 
-@import_package
 def get_vmomi_support():
-    return vmomi_support
+    return pyVmomi.VmomiSupport

--- a/sky/adaptors/vsphere.py
+++ b/sky/adaptors/vsphere.py
@@ -2,7 +2,7 @@
 
 from sky.adaptors import common
 
-_IMPORT_ERROR_MESSAGE = ('Fail to import dependencies for vSphere. '
+_IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for vSphere. '
                          'Try running: pip install "skypilot[vsphere]"')
 vmware_vapi = common.LazyImport('vmware.vapi',
                                 import_error_message=_IMPORT_ERROR_MESSAGE)

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -410,7 +410,7 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     secret_name = clouds.Kubernetes.SKY_SSH_KEY_SECRET_NAME
     secret_field_name = clouds.Kubernetes.SKY_SSH_KEY_SECRET_FIELD_NAME
     namespace = kubernetes_utils.get_current_kube_config_context_namespace()
-    k8s = kubernetes.get_kubernetes()
+    k8s = kubernetes.kubernetes
     with open(public_key_path, 'r', encoding='utf-8') as f:
         public_key = f.read()
         if not public_key.endswith('\n'):
@@ -476,7 +476,7 @@ def setup_runpod_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     _, public_key_path = get_or_generate_keys()
     with open(public_key_path, 'r', encoding='UTF-8') as pub_key_file:
         public_key = pub_key_file.read().strip()
-        runpod.runpod().cli.groups.ssh.functions.add_ssh_key(public_key)
+        runpod.runpod.cli.groups.ssh.functions.add_ssh_key(public_key)
 
     return configure_ssh_info(config)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -745,7 +745,7 @@ def write_cluster_config(
         cluster_name: str,
         local_wheel_path: pathlib.Path,
         wheel_hash: str,
-        region: Optional[clouds.Region] = None,
+        region: clouds.Region,
         zones: Optional[List[clouds.Zone]] = None,
         dryrun: bool = False,
         keep_launch_fields_in_existing_config: bool = True) -> Dict[str, str]:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -38,6 +38,7 @@ from sky import status_lib
 from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.backends import wheel_utils
+from sky.clouds import service_catalog
 from sky.clouds.utils import gcp_utils
 from sky.data import data_utils
 from sky.data import storage as storage_lib
@@ -751,7 +752,7 @@ class FailoverCloudErrorHandlerV1:
         # Sometimes, LambdaCloudError will list available regions.
         for e in errors:
             if e.find('Regions with capacity available:') != -1:
-                for r in clouds.Lambda.regions():
+                for r in service_catalog.regions('lambda'):
                     if e.find(r.name) == -1:
                         _add_to_blocked_resources(
                             blocked_resources,
@@ -823,7 +824,7 @@ class FailoverCloudErrorHandlerV1:
         # Sometimes, SCPError will list available regions.
         for e in errors:
             if e.find('Regions with capacity available:') != -1:
-                for r in clouds.SCP.regions():
+                for r in service_catalog.regions('scp'):
                     if e.find(r.name) == -1:
                         _add_to_blocked_resources(
                             blocked_resources,
@@ -1076,7 +1077,8 @@ class FailoverCloudErrorHandlerV2:
                     blocked_resources,
                     launchable_resources.copy(region=None, zone=None))
             elif code == 'SUBNET_NOT_FOUND_FOR_VPC':
-                if (any(acc.lower().startswith('tpu-v4')
+                if (launchable_resources.accelerators is not None and any(
+                        acc.lower().startswith('tpu-v4')
                         for acc in launchable_resources.accelerators.keys()) and
                         region.name == 'us-central2'):
                     # us-central2 is a TPU v4 only region. The subnet for

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3112,7 +3112,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         mkdir_code = (f'{cd} && mkdir -p {remote_log_dir} && '
                       f'touch {remote_log_path}')
-        create_script_code = f'{{ echo {shlex.quote(codegen)} > {script_path}; }}'
+        create_script_code = (f'{{ echo {shlex.quote(codegen)} > '
+                              f'{script_path}; }}')
         job_submit_cmd = (
             f'RAY_DASHBOARD_PORT=$({constants.SKY_PYTHON_CMD} -c "from sky.skylet import job_lib; print(job_lib.get_job_submission_port())" 2> /dev/null || echo 8265);'  # pylint: disable=line-too-long
             f'{cd} && {constants.SKY_RAY_CMD} job submit '

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1,4 +1,5 @@
 """Backend: runs on cloud virtual machines, managed by Ray."""
+import base64
 import copy
 import enum
 import getpass
@@ -8,7 +9,6 @@ import math
 import os
 import pathlib
 import re
-import shlex
 import signal
 import subprocess
 import sys
@@ -3112,7 +3112,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         mkdir_code = (f'{cd} && mkdir -p {remote_log_dir} && '
                       f'touch {remote_log_path}')
-        create_script_code = (f'{{ echo {shlex.quote(codegen)} > '
+        encoded_script = base64.b64encode(
+            codegen.encode('utf-8')).decode('utf-8')
+        create_script_code = (f'{{ echo "{encoded_script}" | base64 --decode > '
                               f'{script_path}; }}')
         job_submit_cmd = (
             f'RAY_DASHBOARD_PORT=$({constants.SKY_PYTHON_CMD} -c "from sky.skylet import job_lib; print(job_lib.get_job_submission_port())" 2> /dev/null || echo 8265);'  # pylint: disable=line-too-long

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3103,7 +3103,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         """Executes generated code on the head node."""
         style = colorama.Style
         fore = colorama.Fore
-        
+
         script_path = os.path.join(SKY_REMOTE_APP_DIR, f'sky_job_{job_id}')
         remote_log_dir = self.log_dir
         remote_log_path = os.path.join(remote_log_dir, 'run.log')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -8,6 +8,7 @@ import math
 import os
 import pathlib
 import re
+import shlex
 import signal
 import subprocess
 import sys
@@ -3102,28 +3103,16 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         """Executes generated code on the head node."""
         style = colorama.Style
         fore = colorama.Fore
-        ssh_credentials = backend_utils.ssh_credential_from_yaml(
-            handle.cluster_yaml, handle.docker_user, handle.ssh_user)
-        head_ssh_port = handle.head_ssh_port
-        runner = command_runner.SSHCommandRunner(handle.head_ip,
-                                                 port=head_ssh_port,
-                                                 **ssh_credentials)
-        with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:
-            fp.write(codegen)
-            fp.flush()
-            script_path = os.path.join(SKY_REMOTE_APP_DIR, f'sky_job_{job_id}')
-            # We choose to sync code + exec, because the alternative of 'ray
-            # submit' may not work as it may use system python (python2) to
-            # execute the script.  Happens for AWS.
-            runner.rsync(source=fp.name,
-                         target=script_path,
-                         up=True,
-                         stream_logs=False)
+        
+        script_path = os.path.join(SKY_REMOTE_APP_DIR, f'sky_job_{job_id}')
         remote_log_dir = self.log_dir
         remote_log_path = os.path.join(remote_log_dir, 'run.log')
 
         cd = f'cd {SKY_REMOTE_WORKDIR}'
 
+        mkdir_code = (f'{cd} && mkdir -p {remote_log_dir} && '
+                      f'touch {remote_log_path}')
+        create_script_code = f'{{ echo {shlex.quote(codegen)} > {script_path}; }}'
         job_submit_cmd = (
             f'RAY_DASHBOARD_PORT=$({constants.SKY_PYTHON_CMD} -c "from sky.skylet import job_lib; print(job_lib.get_job_submission_port())" 2> /dev/null || echo 8265);'  # pylint: disable=line-too-long
             f'{cd} && {constants.SKY_RAY_CMD} job submit '
@@ -3133,10 +3122,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             f'"{constants.SKY_PYTHON_CMD} -u {script_path} > {remote_log_path} 2> /dev/null"'
         )
 
-        mkdir_code = (f'{cd} && mkdir -p {remote_log_dir} && '
-                      f'touch {remote_log_path}')
         code = job_lib.JobLibCodeGen.queue_job(job_id, job_submit_cmd)
-        job_submit_cmd = mkdir_code + ' && ' + code
+        job_submit_cmd = ' && '.join([mkdir_code, create_script_code, code])
 
         if spot_dag is not None:
             # Add the spot job to spot queue table.

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -107,14 +107,14 @@ def _build_sky_wheel():
                            stderr=subprocess.PIPE,
                            check=True)
         except subprocess.CalledProcessError as e:
-            raise RuntimeError('Fail to build pip wheel for SkyPilot. '
+            raise RuntimeError('Failed to build pip wheel for SkyPilot. '
                                f'Error message: {e.stderr.decode()}') from e
 
         try:
             wheel_path = next(tmp_dir.glob(_WHEEL_PATTERN))
         except StopIteration:
             raise RuntimeError(
-                f'Fail to find pip wheel for SkyPilot under {tmp_dir} with '
+                f'Failed to find pip wheel for SkyPilot under {tmp_dir} with '
                 f'glob pattern {_WHEEL_PATTERN!r}. '
                 f'Found: {list(map(str, tmp_dir.glob("*")))}.'
                 'No wheel file is generated.') from None

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -56,7 +56,7 @@ from sky import serve as serve_lib
 from sky import sky_logging
 from sky import spot as spot_lib
 from sky import status_lib
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.backends import backend_utils
 from sky.benchmark import benchmark_state
 from sky.benchmark import benchmark_utils
@@ -81,7 +81,7 @@ from sky.utils.cli_utils import status_utils
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
 
-pd = adaptor_common.LazyImport('pandas')
+pd = adaptors_common.LazyImport('pandas')
 logger = sky_logging.init_logger(__name__)
 
 _CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -56,6 +56,7 @@ from sky import serve as serve_lib
 from sky import sky_logging
 from sky import spot as spot_lib
 from sky import status_lib
+from sky.adaptors import common as adaptor_common
 from sky.backends import backend_utils
 from sky.benchmark import benchmark_state
 from sky.benchmark import benchmark_utils
@@ -80,6 +81,7 @@ from sky.utils.cli_utils import status_utils
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
 
+pd = adaptor_common.LazyImport('pandas')
 logger = sky_logging.init_logger(__name__)
 
 _CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -2994,7 +2996,6 @@ def show_gpus(
             yield 'to show available accelerators.'
             return
 
-        import pandas as pd  # pylint: disable=import-outside-toplevel
         for i, (gpu, items) in enumerate(result.items()):
             accelerator_table_headers = [
                 'GPU',

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -378,7 +378,7 @@ class Kubernetes(clouds.Cloud):
 
     @classmethod
     def get_current_user_identity(cls) -> Optional[List[str]]:
-        k8s = kubernetes.get_kubernetes()
+        k8s = kubernetes.kubernetes
         try:
             _, current_context = k8s.config.list_kube_config_contexts()
             if 'namespace' in current_context['context']:

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -269,8 +269,8 @@ class OCI(clouds.Cloud):
 
                 first_ad = ad_list[0]
                 _tenancy_prefix = str(first_ad.name).split(':', maxsplit=1)[0]
-            except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
-                    oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
+            except (oci_adaptor.oci.exceptions.ConfigFileNotFound,
+                    oci_adaptor.oci.exceptions.InvalidConfig) as e:
                 # This should only happen in testing where oci config is
                 # monkeypatched. In real use, if the OCI config is not
                 # valid, the 'sky check' would fail (OCI disabled).
@@ -403,8 +403,8 @@ class OCI(clouds.Cloud):
             del user
             # TODO[Hysun]: More privilege check can be added
             return True, None
-        except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
-                oci_adaptor.get_oci().exceptions.InvalidConfig,
+        except (oci_adaptor.oci.exceptions.ConfigFileNotFound,
+                oci_adaptor.oci.exceptions.InvalidConfig,
                 oci_adaptor.service_exception()) as e:
             return False, (
                 f'OCI credential is not correctly set. '

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -101,7 +101,7 @@ def _get_az_mappings(aws_user_hash: str) -> Optional['pd.DataFrame']:
     return az_mappings
 
 
-def _fetch_and_apply_az_mapping(df: 'pd.DataFrame') -> 'pd.DataFrame':
+def _fetch_and_apply_az_mapping(df: common.LazyDataFrame) -> 'pd.DataFrame':
     """Maps zone IDs (use1-az1) to zone names (us-east-1x).
 
     The upper-level functions that use the availability zone information

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -14,7 +14,7 @@ import colorama
 
 from sky import exceptions
 from sky import sky_logging
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds import aws
 from sky.clouds.service_catalog import common
 from sky.clouds.service_catalog import config
@@ -27,7 +27,7 @@ if typing.TYPE_CHECKING:
 
     from sky.clouds import cloud
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -11,10 +11,10 @@ import typing
 from typing import Dict, List, Optional, Tuple
 
 import colorama
-import pandas as pd
 
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptor_common
 from sky.clouds import aws
 from sky.clouds.service_catalog import common
 from sky.clouds.service_catalog import config
@@ -23,7 +23,11 @@ from sky.utils import common_utils
 from sky.utils import resources_utils
 
 if typing.TYPE_CHECKING:
+    import pandas as pd
+
     from sky.clouds import cloud
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -70,7 +74,7 @@ _quotas_df = common.read_catalog('aws/instance_quota_mapping.csv',
                                  pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 
 
-def _get_az_mappings(aws_user_hash: str) -> Optional[pd.DataFrame]:
+def _get_az_mappings(aws_user_hash: str) -> Optional['pd.DataFrame']:
     filename = f'aws/az_mappings-{aws_user_hash}.csv'
     az_mapping_path = common.get_catalog_path(filename)
     az_mapping_md5_path = common.get_catalog_path(f'.meta/{filename}.md5')
@@ -97,7 +101,7 @@ def _get_az_mappings(aws_user_hash: str) -> Optional[pd.DataFrame]:
     return az_mappings
 
 
-def _fetch_and_apply_az_mapping(df: pd.DataFrame) -> pd.DataFrame:
+def _fetch_and_apply_az_mapping(df: 'pd.DataFrame') -> 'pd.DataFrame':
     """Maps zone IDs (use1-az1) to zone names (us-east-1x).
 
     The upper-level functions that use the availability zone information
@@ -158,7 +162,7 @@ def _fetch_and_apply_az_mapping(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _get_df() -> pd.DataFrame:
+def _get_df() -> 'pd.DataFrame':
     global _user_df
     with _apply_az_mapping_lock:
         if _user_df is None:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -126,7 +126,7 @@ class LazyDataFrame:
 
     def __init__(self, filename: str):
         self._filename = filename
-        self._df = None
+        self._df: Optional['pd.DataFrame'] = None
 
     def _load_df(self) -> 'pd.DataFrame':
         if self._df is None:

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -119,6 +119,7 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
 
 class LazyDataFrame:
     """A lazy data frame that reads the catalog on demand.
+
     We don't need to load the catalog for every SkyPilot call, and this class
     allows us to load the catalog only when needed.
     """

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -118,7 +118,10 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
 
 
 class LazyDataFrame:
-    """A lazy data frame that reads the catalog on demand."""
+    """A lazy data frame that reads the catalog on demand.
+    We don't need to load the catalog for every SkyPilot call, and this class
+    allows us to load the catalog only when needed.
+    """
 
     def __init__(self, filename: str):
         self._filename = filename

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -4,18 +4,24 @@ import difflib
 import hashlib
 import os
 import time
+import typing
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import filelock
-import pandas as pd
 import requests
 
 from sky import sky_logging
+from sky.adaptors import common as adaptor_common
 from sky.clouds import cloud as cloud_lib
 from sky.clouds import cloud_registry
 from sky.clouds.service_catalog import constants
 from sky.utils import rich_utils
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -111,8 +117,39 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
     return modified_catalog_path_map
 
 
+class LazyDataFrame:
+    """A lazy data frame that reads the catalog on demand."""
+
+    def __init__(self, filename: str):
+        self._filename = filename
+        self._df = None
+
+    def _load_df(self) -> 'pd.DataFrame':
+        if self._df is None:
+            try:
+                self._df = pd.read_csv(self._filename)
+            except Exception as e:  # pylint: disable=broad-except
+                # As users can manually modify the catalog, read_csv can fail.
+                logger.error(f'Failed to read {self._filename}. '
+                             'To fix: delete the csv file and try again.')
+                with ux_utils.print_exception_no_traceback():
+                    raise e
+        return self._df
+
+    def __getattr__(self, name: str):
+        return getattr(self._load_df(), name)
+
+    def __getitem__(self, key):
+        # Delegate the indexing operation to the underlying DataFrame
+        return self._load_df()[key]
+
+    def __setitem__(self, key, value):
+        # Delegate the set operation to the underlying DataFrame
+        self._load_df()[key] = value
+
+
 def read_catalog(filename: str,
-                 pull_frequency_hours: Optional[int] = None) -> pd.DataFrame:
+                 pull_frequency_hours: Optional[int] = None) -> LazyDataFrame:
     """Reads the catalog from a local CSV file.
 
     If the file does not exist, download the up-to-date catalog that matches
@@ -182,23 +219,15 @@ def read_catalog(filename: str,
                     with open(meta_path + '.md5', 'w', encoding='utf-8') as f:
                         f.write(hashlib.md5(r.text.encode()).hexdigest())
 
-    try:
-        df = pd.read_csv(catalog_path)
-    except Exception as e:  # pylint: disable=broad-except
-        # As users can manually modify the catalog, read_csv can fail.
-        logger.error(f'Failed to read {catalog_path}. '
-                     'To fix: delete the csv file and try again.')
-        with ux_utils.print_exception_no_traceback():
-            raise e
-    return df
+    return LazyDataFrame(catalog_path)
 
 
 def _get_instance_type(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     instance_type: str,
     region: Optional[str],
     zone: Optional[str] = None,
-) -> pd.DataFrame:
+) -> 'pd.DataFrame':
     idx = df['InstanceType'] == instance_type
     if region is not None:
         idx &= df['Region'].str.lower() == region.lower()
@@ -208,13 +237,13 @@ def _get_instance_type(
     return df[idx]
 
 
-def instance_type_exists_impl(df: pd.DataFrame, instance_type: str) -> bool:
+def instance_type_exists_impl(df: 'pd.DataFrame', instance_type: str) -> bool:
     """Returns True if the instance type is valid."""
     return instance_type in df['InstanceType'].unique()
 
 
 def validate_region_zone_impl(
-        cloud_name: str, df: pd.DataFrame, region: Optional[str],
+        cloud_name: str, df: 'pd.DataFrame', region: Optional[str],
         zone: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
     """Validates whether region and zone exist in the catalog.
 
@@ -284,7 +313,7 @@ def validate_region_zone_impl(
 
 
 def get_hourly_cost_impl(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     instance_type: str,
     use_spot: bool,
     region: Optional[str],
@@ -329,7 +358,7 @@ def _get_value(value):
 
 
 def get_vcpus_mem_from_instance_type_impl(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     instance_type: str,
 ) -> Tuple[Optional[float], Optional[float]]:
     df = _get_instance_type(df, instance_type, None)
@@ -350,7 +379,8 @@ def get_vcpus_mem_from_instance_type_impl(
     return _get_value(vcpus), _get_value(mem)
 
 
-def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
+def _filter_with_cpus(df: 'pd.DataFrame',
+                      cpus: Optional[str]) -> 'pd.DataFrame':
     if cpus is None:
         return df
 
@@ -373,8 +403,8 @@ def _filter_with_cpus(df: pd.DataFrame, cpus: Optional[str]) -> pd.DataFrame:
         return df[df['vCPUs'] == num_cpus]
 
 
-def _filter_with_mem(df: pd.DataFrame,
-                     memory_gb_or_ratio: Optional[str]) -> pd.DataFrame:
+def _filter_with_mem(df: 'pd.DataFrame',
+                     memory_gb_or_ratio: Optional[str]) -> 'pd.DataFrame':
     if memory_gb_or_ratio is None:
         return df
 
@@ -399,8 +429,8 @@ def _filter_with_mem(df: pd.DataFrame,
         return df[df['MemoryGiB'] == memory]
 
 
-def _filter_region_zone(df: pd.DataFrame, region: Optional[str],
-                        zone: Optional[str]) -> pd.DataFrame:
+def _filter_region_zone(df: 'pd.DataFrame', region: Optional[str],
+                        zone: Optional[str]) -> 'pd.DataFrame':
     if region is not None:
         df = df[df['Region'].str.lower() == region.lower()]
     if zone is not None:
@@ -409,7 +439,7 @@ def _filter_region_zone(df: pd.DataFrame, region: Optional[str],
 
 
 def get_instance_type_for_cpus_mem_impl(
-        df: pd.DataFrame, cpus: Optional[str],
+        df: 'pd.DataFrame', cpus: Optional[str],
         memory_gb_or_ratio: Optional[str]) -> Optional[str]:
     """Returns the cheapest instance type that satisfies the requirements.
 
@@ -434,7 +464,7 @@ def get_instance_type_for_cpus_mem_impl(
 
 
 def get_accelerators_from_instance_type_impl(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     instance_type: str,
 ) -> Optional[Dict[str, int]]:
     df = _get_instance_type(df, instance_type, None)
@@ -449,7 +479,7 @@ def get_accelerators_from_instance_type_impl(
 
 
 def get_instance_type_for_accelerator_impl(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     acc_name: str,
     acc_count: int,
     cpus: Optional[str] = None,
@@ -496,7 +526,7 @@ def get_instance_type_for_accelerator_impl(
 
 def list_accelerators_impl(
         cloud: str,
-        df: pd.DataFrame,
+        df: 'pd.DataFrame',
         gpus_only: bool,
         name_filter: Optional[str],
         region_filter: Optional[str],
@@ -590,7 +620,7 @@ def list_accelerators_impl(
     return {k: make_list_from_df(v) for k, v in grouped}
 
 
-def get_region_zones(df: pd.DataFrame,
+def get_region_zones(df: 'pd.DataFrame',
                      use_spot: bool) -> List[cloud_lib.Region]:
     """Returns a list of regions/zones from a dataframe."""
     price_str = 'SpotPrice' if use_spot else 'Price'
@@ -610,7 +640,7 @@ def get_region_zones(df: pd.DataFrame,
 
 
 # Images
-def get_image_id_from_tag_impl(df: pd.DataFrame, tag: str,
+def get_image_id_from_tag_impl(df: 'pd.DataFrame', tag: str,
                                region: Optional[str]) -> Optional[str]:
     """Returns the image ID for the given tag and region.
 
@@ -631,7 +661,7 @@ def get_image_id_from_tag_impl(df: pd.DataFrame, tag: str,
     return image_id
 
 
-def is_image_tag_valid_impl(df: pd.DataFrame, tag: str,
+def is_image_tag_valid_impl(df: 'pd.DataFrame', tag: str,
                             region: Optional[str]) -> bool:
     """Returns True if the image tag is valid."""
     df = df[df['Tag'] == tag]

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -11,7 +11,7 @@ import filelock
 import requests
 
 from sky import sky_logging
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds import cloud as cloud_lib
 from sky.clouds import cloud_registry
 from sky.clouds.service_catalog import constants
@@ -21,7 +21,7 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -2,13 +2,13 @@
 import typing
 from typing import List
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 
 def resource_diff(original_df: 'pd.DataFrame', new_df: 'pd.DataFrame',

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -1,14 +1,19 @@
 """Analyze the new catalog fetched with the original."""
-
+import typing
 from typing import List
 
 import pandas as pd
 
 from sky.clouds.service_catalog import common
 
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
-def resource_diff(original_df: pd.DataFrame, new_df: pd.DataFrame,
-                  check_tuple: List[str]) -> pd.DataFrame:
+
+def resource_diff(original_df: 'pd.DataFrame', new_df: 'pd.DataFrame',
+                  check_tuple: List[str]) -> 'pd.DataFrame':
     """Returns the difference between two dataframes."""
     original_resources = original_df[check_tuple]
     new_resources = new_df[check_tuple]

--- a/sky/clouds/service_catalog/data_fetchers/analyze.py
+++ b/sky/clouds/service_catalog/data_fetchers/analyze.py
@@ -2,8 +2,7 @@
 import typing
 from typing import List
 
-import pandas as pd
-
+from sky.adaptors import common as adaptor_common
 from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -19,14 +19,14 @@ import numpy as np
 
 from sky import exceptions
 from sky.adaptors import aws
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.utils import log_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 # Enable most of the regions. Each user's account may have a subset of these
 # enabled; this is ok because we take the intersection of the list here with

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -12,15 +12,20 @@ import subprocess
 import sys
 import textwrap
 import traceback
+import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
-import pandas as pd
 
 from sky import exceptions
 from sky.adaptors import aws
 from sky.utils import log_utils
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 # Enable most of the regions. Each user's account may have a subset of these
 # enabled; this is ok because we take the intersection of the list here with
@@ -98,7 +103,7 @@ def get_enabled_regions() -> Set[str]:
     return regions_enabled
 
 
-def _get_instance_types(region: str) -> pd.DataFrame:
+def _get_instance_types(region: str) -> 'pd.DataFrame':
     client = aws.client('ec2', region_name=region)
     paginator = client.get_paginator('describe_instance_types')
     items = []
@@ -109,7 +114,7 @@ def _get_instance_types(region: str) -> pd.DataFrame:
     return pd.DataFrame(items)
 
 
-def _get_instance_type_offerings(region: str) -> pd.DataFrame:
+def _get_instance_type_offerings(region: str) -> 'pd.DataFrame':
     client = aws.client('ec2', region_name=region)
     paginator = client.get_paginator('describe_instance_type_offerings')
     items = []
@@ -122,7 +127,7 @@ def _get_instance_type_offerings(region: str) -> pd.DataFrame:
         columns={'Location': 'AvailabilityZoneName'})
 
 
-def _get_availability_zones(region: str) -> pd.DataFrame:
+def _get_availability_zones(region: str) -> 'pd.DataFrame':
     client = aws.client('ec2', region_name=region)
     zones = []
     try:
@@ -156,7 +161,7 @@ def _get_availability_zones(region: str) -> pd.DataFrame:
     return pd.DataFrame(zones)
 
 
-def _get_pricing_table(region: str) -> pd.DataFrame:
+def _get_pricing_table(region: str) -> 'pd.DataFrame':
     print(f'{region} downloading pricing table')
     url = PRICING_TABLE_URL_FMT.format(region=region)
     df = pd.read_csv(url, skiprows=5, low_memory=False)
@@ -174,7 +179,7 @@ def _get_pricing_table(region: str) -> pd.DataFrame:
               ]]
 
 
-def _get_spot_pricing_table(region: str) -> pd.DataFrame:
+def _get_spot_pricing_table(region: str) -> 'pd.DataFrame':
     """Get spot pricing table for a region.
 
     Example output:
@@ -203,8 +208,8 @@ def _get_spot_pricing_table(region: str) -> pd.DataFrame:
     return df
 
 
-def _patch_p4de(region: str, df: pd.DataFrame,
-                pricing_df: pd.DataFrame) -> pd.DataFrame:
+def _patch_p4de(region: str, df: 'pd.DataFrame',
+                pricing_df: 'pd.DataFrame') -> 'pd.DataFrame':
     # Hardcoded patch for p4de.24xlarge, as our credentials doesn't have access
     # to the instance type.
     # Columns:
@@ -232,7 +237,7 @@ def _patch_p4de(region: str, df: pd.DataFrame,
     return df
 
 
-def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
+def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
     try:
         # Fetch the zone info first to make sure the account has access to the
         # region.
@@ -341,7 +346,7 @@ def _get_instance_types_df(region: str) -> Union[str, pd.DataFrame]:
     return df
 
 
-def get_all_regions_instance_types_df(regions: Set[str]) -> pd.DataFrame:
+def get_all_regions_instance_types_df(regions: Set[str]) -> 'pd.DataFrame':
     with mp_pool.Pool() as pool:
         df_or_regions = pool.map(_get_instance_types_df, regions)
     new_dfs = []
@@ -413,7 +418,7 @@ def _get_image_row(
     return tag, region, 'ubuntu', ubuntu_version, image_id, date
 
 
-def get_all_regions_images_df(regions: Set[str]) -> pd.DataFrame:
+def get_all_regions_images_df(regions: Set[str]) -> 'pd.DataFrame':
     image_metas = [
         (r, *i) for r, i in itertools.product(regions, _GPU_UBUNTU_DATE_PYTORCH)
     ]
@@ -426,7 +431,7 @@ def get_all_regions_images_df(regions: Set[str]) -> pd.DataFrame:
     return result_df
 
 
-def fetch_availability_zone_mappings() -> pd.DataFrame:
+def fetch_availability_zone_mappings() -> 'pd.DataFrame':
     """Fetch the availability zone mappings from ID to Name.
 
     Example output:
@@ -504,7 +509,7 @@ if __name__ == '__main__':
         raise RuntimeError('The following regions are not enabled: '
                            f'{set(ALL_REGIONS) - user_regions}')
 
-    def _check_regions_integrity(df: pd.DataFrame, name: str):
+    def _check_regions_integrity(df: 'pd.DataFrame', name: str):
         # Check whether the fetched regions match the requested regions to
         # guard against network issues or glitches in the AWS API.
         fetched_regions = set(df['Region'].unique())

--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from sky import exceptions
 from sky.adaptors import aws
+from sky.adaptors import common as adaptor_common
 from sky.utils import log_utils
 from sky.utils import ux_utils
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -14,12 +14,12 @@ import urllib
 import numpy as np
 import requests
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 US_REGIONS = {
     'centralus',

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -7,12 +7,17 @@ import json
 from multiprocessing import pool as mp_pool
 import os
 import subprocess
+import typing
 from typing import List, Optional, Set
 import urllib
 
 import numpy as np
-import pandas as pd
 import requests
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 US_REGIONS = {
     'centralus',
@@ -103,7 +108,7 @@ def get_pricing_url(region: Optional[str] = None) -> str:
     return f'https://prices.azure.com/api/retail/prices?$filter={filters_str}'
 
 
-def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
+def get_pricing_df(region: Optional[str] = None) -> 'pd.DataFrame':
     all_items = []
     url = get_pricing_url(region)
     print(f'Getting pricing for {region}, url: {url}')
@@ -128,7 +133,7 @@ def get_pricing_df(region: Optional[str] = None) -> pd.DataFrame:
               (df['unitPrice'] > 0)]
 
 
-def get_sku_df(region_set: Set[str]) -> pd.DataFrame:
+def get_sku_df(region_set: Set[str]) -> 'pd.DataFrame':
     print('Fetching SKU list')
     # To get a complete list, --all option is necessary.
     proc = subprocess.run(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -14,6 +14,8 @@ import urllib
 import numpy as np
 import requests
 
+from sky.adaptors import common as adaptor_common
+
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -17,13 +17,13 @@ import google.auth
 from googleapiclient import discovery
 import numpy as np
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import gcp
 
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 # Useful links:
 # GCP SKUs: https://cloud.google.com/skus

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -10,14 +10,19 @@ import io
 import multiprocessing
 import os
 import textwrap
+import typing
 from typing import Any, Callable, Dict, List, Optional, Set
 
 import google.auth
 from googleapiclient import discovery
 import numpy as np
-import pandas as pd
 
 from sky.adaptors import gcp
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 # Useful links:
 # GCP SKUs: https://cloud.google.com/skus
@@ -175,7 +180,7 @@ def _get_all_zones() -> List[str]:
     return zones
 
 
-def _get_machine_type_for_zone(zone: str) -> pd.DataFrame:
+def _get_machine_type_for_zone(zone: str) -> 'pd.DataFrame':
     machine_types_request = gcp_client.machineTypes().list(project=project_id,
                                                            zone=zone)
     print(f'Fetching machine types for zone {zone!r}...')
@@ -196,7 +201,7 @@ def _get_machine_type_for_zone(zone: str) -> pd.DataFrame:
     return pd.DataFrame(machine_types).reset_index(drop=True)
 
 
-def _get_machine_types(region_prefix: str) -> pd.DataFrame:
+def _get_machine_types(region_prefix: str) -> 'pd.DataFrame':
     zones = _get_all_zones()
     zones = [zone for zone in zones if zone.startswith(region_prefix)]
     if SINGLE_THREADED:
@@ -208,7 +213,7 @@ def _get_machine_types(region_prefix: str) -> pd.DataFrame:
     return machine_df
 
 
-def get_vm_df(skus: List[Dict[str, Any]], region_prefix: str) -> pd.DataFrame:
+def get_vm_df(skus: List[Dict[str, Any]], region_prefix: str) -> 'pd.DataFrame':
     df = _get_machine_types(region_prefix)
     if df.empty:
         return df
@@ -281,7 +286,7 @@ def get_vm_df(skus: List[Dict[str, Any]], region_prefix: str) -> pd.DataFrame:
     return df
 
 
-def _get_gpus_for_zone(zone: str) -> pd.DataFrame:
+def _get_gpus_for_zone(zone: str) -> 'pd.DataFrame':
     gpus_request = gcp_client.acceleratorTypes().list(project=project_id,
                                                       zone=zone)
     print(f'Fetching GPUs for zone {zone!r}...')
@@ -346,7 +351,7 @@ def _gpu_info_from_name(name: str) -> Optional[Dict[str, List[Dict[str, Any]]]]:
     return None
 
 
-def _get_gpus(region_prefix: str) -> pd.DataFrame:
+def _get_gpus(region_prefix: str) -> 'pd.DataFrame':
     zones = _get_all_zones()
     zones = [zone for zone in zones if zone.startswith(region_prefix)]
     if SINGLE_THREADED:
@@ -358,7 +363,8 @@ def _get_gpus(region_prefix: str) -> pd.DataFrame:
     return gpu_df
 
 
-def get_gpu_df(skus: List[Dict[str, Any]], region_prefix: str) -> pd.DataFrame:
+def get_gpu_df(skus: List[Dict[str, Any]],
+               region_prefix: str) -> 'pd.DataFrame':
     gpu_skus = [
         sku for sku in skus if sku['category']['resourceGroup'] == 'GPU'
     ]
@@ -407,7 +413,7 @@ def get_gpu_df(skus: List[Dict[str, Any]], region_prefix: str) -> pd.DataFrame:
     return df
 
 
-def _get_tpu_for_zone(zone: str) -> pd.DataFrame:
+def _get_tpu_for_zone(zone: str) -> 'pd.DataFrame':
     tpus = []
     parent = f'projects/{project_id}/locations/{zone}'
     tpus_request = tpu_client.projects().locations().acceleratorTypes().list(
@@ -437,7 +443,7 @@ def _get_tpu_for_zone(zone: str) -> pd.DataFrame:
     return pd.DataFrame(new_tpus).reset_index(drop=True)
 
 
-def _get_tpus() -> pd.DataFrame:
+def _get_tpus() -> 'pd.DataFrame':
     zones = _get_all_zones()
     # Add TPU-v4 zones.
     zones += TPU_V4_ZONES
@@ -451,7 +457,7 @@ def _get_tpus() -> pd.DataFrame:
 
 
 # TODO: the TPUs fetched fails to contain us-east1
-def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
+def get_tpu_df(skus: List[Dict[str, Any]]) -> 'pd.DataFrame':
     df = _get_tpus()
     if df.empty:
         return df
@@ -527,7 +533,7 @@ def get_tpu_df(skus: List[Dict[str, Any]]) -> pd.DataFrame:
     return df
 
 
-def get_catalog_df(region_prefix: str) -> pd.DataFrame:
+def get_catalog_df(region_prefix: str) -> 'pd.DataFrame':
     gcp_skus = get_skus(GCE_SERVICE_ID)
     vm_df = get_vm_df(gcp_skus, region_prefix)
     gpu_df = get_gpu_df(gcp_skus, region_prefix)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -17,6 +17,7 @@ import google.auth
 from googleapiclient import discovery
 import numpy as np
 
+from sky.adaptors import common as adaptor_common
 from sky.adaptors import gcp
 
 if typing.TYPE_CHECKING:

--- a/sky/clouds/service_catalog/data_fetchers/fetch_vsphere.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_vsphere.py
@@ -4,7 +4,7 @@ import logging
 import os
 import typing
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import vsphere as vsphere_adaptor
 from sky.clouds.service_catalog.common import get_catalog_path
 from sky.provision.vsphere.common.cls_api_client import ClsApiClient
@@ -12,7 +12,7 @@ from sky.provision.vsphere.common.cls_api_client import ClsApiClient
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_vsphere.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_vsphere.py
@@ -4,11 +4,15 @@ import logging
 import os
 import typing
 
-import pandas as pd
-
+from sky.adaptors import common as adaptor_common
 from sky.adaptors import vsphere as vsphere_adaptor
 from sky.clouds.service_catalog.common import get_catalog_path
 from sky.provision.vsphere.common.cls_api_client import ClsApiClient
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Tuple
 
 from sky import exceptions
 from sky import sky_logging
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds.service_catalog import common
 from sky.utils import resources_utils
 from sky.utils import ux_utils
@@ -18,7 +18,7 @@ if typing.TYPE_CHECKING:
 
     from sky.clouds import cloud
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -6,16 +6,19 @@ queried from GCP API.
 import typing
 from typing import Dict, List, Optional, Tuple
 
-import pandas as pd
-
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptor_common
 from sky.clouds.service_catalog import common
 from sky.utils import resources_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import pandas as pd
+
     from sky.clouds import cloud
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -323,12 +326,12 @@ def get_region_zones_for_instance_type(instance_type: str,
 
 
 def _get_accelerator(
-    df: pd.DataFrame,
+    df: 'pd.DataFrame',
     accelerator: str,
     count: int,
     region: Optional[str],
     zone: Optional[str] = None,
-) -> pd.DataFrame:
+) -> 'pd.DataFrame':
     idx = (df['AcceleratorName'].str.fullmatch(
         accelerator, case=False)) & (df['AcceleratorCount'] == count)
     if region is not None:

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -7,7 +7,7 @@ import typing
 from typing import Dict, List, Optional, Set, Tuple
 
 from sky import check as sky_check
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds import Kubernetes
 from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
@@ -16,7 +16,7 @@ from sky.provision.kubernetes import utils as kubernetes_utils
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 _PULL_FREQUENCY_HOURS = 7
 

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -3,15 +3,20 @@
 Kubernetes does not require a catalog of instances, but we need an image catalog
 mapping SkyPilot image tags to corresponding container image tags.
 """
+import typing
 from typing import Dict, List, Optional, Set, Tuple
 
-import pandas as pd
-
 from sky import check as sky_check
+from sky.adaptors import common as adaptor_common
 from sky.clouds import Kubernetes
 from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
 from sky.provision.kubernetes import utils as kubernetes_utils
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 _PULL_FREQUENCY_HOURS = 7
 

--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -40,7 +40,7 @@ def _get_df() -> 'pd.DataFrame':
 
         df = common.read_catalog('oci/vms.csv')
         try:
-            oci_adaptor.get_oci()
+            oci_adaptor.oci
         except ImportError:
             _df = df
             return _df
@@ -55,8 +55,8 @@ def _get_df() -> 'pd.DataFrame':
 
             subscribed_regions = [r.region_name for r in subscriptions]
 
-        except (oci_adaptor.get_oci().exceptions.ConfigFileNotFound,
-                oci_adaptor.get_oci().exceptions.InvalidConfig) as e:
+        except (oci_adaptor.oci.exceptions.ConfigFileNotFound,
+                oci_adaptor.oci.exceptions.InvalidConfig) as e:
             # This should only happen in testing where oci config is
             # missing, because it means the 'sky check' will fail if
             # enter here (meaning OCI disabled).

--- a/sky/clouds/service_catalog/vsphere_catalog.py
+++ b/sky/clouds/service_catalog/vsphere_catalog.py
@@ -4,7 +4,7 @@ import os
 import typing
 from typing import Dict, List, Optional, Tuple
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
 
     from sky.clouds import cloud
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 _DEFAULT_NUM_VCPUS = 2
 _DEFAULT_MEMORY_CPU_RATIO = 4

--- a/sky/clouds/service_catalog/vsphere_catalog.py
+++ b/sky/clouds/service_catalog/vsphere_catalog.py
@@ -4,12 +4,15 @@ import os
 import typing
 from typing import Dict, List, Optional, Tuple
 
-import pandas as pd
-
+from sky.adaptors import common as adaptor_common
 from sky.clouds.service_catalog import common
 
 if typing.TYPE_CHECKING:
+    import pandas as pd
+
     from sky.clouds import cloud
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 _DEFAULT_NUM_VCPUS = 2
 _DEFAULT_MEMORY_CPU_RATIO = 4
@@ -23,7 +26,7 @@ _LOCAL_CATALOG = common.get_catalog_path('vsphere/vms.csv')
 _df = None
 
 
-def _get_df() -> pd.DataFrame:
+def _get_df() -> 'pd.DataFrame':
     """Returns the catalog as a DataFrame."""
     global _df
     if _df is not None:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -7,7 +7,6 @@ import typing
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import colorama
-import networkx as nx
 import numpy as np
 import prettytable
 
@@ -17,13 +16,17 @@ from sky import exceptions
 from sky import resources as resources_lib
 from sky import sky_logging
 from sky import task as task_lib
+from sky.adaptors import common as adaptor_common
 from sky.utils import env_options
 from sky.utils import log_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    # pylint: disable=ungrouped-imports
+    import networkx as nx
+
     from sky import dag as dag_lib
+else:
+    nx = adaptor_common.LazyImport('networkx')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -16,7 +16,7 @@ from sky import exceptions
 from sky import resources as resources_lib
 from sky import sky_logging
 from sky import task as task_lib
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.utils import env_options
 from sky.utils import log_utils
 from sky.utils import ux_utils
@@ -26,7 +26,7 @@ if typing.TYPE_CHECKING:
 
     from sky import dag as dag_lib
 else:
-    nx = adaptor_common.LazyImport('networkx')
+    nx = adaptors_common.LazyImport('networkx')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -3,7 +3,7 @@ import time
 from typing import Dict
 
 from sky import sky_logging
-from sky.adaptors.cudo import cudo
+from sky.adaptors import cudo
 
 logger = sky_logging.init_logger(__name__)
 
@@ -12,10 +12,10 @@ def launch(name: str, data_center_id: str, ssh_key: str, machine_type: str,
            memory_gib: int, vcpu_count: int, gpu_count: int, gpu_model: str,
            tags: Dict[str, str], disk_size: int):
     """Launches an instance with the given parameters."""
-    disk = cudo().Disk(storage_class='STORAGE_CLASS_NETWORK',
+    disk = cudo.cudo.Disk(storage_class='STORAGE_CLASS_NETWORK',
                        size_gib=disk_size)
 
-    request = cudo().CreateVMBody(ssh_key_source='SSH_KEY_SOURCE_NONE',
+    request = cudo.cudo.CreateVMBody(ssh_key_source='SSH_KEY_SOURCE_NONE',
                                   custom_ssh_keys=[ssh_key],
                                   vm_id=name,
                                   machine_type=machine_type,
@@ -29,10 +29,10 @@ def launch(name: str, data_center_id: str, ssh_key: str, machine_type: str,
                                   metadata=tags)
 
     try:
-        api = cudo().cudo_api.virtual_machines()
-        vm = api.create_vm(cudo().cudo_api.project_id(), request)
+        api = cudo.cudo.cudo_api.virtual_machines()
+        vm = api.create_vm(cudo.cudo.cudo_api.project_id(), request)
         return vm.to_dict()['id']
-    except cudo().rest.ApiException as e:
+    except cudo.cudo.rest.ApiException as e:
         raise e
 
 
@@ -47,17 +47,17 @@ def remove(instance_id: str):
         'unde',
         'fail',
     ]
-    api = cudo().cudo_api.virtual_machines()
+    api = cudo.cudo.cudo_api.virtual_machines()
     max_retries = 10
     retry_interval = 5
     retry_count = 0
     state = 'unknown'
-    project_id = cudo().cudo_api.project_id()
+    project_id = cudo.cudo.cudo_api.project_id()
     while retry_count < max_retries:
         try:
             vm = api.get_vm(project_id, instance_id)
             state = vm.to_dict()['vm']['short_state']
-        except cudo().rest.ApiException as e:
+        except cudo.cudo.rest.ApiException as e:
             raise e
 
         if state in terminate_ok:
@@ -71,37 +71,37 @@ def remove(instance_id: str):
 
     try:
         api.terminate_vm(project_id, instance_id)
-    except cudo().rest.ApiException as e:
+    except cudo.cudo.rest.ApiException as e:
         raise e
 
 
 def set_tags(instance_id: str, tags: Dict):
     """Sets the tags for the given instance."""
     try:
-        api = cudo().cudo_api.virtual_machines()
+        api = cudo.cudo.cudo_api.virtual_machines()
         api.update_vm_metadata(
-            cudo().cudo_api.project_id(), instance_id,
-            cudo().UpdateVMMetadataBody(
+            cudo.cudo.cudo_api.project_id(), instance_id,
+            cudo.cudo.UpdateVMMetadataBody(
                 metadata=tags,
                 merge=True))  # TODO (skypilot team) merge or overwrite?
-    except cudo().rest.ApiException as e:
+    except cudo.cudo.rest.ApiException as e:
         raise e
 
 
 def get_instance(vm_id):
     try:
-        api = cudo().cudo_api.virtual_machines()
-        vm = api.get_vm(cudo().cudo_api.project_id(), vm_id)
+        api = cudo.cudo.cudo_api.virtual_machines()
+        vm = api.get_vm(cudo.cudo.cudo_api.project_id(), vm_id)
         vm_dict = vm.to_dict()
         return vm_dict
-    except cudo().rest.ApiException as e:
+    except cudo.cudo.rest.ApiException as e:
         raise e
 
 
 def list_instances():
     try:
-        api = cudo().cudo_api.virtual_machines()
-        vms = api.list_vms(cudo().cudo_api.project_id())
+        api = cudo.cudo.cudo_api.virtual_machines()
+        vms = api.list_vms(cudo.cudo.cudo_api.project_id())
         instances = {}
         for vm in vms.to_dict()['vms']:
             ex_ip = vm['external_ip_address']
@@ -119,5 +119,5 @@ def list_instances():
             }
             instances[vm['id']] = instance
         return instances
-    except cudo().rest.ApiException as e:
+    except cudo.cudo.rest.ApiException as e:
         raise e

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -13,20 +13,20 @@ def launch(name: str, data_center_id: str, ssh_key: str, machine_type: str,
            tags: Dict[str, str], disk_size: int):
     """Launches an instance with the given parameters."""
     disk = cudo.cudo.Disk(storage_class='STORAGE_CLASS_NETWORK',
-                       size_gib=disk_size)
+                          size_gib=disk_size)
 
     request = cudo.cudo.CreateVMBody(ssh_key_source='SSH_KEY_SOURCE_NONE',
-                                  custom_ssh_keys=[ssh_key],
-                                  vm_id=name,
-                                  machine_type=machine_type,
-                                  data_center_id=data_center_id,
-                                  boot_disk_image_id='ubuntu-nvidia-docker',
-                                  memory_gib=memory_gib,
-                                  vcpus=vcpu_count,
-                                  gpus=gpu_count,
-                                  gpu_model=gpu_model,
-                                  boot_disk=disk,
-                                  metadata=tags)
+                                     custom_ssh_keys=[ssh_key],
+                                     vm_id=name,
+                                     machine_type=machine_type,
+                                     data_center_id=data_center_id,
+                                     boot_disk_image_id='ubuntu-nvidia-docker',
+                                     memory_gib=memory_gib,
+                                     vcpus=vcpu_count,
+                                     gpus=gpu_count,
+                                     gpu_model=gpu_model,
+                                     boot_disk=disk,
+                                     metadata=tags)
 
     try:
         api = cudo.cudo.cudo_api.virtual_machines()

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -412,7 +412,7 @@ class GCPComputeInstance(GCPInstance):
             f'Waiting GCP operation {operation["name"]} to be ready ...')
 
         @_retry_on_http_exception(
-            f'Fail to wait for operation {operation["name"]}')
+            f'Failed to wait for operation {operation["name"]}')
         def call_operation(fn, timeout: int):
             request = fn(
                 project=project_id,
@@ -965,7 +965,7 @@ class GCPTPUVMInstance(GCPInstance):
         del project_id, zone  # unused
 
         @_retry_on_http_exception(
-            f'Fail to wait for operation {operation["name"]}')
+            f'Failed to wait for operation {operation["name"]}')
         def call_operation(fn, timeout: int):
             request = fn(name=operation['name'])
             request.http.timeout = timeout

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -453,7 +453,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     nvidia_runtime_exists = False
     try:
         nvidia_runtime_exists = kubernetes_utils.check_nvidia_runtime_class()
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         logger.warning('run_instances: Error occurred while checking for '
                        f'nvidia RuntimeClass - '
                        f'{common_utils.format_exception(e)}'

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -193,7 +193,7 @@ def query_ports(
             )
         else:
             return {}
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
             return {}
         raise e

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -98,7 +98,7 @@ def create_or_replace_namespaced_ingress(
     try:
         networking_api.read_namespaced_ingress(
             ingress_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
             networking_api.create_namespaced_ingress(
                 namespace,
@@ -120,7 +120,7 @@ def delete_namespaced_ingress(namespace: str, ingress_name: str) -> None:
     try:
         networking_api.delete_namespaced_ingress(
             ingress_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
             raise exceptions.PortDoesNotExistError(
                 f'Port {ingress_name.split("--")[-1]} does not exist.')
@@ -136,7 +136,7 @@ def create_or_replace_namespaced_service(
     try:
         core_api.read_namespaced_service(
             service_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
             core_api.create_namespaced_service(
                 namespace,
@@ -158,7 +158,7 @@ def delete_namespaced_service(namespace: str, service_name: str) -> None:
     try:
         core_api.delete_namespaced_service(
             service_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
-    except kubernetes.get_kubernetes().client.ApiException as e:
+    except kubernetes.kubernetes.client.ApiException as e:
         if e.status == 404:
             raise exceptions.PortDoesNotExistError(
                 f'Port {service_name.split("--")[-1]} does not exist.')

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -531,7 +531,7 @@ def get_current_kube_config_context_name() -> Optional[str]:
     Returns:
         str | None: The current kubernetes context if it exists, None otherwise
     """
-    k8s = kubernetes.get_kubernetes()
+    k8s = kubernetes.kubernetes
     try:
         _, current_context = k8s.config.list_kube_config_contexts()
         return current_context['name']
@@ -546,7 +546,7 @@ def get_current_kube_config_context_namespace() -> str:
         str | None: The current kubernetes context namespace if it exists, else
             the default namespace.
     """
-    k8s = kubernetes.get_kubernetes()
+    k8s = kubernetes.kubernetes
     try:
         _, current_context = k8s.config.list_kube_config_contexts()
         if 'namespace' in current_context['context']:

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -54,7 +54,7 @@ def retry(func):
         while True:
             try:
                 return func(*args, **kwargs)
-            except runpod.runpod().error.QueryError as e:
+            except runpod.runpod.error.QueryError as e:
                 if cnt >= 3:
                     raise
                 logger.warning('Retrying for exception: '
@@ -66,7 +66,7 @@ def retry(func):
 
 def list_instances() -> Dict[str, Dict[str, Any]]:
     """Lists instances associated with API key."""
-    instances = runpod.runpod().get_pods()
+    instances = runpod.runpod.get_pods()
 
     instance_dict: Dict[str, Dict[str, Any]] = {}
     for instance in instances:
@@ -98,9 +98,9 @@ def launch(name: str, instance_type: str, region: str, disk_size: int) -> str:
     gpu_quantity = int(instance_type.split('_')[0].replace('x', ''))
     cloud_type = instance_type.split('_')[2]
 
-    gpu_specs = runpod.runpod().get_gpu(gpu_type)
+    gpu_specs = runpod.runpod.get_gpu(gpu_type)
 
-    new_instance = runpod.runpod().create_pod(
+    new_instance = runpod.runpod.create_pod(
         name=name,
         image_name='runpod/base:0.0.2',
         gpu_type_id=gpu_type,
@@ -121,7 +121,7 @@ def launch(name: str, instance_type: str, region: str, disk_size: int) -> str:
 
 def remove(instance_id: str) -> None:
     """Terminates the given instance."""
-    runpod.runpod().terminate_pod(instance_id)
+    runpod.runpod.terminate_pod(instance_id)
 
 
 def get_ssh_ports(cluster_name) -> List[int]:

--- a/sky/provision/vsphere/instance.py
+++ b/sky/provision/vsphere/instance.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from sky import exceptions
 from sky import sky_logging
 from sky import status_lib
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import vsphere as vsphere_adaptor
 from sky.clouds.service_catalog.common import get_catalog_path
 from sky.provision import common
@@ -22,7 +22,7 @@ from sky.provision.vsphere.vsphere_utils import VsphereClient
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/vsphere/instance.py
+++ b/sky/provision/vsphere/instance.py
@@ -1,13 +1,13 @@
 """Vsphere instance provisioning."""
 import json
 import os
+import typing
 from typing import Any, Dict, List, Optional
-
-import pandas as pd
 
 from sky import exceptions
 from sky import sky_logging
 from sky import status_lib
+from sky.adaptors import common as adaptor_common
 from sky.adaptors import vsphere as vsphere_adaptor
 from sky.clouds.service_catalog.common import get_catalog_path
 from sky.provision import common
@@ -18,6 +18,11 @@ from sky.provision.vsphere.common.vim_utils import poweroff_vm
 from sky.provision.vsphere.common.vim_utils import wait_for_tasks
 from sky.provision.vsphere.common.vim_utils import wait_internal_ip_ready
 from sky.provision.vsphere.vsphere_utils import VsphereClient
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/skylet/providers/oci/node_provider.py
+++ b/sky/skylet/providers/oci/node_provider.py
@@ -208,7 +208,7 @@ class OCINodeProvider(NodeProvider):
                         self.region,
                         oci_utils.oci_config.get_profile()).get_instance(
                             instance_id=reuse_node["id"])
-                    oci_adaptor.get_oci().wait_until(
+                    oci_adaptor.oci.wait_until(
                         oci_adaptor.get_core_client(
                             self.region, oci_utils.oci_config.get_profile()),
                         get_instance_response,
@@ -266,21 +266,21 @@ class OCINodeProvider(NodeProvider):
             if ocpu_count > 0:
                 mem = node_config["MemoryInGbs"]
                 if mem is not None and mem != "None":
-                    machine_shape_config = (oci_adaptor.get_oci().core.models.
+                    machine_shape_config = (oci_adaptor.oci.core.models.
                                             LaunchInstanceShapeConfigDetails(
                                                 ocpus=ocpu_count,
                                                 memory_in_gbs=mem))
                 else:
-                    machine_shape_config = (oci_adaptor.get_oci().core.models.
+                    machine_shape_config = (oci_adaptor.oci.core.models.
                                             LaunchInstanceShapeConfigDetails(
                                                 ocpus=ocpu_count))
 
-            preempitible_config = (oci_adaptor.get_oci(
-            ).core.models.PreemptibleInstanceConfigDetails(
-                preemption_action=oci_adaptor.get_oci().core.models.
-                TerminatePreemptionAction(type="TERMINATE",
-                                          preserve_boot_volume=False))
-                                   if node_config["Preemptible"] else None)
+            preempitible_config = (
+                oci_adaptor.oci.core.models.PreemptibleInstanceConfigDetails(
+                    preemption_action=oci_adaptor.oci.core.models.
+                    TerminatePreemptionAction(type="TERMINATE",
+                                              preserve_boot_volume=False))
+                if node_config["Preemptible"] else None)
 
             logger.debug(f"Shape: {instance_type_str}, ocpu: {ocpu_count}")
             logger.debug(f"Shape config is {machine_shape_config}")
@@ -306,33 +306,35 @@ class OCINodeProvider(NodeProvider):
             for seq in range(1, count + 1):
                 launch_instance_response = oci_adaptor.get_core_client(
                     self.region, oci_utils.oci_config.get_profile()
-                ).launch_instance(launch_instance_details=oci_adaptor.get_oci(
-                ).core.models.LaunchInstanceDetails(
-                    availability_domain=node_config["AvailabilityDomain"],
-                    compartment_id=compartment,
-                    shape=instance_type_str,
-                    display_name=
-                    f"{self.cluster_name}_{node_type}_{batch_id}_{seq}",
-                    freeform_tags=vm_tags,
-                    metadata={
-                        "ssh_authorized_keys": node_config["AuthorizedKey"]
-                    },
-                    source_details=oci_adaptor.get_oci(
-                    ).core.models.InstanceSourceViaImageDetails(
-                        source_type="image",
-                        image_id=node_config["ImageId"],
-                        boot_volume_size_in_gbs=node_config["BootVolumeSize"],
-                        boot_volume_vpus_per_gb=int(
-                            node_config["BootVolumePerf"]),
-                    ),
-                    create_vnic_details=oci_adaptor.get_oci(
-                    ).core.models.CreateVnicDetails(
-                        assign_public_ip=True,
-                        subnet_id=vcn,
-                    ),
-                    shape_config=machine_shape_config,
-                    preemptible_instance_config=preempitible_config,
-                ))
+                ).launch_instance(
+                    launch_instance_details=oci_adaptor.oci.core.models.
+                    LaunchInstanceDetails(
+                        availability_domain=node_config["AvailabilityDomain"],
+                        compartment_id=compartment,
+                        shape=instance_type_str,
+                        display_name=
+                        f"{self.cluster_name}_{node_type}_{batch_id}_{seq}",
+                        freeform_tags=vm_tags,
+                        metadata={
+                            "ssh_authorized_keys": node_config["AuthorizedKey"]
+                        },
+                        source_details=oci_adaptor.oci.core.models.
+                        InstanceSourceViaImageDetails(
+                            source_type="image",
+                            image_id=node_config["ImageId"],
+                            boot_volume_size_in_gbs=node_config[
+                                "BootVolumeSize"],
+                            boot_volume_vpus_per_gb=int(
+                                node_config["BootVolumePerf"]),
+                        ),
+                        create_vnic_details=oci_adaptor.oci.core.models.
+                        CreateVnicDetails(
+                            assign_public_ip=True,
+                            subnet_id=vcn,
+                        ),
+                        shape_config=machine_shape_config,
+                        preemptible_instance_config=preempitible_config,
+                    ))
 
                 new_inst = launch_instance_response.data
                 starting_insts.append({
@@ -354,7 +356,7 @@ class OCINodeProvider(NodeProvider):
             get_instance_response = oci_adaptor.get_core_client(
                 self.region, oci_utils.oci_config.get_profile()).get_instance(
                     instance_id=ninst["inst_id"])
-            oci_adaptor.get_oci().wait_until(
+            oci_adaptor.oci.wait_until(
                 oci_adaptor.get_core_client(self.region,
                                             oci_utils.oci_config.get_profile()),
                 get_instance_response,
@@ -409,9 +411,8 @@ class OCINodeProvider(NodeProvider):
                     self.region,
                     oci_utils.oci_config.get_profile()).update_instance(
                         instance_id=node_id,
-                        update_instance_details=oci_adaptor.get_oci().core.
-                        models.UpdateInstanceDetails(
-                            freeform_tags=combined_tags),
+                        update_instance_details=oci_adaptor.oci.core.models.
+                        UpdateInstanceDetails(freeform_tags=combined_tags),
                     )
                 logger.info(f"Tags are well set for node {node_id}")
                 break

--- a/sky/skylet/providers/oci/query_helper.py
+++ b/sky/skylet/providers/oci/query_helper.py
@@ -15,7 +15,7 @@ import traceback
 import typing
 from typing import Optional
 
-from sky.adaptors import common as adaptor_common
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import oci as oci_adaptor
 from sky.clouds.utils import oci_utils
 from sky.skylet.providers.oci import utils
@@ -23,7 +23,7 @@ from sky.skylet.providers.oci import utils
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
-    pd = adaptor_common.LazyImport('pandas')
+    pd = adaptors_common.LazyImport('pandas')
 
 logger = logging.getLogger(__name__)
 

--- a/sky/skylet/providers/oci/query_helper.py
+++ b/sky/skylet/providers/oci/query_helper.py
@@ -48,11 +48,10 @@ class oci_query_helper:
                   f" && (lifecycleState != 'TERMINATED'"
                   f" && lifecycleState != 'TERMINATING')")
 
-        qv = oci_adaptor.get_oci(
-        ).resource_search.models.StructuredSearchDetails(
+        qv = oci_adaptor.oci.resource_search.models.StructuredSearchDetails(
             query=qv_str,
             type="Structured",
-            matching_context_type=oci_adaptor.get_oci().resource_search.models.
+            matching_context_type=oci_adaptor.oci.resource_search.models.
             SearchDetails.MATCHING_CONTEXT_TYPE_NONE,
         )
 
@@ -104,8 +103,8 @@ class oci_query_helper:
             agreements = agreements_response.data
 
             core_client.create_app_catalog_subscription(
-                create_app_catalog_subscription_details=oci_adaptor.get_oci(
-                ).core.models.CreateAppCatalogSubscriptionDetails(
+                create_app_catalog_subscription_details=oci_adaptor.oci.core.
+                models.CreateAppCatalogSubscriptionDetails(
                     compartment_id=compartment_id,
                     listing_id=listing_id,
                     listing_resource_version=agreements.
@@ -207,12 +206,12 @@ class oci_query_helper:
                           skypilot_compartment) -> Optional[str]:
         try:
             create_vcn_response = net_client.create_vcn(
-                create_vcn_details=oci_adaptor.get_oci().core.models.
-                CreateVcnDetails(compartment_id=skypilot_compartment,
-                                 cidr_blocks=[oci_utils.oci_config.VCN_CIDR],
-                                 display_name=oci_utils.oci_config.VCN_NAME,
-                                 is_ipv6_enabled=False,
-                                 dns_label=oci_utils.oci_config.VCN_DNS_LABEL))
+                create_vcn_details=oci_adaptor.oci.core.models.CreateVcnDetails(
+                    compartment_id=skypilot_compartment,
+                    cidr_blocks=[oci_utils.oci_config.VCN_CIDR],
+                    display_name=oci_utils.oci_config.VCN_NAME,
+                    is_ipv6_enabled=False,
+                    dns_label=oci_utils.oci_config.VCN_DNS_LABEL))
             vcn_data = create_vcn_response.data
             logger.debug(f'Created VCN \n{vcn_data}')
             skypilot_vcn = vcn_data.id
@@ -222,21 +221,21 @@ class oci_query_helper:
 
             # Create internet gateway for internet access
             create_ig_response = net_client.create_internet_gateway(
-                create_internet_gateway_details=oci_adaptor.get_oci(
-                ).core.models.CreateInternetGatewayDetails(
+                create_internet_gateway_details=oci_adaptor.oci.core.models.
+                CreateInternetGatewayDetails(
                     compartment_id=skypilot_compartment,
                     is_enabled=True,
                     vcn_id=skypilot_vcn,
-                    display_name=oci_utils.oci_config.VCN_INTERNET_GATEWAY_NAME)
-            )
+                    display_name=oci_utils.oci_config.VCN_INTERNET_GATEWAY_NAME
+                ))
             logger.debug(
                 f'Created internet gateway \n{create_ig_response.data}')
             ig = create_ig_response.data.id
 
             # Create a public subnet.
             create_subnet_response = net_client.create_subnet(
-                create_subnet_details=oci_adaptor.get_oci(
-                ).core.models.CreateSubnetDetails(
+                create_subnet_details=oci_adaptor.oci.core.models.
+                CreateSubnetDetails(
                     cidr_block=oci_utils.oci_config.VCN_SUBNET_CIDR,
                     compartment_id=skypilot_compartment,
                     vcn_id=skypilot_vcn,
@@ -258,12 +257,12 @@ class oci_query_helper:
             if len(services) > 0:
                 # Create service gateway for regional services.
                 create_sg_response = net_client.create_service_gateway(
-                    create_service_gateway_details=oci_adaptor.get_oci(
-                    ).core.models.CreateServiceGatewayDetails(
+                    create_service_gateway_details=oci_adaptor.oci.core.models.
+                    CreateServiceGatewayDetails(
                         compartment_id=skypilot_compartment,
                         services=[
-                            oci_adaptor.get_oci().core.models.
-                            ServiceIdRequestDetails(service_id=services[0].id)
+                            oci_adaptor.oci.core.models.ServiceIdRequestDetails(
+                                service_id=services[0].id)
                         ],
                         vcn_id=skypilot_vcn))
                 logger.debug(f'Service Gateway: \n{create_sg_response.data}')
@@ -272,40 +271,40 @@ class oci_query_helper:
             # Update security list: Allow all traffic in the same subnet
             update_security_list_response = net_client.update_security_list(
                 security_list_id=security_list,
-                update_security_list_details=oci_adaptor.get_oci(
-                ).core.models.UpdateSecurityListDetails(ingress_security_rules=[
-                    oci_adaptor.get_oci().core.models.IngressSecurityRule(
+                update_security_list_details=oci_adaptor.oci.core.models.
+                UpdateSecurityListDetails(ingress_security_rules=[
+                    oci_adaptor.oci.core.models.IngressSecurityRule(
                         protocol="6",
                         source=oci_utils.oci_config.VCN_CIDR_INTERNET,
                         is_stateless=False,
                         source_type="CIDR_BLOCK",
-                        tcp_options=oci_adaptor.get_oci().core.models.
-                        TcpOptions(destination_port_range=oci_adaptor.get_oci().
-                                   core.models.PortRange(max=22, min=22),
-                                   source_port_range=oci_adaptor.get_oci(
-                                   ).core.models.PortRange(max=65535, min=1)),
+                        tcp_options=oci_adaptor.oci.core.models.TcpOptions(
+                            destination_port_range=oci_adaptor.oci.core.models.
+                            PortRange(max=22, min=22),
+                            source_port_range=oci_adaptor.oci.core.models.
+                            PortRange(max=65535, min=1)),
                         description="Allow SSH port."),
-                    oci_adaptor.get_oci().core.models.IngressSecurityRule(
+                    oci_adaptor.oci.core.models.IngressSecurityRule(
                         protocol="all",
                         source=oci_utils.oci_config.VCN_SUBNET_CIDR,
                         is_stateless=False,
                         source_type="CIDR_BLOCK",
                         description="Allow all traffic from/to same subnet."),
-                    oci_adaptor.get_oci().core.models.IngressSecurityRule(
+                    oci_adaptor.oci.core.models.IngressSecurityRule(
                         protocol="1",
                         source=oci_utils.oci_config.VCN_CIDR_INTERNET,
                         is_stateless=False,
                         source_type="CIDR_BLOCK",
-                        icmp_options=oci_adaptor.get_oci(
-                        ).core.models.IcmpOptions(type=3, code=4),
+                        icmp_options=oci_adaptor.oci.core.models.IcmpOptions(
+                            type=3, code=4),
                         description="ICMP traffic."),
-                    oci_adaptor.get_oci().core.models.IngressSecurityRule(
+                    oci_adaptor.oci.core.models.IngressSecurityRule(
                         protocol="1",
                         source=oci_utils.oci_config.VCN_CIDR,
                         is_stateless=False,
                         source_type="CIDR_BLOCK",
-                        icmp_options=oci_adaptor.get_oci(
-                        ).core.models.IcmpOptions(type=3),
+                        icmp_options=oci_adaptor.oci.core.models.IcmpOptions(
+                            type=3),
                         description="ICMP traffic (VCN)."),
                 ]))
             logger.debug(
@@ -315,9 +314,9 @@ class oci_query_helper:
             # Update route table: bind to the internet gateway
             update_route_table_response = net_client.update_route_table(
                 rt_id=route_table,
-                update_route_table_details=oci_adaptor.get_oci(
-                ).core.models.UpdateRouteTableDetails(route_rules=[
-                    oci_adaptor.get_oci().core.models.RouteRule(
+                update_route_table_details=oci_adaptor.oci.core.models.
+                UpdateRouteTableDetails(route_rules=[
+                    oci_adaptor.oci.core.models.RouteRule(
                         network_entity_id=create_ig_response.data.id,
                         destination='0.0.0.0/0',
                         destination_type='CIDR_BLOCK',

--- a/sky/skylet/providers/oci/query_helper.py
+++ b/sky/skylet/providers/oci/query_helper.py
@@ -12,13 +12,18 @@ import logging
 import re
 import time
 import traceback
+import typing
 from typing import Optional
 
-import pandas as pd
-
+from sky.adaptors import common as adaptor_common
 from sky.adaptors import oci as oci_adaptor
 from sky.clouds.utils import oci_utils
 from sky.skylet.providers.oci import utils
+
+if typing.TYPE_CHECKING:
+    import pandas as pd
+else:
+    pd = adaptor_common.LazyImport('pandas')
 
 logger = logging.getLogger(__name__)
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -12,7 +12,6 @@ from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
-from sky.utils import timeline
 
 logger = sky_logging.init_logger(__name__)
 
@@ -252,7 +251,6 @@ class SSHCommandRunner:
                 f'{self.ssh_user}@{self.ip}'
             ]
 
-    @timeline.event
     def run(
             self,
             cmd: Union[str, List[str]],
@@ -356,7 +354,6 @@ class SSHCommandRunner:
                                     executable=executable,
                                     **kwargs)
 
-    @timeline.event
     def rsync(
         self,
         source: str,

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -12,6 +12,7 @@ from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
+from sky.utils import timeline
 
 logger = sky_logging.init_logger(__name__)
 
@@ -251,6 +252,7 @@ class SSHCommandRunner:
                 f'{self.ssh_user}@{self.ip}'
             ]
 
+    @timeline.event
     def run(
             self,
             cmd: Union[str, List[str]],
@@ -354,6 +356,7 @@ class SSHCommandRunner:
                                     executable=executable,
                                     **kwargs)
 
+    @timeline.event
     def rsync(
         self,
         source: str,

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -323,7 +323,8 @@ def dump_yaml_str(config):
                      default_flow_style=False)
 
 
-def make_decorator(cls, name_or_fn: Union[str, Callable], **ctx_kwargs):
+def make_decorator(cls, name_or_fn: Union[str, Callable],
+                   **ctx_kwargs) -> Callable:
     """Make the cls a decorator.
 
     class cls:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -146,8 +146,13 @@ def _get_cloud_dependencies_installation_commands(
         'boto3>=1.26.1 > /dev/null 2>&1',
         # gcp
         'pip list | grep google-api-python-client > /dev/null 2>&1 || '
-        'pip install google-api-python-client>=2.69.0 google-cloud-storage '
+        'pip install google-api-python-client>=2.69.0 '
         '> /dev/null 2>&1',
+        # Have to separate the installation of google-cloud-storage from above
+        # because for a VM launched on GCP, the VM may have
+        # google-api-python-client installed alone.
+        'pip list | grep google-cloud-storage > /dev/null 2>&1 || '
+        'pip install google-cloud-storage > /dev/null 2>&1',
         f'{gcp.GOOGLE_SDK_INSTALLATION_COMMAND}',
         # fluidstack does not need to install any cloud dependencies.
     ]

--- a/tests/mypy_files.txt
+++ b/tests/mypy_files.txt
@@ -2,7 +2,6 @@ sky
 
 --exclude sky/benchmark
 --exclude sky/callbacks
---exclude sky/skylet/providers/gcp
 --exclude sky/skylet/providers/azure
 --exclude sky/resources.py
 --exclude sky/backends/monkey_patches

--- a/tests/skyserve/restart/user_bug.yaml
+++ b/tests/skyserve/restart/user_bug.yaml
@@ -10,6 +10,6 @@ resources:
   cpus: 2+
   use_spot: True
 
-workdir: tests/skyserve/spot
+workdir: tests/skyserve/restart
 
 run: python3 user_bug.py

--- a/tests/skyserve/spot/base_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/base_ondemand_fallback.yaml
@@ -6,6 +6,8 @@ service:
     min_replicas: 2
     max_replicas: 3
     base_ondemand_fallback_replicas: 1
+    # Use a large qps per replica to avoid scale up for testing purpose.
+    target_qps_per_replica: 10000
 
 resources:
   ports: 8080

--- a/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
@@ -6,6 +6,8 @@ service:
     min_replicas: 2
     max_replicas: 3
     dynamic_ondemand_fallback: true
+    # Use a large qps per replica to avoid scale up for testing purpose.
+    target_qps_per_replica: 10000
 
 resources:
   ports: 8080


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to get rid of some time-consuming packages on the critical path, to reduce the import time, which will both improve the import time and some remote command execution.

The first step of #3157 

### Reduce import time by 2x
master: `python -c "import sky"` -- 1.002s
This PR: `python -c "import sky"` -- 0.494s

### Reduce the `exec` time
`sky launch -c test --cloud kubernetes --cpus 1`
``for i in `seq 1 5`; do time sky exec test -d echo hi; done``
Master: 17.89s
This PR: 13.91s

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` (except for `tests/test_smoke.py::test_skyserve_new_autoscaler_update`, `tests/test_smoke.py::test_skyserve_base_ondemand_fallback`, `tests/test_smoke.py::test_skyserve_user_bug_restart` due to #3405)
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
