### PR TITLE
[k8s] Use soft constraints on pod anti-affinity for multi-node tasks

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -496,18 +496,25 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
             # "nodes".
             pod_spec['spec']['affinity'] = {
                 'podAntiAffinity': {
-                    'requiredDuringSchedulingIgnoredDuringExecution': [{
-                        'labelSelector': {
-                            'matchExpressions': [{
-                                'key': TAG_SKYPILOT_CLUSTER_NAME,
-                                'operator': 'In',
-                                'values': [cluster_name_on_cloud]
-                            }]
-                        },
-                        'topologyKey': 'kubernetes.io/hostname'
+                    # Set as a soft constraint
+                    'preferredDuringSchedulingIgnoredDuringExecution': [{
+                        # Max weight to avoid scheduling on the
+                        # same physical node unless necessary.
+                        'weight': 100,
+                        'podAffinityTerm': {
+                            'labelSelector': {
+                                'matchExpressions': [{
+                                    'key': TAG_SKYPILOT_CLUSTER_NAME,
+                                    'operator': 'In',
+                                    'values': [cluster_name_on_cloud]
+                                }]
+                            },
+                            'topologyKey': 'kubernetes.io/hostname'
+                        }
                     }]
                 }
             }
+
         pod = kubernetes.core_api().create_namespaced_pod(namespace, pod_spec)
         created_pods[pod.metadata.name] = pod
         if head_pod_name is None:


### PR DESCRIPTION
Our current k8s multi-node implementation enforces strict pod anti-affinity requirements. As a result, if your Kubernetes cluster contains a single physical node, SkyPilot cannot launch multi-node jobs even though logically multiple pods can fit on the node. Notably, this is contrary to the inline code comments.

Repro - `sky local up` then try `sky launch -c clus --num-nodes 2 --cpus 1`. This will fail to get scheduled even though the cluster has enough resources.

This PR changes the pod anti-affinity to be a soft requirement.  Multi-node SkyPilot pods are now spread across nodes when possible, but can still be placed on the same node if resources are unavailable on other nodes.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual test - single node cluster - `sky local up` then `sky launch -c clus --num-nodes 2 --cpus 1` -> pods are placed on the same node.
- [x] Manual test - multi node GKE cluster - `sky launch -c clus --num-nodes 2 --cpus 1` -> pods are spread across nodes.
