### PR TITLE
[Core] skylet periodically update job status

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -64,7 +64,7 @@ class JobSchedulerEvent(SkyletEvent):
     EVENT_INTERVAL_SECONDS = 300
 
     def _run(self):
-        job_lib.scheduler.schedule_step()
+        job_lib.scheduler.schedule_step(force_update_jobs=True)
 
 
 class SpotJobUpdateEvent(SkyletEvent):

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -165,9 +165,9 @@ class JobScheduler:
         _CONN.commit()
         subprocess.Popen(run_cmd, shell=True, stdout=subprocess.DEVNULL)
 
-    def schedule_step(self) -> None:
+    def schedule_step(self, force_update_jobs: bool = False) -> None:
         jobs = self._get_jobs()
-        if len(jobs) > 0:
+        if len(jobs) > 0 or force_update_jobs:
             update_status()
         # TODO(zhwu, mraheja): One optimization can be allowing more than one
         # job staying in the pending state after ray job submit, so that to be


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The periodic job status update was accidentally dropped due to the job queue scheduling. This will cause job failed in `ray job` failed to be set to `FAILED` but stuck in RUNNING.

The following could reproduce the issue:
1. `git reset --hard 1bdc` (the commit before the fix for the ray.wait timeout, #3460)
2. Add `timeout=600` for `ray.wait` to simulate the issue in `cloud_vm_ray_backend.py`
3. `sky serve up -n test-index-recover-2 examples/serve/http_server/task.yaml --cloud gcp`

After 10 mins, the serve controller job fails, but the service is shown `READY` forever, and `sky queue sky-serve-controller-<hash>` shows the controller job is running, while `ray job list` shows the job is failed already on the controller VM.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
