### PR TITLE
[Kubernetes] Fix kubernetes available GPUs

### DIFF
--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -136,15 +136,13 @@ def list_accelerators_realtime(
                     total_accelerators_capacity[
                         accelerator_name] += quantized_count
 
+            if accelerator_name not in total_accelerators_available:
+                total_accelerators_available[accelerator_name] = 0
             if accelerators_available >= min_quantity_filter:
                 quantized_availability = min_quantity_filter * (
                     accelerators_available // min_quantity_filter)
-                if accelerator_name not in total_accelerators_available:
-                    total_accelerators_available[
-                        accelerator_name] = quantized_availability
-                else:
-                    total_accelerators_available[
-                        accelerator_name] += quantized_availability
+                total_accelerators_available[
+                    accelerator_name] += quantized_availability
 
     result = []
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When none of the GPUs is available in a kubernetes cluster, the following error will occur:
```bash
sky show-gpus --cloud kubernetes

  File "/home/gcpuser/skypilot/sky/utils/common_utils.py", line 388, in _record
    return f(*args, **kwargs)
  File "/home/gcpuser/skypilot/sky/cli.py", line 3331, in show_gpus
    for out in _output():
  File "/home/gcpuser/skypilot/sky/cli.py", line 3104, in _output
    k8s_realtime_table = _get_kubernetes_realtime_gpu_table()
  File "/home/gcpuser/skypilot/sky/cli.py", line 3048, in _get_kubernetes_realtime_gpu_table
    assert (set(counts.keys()) == set(capacity.keys()) == set(
AssertionError: Keys of counts (['T4', 'V100']), capacity (['T4', 'V100']), and available ([]) must be same.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
