### PR TITLE
[Storage] gcsfuse version update to 2.2.0

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -12,7 +12,7 @@ _STAT_CACHE_CAPACITY = 4096
 _TYPE_CACHE_TTL = '5s'
 _RENAME_DIR_LIMIT = 10000
 # https://github.com/GoogleCloudPlatform/gcsfuse/releases
-GCSFUSE_VERSION = '1.3.0'
+GCSFUSE_VERSION = '2.2.0'
 
 
 def get_s3_mount_install_cmd() -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
As discovered in the test from this [thread](https://github.com/skypilot-org/skypilot/issues/3353#issuecomment-2141052374), there was a significant performance update since version `1.3.0`, which we by default currently install for the users. This PR updates the version to `2.2.0`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [x] `pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop --gcp`
- [x] Manual test launching aws instance with gcs `MOUNT` mode using `gcsfuse` 2.2.0