### PR TITLE
[Core][AWS] Allow specification of Security Groups for resources.

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -158,11 +158,27 @@ Available fields and semantics:
 
     # Security group (optional).
     #
-    # The name of the security group to use for all instances. If not specified,
+    # Security group name to use for AWS instances. If not specified,
     # SkyPilot will use the default name for the security group: sky-sg-<hash>
     # Note: please ensure the security group name specified exists in the
     # regions the instances are going to be launched or the AWS account has the
     # permission to create a security group.
+    #
+    # Some example use cases are shown below. All fields are optional.
+    # - <string>: apply the service account with the specified name to all instances.
+    #    Example:
+    #       security_group_name: my-security-group
+    # - <list of single-element dict>: A list of single-element dict mapping from the cluster name (pattern)
+    #   to the security group name to use. The matching of the cluster name is done in the same order
+    #   as the list.
+    #   NOTE: If none of the wildcard expressions in the dict match the cluster name, SkyPilot will use the default
+    #   security group name as mentioned above:  sky-sg-<hash>
+    #   To specify your default, use "*" as the wildcard expression.
+    #   Example:
+    #       security_group_name:
+    #         - my-cluster-name: my-security-group-1
+    #         - sky-serve-controller-*: my-security-group-2
+    #         - "*": my-default-security-group
     security_group_name: my-security-group
 
     # Identity to use for AWS instances (optional).

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -810,11 +810,13 @@ def write_cluster_config(
 
     assert cluster_name is not None
     excluded_clouds = []
-    remote_identity = skypilot_config.get_nested(
-        (str(cloud).lower(), 'remote_identity'),
-        schemas.get_default_remote_identity(str(cloud).lower()))
-    if remote_identity is not None and not isinstance(remote_identity, str):
-        for profile in remote_identity:
+    remote_identity_config = skypilot_config.get_nested(
+        (str(cloud).lower(), 'remote_identity'), None)
+    remote_identity = schemas.get_default_remote_identity(str(cloud).lower())
+    if isinstance(remote_identity_config, str):
+        remote_identity = remote_identity_config
+    if isinstance(remote_identity_config, list):
+        for profile in remote_identity_config:
             if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
                 remote_identity = list(profile.values())[0]
                 break

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -158,8 +158,6 @@ _RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS = [
     ('available_node_types', 'ray.head.default', 'node_config',
      'IamInstanceProfile'),
     ('available_node_types', 'ray.head.default', 'node_config', 'UserData'),
-    ('available_node_types', 'ray.worker.default', 'node_config',
-     'IamInstanceProfile'),
     ('available_node_types', 'ray.worker.default', 'node_config', 'UserData'),
 ]
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -155,7 +155,11 @@ _RAY_YAML_KEYS_TO_RESTORE_EXCEPTIONS = [
     # we need to take this field from the new yaml.
     ('provider', 'tpu_node'),
     ('provider', 'security_group', 'GroupName'),
+    ('available_node_types', 'ray.head.default', 'node_config',
+     'IamInstanceProfile'),
     ('available_node_types', 'ray.head.default', 'node_config', 'UserData'),
+    ('available_node_types', 'ray.worker.default', 'node_config',
+     'IamInstanceProfile'),
     ('available_node_types', 'ray.worker.default', 'node_config', 'UserData'),
 ]
 
@@ -793,8 +797,11 @@ def write_cluster_config(
     # move the check out of this function, i.e. the caller should be responsible
     # for the validation.
     # TODO(tian): Move more cloud agnostic vars to resources.py.
-    resources_vars = to_provision.make_deploy_variables(cluster_name_on_cloud,
-                                                        region, zones, dryrun)
+    resources_vars = to_provision.make_deploy_variables(
+        resources_utils.ClusterName(
+            cluster_name,
+            cluster_name_on_cloud,
+        ), region, zones, dryrun)
     config_dict = {}
 
     specific_reservations = set(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1566,8 +1566,8 @@ class RetryingVmProvisioner(object):
                         to_provision.cloud,
                         region,
                         zones,
-                        provisioner.ClusterName(cluster_name,
-                                                handle.cluster_name_on_cloud),
+                        resources_utils.ClusterName(
+                            cluster_name, handle.cluster_name_on_cloud),
                         num_nodes=num_nodes,
                         cluster_yaml=handle.cluster_yaml,
                         prev_cluster_ever_up=prev_cluster_ever_up,
@@ -1577,8 +1577,10 @@ class RetryingVmProvisioner(object):
                     # caller.
                     resources_vars = (
                         to_provision.cloud.make_deploy_resources_variables(
-                            to_provision, handle.cluster_name_on_cloud, region,
-                            zones))
+                            to_provision,
+                            resources_utils.ClusterName(
+                                cluster_name, handle.cluster_name_on_cloud),
+                            region, zones))
                     config_dict['provision_record'] = provision_record
                     config_dict['resources_vars'] = resources_vars
                     config_dict['handle'] = handle
@@ -2898,8 +2900,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # 4. Starting ray cluster and skylet.
                 cluster_info = provisioner.post_provision_runtime_setup(
                     repr(handle.launched_resources.cloud),
-                    provisioner.ClusterName(handle.cluster_name,
-                                            handle.cluster_name_on_cloud),
+                    resources_utils.ClusterName(handle.cluster_name,
+                                                handle.cluster_name_on_cloud),
                     handle.cluster_yaml,
                     provision_record=provision_record,
                     custom_resource=resources_vars.get('custom_resources'),
@@ -3877,7 +3879,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
             try:
                 provisioner.teardown_cluster(repr(cloud),
-                                             provisioner.ClusterName(
+                                             resources_utils.ClusterName(
                                                  cluster_name,
                                                  cluster_name_on_cloud),
                                              terminate=terminate,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3868,7 +3868,7 @@ def _generate_task_with_service(
     env: List[Tuple[str, str]],
     gpus: Optional[str],
     instance_type: Optional[str],
-    ports: Tuple[str],
+    ports: Optional[Tuple[str]],
     cpus: Optional[str],
     memory: Optional[str],
     disk_size: Optional[int],

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -409,12 +409,12 @@ class AWS(clouds.Cloud):
                     user_security_group = list(profile.values())[0]
                     break
         security_group = user_security_group
-        if user_security_group is None and resources.ports is not None:
-            # Already checked in Resources._try_validate_ports
-            security_group = USER_PORTS_SECURITY_GROUP_NAME.format(
-                cluster_name.name_on_cloud)
-        elif user_security_group is None:
+        if security_group is None:
             security_group = DEFAULT_SECURITY_GROUP_NAME
+            if resources.ports is not None:
+                # Already checked in Resources._try_validate_ports
+                security_group = USER_PORTS_SECURITY_GROUP_NAME.format(
+                    cluster_name.name_on_cloud)
         elif user_security_group is not None and resources.ports is not None:
             with ux_utils.print_exception_no_traceback():
                 logger.warning(

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -415,11 +415,11 @@ class AWS(clouds.Cloud):
                 # Already checked in Resources._try_validate_ports
                 security_group = USER_PORTS_SECURITY_GROUP_NAME.format(
                     cluster_name.name_on_cloud)
-        elif user_security_group is not None and resources.ports is not None:
+        elif security_group is not None and resources.ports is not None:
             with ux_utils.print_exception_no_traceback():
                 logger.warning(
                     f'Ports {resources.ports} and security group name are '
-                    f'specified: {user_security_group}. It is not '
+                    f'specified: {security_group}. It is not '
                     'guaranteed that the ports will be opened if the '
                     'specified security group is not correctly set up. '
                     'Please try to specify `ports` only and leave out '

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -400,9 +400,11 @@ class AWS(clouds.Cloud):
 
         user_security_group = skypilot_config.get_nested(
             ('aws', 'security_group_name'), None)
-        if user_security_group is not None and not isinstance(user_security_group, str):
+        if user_security_group is not None and not isinstance(
+                user_security_group, str):
             for profile in user_security_group:
-                if fnmatch.fnmatchcase(cluster_name_on_cloud, list(profile.keys())[0]):
+                if fnmatch.fnmatchcase(cluster_name_on_cloud,
+                                       list(profile.keys())[0]):
                     user_security_group = list(profile.values())[0]
                     break
         security_group = user_security_group

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -415,6 +415,17 @@ class AWS(clouds.Cloud):
                 cluster_name.name_on_cloud)
         elif user_security_group is None:
             security_group = DEFAULT_SECURITY_GROUP_NAME
+        elif user_security_group is not None and resources.ports is not None:
+            with ux_utils.print_exception_no_traceback():
+                logger.warning(
+                    f'Ports {resources.ports} and security group name are '
+                    f'specified: {user_security_group}. It is not '
+                    'guaranteed that the ports will be opened if the '
+                    'specified security group is not correctly set up. '
+                    'Please try to specify `ports` only and leave out '
+                    '`aws.security_group_name` in `~/.sky/config.yaml` to '
+                    'allow SkyPilot to automatically create and configure '
+                    'the security group.')
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -1,5 +1,6 @@
 """Amazon Web Services."""
 import enum
+import fnmatch
 import functools
 import json
 import os
@@ -399,15 +400,11 @@ class AWS(clouds.Cloud):
 
         user_security_group = skypilot_config.get_nested(
             ('aws', 'security_group_name'), None)
-        if user_security_group is not None and not isinstance(
-                user_security_group, str):
-            for sg_name in user_security_group:
-                if cluster_name_on_cloud.startswith(
-                        sg_name) and sg_name != 'default':
-                    user_security_group = user_security_group[sg_name]
+        if user_security_group is not None and not isinstance(user_security_group, str):
+            for profile in user_security_group:
+                if fnmatch.fnmatchcase(cluster_name_on_cloud, list(profile.keys())[0]):
+                    user_security_group = list(profile.values())[0]
                     break
-                elif sg_name == 'default':
-                    user_security_group = user_security_group[sg_name]
         security_group = user_security_group
         if user_security_group is None and resources.ports is not None:
             # Already checked in Resources._try_validate_ports

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -399,7 +399,6 @@ class AWS(clouds.Cloud):
         image_id = self._get_image_id(image_id_to_use, region_name,
                                       r.instance_type)
 
-
         user_security_group_config = skypilot_config.get_nested(
             ('aws', 'security_group_name'), None)
         user_security_group = None

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -399,15 +399,21 @@ class AWS(clouds.Cloud):
 
         user_security_group = skypilot_config.get_nested(
             ('aws', 'security_group_name'), None)
-        if resources.ports is not None:
+        if user_security_group is not None and not isinstance(
+                user_security_group, str):
+            for sg_name in user_security_group:
+                if cluster_name_on_cloud.startswith(
+                        sg_name) and sg_name != 'default':
+                    user_security_group = user_security_group[sg_name]
+                    break
+                elif sg_name == 'default':
+                    user_security_group = user_security_group[sg_name]
+        security_group = user_security_group
+        if user_security_group is None and resources.ports is not None:
             # Already checked in Resources._try_validate_ports
-            assert user_security_group is None
             security_group = USER_PORTS_SECURITY_GROUP_NAME.format(
                 cluster_name_on_cloud)
-        elif user_security_group is not None:
-            assert resources.ports is None
-            security_group = user_security_group
-        else:
+        elif user_security_group is None:
             security_group = DEFAULT_SECURITY_GROUP_NAME
 
         return {

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -269,12 +269,13 @@ class Azure(clouds.Cloud):
     def get_zone_shell_cmd(cls) -> Optional[str]:
         return None
 
-    def make_deploy_resources_variables(self,
-                                        resources: 'resources.Resources',
-                                        cluster_name_on_cloud: str,
-                                        region: 'clouds.Region',
-                                        zones: Optional[List['clouds.Zone']],
-                                        dryrun: bool = False) -> Dict[str, Any]:
+    def make_deploy_resources_variables(
+            self,
+            resources: 'resources.Resources',
+            cluster_name: resources_utils.ClusterName,
+            region: 'clouds.Region',
+            zones: Optional[List['clouds.Zone']],
+            dryrun: bool = False) -> Dict[str, Any]:
         assert zones is None, ('Azure does not support zones', zones)
 
         region_name = region.name
@@ -374,7 +375,7 @@ class Azure(clouds.Cloud):
             'disk_tier': Azure._get_disk_type(_failover_disk_tier()),
             'cloud_init_setup_commands': cloud_init_setup_commands,
             'azure_subscription_id': self.get_project_id(dryrun),
-            'resource_group': f'{cluster_name_on_cloud}-{region_name}',
+            'resource_group': f'{cluster_name.name_on_cloud}-{region_name}',
         }
 
     def _get_feasible_launchable_resources(

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -253,7 +253,7 @@ class Cloud:
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',
-        cluster_name_on_cloud: str,
+        cluster_name: resources_utils.ClusterName,
         region: 'Region',
         zones: Optional[List['Zone']],
         dryrun: bool = False,
@@ -726,8 +726,8 @@ class Cloud:
     # cloud._cloud_unsupported_features().
 
     @classmethod
-    def create_image_from_cluster(cls, cluster_name: str,
-                                  cluster_name_on_cloud: str,
+    def create_image_from_cluster(cls,
+                                  cluster_name: resources_utils.ClusterName,
                                   region: Optional[str],
                                   zone: Optional[str]) -> str:
         """Creates an image from the cluster.

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -194,12 +194,12 @@ class Cudo(clouds.Cloud):
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',
-        cluster_name_on_cloud: str,
+        cluster_name: resources_utils.ClusterName,
         region: 'clouds.Region',
         zones: Optional[List['clouds.Zone']],
         dryrun: bool = False,
     ) -> Dict[str, Optional[str]]:
-        del zones
+        del zones, cluster_name  # unused
         r = resources
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         if acc_dict is not None:

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -10,6 +10,7 @@ from sky import clouds
 from sky import status_lib
 from sky.clouds import service_catalog
 from sky.provision.fluidstack import fluidstack_utils
+from sky.utils import resources_utils
 from sky.utils.resources_utils import DiskTier
 
 _CREDENTIAL_FILES = [
@@ -174,7 +175,7 @@ class Fluidstack(clouds.Cloud):
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',
-        cluster_name_on_cloud: str,
+        cluster_name: resources_utils.ClusterName,
         region: clouds.Region,
         zones: Optional[List[clouds.Zone]],
         dryrun: bool = False,
@@ -189,7 +190,7 @@ class Fluidstack(clouds.Cloud):
         else:
             custom_resources = None
         cuda_installation_commands = """
-        sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb -O /usr/local/cuda-keyring_1.1-1_all.deb; 
+        sudo wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb -O /usr/local/cuda-keyring_1.1-1_all.deb;
         sudo dpkg -i /usr/local/cuda-keyring_1.1-1_all.deb;
         sudo apt-get update;
         sudo apt-get -y install cuda-toolkit-12-3;

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -168,7 +168,7 @@ class IBM(clouds.Cloud):
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',
-        cluster_name_on_cloud: str,
+        cluster_name: resources_utils.ClusterName,
         region: 'clouds.Region',
         zones: Optional[List['clouds.Zone']],
         dryrun: bool = False,
@@ -184,7 +184,7 @@ class IBM(clouds.Cloud):
         Returns:
           A dictionary of cloud-specific node type variables.
         """
-        del cluster_name_on_cloud, dryrun  # Unused.
+        del cluster_name, dryrun  # Unused.
 
         def _get_profile_resources(instance_profile):
             """returns a dict representing the

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -224,11 +224,11 @@ class Kubernetes(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: Optional['clouds.Region'],
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del cluster_name_on_cloud, zones, dryrun  # Unused.
+        del cluster_name, zones, dryrun  # Unused.
         if region is None:
             region = self._regions[0]
 

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -156,11 +156,11 @@ class Lambda(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del cluster_name_on_cloud, dryrun  # Unused.
+        del cluster_name, dryrun  # Unused.
         assert zones is None, 'Lambda does not support zones.'
 
         r = resources

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -187,11 +187,11 @@ class OCI(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: Optional['clouds.Region'],
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del cluster_name_on_cloud, dryrun  # Unused.
+        del cluster_name, dryrun  # Unused.
         assert region is not None, resources
 
         acc_dict = self.get_accelerators_from_instance_type(

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -173,11 +173,11 @@ class Paperspace(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del zones, dryrun
+        del zones, dryrun, cluster_name
 
         r = resources
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -166,11 +166,11 @@ class RunPod(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del zones, dryrun  # unused
+        del zones, dryrun, cluster_name  # unused
 
         r = resources
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -179,11 +179,11 @@ class SCP(clouds.Cloud):
     def make_deploy_resources_variables(
             self,
             resources: 'resources_lib.Resources',
-            cluster_name_on_cloud: str,
+            cluster_name: resources_utils.ClusterName,
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             dryrun: bool = False) -> Dict[str, Optional[str]]:
-        del cluster_name_on_cloud, dryrun  # Unused.
+        del cluster_name, dryrun  # Unused.
         assert zones is None, 'SCP does not support zones.'
 
         r = resources

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -171,13 +171,13 @@ class Vsphere(clouds.Cloud):
     def make_deploy_resources_variables(
         self,
         resources: 'resources_lib.Resources',
-        cluster_name_on_cloud: str,
+        cluster_name: resources_utils.ClusterName,
         region: 'clouds.Region',
         zones: Optional[List['clouds.Zone']],
         dryrun: bool = False,
     ) -> Dict[str, Optional[str]]:
         # TODO get image id here.
-        del cluster_name_on_cloud, dryrun  # unused
+        del cluster_name, dryrun  # unused
         assert zones is not None, (region, zones)
         zone_names = [zone.name for zone in zones]
         r = resources

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -56,8 +56,7 @@ def _maybe_clone_disk_from_cluster(clone_disk_from: Optional[str],
     with rich_utils.safe_status('Creating image from source cluster '
                                 f'{clone_disk_from!r}'):
         image_id = original_cloud.create_image_from_cluster(
-            clone_disk_from,
-            resources_utils.ClusterName(
+            cluster_name=resources_utils.ClusterName(
                 display_name=handle.cluster_name,
                 name_on_cloud=handle.cluster_name_on_cloud),
             region=handle.launched_resources.region,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -19,6 +19,7 @@ from sky.usage import usage_lib
 from sky.utils import controller_utils
 from sky.utils import dag_utils
 from sky.utils import env_options
+from sky.utils import resources_utils
 from sky.utils import rich_utils
 from sky.utils import subprocess_utils
 from sky.utils import timeline
@@ -56,7 +57,9 @@ def _maybe_clone_disk_from_cluster(clone_disk_from: Optional[str],
                                 f'{clone_disk_from!r}'):
         image_id = original_cloud.create_image_from_cluster(
             clone_disk_from,
-            handle.cluster_name_on_cloud,
+            resources_utils.ClusterName(
+                display_name=handle.cluster_name,
+                name_on_cloud=handle.cluster_name_on_cloud),
             region=handle.launched_resources.region,
             zone=handle.launched_resources.zone,
         )

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -57,7 +57,7 @@ def _maybe_clone_disk_from_cluster(clone_disk_from: Optional[str],
                                 f'{clone_disk_from!r}'):
         image_id = original_cloud.create_image_from_cluster(
             cluster_name=resources_utils.ClusterName(
-                display_name=handle.cluster_name,
+                display_name=clone_disk_from,
                 name_on_cloud=handle.cluster_name_on_cloud),
             region=handle.launched_resources.region,
             zone=handle.launched_resources.zone,

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -25,6 +25,7 @@ from sky.provision import logging as provision_logging
 from sky.provision import metadata_utils
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import resources_utils
 from sky.utils import rich_utils
 from sky.utils import ux_utils
 
@@ -38,23 +39,11 @@ _MAX_RETRY = 3
 _TITLE = '\n\n' + '=' * 20 + ' {} ' + '=' * 20 + '\n'
 
 
-@dataclasses.dataclass
-class ClusterName:
-    display_name: str
-    name_on_cloud: str
-
-    def __repr__(self) -> str:
-        return repr(self.display_name)
-
-    def __str__(self) -> str:
-        return self.display_name
-
-
 def _bulk_provision(
     cloud: clouds.Cloud,
     region: clouds.Region,
     zones: Optional[List[clouds.Zone]],
-    cluster_name: ClusterName,
+    cluster_name: resources_utils.ClusterName,
     bootstrap_config: provision_common.ProvisionConfig,
 ) -> provision_common.ProvisionRecord:
     provider_name = repr(cloud)
@@ -135,7 +124,7 @@ def bulk_provision(
     cloud: clouds.Cloud,
     region: clouds.Region,
     zones: Optional[List[clouds.Zone]],
-    cluster_name: ClusterName,
+    cluster_name: resources_utils.ClusterName,
     num_nodes: int,
     cluster_yaml: str,
     prev_cluster_ever_up: bool,
@@ -225,7 +214,7 @@ def bulk_provision(
             raise
 
 
-def teardown_cluster(cloud_name: str, cluster_name: ClusterName,
+def teardown_cluster(cloud_name: str, cluster_name: resources_utils.ClusterName,
                      terminate: bool, provider_config: Dict) -> None:
     """Deleting or stopping a cluster.
 
@@ -411,8 +400,8 @@ def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
 
 
 def _post_provision_setup(
-        cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        provision_record: provision_common.ProvisionRecord,
+        cloud_name: str, cluster_name: resources_utils.ClusterName,
+        cluster_yaml: str, provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str]) -> provision_common.ClusterInfo:
     config_from_yaml = common_utils.read_yaml(cluster_yaml)
     provider_config = config_from_yaml.get('provider')
@@ -563,8 +552,8 @@ def _post_provision_setup(
 
 
 def post_provision_runtime_setup(
-        cloud_name: str, cluster_name: ClusterName, cluster_yaml: str,
-        provision_record: provision_common.ProvisionRecord,
+        cloud_name: str, cluster_name: resources_utils.ClusterName,
+        cluster_yaml: str, provision_record: provision_common.ProvisionRecord,
         custom_resource: Optional[str],
         log_dir: str) -> provision_common.ClusterInfo:
     """Run internal setup commands after provisioning and before user setup.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -929,12 +929,6 @@ class Resources:
         """
         if self.ports is None:
             return
-        if skypilot_config.get_nested(('aws', 'security_group_name'),
-                                      None) is not None:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Cannot specify ports when AWS security group name is '
-                    'specified.')
         if self.cloud is not None:
             self.cloud.check_features_are_supported(
                 self, {clouds.CloudImplementationFeatures.OPEN_PORTS})

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -929,6 +929,20 @@ class Resources:
         """
         if self.ports is None:
             return
+        if self.cloud is None or isinstance(self.cloud, clouds.AWS):
+            security_group_name = skypilot_config.get_nested(
+                ('aws', 'security_group_name'), None)
+            if security_group_name is not None:
+                with ux_utils.print_exception_no_traceback():
+                    logger.warning(
+                        f'Ports {self.ports} and security group name are '
+                        f'specified: {security_group_name}. It is not '
+                        'guaranteed that the ports will be opened if the '
+                        'specified security group is not correctly set up. '
+                        'Please try to specify `ports` only and leave out '
+                        '`aws.security_group_name` in `~/.sky/config.yaml` to '
+                        'allow SkyPilot to automatically create and configure '
+                        'the security group.')
         if self.cloud is not None:
             self.cloud.check_features_are_supported(
                 self, {clouds.CloudImplementationFeatures.OPEN_PORTS})
@@ -1003,7 +1017,7 @@ class Resources:
     def get_spot_str(self) -> str:
         return '[Spot]' if self.use_spot else ''
 
-    def make_deploy_variables(self, cluster_name_on_cloud: str,
+    def make_deploy_variables(self, cluster_name: resources_utils.ClusterName,
                               region: clouds.Region,
                               zones: Optional[List[clouds.Zone]],
                               dryrun: bool) -> Dict[str, Optional[str]]:
@@ -1041,7 +1055,7 @@ class Resources:
 
         # Cloud specific variables
         cloud_specific_variables = self.cloud.make_deploy_resources_variables(
-            self, cluster_name_on_cloud, region, zones, dryrun)
+            self, cluster_name, region, zones, dryrun)
         return dict(
             cloud_specific_variables,
             **{

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -929,20 +929,6 @@ class Resources:
         """
         if self.ports is None:
             return
-        if self.cloud is None or isinstance(self.cloud, clouds.AWS):
-            security_group_name = skypilot_config.get_nested(
-                ('aws', 'security_group_name'), None)
-            if security_group_name is not None:
-                with ux_utils.print_exception_no_traceback():
-                    logger.warning(
-                        f'Ports {self.ports} and security group name are '
-                        f'specified: {security_group_name}. It is not '
-                        'guaranteed that the ports will be opened if the '
-                        'specified security group is not correctly set up. '
-                        'Please try to specify `ports` only and leave out '
-                        '`aws.security_group_name` in `~/.sky/config.yaml` to '
-                        'allow SkyPilot to automatically create and configure '
-                        'the security group.')
         if self.cloud is not None:
             self.cloud.check_features_are_supported(
                 self, {clouds.CloudImplementationFeatures.OPEN_PORTS})

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -1,4 +1,5 @@
 """Utility functions for resources."""
+import dataclasses
 import enum
 import itertools
 import re
@@ -41,6 +42,18 @@ class DiskTier(enum.Enum):
     def __le__(self, other: 'DiskTier') -> bool:
         types = list(DiskTier)
         return types.index(self) <= types.index(other)
+
+
+@dataclasses.dataclass
+class ClusterName:
+    display_name: str
+    name_on_cloud: str
+
+    def __repr__(self) -> str:
+        return repr(self.display_name)
+
+    def __str__(self) -> str:
+        return self.display_name
 
 
 def check_port_str(port: str) -> None:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -708,21 +708,28 @@ def get_config_schema():
             'additionalProperties': False,
             'properties': {
                 'security_group_name': {
-                    'oneOf': [{
-                        'type': 'string'
-                    }, {
-                        'type': 'object',
-                        'additionalProperties': False,
-                        'required': ['default'],
-                        'properties': {
-                            'sky-serve-controller': {
-                                'type': 'string',
+                    'oneOf': [
+                        {
+                            'type': 'string'
+                        },
+                        {
+                            # A list of single-element dict to pretain the order.
+                            # Example:
+                            #  security_group_name:
+                            #    - my-cluster1-*: my-security-group-1
+                            #    - my-cluster2-*: my-security-group-2
+                            #    - "*"": my-security-group-3
+                            'type': 'array',
+                            'items': {
+                                'type': 'object',
+                                'additionalProperties': {
+                                    'type': 'string'
+                                },
+                                'maxProperties': 1,
+                                'minProperties': 1,
                             },
-                            'default': {
-                                'type': 'string'
-                            }
                         }
-                    }]
+                    ]
                 },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -713,7 +713,8 @@ def get_config_schema():
                             'type': 'string'
                         },
                         {
-                            # A list of single-element dict to pretain the order.
+                            # A list of single-element dict to pretain the
+                            # order.
                             # Example:
                             #  security_group_name:
                             #    - my-cluster1-*: my-security-group-1

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -33,6 +33,36 @@ def _check_not_both_fields_present(field1: str, field2: str):
     }
 
 
+def _get_cloud_name_property_mapping(field: str):
+    return {
+        field: {
+            'oneOf': [
+                {
+                    'type': 'string'
+                },
+                {
+                    # A list of single-element dict to pretain the
+                    # order.
+                    # Example:
+                    #  property_name:
+                    #    - my-cluster1-*: my-property-1
+                    #    - my-cluster2-*: my-property-2
+                    #    - "*"": my-property-3
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'additionalProperties': {
+                            'type': 'string'
+                        },
+                        'maxProperties': 1,
+                        'minProperties': 1,
+                    },
+                }
+            ]
+        }
+    }
+
+
 def _get_single_resources_schema():
     """Schema for a single resource in a resources list."""
     # To avoid circular imports, only import when needed.
@@ -640,33 +670,6 @@ _REMOTE_IDENTITY_SCHEMA = {
     }
 }
 
-_REMOTE_IDENTITY_SCHEMA_AWS = {
-    'remote_identity': {
-        'oneOf': [
-            {
-                'type': 'string'
-            },
-            {
-                # A list of single-element dict to pretain the order.
-                # Example:
-                #  remote_identity:
-                #    - my-cluster1-*: my-iam-role-1
-                #    - my-cluster2-*: my-iam-role-2
-                #    - "*"": my-iam-role-3
-                'type': 'array',
-                'items': {
-                    'type': 'object',
-                    'additionalProperties': {
-                        'type': 'string'
-                    },
-                    'maxProperties': 1,
-                    'minProperties': 1,
-                },
-            }
-        ]
-    }
-}
-
 _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
     'remote_identity': {
         'type': 'string'
@@ -685,7 +688,7 @@ def get_config_schema():
         # Validation may fail if $schema is included.
         if k != '$schema'
     }
-    resources_schema['properties'].pop('port', None)
+    resources_schema['properties'].pop('ports')
     controller_resources_schema = {
         'type': 'object',
         'required': [],
@@ -707,31 +710,7 @@ def get_config_schema():
             'required': [],
             'additionalProperties': False,
             'properties': {
-                'security_group_name': {
-                    'oneOf': [
-                        {
-                            'type': 'string'
-                        },
-                        {
-                            # A list of single-element dict to pretain the
-                            # order.
-                            # Example:
-                            #  security_group_name:
-                            #    - my-cluster1-*: my-security-group-1
-                            #    - my-cluster2-*: my-security-group-2
-                            #    - "*"": my-security-group-3
-                            'type': 'array',
-                            'items': {
-                                'type': 'object',
-                                'additionalProperties': {
-                                    'type': 'string'
-                                },
-                                'maxProperties': 1,
-                                'minProperties': 1,
-                            },
-                        }
-                    ]
-                },
+                **_get_cloud_name_property_mapping('security_group_name'),
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },
@@ -890,7 +869,8 @@ def get_config_schema():
 
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
-            config['properties'].update(_REMOTE_IDENTITY_SCHEMA_AWS)
+            config['properties'].update(
+                _get_cloud_name_property_mapping('remote_identity'))
         elif cloud == 'kubernetes':
             config['properties'].update(_REMOTE_IDENTITY_SCHEMA_KUBERNETES)
         else:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -114,6 +114,8 @@ def _get_single_resources_schema():
                             'type': 'integer',
                         }]
                     }
+                }, {
+                    'type': 'null',
                 }],
             },
             'labels': {
@@ -683,7 +685,7 @@ def get_config_schema():
         # Validation may fail if $schema is included.
         if k != '$schema'
     }
-    resources_schema['properties'].pop('ports')
+    resources_schema['properties'].pop('port', None)
     controller_resources_schema = {
         'type': 'object',
         'required': [],
@@ -706,7 +708,21 @@ def get_config_schema():
             'additionalProperties': False,
             'properties': {
                 'security_group_name': {
-                    'type': 'string'
+                    'oneOf': [{
+                        'type': 'string'
+                    }, {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'required': ['default'],
+                        'properties': {
+                            'sky-serve-controller': {
+                                'type': 'string',
+                            },
+                            'default': {
+                                'type': 'string'
+                            }
+                        }
+                    }]
                 },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -706,7 +706,8 @@ def get_config_schema():
             'required': [],
             'additionalProperties': False,
             'properties': {
-                'security_group_name': _PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY,
+                'security_group_name':
+                    (_PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },

--- a/tests/test_yamls/test_aws_config.yaml
+++ b/tests/test_yamls/test_aws_config.yaml
@@ -2,7 +2,7 @@ aws:
   vpc_name: fake-vpc
   remote_identity:
     - sky-serve-fake1-*: fake1-skypilot-role
-    - sky-serve-fake2-*: fake1-skypilot-role
+    - sky-serve-fake2-*: fake2-skypilot-role
 
   security_group_name:
     - sky-serve-fake1-*: fake-1-sg

--- a/tests/test_yamls/test_aws_config.yaml
+++ b/tests/test_yamls/test_aws_config.yaml
@@ -1,0 +1,11 @@
+aws:
+  vpc_name: fake-vpc
+  remote_identity:
+    - sky-serve-fake1-*: fake1-skypilot-role
+    - sky-serve-fake2-*: fake1-skypilot-role
+    - "*": fake-skypilot-default-role
+
+  security_group_name:
+    - sky-serve-fake1-*: fake-1-sg
+    - sky-serve-fake2-*: fake-2-sg
+    - "*": fake-skypilot-default

--- a/tests/test_yamls/test_aws_config.yaml
+++ b/tests/test_yamls/test_aws_config.yaml
@@ -3,9 +3,7 @@ aws:
   remote_identity:
     - sky-serve-fake1-*: fake1-skypilot-role
     - sky-serve-fake2-*: fake1-skypilot-role
-    - "*": fake-skypilot-default-role
 
   security_group_name:
     - sky-serve-fake1-*: fake-1-sg
     - sky-serve-fake2-*: fake-2-sg
-    - "*": fake-skypilot-default

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -7,9 +7,9 @@ import pytest
 
 from sky import clouds
 from sky import skypilot_config
+from sky.backends import backend_utils
 from sky.resources import Resources
 from sky.resources import resources_utils
-from sky.backends import backend_utils
 
 
 @patch.object(skypilot_config, 'CONFIG_PATH',
@@ -22,10 +22,13 @@ from sky.backends import backend_utils
 @patch('sky.clouds.service_catalog.get_image_id_from_tag',
        return_value='fake-image')
 @patch.object(clouds.aws, 'DEFAULT_SECURITY_GROUP_NAME', 'fake-default-sg')
-@patch('sky.check.get_cloud_credential_file_mounts', return_value='~/.aws/credentials')
-@patch('sky.backends.backend_utils._get_yaml_path_from_cluster_name', return_value='/tmp/fake/path')
+@patch('sky.check.get_cloud_credential_file_mounts',
+       return_value='~/.aws/credentials')
+@patch('sky.backends.backend_utils._get_yaml_path_from_cluster_name',
+       return_value='/tmp/fake/path')
 @patch('sky.utils.common_utils.fill_template')
-def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> None:
+def test_write_cluster_config_w_remote_identity(mock_fill_template,
+                                                *mocks) -> None:
     skypilot_config._try_load_config()
 
     cloud = clouds.AWS()
@@ -47,8 +50,7 @@ def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> N
         region=region,
         zones=zones,
         dryrun=True,
-        keep_launch_fields_in_existing_config=True
-    )
+        keep_launch_fields_in_existing_config=True)
 
     expected_subset = {
         'instance_type': 'fake-type: 3',
@@ -65,8 +67,10 @@ def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> N
     }
 
     mock_fill_template.assert_called_once()
-    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
-    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"
+    assert mock_fill_template.call_args[0][
+        0] == cluster_config_template, "config template incorrect"
+    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(
+    ), "config fill values incorrect"
 
     # test using cluster matches regex, top
     mock_fill_template.reset_mock()
@@ -85,12 +89,13 @@ def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> N
         region=region,
         zones=zones,
         dryrun=True,
-        keep_launch_fields_in_existing_config=True
-    )
+        keep_launch_fields_in_existing_config=True)
 
     mock_fill_template.assert_called_once()
-    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
-    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"
+    assert (mock_fill_template.call_args[0][0] == cluster_config_template,
+            "config template incorrect")
+    assert (mock_fill_template.call_args[0][1].items() >=
+            expected_subset.items(), "config fill values incorrect")
 
     # test using cluster matches regex, middle
     mock_fill_template.reset_mock()
@@ -109,9 +114,10 @@ def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> N
         region=region,
         zones=zones,
         dryrun=True,
-        keep_launch_fields_in_existing_config=True
-    )
+        keep_launch_fields_in_existing_config=True)
 
     mock_fill_template.assert_called_once()
-    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
-    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"
+    assert (mock_fill_template.call_args[0][0] == cluster_config_template,
+            "config template incorrect")
+    assert (mock_fill_template.call_args[0][1].items() >=
+            expected_subset.items(), "config fill values incorrect")

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -1,0 +1,117 @@
+import pathlib
+from typing import Dict
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from sky import clouds
+from sky import skypilot_config
+from sky.resources import Resources
+from sky.resources import resources_utils
+from sky.backends import backend_utils
+
+
+@patch.object(skypilot_config, 'CONFIG_PATH',
+              './tests/test_yamls/test_aws_config.yaml')
+@patch.object(skypilot_config, '_dict', None)
+@patch.object(skypilot_config, '_loaded_config_path', None)
+@patch('sky.clouds.service_catalog.instance_type_exists', return_value=True)
+@patch('sky.clouds.service_catalog.get_accelerators_from_instance_type',
+       return_value={'fake-acc': 2})
+@patch('sky.clouds.service_catalog.get_image_id_from_tag',
+       return_value='fake-image')
+@patch.object(clouds.aws, 'DEFAULT_SECURITY_GROUP_NAME', 'fake-default-sg')
+@patch('sky.check.get_cloud_credential_file_mounts', return_value='~/.aws/credentials')
+@patch('sky.backends.backend_utils._get_yaml_path_from_cluster_name', return_value='/tmp/fake/path')
+@patch('sky.utils.common_utils.fill_template')
+def test_write_cluster_config_w_remote_identity(mock_fill_template, *mocks) -> None:
+    skypilot_config._try_load_config()
+
+    cloud = clouds.AWS()
+
+    region = clouds.Region(name='fake-region')
+    zones = [clouds.Zone(name='fake-zone')]
+    resource = Resources(cloud=cloud, instance_type='fake-type: 3')
+
+    cluster_config_template = 'aws-ray.yml.j2'
+
+    # test default
+    backend_utils.write_cluster_config(
+        to_provision=resource,
+        num_nodes=2,
+        cluster_config_template=cluster_config_template,
+        cluster_name="display",
+        local_wheel_path=pathlib.Path('/tmp/fake'),
+        wheel_hash='b1bd84059bc0342f7843fcbe04ab563e',
+        region=region,
+        zones=zones,
+        dryrun=True,
+        keep_launch_fields_in_existing_config=True
+    )
+
+    expected_subset = {
+        'instance_type': 'fake-type: 3',
+        'custom_resources': '{"fake-acc":2}',
+        'region': 'fake-region',
+        'zones': 'fake-zone',
+        'image_id': 'fake-image',
+        'security_group': 'fake-default-sg',
+        'security_group_managed_by_skypilot': 'true',
+        'vpc_name': 'fake-vpc',
+        'remote_identity': 'LOCAL_CREDENTIALS',  # remote identity
+        'sky_local_path': '/tmp/fake',
+        'sky_wheel_hash': 'b1bd84059bc0342f7843fcbe04ab563e',
+    }
+
+    mock_fill_template.assert_called_once()
+    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
+    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"
+
+    # test using cluster matches regex, top
+    mock_fill_template.reset_mock()
+    expected_subset.update({
+        'security_group': 'fake-1-sg',
+        'security_group_managed_by_skypilot': 'false',
+        'remote_identity': 'fake1-skypilot-role'
+    })
+    backend_utils.write_cluster_config(
+        to_provision=resource,
+        num_nodes=2,
+        cluster_config_template=cluster_config_template,
+        cluster_name="sky-serve-fake1-1234",
+        local_wheel_path=pathlib.Path('/tmp/fake'),
+        wheel_hash='b1bd84059bc0342f7843fcbe04ab563e',
+        region=region,
+        zones=zones,
+        dryrun=True,
+        keep_launch_fields_in_existing_config=True
+    )
+
+    mock_fill_template.assert_called_once()
+    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
+    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"
+
+    # test using cluster matches regex, middle
+    mock_fill_template.reset_mock()
+    expected_subset.update({
+        'security_group': 'fake-2-sg',
+        'security_group_managed_by_skypilot': 'false',
+        'remote_identity': 'fake2-skypilot-role'
+    })
+    backend_utils.write_cluster_config(
+        to_provision=resource,
+        num_nodes=2,
+        cluster_config_template=cluster_config_template,
+        cluster_name="sky-serve-fake2-1234",
+        local_wheel_path=pathlib.Path('/tmp/fake'),
+        wheel_hash='b1bd84059bc0342f7843fcbe04ab563e',
+        region=region,
+        zones=zones,
+        dryrun=True,
+        keep_launch_fields_in_existing_config=True
+    )
+
+    mock_fill_template.assert_called_once()
+    assert mock_fill_template.call_args[0][0] == cluster_config_template, "config template incorrect"
+    assert mock_fill_template.call_args[0][1].items() >= expected_subset.items(), "config fill values incorrect"

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -95,12 +95,12 @@ def test_kubernetes_labels_resources():
               './tests/test_yamls/test_aws_config.yaml')
 @patch.object(skypilot_config, '_dict', None)
 @patch.object(skypilot_config, '_loaded_config_path', None)
-@patch("sky.clouds.service_catalog.instance_type_exists", return_value=True)
-@patch("sky.clouds.service_catalog.get_accelerators_from_instance_type",
-       return_value={"fake-acc": 2})
-@patch("sky.clouds.service_catalog.get_image_id_from_tag",
-       return_value="fake-image")
-@patch.object(clouds.aws, "DEFAULT_SECURITY_GROUP_NAME", "fake-default-sg")
+@patch('sky.clouds.service_catalog.instance_type_exists', return_value=True)
+@patch('sky.clouds.service_catalog.get_accelerators_from_instance_type',
+       return_value={'fake-acc': 2})
+@patch('sky.clouds.service_catalog.get_image_id_from_tag',
+       return_value='fake-image')
+@patch.object(clouds.aws, 'DEFAULT_SECURITY_GROUP_NAME', 'fake-default-sg')
 def test_aws_make_deploy_variables(*mocks) -> None:
     skypilot_config._try_load_config()
 
@@ -109,7 +109,7 @@ def test_aws_make_deploy_variables(*mocks) -> None:
                                                name_on_cloud='cloud')
     region = clouds.Region(name='fake-region')
     zones = [clouds.Zone(name='fake-zone')]
-    resource = Resources(cloud=cloud, instance_type="fake-type: 3")
+    resource = Resources(cloud=cloud, instance_type='fake-type: 3')
     config = resource.make_deploy_variables(cluster_name,
                                             region,
                                             zones,
@@ -134,18 +134,18 @@ def test_aws_make_deploy_variables(*mocks) -> None:
     # test using defaults
     expected_config = expected_config_base.copy()
     expected_config.update({
-        'security_group': "fake-default-sg",
+        'security_group': 'fake-default-sg',
         'security_group_managed_by_skypilot': 'true'
     })
     assert config == expected_config, ('unexpected resource '
                                        'variables generated')
 
-    # test using culuster matches regex, top
+    # test using cluster matches regex, top
     cluster_name = resources_utils.ClusterName(
         display_name='sky-serve-fake1-1234', name_on_cloud='name-on-cloud')
     expected_config = expected_config_base.copy()
     expected_config.update({
-        'security_group': "fake-1-sg",
+        'security_group': 'fake-1-sg',
         'security_group_managed_by_skypilot': 'false'
     })
     config = resource.make_deploy_variables(cluster_name,
@@ -155,12 +155,12 @@ def test_aws_make_deploy_variables(*mocks) -> None:
     assert config == expected_config, ('unexpected resource '
                                        'variables generated')
 
-    # test using culuster matches regex, middle
+    # test using cluster matches regex, middle
     cluster_name = resources_utils.ClusterName(
         display_name='sky-serve-fake2-1234', name_on_cloud='name-on-cloud')
     expected_config = expected_config_base.copy()
     expected_config.update({
-        'security_group': "fake-2-sg",
+        'security_group': 'fake-2-sg',
         'security_group_managed_by_skypilot': 'false'
     })
     config = resource.make_deploy_variables(cluster_name,

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -100,6 +100,7 @@ def test_kubernetes_labels_resources():
        return_value={"fake-acc": 2})
 @patch("sky.clouds.service_catalog.get_image_id_from_tag",
        return_value="fake-image")
+@patch.object(clouds.aws, "DEFAULT_SECURITY_GROUP_NAME", "fake-default-sg")
 def test_aws_make_deploy_variables(*mocks) -> None:
     skypilot_config._try_load_config()
 
@@ -133,15 +134,15 @@ def test_aws_make_deploy_variables(*mocks) -> None:
     # test using defaults
     expected_config = expected_config_base.copy()
     expected_config.update({
-        'security_group': "fake-skypilot-default",
-        'security_group_managed_by_skypilot': 'false'
+        'security_group': "fake-default-sg",
+        'security_group_managed_by_skypilot': 'true'
     })
     assert config == expected_config, ('unexpected resource '
                                        'variables generated')
 
     # test using culuster matches regex, top
     cluster_name = resources_utils.ClusterName(
-        display_name='display', name_on_cloud='sky-serve-fake1-1234')
+        display_name='sky-serve-fake1-1234', name_on_cloud='name-on-cloud')
     expected_config = expected_config_base.copy()
     expected_config.update({
         'security_group': "fake-1-sg",
@@ -156,7 +157,7 @@ def test_aws_make_deploy_variables(*mocks) -> None:
 
     # test using culuster matches regex, middle
     cluster_name = resources_utils.ClusterName(
-        display_name='display', name_on_cloud='sky-serve-fake2-1234')
+        display_name='sky-serve-fake2-1234', name_on_cloud='name-on-cloud')
     expected_config = expected_config_base.copy()
     expected_config.update({
         'security_group': "fake-2-sg",

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -128,6 +128,8 @@ def test_aws_make_deploy_variables(*mocks) -> None:
         'docker_image': None,
         'docker_container_name': 'sky_container',
         'docker_login_config': None,
+        'docker_run_options': [],
+        'initial_setup_commands': [],
         'zones': 'fake-zone'
     }
 

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -1,10 +1,13 @@
 from typing import Dict
 from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
 from sky import clouds
+from sky import skypilot_config
 from sky.resources import Resources
+from sky.utils import resources_utils
 
 GLOBAL_VALID_LABELS = {
     'plaintext': 'plainvalue',
@@ -86,3 +89,82 @@ def test_kubernetes_labels_resources():
     }
     cloud = clouds.Kubernetes()
     _run_label_test(allowed_labels, invalid_labels, cloud)
+
+
+@patch.object(skypilot_config, 'CONFIG_PATH',
+              './tests/test_yamls/test_aws_config.yaml')
+@patch.object(skypilot_config, '_dict', None)
+@patch.object(skypilot_config, '_loaded_config_path', None)
+@patch("sky.clouds.service_catalog.instance_type_exists", return_value=True)
+@patch("sky.clouds.service_catalog.get_accelerators_from_instance_type",
+       return_value={"fake-acc": 2})
+@patch("sky.clouds.service_catalog.get_image_id_from_tag",
+       return_value="fake-image")
+def test_aws_make_deploy_variables(*mocks) -> None:
+    skypilot_config._try_load_config()
+
+    cloud = clouds.AWS()
+    cluster_name = resources_utils.ClusterName(display_name='display',
+                                               name_on_cloud='cloud')
+    region = clouds.Region(name='fake-region')
+    zones = [clouds.Zone(name='fake-zone')]
+    resource = Resources(cloud=cloud, instance_type="fake-type: 3")
+    config = resource.make_deploy_variables(cluster_name,
+                                            region,
+                                            zones,
+                                            dryrun=True)
+
+    expected_config_base = {
+        'instance_type': resource.instance_type,
+        'custom_resources': '{"fake-acc":2}',
+        'use_spot': False,
+        'region': 'fake-region',
+        'image_id': 'fake-image',
+        'disk_tier': 'gp3',
+        'disk_throughput': 218,
+        'disk_iops': 3500,
+        'custom_disk_perf': True,
+        'docker_image': None,
+        'docker_container_name': 'sky_container',
+        'docker_login_config': None,
+        'zones': 'fake-zone'
+    }
+
+    # test using defaults
+    expected_config = expected_config_base.copy()
+    expected_config.update({
+        'security_group': "fake-skypilot-default",
+        'security_group_managed_by_skypilot': 'false'
+    })
+    assert config == expected_config, ('unexpected resource '
+                                       'variables generated')
+
+    # test using culuster matches regex, top
+    cluster_name = resources_utils.ClusterName(
+        display_name='display', name_on_cloud='sky-serve-fake1-1234')
+    expected_config = expected_config_base.copy()
+    expected_config.update({
+        'security_group': "fake-1-sg",
+        'security_group_managed_by_skypilot': 'false'
+    })
+    config = resource.make_deploy_variables(cluster_name,
+                                            region,
+                                            zones,
+                                            dryrun=True)
+    assert config == expected_config, ('unexpected resource '
+                                       'variables generated')
+
+    # test using culuster matches regex, middle
+    cluster_name = resources_utils.ClusterName(
+        display_name='display', name_on_cloud='sky-serve-fake2-1234')
+    expected_config = expected_config_base.copy()
+    expected_config.update({
+        'security_group': "fake-2-sg",
+        'security_group_managed_by_skypilot': 'false'
+    })
+    config = resource.make_deploy_variables(cluster_name,
+                                            region,
+                                            zones,
+                                            dryrun=True)
+    assert config == expected_config, ('unexpected resource '
+                                       'variables generated')


### PR DESCRIPTION
Similar to https://github.com/skypilot-org/skypilot/pull/3488 but for SGs
This PR:
 * Allows specification of SGs for controllers vs workers.
 * **Currently removes the port requirement to be able to allow SG specification in serve.**


Addresses: https://github.com/skypilot-org/skypilot/issues/3473

In `~/.sky/config.yaml`:
 * When setting for a controller wildcard and all other resources ("*")
```yaml
aws:
  security_group_name:
    - sky-serve-controller-*: skypilot-controller-fake-sg
    - "*": skypilot-default-fake-sg 
```

 * When setting for everything by specifying a default ("*")
```yaml
aws:
  security_group_name:
    - "*": skypilot-default-fake-sg
```

 * When setting for everything by specifying just the `security_group_name` via string
```yaml
aws:
  security_group_name: skypilot-default-fake-sg
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  * tested running in all 3 configs in AWS
    - Nothing set
    - setting different controller and default values (controller vs replica in serve received different remote_identities)
    - setting default only
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`

 
EDITED:
* refactored to match the IAM format.