### PR TITLE
[Tests] Fix benchmark smoke test `test_sky_bench`

### DIFF
--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -172,7 +172,7 @@ def _create_benchmark_bucket() -> Tuple[str, str]:
         raise_if_no_cloud_access=True)
     # Already checked by raise_if_no_cloud_access=True.
     assert enabled_clouds
-    bucket_type = data.StoreType.from_cloud(enabled_clouds[0])
+    bucket_type = data.StoreType.from_cloud(enabled_clouds[0]).value
 
     # Create a benchmark bucket.
     logger.info(f'Creating a bucket {bucket_name} to save the benchmark logs.')


### PR DESCRIPTION
Smoke test `test_sky_bench` had been failing with:
```
Traceback (most recent call last):
  File "/opt/conda/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/utils/common_utils.py", line 354, in _record
    return f(*args, **kwargs)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/cli.py", line 805, in invoke
    return super().invoke(ctx)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/utils/common_utils.py", line 354, in _record
    return f(*args, **kwargs)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/cli.py", line 805, in invoke
    return super().invoke(ctx)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/conda/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/utils/common_utils.py", line 375, in _record
    return f(*args, **kwargs)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/cli.py", line 4390, in benchmark_launch
    benchmark_created = benchmark_utils.launch_benchmark_clusters(
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/benchmark/benchmark_utils.py", line 506, in launch_benchmark_clusters
    bucket_name, bucket_type = _create_benchmark_bucket()
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/benchmark/benchmark_utils.py", line 183, in _create_benchmark_bucket
    benchmark_state.set_benchmark_bucket(bucket_name, bucket_type)
  File "/home/gcpuser/.sky/file_mounts/sky_repo/sky/benchmark/benchmark_state.py", line 204, in set_benchmark_bucket
    _BENCHMARK_DB.cursor.execute(
sqlite3.InterfaceError: Error binding parameter 1 - probably unsupported type.
```

This is caused by [trying to write](https://github.com/skypilot-org/skypilot/blob/7967938d479378edeb87cc8ee700dd65c514809c/sky/benchmark/benchmark_utils.py#L175) `StoreType` object instead of `StoreType.value` (like we had [before](https://github.com/skypilot-org/skypilot/blob/5cc68d2c9be0870d23b5e73ded1484b2e851268e/sky/benchmark/benchmark_utils.py#L172-L175C9)).

- [x] `pytest tests/test_smoke.py::test_sky_bench`