### PR TITLE
[GCP] Switch to Ubuntu image for GCP for better alignment with other clouds

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -453,7 +453,7 @@ class GCP(clouds.Cloud):
                     # CUDA driver version 470.57.02, CUDA Library 11.4
                     image_id = 'skypilot:k80-debian-10'
                 else:
-                    # CUDA driver version 535.86.10, CUDA Library 12.4
+                    # CUDA driver version 550.54.15, CUDA Library 12.4
                     image_id = 'skypilot:gpu-ubuntu-2204'
 
         if (resources.image_id is not None and

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -453,7 +453,7 @@ class GCP(clouds.Cloud):
                     # CUDA driver version 470.57.02, CUDA Library 11.4
                     image_id = 'skypilot:k80-debian-10'
                 else:
-                    # CUDA driver version 535.86.10, CUDA Library 12.2
+                    # CUDA driver version 535.86.10, CUDA Library 12.4
                     image_id = 'skypilot:gpu-ubuntu-2204'
 
         if (resources.image_id is not None and

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -402,9 +402,7 @@ class GCP(clouds.Cloud):
         # gcloud compute images list \
         # --project deeplearning-platform-release \
         # --no-standard-images
-        # We use the debian image, as the ubuntu image has some connectivity
-        # issue when first booted.
-        image_id = 'skypilot:cpu-debian-11'
+        image_id = 'skypilot:cpu-ubuntu-2204'
 
         r = resources
         # Find GPU spec, if any.
@@ -456,7 +454,7 @@ class GCP(clouds.Cloud):
                     image_id = 'skypilot:k80-debian-10'
                 else:
                     # CUDA driver version 535.86.10, CUDA Library 12.2
-                    image_id = 'skypilot:gpu-debian-11'
+                    image_id = 'skypilot:gpu-ubuntu-2204'
 
         if (resources.image_id is not None and
                 resources.extract_docker_image() is None):

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -34,7 +34,7 @@ _image_df = common.read_catalog('gcp/images.csv',
                                 pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 if _image_df[_image_df['Tag'] == 'skypilot:cpu-ubuntu-2004'].empty:
     # Update the image catalog if it does not include the updated images
-    # https://github.com/skypilot-org/skypilot-catalog/pull/25.
+    # https://github.com/skypilot-org/skypilot-catalog/pull/71.
     _image_df = common.read_catalog('gcp/images.csv', pull_frequency_hours=0)
 
 _quotas_df = common.read_catalog('gcp/accelerator_quota_mapping.csv',

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -32,6 +32,10 @@ _df = common.read_catalog('gcp/vms.csv',
                           pull_frequency_hours=_PULL_FREQUENCY_HOURS)
 _image_df = common.read_catalog('gcp/images.csv',
                                 pull_frequency_hours=_PULL_FREQUENCY_HOURS)
+if _image_df[_image_df['Tag'] == 'skypilot:cpu-ubuntu-2004'].empty:
+    # Update the image catalog if it does not include the updated images
+    # https://github.com/skypilot-org/skypilot-catalog/pull/25.
+    _image_df = common.read_catalog('gcp/images.csv', pull_frequency_hours=0)
 
 _quotas_df = common.read_catalog('gcp/accelerator_quota_mapping.csv',
                                  pull_frequency_hours=_PULL_FREQUENCY_HOURS)

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -126,6 +126,19 @@ available_node_types:
             # This is a specific syntax required by GCP https://cloud.google.com/compute/docs/connect/add-ssh-keys
             value: |-
               skypilot:ssh_user:skypilot:ssh_public_key_content
+          - key: user-data
+            value: |
+              #cloud-config
+              write_files:
+                - path: /etc/apt/apt.conf.d/20auto-upgrades
+                  content: |
+                    APT::Periodic::Update-Package-Lists "0";
+                    APT::Periodic::Download-Upgradeable-Packages "0";
+                    APT::Periodic::AutocleanInterval "0";
+                    APT::Periodic::Unattended-Upgrade "0";
+                - path: /etc/apt/apt.conf.d/10cloudinit-disable
+                  content: |
+                    APT::Periodic::Enable "0";
   {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"
@@ -174,19 +187,7 @@ setup_commands:
   # Line 'sudo systemctl stop jupyter ..': stop jupyter service to avoid port conflict on 8080
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  - function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
-    {%- if docker_image is none %}
-    sudo systemctl stop unattended-upgrades || true;
-    sudo systemctl disable unattended-upgrades || true;
-    sudo sed -i 's/Unattended-Upgrade "1"/Unattended-Upgrade "0"/g' /etc/apt/apt.conf.d/20auto-upgrades || true;
-    {%- endif %}
-    p=$(mylsof "/var/lib/dpkg/lock-frontend"); echo "$p";
-    sudo kill -9 `echo "$p" | tail -n 1` || true;
-    sudo rm /var/lib/dpkg/lock-frontend;
-    sudo pkill -9 dpkg;
-    sudo pkill -9 apt-get;
-    sudo dpkg --configure --force-overwrite -a;
-    mkdir -p ~/.ssh; touch ~/.ssh/config;
+  - mkdir -p ~/.ssh; touch ~/.ssh/config;
     {{ conda_installation_commands }}
     source ~/.bashrc;
   {%- if tpu_vm %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Blocked by https://github.com/skypilot-org/skypilot-catalog/pull/71

Benefits:
1. Align with the other clouds' default image
2. C++ compiler is more up-to-date and can work with llm.c #3611 
3. Enables cloud-init, so we can disable the unattended-upgrade without running error-prone commands for sudo apt
4. The pre-installed conda is more up-to-date which is way faster for solving environment.

TODO:
- [ ] The disconnection issue still exists, as GCP `install-nvidia-driver` will reboot the VM after the installation of the driver.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] All smoke tests: `pytest tests/test_smoke.py --gcp` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
