### PR TITLE
[Spot/Serve] Fix controller resources fetching

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -337,7 +337,7 @@ def get_controller_resources(
         controller_resources)[0]
 
     controller_exist = (global_user_state.get_cluster_from_name(
-        controller.value.name) is not None)
+        controller.value.cluster_name) is not None)
     if controller_exist or controller_resources_to_use.cloud is not None:
         return {controller_resources_to_use}
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -336,9 +336,14 @@ def get_controller_resources(
     controller_resources_to_use: resources.Resources = list(
         controller_resources)[0]
 
-    controller_exist = (global_user_state.get_cluster_from_name(
-        controller.value.cluster_name) is not None)
-    if controller_exist or controller_resources_to_use.cloud is not None:
+    controller_record = global_user_state.get_cluster_from_name(
+        controller.value.cluster_name)
+    if controller_record is not None:
+        handle = controller_record.get('handle', None)
+        if handle is not None:
+            controller_resources_to_use = handle.launched_resources
+
+    if controller_resources_to_use.cloud is not None:
         return {controller_resources_to_use}
 
     # If the controller and replicas are from the same cloud, it should


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The previous code fetch the controller record with the wrong name causing the controller fail to use the same resources when starting a service/spot job when the controller already exists.

To reproduce:
1. Have a serve controller on AWS
2. `sky serve up --cloud gcp ...`
The service launching command will fail with the following error:
```
sky.exceptions.ResourcesMismatchError: Requested resources do not match the existing cluster.
  Requested:    {1x GCP(cpus=4+, disk_size=200, ports=['30001-30100'])}
  Existing:     1x AWS(m6i.xlarge, disk_size=200, ports=['30001-30100'])
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] The reproducible scripts above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
