### PR TITLE
[core] Add `allowed_clouds` to config to check only specific clouds

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -27,6 +27,19 @@ Available fields and semantics:
         cpus: 4+  # number of vCPUs, max concurrent spot jobs = 2 * cpus
         disk_size: 100
 
+  # Allow list for clouds to be used in `sky check`
+  #
+  # This field is used to restrict the clouds that SkyPilot will check and use
+  # when running `sky check`. Any cloud already enabled but not specified here
+  # will be disabled on the next `sky check` run.
+  # If this field is not set, SkyPilot will check and use all supported clouds.
+  #
+  # Default: null (use all supported clouds).
+  allowed_clouds:
+    - aws
+    - gcp
+    - kubernetes
+
   # Advanced AWS configurations (optional).
   # Apply to all new instances but not existing ones.
   aws:

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -23,6 +23,7 @@ R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 NAME = 'Cloudflare'
+SKY_CHECK_NAME = 'Cloudflare (for R2 object store)'
 
 
 @contextlib.contextmanager

--- a/sky/check.py
+++ b/sky/check.py
@@ -65,8 +65,8 @@ def check(
             return repr(cloud_obj), cloud_obj
 
     def get_all_clouds():
-        return tuple([repr(c) for c in sky_clouds.CLOUD_REGISTRY.values()]
-                     + [cloudflare.SKY_CHECK_NAME])
+        return tuple([repr(c) for c in sky_clouds.CLOUD_REGISTRY.values()] +
+                     [cloudflare.SKY_CHECK_NAME])
 
     if clouds is not None:
         cloud_list = clouds
@@ -85,14 +85,10 @@ def check(
     disallowed_cloud_names = [
         c for c in get_all_clouds() if c not in config_allowed_cloud_names
     ]
-    print(f'config_allowed_cloud_names: {config_allowed_cloud_names}'
-          f'\nclouds_to_check: {clouds_to_check}'
-          f'\ndisallowed_cloud_names: {disallowed_cloud_names}')
     # Check only the clouds which are allowed in the config.
     clouds_to_check = [
         c for c in clouds_to_check if c[0] in config_allowed_cloud_names
     ]
-    print(f'clouds_to_check: {clouds_to_check}')
 
     for cloud_tuple in sorted(clouds_to_check):
         check_one_cloud(cloud_tuple)

--- a/sky/check.py
+++ b/sky/check.py
@@ -75,17 +75,17 @@ def check(
 
     # Use allowed_clouds from config if it exists, otherwise check all clouds.
     # Also validate names with get_cloud_tuple.
-    config_allowed_clouds = [
+    config_allowed_cloud_names = [
         get_cloud_tuple(c)[0] for c in skypilot_config.get_nested(
             ['allowed_clouds'], get_all_clouds())
     ]
     # Use skipped_clouds for logging the skipped clouds.
     skipped_clouds = [
-        c for c in clouds_to_check if c[0] not in config_allowed_clouds
+        c for c in clouds_to_check if c[0] not in config_allowed_cloud_names
     ]
     # Check only the clouds which are allowed in the config.
     clouds_to_check = [
-        c for c in clouds_to_check if c[0] in config_allowed_clouds
+        c for c in clouds_to_check if c[0] in config_allowed_cloud_names
     ]
 
     for cloud_tuple in sorted(clouds_to_check):
@@ -101,7 +101,7 @@ def check(
         cloud for cloud in disabled_clouds if not cloud.startswith('Cloudflare')
     }
     config_allowed_clouds_set = {
-        cloud for cloud in config_allowed_clouds
+        cloud for cloud in config_allowed_cloud_names
         if not cloud.startswith('Cloudflare')
     }
     previously_enabled_clouds_set = {
@@ -121,7 +121,7 @@ def check(
     skipped_clouds_hint = None
     if skipped_clouds:
         skipped_clouds_hint = (
-            '\nNote: The following clouds were skipped because they were not '
+            '\nNote: The following clouds were disabled because they were not '
             'included in allowed_clouds in ~/.sky/config.yaml: '
             f'{", ".join([c[0] for c in skipped_clouds])}')
     if len(all_enabled_clouds) == 0:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -722,8 +722,8 @@ def get_config_schema():
         },
     }
 
-    candidate_clouds = {
-        # A list of cloud names that should be used for execution
+    allowed_clouds = {
+        # A list of cloud names that are allowed to be used
         'type': 'array',
         'items': {
             'type': 'string',
@@ -746,7 +746,7 @@ def get_config_schema():
             'jobs': controller_resources_schema,
             'spot': controller_resources_schema,
             'serve': controller_resources_schema,
-            'candidate_clouds': candidate_clouds,
+            'allowed_clouds': allowed_clouds,
             **cloud_configs,
         },
         # Avoid spot and jobs being present at the same time.

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -588,6 +588,7 @@ _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
 def get_config_schema():
     # pylint: disable=import-outside-toplevel
     from sky.utils import kubernetes_enums
+    from sky.clouds import service_catalog
 
     resources_schema = {
         k: v
@@ -727,6 +728,8 @@ def get_config_schema():
         'type': 'array',
         'items': {
             'type': 'string',
+            'case_insensitive_enum': (list(service_catalog.ALL_CLOUDS) +
+                                      ['cloudflare'])
         }
     }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -722,6 +722,14 @@ def get_config_schema():
         },
     }
 
+    candidate_clouds = {
+        # A list of cloud names that should be used for execution
+        'type': 'array',
+        'items': {
+            'type': 'string',
+        }
+    }
+
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update(_REMOTE_IDENTITY_SCHEMA_AWS)
@@ -738,6 +746,7 @@ def get_config_schema():
             'jobs': controller_resources_schema,
             'spot': controller_resources_schema,
             'serve': controller_resources_schema,
+            'candidate_clouds': candidate_clouds,
             **cloud_configs,
         },
         # Avoid spot and jobs being present at the same time.

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -587,8 +587,8 @@ _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
 
 def get_config_schema():
     # pylint: disable=import-outside-toplevel
-    from sky.utils import kubernetes_enums
     from sky.clouds import service_catalog
+    from sky.utils import kubernetes_enums
 
     resources_schema = {
         k: v
@@ -728,8 +728,8 @@ def get_config_schema():
         'type': 'array',
         'items': {
             'type': 'string',
-            'case_insensitive_enum': (list(service_catalog.ALL_CLOUDS) +
-                                      ['cloudflare'])
+            'case_insensitive_enum':
+                (list(service_catalog.ALL_CLOUDS) + ['cloudflare'])
         }
     }
 


### PR DESCRIPTION
Adds a `allowed_clouds` field to config.yaml which limits the clouds that will be checked/enabled by `sky check`.
```
allowed_clouds:
  - kubernetes
  - aws
  - gcp
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual tests:
  - [x] With `allowed_clouds` not specified - `sky check`.
  - [x] With `allowed_clouds: [aws, cloudflare]` - `sky check`, `sky check aws`, `sky check gcp`. Note is shown when checking `sky check` and `sky check gcp`.
  - [x] With `allowed_clouds: [aws, gcp]` with other clouds enabled already  - `sky check`. Other clouds will be disabled.