### PR TITLE
[Docker/k8s] Make retrieving home dir more robust to warnings

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -157,7 +157,6 @@ class DockerInitializer:
         while True:
             rc, stdout, stderr = self.runner.run(cmd,
                                                  require_outputs=True,
-                                                 separate_stderr=True,
                                                  stream_logs=False,
                                                  log_path=self.log_path)
             if (not wait_for_docker_daemon or

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -9,7 +9,6 @@ from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import command_runner
 from sky.utils import subprocess_utils
-from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -157,6 +157,7 @@ class DockerInitializer:
         while True:
             rc, stdout, stderr = self.runner.run(cmd,
                                                  require_outputs=True,
+                                                 separate_stderr=True,
                                                  stream_logs=False,
                                                  log_path=self.log_path)
             if (not wait_for_docker_daemon or

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -346,7 +346,6 @@ class DockerInitializer:
                 cmd = (f'{self.docker_cmd} exec {self.container_name} '
                        'printenv HOME')
                 self.home_dir = self._run(cmd, separate_stderr=True)
-                self.home_dir = self.home_dir.strip()
                 # Check for unexpected newline in home directory, which can be
                 # a common issue when the output is mixed with stderr.
                 assert '\n' not in self.home_dir, (

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -308,12 +308,13 @@ def _check_user_privilege(namespace: str, new_nodes: List) -> None:
         runner = command_runner.KubernetesCommandRunner(
             (namespace, new_node.metadata.name))
         rc, stdout, stderr = runner.run(check_k8s_user_sudo_cmd,
-                                   require_outputs=True,
-                                   separate_stderr=True,
-                                   stream_logs=False)
+                                        require_outputs=True,
+                                        separate_stderr=True,
+                                        stream_logs=False)
         _raise_command_running_error('check user privilege',
                                      check_k8s_user_sudo_cmd,
-                                     new_node.metadata.name, rc, stdout + stderr)
+                                     new_node.metadata.name, rc,
+                                     stdout + stderr)
         if stdout == str(exceptions.INSUFFICIENT_PRIVILEGES_CODE):
             raise config_lib.KubernetesError(
                 'Insufficient system privileges detected. '
@@ -692,9 +693,9 @@ def get_cluster_info(
     assert head_pod_name is not None
     runner = command_runner.KubernetesCommandRunner((namespace, head_pod_name))
     rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
-                               require_outputs=True,
-                               separate_stderr=True,
-                               stream_logs=False)
+                                    require_outputs=True,
+                                    separate_stderr=True,
+                                    stream_logs=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
                                  head_pod_name, rc, stdout + stderr)
     ssh_user = stdout.strip()

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -307,12 +307,13 @@ def _check_user_privilege(namespace: str, new_nodes: List) -> None:
     for new_node in new_nodes:
         runner = command_runner.KubernetesCommandRunner(
             (namespace, new_node.metadata.name))
-        rc, stdout, _ = runner.run(check_k8s_user_sudo_cmd,
+        rc, stdout, stderr = runner.run(check_k8s_user_sudo_cmd,
                                    require_outputs=True,
+                                   separate_stderr=True,
                                    stream_logs=False)
         _raise_command_running_error('check user privilege',
                                      check_k8s_user_sudo_cmd,
-                                     new_node.metadata.name, rc, stdout)
+                                     new_node.metadata.name, rc, stdout + stderr)
         if stdout == str(exceptions.INSUFFICIENT_PRIVILEGES_CODE):
             raise config_lib.KubernetesError(
                 'Insufficient system privileges detected. '
@@ -690,11 +691,12 @@ def get_cluster_info(
     get_k8s_ssh_user_cmd = 'echo $(whoami)'
     assert head_pod_name is not None
     runner = command_runner.KubernetesCommandRunner((namespace, head_pod_name))
-    rc, stdout, _ = runner.run(get_k8s_ssh_user_cmd,
+    rc, stdout, stderr = runner.run(get_k8s_ssh_user_cmd,
                                require_outputs=True,
+                               separate_stderr=True,
                                stream_logs=False)
     _raise_command_running_error('get ssh user', get_k8s_ssh_user_cmd,
-                                 head_pod_name, rc, stdout)
+                                 head_pod_name, rc, stdout + stderr)
     ssh_user = stdout.strip()
     logger.debug(
         f'Using ssh user {ssh_user} for cluster {cluster_name_on_cloud}')

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -780,11 +780,13 @@ class KubernetesCommandRunner(CommandRunner):
             # Use `echo ~` to get the remote home directory, instead of pwd or
             # echo $HOME, because pwd can be `/` when the remote user is root
             # and $HOME is not always set.
-            rc, remote_home_dir, _ = self.run('echo ~',
+            rc, remote_home_dir, stderr = self.run('echo ~',
                                               require_outputs=True,
+                                              separate_stderr=True,
                                               stream_logs=False)
             if rc != 0:
-                raise ValueError('Failed to get remote home directory.')
+                raise ValueError('Failed to get remote home directory: '
+                                 f'{remote_home_dir + stderr}')
             remote_home_dir = remote_home_dir.strip()
             return remote_home_dir
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -781,9 +781,9 @@ class KubernetesCommandRunner(CommandRunner):
             # echo $HOME, because pwd can be `/` when the remote user is root
             # and $HOME is not always set.
             rc, remote_home_dir, stderr = self.run('echo ~',
-                                              require_outputs=True,
-                                              separate_stderr=True,
-                                              stream_logs=False)
+                                                   require_outputs=True,
+                                                   separate_stderr=True,
+                                                   stream_logs=False)
             if rc != 0:
                 raise ValueError('Failed to get remote home directory: '
                                  f'{remote_home_dir + stderr}')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We now make the home dir retrieving for the docker and k8s cluster more robust by avoiding the stderr polluting the stdout.

To reproduce:
1. Dockerfile
```dockerfile
FROM continuumio/miniconda3:23.3.1-0

RUN apt update -y && \
    apt install gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat curl -y && \
    rm -rf /var/lib/apt/lists/* 

# Setup SSH and generate hostkeys
RUN mkdir -p /var/run/sshd && \
    sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
    sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
    cd /etc/ssh/ && \
    ssh-keygen -A

# Setup new user named sky and add to sudoers. Also add /opt/conda/bin to sudo path.
RUN useradd -m -s /bin/bash sky && \
    echo "sky ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
    echo 'Defaults        secure_path="/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/sudoers.d/sky

# Switch to sky user
USER sky


WORKDIR /home/sky

ENV LC_ALL=invalid_locale
```
2. `sky launch --cloud kubernetes --image-id docker:michaelvll/skypilot-test:v3 --cpus 1 echo hi`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Reproducible scripts above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_job_queue_with_docker`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
