### PR TITLE
[Tests][BugFix] Fix invalid YAML in SkyServe smoke test w/ autoscaling

### DIFF
--- a/tests/skyserve/spot/base_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/base_ondemand_fallback.yaml
@@ -6,6 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     base_ondemand_fallback_replicas: 1
+    target_qps_per_replica: 1
 
 resources:
   ports: 8080

--- a/tests/skyserve/spot/base_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/base_ondemand_fallback.yaml
@@ -6,7 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     base_ondemand_fallback_replicas: 1
-    target_qps_per_replica: 1
+    target_qps_per_replica: 1000
 
 resources:
   ports: 8080

--- a/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
@@ -6,6 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     dynamic_ondemand_fallback: true
+    target_qps_per_replica: 1
 
 resources:
   ports: 8080

--- a/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
@@ -6,7 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     dynamic_ondemand_fallback: true
-    target_qps_per_replica: 1
+    target_qps_per_replica: 1000
 
 resources:
   ports: 8080


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In #3361 we introduced new checks for the service YAML, which caused several of our smoke test failures. This PR fixes the bug.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] Manually `sky serve up` every YAML in `tests/skyserve` folder and make sure it works
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
     - [x] `tests/test_smoke.py::test_skyserve_dynamic_ondemand_fallback`
     - [x] `tests/test_smoke.py::test_skyserve_base_ondemand_fallback`
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
