### PR TITLE
triton resnet example

### DIFF
--- a/examples/tritonserver/models/resnet18/config.pbtxt
+++ b/examples/tritonserver/models/resnet18/config.pbtxt
@@ -1,0 +1,19 @@
+name: "resnet18"
+platform: "pytorch_libtorch"
+max_batch_size : 0
+input [
+  {
+    name: "input__0"
+    data_type: TYPE_FP32
+    dims: [ 3, 224, 224 ]
+    reshape { shape: [ 1, 3, 224, 224 ] }
+  }
+]
+output [
+  {
+    name: "output__0"
+    data_type: TYPE_FP32
+    dims: [ 1, 1000 ,1, 1]
+    reshape { shape: [ 1, 1000 ] }
+  }
+]

--- a/examples/tritonserver/trace_resnet.py
+++ b/examples/tritonserver/trace_resnet.py
@@ -1,0 +1,17 @@
+"""
+Downloads ImageNet pretrained resnet18 model, exports a `torch.jit.script`
+model for use in NVIDIA triton inference server. `torch.jit.trace` can
+equally work well.
+
+Usage: 
+    $ python script_resnet.py
+"""
+        
+import torch
+import torchvision.models as models
+
+r18 = models.resnet18(pretrained=True)       # We now have an instance of the pretrained model
+r18_scripted = torch.jit.script(r18)         # *** This is the TorchScript export
+torch.jit.save(r18_scripted, "./models/resnet18/1/model.pt") # save into triton repo
+
+

--- a/examples/tritonserver/trace_resnet.py
+++ b/examples/tritonserver/trace_resnet.py
@@ -6,12 +6,12 @@ equally work well.
 Usage: 
     $ python script_resnet.py
 """
-        
+
 import torch
 import torchvision.models as models
 
-r18 = models.resnet18(pretrained=True)       # We now have an instance of the pretrained model
-r18_scripted = torch.jit.script(r18)         # *** This is the TorchScript export
-torch.jit.save(r18_scripted, "./models/resnet18/1/model.pt") # save into triton repo
-
-
+r18 = models.resnet18(
+    pretrained=True)  # We now have an instance of the pretrained model
+r18_scripted = torch.jit.script(r18)  # *** This is the TorchScript export
+torch.jit.save(r18_scripted,
+               "./models/resnet18/1/model.pt")  # save into triton repo

--- a/examples/tritonserver/triton_client.py
+++ b/examples/tritonserver/triton_client.py
@@ -1,0 +1,26 @@
+"""
+An example triton client request. This example just sends a dummy
+input. More info on how to write a client can be found here:
+
+https://pytorch.org/TensorRT/tutorials/serving_torch_tensorrt_with_triton.html
+
+Usage:
+    $ python triton_client.py
+"""
+
+import numpy as np
+import os
+import tritonclient.http as httpclient
+from tritonclient.utils import triton_to_np_dtype
+
+# create the client and define the inputs and outputs
+client = httpclient.InferenceServerClient(url=f"{os.environ['TRITONSERVER']}:8000")
+img = np.random.rand(3, 224, 224).astype(np.float32)
+inputs = httpclient.InferInput("input__0", img.shape, datatype="FP32")
+inputs.set_data_from_numpy(img, binary_data=True)
+outputs = httpclient.InferRequestedOutput("output__0", binary_data=True, class_count=1000)
+
+# send a request
+results = client.infer(model_name="resnet18", inputs=[inputs], outputs=[outputs])
+inference_output = results.as_numpy('output__0')
+print(inference_output[:5])

--- a/examples/tritonserver/triton_client.py
+++ b/examples/tritonserver/triton_client.py
@@ -8,19 +8,25 @@ Usage:
     $ python triton_client.py
 """
 
-import numpy as np
 import os
+
+import numpy as np
 import tritonclient.http as httpclient
 from tritonclient.utils import triton_to_np_dtype
 
 # create the client and define the inputs and outputs
-client = httpclient.InferenceServerClient(url=f"{os.environ['TRITONSERVER']}:8000")
+client = httpclient.InferenceServerClient(
+    url=f"{os.environ['TRITONSERVER']}:8000")
 img = np.random.rand(3, 224, 224).astype(np.float32)
 inputs = httpclient.InferInput("input__0", img.shape, datatype="FP32")
 inputs.set_data_from_numpy(img, binary_data=True)
-outputs = httpclient.InferRequestedOutput("output__0", binary_data=True, class_count=1000)
+outputs = httpclient.InferRequestedOutput("output__0",
+                                          binary_data=True,
+                                          class_count=1000)
 
 # send a request
-results = client.infer(model_name="resnet18", inputs=[inputs], outputs=[outputs])
+results = client.infer(model_name="resnet18",
+                       inputs=[inputs],
+                       outputs=[outputs])
 inference_output = results.as_numpy('output__0')
 print(inference_output[:5])

--- a/examples/tritonserver/tritonserver.yaml
+++ b/examples/tritonserver/tritonserver.yaml
@@ -1,0 +1,32 @@
+# Runs an NVIDIA Triton inference server for ImageNet classification on a pretrained resnet model.
+# This demo includes code to create a TorchScripted model checkpoint, a minimal config to run it,
+# and a python client to send requests to it. Triton can also serve tensorflow, ONNX, TensorRT and more. 
+# More information about triton can be found in their docs:
+# https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/contents.html
+
+# More details about serving torch on triton can be found here:
+# https://pytorch.org/TensorRT/tutorials/serving_torch_tensorrt_with_triton.html
+#
+# To launch the server:
+#   $ sky launch -c triton tritonserver.yaml
+#
+# To send an inference request (from your laptop to the server):
+#   $ pip install tritonclient[http] numpy
+#   $ export TRITONSERVER=$(sky status --ip triton)
+#   $ python triton_client.py
+
+resources:
+  accelerators: V100:1
+  ports: 8000
+
+workdir: ./
+
+setup: |
+  set -ex
+  pip install torch torchvision
+  python trace_resnet.py
+
+run: |
+  docker run --gpus all --rm -p 8000:8000 -p 8001:8001 -p 8002:8002 \
+    -v $(pwd)/models:/models nvcr.io/nvidia/tritonserver:23.10-py3 \
+    tritonserver --model-repository=/models


### PR DESCRIPTION
Requested by #3347. This shows how run a torch model server with NVIDIA triton. Requires torch models to be exportable by `torch.jit`

To run the example:

```
sky launch -c triton tritonserver.yaml
pip install tritonclient[http] numpy
export TRITONSERVER=$(sky status --ip triton)
python triton_client.py
```