### PR TITLE
[k8s] Fix GKELabelFormatter for H100s

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -98,10 +98,13 @@ def get_gke_accelerator_name(accelerator: str) -> str:
     """Returns the accelerator name for GKE clusters
 
     Uses the format - nvidia-tesla-<accelerator>.
-    A100-80GB, H100 and L4 are an exception. They use nvidia-<accelerator>.
+    A100-80GB, H100-80GB and L4 are an exception. They use nvidia-<accelerator>.
     """
-    if accelerator in ('A100-80GB', 'L4', 'H100'):
-        # A100-80GB, L4 and H100 have a different name pattern.
+    if accelerator == 'H100':
+        # H100 is named as H100-80GB in GKE.
+        accelerator = 'H100-80GB'
+    if accelerator in ('A100-80GB', 'L4', 'H100-80GB'):
+        # A100-80GB, L4 and H100-80GB have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
         return 'nvidia-tesla-{}'.format(accelerator.lower())
@@ -183,7 +186,11 @@ class GKELabelFormatter(GPULabelFormatter):
         if value.startswith('nvidia-tesla-'):
             return value.replace('nvidia-tesla-', '').upper()
         elif value.startswith('nvidia-'):
-            return value.replace('nvidia-', '').upper()
+            acc = value.replace('nvidia-', '').upper()
+            if acc == 'H100-80GB':
+                # H100 is named as H100-80GB in GKE.
+                return 'H100'
+            return acc
         else:
             raise ValueError(
                 f'Invalid accelerator name in GKE cluster: {value}')

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -98,10 +98,10 @@ def get_gke_accelerator_name(accelerator: str) -> str:
     """Returns the accelerator name for GKE clusters
 
     Uses the format - nvidia-tesla-<accelerator>.
-    A100-80GB, H100-80GB and L4 are an exception. They use nvidia-<accelerator>.
+    A100-80GB, H100 and L4 are an exception. They use nvidia-<accelerator>.
     """
-    if accelerator in ('A100-80GB', 'L4', 'H100-80GB'):
-        # A100-80GB, L4 and H100-80GB have a different name pattern.
+    if accelerator in ('A100-80GB', 'L4', 'H100'):
+        # A100-80GB, L4 and H100 have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
         return 'nvidia-tesla-{}'.format(accelerator.lower())


### PR DESCRIPTION
`get_gke_accelerator_name` returns the incorrect label for H100 (`nvidia-tesla-h100` instead of `nvidia-h100`). This PR fixes it by removing the incorrect conditional check for H100.

Tested:
- [ ] `sky launch --gpus H100:1` on a GKE cluster with H100s.