### PR TITLE
[Serve] Return service name and endpoint from `sky.serve.up`

### DIFF
--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -94,7 +94,7 @@ def _validate_service_task(task: 'sky.Task') -> None:
 def up(
     task: 'sky.Task',
     service_name: Optional[str] = None,
-) -> None:
+) -> Tuple[str, str]:
     """Spin up a service.
 
     Please refer to the sky.cli.serve_up for the document.

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -104,7 +104,8 @@ def up(
         service_name: Name of the service.
 
     Returns:
-        A tuple with two values: the service name and the endpoint.
+        service_name: str; The name of the service.  Same if passed in as an argument.
+        endpoint: str; The service endpoint.
     """
     if service_name is None:
         service_name = serve_utils.generate_service_name()

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -1,7 +1,7 @@
-"""SkyServe core APIs."""
+"#""SkyServe core APIs."""
 import re
 import tempfile
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import colorama
 
@@ -292,6 +292,7 @@ def up(
             f'{style.RESET_ALL}'
             f'\n{fore.GREEN}The replicas should be ready within a '
             f'short time.{style.RESET_ALL}')
+        return service_name, endpoint
 
 
 @usage_lib.entrypoint

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -102,6 +102,9 @@ def up(
     Args:
         task: sky.Task to serve up.
         service_name: Name of the service.
+
+    Returns:
+        A tuple with two values: the service name and the endpoint.
     """
     if service_name is None:
         service_name = serve_utils.generate_service_name()

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -104,7 +104,8 @@ def up(
         service_name: Name of the service.
 
     Returns:
-        service_name: str; The name of the service.  Same if passed in as an argument.
+        service_name: str; The name of the service.  Same if passed in as an
+            argument.
         endpoint: str; The service endpoint.
     """
     if service_name is None:

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -1,4 +1,4 @@
-"#""SkyServe core APIs."""
+"""SkyServe core APIs."""
 import re
 import tempfile
 from typing import Any, Dict, List, Optional, Tuple, Union


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes  #3545

This returns the generated (or specified) service name and the generated endpoint.  This moves closer to supporting `sky.serve.core.up` as a library function.

<!-- Describe the tests ran -->
Manually ran the following:

```
import sky
from sky.serve.service_spec import SkyServiceSpec 

run_str = """
docker run  \
--runtime nvidia \
--gpus all \
--shm-size 1g \
-v ~/.cache/huggingface:/root/.cache/huggingface \
--env "HUGGING_FACE_HUB_TOKEN=${HUGGINGFACE_TOKEN}" \
--ipc=host \
-p 8000:8000 \
vllm/vllm-openai:latest \
--trust-remote-code \                                                                            
--tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
--max-model-len 18000 \
--chat-template '<s>[INST] You are a fair judge assistant tasked with providing clear, objective feedback based on specific criteria, ensuring each assessment reflects the absolute standards set for performance. </s>{% for message in messages %}{% if message["role"] == "user" %}{{ "[INST] " + message["content"] + " [/INST]" }}{% elif message["role"] == "assistant" %}{{ message["content"] + "</s> " }}{% endif %}{% endfor %}' \
--model prometheus-eval/prometheus-7b-v2.0
"""
task = sky.Task(
    envs={
        "HUGGINGFACE_TOKEN": "<token>",
    },
    run=run_str,
)

task.set_service(SkyServiceSpec(
    "/v1/models",
    1200,
    1,
))
resources = sky.Resources(
    cloud=sky.clouds.AWS(),
    ports="8080",
    region="us-west-2",
    accelerators="A10G:1",
    instance_type="g5.8xlarge",
)
task.set_resources(resources)
service_name, endpoint = sky.serve.core.up(task)
```
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
