### PR TITLE
[Docs] Clarify managed spot jobs against sky launch

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -24,7 +24,8 @@ In this mode, :code:`sky jobs launch --use-spot` is used to launch a managed spo
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
 
-Quick comparison between _unmanaged spot clusters_ vs. _managed spot jobs_:
+Quick comparison between *unmanaged spot clusters* vs. *managed spot jobs*:
+
 .. list-table::
    :widths: 30 18 12 35
    :header-rows: 1
@@ -36,7 +37,7 @@ Quick comparison between _unmanaged spot clusters_ vs. _managed spot jobs_:
    * - :code:`sky launch --use-spot`
      - Unmanaged spot cluster
      - Yes
-     - Interactive dev on spot instances (best for hardware with low preemption rates)
+     - Interactive dev on spot instances (especially for hardware with low preemption rates)
    * - :code:`sky jobs launch --use-spot`
      - Managed spot job (auto-recovery)
      - No

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -36,7 +36,7 @@ Quick comparison between _unmanaged spot clusters_ vs. _managed spot jobs_:
    * - :code:`sky launch --use-spot`
      - Unmanaged spot cluster
      - Yes
-     - Interactive dev on spot instances (e.g., :ref:`SSH, VSCode, Jupyter <dev-connect>`).
+     - Interactive dev on spot instances (best for hardware with low preemption rates)
    * - :code:`sky jobs launch --use-spot`
      - Managed spot job (auto-recovery)
      - No

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -20,7 +20,7 @@ It can be used in three modes:
 Managed Spot Jobs
 -----------------
 
-*SkyPilot managed spot job* (:code:`sky jobs launch --use-spot`) automatically finds available spot resources across regions and clouds to maximize availability.
+In this mode, :code:`sky jobs launch --use-spot` is used to launch a managed spot job. SkyPilot automatically finds available spot resources across regions and clouds to maximize availability.
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
 

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -23,6 +23,12 @@ Managed Spot Jobs
 SkyPilot automatically finds available spot resources across regions and clouds to maximize availability.
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
+.. tip::
+
+  :code:`sky launch --use-spot` is a "serverful" command that launches a cluster for
+  running jobs, where recoveries of the cluster after preemptions is user's responsibility. In contrast, managed spot jobs, :code:`sky jobs launch --use-spot`, is a "serverless" command, where SkyPilot is in charge of the whole
+  lifecycle of each job, including provisioning clusters, monitoring job status, and recovering the job from preemptions. 
+
 Here is an example of a BERT training job failing over different regions across AWS and GCP.
 
 .. image:: https://i.imgur.com/Vteg3fK.gif

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -20,13 +20,12 @@ It can be used in three modes:
 Managed Spot Jobs
 -----------------
 
-SkyPilot managed spot jobs automatically finds available spot resources across regions and clouds to maximize availability.
+*SkyPilot managed spot job* (:code:`sky jobs launch --use-spot`) automatically finds available spot resources across regions and clouds to maximize availability.
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
-Difference between **managed spot jobs** and **unmanaged spot cluster** (:code:`sky jobs launch --use-spot` vs :code:`sky launch --use-spot`):
 
 .. list-table::
-   :widths: 30 15 12 37
+   :widths: 30 18 12 35
    :header-rows: 1
 
    * - Command
@@ -34,13 +33,13 @@ Difference between **managed spot jobs** and **unmanaged spot cluster** (:code:`
      - SSH-able?
      - Best for
    * - :code:`sky launch --use-spot`
-     - No
+     - Unmanaged spot cluster
      - Yes
      - Interactive dev on spot instances (e.g., :ref:`SSH, VSCode, Jupyter <dev-connect>`).
    * - :code:`sky jobs launch --use-spot`
-     - Yes (monitoring and recovery)
+     - Managed spot job (auto-recovery)
      - No
-     - Scaling out long-running jobs (e.g., training, batch inference, data processing).
+     - Scaling out long-running jobs (e.g., data processing, training, batch inference).
 
 Here is an example of a BERT training job failing over different regions across AWS and GCP.
 

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -40,7 +40,7 @@ Quick comparison between _unmanaged spot clusters_ vs. _managed spot jobs_:
    * - :code:`sky jobs launch --use-spot`
      - Managed spot job (auto-recovery)
      - No
-     - Scaling out long-running jobs (e.g., data processing, training, batch inference).
+     - Scaling out long-running jobs (e.g., data processing, training, batch inference)
 
 Here is an example of a BERT training job failing over different regions across AWS and GCP.
 

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -24,6 +24,7 @@ Managed Spot Jobs
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
 
+Quick comparison between _unmanaged spot clusters_ vs. _managed spot jobs_:
 .. list-table::
    :widths: 30 18 12 35
    :header-rows: 1

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -7,7 +7,7 @@ Managed Jobs
 
   This feature is great for scaling out: running a single job for long durations, or running many jobs (pipelines).
 
-SkyPilot supports **managed jobs**, which can automatically recover from any spot preemptions or hardware failures.
+SkyPilot supports **managed jobs** (:code:`sky jobs`), which can automatically recover from any spot preemptions or hardware failures.
 It can be used in three modes:
 
 #. :ref:`Managed Spot Jobs <spot-jobs>`: Jobs run on auto-recovering spot instances. This can **save significant costs** (e.g., up to 70\% for GPU VMs) by making preemptible spot instances useful for long-running jobs.
@@ -20,14 +20,27 @@ It can be used in three modes:
 Managed Spot Jobs
 -----------------
 
-SkyPilot automatically finds available spot resources across regions and clouds to maximize availability.
+SkyPilot managed spot jobs automatically finds available spot resources across regions and clouds to maximize availability.
 Any spot preemptions are automatically handled by SkyPilot without user intervention.
 
-.. tip::
+Difference between **managed spot jobs** and **unmanaged spot cluster** (:code:`sky jobs launch --use-spot` vs :code:`sky launch --use-spot`):
 
-  :code:`sky launch --use-spot` is a "serverful" command that launches a cluster for
-  running jobs, where recoveries of the cluster after preemptions is user's responsibility. In contrast, managed spot jobs, :code:`sky jobs launch --use-spot`, is a "serverless" command, where SkyPilot is in charge of the whole
-  lifecycle of each job, including provisioning clusters, monitoring job status, and recovering the job from preemptions. 
+.. list-table::
+   :widths: 30 15 12 37
+   :header-rows: 1
+
+   * - Command
+     - Managed?
+     - SSH-able?
+     - Best for
+   * - :code:`sky launch --use-spot`
+     - No
+     - Yes
+     - Interactive dev on spot instances (e.g., :ref:`SSH, VSCode, Jupyter <dev-connect>`).
+   * - :code:`sky jobs launch --use-spot`
+     - Yes (monitoring and recovery)
+     - No
+     - Scaling out long-running jobs (e.g., training, batch inference, data processing).
 
 Here is an example of a BERT training job failing over different regions across AWS and GCP.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We add a hint box for managed spot jobs comparing to `sky launch --use-spot` in docs.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
