### PR TITLE
[Core] Error out for a non-exist SKYPILOT_CONFIG

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -51,6 +51,7 @@ import yaml
 from sky import sky_logging
 from sky.utils import common_utils
 from sky.utils import schemas
+from sky.utils import ux_utils
 
 # The config path is discovered in this order:
 #
@@ -129,6 +130,13 @@ def _try_load_config() -> None:
     config_path_via_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
     if config_path_via_env_var is not None:
         config_path = config_path_via_env_var
+        if not os.path.exists(config_path):
+            with ux_utils.print_exception_no_traceback():
+                raise FileNotFoundError(
+                    'Config file specified by env var '
+                    f'{ENV_VAR_SKYPILOT_CONFIG} ({config_path!r}) does not '
+                    'exist. Please double check the path or unset the env var: '
+                    f'unset {ENV_VAR_SKYPILOT_CONFIG}')
     else:
         config_path = CONFIG_PATH
     config_path = os.path.expanduser(config_path)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -129,7 +129,7 @@ def _try_load_config() -> None:
     global _dict, _loaded_config_path
     config_path_via_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
     if config_path_via_env_var is not None:
-        config_path = config_path_via_env_var
+        config_path = os.path.expanduser(config_path_via_env_var)
         if not os.path.exists(config_path):
             with ux_utils.print_exception_no_traceback():
                 raise FileNotFoundError(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

If the user's `SKYPILOT_CONFIG` does not point to a file, currently, it will just slient go through without any message. We should error out as it is likely unintentional.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `SKYPILOT_CONFIG="" sky launch -c test` error out correctly
  - [x] `SKYPILOT_CONFIG="existing-path" sky launch -c test` works correctly
  - [x] `SKYPILOT_DEBUG=1 SKYPILOT_CONFIG="existing-path" sky spot launch -n test echo hi`
  - [x] `SKYPILOT_DEBUG=1 sky spot launch -n test echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
