### PR TITLE
[Core] Downgrade setup tools for runtime setup

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -140,6 +140,10 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     'export PIP_DISABLE_PIP_VERSION_CHECK=1;'
     # Print the PATH in provision.log to help debug PATH issues.
     'echo PATH=$PATH; '
+    # Install setuptools<=69.5.1 to avoid the issue with the latest setuptools
+    # causing the error:
+    #   ImportError: cannot import name 'packaging' from 'pkg_resources'"
+    f'{SKY_PIP_CMD} install "setuptools<=69.5.1"'
     # Backward compatibility for ray upgrade (#3248): do not upgrade ray if the
     # ray cluster is already running, to avoid the ray cluster being restarted.
     #

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -143,7 +143,7 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     # Install setuptools<=69.5.1 to avoid the issue with the latest setuptools
     # causing the error:
     #   ImportError: cannot import name 'packaging' from 'pkg_resources'"
-    f'{SKY_PIP_CMD} install "setuptools<=69.5.1"'
+    f'{SKY_PIP_CMD} install "setuptools<70"; '
     # Backward compatibility for ray upgrade (#3248): do not upgrade ray if the
     # ray cluster is already running, to avoid the ray cluster being restarted.
     #

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -123,6 +123,8 @@ CONDA_INSTALLATION_COMMANDS = (
     f'conda create -y -n {SKY_REMOTE_PYTHON_ENV_NAME} python=3.10 && '
     f'conda activate {SKY_REMOTE_PYTHON_ENV_NAME};'
     # Create a separate conda environment for SkyPilot dependencies.
+    # We use --system-site-packages to reuse the system site packages to avoid
+    # the overhead of installing the same packages in the new environment.
     f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || '
     f'{{ {SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages && '
     f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE}; }};'

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -16,7 +16,6 @@ import requests
 
 import sky
 from sky import sky_logging
-from sky import skypilot_config
 from sky.usage import constants
 from sky.utils import common_utils
 from sky.utils import env_options

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -16,11 +16,11 @@ import requests
 
 import sky
 from sky import sky_logging
+from sky import skypilot_config
 from sky.usage import constants
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
-from sky import skypilot_config
 
 if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
@@ -141,6 +141,7 @@ class UsageMessageToReport(MessageToReport):
         #: Requested number of nodes
         self.task_num_nodes: Optional[int] = None  # update_actual_task
         # YAMLs converted to JSON.
+        # TODO: include the skypilot config used in task yaml.
         self.user_task_yaml: Optional[List[Dict[
             str, Any]]] = None  # update_user_task_yaml
         self.actual_task: Optional[List[Dict[str,
@@ -151,9 +152,6 @@ class UsageMessageToReport(MessageToReport):
         self.runtimes: Dict[str, float] = {}  # update_runtime
         self.exception: Optional[str] = None  # entrypoint_context
         self.stacktrace: Optional[str] = None  # entrypoint_context
-
-        #: SkyPilot config.
-        self.skypilot_config: Dict[str, Any] = skypilot_config.to_dict()
 
     def __repr__(self) -> str:
         d = self.get_properties()

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -20,6 +20,7 @@ from sky.usage import constants
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
+from sky import skypilot_config
 
 if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
@@ -150,6 +151,9 @@ class UsageMessageToReport(MessageToReport):
         self.runtimes: Dict[str, float] = {}  # update_runtime
         self.exception: Optional[str] = None  # entrypoint_context
         self.stacktrace: Optional[str] = None  # entrypoint_context
+
+        #: SkyPilot config.
+        self.skypilot_config: Dict[str, Any] = skypilot_config.to_dict()
 
     def __repr__(self) -> str:
         d = self.get_properties()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

For some image_id specified by users, there might be `setuptools>=70` installed, which will cause the runtime setup to fail for SkyPilot with the following error. We should downgrade the `setuptools` in SkyPilot runtime environment.
```
  File "/home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/modules/dashboard_sdk.py", line 10, in <module>
    from pkg_resources import packaging
ImportError: cannot import name 'packaging' from 'pkg_resources' (/home/sky/skypilot-runtime/lib/python3.10/site-packages/pkg_resources/__init__.py)
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test --cloud gcp --cpus 2 "pip install -U setuptools"`; `sky launch -c test --cloud gcp --cpus 2 echo hi` (this fails in `skypilot-nightly==1.0.0.dev20240523` but works on master and this PR due to the fix in #3639)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
