### PR TITLE
[FluidStack] Add Nvlink Accelerator Mappings

### DIFF
--- a/sky/provision/fluidstack/fluidstack_utils.py
+++ b/sky/provision/fluidstack/fluidstack_utils.py
@@ -8,8 +8,6 @@ import uuid
 
 import requests
 
-from sky.clouds.service_catalog.data_fetchers import fetch_fluidstack
-
 
 def get_key_suffix():
     return str(uuid.uuid4()).replace('-', '')[:8]
@@ -119,17 +117,8 @@ class FluidstackClient:
     ) -> List[str]:
         """Launch new instances."""
 
-        config = {}
+        config: Dict[str, Any] = {}
         plans = self.get_plans()
-        if 'custom' in instance_type:
-            values = instance_type.split(':')
-            index = values[1]
-            instance_type = values[2]
-            config = fetch_fluidstack.CUSTOM_PLANS_CONFIG[int(index)]
-            plan = [plan for plan in plans if plan['plan_id'] == instance_type
-                   ][0]
-            config['gpu_model'] = plan['gpu_type']
-
         regions = self.list_regions()
         plans = [
             plan for plan in plans if plan['plan_id'] == instance_type and


### PR DESCRIPTION
* Add A100-80GB and H100 Nvlink accelerator mappings

* Remove custom/configurable plans

*Changes Description*
<!-- Describe the changes in this PR -->
- New gpu types mapped to Skypilot types
- Removed unsupported custom plans

*Tests ran*
<!-- Describe the tests ran -->
`sky launch` 
`python sky/clouds/service_catalog/data_fetchers/fetch_fluidstack.py` 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [* ] Code formatting: `bash format.sh`
- [* ] Any manual or new tests for this PR (please specify below)
     * `sky launch`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
