### PR TITLE
[k8s] `sky local up` gpu support - ignore if ldconfig.real already exists

### DIFF
--- a/sky/utils/kubernetes/create_cluster.sh
+++ b/sky/utils/kubernetes/create_cluster.sh
@@ -195,7 +195,7 @@ if $ENABLE_GPUS; then
     echo "Enabling GPU support..."
     # Run patch for missing ldconfig.real
     # https://github.com/NVIDIA/nvidia-docker/issues/614#issuecomment-423991632
-    docker exec -ti skypilot-control-plane ln -s /sbin/ldconfig /sbin/ldconfig.real
+    docker exec -ti skypilot-control-plane /bin/bash -c '[ ! -f /sbin/ldconfig.real ] && ln -s /sbin/ldconfig /sbin/ldconfig.real || echo "/sbin/ldconfig.real already exists"'
 
     echo "Installing NVIDIA GPU operator..."
     # Install the NVIDIA GPU operator


### PR DESCRIPTION
User shared bug report on slack:
```
No kind clusters found.
Generating /tmp/skypilot-kind.yaml
Creating cluster "skypilot" ...
 • Ensuring node image (kindest/node:v1.21.1) 🖼  ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 • Preparing nodes 📦   ...
 ✓ Preparing nodes 📦 
 • Writing configuration 📜  ...
 ✓ Writing configuration 📜
 • Starting control-plane 🕹️  ...
 ✓ Starting control-plane 🕹️
 • Installing CNI 🔌  ...
 ✓ Installing CNI 🔌
 • Installing StorageClass 💾  ...
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-skypilot"
You can now use your cluster with:

kubectl cluster-info --context kind-skypilot

Have a nice day! 👋
Kind cluster created.

Enabling GPU support...
ln: failed to create symbolic link '/sbin/ldconfig.real': File exists
```

Kind node may have ldconfig.real already exist on the node. In that case symlinking is not required. This patch skips symlinking if it already exists.

Tested (run the relevant ones):

- [x] Manually tested with on a GCP T4 with `sky local up`