### PR TITLE
[Core] Fix inline script length checking

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -150,7 +150,7 @@ _RAY_UP_WITH_MONKEY_PATCHED_HASH_LAUNCH_CONF_PATH = (
 _MAX_INLINE_SCRIPT_LENGTH = 120 * 1024
 
 
-def _is_command_length_exceeds_limit(command: str) -> bool:
+def _is_command_length_exceeding_limit(command: str) -> bool:
     """Check if the length of the command exceeds the limit.
 
     We calculate the length of the command after quoting the command twice as
@@ -3162,7 +3162,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)
             encoded_script = shlex.quote(setup_script)
-            if detach_setup or _is_command_length_exceeds_limit(encoded_script):
+            if detach_setup or _is_command_length_exceeding_limit(encoded_script):
                 with tempfile.NamedTemporaryFile('w', prefix='sky_setup_') as f:
                     f.write(setup_script)
                     f.flush()
@@ -3273,7 +3273,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         code = job_lib.JobLibCodeGen.queue_job(job_id, job_submit_cmd)
         job_submit_cmd = ' && '.join([mkdir_code, create_script_code, code])
-        if _is_command_length_exceeds_limit(job_submit_cmd):
+        if _is_command_length_exceeding_limit(job_submit_cmd):
             runners = handle.get_command_runners()
             head_runner = runners[0]
             with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3162,7 +3162,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)
             encoded_script = shlex.quote(setup_script)
-            if detach_setup or _is_command_length_exceeding_limit(encoded_script):
+            if detach_setup or _is_command_length_exceeding_limit(
+                    encoded_script):
                 with tempfile.NamedTemporaryFile('w', prefix='sky_setup_') as f:
                     f.write(setup_script)
                     f.flush()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -150,7 +150,7 @@ _RAY_UP_WITH_MONKEY_PATCHED_HASH_LAUNCH_CONF_PATH = (
 _MAX_INLINE_SCRIPT_LENGTH = 120 * 1024
 
 
-def _is_command_length_exceeding_limit(command: str) -> bool:
+def _is_command_length_over_limit(command: str) -> bool:
     """Check if the length of the command exceeds the limit.
 
     We calculate the length of the command after quoting the command twice as
@@ -3162,7 +3162,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)
             encoded_script = shlex.quote(setup_script)
-            if detach_setup or _is_command_length_exceeding_limit(
+            if detach_setup or _is_command_length_over_limit(
                     encoded_script):
                 with tempfile.NamedTemporaryFile('w', prefix='sky_setup_') as f:
                     f.write(setup_script)
@@ -3274,7 +3274,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         code = job_lib.JobLibCodeGen.queue_job(job_id, job_submit_cmd)
         job_submit_cmd = ' && '.join([mkdir_code, create_script_code, code])
-        if _is_command_length_exceeding_limit(job_submit_cmd):
+        if _is_command_length_over_limit(job_submit_cmd):
             runners = handle.get_command_runners()
             head_runner = runners[0]
             with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -150,6 +150,18 @@ _RAY_UP_WITH_MONKEY_PATCHED_HASH_LAUNCH_CONF_PATH = (
 _MAX_INLINE_SCRIPT_LENGTH = 120 * 1024
 
 
+def _is_command_length_exceeds_limit(command: str) -> bool:
+    """Check if the length of the command exceeds the limit.
+    
+    We quote the command twice as when it is executed by the CommandRunner, the
+    command will be quoted twice, which will add significant length to the
+    command.
+    """
+
+    quoted_length = len(shlex.quote(shlex.quote(command)))
+    return quoted_length > _MAX_INLINE_SCRIPT_LENGTH
+
+
 def _get_cluster_config_template(cloud):
     cloud_to_template = {
         clouds.AWS: 'aws-ray.yml.j2',
@@ -3150,8 +3162,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)
             encoded_script = shlex.quote(setup_script)
-            if (detach_setup or
-                    len(encoded_script) > _MAX_INLINE_SCRIPT_LENGTH):
+            if detach_setup or _is_command_length_exceeds_limit(encoded_script):
                 with tempfile.NamedTemporaryFile('w', prefix='sky_setup_') as f:
                     f.write(setup_script)
                     f.flush()
@@ -3262,7 +3273,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         code = job_lib.JobLibCodeGen.queue_job(job_id, job_submit_cmd)
         job_submit_cmd = ' && '.join([mkdir_code, create_script_code, code])
-        if len(job_submit_cmd) > _MAX_INLINE_SCRIPT_LENGTH:
+        if _is_command_length_exceeds_limit(job_submit_cmd):
             runners = handle.get_command_runners()
             head_runner = runners[0]
             with tempfile.NamedTemporaryFile('w', prefix='sky_app_') as fp:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3162,8 +3162,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             setup_script = log_lib.make_task_bash_script(setup,
                                                          env_vars=setup_envs)
             encoded_script = shlex.quote(setup_script)
-            if detach_setup or _is_command_length_over_limit(
-                    encoded_script):
+            if detach_setup or _is_command_length_over_limit(encoded_script):
                 with tempfile.NamedTemporaryFile('w', prefix='sky_setup_') as f:
                     f.write(setup_script)
                     f.flush()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -153,9 +153,9 @@ _MAX_INLINE_SCRIPT_LENGTH = 120 * 1024
 def _is_command_length_exceeds_limit(command: str) -> bool:
     """Check if the length of the command exceeds the limit.
 
-    We quote the command twice as when it is executed by the CommandRunner, the
-    command will be quoted twice, which will add significant length to the
-    command.
+    We calculate the length of the command after quoting the command twice as
+    when it is executed by the CommandRunner, the command will be quoted twice
+    to ensure the correctness, which will add significant length to the command.
     """
 
     quoted_length = len(shlex.quote(shlex.quote(command)))

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -152,7 +152,7 @@ _MAX_INLINE_SCRIPT_LENGTH = 120 * 1024
 
 def _is_command_length_exceeds_limit(command: str) -> bool:
     """Check if the length of the command exceeds the limit.
-    
+
     We quote the command twice as when it is executed by the CommandRunner, the
     command will be quoted twice, which will add significant length to the
     command.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that the following task yaml fails:
```
num_nodes: 30

setup: echo setup
run: echo run
```

This is due to the length checking before does not include the quotes, which will add significant length. We derived the current threshold with binary search.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] reproducible script in #3511 with ``for i in `seq 1 8511`; do echo "  echo $i" >> test.yaml; done`` (not trigger file upload)
  - [x] reproducible script in #3511 with ``for i in `seq 1 8512`; do echo "  echo $i" >> test.yaml; done`` (not trigger file upload)
  - [x] scripts with 30 nodes above.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
