### PR TITLE
[Provisioner] make azure state check more robust

### DIFF
--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -116,7 +116,12 @@ class AzureNodeProvider(NodeProvider):
             resource_group_name=resource_group, vm_name=vm.name
         ).as_dict()
         for status in instance["statuses"]:
-            code, state = status["code"].split("/")
+            code_state = status["code"].split("/")
+            # It is possible that sometimes the 'code' is empty string, and we
+            # should skip them.
+            if len(code_state) != 2:
+                continue
+            code, state = code_state
             # skip provisioning status
             if code == "PowerState":
                 metadata["status"] = state


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that when launching a spot Azure VM, it is possible that a state code does not contain `/` which causes the following error:
```
  File "/home/azureuser/miniconda3/lib/python3.10/site-packages/sky/skylet/providers/azure/node_provider.py", line 105, in <listcomp>
    nodes = [self._extract_metadata(vm) for vm in filter(match_tags, vms)]
  File "/home/azureuser/miniconda3/lib/python3.10/site-packages/sky/skylet/providers/azure/node_provider.py", line 119, in _extract_metadata
    code, state = status["code"].split("/")
ValueError: too many values to unpack (expected 2)
```

We now add a handling for this special case.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
