### PR TITLE
[Serve][Doc] Authorization doc

### DIFF
--- a/docs/source/serving/auth.rst
+++ b/docs/source/serving/auth.rst
@@ -74,6 +74,16 @@ To send a request to the service endpoint, a service client need to include the 
         ],
         "stop_token_ids": [128009, 128001]
       }' | jq
+
+.. raw:: HTML
+
+  <details>
+  
+  <summary>Example output</summary>
+  
+  
+.. code-block:: console
+
   {
     "id": "cmpl-cad2c1a2a6ee44feabed0b28be294d6f",
     "object": "chat.completion",
@@ -97,6 +107,10 @@ To send a request to the service endpoint, a service client need to include the 
       "completion_tokens": 134
     }
   }
+  
+.. raw:: html
+
+  </details>
 
 A service client without an API key will not be able to access the service and get a :code:`401 Unauthorized` error:
 

--- a/docs/source/serving/auth.rst
+++ b/docs/source/serving/auth.rst
@@ -3,14 +3,14 @@
 Authorization
 =============
 
-SkyServe provides robust authorization capabilities at the replica level, allowing you to control access to service endpoints. By leveraging the authorization features of the underlying inference engine, you can manage who can read and write data, making it ideal for securing sensitive information or operations.
+SkyServe provides robust authorization capabilities at the replica level, allowing you to control access to service endpoints with API keys.
 
-vLLM Example
+Setup API Keys
 ------------
 
-Let's walk through an example of setting up authorization on a replica using the vLLM inference engine. The vLLM engine supports authorization via the :code:`--api-key` flag, which specifies a static API key needed to access the service endpoint. This key is defined in the :code:`AUTH_TOKEN` environment variable.
+SkyServe relies on the authorization of the service running on underlying service replicas, e.g., the inference engine. We take an example vLLM inference engine, which supports static API key authorization with an argument :code`--api-key`.
 
-Here's a sample configuration in YAML:
+We first define a normal SkyPilot job with an LLM service setup with vLLM and an API key set:
 
 .. code-block:: yaml
     :emphasize-lines: 26
@@ -25,17 +25,11 @@ Here's a sample configuration in YAML:
       ports: 8000
 
     setup: |
-      conda activate vllm
-      if [ $? -ne 0 ]; then
-          conda create -n vllm python=3.10 -y
-          conda activate vllm
-      fi
       pip install transformers==4.38.0
       pip install vllm==0.3.2
       python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 
     run: |
-      conda activate vllm
       echo 'Starting vllm openai api server...'
       python -m vllm.entrypoints.openai.api_server \
         --model $MODEL_NAME --tokenizer hf-internal-testing/llama-tokenizer \

--- a/docs/source/serving/auth.rst
+++ b/docs/source/serving/auth.rst
@@ -56,7 +56,8 @@ With the :code:`--api-key` set, a user's request needs to include an Authorizati
 
 .. code-block:: bash
 
-  $ ENDPOINT=$(sky serve status -n auth)
+  $ ENDPOINT=$(sky serve status --endpoint auth)
+  $ AUTH_TOKEN=sky-authkey-3d2105b9-a9ba-4f13
   $ curl http://$ENDPOINT/v1/chat/completions \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer $AUTH_TOKEN" \

--- a/docs/source/serving/auth.rst
+++ b/docs/source/serving/auth.rst
@@ -1,0 +1,59 @@
+.. _serve-auth:
+
+Authorization
+=============
+
+SkyServe provides robust authorization capabilities at the replica level, allowing you to control access to service endpoints. By leveraging the authorization features of the underlying inference engine, you can manage who can read and write data, making it ideal for securing sensitive information or operations.
+
+vLLM Example
+------------
+
+Let's walk through an example of setting up authorization on a replica using the vLLM inference engine. The vLLM engine supports authorization via the :code:`--api-key` flag, which specifies a static API key needed to access the service endpoint. This key is defined in the :code:`AUTH_TOKEN` environment variable.
+
+Here's a sample configuration in YAML:
+
+.. code-block:: yaml
+    :emphasize-lines: 26
+
+    envs:
+      MODEL_NAME: meta-llama/Llama-2-7b-chat-hf
+      HF_TOKEN: # TODO: Fill with your own huggingface token, or use --env to pass.
+      AUTH_TOKEN: # TODO: Fill with your own auth token (a random string), or use --env to pass.
+
+    resources:
+      accelerators: {L4:1, A10G:1, A10:1, A100:1, A100-80GB:1}
+      ports: 8000
+
+    setup: |
+      conda activate vllm
+      if [ $? -ne 0 ]; then
+          conda create -n vllm python=3.10 -y
+          conda activate vllm
+      fi
+      pip install transformers==4.38.0
+      pip install vllm==0.3.2
+      python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
+
+    run: |
+      conda activate vllm
+      echo 'Starting vllm openai api server...'
+      python -m vllm.entrypoints.openai.api_server \
+        --model $MODEL_NAME --tokenizer hf-internal-testing/llama-tokenizer \
+        --host 0.0.0.0 --port 8000 \
+        --api-key $AUTH_TOKEN
+
+SkyServe's proxy design ensures that all headers in the original request, including the authorization token, are forwarded to the vLLM inference engine. The engine then validates the token.
+
+To enable this feature in SkyServe, you need to configure the readiness probe to include the access token. This ensures the readiness probe passes the authorization check. Here's how you set it up in the :code:`service.readiness_probe` section:
+
+.. code-block:: yaml
+    :emphasize-lines: 4-5
+
+    service:
+      readiness_probe:
+        path: /v1/models
+        headers:
+          Authorization: Bearer $AUTH_TOKEN
+      replicas: 1
+
+Notice that we will automatically replace the :code:`$AUTH_TOKEN` in the service section with the actual token value as well.

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -444,6 +444,11 @@ Autoscaling
 
 See :ref:`Autoscaling <serve-autoscaling>` for more information.
 
+Authorization
+-------------
+
+See :ref:`Authorization <serve-auth>` for more information.
+
 
 SkyServe Architecture
 ---------------------

--- a/docs/source/serving/user-guides.rst
+++ b/docs/source/serving/user-guides.rst
@@ -5,3 +5,4 @@ Serving User Guides
 
    autoscaling
    update
+   auth


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adding docs for authorization (introduced in #3552)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] The YAML in the doc
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
