### PR TITLE
[Core][Serve] Support TailScale VPN

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -854,6 +854,9 @@ def write_cluster_config(
         f'open(os.path.expanduser("{constants.SKY_REMOTE_RAY_PORT_FILE}"), "w", encoding="utf-8"))\''
     )
 
+    # TODO(tian): Hack. Reformat here.
+    default_use_internal_ips = 'vpn_authkey' in resources_vars
+
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -874,7 +877,8 @@ def write_cluster_config(
 
                 # Networking configs
                 'use_internal_ips': skypilot_config.get_nested(
-                    (str(cloud).lower(), 'use_internal_ips'), False),
+                    (str(cloud).lower(), 'use_internal_ips'),
+                    default_use_internal_ips),
                 'ssh_proxy_command': ssh_proxy_command,
                 'vpc_name': skypilot_config.get_nested(
                     (str(cloud).lower(), 'vpc_name'), None),

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2890,6 +2890,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         open_new_ports = bool(
             resources_utils.port_ranges_to_set(current_ports) -
             resources_utils.port_ranges_to_set(prev_ports))
+        # TODO(tian): Skip open ports if VPN is used.
         if open_new_ports:
             with rich_utils.safe_status(
                     '[bold cyan]Launching - Opening new ports'):

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -456,7 +456,7 @@ def _post_provision_setup(
         logger.debug(
             f'\nWaiting for SSH to be available for {cluster_name!r} ...')
         wait_for_ssh(cluster_info, ssh_credentials)
-        logger.debug(f'SSH Conection ready for {cluster_name!r}')
+        logger.debug(f'SSH Connection ready for {cluster_name!r}')
         plural = '' if len(cluster_info.instances) == 1 else 's'
         logger.info(f'{colorama.Fore.GREEN}Successfully provisioned '
                     f'or found existing instance{plural}.'

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -42,6 +42,9 @@ provider:
   vpc_name: {{vpc_name}}
 {% endif %}
   use_internal_ips: {{use_internal_ips}}
+{% if vpn_authkey is not none %}
+  vpn_unique_id: {{vpn_unique_id}}
+{% endif %}
   # Disable launch config check for worker nodes as it can cause resource
   # leakage.
   # Reference: https://github.com/ray-project/ray/blob/cd1ba65e239360c8a7b130f991ed414eccc063ce/python/ray/autoscaler/_private/autoscaler.py#L1115
@@ -90,6 +93,7 @@ available_node_types:
       # The bootcmd is to disable automatic APT updates, to avoid the lock
       # when user call `apt install` on the node.
       # Reference: https://askubuntu.com/questions/1322292/how-do-i-turn-off-automatic-updates-completely-and-for-real
+      # TODO(tian): Have a class for different VPN provider and return different setup commands.
       UserData: |
         #cloud-config
         users:
@@ -109,6 +113,12 @@ available_node_types:
           - path: /etc/apt/apt.conf.d/10cloudinit-disable
             content: |
               APT::Periodic::Enable "0";
+        {% if vpn_authkey is not none %}
+        runcmd:
+          - ['sh', '-c', 'curl -fsSL https://tailscale.com/install.sh | sh']
+          - ['sh', '-c', "echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf && echo 'net.ipv6.conf.all.forwarding = 1' | sudo tee -a /etc/sysctl.d/99-tailscale.conf && sudo sysctl -p /etc/sysctl.d/99-tailscale.conf" ]
+          - ['tailscale', 'up', '--authkey={{vpn_authkey}}', '--hostname={{vpn_unique_id}}' ]
+        {% endif %}
       TagSpecifications:
         - ResourceType: instance
           Tags:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -484,6 +484,19 @@ def get_cluster_schema():
     }
 
 
+_VPN_CONFIG_SCHEMA = {
+    'vpn': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'tailscale': {
+                'type': 'string',
+            },
+        }
+    }
+}
+
 _NETWORK_CONFIG_SCHEMA = {
     'vpc_name': {
         'oneOf': [{
@@ -570,6 +583,7 @@ def get_config_schema():
                 'security_group_name': {
                     'type': 'string',
                 },
+                **_VPN_CONFIG_SCHEMA,
                 **_INSTANCE_TAGS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A revised version of #3276. If VPN is enabled, does not provision pu

TODO:
- [ ] Support multi-node cluster
- [ ] Maybe does not use Private IP in VPN to setup SkyPilot runtime env as it needs to wait until instance is up (to discuss)
- [ ] Cleanup VPN record after cluster termination
- [ ] Skip open ports if VPN is used
- [ ] Reformat to support other VPN providers
- [ ] Smoke tests

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
All of the following is with this skypilot config:
```yaml
aws:
  vpn:
    tailscale: <tailscale-auth-key>
```
1. Launch a single cluster
```bash
$ sky launch --cloud aws --cpus 2 -c t-aws-vpn 'python -m http.server 7001' # without open ports
...

$ sky status --ip t-aws-vpn
100.73.240.56 # an internal ip

$ curl $(sky status --ip t-aws-vpn):7001/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>

# in a machine that joins the VPN
$ curl 100.73.240.56:7001/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>

# in a random machine
$ curl 100.73.240.56:7001/
# blocking and cannot got response
```
2. Basic SkyServe example
```yaml
# aws-vpn.yaml
service:
  readiness_probe: /
  replicas: 1
resources:
  ports: 8080
  cloud: aws
  cpus: 2
run: python -m http.server 8080
```
```bash
$ sky serve up aws-vpn.yaml -n aws-vpn
...

$ sky serve status --endpoint aws-vpn
100.95.198.34:30001

$ curl -L $(sky serve status --endpoint aws-vpn)/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>

# from a machine that joins the VPN
$ curl -L 100.95.198.34:30001/
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /</title>
</head>
<body>
<h1>Directory listing for /</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
