### PR TITLE
Replace deprecated azure.common usages

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -7,7 +7,8 @@ import subprocess
 import threading
 
 from sky.adaptors import common
-from sky.utils.subprocess_utils import run
+from sky.utils import subprocess_utils
+from sky.utils import ux_utils
 
 azure = common.LazyImport(
     'azure',
@@ -22,25 +23,25 @@ _session_creation_lock = threading.RLock()
 
 
 def _get_account():
-    result = run('az account show -o json',
-                 stdout=subprocess.PIPE,
-                 stderr=subprocess.PIPE)
+    result = subprocess_utils.run('az account show -o json',
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE)
 
     if result.returncode != 0:
         error_message = result.stderr.decode()
-        print(f'Error executing command: {error_message}')
-        raise RuntimeError(
-            'Failed to execute az account show -o json command.')
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                'Failed to execute az account show -o json command. '
+                f'Error: {error_message}')
 
     try:
         return json.loads(result.stdout.decode())
     except json.JSONDecodeError as e:
         error_message = result.stderr.decode()
-        print(f'JSON parsing error: {e.msg}')
-        raise RuntimeError(
-            f'Failed to parse JSON output. Error: {e.msg}\n'
-            f'Command Error: {error_message}'
-        ) from e
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError(
+                'Failed to parse the output of az account show -o json '
+                f'command. Error: {error_message}') from e
 
 
 def get_subscription_id() -> str:

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 
 from sky.adaptors import common
+from sky.utils.subprocess_utils import run
 
 azure = common.LazyImport(
     'azure',
@@ -16,22 +17,15 @@ _LAZY_MODULES = (azure,)
 
 _session_creation_lock = threading.RLock()
 
-
-def _run_output(cmd):
-    proc = subprocess.run(cmd,
-                          shell=True,
-                          check=True,
-                          stderr=subprocess.PIPE,
-                          stdout=subprocess.PIPE)
-    return proc.stdout.decode('ascii')
-
-
 # There is no programmatic way to get current account details anymore.
 # https://github.com/Azure/azure-sdk-for-python/issues/21561
 
 
 def _get_account():
-    return json.loads(_run_output('az account show -o json'))
+    return json.loads(
+        run('az account show -o json',
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL).stdout.decode())
 
 
 def get_subscription_id() -> str:

--- a/sky/skylet/providers/azure/config.py
+++ b/sky/skylet/providers/azure/config.py
@@ -8,10 +8,11 @@ from typing import Any, Callable
 
 from azure.identity import AzureCliCredential
 from azure.mgmt.network import NetworkManagementClient
-from azure.mgmt.resource import ResourceManagementClient, SubscriptionClient
+from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
 
 from sky.utils import common_utils
+from sky.adaptors.azure import get_subscription_id
 
 UNIQUE_ID_LEN = 4
 _WAIT_NSG_CREATION_NUM_TIMEOUT_SECONDS = 600
@@ -49,15 +50,12 @@ def _configure_resource_group(config):
     # TODO: look at availability sets
     # https://docs.microsoft.com/en-us/azure/virtual-machines/windows/tutorial-availability-sets
     subscription_id = config["provider"].get("subscription_id")
+    if subscription_id is None:
+        subscription_id = get_subscription_id()
     # Increase the timeout to fix the Azure get-access-token (used by ray azure
     # node_provider) timeout issue.
     # Tracked in https://github.com/Azure/azure-cli/issues/20404#issuecomment-1249575110
     credentials = AzureCliCredential(process_timeout=30)
-
-    if subscription_id is None:
-        subscription_client = SubscriptionClient(credentials)
-        subscription_id = next(subscription_client.subscriptions.list()).subscription_id
-
     resource_client = ResourceManagementClient(credentials, subscription_id)
     config["provider"]["subscription_id"] = subscription_id
     logger.info("Using subscription id: %s", subscription_id)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`azure.common` is deprecated and throws the following error on newer version:
```
The public API of azure-cli-core has been deprecated starting 2.21.0, and this method can no longer return a valid credential. If you need to still use this method, you need to install 'azure-cli-core<2.21.0'. You may corrupt data if you use current CLI and old azure-cli-core.
```

This PR replaces the relevant code (very few places), using new APIs and CLI parsing instead ([unfortunately the recommended route](https://github.com/Azure/azure-sdk-for-python/issues/21561))

I'm not able to run smoke tests on my machine, so if someone wants to make sure the changes to the skylet code are OK, that would be good.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
