### PR TITLE
[Serve] Expose detailed replica failure reason and rename service failure to crash loop

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -330,20 +330,20 @@ class ReplicaStatusProperty:
                 return serve_state.ReplicaStatus.FAILED_CLEANUP
             if self.user_app_failed:
                 # Failed on user setup/run
-                return serve_state.ReplicaStatus.FAILED
+                return serve_state.ReplicaStatus.FAILED_USER_APP
             if self.sky_launch_status == ProcessStatus.FAILED:
                 # sky.launch failed
-                return serve_state.ReplicaStatus.FAILED
+                return serve_state.ReplicaStatus.FAILED_PROVISION
             if self.first_ready_time is None:
                 # readiness probe is not executed yet, but a scale down is
                 # triggered.
                 return serve_state.ReplicaStatus.SHUTTING_DOWN
             if self.first_ready_time == -1:
                 # initial delay seconds exceeded
-                return serve_state.ReplicaStatus.FAILED
+                return serve_state.ReplicaStatus.FAILED_PROBE
             if not self.service_ready_now:
                 # Max continuous failure exceeded
-                return serve_state.ReplicaStatus.FAILED
+                return serve_state.ReplicaStatus.FAILED_PROBE
             # This indicate it is a scale_down with correct teardown.
             # Should have been cleaned from the replica table.
             return serve_state.ReplicaStatus.UNKNOWN

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -340,7 +340,7 @@ class ReplicaStatusProperty:
                 return serve_state.ReplicaStatus.SHUTTING_DOWN
             if self.first_ready_time == -1:
                 # initial delay seconds exceeded
-                return serve_state.ReplicaStatus.FAILED_PROBING
+                return serve_state.ReplicaStatus.FAILED_INITIAL_DELAY
             if not self.service_ready_now:
                 # Max continuous failure exceeded
                 return serve_state.ReplicaStatus.FAILED_PROBING

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -340,10 +340,10 @@ class ReplicaStatusProperty:
                 return serve_state.ReplicaStatus.SHUTTING_DOWN
             if self.first_ready_time == -1:
                 # initial delay seconds exceeded
-                return serve_state.ReplicaStatus.FAILED_PROBE
+                return serve_state.ReplicaStatus.FAILED_PROBING
             if not self.service_ready_now:
                 # Max continuous failure exceeded
-                return serve_state.ReplicaStatus.FAILED_PROBE
+                return serve_state.ReplicaStatus.FAILED_PROBING
             # This indicate it is a scale_down with correct teardown.
             # Should have been cleaned from the replica table.
             return serve_state.ReplicaStatus.UNKNOWN

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -102,7 +102,7 @@ class ReplicaStatus(enum.Enum):
     FAILED = 'FAILED'
 
     # The replica fails due to healthiness check.
-    FAILED_PROBE = 'FAILED_PROBE'
+    FAILED_PROBING = 'FAILED_PROBING'
 
     # The replica fails during launching
     FAILED_PROVISION = 'FAILED_PROVISION'
@@ -125,14 +125,14 @@ class ReplicaStatus(enum.Enum):
     @classmethod
     def failed_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBE,
+            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBING,
             cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.UNKNOWN
         ]
 
     @classmethod
     def terminal_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBE,
+            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBING,
             cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.PREEMPTED,
             cls.UNKNOWN
         ]
@@ -158,7 +158,7 @@ _REPLICA_STATUS_TO_COLOR = {
     ReplicaStatus.NOT_READY: colorama.Fore.YELLOW,
     ReplicaStatus.SHUTTING_DOWN: colorama.Fore.MAGENTA,
     ReplicaStatus.FAILED: colorama.Fore.RED,
-    ReplicaStatus.FAILED_PROBE: colorama.Fore.RED,
+    ReplicaStatus.FAILED_PROBING: colorama.Fore.RED,
     ReplicaStatus.FAILED_USER_APP: colorama.Fore.RED,
     ReplicaStatus.FAILED_PROVISION: colorama.Fore.RED,
     ReplicaStatus.FAILED_CLEANUP: colorama.Fore.RED,

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -101,6 +101,15 @@ class ReplicaStatus(enum.Enum):
     # The replica VM is once failed and has been deleted.
     FAILED = 'FAILED'
 
+    # The replica fails due to healthiness check.
+    FAILED_PROBE = 'FAILED_PROBE'
+
+    # The replica fails during launching
+    FAILED_PROVISION = 'FAILED_PROVISION'
+
+    # The replica fails due to the failure of user app.
+    FAILED_USER_APP = 'FAILED_USER_APP'
+
     # `sky.down` failed during service teardown.
     # This could mean resource leakage.
     # TODO(tian): This status should be removed in the future, at which point
@@ -145,6 +154,9 @@ _REPLICA_STATUS_TO_COLOR = {
     ReplicaStatus.NOT_READY: colorama.Fore.YELLOW,
     ReplicaStatus.SHUTTING_DOWN: colorama.Fore.MAGENTA,
     ReplicaStatus.FAILED: colorama.Fore.RED,
+    ReplicaStatus.FAILED_PROBE: colorama.Fore.RED,
+    ReplicaStatus.FAILED_USER_APP: colorama.Fore.RED,
+    ReplicaStatus.FAILED_PROVISION: colorama.Fore.RED,
     ReplicaStatus.FAILED_CLEANUP: colorama.Fore.RED,
     ReplicaStatus.PREEMPTED: colorama.Fore.MAGENTA,
     ReplicaStatus.UNKNOWN: colorama.Fore.RED,
@@ -171,7 +183,10 @@ class ServiceStatus(enum.Enum):
     SHUTTING_DOWN = 'SHUTTING_DOWN'
 
     # At least one replica is failed and no replica is ready
+    # Deprecated: Failed state will be renamed to CrashLoop
     FAILED = 'FAILED'
+
+    CRASH_LOOP = 'CRASH_LOOP'
 
     # Clean up failed
     FAILED_CLEANUP = 'FAILED_CLEANUP'
@@ -200,7 +215,7 @@ class ServiceStatus(enum.Enum):
             return cls.READY
         if sum(status2num[status]
                for status in ReplicaStatus.failed_statuses()) > 0:
-            return cls.FAILED
+            return cls.CRASH_LOOP
         # When min_replicas = 0, there is no (provisioning) replica.
         if len(replica_statuses) == 0:
             return cls.NO_REPLICA
@@ -213,6 +228,7 @@ _SERVICE_STATUS_TO_COLOR = {
     ServiceStatus.CONTROLLER_FAILED: colorama.Fore.RED,
     ServiceStatus.READY: colorama.Fore.GREEN,
     ServiceStatus.SHUTTING_DOWN: colorama.Fore.YELLOW,
+    ServiceStatus.CRASH_LOOP: colorama.Fore.RED,
     ServiceStatus.FAILED: colorama.Fore.RED,
     ServiceStatus.FAILED_CLEANUP: colorama.Fore.RED,
     ServiceStatus.NO_REPLICA: colorama.Fore.MAGENTA,

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -183,10 +183,7 @@ class ServiceStatus(enum.Enum):
     SHUTTING_DOWN = 'SHUTTING_DOWN'
 
     # At least one replica is failed and no replica is ready
-    # Deprecated: Failed state will be renamed to CrashLoop
     FAILED = 'FAILED'
-
-    CRASH_LOOP = 'CRASH_LOOP'
 
     # Clean up failed
     FAILED_CLEANUP = 'FAILED_CLEANUP'
@@ -215,7 +212,7 @@ class ServiceStatus(enum.Enum):
             return cls.READY
         if sum(status2num[status]
                for status in ReplicaStatus.failed_statuses()) > 0:
-            return cls.CRASH_LOOP
+            return cls.FAILED
         # When min_replicas = 0, there is no (provisioning) replica.
         if len(replica_statuses) == 0:
             return cls.NO_REPLICA
@@ -228,7 +225,6 @@ _SERVICE_STATUS_TO_COLOR = {
     ServiceStatus.CONTROLLER_FAILED: colorama.Fore.RED,
     ServiceStatus.READY: colorama.Fore.GREEN,
     ServiceStatus.SHUTTING_DOWN: colorama.Fore.YELLOW,
-    ServiceStatus.CRASH_LOOP: colorama.Fore.RED,
     ServiceStatus.FAILED: colorama.Fore.RED,
     ServiceStatus.FAILED_CLEANUP: colorama.Fore.RED,
     ServiceStatus.NO_REPLICA: colorama.Fore.MAGENTA,

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -132,9 +132,9 @@ class ReplicaStatus(enum.Enum):
     @classmethod
     def terminal_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBING,
-            cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.PREEMPTED,
-            cls.UNKNOWN
+            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP,
+            cls.FAILED_PROBING, cls.FAILED_PROVISION, cls.FAILED_USER_APP,
+            cls.PREEMPTED, cls.UNKNOWN
         ]
 
     @classmethod

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -104,7 +104,6 @@ class ReplicaStatus(enum.Enum):
     # The replica fails due to initial delay.
     FAILED_INITIAL_DELAY = 'FAILED_INITIAL_DELAY'
 
-
     # The replica fails due to healthiness check.
     FAILED_PROBING = 'FAILED_PROBING'
 
@@ -129,16 +128,17 @@ class ReplicaStatus(enum.Enum):
     @classmethod
     def failed_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_INITIAL_DELAY, cls.FAILED_PROBING,
-            cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.UNKNOWN
+            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_INITIAL_DELAY,
+            cls.FAILED_PROBING, cls.FAILED_PROVISION, cls.FAILED_USER_APP,
+            cls.UNKNOWN
         ]
 
     @classmethod
     def terminal_statuses(cls) -> List['ReplicaStatus']:
         return [
             cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP,
-            cls.FAILED_INITIAL_DELAY, cls.FAILED_PROBING, cls.FAILED_PROVISION, cls.FAILED_USER_APP,
-            cls.PREEMPTED, cls.UNKNOWN
+            cls.FAILED_INITIAL_DELAY, cls.FAILED_PROBING, cls.FAILED_PROVISION,
+            cls.FAILED_USER_APP, cls.PREEMPTED, cls.UNKNOWN
         ]
 
     @classmethod

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -101,6 +101,10 @@ class ReplicaStatus(enum.Enum):
     # The replica VM is once failed and has been deleted.
     FAILED = 'FAILED'
 
+    # The replica fails due to initial delay.
+    FAILED_INITIAL_DELAY = 'FAILED_INITIAL_DELAY'
+
+
     # The replica fails due to healthiness check.
     FAILED_PROBING = 'FAILED_PROBING'
 
@@ -125,7 +129,7 @@ class ReplicaStatus(enum.Enum):
     @classmethod
     def failed_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBING,
+            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_INITIAL_DELAY, cls.FAILED_PROBING,
             cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.UNKNOWN
         ]
 
@@ -133,7 +137,7 @@ class ReplicaStatus(enum.Enum):
     def terminal_statuses(cls) -> List['ReplicaStatus']:
         return [
             cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP,
-            cls.FAILED_PROBING, cls.FAILED_PROVISION, cls.FAILED_USER_APP,
+            cls.FAILED_INITIAL_DELAY, cls.FAILED_PROBING, cls.FAILED_PROVISION, cls.FAILED_USER_APP,
             cls.PREEMPTED, cls.UNKNOWN
         ]
 
@@ -158,6 +162,7 @@ _REPLICA_STATUS_TO_COLOR = {
     ReplicaStatus.NOT_READY: colorama.Fore.YELLOW,
     ReplicaStatus.SHUTTING_DOWN: colorama.Fore.MAGENTA,
     ReplicaStatus.FAILED: colorama.Fore.RED,
+    ReplicaStatus.FAILED_INITIAL_DELAY: colorama.Fore.RED,
     ReplicaStatus.FAILED_PROBING: colorama.Fore.RED,
     ReplicaStatus.FAILED_USER_APP: colorama.Fore.RED,
     ReplicaStatus.FAILED_PROVISION: colorama.Fore.RED,

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -124,12 +124,16 @@ class ReplicaStatus(enum.Enum):
 
     @classmethod
     def failed_statuses(cls) -> List['ReplicaStatus']:
-        return [cls.FAILED, cls.FAILED_CLEANUP, cls.UNKNOWN]
+        return [
+            cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBE,
+            cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.UNKNOWN
+        ]
 
     @classmethod
     def terminal_statuses(cls) -> List['ReplicaStatus']:
         return [
-            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP, cls.PREEMPTED,
+            cls.SHUTTING_DOWN, cls.FAILED, cls.FAILED_CLEANUP, cls.FAILED_PROBE,
+            cls.FAILED_PROVISION, cls.FAILED_USER_APP, cls.PREEMPTED,
             cls.UNKNOWN
         ]
 

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -715,7 +715,7 @@ def _get_replicas(service_record: Dict[str, Any]) -> str:
         if info['status'] == serve_state.ReplicaStatus.READY:
             ready_replica_num += 1
         # TODO(MaoZiming): add a column showing failed replicas number.
-        if info['status'] != serve_state.ReplicaStatus.FAILED:
+        if info['status'] not in serve_state.ReplicaStatus.failed_statuses():
             total_replica_num += 1
     return f'{ready_replica_num}/{total_replica_num}'
 

--- a/tests/skyserve/restart/user_bug.yaml
+++ b/tests/skyserve/restart/user_bug.yaml
@@ -10,6 +10,6 @@ resources:
   cpus: 2+
   use_spot: True
 
-workdir: tests/skyserve/spot
+workdir: tests/skyserve/restart
 
 run: python3 user_bug.py

--- a/tests/skyserve/spot/base_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/base_ondemand_fallback.yaml
@@ -6,6 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     base_ondemand_fallback_replicas: 1
+    target_qps_per_replica: 1000
 
 resources:
   ports: 8080

--- a/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/dynamic_ondemand_fallback.yaml
@@ -6,6 +6,7 @@ service:
     min_replicas: 2
     max_replicas: 3
     dynamic_ondemand_fallback: true
+    target_qps_per_replica: 1000
 
 resources:
   ports: 8080

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3268,7 +3268,7 @@ def test_skyserve_user_bug_restart(generic_cloud: str):
             f's=$(sky serve status {name}); echo "$s";'
             'until echo "$s" | grep -A2 "Service Replicas" | grep "SHUTTING_DOWN"; '
             'do echo "Waiting for first service to be SHUTTING DOWN..."; '
-            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; sleep 20; '
+            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; sleep 10; '
             + _SERVE_STATUS_WAIT.format(name=name) +
             # When the first replica is detected failed, the controller will
             # start to provision a new replica, and shut down the first one.

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3089,7 +3089,9 @@ def _check_replica_in_status(name: str, check_tuples: List[Tuple[int, bool,
     for check_tuple in check_tuples:
         count, is_spot, status = check_tuple
         resource_str = ''
-        if status not in ['PENDING', 'SHUTTING_DOWN', 'FAILED', 'FAILED_USER_APP']:
+        if status not in [
+                'PENDING', 'SHUTTING_DOWN', 'FAILED', 'FAILED_USER_APP'
+        ]:
             spot_str = ''
             if is_spot:
                 spot_str = '\[Spot\]'
@@ -3424,7 +3426,7 @@ def test_skyserve_rolling_update(generic_cloud: str):
             # should be able to get observe the period that the traffic is mixed
             # across two versions.
             f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
-            'until curl -L http://$endpoint | grep "Hi, new SkyPilot here!"; do sleep 2; done; sleep 2'
+            'until curl -L http://$endpoint | grep "Hi, new SkyPilot here!"; do sleep 2; done; sleep 2; '
             # The latest version should have one READY and the one of the older versions should be shutting down
             f'{single_new_replica} {_check_service_version(name, "1,2")} '
             # Check the output from the old version, immediately after the

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3268,13 +3268,7 @@ def test_skyserve_user_bug_restart(generic_cloud: str):
             f's=$(sky serve status {name}); echo "$s";'
             'until echo "$s" | grep -A2 "Service Replicas" | grep "SHUTTING_DOWN"; '
             'do echo "Waiting for first service to be SHUTTING DOWN..."; '
-            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; '
-            + _SERVE_STATUS_WAIT.format(name=name) +
-            # When the first replica is detected failed, the controller will
-            # start to provision a new replica, and shut down the first one.
-            _check_replica_in_status(
-                name, [(1, True, 'SHUTTING_DOWN'),
-                       (1, True, _SERVICE_LAUNCHING_STATUS_REGEX)]),
+            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; ',
             f's=$(sky serve status {name}); echo "$s";'
             'until echo "$s" | grep -A2 "Service Replicas" | grep "FAILED_USER_APP"; '
             'do echo "Waiting for first service to be FAILED..."; '

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3089,7 +3089,7 @@ def _check_replica_in_status(name: str, check_tuples: List[Tuple[int, bool,
     for check_tuple in check_tuples:
         count, is_spot, status = check_tuple
         resource_str = ''
-        if status not in ['PENDING', 'SHUTTING_DOWN', 'FAILED']:
+        if status not in ['PENDING', 'SHUTTING_DOWN', 'FAILED', 'FAILED_USER_APP']:
             spot_str = ''
             if is_spot:
                 spot_str = '\[Spot\]'
@@ -3268,7 +3268,7 @@ def test_skyserve_user_bug_restart(generic_cloud: str):
             f's=$(sky serve status {name}); echo "$s";'
             'until echo "$s" | grep -A2 "Service Replicas" | grep "SHUTTING_DOWN"; '
             'do echo "Waiting for first service to be SHUTTING DOWN..."; '
-            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; sleep 10; '
+            f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; '
             + _SERVE_STATUS_WAIT.format(name=name) +
             # When the first replica is detected failed, the controller will
             # start to provision a new replica, and shut down the first one.
@@ -3430,7 +3430,7 @@ def test_skyserve_rolling_update(generic_cloud: str):
             # should be able to get observe the period that the traffic is mixed
             # across two versions.
             f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
-            'until curl -L http://$endpoint | grep "Hi, new SkyPilot here!"; do sleep 2; done; '
+            'until curl -L http://$endpoint | grep "Hi, new SkyPilot here!"; do sleep 2; done; sleep 2'
             # The latest version should have one READY and the one of the older versions should be shutting down
             f'{single_new_replica} {_check_service_version(name, "1,2")} '
             # Check the output from the old version, immediately after the

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3276,11 +3276,11 @@ def test_skyserve_user_bug_restart(generic_cloud: str):
                 name, [(1, True, 'SHUTTING_DOWN'),
                        (1, True, _SERVICE_LAUNCHING_STATUS_REGEX)]),
             f's=$(sky serve status {name}); echo "$s";'
-            'until echo "$s" | grep -A2 "Service Replicas" | grep "FAILED"; '
+            'until echo "$s" | grep -A2 "Service Replicas" | grep "FAILED_USER_APP"; '
             'do echo "Waiting for first service to be FAILED..."; '
             f'sleep 5; s=$(sky serve status {name}); echo "$s"; done; echo "$s"; '
             + _check_replica_in_status(
-                name, [(1, True, 'FAILED'),
+                name, [(1, True, 'FAILED_USER_APP'),
                        (1, True, _SERVICE_LAUNCHING_STATUS_REGEX)]),
         ],
         _TEARDOWN_SERVICE.format(name=name),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This makes the failure reason for serving more visible and aligns with Kubernetes behavior when the underlying replicas fail. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py --serve`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
