### PR TITLE
[Serve] Reword no Spot Policy in SkyServe

### DIFF
--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -260,7 +260,9 @@ class SkyServiceSpec:
                 policy_strs.append('Static spot mixture with '
                                    f'{self.base_ondemand_fallback_replicas} '
                                    f'base on-demand replica{plural}')
-        return ' '.join(policy_strs) if policy_strs else 'No spot policy'
+        if not policy_strs:
+            return 'No spot fallback policy'
+        return ' '.join(policy_strs)
 
     def autoscaling_policy_str(self):
         # TODO(MaoZiming): Update policy_str


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when no spot fallback policy was specified, `No spot policy` would be shown on the terminal, which is confusing when users are using spot resources. This PR reword it to `No spot fallback policy` to reduce confusion.

```bash
# previously
$ sky serve up -n http examples/serve/http_server/task.yaml --cloud aws --use-spot
Service from YAML spec: examples/serve/http_server/task.yaml
Service Spec:
Readiness probe method:           GET /health
Readiness initial delay seconds:  20
Readiness probe timeout seconds:  15
Replica autoscaling policy:       Fixed 2 replicas
Spot Policy:                      No spot policy
# this PR
$ sky serve up -n http examples/serve/http_server/task.yaml --cloud aws --use-spot
Service from YAML spec: examples/serve/http_server/task.yaml
Service Spec:
Readiness probe method:           GET /health
Readiness initial delay seconds:  20
Readiness probe timeout seconds:  15
Replica autoscaling policy:       Fixed 2 replicas
Spot Policy:                      No spot fallback policy
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] Test in the PR description
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
