### PR TITLE
[Serve] Support headers in Readiness Probe

### DIFF
--- a/llm/vllm/service-with-auth.yaml
+++ b/llm/vllm/service-with-auth.yaml
@@ -13,8 +13,8 @@ service:
 # Fields below are the same with `serve-openai-api.yaml`.
 envs:
   MODEL_NAME: meta-llama/Llama-2-7b-chat-hf
-  HF_TOKEN: <your-huggingface-token> # Change to your own huggingface token
-  AUTH_TOKEN: sky-authkey-3d2105b9-a9ba-4f13 # Change to your own auth token
+  HF_TOKEN: # TODO: Fill with your own huggingface token, or use --env to pass.
+  AUTH_TOKEN: # TODO: Fill with your own auth token (a random string), or use --env to pass.
 
 resources:
   accelerators: {L4:1, A10G:1, A10:1, A100:1, A100-80GB:1}

--- a/llm/vllm/service-with-auth.yaml
+++ b/llm/vllm/service-with-auth.yaml
@@ -1,0 +1,42 @@
+# service.yaml
+# The newly-added `service` section to the `serve-openai-api.yaml` file.
+service:
+  # Specifying the path to the endpoint to check the readiness of the service.
+  readiness_probe:
+    path: /v1/models
+    # Set authorization headers here if needed.
+    headers:
+      Authorization: Bearer $AUTH_TOKEN
+  # How many replicas to manage.
+  replicas: 1
+
+# Fields below are the same with `serve-openai-api.yaml`.
+envs:
+  MODEL_NAME: meta-llama/Llama-2-7b-chat-hf
+  HF_TOKEN: <your-huggingface-token> # Change to your own huggingface token
+  AUTH_TOKEN: sky-authkey-3d2105b9-a9ba-4f13 # Change to your own auth token
+
+resources:
+  accelerators: {L4:1, A10G:1, A10:1, A100:1, A100-80GB:1}
+  ports: 8000
+
+setup: |
+  conda activate vllm
+  if [ $? -ne 0 ]; then
+    conda create -n vllm python=3.10 -y
+    conda activate vllm
+  fi
+
+  pip install transformers==4.38.0
+  pip install vllm==0.3.2
+
+  python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
+
+
+run: |
+  conda activate vllm
+  echo 'Starting vllm openai api server...'
+  python -m vllm.entrypoints.openai.api_server \
+    --model $MODEL_NAME --tokenizer hf-internal-testing/llama-tokenizer \
+    --host 0.0.0.0 --port 8000 --api-key $AUTH_TOKEN
+

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -568,10 +568,13 @@ class ReplicaManager:
         self._service_name: str = service_name
         self._uptime: Optional[float] = None
         self._update_mode = serve_utils.DEFAULT_UPDATE_MODE
+        header_keys = None
+        if spec.readiness_headers is not None:
+            header_keys = list(spec.readiness_headers.keys())
         logger.info(f'Readiness probe path: {spec.readiness_path}\n'
                     f'Initial delay seconds: {spec.initial_delay_seconds}\n'
                     f'Post data: {spec.post_data}\n'
-                    f'Readiness headers: {spec.readiness_headers}')
+                    f'Readiness header keys: {header_keys}')
 
         # Newest version among the currently provisioned and launched replicas
         self.latest_version: int = serve_constants.INITIAL_VERSION

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -229,10 +229,8 @@ class SkyServiceSpec:
             method = f'GET {self.readiness_path}'
         else:
             method = f'POST {self.readiness_path} {json.dumps(self.post_data)}'
-        if self.readiness_headers is None:
-            headers = ''
-        else:
-            headers = f' with headers {json.dumps(self.readiness_headers)}'
+        headers = ('' if self.readiness_headers is None else
+                   ' with custom headers')
         return f'{method}{headers}'
 
     def spot_policy_str(self):

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -23,6 +23,7 @@ class SkyServiceSpec:
         max_replicas: Optional[int] = None,
         target_qps_per_replica: Optional[float] = None,
         post_data: Optional[Dict[str, Any]] = None,
+        readiness_headers: Optional[Dict[str, str]] = None,
         dynamic_ondemand_fallback: Optional[bool] = None,
         base_ondemand_fallback_replicas: Optional[int] = None,
         upscale_delay_seconds: Optional[int] = None,
@@ -81,6 +82,7 @@ class SkyServiceSpec:
         self._max_replicas: Optional[int] = max_replicas
         self._target_qps_per_replica: Optional[float] = target_qps_per_replica
         self._post_data: Optional[Dict[str, Any]] = post_data
+        self._readiness_headers: Optional[Dict[str, str]] = readiness_headers
         self._dynamic_ondemand_fallback: Optional[
             bool] = dynamic_ondemand_fallback
         self._base_ondemand_fallback_replicas: Optional[
@@ -111,11 +113,13 @@ class SkyServiceSpec:
             service_config['readiness_path'] = readiness_section
             initial_delay_seconds = None
             post_data = None
+            readiness_headers = None
         else:
             service_config['readiness_path'] = readiness_section['path']
             initial_delay_seconds = readiness_section.get(
                 'initial_delay_seconds', None)
             post_data = readiness_section.get('post_data', None)
+            readiness_headers = readiness_section.get('headers', None)
         if initial_delay_seconds is None:
             initial_delay_seconds = constants.DEFAULT_INITIAL_DELAY_SECONDS
         service_config['initial_delay_seconds'] = initial_delay_seconds
@@ -129,6 +133,7 @@ class SkyServiceSpec:
                         '`readiness_probe` section of your service YAML.'
                     ) from e
         service_config['post_data'] = post_data
+        service_config['readiness_headers'] = readiness_headers
 
         policy_section = config.get('replica_policy', None)
         simplified_policy_section = config.get('replicas', None)
@@ -204,6 +209,7 @@ class SkyServiceSpec:
         add_if_not_none('readiness_probe', 'initial_delay_seconds',
                         self.initial_delay_seconds)
         add_if_not_none('readiness_probe', 'post_data', self.post_data)
+        add_if_not_none('readiness_probe', 'headers', self._readiness_headers)
         add_if_not_none('replica_policy', 'min_replicas', self.min_replicas)
         add_if_not_none('replica_policy', 'max_replicas', self.max_replicas)
         add_if_not_none('replica_policy', 'target_qps_per_replica',
@@ -220,8 +226,14 @@ class SkyServiceSpec:
 
     def probe_str(self):
         if self.post_data is None:
-            return f'GET {self.readiness_path}'
-        return f'POST {self.readiness_path} {json.dumps(self.post_data)}'
+            method = f'GET {self.readiness_path}'
+        else:
+            method = f'POST {self.readiness_path} {json.dumps(self.post_data)}'
+        if self.readiness_headers is None:
+            headers = ''
+        else:
+            headers = f' with headers {json.dumps(self.readiness_headers)}'
+        return f'{method}{headers}'
 
     def spot_policy_str(self):
         policy_strs = []
@@ -286,6 +298,10 @@ class SkyServiceSpec:
     @property
     def post_data(self) -> Optional[Dict[str, Any]]:
         return self._post_data
+
+    @property
+    def readiness_headers(self) -> Optional[Dict[str, str]]:
+        return self._readiness_headers
 
     @property
     def base_ondemand_fallback_replicas(self) -> Optional[int]:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -303,7 +303,13 @@ def get_service_schema():
                             }, {
                                 'type': 'object',
                             }]
-                        }
+                        },
+                        'headers': {
+                            'type': 'object',
+                            'additionalProperties': {
+                                'type': 'string'
+                            }
+                        },
                     }
                 }]
             },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Closes #3549 by adding headers configuration in readiness probe.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `llm/vllm/service-with-auth.yaml`
```bash
$ sky serve up llm/vllm/service-with-auth.yaml --gpus L4
Service from YAML spec: llm/vllm/service-with-auth.yaml
Service Spec:
Readiness probe method:           GET /v1/models with headers {"Authorization": "Bearer sky-authkey-3d2105b9-a9ba-4f13"}
Readiness initial delay seconds:  1200
Replica autoscaling policy:       Fixed 1 replica
Spot Policy:                      No spot policy
$ curl $(sky serve status --endpoint sky-service-4233)/v1/models -H 'Authorization: Bearer sky-authkey-3d2105b9-a9ba-4f13' 
{"object":"list","data":[{"id":"meta-llama/Llama-2-7b-chat-hf","object":"model","created":1715746959,"owned_by":"vllm","root":"meta-llama/Llama-2-7b-chat-hf","parent":null,"permission":[{"id":"modelperm-5cf910e014484663a648f66e38b08174","object":"model_permission","created":1715746959,"allow_create_engine":false,"allow_sampling":true,"allow_logprobs":true,"allow_search_indices":false,"allow_view":true,"allow_fine_tuning":false,"organization":"*","group":null,"is_blocking":false}]}]}
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
