### PR TITLE
[AWS] Add pass role permission back for skypilot-v1

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -191,9 +191,10 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
             for policy_arn in attach_policy_arns:
                 role.attach_policy(PolicyArn=policy_arn)
 
-            # SkyPilot: 'PassRole' is required by the head node to pass the role to
-            # the workers, so we can access S3 buckets on the workers. 'Resource'
-            # is to limit the role to only able to pass itself to the workers.
+            # SkyPilot: 'PassRole' is required by the head node to pass the role
+            # to the workers, so we can access S3 buckets on the workers.
+            # 'Resource' is to limit the role to only able to pass itself to the
+            # workers.
             skypilot_pass_role_policy_doc = {
                 'Statement': [
                     {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

skypilot-v1 IAM role requires permission for passing the role and getting the instance profile, so a controller started with this IAM role with this account can create an instance with this IAM role assigned.

The change was included in the previous ray autoscaler-based provisioner, but accidentally dropped in the new provisioner refactoring #1702. Adding it back now:
https://github.com/skypilot-org/skypilot/blob/19ebc3d394b2adf26f72bbb5f341ac9763f3bdf0/sky/skylet/providers/aws/config.py#L361C13-L386C45


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
