### PR TITLE
[k8s] Add support for autoscaling kubernetes clusters

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -313,6 +313,23 @@ Available fields and semantics:
     # Default: 10 seconds
     provision_timeout: 10
 
+    # Autoscaler configured in the Kubernetes cluster (optional)
+    #
+    # This field informs SkyPilot about the cluster autoscaler used in the
+    # Kubernetes cluster. Setting this field disables pre-launch checks for
+    # GPU capacity in the cluster and SkyPilot relies on the autoscaler to
+    # provision nodes with the required GPU capacity.
+    #
+    # Remember to set provision_timeout accordingly when using an autoscaler.
+    #
+    # Supported values: gke, karpenter, generic
+    #   gke: uses cloud.google.com/gke-accelerator label to identify GPUs on nodes
+    #   karpenter: uses karpenter.k8s.aws/instance-gpu-name label to identify GPUs on nodes
+    #   generic: uses skypilot.co/accelerator labels to identify GPUs on nodes
+    #
+    # Default: not set (no autoscaler)
+    autoscaler: gke
+
     # Additional fields to override the pod fields used by SkyPilot (optional)
     #
     # Any key:value pairs added here would get added to the pod spec used to

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -326,8 +326,10 @@ Available fields and semantics:
     #   gke: uses cloud.google.com/gke-accelerator label to identify GPUs on nodes
     #   karpenter: uses karpenter.k8s.aws/instance-gpu-name label to identify GPUs on nodes
     #   generic: uses skypilot.co/accelerator labels to identify GPUs on nodes
+    # Refer to https://skypilot.readthedocs.io/en/latest/reference/kubernetes/kubernetes-setup.html#setting-up-gpu-support
+    # for more details on setting up labels for GPU support.
     #
-    # Default: not set (no autoscaler, autodetect label format for GPU nodes)
+    # Default: null (no autoscaler, autodetect label format for GPU nodes)
     autoscaler: gke
 
     # Additional fields to override the pod fields used by SkyPilot (optional)

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -327,7 +327,7 @@ Available fields and semantics:
     #   karpenter: uses karpenter.k8s.aws/instance-gpu-name label to identify GPUs on nodes
     #   generic: uses skypilot.co/accelerator labels to identify GPUs on nodes
     #
-    # Default: not set (no autoscaler)
+    # Default: not set (no autoscaler, autodetect label format for GPU nodes)
     autoscaler: gke
 
     # Additional fields to override the pod fields used by SkyPilot (optional)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3000,8 +3000,9 @@ def show_gpus(
 
         # Kubernetes specific bools
         cloud_is_kubernetes = (cloud_obj is not None and
-         cloud_obj.is_same_cloud(clouds.Kubernetes()))
-        kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type() is not None
+                               cloud_obj.is_same_cloud(clouds.Kubernetes()))
+        kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type(
+        ) is not None
 
         if accelerator_str is None:
             result = service_catalog.list_accelerator_counts(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3044,13 +3044,15 @@ def show_gpus(
                     other_table.add_row([gpu, _list_to_str(qty)])
                 yield from other_table.get_string()
                 yield '\n\n'
-                if (cloud_is_kubernetes or cloud is None) and kubernetes_autoscaling:
+                if (cloud_is_kubernetes or
+                        cloud is None) and kubernetes_autoscaling:
                     yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
                     yield '\n\n'
             else:
                 yield ('\n\nHint: use -a/--all to see all accelerators '
                        '(including non-common ones) and pricing.')
-                if (cloud_is_kubernetes or cloud is None) and kubernetes_autoscaling:
+                if (cloud_is_kubernetes or
+                        cloud is None) and kubernetes_autoscaling:
                     yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
                 return
         else:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2999,8 +2999,7 @@ def show_gpus(
         name, quantity = None, None
 
         # Kubernetes specific bools
-        cloud_is_kubernetes = (cloud_obj is not None and
-                               cloud_obj.is_same_cloud(clouds.Kubernetes()))
+        cloud_is_kubernetes = isinstance(cloud_obj, clouds.Kubernetes)
         kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type(
         ) is not None
 
@@ -3045,10 +3044,13 @@ def show_gpus(
                     other_table.add_row([gpu, _list_to_str(qty)])
                 yield from other_table.get_string()
                 yield '\n\n'
+                if (cloud_is_kubernetes or cloud is None) and kubernetes_autoscaling:
+                    yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
+                    yield '\n\n'
             else:
                 yield ('\n\nHint: use -a/--all to see all accelerators '
                        '(including non-common ones) and pricing.')
-                if cloud_is_kubernetes and kubernetes_autoscaling:
+                if (cloud_is_kubernetes or cloud is None) and kubernetes_autoscaling:
                     yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
                 return
         else:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2998,6 +2998,11 @@ def show_gpus(
 
         name, quantity = None, None
 
+        # Kubernetes specific bools
+        cloud_is_kubernetes = (cloud_obj is not None and
+         cloud_obj.is_same_cloud(clouds.Kubernetes()))
+        kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type() is not None
+
         if accelerator_str is None:
             result = service_catalog.list_accelerator_counts(
                 gpus_only=True,
@@ -3005,16 +3010,17 @@ def show_gpus(
                 region_filter=region,
             )
 
-            if (len(result) == 0 and cloud_obj is not None and
-                    cloud_obj.is_same_cloud(clouds.Kubernetes())):
+            if len(result) == 0 and cloud_is_kubernetes:
                 yield kubernetes_utils.NO_GPU_ERROR_MESSAGE
+                if kubernetes_autoscaling:
+                    yield '\n'
+                    yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
                 return
 
             # "Common" GPUs
             # If cloud is kubernetes, we want to show all GPUs here, even if
             # they are not listed as common in SkyPilot.
-            if (cloud_obj is not None and
-                    cloud_obj.is_same_cloud(clouds.Kubernetes())):
+            if cloud_is_kubernetes:
                 for gpu, _ in sorted(result.items()):
                     gpu_table.add_row([gpu, _list_to_str(result.pop(gpu))])
             else:
@@ -3041,6 +3047,8 @@ def show_gpus(
             else:
                 yield ('\n\nHint: use -a/--all to see all accelerators '
                        '(including non-common ones) and pricing.')
+                if cloud_is_kubernetes and kubernetes_autoscaling:
+                    yield kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE
                 return
         else:
             # Parse accelerator string

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -388,7 +388,8 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
             # node provisioning.
             return '', ''
         formatter = AUTOSCALER_TO_LABEL_FORMATTER.get(autoscaler_type)
-        assert formatter is not None, f'Unsupported autoscaler type: {autoscaler_type}'
+        assert formatter is not None, ('Unsupported autoscaler type:'
+                                       f' {autoscaler_type}')
         return formatter.get_label_key(), formatter.get_label_value(acc_type)
 
     has_gpus, cluster_resources = detect_gpu_resource()
@@ -1357,5 +1358,6 @@ def get_autoscaler_type(
     autoscaler_type = skypilot_config.get_nested(['kubernetes', 'autoscaler'],
                                                  None)
     if autoscaler_type is not None:
-        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType(autoscaler_type)
+        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType(
+            autoscaler_type)
     return autoscaler_type

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -388,12 +388,7 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
             # node provisioning.
             return '', ''
         formatter = AUTOSCALER_TO_LABEL_FORMATTER.get(autoscaler_type)
-        if formatter is None:
-            # This should never be reached unless schema checks fail or
-            # AUTOSCALER_TO_LABEL_FORMATTER dict is not up to date.
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    f'Unsupported autoscaler type: {autoscaler_type}')
+        assert formatter is not None, f'Unsupported autoscaler type: {autoscaler_type}'
         return formatter.get_label_key(), formatter.get_label_value(acc_type)
 
     has_gpus, cluster_resources = detect_gpu_resource()
@@ -1362,6 +1357,5 @@ def get_autoscaler_type(
     autoscaler_type = skypilot_config.get_nested(['kubernetes', 'autoscaler'],
                                                  None)
     if autoscaler_type is not None:
-        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType.from_str(
-            autoscaler_type)
+        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType(autoscaler_type)
     return autoscaler_type

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -204,12 +204,9 @@ LABEL_FORMATTER_REGISTRY = [
 
 # Mapping of autoscaler type to label formatter
 AUTOSCALER_TO_LABEL_FORMATTER = {
-    kubernetes_enums.KubernetesAutoscalerType.GKE:
-        GKELabelFormatter,
-    kubernetes_enums.KubernetesAutoscalerType.KARPENTER:
-        KarpenterLabelFormatter,
-    kubernetes_enums.KubernetesAutoscalerType.GENERIC:
-        SkyPilotLabelFormatter,
+    kubernetes_enums.KubernetesAutoscalerType.GKE: GKELabelFormatter,
+    kubernetes_enums.KubernetesAutoscalerType.KARPENTER: KarpenterLabelFormatter,  # pylint: disable=line-too-long
+    kubernetes_enums.KubernetesAutoscalerType.GENERIC: SkyPilotLabelFormatter,
 }
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -178,11 +178,21 @@ class GKELabelFormatter(GPULabelFormatter):
                 f'Invalid accelerator name in GKE cluster: {value}')
 
 
+class KarpenterLabelFormatter(SkyPilotLabelFormatter):
+    """Karpeneter label formatter
+    Karpenter uses the label `karpenter.k8s.aws/instance-gpu-name` to identify
+    the GPU type. Details: https://karpenter.sh/docs/reference/instance-types/
+    The naming scheme is same as the SkyPilot formatter, so we inherit from it.
+    """
+    LABEL_KEY = 'karpenter.k8s.aws/instance-gpu-name'
+
+
 # LABEL_FORMATTER_REGISTRY stores the label formats SkyPilot will try to
 # discover the accelerator type from. The order of the list is important, as
 # it will be used to determine the priority of the label formats.
 LABEL_FORMATTER_REGISTRY = [
-    SkyPilotLabelFormatter, CoreWeaveLabelFormatter, GKELabelFormatter
+    SkyPilotLabelFormatter, CoreWeaveLabelFormatter, GKELabelFormatter,
+    KarpenterLabelFormatter
 ]
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -35,10 +35,11 @@ If your cluster contains GPUs, make sure nvidia.com/gpu resource is available on
 (e.g., skypilot.co/accelerator) are setup correctly. \
 To further debug, run: sky check.'
 
-KUBERNETES_AUTOSCALER_NOTE = ('Note: Kubernetes cluster autoscaling is enabled. '
-                   'All GPUs that can be provisioned may not be listed '
-                   'here. Refer to your autoscaler\'s node pool '
-                   'configuration to see the list of supported GPUs.')
+KUBERNETES_AUTOSCALER_NOTE = (
+    'Note: Kubernetes cluster autoscaling is enabled. '
+    'All GPUs that can be provisioned may not be listed '
+    'here. Refer to your autoscaler\'s node pool '
+    'configuration to see the list of supported GPUs.')
 
 # TODO(romilb): Add links to docs for configuration instructions when ready.
 ENDPOINTS_DEBUG_MESSAGE = ('Additionally, make sure your {endpoint_type} '
@@ -203,10 +204,14 @@ LABEL_FORMATTER_REGISTRY = [
 
 # Mapping of autoscaler type to label formatter
 AUTOSCALER_TO_LABEL_FORMATTER = {
-    kubernetes_enums.KubernetesAutoscalerType.GKE: GKELabelFormatter,
-    kubernetes_enums.KubernetesAutoscalerType.KARPENTER: KarpenterLabelFormatter,
-    kubernetes_enums.KubernetesAutoscalerType.GENERIC: SkyPilotLabelFormatter,
+    kubernetes_enums.KubernetesAutoscalerType.GKE:
+        GKELabelFormatter,
+    kubernetes_enums.KubernetesAutoscalerType.KARPENTER:
+        KarpenterLabelFormatter,
+    kubernetes_enums.KubernetesAutoscalerType.GENERIC:
+        SkyPilotLabelFormatter,
 }
+
 
 def detect_gpu_label_formatter(
 ) -> Tuple[Optional[GPULabelFormatter], Dict[str, List[Tuple[str, str]]]]:
@@ -382,16 +387,14 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
             # early since we assume the cluster autoscaler will handle GPU
             # node provisioning.
             return '', ''
-        label_formatter = AUTOSCALER_TO_LABEL_FORMATTER.get(autoscaler_type)
-        if label_formatter is None:
+        formatter = AUTOSCALER_TO_LABEL_FORMATTER.get(autoscaler_type)
+        if formatter is None:
             # This should never be reached unless schema checks fail or
             # AUTOSCALER_TO_LABEL_FORMATTER dict is not up to date.
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'Unsupported autoscaler type: {autoscaler_type}')
-        return label_formatter.get_label_key(), label_formatter.get_label_value(
-            acc_type)
-
+        return formatter.get_label_key(), formatter.get_label_value(acc_type)
 
     has_gpus, cluster_resources = detect_gpu_resource()
     if has_gpus:
@@ -1353,9 +1356,12 @@ def get_head_pod_name(cluster_name_on_cloud: str):
     return f'{cluster_name_on_cloud}-head'
 
 
-def get_autoscaler_type() -> Optional[kubernetes_enums.KubernetesAutoscalerType]:
+def get_autoscaler_type(
+) -> Optional[kubernetes_enums.KubernetesAutoscalerType]:
     """Returns the autoscaler type by reading from config"""
-    autoscaler_type = skypilot_config.get_nested(['kubernetes', 'autoscaler'],None)
+    autoscaler_type = skypilot_config.get_nested(['kubernetes', 'autoscaler'],
+                                                 None)
     if autoscaler_type is not None:
-        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType.from_str(autoscaler_type)
+        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType.from_str(
+            autoscaler_type)
     return autoscaler_type

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -372,13 +372,16 @@ def get_gpu_label_key_value(acc_type: str, check_mode=False) -> Tuple[str, str]:
     # Check if the cluster has GPU resources
     # TODO(romilb): This assumes the accelerator is a nvidia GPU. We
     #  need to support TPUs and other accelerators as well.
-    # TODO(romilb): This will fail early for autoscaling clusters.
-    #  For AS clusters, we may need a way for users to specify GPU node pools
-    #  to use since the cluster may be scaling up from zero nodes and may not
-    #  have any GPU nodes yet.
+    # TODO(romilb): Currently, we broadly disable all GPU checks if autoscaling
+    #  is configured in config.yaml since the cluster may be scaling up from
+    #  zero nodes and may not have any GPU nodes yet. In the future, we should
+    #  support pollingthe clusters for autoscaling information, such as the
+    #  node pools configured etc.
 
     autoscaler_type = get_autoscaler_type()
     if autoscaler_type is not None:
+        # If autoscaler is set in config.yaml, override the label key and value
+        # to the autoscaler's format and bypass the GPU checks.
         if check_mode:
             # If check mode is enabled and autoscaler is set, we can return
             # early since we assume the cluster autoscaler will handle GPU

--- a/sky/utils/kubernetes_enums.py
+++ b/sky/utils/kubernetes_enums.py
@@ -36,3 +36,26 @@ class KubernetesPortMode(enum.Enum):
     INGRESS = 'ingress'
     LOADBALANCER = 'loadbalancer'
     PODIP = 'podip'
+
+
+class KubernetesAutoscalerType(enum.Enum):
+    """Enum for the different types of cluster autoscalers for Kubernetes."""
+    GKE = 'gke'
+    KARPENTER = 'karpenter'
+    GENERIC = 'generic'
+
+    @classmethod
+    def from_str(cls, autoscaler: str) -> 'KubernetesAutoscalerType':
+        """Returns the enum value for the given string."""
+        if autoscaler.lower() == cls.GKE.value:
+            return cls.GKE
+        elif autoscaler.lower() == cls.KARPENTER.value:
+            return cls.KARPENTER
+        elif autoscaler.lower() == cls.GENERIC.value:
+            return cls.GENERIC
+        else:
+            raise ValueError(f'Unsupported kubernetes autoscaler type: '
+                             f'{autoscaler}. The autoscaler must be either '
+                             f'\'{cls.GKE.value}\', '
+                             f'\'{cls.KARPENTER.value}\', or '
+                             f'\'{cls.GENERIC.value}\'. ')

--- a/sky/utils/kubernetes_enums.py
+++ b/sky/utils/kubernetes_enums.py
@@ -43,19 +43,3 @@ class KubernetesAutoscalerType(enum.Enum):
     GKE = 'gke'
     KARPENTER = 'karpenter'
     GENERIC = 'generic'
-
-    @classmethod
-    def from_str(cls, autoscaler: str) -> 'KubernetesAutoscalerType':
-        """Returns the enum value for the given string."""
-        if autoscaler.lower() == cls.GKE.value:
-            return cls.GKE
-        elif autoscaler.lower() == cls.KARPENTER.value:
-            return cls.KARPENTER
-        elif autoscaler.lower() == cls.GENERIC.value:
-            return cls.GENERIC
-        else:
-            raise ValueError(f'Unsupported kubernetes autoscaler type: '
-                             f'{autoscaler}. The autoscaler must be either '
-                             f'\'{cls.GKE.value}\', '
-                             f'\'{cls.KARPENTER.value}\', or '
-                             f'\'{cls.GENERIC.value}\'. ')

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -631,6 +631,13 @@ def get_config_schema():
                 'provision_timeout': {
                     'type': 'integer',
                 },
+                'autoscaler': {
+                    'type': 'string',
+                    'case_insensitive_enum': [
+                        type.value
+                        for type in kubernetes_enums.KubernetesAutoscalerType
+                    ]
+                },
             }
         },
         'oci': {


### PR DESCRIPTION
Adds `autoscaler` field to config.yaml to allow the user to specify the autoscaler used in the underlying kubernetes cluster:
```
kubernetes:
  autoscaler: gke/karpenter/generic
```

Setting this field:
1. Disables gpu capacity checks during provisioning
2. Uses the appropriate label formatter for specifying GPU labels

When used in conjunction with `provision_timeout`, this allows users to bring in their scale-to-zero k8s clusters and use them with SkyPilot.

Currently supported autoscalers: GKE nodepools, Karpenter, any generic CA that can label new nodes with `skypilot.co/accelerator` (Related - https://github.com/skypilot-org/skypilot/issues/3432)

More context: https://docs.google.com/document/d/17LRYGCKDsY9AygAJbUIiQR4KkHZqSakL8G0SF7WNOR8/edit?usp=sharing

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested manually on a Karpenter cluster with autoscaling T4 GPU nodes
- [x] Tested manually on a GKE fixed cluster with 1x T4 GPU nodes 
- [x] Tested manually on a GKE autoscaling cluster with T4 GPU nodepool
