### PR TITLE
[Core] Bug fix for Tag Values representing booleans being loaded as boolean instead of strings

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -116,7 +116,7 @@ available_node_types:
               Value: {{ user }}
 {%- for tag_key, tag_value in instance_tags.items() %}
             - Key: {{ tag_key }}
-              Value: {{ tag_value }}
+              Value: {{ tag_value|tojson }}
 {%- endfor %}
 
 head_node_type: ray.head.default
@@ -161,5 +161,3 @@ setup_commands:
 
 # Command to start ray clusters are now placed in `sky.provision.instance_setup`.
 # We do not need to list it here anymore.
-
-

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -77,7 +77,7 @@ available_node_types:
       labels:
         skypilot-user: {{ user }}
       {%- for tag_key, tag_value in instance_tags.items() %}
-        {{ tag_key }}: {{ tag_value }}
+        {{ tag_key }}: {{ tag_value|tojson }}
       {%- endfor %}
       {%- if specific_reservations %}
       reservationAffinity:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR updates jinja2 ray templates for gcp and aws when utilizing Tags.
Currently, boolean strings are inserted into the Ray YAML without being escaped. This fixes that by using the builtin `tojson` function for jinja2.

Otherwise, tags which had the values: `false` or `true` would fail to launch.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    * AWS launch with tags which which include values of `false` and `true` set in the `~/.sky/config.yaml` `aws.instance_tags` section
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
