### PR TITLE
[Serve] Scale down old terminal replicas

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -314,7 +314,19 @@ class RequestRateAutoscaler(Autoscaler):
             self,
             replica_infos: List['replica_managers.ReplicaInfo']) -> List[int]:
         """Select outdated replicas to scale down."""
+        all_replica_ids_to_scale_down = []
+        for info in replica_infos:
+            if info.version < self.latest_version and info.is_terminal:
+                all_replica_ids_to_scale_down.append(info.replica_id)
+        all_replica_ids_to_scale_down.extend(
+            self._select_outdated_nonterminal_replicas_to_scale_down(
+                replica_infos))
+        return all_replica_ids_to_scale_down
 
+    def _select_outdated_nonterminal_replicas_to_scale_down(
+            self,
+            replica_infos: List['replica_managers.ReplicaInfo']) -> List[int]:
+        """Select outdated nonterminal replicas to scale down."""
         if self.update_mode == serve_utils.UpdateMode.ROLLING:
             latest_ready_replicas = []
             old_nonterminal_replicas = []

--- a/tests/skyserve/failures/initial_delay.yaml
+++ b/tests/skyserve/failures/initial_delay.yaml
@@ -2,7 +2,7 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 10
-  replicas: 2
+  replicas: 1
 
 resources:
   cpus: 2

--- a/tests/skyserve/failures/initial_delay.yaml
+++ b/tests/skyserve/failures/initial_delay.yaml
@@ -2,7 +2,7 @@ service:
   readiness_probe:
     path: /health
     initial_delay_seconds: 10
-  replicas: 1
+  replicas: 2
 
 resources:
   cpus: 2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previous implementation will keep old terminated (i.e. failed) replicas forever. This PR changes the behaviour to scale down old terminal replicas as well when an update is initiated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```bash
$ sky serve up tests/skyserve/failures/initial_delay.yaml -n fail-2
$ sky serve status
Services
NAME    VERSION  UPTIME  STATUS      REPLICAS  ENDPOINT                                                                  
fail-2  -        -       NO_REPLICA  0/0       http://localhost:30072/skypilot/sky-serve-controller-402b1bba-402b/30001  

Service Replicas
SERVICE_NAME  ID  VERSION  ENDPOINT  LAUNCHED  RESOURCES  STATUS                REGION  
fail-2        1   1        -         -         -          FAILED_INITIAL_DELAY  -       
$ sky serve update fail-2 tests/skyserve/failures/initial_delay.yaml
$ sky serve status
Services
NAME    VERSION  UPTIME  STATUS      REPLICAS  ENDPOINT                                                                  
fail-2  -        -       NO_REPLICA  0/2       http://localhost:30072/skypilot/sky-serve-controller-402b1bba-402b/30001  

Service Replicas
SERVICE_NAME  ID  VERSION  ENDPOINT  LAUNCHED     RESOURCES              STATUS         REGION      
fail-2        1   1        -         -            -                      SHUTTING_DOWN  -           
fail-2        2   2        -         30 secs ago  1x Kubernetes(vCPU=2)  STARTING       Kubernetes 
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
