### PR TITLE
map gke h100 megas to 'H100'

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -188,10 +188,12 @@ class GKELabelFormatter(GPULabelFormatter):
         elif value.startswith('nvidia-'):
             acc = value.replace('nvidia-', '').upper()
             if acc in ['H100-80GB', 'H100-MEGA-80GB']:
-                # H100 is named H100-80GB or H100-MEGA-80GB in GKE, where
-                # the latter has improved bandwidth. See a3-mega instances on GCP.
-                # TODO: we do not distinguish the two GPUs for simplicity, but we can
-                # evaluate whether we should distinguish them based on users' requests.
+                # H100 is named H100-80GB or H100-MEGA-80GB in GKE,
+                # where the latter has improved bandwidth.
+                # See a3-mega instances on GCP.
+                # TODO: we do not distinguish the two GPUs for simplicity,
+                # but we can evaluate whether we should distinguish
+                # them based on users' requests.
                 return 'H100'
             return acc
         else:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -188,7 +188,10 @@ class GKELabelFormatter(GPULabelFormatter):
         elif value.startswith('nvidia-'):
             acc = value.replace('nvidia-', '').upper()
             if acc in ['H100-80GB', 'H100-MEGA-80GB']:
-                # H100 is named as H100-80GB in GKE.
+                # H100 is named H100-80GB or H100-MEGA-80GB in GKE, where
+                # the latter has improved bandwidth. See a3-mega instances on GCP.
+                # TODO: we do not distinguish the two GPUs for simplicity, but we can
+                # evaluate whether we should distinguish them based on users' requests.
                 return 'H100'
             return acc
         else:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -187,7 +187,7 @@ class GKELabelFormatter(GPULabelFormatter):
             return value.replace('nvidia-tesla-', '').upper()
         elif value.startswith('nvidia-'):
             acc = value.replace('nvidia-', '').upper()
-            if acc == 'H100-80GB':
+            if acc in ['H100-80GB', 'H100-MEGA-80GB']:
                 # H100 is named as H100-80GB in GKE.
                 return 'H100'
             return acc


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

GCP recently introduced `a3-mega` instances with improved bandwidth instances. On GKE, such nodes are labeled as `cloud.google.com/gke-accelerator=nvidia-h100-mega-80gb` which was causing these to be recognized as `H100-MEGA-80GB`. This change fixes this.

Before
```
(sky) Andrews-MacBook-Air:skypilot asai$ sky show-gpus --cloud kubernetes
Kubernetes GPUs
GPU             QTY_PER_NODE            TOTAL_GPUS  TOTAL_FREE_GPUS  
H100-MEGA-80GB  1, 2, 3, 4, 5, 6, 7, 8  16          16               
(sky) Andrews-MacBook-Air:skypilot asai$ sky launch --cloud kubernetes --gpus H100:8
I 06-26 15:58:20 optimizer.py:1264] No resource satisfying Kubernetes({'H100': 8}) on Kubernetes.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request:
Task<name=sky-cmd>(run=<empty>)
  resources: Kubernetes({'H100': 8}).

To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
```

<!-- Describe the tests ran -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual test 
```
(sky) Andrews-MacBook-Air:skypilot asai$  sky show-gpus --cloud kubernetes
Kubernetes GPUs
GPU   QTY_PER_NODE            TOTAL_GPUS  TOTAL_FREE_GPUS  
H100  1, 2, 3, 4, 5, 6, 7, 8  16          16               
(sky) Andrews-MacBook-Air:skypilot asai$ sky launch --cloud kubernetes --gpus H100:8
I 06-26 16:02:26 optimizer.py:695] == Optimizer ==
I 06-26 16:02:26 optimizer.py:718] Estimated cost: $0.0 / hour
I 06-26 16:02:26 optimizer.py:718] 
I 06-26 16:02:26 optimizer.py:843] Considered resources (1 node):
I 06-26 16:02:26 optimizer.py:913] ----------------------------------------------------------------------------------------------------
I 06-26 16:02:26 optimizer.py:913]  CLOUD        INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
I 06-26 16:02:26 optimizer.py:913] ----------------------------------------------------------------------------------------------------
I 06-26 16:02:26 optimizer.py:913]  Kubernetes   2CPU--8GB--8H100   2       8         H100:8         kubernetes    0.00          ✔     
I 06-26 16:02:26 optimizer.py:913] ----------------------------------------------------------------------------------------------------
I 06-26 16:02:26 optimizer.py:913] 
Launching a new cluster 'sky-adb3-asai'. Proceed? [Y/n]: n
Aborted!
```
