### PR TITLE
[Core][AWS] Allow specification of IAM roles for resources.

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -144,18 +144,7 @@ Available fields and semantics:
     #   files to assign to these non-AWS instances).
     #
     # Default: 'LOCAL_CREDENTIALS'.
-    ### Format 1 ###
-    # A string; the same remote identity is applied to all launched resources.
     remote_identity: LOCAL_CREDENTIALS
-    ### Format 2 ###
-    # A dict mapping wildcard expression of cloud names to the resources to the
-    # resource identity.
-    # NOTE: If not a wildcard expression in the dict mapping does not match a
-    # cloud name for a resouce being deployed, the default remote identity is used.
-    # To specify your own default, utilize "*" as the wildcard expression.
-    remote_identity:
-      sky-serve-controller-*: my-controller-specific-identity
-      "*": SERVICE_ACCOUNT
 
   # Advanced GCP configurations (optional).
   # Apply to all new instances but not existing ones.

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -109,7 +109,7 @@ Available fields and semantics:
     # permission to create a security group.
     security_group_name: my-security-group
 
-    # Identity to use for deployed AWS instances (optional).
+    # Identity to use for AWS instances (optional).
     #
     # LOCAL_CREDENTIALS: The user's local credential files will be uploaded to
     # AWS instances created by SkyPilot. They are used for accessing cloud

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -120,8 +120,18 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account (IAM
     # role) for AWS instances.
     #
-    # User Specified SERVICE_ACCOUNT (IAM role): The name of the remote identity
-    # to give the launched resouce.
+    # Customized service account (IAM role): <string> or <dict>
+    # - <string>: apply the service account with the specified name to all instances.
+    #    Example:
+    #       remote_identity: my-service-account-name
+    # - <dict>: A dict mapping from the cluster name (pattern) to the service account name to use.
+    #    NOTE: If none of the wildcard expressions in the dict match the cluster name, LOCAL_CREDENTIALS will be used.
+    #    To specify your default, use "*" as the wildcard expression.
+    #    Example:
+    #       remote_identity:
+    #         my-cluster-name: my-service-account-1
+    #         sky-serve-controller-*: my-service-account-2
+    #         "*": my-default-service-account
     #
     # Two caveats of SERVICE_ACCOUNT for multicloud users:
     #

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -144,8 +144,8 @@ Available fields and semantics:
     # cloud name for a resouce being deployed, the default remote identity is used.
     # To specify your own default, utilize "*" as the wildcard expression.
     remote_identity:
-      sky-serve-controller-*: my-controller-specific-value
-      "*": my-default-value
+      sky-serve-controller-*: my-controller-specific-identity
+      "*": SERVICE_ACCOUNT
 
   # Advanced GCP configurations (optional).
   # Apply to all new instances but not existing ones.

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -109,7 +109,7 @@ Available fields and semantics:
     # permission to create a security group.
     security_group_name: my-security-group
 
-    # Identity to use for all AWS instances (optional).
+    # Identity to use for deployed AWS instances (optional).
     #
     # LOCAL_CREDENTIALS: The user's local credential files will be uploaded to
     # AWS instances created by SkyPilot. They are used for accessing cloud
@@ -119,6 +119,9 @@ Available fields and semantics:
     # SERVICE_ACCOUNT: Local credential files are not uploaded to AWS
     # instances. SkyPilot will auto-create and reuse a service account (IAM
     # role) for AWS instances.
+    #
+    # User Specified SERVICE_ACCOUNT (IAM role): The name of the remote identity
+    # to give the launched resouce.
     #
     # Two caveats of SERVICE_ACCOUNT for multicloud users:
     #
@@ -131,7 +134,18 @@ Available fields and semantics:
     #   files to assign to these non-AWS instances).
     #
     # Default: 'LOCAL_CREDENTIALS'.
+    ### Format 1 ###
+    # A string; the same remote identity is applied to all launched resources.
     remote_identity: LOCAL_CREDENTIALS
+    ### Format 2 ###
+    # A dict mapping wildcard expression of cloud names to the resources to the
+    # resource identity.
+    # NOTE: If not a wildcard expression in the dict mapping does not match a
+    # cloud name for a resouce being deployed, the default remote identity is used.
+    # To specify your own default, utilize "*" as the wildcard expression.
+    remote_identity:
+      sky-serve-controller-*: my-controller-specific-value
+      "*": my-default-value
 
   # Advanced GCP configurations (optional).
   # Apply to all new instances but not existing ones.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1531,7 +1531,7 @@ def check_owner_identity(cluster_name: str) -> None:
         for i, (owner,
                 current) in enumerate(zip(owner_identity,
                                           current_user_identity)):
-            # Clean up the owner identiy for the backslash and newlines, caused
+            # Clean up the owner identity for the backslash and newlines, caused
             # by the cloud CLI output, e.g. gcloud.
             owner = owner.replace('\n', '').replace('\\', '')
             if owner == current:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -801,7 +801,7 @@ def write_cluster_config(
         (str(cloud).lower(), 'remote_identity'), 'LOCAL_CREDENTIALS')
     if remote_identity is not None and not isinstance(remote_identity, str):
         for profile in remote_identity:
-            if fnmatch.fnmatchcase(cluster_name_on_cloud, profile):
+            if fnmatch.fnmatchcase(cluster_name, profile):
                 remote_identity = remote_identity[profile]
                 break
     if remote_identity != 'LOCAL_CREDENTIALS':

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -895,7 +895,7 @@ def write_cluster_config(
                 # User-supplied labels.
                 'labels': labels,
                 # User-supplied remote_identity
-                "remote_identity": remote_identity,
+                'remote_identity': remote_identity,
                 # The reservation pools that specified by the user. This is
                 # currently only used by GCP.
                 'specific_reservations': specific_reservations,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -799,8 +799,7 @@ def write_cluster_config(
     excluded_clouds = []
     remote_identity = skypilot_config.get_nested(
         (str(cloud).lower(), 'remote_identity'), 'LOCAL_CREDENTIALS')
-    if remote_identity is not None and not isinstance(
-            remote_identity, str):
+    if remote_identity is not None and not isinstance(remote_identity, str):
         for profile in remote_identity:
             if fnmatch.fnmatchcase(cluster_name_on_cloud, profile):
                 remote_identity = remote_identity[profile]

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -411,18 +411,6 @@ class AWS(clouds.Cloud):
         else:
             security_group = DEFAULT_SECURITY_GROUP_NAME
 
-        iam_instance_profile = skypilot_config.get_nested(
-            ('aws', 'iam_instance_profile'), None)
-        if iam_instance_profile is not None and not isinstance(
-                iam_instance_profile, str):
-            for profile in iam_instance_profile:
-                if cluster_name_on_cloud.startswith(
-                        profile) and profile != 'default':
-                    iam_instance_profile = iam_instance_profile[profile]
-                    break
-                elif profile == 'default':
-                    iam_instance_profile = iam_instance_profile[profile]
-
         return {
             'instance_type': r.instance_type,
             'custom_resources': custom_resources,
@@ -430,7 +418,6 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
-            'iam_instance_profile': iam_instance_profile,
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group != user_security_group).lower(),

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -412,10 +412,12 @@ class AWS(clouds.Cloud):
             security_group = DEFAULT_SECURITY_GROUP_NAME
 
         iam_instance_profile = skypilot_config.get_nested(
-                ('aws', 'iam_instance_profile'), None)
-        if iam_instance_profile is not None and not isinstance(iam_instance_profile, str):
+            ('aws', 'iam_instance_profile'), None)
+        if iam_instance_profile is not None and not isinstance(
+                iam_instance_profile, str):
             for profile in iam_instance_profile:
-                if cluster_name_on_cloud.startswith(profile) and profile != 'default':
+                if cluster_name_on_cloud.startswith(
+                        profile) and profile != 'default':
                     iam_instance_profile = iam_instance_profile[profile]
                     break
                 elif profile == 'default':

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -411,6 +411,16 @@ class AWS(clouds.Cloud):
         else:
             security_group = DEFAULT_SECURITY_GROUP_NAME
 
+        iam_instance_profile = skypilot_config.get_nested(
+                ('aws', 'iam_instance_profile'), None)
+        if iam_instance_profile is not None and not isinstance(iam_instance_profile, str):
+            for profile in iam_instance_profile:
+                if cluster_name_on_cloud.startswith(profile) and profile != 'default':
+                    iam_instance_profile = iam_instance_profile[profile]
+                    break
+                elif profile == 'default':
+                    iam_instance_profile = iam_instance_profile[profile]
+
         return {
             'instance_type': r.instance_type,
             'custom_resources': custom_resources,
@@ -418,6 +428,7 @@ class AWS(clouds.Cloud):
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
+            'iam_instance_profile': iam_instance_profile,
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group != user_security_group).lower(),

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -60,9 +60,9 @@ available_node_types:
   ray.head.default:
     resources: {}
     node_config:
-      {% if iam_instance_profile %}
+      {% if remote_identity not in ['LOCAL_CREDENTIALS', 'SERVICE_ACCOUNT'] %}
       IamInstanceProfile:
-        Name: {{iam_instance_profile}}
+        Name: {{remote_identity}}
       {% endif %}
       InstanceType: {{instance_type}}
       ImageId: {{image_id}}  # Deep Learning AMI (Ubuntu 18.04); see aws.py.

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -60,6 +60,10 @@ available_node_types:
   ray.head.default:
     resources: {}
     node_config:
+      {% if iam_instance_profile %}
+      IamInstanceProfile:
+        Name: {{iam_instance_profile}}
+      {% endif %}
       InstanceType: {{instance_type}}
       ImageId: {{image_id}}  # Deep Learning AMI (Ubuntu 18.04); see aws.py.
       # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -517,6 +517,13 @@ _LABELS_SCHEMA = {
 
 _REMOTE_IDENTITY_SCHEMA = {
     'remote_identity': {
+        'type': 'string',
+        'case_insensitive_enum': ['LOCAL_CREDENTIALS', 'SERVICE_ACCOUNT']
+    }
+}
+
+_REMOTE_IDENTITY_SCHEMA_AWS = {
+    'remote_identity': {
         'oneOf': [{
             'type': 'string'
         }, {
@@ -660,8 +667,11 @@ def get_config_schema():
         },
     }
 
-    for config in cloud_configs.values():
-        config['properties'].update(_REMOTE_IDENTITY_SCHEMA)
+    for cloud, config in cloud_configs.items():
+        if cloud == 'aws':
+            config['properties'].update(_REMOTE_IDENTITY_SCHEMA_AWS)
+        else:
+            config['properties'].update(_REMOTE_IDENTITY_SCHEMA)
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'type': 'object',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -569,7 +569,7 @@ def get_config_schema():
                             'sky-serve-controller': {
                                 'type': 'string',
                             },
-                            'default':{
+                            'default': {
                                 'type': 'string'
                             }
                         }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -517,8 +517,15 @@ _LABELS_SCHEMA = {
 
 _REMOTE_IDENTITY_SCHEMA = {
     'remote_identity': {
-        'type': 'string',
-        'case_insensitive_enum': ['LOCAL_CREDENTIALS', 'SERVICE_ACCOUNT'],
+        'oneOf': [{
+            'type': 'string'
+        }, {
+            'type': 'object',
+            'required': [],
+            'additionalProperties': {
+                'type': 'string',
+            },
+        }]
     }
 }
 
@@ -557,23 +564,6 @@ def get_config_schema():
             'properties': {
                 'security_group_name': {
                     'type': 'string'
-                },
-                'iam_instance_profile': {
-                    'oneOf': [{
-                        'type': 'string'
-                    }, {
-                        'type': 'object',
-                        'additionalProperties': False,
-                        'required': [],
-                        'properties': {
-                            'sky-serve-controller': {
-                                'type': 'string',
-                            },
-                            'default': {
-                                'type': 'string'
-                            }
-                        }
-                    }]
                 },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -556,7 +556,28 @@ def get_config_schema():
             'additionalProperties': False,
             'properties': {
                 'security_group_name': {
-                    'type': 'string',
+                     'type': 'string'
+                },
+                'iam_instance_profile': {
+                    'oneOf': [{
+                        'type': 'string'
+                    }, {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'required': ['default'],
+                        'properties': {
+                            'sky-serve-controller': {
+                                'type': 'string',
+                            },
+                            'default':{
+                                'oneOf': [{
+                                    'type': 'string'
+                                }, {
+                                    'type': 'null'
+                                }]
+                            }
+                        }
+                    }]
                 },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -556,7 +556,7 @@ def get_config_schema():
             'additionalProperties': False,
             'properties': {
                 'security_group_name': {
-                     'type': 'string'
+                    'type': 'string'
                 },
                 'iam_instance_profile': {
                     'oneOf': [{
@@ -564,17 +564,13 @@ def get_config_schema():
                     }, {
                         'type': 'object',
                         'additionalProperties': False,
-                        'required': ['default'],
+                        'required': [],
                         'properties': {
                             'sky-serve-controller': {
                                 'type': 'string',
                             },
                             'default':{
-                                'oneOf': [{
-                                    'type': 'string'
-                                }, {
-                                    'type': 'null'
-                                }]
+                                'type': 'string'
                             }
                         }
                     }]


### PR DESCRIPTION
This PR updates the schema config to allow specification of IAM roles for resources based on the skypilot naming conventions.

Address: https://github.com/skypilot-org/skypilot/issues/3487

In `~/.sky/config.yaml`:
 * When setting for the controller and all other resources (`default`)
```yaml
aws:
  remote_identity:
    sky-serve-controller-*: skypilot-v1-fake
    "*": skypilot-default-fake
```

 * When setting for everything by specifying a default
```yaml
aws:
  remote_identity:
    "*": skypilot-default-fake
```

 * When setting for everything by specifying just the `remote_identity` via string
```yaml
aws:
  remote_identity: skypilot-default-fake
```

 * When first profile doesn't match it chooses the next in line if viable
```yaml
aws:
  remote_identity:
    does-not-match: skypilot-default-fake
    "*": skypilot-default-fake
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  * tested running in all 4 configs in AWS
    - Nothing set
    - setting different controller and default values
    - setting default only
    - setting two profile names where the first one doesn't match to ensure it selects the viable candidate in order
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
