### PR TITLE
[k8s] Remove SSH jump pod for port-forward mode

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -448,7 +448,8 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         kubernetes_utils.setup_ssh_jump_svc(ssh_jump_name, namespace,
                                             service_type)
         ssh_proxy_cmd = kubernetes_utils.get_ssh_proxy_command(
-            ssh_jump_name, nodeport_mode,
+            ssh_jump_name,
+            nodeport_mode,
             private_key_path=PRIVATE_SSH_KEY_PATH,
             namespace=namespace)
     elif network_mode == port_forward_mode:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -47,6 +47,7 @@ from sky.provision import common as provision_common
 from sky.provision import instance_setup
 from sky.provision import metadata_utils
 from sky.provision import provisioner
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import autostop_lib
 from sky.skylet import constants
 from sky.skylet import job_lib
@@ -4120,6 +4121,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                                      handle.head_ip,
                                                      auth_config,
                                                      handle.docker_user)
+
+        # If cloud was kubernetes, remove the ProxyCommand script used for
+        # port-forwarding.
+        if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
+            kubernetes_utils.remove_proxy_command_script(handle.cluster_name_on_cloud + '-head')
+
 
         global_user_state.remove_cluster(handle.cluster_name,
                                          terminate=terminate)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4125,8 +4125,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # If cloud was kubernetes, remove the ProxyCommand script used for
         # port-forwarding.
         if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
-            kubernetes_utils.remove_proxy_command_script(handle.cluster_name_on_cloud + '-head')
-
+            kubernetes_utils.remove_proxy_command_script(
+                handle.cluster_name_on_cloud + '-head')
 
         global_user_state.remove_cluster(handle.cluster_name,
                                          terminate=terminate)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -38,9 +38,6 @@ class Kubernetes(clouds.Cloud):
 
     SKY_SSH_KEY_SECRET_NAME = 'sky-ssh-keys'
     SKY_SSH_JUMP_NAME = 'sky-ssh-jump-pod'
-    PORT_FORWARD_PROXY_CMD_TEMPLATE = \
-        'kubernetes-port-forward-proxy-command.sh.j2'
-    PORT_FORWARD_PROXY_CMD_PATH = '~/.sky/port-forward-proxy-cmd.sh'
     # Timeout for resource provisioning. This timeout determines how long to
     # wait for pod to be in pending status before giving up.
     # Larger timeout may be required for autoscaling clusters, since autoscaler
@@ -304,6 +301,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_namespace':
                 kubernetes_utils.get_current_kube_config_context_namespace(),
             'k8s_port_mode': port_mode.value,
+            'k8s_networking_mode': network_utils.get_networking_mode().value,
             'k8s_ssh_key_secret_name': self.SKY_SSH_KEY_SECRET_NAME,
             'k8s_acc_label_key': k8s_acc_label_key,
             'k8s_acc_label_value': k8s_acc_label_value,

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -9,8 +9,8 @@ import yaml
 
 from sky.adaptors import kubernetes
 from sky.provision import common
-from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import network_utils
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import kubernetes_enums
 
 logger = logging.getLogger(__name__)
@@ -27,7 +27,8 @@ def bootstrap_instances(
 
     _configure_services(namespace, config.provider_config)
 
-    networking_mode = network_utils.get_networking_mode(config.provider_config.get('networking_mode'))
+    networking_mode = network_utils.get_networking_mode(
+        config.provider_config.get('networking_mode'))
     if networking_mode == kubernetes_enums.KubernetesNetworkingMode.NODEPORT:
         config = _configure_ssh_jump(namespace, config)
 

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -10,6 +10,8 @@ import yaml
 from sky.adaptors import kubernetes
 from sky.provision import common
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.provision.kubernetes import network_utils
+from sky.utils import kubernetes_enums
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +27,9 @@ def bootstrap_instances(
 
     _configure_services(namespace, config.provider_config)
 
-    config = _configure_ssh_jump(namespace, config)
+    networking_mode = network_utils.get_networking_mode(config.provider_config.get('networking_mode'))
+    if networking_mode == kubernetes_enums.KubernetesNetworkingMode.NODEPORT:
+        config = _configure_ssh_jump(namespace, config)
 
     requested_service_account = config.node_config['spec']['serviceAccountName']
     if (requested_service_account ==

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -12,6 +12,7 @@ from sky.adaptors import kubernetes
 from sky.provision import common
 from sky.provision.kubernetes import config as config_lib
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.provision.kubernetes import network_utils
 from sky.utils import common_utils
 from sky.utils import kubernetes_enums
 from sky.utils import ux_utils
@@ -520,14 +521,18 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
         if head_pod_name is None:
             head_pod_name = pod.metadata.name
 
-    # Adding the jump pod to the new_nodes list as well so it can be
-    # checked if it's scheduled and running along with other pods.
-    ssh_jump_pod_name = pod_spec['metadata']['labels']['skypilot-ssh-jump']
-    jump_pod = kubernetes.core_api().read_namespaced_pod(
-        ssh_jump_pod_name, namespace)
+
     wait_pods_dict = _filter_pods(namespace, tags, ['Pending'])
     wait_pods = list(wait_pods_dict.values())
-    wait_pods.append(jump_pod)
+
+    networking_mode = network_utils.get_networking_mode(config.provider_config.get('networking_mode'))
+    if networking_mode == kubernetes_enums.KubernetesNetworkingMode.NODEPORT:
+        # Adding the jump pod to the new_nodes list as well so it can be
+        # checked if it's scheduled and running along with other pods.
+        ssh_jump_pod_name = pod_spec['metadata']['labels']['skypilot-ssh-jump']
+        jump_pod = kubernetes.core_api().read_namespaced_pod(
+            ssh_jump_pod_name, namespace)
+        wait_pods.append(jump_pod)
     provision_timeout = provider_config['timeout']
 
     wait_str = ('indefinitely'

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -11,8 +11,8 @@ from sky import status_lib
 from sky.adaptors import kubernetes
 from sky.provision import common
 from sky.provision.kubernetes import config as config_lib
-from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import network_utils
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import common_utils
 from sky.utils import kubernetes_enums
 from sky.utils import ux_utils
@@ -521,11 +521,11 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
         if head_pod_name is None:
             head_pod_name = pod.metadata.name
 
-
     wait_pods_dict = _filter_pods(namespace, tags, ['Pending'])
     wait_pods = list(wait_pods_dict.values())
 
-    networking_mode = network_utils.get_networking_mode(config.provider_config.get('networking_mode'))
+    networking_mode = network_utils.get_networking_mode(
+        config.provider_config.get('networking_mode'))
     if networking_mode == kubernetes_enums.KubernetesNetworkingMode.NODEPORT:
         # Adding the jump pod to the new_nodes list as well so it can be
         # checked if it's scheduled and running along with other pods.

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -44,13 +44,15 @@ def get_port_mode(
 
 
 def get_networking_mode(
-        mode_str: Optional[str] = None) -> kubernetes_enums.KubernetesNetworkingMode:
+    mode_str: Optional[str] = None
+) -> kubernetes_enums.KubernetesNetworkingMode:
     """Get the networking mode from the provider config."""
     mode_str = mode_str or skypilot_config.get_nested(
         ('kubernetes', 'networking_mode'),
         kubernetes_enums.KubernetesNetworkingMode.PORTFORWARD.value)
     try:
-        networking_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(mode_str)
+        networking_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(
+            mode_str)
     except ValueError as e:
         # Add message saying "Please check: ~/.sky/config.yaml" to the error
         # message.
@@ -58,7 +60,6 @@ def get_networking_mode(
             raise ValueError(str(e) + ' Please check: ~/.sky/config.yaml.') \
                 from None
     return networking_mode
-
 
 
 def fill_loadbalancer_template(namespace: str, service_name: str,

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -43,6 +43,24 @@ def get_port_mode(
     return port_mode
 
 
+def get_networking_mode(
+        mode_str: Optional[str] = None) -> kubernetes_enums.KubernetesNetworkingMode:
+    """Get the networking mode from the provider config."""
+    mode_str = mode_str or skypilot_config.get_nested(
+        ('kubernetes', 'networking_mode'),
+        kubernetes_enums.KubernetesNetworkingMode.PORTFORWARD.value)
+    try:
+        networking_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(mode_str)
+    except ValueError as e:
+        # Add message saying "Please check: ~/.sky/config.yaml" to the error
+        # message.
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(str(e) + ' Please check: ~/.sky/config.yaml.') \
+                from None
+    return networking_mode
+
+
+
 def fill_loadbalancer_template(namespace: str, service_name: str,
                                ports: List[int], selector_key: str,
                                selector_value: str) -> Dict:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -936,7 +936,8 @@ def create_proxy_command_script(k8s_ssh_target: str) -> str:
     }
     port_fwd_proxy_cmd_path = os.path.expanduser(
         PORT_FORWARD_PROXY_CMD_PATH.format(k8s_ssh_target))
-    os.makedirs(os.path.dirname(port_fwd_proxy_cmd_path), exist_ok=True,
+    os.makedirs(os.path.dirname(port_fwd_proxy_cmd_path),
+                exist_ok=True,
                 mode=0o700)
     common_utils.fill_template(PORT_FORWARD_PROXY_CMD_TEMPLATE,
                                vars_to_fill,

--- a/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
+++ b/sky/templates/kubernetes-port-forward-proxy-command.sh.j2
@@ -18,7 +18,7 @@ fi
 # This is preferred because of socket re-use issues in kubectl port-forward,
 # see - https://github.com/kubernetes/kubernetes/issues/74551#issuecomment-769185879
 KUBECTL_OUTPUT=$(mktemp)
-kubectl port-forward svc/{{ ssh_jump_name }} :22 > "${KUBECTL_OUTPUT}" 2>&1 &
+kubectl port-forward pod/{{ pod_name }} :22 > "${KUBECTL_OUTPUT}" 2>&1 &
 
 # Capture the PID for the backgrounded kubectl command
 K8S_PORT_FWD_PID=$!

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -24,6 +24,9 @@ provider:
     # This should be one of KubernetesPortMode
     port_mode: {{k8s_port_mode}}
 
+    # The networking mode used to ssh to pods. One of KubernetesNetworkingMode.
+    networking_mode: {{k8s_networking_mode}}
+
     # We use internal IPs since we set up a port-forward between the kubernetes
     # cluster and the local machine, or directly use NodePort to reach the
     # head node.


### PR DESCRIPTION
Closes #3566. SSH jump pod is not required when using port-forward mode. This PR directly `kubectl port-forwards` to the relevant pod. 

Reduces SSH time by ~25% (1s) on a GKE cluster.

Also lays the groundwork for easy switching between kubecontexts/kubeconfigs while retaining SSH functionality (requested by user).

TODOs - 
- [ ] Need to figure out multi-node support with this, since each worker will now require a unique SSH ProxyCommand. Current SkyPilot plumbing assumes a common ProxyCommand across all workers.


### Benchmarks
======= This branch - After removing SSH Jump pod =======
```
1: ssh test ls
            Mean        Std.Dev.    Min         Median      Max
real        3.014       0.277       2.525       3.125       3.309
user        0.020       0.002       0.016       0.020       0.022
sys         0.008       0.001       0.005       0.008       0.009

multitime -n 5 sky launch -y --cpus 1 --cloud kubernetes task4.yaml
1: sky launch -y --cpus 1 --cloud kubernetes task4.yaml
            Mean        Std.Dev.    Min         Median      Max
real        60.359      2.530       57.249      61.003      63.215
user        4.299       0.492       3.875       3.942       5.095
sys         3.770       0.325       3.492       3.563       4.360
```

======= Master - with SSH Jump pod =======
```
===> multitime results
1: ssh test ls
            Mean        Std.Dev.    Min         Median      Max
real        3.960       0.386       3.310       4.099       4.454
user        0.019       0.002       0.017       0.018       0.022
sys         0.007       0.000       0.006       0.007       0.008

multitime -n 5 sky launch -y --cpus 1 --cloud kubernetes task4.yaml
1: sky launch -y --cpus 1 --cloud kubernetes task4.yaml
            Mean        Std.Dev.    Min         Median      Max
real        63.814      2.132       61.270      63.385      66.609
user        3.791       0.155       3.535       3.854       3.976
sys         3.590       0.062       3.509       3.573       3.670
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Smoke tests
