### PR TITLE
[k8s] Robust service account and namespace support

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -66,7 +66,7 @@ SkyPilot requires permissions equivalent to the following roles to be able to ma
     kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: sky-sa-role
+      name: sky-sa-role  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
     rules:
       - apiGroups: ["*"]
@@ -77,7 +77,7 @@ SkyPilot requires permissions equivalent to the following roles to be able to ma
     kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: sky-sa-cluster-role
+      name: sky-sa-cluster-role  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
@@ -98,7 +98,7 @@ These roles must apply to both the user account configured in the kubeconfig fil
 
 If your tasks use object store mounting or require access to ingress resources, you will need to grant additional permissions as described below.
 
-Permissions for object store mounting
+Permissions for Object Store Mounting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your tasks use object store mounting (e.g., S3, GCS, etc.), SkyPilot will need to run a DaemonSet to expose the FUSE device as a Kubernetes resource to SkyPilot pods.
@@ -113,7 +113,7 @@ To allow this, you will need to also create a ``skypilot-system`` namespace whic
     apiVersion: v1
     kind: Namespace
     metadata:
-      name: skypilot-system
+      name: skypilot-system  # Do not change this
       labels:
         parent: skypilot
     ---
@@ -123,7 +123,7 @@ To allow this, you will need to also create a ``skypilot-system`` namespace whic
     kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: skypilot-system-service-account-role
+      name: skypilot-system-service-account-role  # Can be changed if needed
       namespace: skypilot-system  # Do not change this namespace
       labels:
         parent: skypilot
@@ -133,7 +133,7 @@ To allow this, you will need to also create a ``skypilot-system`` namespace whic
         verbs: ["*"]
 
 
-Permissions for using ingress
+Permissions for using Ingress
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your tasks use :ref:`Ingress <kubernetes-ingress>` for exposing ports, you will need to grant the necessary permissions to the service account in the ``ingress-nginx`` namespace.
@@ -145,8 +145,8 @@ If your tasks use :ref:`Ingress <kubernetes-ingress>` for exposing ports, you wi
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      namespace: ingress-nginx
-      name: sky-sa-role-ingress-nginx
+      namespace: ingress-nginx  # Do not change this
+      name: sky-sa-role-ingress-nginx  # Can be changed if needed
     rules:
       - apiGroups: [""]
         resources: ["services"]
@@ -167,6 +167,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
 
 
 .. code-block:: yaml
+   :linenos:
 
     # create-sky-sa.yaml
     kind: ServiceAccount
@@ -181,7 +182,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: sky-sa-role
+      name: sky-sa-role  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
@@ -194,7 +195,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: sky-sa-rb
+      name: sky-sa-rb  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
@@ -203,14 +204,14 @@ To create a service account that has all necessary permissions for SkyPilot (inc
         name: sky-sa  # Change to your service account name
     roleRef:
       kind: Role
-      name: sky-sa-role
+      name: sky-sa-role  # Use the same name as the role at line 14
       apiGroup: rbac.authorization.k8s.io
     ---
     # ClusterRole for the service account
     kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: sky-sa-cluster-role
+      name: sky-sa-cluster-role  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
@@ -229,7 +230,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
-      name: sky-sa-cluster-role-binding
+      name: sky-sa-cluster-role-binding  # Can be changed if needed
       namespace: default  # Change to your namespace if using a different one.
       labels:
         parent: skypilot
@@ -239,14 +240,14 @@ To create a service account that has all necessary permissions for SkyPilot (inc
         namespace: default  # Change to your namespace if using a different one.
     roleRef:
       kind: ClusterRole
-      name: sky-sa-cluster-role
+      name: sky-sa-cluster-role  # Use the same name as the cluster role at line 43
       apiGroup: rbac.authorization.k8s.io
     ---
     # Optional: If using object store mounting, create the skypilot-system namespace
     apiVersion: v1
     kind: Namespace
     metadata:
-      name: skypilot-system
+      name: skypilot-system  # Do not change this
       labels:
         parent: skypilot
     ---
@@ -255,7 +256,7 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: skypilot-system-service-account-role
+      name: skypilot-system-service-account-role  # Can be changed if needed
       namespace: skypilot-system  # Do not change this namespace
       labels:
         parent: skypilot
@@ -279,15 +280,17 @@ To create a service account that has all necessary permissions for SkyPilot (inc
         namespace: default  # Change this to the namespace where the service account is created
     roleRef:
       kind: Role
-      name: skypilot-system-service-account-role
+      name: skypilot-system-service-account-role  # Use the same name as the role at line 88
       apiGroup: rbac.authorization.k8s.io
     ---
     # Optional: Role for accessing ingress resources
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      name: sky-sa-role-ingress-nginx
+      name: sky-sa-role-ingress-nginx  # Can be changed if needed
       namespace: ingress-nginx  # Do not change this namespace
+      labels:
+        parent: skypilot
     rules:
       - apiGroups: [""]
         resources: ["services"]
@@ -300,15 +303,17 @@ To create a service account that has all necessary permissions for SkyPilot (inc
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: sky-sa-rolebinding-ingress-nginx
+      name: sky-sa-rolebinding-ingress-nginx  # Can be changed if needed
       namespace: ingress-nginx  # Do not change this namespace
+      labels:
+        parent: skypilot
     subjects:
       - kind: ServiceAccount
         name: sky-sa  # Change to your service account name
         namespace: default  # Change this to the namespace where the service account is created
     roleRef:
       kind: Role
-      name: sky-sa-role-ingress-nginx
+      name: sky-sa-role-ingress-nginx  # Use the same name as the role at line 119
       apiGroup: rbac.authorization.k8s.io
 
 Create the service account using the following command:

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -19,8 +19,8 @@ To connect and use a Kubernetes cluster, SkyPilot needs:
 
 In a typical workflow:
 
-1. A cluster administrator sets up a Kubernetes cluster. Detailed admin guides for
-   different deployment environments (Amazon EKS, Google GKE, On-Prem and local debugging) are included in the :ref:`Kubernetes cluster setup guide <kubernetes-setup>`.
+1. A cluster administrator sets up a Kubernetes cluster. Refer to admin guides for
+   :ref:`Kubernetes cluster setup <kubernetes-setup>` for different deployment environments (Amazon EKS, Google GKE, On-Prem and local debugging) and :ref:`required permissions <cloud-permissions-kubernetes>`.
 
 2. Users who want to run SkyPilot tasks on this cluster are issued Kubeconfig
    files containing their credentials (`kube-context <https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#define-clusters-users-and-contexts>`_).

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -18,7 +18,7 @@ SkyPilot's Kubernetes support is designed to work with most Kubernetes distribut
 To connect to a Kubernetes cluster, SkyPilot needs:
 
 * An existing Kubernetes cluster running Kubernetes v1.20 or later.
-* A `Kubeconfig <kubeconfig>`_ file containing access credentials and namespace to be used. Refer to :ref:`required permissions <cloud-permissions-kubernetes>` guide for details.
+* A `Kubeconfig <kubeconfig>`_ file containing access credentials and namespace to be used. To reduce the permissions for a user, check :ref:`required permissions guide<cloud-permissions-kubernetes>`.
 
 
 Deployment Guides

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -18,7 +18,7 @@ SkyPilot's Kubernetes support is designed to work with most Kubernetes distribut
 To connect to a Kubernetes cluster, SkyPilot needs:
 
 * An existing Kubernetes cluster running Kubernetes v1.20 or later.
-* A `Kubeconfig <kubeconfig>`_ file containing access credentials and namespace to be used.
+* A `Kubeconfig <kubeconfig>`_ file containing access credentials and namespace to be used. Refer to :ref:`required permissions <cloud-permissions-kubernetes>` guide for details.
 
 
 Deployment Guides

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -60,8 +60,7 @@ def bootstrap_instances(
         #    using DEFAULT_SERVICE_ACCOUNT_NAME, it does not have the necessary
         #    permissions to create a role for itself to create the FUSE manager.
         # 4. The job fails to launch.
-        _configure_skypilot_system_namespace(config.provider_config,
-                                             requested_service_account)
+        _configure_skypilot_system_namespace(config.provider_config)
         if config.provider_config.get('port_mode', 'loadbalancer') == 'ingress':
             logger.info('Port mode is set to ingress, setting up ingress role '
                         'and role binding.')
@@ -500,8 +499,7 @@ def _configure_ssh_jump(namespace, config: common.ProvisionConfig):
 
 
 def _configure_skypilot_system_namespace(
-        provider_config: Dict[str,
-                              Any], service_account: Optional[str]) -> None:
+        provider_config: Dict[str, Any]) -> None:
     """Creates the namespace for skypilot-system mounting if it does not exist.
 
     Also patches the SkyPilot service account to have the necessary permissions
@@ -521,9 +519,8 @@ def _configure_skypilot_system_namespace(
     # running in, so we override the name with a unique name identifying
     # the namespace. This is required for multi-tenant setups where
     # different SkyPilot instances may be running in different namespaces.
-    override_name = provider_config[
-        'autoscaler_skypilot_system_role_binding']['metadata'][
-            'name'] + '-' + svc_account_namespace
+    override_name = provider_config['autoscaler_skypilot_system_role_binding'][
+        'metadata']['name'] + '-' + svc_account_namespace
 
     # Create the role binding in the skypilot-system namespace, and have
     # the subject namespace be the namespace that the SkyPilot service

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -46,6 +46,22 @@ def bootstrap_instances(
         _configure_autoscaler_cluster_role(namespace, config.provider_config)
         _configure_autoscaler_cluster_role_binding(namespace,
                                                    config.provider_config)
+        # SkyPilot system namespace is required for FUSE mounting. Here we just
+        # create the namespace and set up the necessary permissions.
+        #
+        # We need to setup the namespace outside the
+        # if config.provider_config.get('fuse_device_required') block below
+        # because if we put in the if block, the following happens:
+        # 1. User launches job controller on Kubernetes with SERVICE_ACCOUNT. No
+        #    namespace is created at this point since the controller does not
+        #    require FUSE.
+        # 2. User submits a job requiring FUSE.
+        # 3. The namespace is created here, but since the job controller is
+        #    using DEFAULT_SERVICE_ACCOUNT_NAME, it does not have the necessary
+        #    permissions to create a role for itself to create the FUSE manager.
+        # 4. The job fails to launch.
+        _configure_skypilot_system_namespace(config.provider_config,
+                                             requested_service_account)
         if config.provider_config.get('port_mode', 'loadbalancer') == 'ingress':
             logger.info('Port mode is set to ingress, setting up ingress role '
                         'and role binding.')
@@ -69,26 +85,8 @@ def bootstrap_instances(
     elif requested_service_account != 'default':
         logger.info(f'Using service account {requested_service_account!r}, '
                     'skipping role and role binding setup.')
-
-    # SkyPilot system namespace is required for FUSE mounting. Here we just
-    # create the namespace and set up the necessary permissions.
-    #
-    # We need to setup the namespace outside the if block below because if
-    # we put in the if block, the following happens:
-    # 1. User launches job controller on Kubernetes with SERVICE_ACCOUNT. No
-    #    namespace is created at this point since the controller does not
-    #    require FUSE.
-    # 2. User submits a job requiring FUSE.
-    # 3. The namespace is created here, but since the job controller is using
-    #    SERVICE_ACCOUNT, it does not have the necessary permissions to create
-    #    a role for itself to create the FUSE device manager.
-    # 4. The job fails to launch.
-    _configure_skypilot_system_namespace(config.provider_config,
-                                         requested_service_account)
-
     if config.provider_config.get('fuse_device_required', False):
         _configure_fuse_mounting(config.provider_config)
-
     return config
 
 
@@ -513,34 +511,29 @@ def _configure_skypilot_system_namespace(
     skypilot_system_namespace = provider_config['skypilot_system_namespace']
     kubernetes_utils.create_namespace(skypilot_system_namespace)
 
-    # Setup permissions if using the default service account.
-    # If the user has requested a different service account (via
-    # remote_identity in ~/.sky/config.yaml), we assume they have already set
-    # up the necessary roles and role bindings.
-    if service_account == kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME:
-        # Note - this must be run only after the service account has been
-        # created in the cluster (in bootstrap_instances).
-        # Create the role in the skypilot-system namespace if it does not exist.
-        _configure_autoscaler_role(skypilot_system_namespace,
-                                   provider_config,
-                                   role_field='autoscaler_skypilot_system_role')
-        # We must create a unique role binding per-namespace that SkyPilot is
-        # running in, so we override the name with a unique name identifying
-        # the namespace. This is required for multi-tenant setups where
-        # different SkyPilot instances may be running in different namespaces.
-        override_name = provider_config[
-            'autoscaler_skypilot_system_role_binding']['metadata'][
-                'name'] + '-' + svc_account_namespace
+    # Note - this must be run only after the service account has been
+    # created in the cluster (in bootstrap_instances).
+    # Create the role in the skypilot-system namespace if it does not exist.
+    _configure_autoscaler_role(skypilot_system_namespace,
+                               provider_config,
+                               role_field='autoscaler_skypilot_system_role')
+    # We must create a unique role binding per-namespace that SkyPilot is
+    # running in, so we override the name with a unique name identifying
+    # the namespace. This is required for multi-tenant setups where
+    # different SkyPilot instances may be running in different namespaces.
+    override_name = provider_config[
+        'autoscaler_skypilot_system_role_binding']['metadata'][
+            'name'] + '-' + svc_account_namespace
 
-        # Create the role binding in the skypilot-system namespace, and have
-        # the subject namespace be the namespace that the SkyPilot service
-        # account is created in.
-        _configure_autoscaler_role_binding(
-            skypilot_system_namespace,
-            provider_config,
-            binding_field='autoscaler_skypilot_system_role_binding',
-            override_name=override_name,
-            override_subject_namespace=svc_account_namespace)
+    # Create the role binding in the skypilot-system namespace, and have
+    # the subject namespace be the namespace that the SkyPilot service
+    # account is created in.
+    _configure_autoscaler_role_binding(
+        skypilot_system_namespace,
+        provider_config,
+        binding_field='autoscaler_skypilot_system_role_binding',
+        override_name=override_name,
+        override_subject_namespace=svc_account_namespace)
 
 
 def _configure_fuse_mounting(provider_config: Dict[str, Any]) -> None:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -699,6 +699,12 @@ def get_current_kube_config_context_namespace() -> str:
             the default namespace.
     """
     k8s = kubernetes.kubernetes
+    # Get namespace if using in-cluster config
+    ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    if os.path.exists(ns_path):
+        with open(ns_path) as f:
+            return f.read().strip()
+    # If not in-cluster, get the namespace from kubeconfig
     try:
         _, current_context = k8s.config.list_kube_config_contexts()
         if 'namespace' in current_context['context']:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -700,9 +700,9 @@ def get_current_kube_config_context_namespace() -> str:
     """
     k8s = kubernetes.kubernetes
     # Get namespace if using in-cluster config
-    ns_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    ns_path = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
     if os.path.exists(ns_path):
-        with open(ns_path) as f:
+        with open(ns_path, encoding='utf-8') as f:
             return f.read().strip()
     # If not in-cluster, get the namespace from kubeconfig
     try:

--- a/sky/utils/kubernetes/generate_static_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_static_kubeconfig.sh
@@ -1,25 +1,37 @@
 #!/bin/bash
 # This script creates a new k8s Service Account and generates a kubeconfig with
-# its credentials. This Service Account has all the necessary permissions for
+# its credentials. This Service Account has the minimal permissions necessary for
 # SkyPilot. The kubeconfig is written in the current directory.
 #
-# You must configure your local kubectl to point to the right k8s cluster and
-# have admin-level access.
+# Before running this script, you must configure your local kubectl to point to
+# the right k8s cluster and have admin-level access.
 #
-# Note: all of the k8s resources are created in namespace "skypilot". If you
-# delete any of these objects, SkyPilot will stop working.
+# By default, this script will create a service account "sky-sa" in "default"
+# namespace. If you want to use a different namespace or service account name:
 #
-# You can override the default namespace "skypilot" using the
-# SKYPILOT_NAMESPACE environment variable.
-# You can override the default service account name "skypilot-sa" using the
-# SKYPILOT_SA_NAME environment variable.
+#   * Specify SKYPILOT_NAMESPACE env var to override the default namespace
+#   * Specify SKYPILOT_SA_NAME env var to override the default service account name
+#   * Specify SKIP_SA_CREATION=1 to skip creating the service account and use an existing one
+#
+# Usage:
+#   # Create "sky-sa" service account with minimal permissions in "default" namespace and generate kubeconfig
+#   $ ./generate_static_kubeconfig.sh
+#
+#   # Create "my-sa" account with minimal permissions in "my-namespace" namespace and generate kubeconfig
+#   $ SKYPILOT_SA_NAME=my-sa SKYPILOT_NAMESPACE=my-namespace ./generate_static_kubeconfig.sh
+#
+#   # Use an existing service account "my-sa" in "my-namespace" namespace and generate kubeconfig
+#   $ SKIP_SA_CREATION=1 SKYPILOT_SA_NAME=my-sa SKYPILOT_NAMESPACE=my-namespace ./generate_static_kubeconfig.sh
 
 set -eu -o pipefail
 
 # Allow passing in common name and username in environment. If not provided,
 # use default.
-SKYPILOT_SA=${SKYPILOT_SA_NAME:-skypilot-sa}
+SKYPILOT_SA=${SKYPILOT_SA_NAME:-sky-sa}
 NAMESPACE=${SKYPILOT_NAMESPACE:-default}
+
+echo "Service account: ${SKYPILOT_SA}"
+echo "Namespace: ${NAMESPACE}"
 
 # Set OS specific values.
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
@@ -33,42 +45,163 @@ else
     exit 1
 fi
 
-# Check if SKYPILOT_SA_NAME env var exists
-if [ -z ${SKYPILOT_SA_NAME+x} ]; then
+# If the user has set SKIP_SA_CREATION=1, skip creating the service account.
+if [ -z ${SKIP_SA_CREATION+x} ]; then
   echo "Creating the Kubernetes Service Account with minimal RBAC permissions."
   kubectl apply -f - <<EOF
+# Create/update namespace specified by the user
 apiVersion: v1
 kind: Namespace
 metadata:
   name: ${NAMESPACE}
+  labels:
+    parent: skypilot
 ---
-apiVersion: v1
 kind: ServiceAccount
+apiVersion: v1
 metadata:
   name: ${SKYPILOT_SA}
   namespace: ${NAMESPACE}
+  labels:
+    parent: skypilot
 ---
+# Role for the service account
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
 metadata:
-  name: skypilot-role
+  name: ${SKYPILOT_SA}-role
+  namespace: ${NAMESPACE}
+  labels:
+    parent: skypilot
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["*"]
+  - apiGroups: ["*"]  # Required for creating pods, services, secrets and other necessary resources in the namespace.
+    resources: ["*"]
+    verbs: ["*"]
 ---
+# RoleBinding for the service account
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SKYPILOT_SA}-rb
+  namespace: ${NAMESPACE}
+  labels:
+    parent: skypilot
+subjects:
+  - kind: ServiceAccount
+    name: ${SKYPILOT_SA}
+roleRef:
+  kind: Role
+  name: ${SKYPILOT_SA}-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# ClusterRole for the service account
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SKYPILOT_SA}-cluster-role
+  namespace: ${NAMESPACE}
+  labels:
+    parent: skypilot
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]  # Required for getting node resources.
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["node.k8s.io"]
+    resources: ["runtimeclasses"]   # Required for autodetecting the runtime class of the nodes.
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]   # Required for exposing services through ingresses
+    resources: ["ingressclasses"]
+    verbs: ["get", "list", "watch"]
+---
+# ClusterRoleBinding for the service account
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: skypilot-crb
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: skypilot-role
-subjects:
-- kind: ServiceAccount
-  name: ${SKYPILOT_SA}
+  name: ${SKYPILOT_SA}-cluster-role-binding
   namespace: ${NAMESPACE}
+  labels:
+    parent: skypilot
+subjects:
+  - kind: ServiceAccount
+    name: ${SKYPILOT_SA}
+    namespace: ${NAMESPACE}
+roleRef:
+  kind: ClusterRole
+  name: ${SKYPILOT_SA}-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Optional: If using object store mounting, create the skypilot-system namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: skypilot-system
+  labels:
+    parent: skypilot
+---
+# Optional: If using object store mounting, create role in the skypilot-system
+# namespace to create FUSE device manager.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: skypilot-system-service-account-role
+  namespace: skypilot-system
+  labels:
+    parent: skypilot
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+# Optional: If using object store mounting, create rolebinding in the skypilot-system
+# namespace to create FUSE device manager.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${SKYPILOT_SA}-skypilot-system-role-binding-${NAMESPACE}
+  namespace: skypilot-system  # Do not change this namespace
+  labels:
+    parent: skypilot
+subjects:
+  - kind: ServiceAccount
+    name: ${SKYPILOT_SA}
+    namespace: ${NAMESPACE}
+roleRef:
+  kind: Role
+  name: skypilot-system-service-account-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Optional: Role for accessing ingress resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ${SKYPILOT_SA}-role-ingress-nginx
+  namespace: ingress-nginx  # Do not change this namespace
+  labels:
+    parent: skypilot
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["list", "get", "watch"]
+---
+# Optional: RoleBinding for accessing ingress resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ${SKYPILOT_SA}-rolebinding-ingress-nginx
+  namespace: ingress-nginx  # Do not change this namespace
+  labels:
+    parent: skypilot
+subjects:
+  - kind: ServiceAccount
+    name: ${SKYPILOT_SA}
+    namespace: ${NAMESPACE}
+roleRef:
+  kind: Role
+  name: ${SKYPILOT_SA}-role-ingress-nginx  # Use the same name as the role at line 119
+  apiGroup: rbac.authorization.k8s.io
 EOF
 fi
 
@@ -96,6 +229,9 @@ EOF
 
 SA_SECRET_NAME=${SKYPILOT_SA}
 fi
+
+# Sleep for 2 seconds to allow the secret to be created before fetching it.
+sleep 2
 
 # Note: service account token is stored base64-encoded in the secret but must
 # be plaintext in kubeconfig.
@@ -133,11 +269,19 @@ EOF
 echo "---
 Done!
 
-Copy the generated kubeconfig file to your SkyPilot Proxy server, and set the
-kubeconfig_file parameter in your skypilot.yaml config file to point to this
-kubeconfig file.
+Copy the generated kubeconfig file to your ~/.kube/ directory to use it with
+kubectl and skypilot:
 
-If you need access to multiple kubernetes clusters, you can generate additional
-kubeconfig files using this script and then merge them using merge-kubeconfigs.sh.
+# Backup your existing kubeconfig file
+mv ~/.kube/config ~/.kube/config.bak
+cp kubeconfig ~/.kube/config
 
-Note: Kubernetes RBAC rules for SkyPilot were created, you won't need to create them manually."
+# Verify that you can access the cluster
+kubectl get pods
+
+Also add this to your ~/.sky/config.yaml to use the new service account:
+
+# ~/.sky/config.yaml
+kubernetes:
+  remote_identity: ${SKYPILOT_SA}
+"


### PR DESCRIPTION
This PR has a few updates for k8s SA and namespace support:

Code:
1. Moves the `skypilot-system` namespace creation to happen only if the default `SERVICE_ACCOUNT` remote_identity is used. This is to reduce the scope of permissions required if a SA already exists. 
2. Update namespace fetching logic to also account for the case when the cluster is running in a in-cluster auth config but in a namespace different than 'default'. Previously we had been testing on `default` namespace so this bug was not caught.

Docs:
1. Updated the minimum permissions for Kubernetes docs and confirms that the permissions listed in the docs work. 
3. Added permissions required if storage mounting is used
4. Add comments if the user needs to specify their own namespace.

Ran the following tests for two scenarios on a GKE cluster:
1. User does not have a special service account and uses the `default` namespace. This is a base case to verify existing functionality does not break.
2. User creates a service account in a special `myns` namespace following the create-sky-sa.yaml example in the docs, creates a kubeconfig that uses this namespace and service account to authenticate then uses this kubeconfig to run SkyPilot in the `myns` namespace with `remote_identity: sky-sa`.

- [x] Manual sky launch test both from laptop and from pod launched by SkyPilot
- [x] Managed Job controller smoke test on Kubernetes using storage mounting: `pytest -v tests/test_smoke.py::test_managed_jobs_storage --kubernetes`