### PR TITLE
[Core] Fix quote in command runner

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3175,7 +3175,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 f'{create_script_code} && {setup_cmd}',
                 log_path=setup_log_path,
                 process_stream=False,
-                source_bashrc=True,
+                # We do not source bashrc for setup, since bashrc is sourced
+                # in the script already.
             )
 
             def error_message() -> str:
@@ -3724,7 +3725,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             process_stream=False,
             ssh_mode=command_runner.SshMode.INTERACTIVE,
             stdin=subprocess.DEVNULL,
-            source_bashrc=True,
         )
 
     def tail_serve_logs(self, handle: CloudVmRayResourceHandle,
@@ -3762,7 +3762,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             process_stream=False,
             ssh_mode=command_runner.SshMode.INTERACTIVE,
             stdin=subprocess.DEVNULL,
-            source_bashrc=True,
         )
 
     def teardown_no_lock(self,

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -197,10 +197,10 @@ def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                 cmd,
                 stream_logs=False,
                 log_path=log_path,
-                require_outputs=True
-                # No need to source bashrc, as it should be sourced in the setup
-                # commands already.
-            )
+                require_outputs=True,
+                # Installing dependencies requires source bashrc to access
+                # conda.
+                source_bashrc=True)
             retry_cnt = 0
             while returncode == 255 and retry_cnt < _MAX_RETRY:
                 # Got network connection issue occur during setup. This could
@@ -214,7 +214,8 @@ def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                 returncode, stdout, stderr = runner.run(cmd,
                                                         stream_logs=False,
                                                         log_path=log_path,
-                                                        require_outputs=True)
+                                                        require_outputs=True,
+                                                        source_bashrc=True)
                 if not returncode:
                     break
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -197,10 +197,10 @@ def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                 cmd,
                 stream_logs=False,
                 log_path=log_path,
-                require_outputs=True,
-                # Installing depencies requires source bashrc to access the PATH
-                # in bashrc.
-                source_bashrc=True)
+                require_outputs=True
+                # No need to source bashrc, as it should be sourced in the setup
+                # commands already.
+                )
             retry_cnt = 0
             while returncode == 255 and retry_cnt < _MAX_RETRY:
                 # Got network connection issue occur during setup. This could
@@ -214,8 +214,7 @@ def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                 returncode, stdout, stderr = runner.run(cmd,
                                                         stream_logs=False,
                                                         log_path=log_path,
-                                                        require_outputs=True,
-                                                        source_bashrc=True)
+                                                        require_outputs=True)
                 if not returncode:
                     break
 

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -200,7 +200,7 @@ def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                 require_outputs=True
                 # No need to source bashrc, as it should be sourced in the setup
                 # commands already.
-                )
+            )
             retry_cnt = 0
             while returncode == 255 and retry_cnt < _MAX_RETRY:
                 # Got network connection issue occur during setup. This could

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -91,15 +91,18 @@ DOCKER_LOGIN_ENV_VARS = {
 # AWS's Deep Learning AMI's default conda environment.
 CONDA_INSTALLATION_COMMANDS = (
     'which conda > /dev/null 2>&1 || '
-    '(wget -nc https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -O Miniconda3-Linux-x86_64.sh && '  # pylint: disable=line-too-long
+    '{ wget -nc https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -O Miniconda3-Linux-x86_64.sh && '  # pylint: disable=line-too-long
     'bash Miniconda3-Linux-x86_64.sh -b && '
     'eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && '
-    'conda config --set auto_activate_base true); '
-    'grep "# >>> conda initialize >>>" ~/.bashrc || conda init;'
+    'conda config --set auto_activate_base true && '
+    # Use $(echo ~) instead of ~ to avoid the error "no such file or directory".
+    # Also, not using $HOME to avoid the error HOME variable not set.
+    f'echo "$(echo ~)/miniconda3/bin/python" > {SKY_PYTHON_PATH_FILE}; }}; '
+    'grep "# >>> conda initialize >>>" ~/.bashrc || '
+    '{ conda init && source ~/.bashrc; };'
     '(type -a python | grep -q python3) || '
     'echo \'alias python=python3\' >> ~/.bashrc;'
     '(type -a pip | grep -q pip3) || echo \'alias pip=pip3\' >> ~/.bashrc;'
-    'source ~/.bashrc;'
     # Writes Python path to file if it does not exist or the file is empty.
     f'[ -s {SKY_PYTHON_PATH_FILE} ] || which python3 > {SKY_PYTHON_PATH_FILE};')
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -184,9 +184,8 @@ class CommandRunner:
             # cluster by 1 second.
             # sourcing ~/.bashrc is not required for internal executions
             command += [
-                shlex.quote(
-                    'true && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore'
-                    f' && ({cmd})')
+                shlex.quote('true && export OMP_NUM_THREADS=1 '
+                            f'PYTHONWARNINGS=ignore && ({cmd})')
             ]
         if not separate_stderr:
             command.append('2>&1')
@@ -433,8 +432,7 @@ class SSHCommandRunner(CommandRunner):
             process_stream,
             separate_stderr,
             # A hack to remove the following SSH warning+bash warnings (twice):
-            # Warning: Permanently added 'xx.xx.xx.xx' to the list of known
-            # hosts.
+            #  Warning: Permanently added 'xx.xx.xx.xx' to the list of known...
             #  bash: cannot set terminal process group
             #  bash: no job control in this shell
             # When not source_bashrc, the bash warning will only show once.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -184,8 +184,9 @@ class CommandRunner:
             # cluster by 1 second.
             # sourcing ~/.bashrc is not required for internal executions
             command += [
-                'true && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore'
-                f' && ({cmd})'
+                shlex.quote(
+                    'true && export OMP_NUM_THREADS=1 PYTHONWARNINGS=ignore'
+                    f' && ({cmd})')
             ]
         if not separate_stderr:
             command.append('2>&1')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -433,7 +433,8 @@ class SSHCommandRunner(CommandRunner):
             process_stream,
             separate_stderr,
             # A hack to remove the following SSH warning+bash warnings (twice):
-            # Warning: Permanently added 'xx.xx.xx.xx' to the list of known hosts.
+            # Warning: Permanently added 'xx.xx.xx.xx' to the list of known
+            # hosts.
             #  bash: cannot set terminal process group
             #  bash: no job control in this shell
             # When not source_bashrc, the bash warning will only show once.

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -432,10 +432,12 @@ class SSHCommandRunner(CommandRunner):
             cmd,
             process_stream,
             separate_stderr,
-            # A hack to remove the following bash warnings (twice):
+            # A hack to remove the following SSH warning+bash warnings (twice):
+            # Warning: Permanently added 'xx.xx.xx.xx' to the list of known hosts.
             #  bash: cannot set terminal process group
             #  bash: no job control in this shell
-            skip_lines=5 if source_bashrc else 0,
+            # When not source_bashrc, the bash warning will only show once.
+            skip_lines=5 if source_bashrc else 3,
             source_bashrc=source_bashrc)
         command = base_ssh_command + [shlex.quote(command_str)]
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We did not quote the command to be executed by SSH correctly when the command_runner runs a command with `source_bashrc=False`.
This should also fix #3531 without adding `source_bashrc=True` for the jobs and serve logs in #3536 and #3537

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] #3531
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws`
- [x] All smoke tests: `pytest tests/test_smoke.py --kubernetes` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
