### PR TITLE
[AWS] Fix config syntax for IAM profile

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -120,18 +120,19 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account (IAM
     # role) for AWS instances.
     #
-    # Customized service account (IAM role): <string> or <dict>
+    # Customized service account (IAM role): <string> or <list of single-element dict>
     # - <string>: apply the service account with the specified name to all instances.
     #    Example:
     #       remote_identity: my-service-account-name
-    # - <dict>: A dict mapping from the cluster name (pattern) to the service account name to use.
-    #    NOTE: If none of the wildcard expressions in the dict match the cluster name, LOCAL_CREDENTIALS will be used.
-    #    To specify your default, use "*" as the wildcard expression.
-    #    Example:
+    # - <list of single-element dict>: A list single-element dict mapping from the cluster name (pattern)
+    #   to the service account name to use.
+    #   NOTE: If none of the wildcard expressions in the dict match the cluster name, LOCAL_CREDENTIALS will be used.
+    #   To specify your default, use "*" as the wildcard expression.
+    #   Example:
     #       remote_identity:
-    #         my-cluster-name: my-service-account-1
-    #         sky-serve-controller-*: my-service-account-2
-    #         "*": my-default-service-account
+    #         - my-cluster-name: my-service-account-1
+    #         - sky-serve-controller-*: my-service-account-2
+    #         - "*": my-default-service-account
     #
     # Two caveats of SERVICE_ACCOUNT for multicloud users:
     #

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -125,7 +125,8 @@ Available fields and semantics:
     #    Example:
     #       remote_identity: my-service-account-name
     # - <list of single-element dict>: A list single-element dict mapping from the cluster name (pattern)
-    #   to the service account name to use.
+    #   to the service account name to use. The matching of the cluster name is done in the same order
+    #   as the list.
     #   NOTE: If none of the wildcard expressions in the dict match the cluster name, LOCAL_CREDENTIALS will be used.
     #   To specify your default, use "*" as the wildcard expression.
     #   Example:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -801,8 +801,8 @@ def write_cluster_config(
         (str(cloud).lower(), 'remote_identity'), 'LOCAL_CREDENTIALS')
     if remote_identity is not None and not isinstance(remote_identity, str):
         for profile in remote_identity:
-            if fnmatch.fnmatchcase(cluster_name, profile):
-                remote_identity = remote_identity[profile]
+            if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
+                remote_identity = list(profile.values())[0]
                 break
     if remote_identity != 'LOCAL_CREDENTIALS':
         if not cloud.supports_service_account_on_remote():

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -152,7 +152,9 @@ def _try_load_config() -> None:
             common_utils.validate_schema(
                 _dict,
                 schemas.get_config_schema(),
-                f'Invalid config YAML ({config_path}): ',
+                f'Invalid config YAML ({config_path}). See: '
+                'https://skypilot.readthedocs.io/en/latest/reference/config.html. ' # pylint: disable=line-too-long
+                'Error: ',
                 skip_none=False)
 
         logger.debug('Config syntax check passed.')

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -153,7 +153,7 @@ def _try_load_config() -> None:
                 _dict,
                 schemas.get_config_schema(),
                 f'Invalid config YAML ({config_path}). See: '
-                'https://skypilot.readthedocs.io/en/latest/reference/config.html. ' # pylint: disable=line-too-long
+                'https://skypilot.readthedocs.io/en/latest/reference/config.html. '  # pylint: disable=line-too-long
                 'Error: ',
                 skip_none=False)
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -533,11 +533,22 @@ _REMOTE_IDENTITY_SCHEMA_AWS = {
     'remote_identity': {
         'oneOf': [{
             'type': 'string'
-        }, {
-            'type': 'object',
-            'required': [],
-            'additionalProperties': {
-                'type': 'string',
+        },
+        {
+            # A list of single-element dict to pretain the order.
+            # Example:
+            #  remote_identity:
+            #    - my-cluster1-*: my-iam-role-1
+            #    - my-cluster2-*: my-iam-role-2
+            #    - *: my-iam-role-3
+            'type': 'array',
+            'items': {
+                'type': 'object',
+                'additionalProperties': {
+                    'type': 'string'
+                },
+                'maxProperties': 1,
+                'minProperties': 1,
             },
         }]
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -531,26 +531,28 @@ _REMOTE_IDENTITY_SCHEMA = {
 
 _REMOTE_IDENTITY_SCHEMA_AWS = {
     'remote_identity': {
-        'oneOf': [{
-            'type': 'string'
-        },
-        {
-            # A list of single-element dict to pretain the order.
-            # Example:
-            #  remote_identity:
-            #    - my-cluster1-*: my-iam-role-1
-            #    - my-cluster2-*: my-iam-role-2
-            #    - *: my-iam-role-3
-            'type': 'array',
-            'items': {
-                'type': 'object',
-                'additionalProperties': {
-                    'type': 'string'
-                },
-                'maxProperties': 1,
-                'minProperties': 1,
+        'oneOf': [
+            {
+                'type': 'string'
             },
-        }]
+            {
+                # A list of single-element dict to pretain the order.
+                # Example:
+                #  remote_identity:
+                #    - my-cluster1-*: my-iam-role-1
+                #    - my-cluster2-*: my-iam-role-2
+                #    - "*"": my-iam-role-3
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'additionalProperties': {
+                        'type': 'string'
+                    },
+                    'maxProperties': 1,
+                    'minProperties': 1,
+                },
+            }
+        ]
     }
 }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix the syntax for the AWS IAM profile introduced in #3488, so that the wildcard matching will follow the order the user specified.

from 
```yaml
aws:
  remote_identity:
    my-cluster1-*: my-service-account1
    my-cluster2-*: my-service-account2
```

to
```yaml
aws:
  remote_identity:
    - my-cluster1-*: my-service-account1
    - my-cluster2-*: my-service-account2
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky jobs launch -n test echo hi --cloud aws`
```yaml
jobs:
  controller:
    resources:
      cloud: aws

aws:
  remote_identity:
    - sky-jobs-controller-*: SERVICE_ACCOUNT
    - "*": ray-autoscaler-v1
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
