### PR TITLE
[Dependency] Fix the lazy import failure for OCI

### DIFF
--- a/sky/clouds/service_catalog/oci_catalog.py
+++ b/sky/clouds/service_catalog/oci_catalog.py
@@ -40,7 +40,7 @@ def _get_df() -> 'pd.DataFrame':
 
         df = common.read_catalog('oci/vms.csv')
         try:
-            oci_adaptor.oci
+            oci_adaptor.oci.load_module()
         except ImportError:
             _df = df
             return _df


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

~~Fixes #3462~~

~~The problem is caused by we setting the controller resources with an empty resource field when no cloud is specified.~~
#3462 should be fixed in #3363.

This PR now only fixes the issue where OCI is imported even if the user does not have it enabled. This is introduced by #3394.


This can affect all new users of SkyServe who don't have OCI setup.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky serve up -n new llm/llama-3/llama3.yaml` with no existing controller
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
