### PR TITLE
[Core] Fix docker in image_id

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -166,8 +166,7 @@ class DockerInitializer:
             rc,
             cmd,
             error_msg='Failed to run docker setup commands',
-            stderr=stdout + stderr,
-            stream_logs=False)
+            stderr=stdout + stderr)
         return stdout.strip()
 
     def initialize(self) -> str:
@@ -231,6 +230,8 @@ class DockerInitializer:
             # issue with nvidia container toolkit:
             # https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
             self._run(
+                '[ -f /etc/docker/daemon.json ] || '
+                'echo "{}" | sudo tee /etc/docker/daemon.json;'
                 'sudo jq \'.["exec-opts"] = ["native.cgroupdriver=cgroupfs"]\' '
                 '/etc/docker/daemon.json > /tmp/daemon.json;'
                 'sudo mv /tmp/daemon.json /etc/docker/daemon.json;'

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -234,6 +234,8 @@ class SkyDockerCommandRunner(DockerCommandRunner):
             # issue with nvidia container toolkit:
             # https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
             self.run(
+                '[ -f /etc/docker/daemon.json ] || '
+                'echo "{}" | sudo tee /etc/docker/daemon.json;'
                 'sudo jq \'.["exec-opts"] = ["native.cgroupdriver=cgroupfs"]\' '
                 '/etc/docker/daemon.json > /tmp/daemon.json;'
                 'sudo mv /tmp/daemon.json /etc/docker/daemon.json;'

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1463,7 +1463,6 @@ def test_ibm_job_queue_multinode():
 @pytest.mark.no_ibm  # Doesn't support IBM Cloud for now
 @pytest.mark.no_scp  # Doesn't support SCP for now
 @pytest.mark.no_oci  # Doesn't support OCI for now
-@pytest.mark.no_kubernetes  # Doesn't support Kubernetes for now
 def test_docker_preinstalled_package(generic_cloud: str):
     name = _get_cluster_name()
     test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1463,6 +1463,8 @@ def test_ibm_job_queue_multinode():
 @pytest.mark.no_ibm  # Doesn't support IBM Cloud for now
 @pytest.mark.no_scp  # Doesn't support SCP for now
 @pytest.mark.no_oci  # Doesn't support OCI for now
+@pytest.mark.no_kubernetes  # Doesn't support Kubernetes for now
+# TODO(zhwu): we should fix this for kubernetes
 def test_docker_preinstalled_package(generic_cloud: str):
     name = _get_cluster_name()
     test = Test(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes issue introduced in #3436, as some cloud's default images do not have `/etc/docker/daemon.json` by default, which causes the following error, during initializing docker image
```
E 04-25 19:02:45 subprocess_utils.py:84] jq: error: Could not open file /etc/docker/daemon.json: No such file or directory
E 04-25 19:02:45 subprocess_utils.py:84] Job for docker.service failed because the control process exited with error code.
E 04-25 19:02:45 subprocess_utils.py:84] See "systemctl status docker.service" and "journalctl -xe" for details.
E 04-25 19:02:45 subprocess_utils.py:84] 
E 04-25 19:02:54 subprocess_utils.py:84] Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-docker --cloud gcp --image-id docker:continuumio/miniconda3:24.1.2-0 echo hi`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts tests/test_smoke.py::test_docker_preinstalled_package --gcp`
  - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts tests/test_smoke.py::test_docker_preinstalled_package --aws`
  - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts tests/test_smoke.py::test_docker_preinstalled_package --azure`
  - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts tests/test_smoke.py::test_docker_preinstalled_package --fluidstack`
  - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts --kubernetes`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
