### PR TITLE
[Core] Fix jobs longer than 12 days

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -271,8 +271,8 @@ class RayCodeGen:
                 ready = []
                 # Keep invoking ray.wait if ready is empty. This is because
                 # ray.wait with timeout=None will only wait for 10**6 seconds,
-                # which will cause the task longer than 12 days returned before
-                # it is ready.
+                # which will cause tasks running for more than 12 days to return
+                before becoming ready. (Such tasks are common in serving jobs.)
                 # Reference: https://github.com/ray-project/ray/blob/ray-2.9.3/python/ray/_private/worker.py#L2845-L2846
                 while not ready:
                     ready, unready = ray.wait(futures)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`ray.wait` will timeout after 12 days, which is not enough for long-running services, and we have to wait for the job to finish.

Reference: https://github.com/ray-project/ray/blob/ray-2.9.3/python/ray/_private/worker.py#L2845-L2846

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-4 "echo hi; sleep 100; echo bye" --cloud gcp --cpus 2 --num-nodes 4`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
