### PR TITLE
[Serve] Authorization on load balancer

### DIFF
--- a/examples/serve/auth-server.yaml
+++ b/examples/serve/auth-server.yaml
@@ -1,0 +1,10 @@
+service:
+  readiness_probe: /
+  auth_key: sky-authkey-3d2105b9-a9ba-4f13
+  replicas: 1
+
+resources:
+  cpus: 2+
+  ports: 8080
+
+run: python -m http.server 8080

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -203,7 +203,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
                 target=ux_utils.RedirectOutputForProcess(
                     load_balancer.run_load_balancer,
                     load_balancer_log_file).run,
-                args=(controller_addr, load_balancer_port))
+                args=(controller_addr, load_balancer_port,
+                      service_spec.auth_key))
             load_balancer_process.start()
             serve_state.set_service_load_balancer_port(service_name,
                                                        load_balancer_port)

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -678,3 +678,8 @@ def deprecated_function(
         return func(*args, **kwargs)
 
     return new_func
+
+
+def format_authorization_key(key: str) -> str:
+    """Format the authorization key used by the load balancer."""
+    return f'Bearer {key}'

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -355,6 +355,9 @@ def get_service_schema():
             'replicas': {
                 'type': 'integer',
             },
+            'auth_key': {
+                'type': 'string',
+            },
         }
     }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adding an authorization on load balancer.

To discuss: Can this be used in the same time of #3552 ? If so, does that means the api-key on the LB and the replica should algin?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```bash
$ sky serve up examples/serve/auth-server.yaml -n auth
Service from YAML spec: examples/serve/auth-server.yaml
Service Spec:
Readiness probe method:           GET /
Readiness initial delay seconds:  1200
Replica autoscaling policy:       Fixed 1 replica
Spot Policy:                      No spot policy
Authorization:                    Bearer sky-authkey-3d2105b9-a9ba-4f13
$ curl $(sky serve status --endpoint auth) -H 'Authorization: Bearer sky-authkey-3d2105b9-a9ba-4f13'
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
<title>Directory listing for /?</title>
</head>
<body>
<h1>Directory listing for /?</h1>
<hr>
<ul>
</ul>
<hr>
</body>
</html>
$ curl $(sky serve status --endpoint auth) -H 'Authorization: Bearer wrong-token' 
{"error":"Unauthorized"}
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
