### PR TITLE
[SERVE][AWS] Don't open ports when all ports and all protocols are specified

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -721,11 +721,11 @@ def open_ports(
         if existing_rule['IpProtocol'] not in ['tcp', '-1']:
             continue
         # Skip any rules that don't have a FromPort or ToPort.
-        if existing_rule[
-                'IpProtocol'] == 'tcp' and 'FromPort' not in existing_rule or 'ToPort' not in existing_rule:
-            continue
-        existing_ports.update(
-            range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))
+        if 'FromPort' in existing_rule and 'ToPort' in existing_rule:
+            existing_ports.update(
+                range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))
+        elif existing_rule['IpProtocol'] == '-1':
+            existing_ports.add(-1)
 
     ports_to_open = []
     if -1 not in existing_ports:

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -727,9 +727,6 @@ def open_ports(
         elif existing_rule['IpProtocol'] == '-1':
             # For AWS, IpProtocol = -1 means all traffic
             existing_ports.add(-1)
-            # TODO: AWS SGs are permissive, if a deny rule were
-            #       required by Skypilot, this would override the rule
-            #       by making all ports accessible
             break
 
     ports_to_open = []

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -721,7 +721,8 @@ def open_ports(
         if existing_rule['IpProtocol'] not in ['tcp', '-1']:
             continue
         # Skip any rules that don't have a FromPort or ToPort.
-        if 'FromPort' not in existing_rule or 'ToPort' not in existing_rule:
+        if existing_rule[
+                'IpProtocol'] == 'tcp' and 'FromPort' not in existing_rule or 'ToPort' not in existing_rule:
             continue
         existing_ports.update(
             range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -718,15 +718,18 @@ def open_ports(
     existing_ports: Set[int] = set()
     for existing_rule in sg.ip_permissions:
         # Skip any non-tcp rules.
-        if existing_rule['IpProtocol'] != 'tcp':
+        if existing_rule['IpProtocol'] not in ['tcp', '-1']:
             continue
         # Skip any rules that don't have a FromPort or ToPort.
         if 'FromPort' not in existing_rule or 'ToPort' not in existing_rule:
             continue
         existing_ports.update(
             range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))
-    ports_to_open = resources_utils.port_set_to_ranges(
-        resources_utils.port_ranges_to_set(ports) - existing_ports)
+
+    ports_to_open = []
+    if -1 not in existing_ports:
+        ports_to_open = resources_utils.port_set_to_ranges(
+            resources_utils.port_ranges_to_set(ports) - existing_ports)
 
     ip_permissions = []
     for port in ports_to_open:


### PR DESCRIPTION
Currently, ports check for the specific port, but for AWS, `-1` signifies all ports and all protocols.
* Skypilot currently tries to add the port even if all ports are available to an existing SG.
* Now treats -1 as all protocols for `IpProtocol`
* Now treats -1 as all ports for `FromPort` and `ToPort`

Additional:
* If an SG name is specified in the configuration, it should probably not modify if it isn't managed by SkyPilot.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    * tested launching via aws with a custom SG
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
