### PR TITLE
[k8s] Check only kubernetes after `sky local up`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4995,7 +4995,7 @@ def local_up(gpus: bool):
                 f'\nError: {style.BRIGHT}{stderr}{style.RESET_ALL}')
     # Run sky check
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
-        sky_check.check(quiet=True)
+        sky_check.check(clouds=['kubernetes'], quiet=True)
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4995,7 +4995,7 @@ def local_up(gpus: bool):
                 f'\nError: {style.BRIGHT}{stderr}{style.RESET_ALL}')
     # Run sky check
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
-        sky_check.check(clouds=['kubernetes'], quiet=True)
+        sky_check.check(clouds=('kubernetes',), quiet=True)
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs


### PR DESCRIPTION
Simple optimization to check only kubernetes after running `sky local up`. Enabled by our recent improvements to `sky check`.

Reduces `sky local up` time by ~13 seconds.