### PR TITLE
[Dependency] Remove the upper bound for ray in setup

### DIFF
--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -169,7 +169,7 @@ local_ray = [
     # click/grpcio/protobuf.
     # Excluded 2.6.0 as it has a bug in the cluster launcher:
     # https://github.com/ray-project/ray/releases/tag/ray-2.6.1
-    'ray[default] >= 2.2.0, <= 2.9.3, != 2.6.0',
+    'ray[default] >= 2.2.0, != 2.6.0',
 ]
 
 remote = [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Since ray is now changed its releasing loop to be every week, we now remove the upper bound of ray to avoid blocking users to use higher version of ray locally. (This relies on ray's backward compatibility)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-azure --cloud azue --cpus 2 echo hi`; `sky status -r test-azure`; `sky stop test-azure`; `sky down test-azure`
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
