### PR TITLE
[Paperspace] Update machine images

### DIFF
--- a/sky/provision/paperspace/constants.py
+++ b/sky/provision/paperspace/constants.py
@@ -1,14 +1,20 @@
-"""Constants for Paperspace provisioner"""
+"""Constants for Paperspace provisioner
+(TODO) asaiacai: fetch default images using API
+The H100 and A100 family of GPUs use `Ubuntu 22.04 MLaiB`
+V100s use Ubuntu `20.04 MLaiB`
+CPU instances use `Ubuntu 22.04 Server`
+These instances are fetched using:
+    # curl -X GET 'https://api.paperspace.io/templates/getTemplates \
+    # -H 'X-Api-Key: ...'
+"""
 
 CPU_INSTANCES_TEMPLATEID = {f'C{i}': 't0nspur5' for i in range(5, 10)}
 
 INSTANCE_TO_TEMPLATEID = {
-    'H100x8': 'tvimtol9',
-    'H100': 'tiq8mhti',
+    'H100x8': 't7vp562h',
+    'H100': 'tilqt47t',
     'A100-80Gx8': 'tvimtol9',
-    'A100-80Gx4': 'tiq8mhti',
-    'A100-80Gx2': 'tiq8mhti',
-    'A100-80G': 'tiq8mhti',
+    'A100-80G': 'tqqsxr6b',
     'V100-32Gx4': 'twnlo3zj',
     'V100-32Gx2': 'twnlo3zj',
     'V100-32G': 'twnlo3zj',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Paperspace disabled some older Ubuntu 22.04 MLiaB image defaults we had for certain instances which prevented users from being able to launch images for the higher end GPU instances such as A100 and H100. This updates these images accordingly. Resolves #3498 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual tests `sky launch --cloud paperspace --gpus {A100-80G,A100-80G:8,H100,H100:8}`
