### PR TITLE
[AWS] Do not delete user-specified security group

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -419,6 +419,8 @@ class AWS(clouds.Cloud):
             'zones': ','.join(zone_names),
             'image_id': image_id,
             'security_group': security_group,
+            'security_group_managed_by_skypilot':
+                str(security_group != user_security_group).lower(),
             **AWS._get_disk_specs(r.disk_tier)
         }
 

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -755,9 +755,11 @@ def cleanup_ports(
     region = provider_config['region']
     ec2 = _default_ec2_resource(region)
     sg_name = provider_config['security_group']['GroupName']
-    if sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME:
-        # Using default AWS SG. We only want to delete the SG that is dedicated
-        # to this cluster (i.e., this cluster have opened some ports).
+    managed_by_skypilot = provider_config['security_group'].get('ManagedBySkyPilot', True)
+    if sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or not managed_by_skypilot:
+        # 1) Using default AWS SG or 2) the SG is specified by the user.
+        # We only want to delete the SG that is dedicated to this cluster (i.e.,
+        # this cluster have opened some ports).
         return
     sg = _get_sg_from_name(ec2, sg_name)
     if sg is None:

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -588,6 +588,8 @@ def terminate_instances(
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     region = provider_config['region']
     sg_name = provider_config['security_group']['GroupName']
+    managed_by_skypilot = provider_config['security_group'].get(
+        'ManagedBySkyPilot', True)
     ec2 = _default_ec2_resource(region)
     filters = [
         {
@@ -608,7 +610,8 @@ def terminate_instances(
                                   included_instances=None,
                                   excluded_instances=None)
     instances.terminate()
-    if sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME:
+    if (sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or
+            not managed_by_skypilot):
         # Using default AWS SG. We don't need to wait for the
         # termination of the instances.
         return

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -612,8 +612,9 @@ def terminate_instances(
     instances.terminate()
     if (sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or
             not managed_by_skypilot):
-        # Using default AWS SG. We don't need to wait for the
-        # termination of the instances.
+        # Using default AWS SG or user specified security group. We don't need
+        # to wait for the termination of the instances, as we do not need to
+        # delete the SG.
         return
     # If ports are specified, we need to delete the newly created Security
     # Group. Here we wait for all instances to be terminated, since the

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -755,8 +755,10 @@ def cleanup_ports(
     region = provider_config['region']
     ec2 = _default_ec2_resource(region)
     sg_name = provider_config['security_group']['GroupName']
-    managed_by_skypilot = provider_config['security_group'].get('ManagedBySkyPilot', True)
-    if sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or not managed_by_skypilot:
+    managed_by_skypilot = provider_config['security_group'].get(
+        'ManagedBySkyPilot', True)
+    if (sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or
+            not managed_by_skypilot):
         # 1) Using default AWS SG or 2) the SG is specified by the user.
         # We only want to delete the SG that is dedicated to this cluster (i.e.,
         # this cluster have opened some ports).

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -36,6 +36,7 @@ provider:
   security_group:
     # AWS config file must include security group name
     GroupName: {{security_group}}
+    ManagedBySkyPilot: {{security_group_managed_by_skypilot}}
 {% if vpc_name is not none %}
   # NOTE: This is a new field added by SkyPilot to force use a specific VPC.
   vpc_name: {{vpc_name}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that when the security group is specified in `~/.sky/config.yaml`, SkyPilot still tries to delete the security group when terminating the cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch` and `sky down` with a `security_group_name` specified in a `~/.sky/config.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
