### PR TITLE
[UX/show-gpus] Improve sorting.

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2984,7 +2984,9 @@ def show_gpus(
                                                    case_sensitive=False,
                                                    all_regions=all_regions)
         # Import here to save module load speed.
-        from sky.clouds.service_catalog import common  # pylint: disable=import-outside-toplevel,line-too-long
+        # pylint: disable=import-outside-toplevel,line-too-long
+        from sky.clouds.service_catalog import common
+
         # For each gpu name (count not included):
         #   - Group by cloud
         #   - Sort within each group by prices

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2984,8 +2984,7 @@ def show_gpus(
                                                    case_sensitive=False,
                                                    all_regions=all_regions)
         # Import here to save module load speed.
-        from sky.clouds.service_catalog import (
-            common)  # pylint: disable=import-outside-toplevel
+        from sky.clouds.service_catalog import common  # pylint: disable=import-outside-toplevel,line-too-long
         # For each gpu name (count not included):
         #   - Group by cloud
         #   - Sort within each group by prices

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2984,7 +2984,8 @@ def show_gpus(
                                                    case_sensitive=False,
                                                    all_regions=all_regions)
         # Import here to save module load speed.
-        from sky.clouds.service_catalog import (common)  # pylint: disable=import-outside-toplevel
+        from sky.clouds.service_catalog import (
+            common)  # pylint: disable=import-outside-toplevel
         # For each gpu name (count not included):
         #   - Group by cloud
         #   - Sort within each group by prices

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2984,7 +2984,7 @@ def show_gpus(
                                                    case_sensitive=False,
                                                    all_regions=all_regions)
         # Import here to save module load speed.
-        from sky.clouds.service_catalog import common  # pylint: disable=import-outside-toplevel
+        from sky.clouds.service_catalog import (common)  # pylint: disable=import-outside-toplevel
         # For each gpu name (count not included):
         #   - Group by cloud
         #   - Sort within each group by prices
@@ -3042,13 +3042,14 @@ def show_gpus(
                 instance_type_str = item.instance_type if not pd.isna(
                     item.instance_type) else '(attachable)'
                 cpu_count = item.cpu_count
-                if pd.isna(cpu_count):
-                    cpu_str = '-'
-                elif isinstance(cpu_count, (float, int)):
+                if not pd.isna(cpu_count) and isinstance(
+                        cpu_count, (float, int)):
                     if int(cpu_count) == cpu_count:
                         cpu_str = str(int(cpu_count))
                     else:
                         cpu_str = f'{cpu_count:.1f}'
+                else:
+                    cpu_str = '-'
                 device_memory_str = (f'{item.device_memory:.0f}GB' if
                                      not pd.isna(item.device_memory) else '-')
                 host_memory_str = f'{item.memory:.0f}GB' if not pd.isna(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,10 +48,9 @@ def test_accelerator_mismatch(enable_all_clouds):
 
 
 def test_show_gpus():
-    """
-    This is a test suite for `sky show-gpus` to check functionality (but not correctness).
-    The tests below correspond to the following terminal commands,
-    in order:
+    """Tests `sky show-gpus` can be invoked (but not correctness).
+
+    Tests below correspond to the following terminal commands, in order:
 
     -> sky show-gpus
     -> sky show-gpus --all


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previous, prices across clouds + within cloud are not sorted properly.

This PR:
```
        # For each gpu name (count not included):
        #   - Group by cloud
        #   - Sort within each group by prices
        #   - Sort groups by each cloud's (min price, min spot price)
```

Comparison: two text files in https://gist.github.com/concretevitamin/1fda666bfa129aedd3a3ced485e8f05c

Speed seems the same:
```bash
#!/bin/bash
set -ex

export BASH_XTRACEFD=1

sky show-gpus L4
sky show-gpus L4:1
sky show-gpus L4:1 --all-regions
sky show-gpus L4 --cloud aws

sky show-gpus A100
sky show-gpus A100:8
sky show-gpus A100:8 --all-regions
sky show-gpus A100:8 --cloud aws
```
```
master: median 15.454 total

15.454 total
14.471 total
16.712 total

PR: median 15.391 total
15.391 total
15.497 total
14.612 total
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
