### PR TITLE
[Examples] Update stable diffusion example

### DIFF
--- a/examples/stable_diffusion/README.md
+++ b/examples/stable_diffusion/README.md
@@ -8,7 +8,7 @@
 
 4. Run `ssh -L 7860:localhost:7860 stable-diffusion`
 
-5. Open [`http://localhost:7860/`](http://localhost:7860/) in browser.
+5. Open [`http://localhost:7860/`](http://localhost:7860/) in browser. If the page doesn't load, try again in a few minutes to allow the container to start.
 
 6. Type in text prompt and click "Generate".
 

--- a/examples/stable_diffusion/stable_diffusion_docker.yaml
+++ b/examples/stable_diffusion/stable_diffusion_docker.yaml
@@ -7,8 +7,6 @@ file_mounts:
   /stable_diffusion: .
 
 setup: |
-  sudo curl "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-  sudo chmod +x /usr/local/bin/docker-compose
   cd stable-diffusion-webui-docker  
   sudo rm -r stable-diffusion-webui-docker
   git clone https://github.com/AbdBarho/stable-diffusion-webui-docker.git
@@ -17,9 +15,16 @@ setup: |
   wget https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt -P models
   mv models/sd-v1-4.ckpt models/model.ckpt
   docker pull berkeleyskypilot/stable-diffusion
-  rm docker-compose.yml
-  cp /stable_diffusion/docker-compose.yml .
 
 run: |
   cd stable-diffusion-webui-docker
-  docker-compose up
+  docker run -d \
+    --name model \
+    --restart on-failure \
+    -p 7860:7860 \
+    -v $(pwd)/cache:/cache \
+    -v $(pwd)/output:/output \
+    -v $(pwd)/models:/models \
+    -e CLI_ARGS='--extra-models-cpu --optimized-turbo' \
+    --gpus all \
+    berkeleyskypilot/stable-diffusion


### PR DESCRIPTION
Stable diffusion example was broken because docker-compose was not working (prints nothing, shows no error). This PR gets rid of the docker-compose dependency.

Tested:
- [x] `sky launch -c sd --cloud gcp stable_diffusion_docker.yaml`
