### PR TITLE
[Core] Add skypilot-component label for clusters launched by SkyPilot

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -436,7 +436,10 @@ class Resources:
 
     @property
     def labels(self) -> Optional[Dict[str, str]]:
-        return self._labels
+        labels = {constants.TAG_SKYPILOT_COMPONENT: 'cluster'}
+        if self._labels is not None:
+           labels.update(self._labels)
+        return labels
 
     @property
     def is_image_managed(self) -> Optional[bool]:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -438,7 +438,7 @@ class Resources:
     def labels(self) -> Optional[Dict[str, str]]:
         labels = {constants.TAG_SKYPILOT_COMPONENT: 'cluster'}
         if self._labels is not None:
-           labels.update(self._labels)
+            labels.update(self._labels)
         return labels
 
     @property

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -225,3 +225,6 @@ CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP = 10
 # Serve: A default controller with 4 vCPU and 16 GB memory can run up to 16
 # services.
 CONTROLLER_PROCESS_CPU_DEMAND = 0.25
+
+# Tag key for what a cluster serves for in SkyPilot.
+TAG_SKYPILOT_COMPONENT = 'skypilot-component'

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -423,6 +423,12 @@ def get_controller_resources(
                     f'{controller_resources}').capitalize())
     controller_resources_to_use: resources.Resources = list(
         controller_resources)[0]
+    
+    labels = controller_resources_to_use.labels
+    labels.update(
+        {constants.TAG_SKYPILOT_COMPONENT: f'{controller.value.controller_type}-controller'}
+    )
+    controller_resources_to_use = controller_resources_to_use.copy(labels=labels)
 
     controller_record = global_user_state.get_cluster_from_name(
         controller.value.cluster_name)

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -423,12 +423,14 @@ def get_controller_resources(
                     f'{controller_resources}').capitalize())
     controller_resources_to_use: resources.Resources = list(
         controller_resources)[0]
-    
+
     labels = controller_resources_to_use.labels
-    labels.update(
-        {constants.TAG_SKYPILOT_COMPONENT: f'{controller.value.controller_type}-controller'}
-    )
-    controller_resources_to_use = controller_resources_to_use.copy(labels=labels)
+    labels.update({
+        constants.TAG_SKYPILOT_COMPONENT: (f'{controller.value.controller_type}'
+                                           '-controller')
+    })
+    controller_resources_to_use = controller_resources_to_use.copy(
+        labels=labels)
 
     controller_record = global_user_state.get_cluster_from_name(
         controller.value.cluster_name)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

TODO:
- [ ] Add the component label to distinguish clusters used for jobs or service.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
