### PR TITLE
[UX] Show total device memory in `sky show-gpus`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3003,6 +3003,7 @@ def show_gpus(
                 'CLOUD',
                 'INSTANCE_TYPE',
                 'DEVICE_MEM',
+                'TOTAL_DEVICE_MEM',
                 'vCPUs',
                 'HOST_MEM',
                 'HOURLY_PRICE',
@@ -3023,8 +3024,13 @@ def show_gpus(
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
-                device_memory_str = (f'{item.device_memory:.0f}GB' if
-                                     not pd.isna(item.device_memory) else '-')
+                if pd.isna(item.device_memory):
+                    device_memory_str = total_device_memory_str = '-'
+                else:
+                    device_memory_str = f'{item.device_memory:.0f}GB'
+                    total_device_memory = (item.device_memory *
+                                           item.accelerator_count)
+                    total_device_memory_str = f'{total_device_memory:.0f}GB'
                 host_memory_str = f'{item.memory:.0f}GB' if not pd.isna(
                     item.memory) else '-'
                 price_str = f'$ {item.price:.3f}' if not pd.isna(
@@ -3038,6 +3044,7 @@ def show_gpus(
                     item.cloud,
                     instance_type_str,
                     device_memory_str,
+                    total_device_memory_str,
                     cpu_str,
                     host_memory_str,
                     price_str,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

It is handy when one wants to determine whether an LLM fits in an instance type.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```bash
$ sky show-gpus --cloud aws A10G        
GPU   QTY  CLOUD  INSTANCE_TYPE  DEVICE_MEM  TOTAL_DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION     
A10G  1    AWS    g5.16xlarge    24GB        24GB              64     256GB     $ 4.096       $ 0.656            us-west-2  
A10G  1    AWS    g5.2xlarge     24GB        24GB              8      32GB      $ 1.212       $ 0.434            us-west-2  
A10G  1    AWS    g5.4xlarge     24GB        24GB              16     64GB      $ 1.624       $ 0.460            us-west-2  
A10G  1    AWS    g5.8xlarge     24GB        24GB              32     128GB     $ 2.448       $ 0.587            us-west-2  
A10G  1    AWS    g5.xlarge      24GB        24GB              4      16GB      $ 1.006       $ 0.409            us-east-2  
A10G  4    AWS    g5.12xlarge    24GB        96GB              48     192GB     $ 5.672       $ 0.836            us-east-2  
A10G  4    AWS    g5.24xlarge    24GB        96GB              96     384GB     $ 8.144       $ 1.145            us-east-2  
A10G  8    AWS    g5.48xlarge    24GB        192GB             192    768GB     $ 16.288      $ 2.243            us-east-2 
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
