### PR TITLE
[Example] Distributed nccl test with OpenMPI

### DIFF
--- a/examples/distributed_nccl_test_with_mpi.yaml
+++ b/examples/distributed_nccl_test_with_mpi.yaml
@@ -1,5 +1,5 @@
 resources:
-  accelerators: T4
+  accelerators: T4:2
   cloud: gcp
 
 file_mounts:

--- a/examples/distributed_nccl_test_with_mpi.yaml
+++ b/examples/distributed_nccl_test_with_mpi.yaml
@@ -1,0 +1,51 @@
+resources:
+  accelerators: T4
+  cloud: gcp
+
+file_mounts:
+  ~/.ssh/id_rsa: ~/.ssh/sky-key
+
+num_nodes: 2
+
+setup: |
+  sudo mv /etc/apt/sources.list.d/kubernetes.list /etc/apt/sources.list.d/kubernetes.list.save || true
+  sudo apt update
+  sudo apt -y install git
+  # install MPI (optional, if you intend to use multiple GPUs)
+  sudo apt install -y openmpi-bin openmpi-doc libopenmpi-dev
+  # install nccl
+  pip install nvidia-nccl-cu12
+  export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/nccl2/lib
+  echo $LIBRARY_PATH
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib/
+  echo $LD_LIBRARY_PATH
+  export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH:/usr/local/nccl2/include
+  git clone https://github.com/NVIDIA/nccl-tests.git
+  cd ./nccl-tests
+  make MPI=1 NCCL_HOME=/usr/local/nccl2 MPI_HOME=/usr/lib/openmpi
+
+run: |
+  export PATH=/usr/lib/openmpi/bin:$PATH
+  export LD_LIBRARY_PATH=/usr/lib/openmpi/lib:$LD_LIBRARY_PATH
+
+  cd ./nccl-tests
+  NCCL_TEST_PATH=$(pwd)/build/all_reduce_perf
+  HOST_IPS=$(echo "$SKYPILOT_NODE_IPS" | tr '\n' ",")
+  HOST_IPS=${HOST_IPS%,}
+  echo $HOST_IPS
+  MASTER_IP=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+
+  if [ "$SKYPILOT_NODE_RANK" == "0" ]; then
+    mpirun -np $SKYPILOT_NUM_NODES \
+      --allow-run-as-root \
+      -H $HOST_IPS \
+      -x MASTER_ADDR=$MASTER_IP \
+      -x MASTER_PORT=12354 \
+      -mca orte_base_help_aggregate 0 \
+      -map-by node \
+      --mca btl_tcp_if_exclude lo,docker0 \
+      -mca plm_base_verbose 5 \
+      -x PATH \
+      $NCCL_TEST_PATH -b 8 -e 16 -f 2 -g $SKYPILOT_NUM_GPUS_PER_NODE
+  fi
+    

--- a/examples/distributed_nccl_test_with_mpi.yaml
+++ b/examples/distributed_nccl_test_with_mpi.yaml
@@ -25,9 +25,6 @@ setup: |
   make MPI=1 NCCL_HOME=/usr/local/nccl2 MPI_HOME=/usr/lib/openmpi
 
 run: |
-  export PATH=/usr/lib/openmpi/bin:$PATH
-  export LD_LIBRARY_PATH=/usr/lib/openmpi/lib:$LD_LIBRARY_PATH
-
   cd ./nccl-tests
   NCCL_TEST_PATH=$(pwd)/build/all_reduce_perf
   HOST_IPS=$(echo "$SKYPILOT_NODE_IPS" | tr '\n' ",")


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In our example, there is no OpenMPI-based way to start distributed programs. This PR adds an example for it on GCP.

There are several issues discovered:
* OpenMPI/NCCL may be installed in different paths on various clouds' base image, making the task YAML writing a painful experience.
* We do not have SSH config set up for head node to access the worker node, making it hard for setting up the hostfile OpenMPI (in this example, we hack it by uploading the private key `~/.ssh/sky-key` to the remote cluster -- not secure). #3690 


TODO:
- [ ] Make this example runnable on any cloud.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c nccl-test  --cloud gcp --use-spot examples/distributed_nccl_test_with_mpi.yaml`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
