### PR TITLE
[Serve] Change back from autodown to autostop

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2011,10 +2011,10 @@ class RetryingVmProvisioner(object):
                     cloud_user = to_provision.cloud.get_current_user_identity()
 
                 requested_features = self._requested_features.copy()
-                # Skip stop feature for Kubernetes jobs controller.
+                # Skip stop feature for Kubernetes controllers.
                 if (isinstance(to_provision.cloud, clouds.Kubernetes) and
                         controller_utils.Controllers.from_name(cluster_name)
-                        == controller_utils.Controllers.JOBS_CONTROLLER):
+                        is not None):
                     assert (clouds.CloudImplementationFeatures.STOP
                             in requested_features), requested_features
                     requested_features.remove(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4152,11 +4152,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # Skip auto-stop for Kubernetes clusters.
             if (isinstance(handle.launched_resources.cloud, clouds.Kubernetes)
                     and not down and idle_minutes_to_autostop >= 0):
-                # We should hit this code path only for the jobs controller on
+                # We should hit this code path only for the controllers on
                 # Kubernetes clusters.
                 assert (controller_utils.Controllers.from_name(
-                    handle.cluster_name) == controller_utils.Controllers.
-                        JOBS_CONTROLLER), handle.cluster_name
+                    handle.cluster_name) is not None), handle.cluster_name
                 logger.info('Auto-stop is not supported for Kubernetes '
                             'clusters. Skipping.')
                 return

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -186,14 +186,13 @@ def up(
         # whether the service is already running. If the id is the same
         # with the current job id, we know the service is up and running
         # for the first time; otherwise it is a name conflict.
-        idle_minutes_to_autodown = constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
+        idle_minutes_to_autostop = constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
         controller_job_id, controller_handle = sky.launch(
             task=controller_task,
             stream_logs=False,
             cluster_name=controller_name,
             detach_run=True,
-            idle_minutes_to_autostop=idle_minutes_to_autodown,
-            down=True,
+            idle_minutes_to_autostop=idle_minutes_to_autostop,
             retry_until_up=True,
             _disable_controller_check=True,
         )

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -8,7 +8,6 @@ import colorama
 import sky
 from sky import backends
 from sky import exceptions
-from sky import global_user_state
 from sky import sky_logging
 from sky import task as task_lib
 from sky.backends import backend_utils
@@ -187,19 +186,7 @@ def up(
         # whether the service is already running. If the id is the same
         # with the current job id, we know the service is up and running
         # for the first time; otherwise it is a name conflict.
-        idle_minutes_to_autostop: Optional[int] = (
-            constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
-        # Kubernetes does not support autostop. For k8s controller, we skip
-        # the autostop and let it running indefinitely for now.
-        controller_record = global_user_state.get_cluster_from_name(
-            controller_name)
-        if controller_record is not None:
-            current_controller_resources: sky.Resources = (
-                controller_record['handle'].launched_resources)
-            if (current_controller_resources is not None and
-                    current_controller_resources.cloud.is_same_cloud(
-                        sky.Kubernetes())):
-                idle_minutes_to_autostop = None
+        idle_minutes_to_autostop = constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
         controller_job_id, controller_handle = sky.launch(
             task=controller_task,
             stream_logs=False,

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -189,6 +189,8 @@ def up(
         # for the first time; otherwise it is a name conflict.
         idle_minutes_to_autostop: Optional[int] = (
             constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
+        # Kubernetes does not support autostop. For k8s controller, we skip
+        # the autostop and let it running indefinitely for now.
         controller_record = global_user_state.get_cluster_from_name(
             controller_name)
         if controller_record is not None:

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -8,6 +8,7 @@ import colorama
 import sky
 from sky import backends
 from sky import exceptions
+from sky import global_user_state
 from sky import sky_logging
 from sky import task as task_lib
 from sky.backends import backend_utils
@@ -186,7 +187,17 @@ def up(
         # whether the service is already running. If the id is the same
         # with the current job id, we know the service is up and running
         # for the first time; otherwise it is a name conflict.
-        idle_minutes_to_autostop = constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP
+        idle_minutes_to_autostop: Optional[int] = (
+            constants.CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP)
+        controller_record = global_user_state.get_cluster_from_name(
+            controller_name)
+        if controller_record is not None:
+            current_controller_resources: sky.Resources = (
+                controller_record['handle'].launched_resources)
+            if (current_controller_resources is not None and
+                    current_controller_resources.cloud.is_same_cloud(
+                        sky.Kubernetes())):
+                idle_minutes_to_autostop = None
         controller_job_id, controller_handle = sky.launch(
             task=controller_task,
             stream_logs=False,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

#3377 changes the autostop for skyserve controller to autodown, which will teardown the controller when the sky serve controller job exited unexpectedly and remove any related replica information/logs. This PR changes it back to autostop to preserve the info.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] Terminate sky serve controller, and spin up a new service on k8s controller, it successfully launched and without autostop. Using the following config yaml:
```yaml
jobs:
  controller:
    resources:
      cloud: kubernetes
      cpus: 4+
      memory: 4+
kubernetes:
  remote_identity: SERVICE_ACCOUNT
serve:
  controller:
    resources:
      cloud: kubernetes
      cpus: 4+
      memory: 4+

```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
