### PR TITLE
[Core] Add internal configs in schema.py to avoid spot job and serve failure

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -272,7 +272,7 @@ class RayCodeGen:
                 # Keep invoking ray.wait if ready is empty. This is because
                 # ray.wait with timeout=None will only wait for 10**6 seconds,
                 # which will cause tasks running for more than 12 days to return
-                before becoming ready. (Such tasks are common in serving jobs.)
+                # before becoming ready. (Such tasks are common in serving jobs.)
                 # Reference: https://github.com/ray-project/ray/blob/ray-2.9.3/python/ray/_private/worker.py#L2845-L2846
                 while not ready:
                     ready, unready = ray.wait(futures)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -272,7 +272,8 @@ class RayCodeGen:
                 # Keep invoking ray.wait if ready is empty. This is because
                 # ray.wait with timeout=None will only wait for 10**6 seconds,
                 # which will cause tasks running for more than 12 days to return
-                # before becoming ready. (Such tasks are common in serving jobs.)
+                # before becoming ready.
+                # (Such tasks are common in serving jobs.)
                 # Reference: https://github.com/ray-project/ray/blob/ray-2.9.3/python/ray/_private/worker.py#L2845-L2846
                 while not ready:
                     ready, unready = ray.wait(futures)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,4 +1,5 @@
 """Resources: compute requirements of Tasks."""
+import dataclasses
 import functools
 import textwrap
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -1339,6 +1340,8 @@ class Resources:
         if self.disk_tier is not None:
             config['disk_tier'] = self.disk_tier.value
         add_if_not_none('ports', self.ports)
+        if self._docker_login_config is not None:
+            config['_docker_login_config'] = dataclasses.asdict(self._docker_login_config)
         if self._is_image_managed is not None:
             config['_is_image_managed'] = self._is_image_managed
         if self._requires_fuse is not None:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1341,7 +1341,8 @@ class Resources:
             config['disk_tier'] = self.disk_tier.value
         add_if_not_none('ports', self.ports)
         if self._docker_login_config is not None:
-            config['_docker_login_config'] = dataclasses.asdict(self._docker_login_config)
+            config['_docker_login_config'] = dataclasses.asdict(
+                self._docker_login_config)
         if self._is_image_managed is not None:
             config['_is_image_managed'] = self._is_image_managed
         if self._requires_fuse is not None:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -5,7 +5,8 @@ https://json-schema.org/
 """
 
 
-def get_single_resources_schema():
+def _get_single_resources_schema():
+    """Schema for a single resource in a resources list."""
     # To avoid circular imports, only import when needed.
     # pylint: disable=import-outside-toplevel
     from sky.clouds import service_catalog
@@ -134,15 +135,18 @@ def get_single_resources_schema():
 
 
 def get_resources_schema():
-    single_resource_schema = get_single_resources_schema()['properties']
-    single_resource_schema.pop('accelerators')
+    """Resource schema in task config."""
+    single_resources_schema = _get_single_resources_schema()['properties']
+    single_resources_schema.pop('accelerators')
     return {
         '$schema': 'http://json-schema.org/draft-07/schema#',
         'type': 'object',
         'required': [],
         'additionalProperties': False,
         'properties': {
-            **single_resource_schema,
+            **single_resources_schema,
+            # We redefine the 'accelerators' field to allow one line list or
+            # a set of accelerators.
             'accelerators': {
                 # {'V100:1', 'A100:1'} will be
                 # read as a string and converted to dict.
@@ -169,7 +173,7 @@ def get_resources_schema():
                 'type': 'array',
                 'items': {
                     k: v
-                    for k, v in get_single_resources_schema().items()
+                    for k, v in _get_single_resources_schema().items()
                     # Validation may fail if $schema is included.
                     if k != '$schema'
                 },
@@ -178,7 +182,7 @@ def get_resources_schema():
                 'type': 'array',
                 'items': {
                     k: v
-                    for k, v in get_single_resources_schema().items()
+                    for k, v in _get_single_resources_schema().items()
                     # Validation may fail if $schema is included.
                     if k != '$schema'
                 },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -134,9 +134,6 @@ def get_single_resources_schema():
 
 
 def get_resources_schema():
-    # To avoid circular imports, only import when needed.
-    # pylint: disable=import-outside-toplevel
-    from sky.clouds import service_catalog
     single_resource_schema = get_single_resources_schema()
     single_resource_schema.pop('accelerators')
     return {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -134,7 +134,7 @@ def get_single_resources_schema():
 
 
 def get_resources_schema():
-    single_resource_schema = get_single_resources_schema()
+    single_resource_schema = get_single_resources_schema()['properties']
     single_resource_schema.pop('accelerators')
     return {
         '$schema': 'http://json-schema.org/draft-07/schema#',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -105,7 +105,30 @@ def get_single_resources_schema():
                     'type': 'object',
                     'required': [],
                 }]
-            }
+            },
+            # The following fields are for internal use only.
+            '_docker_login_config': {
+                'type': 'object',
+                'required': ['username', 'password', 'server'],
+                'additionalProperties': False,
+                'properties': {
+                    'username': {
+                        'type': 'string',
+                    },
+                    'password': {
+                        'type': 'string',
+                    },
+                    'server': {
+                        'type': 'string',
+                    }
+                }
+            },
+            '_is_image_managed': {
+                'type': 'boolean',
+            },
+            '_requires_fuse': {
+                'type': 'boolean',
+            },
         }
     }
 
@@ -114,36 +137,15 @@ def get_resources_schema():
     # To avoid circular imports, only import when needed.
     # pylint: disable=import-outside-toplevel
     from sky.clouds import service_catalog
+    single_resource_schema = get_single_resources_schema()
+    single_resource_schema.pop('accelerators')
     return {
         '$schema': 'http://json-schema.org/draft-07/schema#',
         'type': 'object',
         'required': [],
         'additionalProperties': False,
         'properties': {
-            'cloud': {
-                'type': 'string',
-                'case_insensitive_enum': list(service_catalog.ALL_CLOUDS)
-            },
-            'region': {
-                'type': 'string',
-            },
-            'zone': {
-                'type': 'string',
-            },
-            'cpus': {
-                'anyOf': [{
-                    'type': 'string',
-                }, {
-                    'type': 'number',
-                }],
-            },
-            'memory': {
-                'anyOf': [{
-                    'type': 'string',
-                }, {
-                    'type': 'number',
-                }],
-            },
+            **single_resource_schema,
             'accelerators': {
                 # {'V100:1', 'A100:1'} will be
                 # read as a string and converted to dict.
@@ -164,61 +166,6 @@ def get_resources_schema():
                     'items': {
                         'type': 'string',
                     }
-                }]
-            },
-            'instance_type': {
-                'type': 'string',
-            },
-            'use_spot': {
-                'type': 'boolean',
-            },
-            'spot_recovery': {
-                'type': 'string',
-            },
-            'disk_size': {
-                'type': 'integer',
-            },
-            'disk_tier': {
-                'type': 'string',
-            },
-            'ports': {
-                'anyOf': [{
-                    'type': 'string',
-                }, {
-                    'type': 'integer',
-                }, {
-                    'type': 'array',
-                    'items': {
-                        'anyOf': [{
-                            'type': 'string',
-                        }, {
-                            'type': 'integer',
-                        }]
-                    }
-                }],
-            },
-            'accelerator_args': {
-                'type': 'object',
-                'required': [],
-                'additionalProperties': False,
-                'properties': {
-                    'runtime_version': {
-                        'type': 'string',
-                    },
-                    'tpu_name': {
-                        'type': 'string',
-                    },
-                    'tpu_vm': {
-                        'type': 'boolean',
-                    }
-                }
-            },
-            'image_id': {
-                'anyOf': [{
-                    'type': 'string',
-                }, {
-                    'type': 'object',
-                    'required': [],
                 }]
             },
             'any_of': {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We should add the internal configs to the `schemas.py` to make sure managed spot and serving can load the dumped task with those internal configs set.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
