### PR TITLE
[Lambda] Fix termination for lambda

### DIFF
--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -280,6 +280,7 @@ class Lambda(clouds.Cloud):
             'booting': status_lib.ClusterStatus.INIT,
             'active': status_lib.ClusterStatus.UP,
             'unhealthy': status_lib.ClusterStatus.INIT,
+            'terminating': None,
             'terminated': None,
         }
         # TODO(ewzeng): filter by hash_filter_string to be safe

--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -152,7 +152,7 @@ class LambdaNodeProvider(NodeProvider):
         def _get_internal_ip(node: Dict[str, Any]):
             # TODO(ewzeng): cache internal ips in metadata file to reduce
             # ssh overhead.
-            if node['external_ip'] is None:
+            if node['external_ip'] is None or node['status'] != 'active':
                 node['internal_ip'] = None
                 return
             runner = command_runner.SSHCommandRunner(node['external_ip'],
@@ -172,6 +172,7 @@ class LambdaNodeProvider(NodeProvider):
         self.metadata.refresh([node['id'] for node in vms])
         self._guess_and_add_missing_tags(vms)
         nodes = [_extract_metadata(vm) for vm in filter(_match_tags, vms)]
+        nodes = [node for node in nodes if node['status'] not in ['terminating', 'terminated']]
         subprocess_utils.run_in_parallel(_get_internal_ip, nodes)
         self.cached_nodes = {node['id']: node for node in nodes}
         return self.cached_nodes

--- a/sky/skylet/providers/lambda_cloud/node_provider.py
+++ b/sky/skylet/providers/lambda_cloud/node_provider.py
@@ -172,7 +172,10 @@ class LambdaNodeProvider(NodeProvider):
         self.metadata.refresh([node['id'] for node in vms])
         self._guess_and_add_missing_tags(vms)
         nodes = [_extract_metadata(vm) for vm in filter(_match_tags, vms)]
-        nodes = [node for node in nodes if node['status'] not in ['terminating', 'terminated']]
+        nodes = [
+            node for node in nodes
+            if node['status'] not in ['terminating', 'terminated']
+        ]
         subprocess_utils.run_in_parallel(_get_internal_ip, nodes)
         self.cached_nodes = {node['id']: node for node in nodes}
         return self.cached_nodes


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This includes the `terminating` status for Lambda Cloud, and `non_terminated_nodes` should filter out the terminating and terminated nodes.

`sky launch -c test-lambda --cloud lambda --gpus A10; sky down test-lambda`
Error out with:
```
  File "/home/azureuser/skypilot/sky/clouds/utils/lambda_utils.py", line 183, in remove_instances
    response = _try_request_with_backoff(
  File "/home/azureuser/skypilot/sky/clouds/utils/lambda_utils.py", line 118, in _try_request_with_backoff
    raise_lambda_error(response)
  File "/home/azureuser/skypilot/sky/clouds/utils/lambda_utils.py", line 95, in raise_lambda_error
    raise LambdaCloudError(f'{code}: {message}')
sky.clouds.utils.lambda_utils.LambdaCloudError: global/unknown: An unknown error occurred.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-lambda --cloud lambda --gpus A10; sky down test-lambda`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
