### PR TITLE
[Core] Fix ray commands used during autostop

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -16,6 +16,7 @@ from sky.backends import cloud_vm_ray_backend
 from sky.clouds import cloud_registry
 from sky.serve import serve_utils
 from sky.skylet import autostop_lib
+from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.spot import spot_utils
 from sky.utils import cluster_yaml_utils
@@ -197,16 +198,19 @@ class AutostopEvent(SkyletEvent):
                 logger.info('Running ray down.')
                 # Stop the workers first to avoid orphan workers.
                 subprocess.run(
-                    ['ray', 'down', '-y', '--workers-only', config_path],
+                    f'{constants.SKY_RAY_CMD} down -y --workers-only '
+                    f'{config_path}',
                     check=True,
+                    shell=True,
                     # We pass env inherited from os.environ due to calling `ray
                     # <cmd>`.
                     env=env)
 
             logger.info('Running final ray down.')
             subprocess.run(
-                ['ray', 'down', '-y', config_path],
+                f'{constants.SKY_RAY_CMD} down -y {config_path}',
                 check=True,
+                shell=True,
                 # We pass env inherited from os.environ due to calling `ray
                 # <cmd>`.
                 env=env)
@@ -228,7 +232,7 @@ class AutostopEvent(SkyletEvent):
         # Stop the ray autoscaler to avoid scaling up, during
         # stopping/terminating of the cluster.
         logger.info('Stopping the ray cluster.')
-        subprocess.run('ray stop', shell=True, check=True)
+        subprocess.run(f'{constants.SKY_RAY_CMD} stop', shell=True, check=True)
 
         operation_fn = provision_lib.stop_instances
         if autostop_config.down:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We have switched our ray path on the remote cluster to be in a file, which should be used for the autostopping.

Before this PR, the autostop for Azure fail to work due to: (`~/.sky/skylet.log`)
```
E 04-27 00:00:54 events.py:56]   File "/home/azureuser/miniconda3/lib/python3.10/subprocess.py", line 503, in run
E 04-27 00:00:54 events.py:56]     with Popen(*popenargs, **kwargs) as process:
E 04-27 00:00:54 events.py:56]   File "/home/azureuser/miniconda3/lib/python3.10/subprocess.py", line 971, in __init__
E 04-27 00:00:54 events.py:56]     self._execute_child(args, executable, preexec_fn, close_fds,
E 04-27 00:00:54 events.py:56]   File "/home/azureuser/miniconda3/lib/python3.10/subprocess.py", line 1863, in _execute_child
E 04-27 00:00:54 events.py:56]     raise child_exception_type(errno_num, err_msg, err_filename)
E 04-27 00:00:54 events.py:56] FileNotFoundError: [Errno 2] No such file or directory: 'ray'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [ ] `sky launch -c test-azure --cloud azure -i 1 echo hi -y; sleep 100; sky status -r test-azure`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
