### PR TITLE
[k8s] Allow autodown for k8s

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1994,10 +1994,9 @@ class RetryingVmProvisioner(object):
 
                 requested_features = self._requested_features.copy()
                 # Skip stop feature for Kubernetes jobs controller.
-                if isinstance(to_provision.cloud, clouds.Kubernetes
-                             ) and controller_utils.Controllers.from_name(
-                                 cluster_name
-                             ) == controller_utils.Controllers.JOBS_CONTROLLER:
+                if (isinstance(to_provision.cloud, clouds.Kubernetes) and
+                        controller_utils.Controllers.from_name(cluster_name)
+                        == controller_utils.Controllers.JOBS_CONTROLLER):
                     assert (clouds.CloudImplementationFeatures.STOP
                             in requested_features), requested_features
                     requested_features.remove(
@@ -4066,7 +4065,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # cloud and resources support requested autostop.
         if idle_minutes_to_autostop is not None:
             # Skip auto-stop for Kubernetes clusters.
-            if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
+            if (isinstance(handle.launched_resources.cloud, clouds.Kubernetes)
+                    and not down):
                 # We should hit this code path only for the jobs controller on
                 # Kubernetes clusters.
                 assert (controller_utils.Controllers.from_name(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes an assertion issue introduced in #3521

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
