### PR TITLE
[k8s] Add podip mode support for exposing ports

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -262,8 +262,7 @@ Available fields and semantics:
 
     # The mode to use for opening ports on Kubernetes
     #
-    # This must be either: 'ingress' or 'loadbalancer'. If not specified,
-    # defaults to 'loadbalancer'.
+    # This must be either: 'loadbalancer', 'ingress' or 'podip'.
     #
     # loadbalancer: Creates services of type `LoadBalancer` to expose ports.
     # See https://skypilot.readthedocs.io/en/latest/reference/kubernetes/kubernetes-setup.html#loadbalancer-service.
@@ -274,6 +273,14 @@ Available fields and semantics:
     # Requires an Nginx ingress controller to be configured on the Kubernetes cluster.
     # Refer to https://skypilot.readthedocs.io/en/latest/reference/kubernetes/kubernetes-setup.html#nginx-ingress
     # for details on deploying the NGINX ingress controller.
+    #
+    # podip: Directly returns the IP address of the pod. This mode does not
+    # create any Kubernetes services and is a lightweight way to expose ports.
+    # NOTE - ports exposed with podip mode are not accessible from outside the
+    # Kubernetes cluster. This mode is useful for hosting internal services
+    # that need to be accessed only by other pods in the same cluster.
+    #
+    # Default: loadbalancer
     ports: loadbalancer
 
     # Attach custom metadata to Kubernetes objects created by SkyPilot

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -31,6 +31,9 @@ def open_ports(
         _open_ports_using_ingress(cluster_name_on_cloud=cluster_name_on_cloud,
                                   ports=ports,
                                   provider_config=provider_config)
+    elif port_mode == kubernetes_enums.KubernetesPortMode.PODIP:
+        # Do nothing, as PodIP mode does not require opening ports
+        pass
 
 
 def _open_ports_using_loadbalancer(
@@ -133,6 +136,9 @@ def cleanup_ports(
         _cleanup_ports_for_ingress(cluster_name_on_cloud=cluster_name_on_cloud,
                                    ports=ports,
                                    provider_config=provider_config)
+    elif port_mode == kubernetes_enums.KubernetesPortMode.PODIP:
+        # Do nothing, as PodIP mode does not require opening ports
+        pass
 
 
 def _cleanup_ports_for_loadbalancer(
@@ -191,6 +197,11 @@ def query_ports(
                 cluster_name_on_cloud=cluster_name_on_cloud,
                 ports=ports,
             )
+        elif port_mode == kubernetes_enums.KubernetesPortMode.PODIP:
+            return _query_ports_for_podip(
+                cluster_name_on_cloud=cluster_name_on_cloud,
+                ports=ports,
+            )
         else:
             return {}
     except kubernetes.kubernetes.client.ApiException as e:
@@ -244,5 +255,23 @@ def _query_ports_for_ingress(
                                  port=https_port,
                                  path=path_prefix.lstrip('/')),
         ]
+
+    return result
+
+
+def _query_ports_for_podip(
+    cluster_name_on_cloud: str,
+    ports: List[int],
+) -> Dict[int, List[common.Endpoint]]:
+    namespace = kubernetes_utils.get_current_kube_config_context_namespace()
+    pod_name = kubernetes_utils.get_pod_name(cluster_name_on_cloud)
+    pod_ip = network_utils.get_pod_ip(namespace, pod_name)
+
+    result: Dict[int, List[common.Endpoint]] = {}
+    if pod_ip is None:
+        return {}
+
+    for port in ports:
+        result[port] = [common.SocketEndpoint(host=pod_ip, port=port)]
 
     return result

--- a/sky/provision/kubernetes/network.py
+++ b/sky/provision/kubernetes/network.py
@@ -264,7 +264,7 @@ def _query_ports_for_podip(
     ports: List[int],
 ) -> Dict[int, List[common.Endpoint]]:
     namespace = kubernetes_utils.get_current_kube_config_context_namespace()
-    pod_name = kubernetes_utils.get_pod_name(cluster_name_on_cloud)
+    pod_name = kubernetes_utils.get_head_pod_name(cluster_name_on_cloud)
     pod_ip = network_utils.get_pod_ip(namespace, pod_name)
 
     result: Dict[int, List[common.Endpoint]] = {}

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -228,3 +228,12 @@ def get_loadbalancer_ip(namespace: str, service_name: str) -> Optional[str]:
     ip = service.status.load_balancer.ingress[
         0].ip or service.status.load_balancer.ingress[0].hostname
     return ip if ip is not None else None
+
+
+def get_pod_ip(namespace: str, pod_name: str) -> Optional[str]:
+    """Returns the IP address of the pod."""
+    core_api = kubernetes.core_api()
+    pod = core_api.read_namespaced_pod(
+        pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+
+    return pod.status.pod_ip if pod.status.pod_ip is not None else None

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -233,7 +233,8 @@ def get_loadbalancer_ip(namespace: str, service_name: str) -> Optional[str]:
 def get_pod_ip(namespace: str, pod_name: str) -> Optional[str]:
     """Returns the IP address of the pod."""
     core_api = kubernetes.core_api()
-    pod = core_api.read_namespaced_pod(
-        pod_name, namespace, _request_timeout=kubernetes.API_TIMEOUT)
+    pod = core_api.read_namespaced_pod(pod_name,
+                                       namespace,
+                                       _request_timeout=kubernetes.API_TIMEOUT)
 
     return pod.status.pod_ip if pod.status.pod_ip is not None else None

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1100,6 +1100,9 @@ def get_endpoint_debug_message() -> str:
     elif port_mode == kubernetes_enums.KubernetesPortMode.LOADBALANCER:
         endpoint_type = 'LoadBalancer'
         debug_cmd = 'kubectl describe service'
+    elif port_mode == kubernetes_enums.KubernetesPortMode.PODIP:
+        endpoint_type = 'PodIP'
+        debug_cmd = 'kubectl describe pod'
     return ENDPOINTS_DEBUG_MESSAGE.format(endpoint_type=endpoint_type,
                                           debug_cmd=debug_cmd)
 
@@ -1271,3 +1274,18 @@ def check_secret_exists(secret_name: str, namespace: str) -> bool:
         raise
     else:
         return True
+
+
+def get_pod_name(cluster_name_on_cloud: str):
+    """Returns the pod name of the head pod for the given cluster name on cloud
+
+    Args:
+        cluster_name_on_cloud: Name of the cluster on cloud
+
+    Returns:
+        str: Pod name of the head pod
+    """
+    # We could have iterated over all pods in the namespace and checked for the
+    # label, but since we know the naming convention, we can directly return the
+    # head pod name.
+    return f'{cluster_name_on_cloud}-head'

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1276,7 +1276,7 @@ def check_secret_exists(secret_name: str, namespace: str) -> bool:
         return True
 
 
-def get_pod_name(cluster_name_on_cloud: str):
+def get_head_pod_name(cluster_name_on_cloud: str):
     """Returns the pod name of the head pod for the given cluster name on cloud
 
     Args:

--- a/sky/utils/kubernetes_enums.py
+++ b/sky/utils/kubernetes_enums.py
@@ -35,3 +35,4 @@ class KubernetesPortMode(enum.Enum):
     """
     INGRESS = 'ingress'
     LOADBALANCER = 'loadbalancer'
+    PODIP = 'podip'


### PR DESCRIPTION
Adds a `podip` mode for exposing ports on Kubernetes clusters. This is useful when the ports need to only be internally accessible from within the Kubernetes cluster and user wants to reduce the number of svcs running.

Since ports exposed using `podip` are not accessible from outside the cluster, we are not adding this mode to our main docs for now. Only covered in the config.yaml documentation, can add to main docs based on demand. 

Added after feedback from user.

Tested manually with `sky launch -c test2 --cloud kubernetes --ports 8888 -- 'python -m http.server 8888'` -> `sky status --endpoints test2` -> Access endpoint from within cluster.
