### PR TITLE
[Core] `source ~/.bashrc` when tailing SkyServe logs

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3749,6 +3749,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             process_stream=False,
             ssh_mode=command_runner.SshMode.INTERACTIVE,
             stdin=subprocess.DEVNULL,
+            source_bashrc=True,
         )
 
     def teardown_no_lock(self,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Similar to #3531, SkyServe logs experienced similar behaviour. This PR fixes it.

```bash
I 05-10 14:45:40 replica_managers.py:103] Replica cluster http-1 launched.
Start streaming logs for task job of replica 1...
I 05-10 14:46:00 cloud_vm_ray_backend.py:3660] Job ID not provided. Streaming the logs of the latest job.
kubectl port-forward failed. Error: E0510 14:46:00.754177    4721 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E0510 14:46:00.754784    4721 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E0510 14:46:00.756412    4721 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
E0510 14:46:00.756954    4721 memcache.go:265] couldn't get current server API group list: Get "http://localhost:8080/api?timeout=32s": dial tcp [::1]:8080: connect: connection refused
The connection to the server localhost:8080 was refused - did you specify the right host or port?
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
kex_exchange_identification: Connection closed by remote host
Connection closed by UNKNOWN port 65535
Failed to stream logs for replica 1.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
