### PR TITLE
[Core][AWS] Allow assumption of AWS Credentials provided in ECS Containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ sky_logs/
 sky/clouds/service_catalog/data_fetchers/*.csv
 .vscode/
 .idea/
-
+.env

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -548,11 +548,10 @@ class AWS(clouds.Cloud):
             # role: skypilot-v1.
             hints = f'AWS IAM role is set.{single_cloud_hint}'
         elif identity_type == AWSIdentityType.CONTAINER_ROLE:
-            # When using an IAM role, the credentials may not exist in the
-            # ~/.aws/credentials file. So we don't check for the existence of the
-            # file. This will happen when the user is on a VM (or spot-controller)
-            # created by an SSO account, i.e. the VM will be assigned the IAM
-            # role: skypilot-v1.
+            # Similar to the IAM ROLE, an ECS container may not store credentials
+            # in the~/.aws/credentials file. So we don't check for the existence of
+            # the file. i.e. the container will be assigned the IAM role of the
+            # task: skypilot-v1.
             hints = f'AWS container-role is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -81,6 +81,8 @@ class AWSIdentityType(enum.Enum):
 
     IAM_ROLE = 'iam-role'
 
+    CONTAINER_ROLE = 'container-role'
+
     #       Name                    Value             Type    Location
     #       ----                    -----             ----    --------
     #    profile                <not set>             None    None
@@ -545,6 +547,13 @@ class AWS(clouds.Cloud):
             # created by an SSO account, i.e. the VM will be assigned the IAM
             # role: skypilot-v1.
             hints = f'AWS IAM role is set.{single_cloud_hint}'
+        elif identity_type == AWSIdentityType.CONTAINER_ROLE:
+            # When using an IAM role, the credentials may not exist in the
+            # ~/.aws/credentials file. So we don't check for the existence of the
+            # file. This will happen when the user is on a VM (or spot-controller)
+            # created by an SSO account, i.e. the VM will be assigned the IAM
+            # role: skypilot-v1.
+            hints = f'AWS container-role is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on
             # other clouds to access private s3 buckets and resources like EC2.
@@ -604,6 +613,8 @@ class AWS(clouds.Cloud):
             return AWSIdentityType.SSO
         elif _is_access_key_of_type(AWSIdentityType.IAM_ROLE.value):
             return AWSIdentityType.IAM_ROLE
+        elif _is_access_key_of_type(AWSIdentityType.CONTAINER_ROLE.value):
+            return AWSIdentityType.CONTAINER_ROLE
         elif _is_access_key_of_type(AWSIdentityType.ENV.value):
             return AWSIdentityType.ENV
         else:


### PR DESCRIPTION
Prior to this PR, ECS containers could not launch skypilot jobs because as the type is considered: `container-role` as opposed to `iam-role` when evaluating `aws configure list`.


This PR:
* Allows ECS container assumed iam credentials to be found by adding the `CONTAINER_ROLE` value to the `AWSIdentityType`.
* adds `.env` to the .gitignore 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->



Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    * Evaluated `sky check` w/o the update in an ECS container (failed)
    * Evaluated running  `sky up ...` w/o the update in an ECS container (failed)
    * Evaluated `sky check` w/ the update in an ECS container (passed)
    * Evaluated running  `sky up ...` w/ the update in an ECS container (passed)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `bash tests/backward_comaptibility_tests.sh`
