### PR TITLE
[TPU VM] Attaching & Mounting Persistent Disk

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -932,6 +932,9 @@ def write_cluster_config(
         config_dict['ray'] = tmp_yaml_path
         return config_dict
     _add_auth_to_cluster_config(cloud, tmp_yaml_path)
+    # _DEFAULT_DISK_SIZE_GB = 256
+    if to_provision.disk_size != 256:
+        _add_disk_size_to_cluster_config(to_provision.disk_size, tmp_yaml_path)
 
     # Add kubernetes config fields from ~/.sky/config
     if isinstance(cloud, clouds.Kubernetes):
@@ -995,6 +998,12 @@ def _add_auth_to_cluster_config(cloud: clouds.Cloud, cluster_config_file: str):
         config = auth.setup_fluidstack_authentication(config)
     else:
         assert False, cloud
+    common_utils.dump_yaml(cluster_config_file, config)
+
+def _add_disk_size_to_cluster_config(disk_size: int, cluster_config_file: str):
+    """Add disk size to the cluster config."""
+    config = common_utils.read_yaml(cluster_config_file)
+    config['initDiskSize'] = str(disk_size)
     common_utils.dump_yaml(cluster_config_file, config)
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4223,6 +4223,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             to_provision = handle_before_refresh.launched_resources
             self.check_resources_fit_cluster(handle_before_refresh, task)
 
+
         logger.info(
             f'{colorama.Fore.CYAN}Creating a new cluster: {cluster_name!r} '
             f'[{task.num_nodes}x {to_provision}].'

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -267,6 +267,7 @@ def _run_instances(region: str, cluster_name_on_cloud: str,
             for instance_id in resumed_instance_ids:
                 resource.start_instance(instance_id, project_id,
                                         availability_zone)
+                resource.resize_disk(project_id, availability_zone, config.node_config, instance_id)
                 resource.set_labels(project_id, availability_zone, instance_id,
                                     labels)
         to_start_count -= len(resumed_instance_ids)

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -1373,7 +1373,10 @@ class GCPTPUVMInstance(GCPInstance):
         """Resizes disk for TPU VMs by adding a persistent disk when needed."""
         import time
         from googleapiclient.errors import HttpError
-        resource = cls.load_resource()
+        from googleapiclient import discovery
+
+        resource = discovery.build("compute", "v1")
+
 
         # Determine the required disk size from configuration
         default_disk_size = 100  # Default boot disk size for TPUVMs

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -164,6 +164,9 @@ def bulk_provision(
         tags={},
         resume_stopped_nodes=True)
 
+    if 'initDiskSize' in original_config:
+        bootstrap_config.node_config['metadata']['diskSize'] = original_config['initDiskSize']
+
     with provision_logging.setup_provision_logging(log_dir):
         try:
             logger.debug(f'SkyPilot version: {sky.__version__}; '


### PR DESCRIPTION
**Issue**
Reference: [#2778](https://github.com/skypilot-org/skypilot/issues/2778)

When launching a TPU VM with `sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 200`, the resulting VM is still initialized with a disk size of 100 GB (default size). Users have to add a persistent disk to expand their local disk capacity as the boot disk of TPU VMs is not resizable.

tpu_vm.yaml:
```
resources:
   accelerators: tpu-v2-8
   accelerator_args:
      runtime_version: tpu-vm-base
```

**Solution**
We currently use the [Cloud TPU API](https://cloud.google.com/tpu/docs/reference/rest/v1/projects.locations.nodes) for managing TPUVMs (e.g. `create_instance, set_labels, and delete_instance`). However, this API lacks functionality for disk attachment. Therefore, this PR includes using the GCP CLI to attach a persistent disk to TPU VMs ([Documentation](https://cloud.google.com/tpu/docs/setup-persistent-disk)).

**Test 1**:

1. Launch the TPUVM with a specified disk size:
   `sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 200`
   `sky stop mucluster`

2. Restart the TPUVM with a specified disk size:
   `sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 200`
3. Verified that a extra disk with size 100GB has been created and attached to the TPUVM
4. Ensured that disk is mounted under the path `/mnt/disks/persist`

**Test 2**:

1. Relaunch the TPUVM multiple times
2. Received Error: `Disk creation failed: The resource projects/project_name/zones/zone_name/disks/mycluster-d9a3-tpu-extra-disk' already exists`

**Test 3**:

1. Launch the TPUVM with a disk size that is less than 100:
   `sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 80`
   `sky stop mucluster`

2. Restart the TPUVM with a specified disk size:
   `sky launch tpu_vm.yaml -c mycluster --cloud gcp --disk-size 80`
3. Verified that no extra disk has been created

**Test 4**:
`pytest tests/test_smoke.py --tpu`

**Note**:

1. Disk attachment only takes effect when the cluster is restarted.
