### PR TITLE
[Jobs] Fix back compatibility for `sky jobs logs` from 0.5

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -751,6 +751,8 @@ class ManagedJobCodeGen:
 
       >> codegen = ManagedJobCodeGen.show_jobs(...)
     """
+    # TODO: the try..except.. block is for backward compatibility. Remove it in
+    # v0.8.0.
     _PREFIX = textwrap.dedent("""\
         managed_job_version = 0
         try:
@@ -800,7 +802,8 @@ class ManagedJobCodeGen:
         # We inspect the source code of the function here for backward
         # compatibility.
         # TODO: change to utils.stream_logs(job_id, job_name, follow) in v0.8.0.
-        # Import libraries required by `stream_logs`
+        # Import libraries required by `stream_logs`. The try...except... block
+        # should be removed in v0.8.0.
         code = textwrap.dedent("""\
         import os
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -809,7 +809,7 @@ class ManagedJobCodeGen:
         try:
             from sky.jobs.utils import stream_logs_by_id
         except ImportError:
-            from sky.spot.utils import stream_logs_by_id
+            from sky.spot.spot_utils import stream_logs_by_id
         from typing import Optional
         """)
         code += inspect.getsource(stream_logs)

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -806,7 +806,10 @@ class ManagedJobCodeGen:
 
         from sky.skylet import job_lib, log_lib
         from sky.skylet import constants
-        from sky.jobs.utils import stream_logs_by_id
+        try:
+            from sky.jobs.utils import stream_logs_by_id
+        except ImportError:
+            from sky.spot.utils import stream_logs_by_id
         from typing import Optional
         """)
         code += inspect.getsource(stream_logs)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3613 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky spot launch -n test --cloud gcp --cpus 2 "echo hi; sleep 1000; echo by"` on v0.5; switch to this PR, and `sky jobs logs`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
