### PR TITLE
[Tests] Fix test for g6 instance type

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -430,11 +430,12 @@ class AWS(clouds.Cloud):
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
             # Check the instance type is valid in the cloud
-            regions = self.regions_with_offering(resources.instance_type,
-                                                 accelerators=resources.accelerators,
-                                                 use_spot=resources.use_spot,
-                                                 region=resources.region,
-                                                 zone=resources.zone)
+            regions = self.regions_with_offering(
+                resources.instance_type,
+                accelerators=resources.accelerators,
+                use_spot=resources.use_spot,
+                region=resources.region,
+                zone=resources.zone)
             if not regions:
                 return ([], [])
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -429,6 +429,14 @@ class AWS(clouds.Cloud):
     ) -> Tuple[List['resources_lib.Resources'], List[str]]:
         if resources.instance_type is not None:
             assert resources.is_launchable(), resources
+            # Check the instance type is valid in the cloud
+            regions = self.regions_with_offering(resources.instance_type,
+                                                 accelerators=resources.accelerators,
+                                                 use_spot=resources.use_spot,
+                                                 region=resources.region,
+                                                 zone=resources.zone)
+            if not regions:
+                return ([], [])
             # Treat Resources(AWS, p3.2x, V100) as Resources(AWS, p3.2x).
             resources = resources.copy(accelerators=None)
             return ([resources], [])

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -350,6 +350,10 @@ def get_hourly_cost_impl(
         # all the zones in the same region.
         assert region is None or len(set(df[price_str])) == 1, df
 
+    if pd.isna(df[price_str]).all():
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'No {price_str} found for instance type '
+                             f'{instance_type!r}.')
     cheapest_idx = df[price_str].idxmin()
     cheapest = df.loc[cheapest_idx]
     return cheapest[price_str]
@@ -523,6 +527,8 @@ def get_instance_type_for_accelerator_impl(
 
     # Current strategy: choose the cheapest instance
     price_str = 'SpotPrice' if use_spot else 'Price'
+    if pd.isna(result[price_str]).all():
+        return ([], [])
     result = result.sort_values(price_str, ascending=True)
     instance_types = list(result['InstanceType'].drop_duplicates())
     return (instance_types, [])

--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -87,6 +87,8 @@ def generate_random_dag(
                     accelerators={
                         candidate.accelerator_name: candidate.accelerator_count
                     })
+                if not resources.get_valid_regions_for_launchable():
+                    continue
                 requested_features = set()
                 if op.num_nodes > 1:
                     requested_features.add(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The newly included g6 instances in AWS fails the optimizer test, as there is no on-demand price (but only spot price) for that instance. Removing it from the test for now to let the CI pass.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
