### PR TITLE
[k8s] Add `provision_timeout` to config for k8s provisioning

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -291,15 +291,16 @@ Available fields and semantics:
     # Timeout for provisioning a pod (in seconds, optional)
     #
     # This timeout determines how long SkyPilot will wait for a pod in PENDING
-    # status before giving up and failing over to the next cloud. Larger
-    # timeouts may be required for autoscaling clusters, since the autoscaler
-    # may take some time to provision new nodes. For example, an autoscaling
-    # CPU node pool on GKE may take upto 4-5 minutes to provision a new node.
+    # status before giving up, deleting the pending pod and failing over to the
+    # next cloud. Larger timeouts may be required for autoscaling clusters,
+    # since the autoscaler may take some time to provision new nodes.
+    # For example, an autoscaling CPU node pool on GKE may take upto 5 minutes
+    # (300 seconds) to provision a new node.
     #
     # Note that this timeout includes time taken by the Kubernetes scheduler
     # itself, which can be upto 2-3 seconds.
     #
-    # Can be set to zero to wait indefinitely for pod provisioning (e.g., in
+    # Can be set to -1 to wait indefinitely for pod provisioning (e.g., in
     # autoscaling clusters or clusters with queuing/admission control).
     #
     # Default: 10 seconds

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -293,9 +293,11 @@ Available fields and semantics:
     # This timeout determines how long SkyPilot will wait for a pod in PENDING
     # status before giving up and failing over to the next cloud. Larger
     # timeouts may be required for autoscaling clusters, since the autoscaler
-    # may take some time to provision new nodes. Note that this timeout
-    # includes time taken by the Kubernetes scheduler itself, which can be
-    # upto 2-3 seconds.
+    # may take some time to provision new nodes. For example, an autoscaling
+    # CPU node pool on GKE may take upto 4-5 minutes to provision a new node.
+    #
+    # Note that this timeout includes time taken by the Kubernetes scheduler
+    # itself, which can be upto 2-3 seconds.
     #
     # Can be set to zero to wait indefinitely for pod provisioning (e.g., in
     # autoscaling clusters or clusters with queuing/admission control).

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -288,6 +288,21 @@ Available fields and semantics:
       annotations:
         myannotation: myvalue
 
+    # Timeout for provisioning a pod (in seconds, optional)
+    #
+    # This timeout determines how long SkyPilot will wait for a pod in PENDING
+    # status before giving up and failing over to the next cloud. Larger
+    # timeouts may be required for autoscaling clusters, since the autoscaler
+    # may take some time to provision new nodes. Note that this timeout
+    # includes time taken by the Kubernetes scheduler itself, which can be
+    # upto 2-3 seconds.
+    #
+    # Can be set to zero to wait indefinitely for pod provisioning (e.g., in
+    # autoscaling clusters or clusters with queuing/admission control).
+    #
+    # Default: 10 seconds
+    provision_timeout: 10
+
     # Additional fields to override the pod fields used by SkyPilot (optional)
     #
     # Any key:value pairs added here would get added to the pod spec used to

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterator, List, Optional, Tuple
 
 from sky import clouds
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import kubernetes
 from sky.clouds import service_catalog
 from sky.provision.kubernetes import network_utils
@@ -42,8 +43,7 @@ class Kubernetes(clouds.Cloud):
     # Note that this timeout includes time taken by the Kubernetes scheduler
     # itself, which can be upto 2-3 seconds.
     # For non-autoscaling clusters, we conservatively set this to 10s.
-    # TODO(romilb): Make the timeout configurable.
-    TIMEOUT = 10
+    TIMEOUT = skypilot_config.get_nested(['kubernetes', 'provision_timeout'], 10)
 
     _DEFAULT_NUM_VCPUS = 2
     _DEFAULT_MEMORY_CPU_RATIO = 1
@@ -273,7 +273,6 @@ class Kubernetes(clouds.Cloud):
             'k8s_acc_label_value': k8s_acc_label_value,
             'k8s_ssh_jump_name': self.SKY_SSH_JUMP_NAME,
             'k8s_ssh_jump_image': ssh_jump_image,
-            # TODO(romilb): Allow user to specify custom images
             'image_id': image_id,
         }
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -43,7 +43,7 @@ class Kubernetes(clouds.Cloud):
     # Note that this timeout includes time taken by the Kubernetes scheduler
     # itself, which can be upto 2-3 seconds.
     # For non-autoscaling clusters, we conservatively set this to 10s.
-    TIMEOUT = skypilot_config.get_nested(['kubernetes', 'provision_timeout'],
+    timeout = skypilot_config.get_nested(['kubernetes', 'provision_timeout'],
                                          10)
 
     _DEFAULT_NUM_VCPUS = 2
@@ -265,7 +265,7 @@ class Kubernetes(clouds.Cloud):
             'cpus': str(cpus),
             'memory': str(mem),
             'accelerator_count': str(acc_count),
-            'timeout': str(self.TIMEOUT),
+            'timeout': str(self.timeout),
             'k8s_namespace':
                 kubernetes_utils.get_current_kube_config_context_namespace(),
             'k8s_port_mode': port_mode.value,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -43,7 +43,8 @@ class Kubernetes(clouds.Cloud):
     # Note that this timeout includes time taken by the Kubernetes scheduler
     # itself, which can be upto 2-3 seconds.
     # For non-autoscaling clusters, we conservatively set this to 10s.
-    TIMEOUT = skypilot_config.get_nested(['kubernetes', 'provision_timeout'], 10)
+    TIMEOUT = skypilot_config.get_nested(['kubernetes', 'provision_timeout'],
+                                         10)
 
     _DEFAULT_NUM_VCPUS = 2
     _DEFAULT_MEMORY_CPU_RATIO = 1

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -523,7 +523,8 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     wait_pods.append(jump_pod)
     provision_timeout = provider_config['timeout']
 
-    wait_str = 'indefinitely' if provision_timeout == 0 else f'for {provision_timeout}s'
+    wait_str = ('indefinitely' if provision_timeout == 0
+                else f'for {provision_timeout}s')
     logger.debug(f'run_instances: waiting {wait_str} for pods to schedule and '
                  f'run: {list(wait_pods_dict.keys())}')
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -169,7 +169,7 @@ def _wait_for_pods_to_schedule(namespace, new_nodes, timeout: int):
     """
     start_time = time.time()
 
-    def _evaluate_timeout():
+    def _evaluate_timeout() -> bool:
         # If timeout is set to zero, retry indefinitely.
         if timeout == 0:
             return True

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -165,12 +165,12 @@ def _wait_for_pods_to_schedule(namespace, new_nodes, timeout: int):
     is ContainerCreating, then we can assume that resources have been
     allocated and we can exit.
 
-    If timeout is set to zero, this method will wait indefinitely.
+    If timeout is set to a negative value, this method will wait indefinitely.
     """
     start_time = time.time()
 
     def _evaluate_timeout() -> bool:
-        # If timeout is set to zero, retry indefinitely.
+        # If timeout is negative, retry indefinitely.
         if timeout < 0:
             return True
         return time.time() - start_time < timeout

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -171,7 +171,7 @@ def _wait_for_pods_to_schedule(namespace, new_nodes, timeout: int):
 
     def _evaluate_timeout() -> bool:
         # If timeout is set to zero, retry indefinitely.
-        if timeout == 0:
+        if timeout < 0:
             return True
         return time.time() - start_time < timeout
 
@@ -524,7 +524,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     provision_timeout = provider_config['timeout']
 
     wait_str = ('indefinitely'
-                if provision_timeout == 0 else f'for {provision_timeout}s')
+                if provision_timeout < 0 else f'for {provision_timeout}s')
     logger.debug(f'run_instances: waiting {wait_str} for pods to schedule and '
                  f'run: {list(wait_pods_dict.keys())}')
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -523,8 +523,8 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     wait_pods.append(jump_pod)
     provision_timeout = provider_config['timeout']
 
-    wait_str = ('indefinitely' if provision_timeout == 0
-                else f'for {provision_timeout}s')
+    wait_str = ('indefinitely'
+                if provision_timeout == 0 else f'for {provision_timeout}s')
     logger.debug(f'run_instances: waiting {wait_str} for pods to schedule and '
                  f'run: {list(wait_pods_dict.keys())}')
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -164,9 +164,18 @@ def _wait_for_pods_to_schedule(namespace, new_nodes, timeout: int):
     exceeds the timeout, raise an exception. If pod's container
     is ContainerCreating, then we can assume that resources have been
     allocated and we can exit.
+
+    If timeout is set to zero, this method will wait indefinitely.
     """
     start_time = time.time()
-    while time.time() - start_time < timeout:
+
+    def _evaluate_timeout():
+        # If timeout is set to zero, retry indefinitely.
+        if timeout == 0:
+            return True
+        return time.time() - start_time < timeout
+
+    while _evaluate_timeout():
         all_pods_scheduled = True
         for node in new_nodes:
             # Iterate over each pod to check their status
@@ -512,12 +521,15 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     wait_pods_dict = _filter_pods(namespace, tags, ['Pending'])
     wait_pods = list(wait_pods_dict.values())
     wait_pods.append(jump_pod)
-    logger.debug('run_instances: waiting for pods to schedule and run: '
-                 f'{list(wait_pods_dict.keys())}')
+    provision_timeout = provider_config['timeout']
+
+    wait_str = 'indefinitely' if provision_timeout == 0 else f'for {provision_timeout}s'
+    logger.debug(f'run_instances: waiting {wait_str} for pods to schedule and '
+                 f'run: {list(wait_pods_dict.keys())}')
 
     # Wait until the pods are scheduled and surface cause for error
     # if there is one
-    _wait_for_pods_to_schedule(namespace, wait_pods, provider_config['timeout'])
+    _wait_for_pods_to_schedule(namespace, wait_pods, provision_timeout)
     # Wait until the pods and their containers are up and running, and
     # fail early if there is an error
     _wait_for_pods_to_run(namespace, wait_pods)

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -630,7 +630,10 @@ def get_config_schema():
                             'required': ['namespace']
                         }]
                     }
-                }
+                },
+                'provision_timeout': {
+                    'type': 'integer',
+                },
             }
         },
         'oci': {


### PR DESCRIPTION
Autoscaling clusters or clusters with admission control may require tweaking the provisioning timeout. This PR adds support for that by adding `kubernetes.provision_timeout` field to ~/.sky/config.yaml. 

- [x] Code formatting: `bash format.sh`
- [x] Manual `sky launch` with and without `kubernetes.provision_timeout` in config.yaml