### PR TITLE
[Core] Allow boolean-like strs in resources.labels

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -867,6 +867,13 @@ def write_cluster_config(
     if to_provision.labels:
         labels.update(to_provision.labels)
 
+    # Prepare labels to be dumped into the yaml file - add quotes to the values
+    # to enforce str type for label values. Unquoted strings may get parsed as
+    # bool by yaml.safe_load (E.g., 'True' without quotes gets parsed as bool),
+    # which may cause issues with downstream code (e.g., Kubernetes python API
+    # does not accept bool values for labels).
+    labels = {k: f'\'{v}\'' for k, v in labels.items()}
+
     # Dump the Ray ports to a file for Ray job submission
     dump_port_command = (
         f'{constants.SKY_PYTHON_CMD} -c \'import json, os; json.dump({constants.SKY_REMOTE_RAY_PORT_DICT_STR}, '

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -867,13 +867,6 @@ def write_cluster_config(
     if to_provision.labels:
         labels.update(to_provision.labels)
 
-    # Prepare labels to be dumped into the yaml file - add quotes to the values
-    # to enforce str type for label values. Unquoted strings may get parsed as
-    # bool by yaml.safe_load (E.g., 'True' without quotes gets parsed as bool),
-    # which may cause issues with downstream code (e.g., Kubernetes python API
-    # does not accept bool values for labels).
-    labels = {k: f'\'{v}\'' for k, v in labels.items()}
-
     # Dump the Ray ports to a file for Ray job submission
     dump_port_command = (
         f'{constants.SKY_PYTHON_CMD} -c \'import json, os; json.dump({constants.SKY_REMOTE_RAY_PORT_DICT_STR}, '

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -261,7 +261,7 @@ available_node_types:
             skypilot-user: {{ user }}
             # Custom tags for the pods
             {%- for label_key, label_value in labels.items() %}
-            {{ label_key }}: {{ label_value }}
+            {{ label_key }}: {{ label_value|tojson }}
             {%- endfor %}
         {% if k8s_fuse_device_required %}
         annotations:


### PR DESCRIPTION
A yaml like this would fail:
```
resources:
  cloud: kubernetes
  labels:
    my-label: 'True'
```

Because when the cluster YAML was dumped for the provisioner in ~/.sky/generated/, it would remove the quotes and write `my-label: True`. This would be parsed as a bool value (instead of str) by yaml.safe_load, which would cause issues with downstream code (e.g., Kubernetes python API does not allow submitting bools as label values). 

This PR adds single quotes around all dumped labels to make sure they are parsed as strings by the provisioner.

Tested:
- [x] YAML above on Kubernetes.