### PR TITLE
[Spot/Serve] Fix file mount translate

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -613,9 +613,9 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
         store_type = list(storage.stores.keys())[0]
         store_prefix = store_type.store_prefix()
         bucket_url = store_prefix + file_bucket_name
-    for dst, src in copy_mounts_with_file_in_src.items():
-        file_id = src_to_file_id[src]
-        new_file_mounts[dst] = bucket_url + f'/file-{file_id}'
+        for dst, src in copy_mounts_with_file_in_src.items():
+            file_id = src_to_file_id[src]
+            new_file_mounts[dst] = bucket_url + f'/file-{file_id}'
     task.update_file_mounts(new_file_mounts)
 
     # Step 6: Replace the source field that is local path in all storage_mounts

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -606,10 +606,13 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
     # Step 5: Add the file download into the file mounts, such as
     #  /original-dst: s3://spot-fm-file-only-bucket-name/file-0
     new_file_mounts = {}
-    storage = task.storage_mounts[file_mount_remote_tmp_dir]
-    store_type = list(storage.stores.keys())[0]
-    store_prefix = store_type.store_prefix()
-    bucket_url = store_prefix + file_bucket_name
+    if copy_mounts_with_file_in_src:
+        # file_mount_remote_tmp_dir will only exist when there are files in
+        # the src for copy mounts.
+        storage = task.storage_mounts[file_mount_remote_tmp_dir]
+        store_type = list(storage.stores.keys())[0]
+        store_prefix = store_type.store_prefix()
+        bucket_url = store_prefix + file_bucket_name
     for dst, src in copy_mounts_with_file_in_src.items():
         file_id = src_to_file_id[src]
         new_file_mounts[dst] = bucket_url + f'/file-{file_id}'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes an issue introduced by #3476, where we access storage_mounts with the key that does not exist.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
