### PR TITLE
[Azure] Avoid azure reconfig everytime, speed up launch by up to 5.8x

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -3,8 +3,10 @@
 # pylint: disable=import-outside-toplevel
 import functools
 import threading
+import time
 
 from sky.adaptors import common
+from sky.utils import common_utils
 
 azure = common.LazyImport(
     'azure',
@@ -13,13 +15,30 @@ azure = common.LazyImport(
 _LAZY_MODULES = (azure,)
 
 _session_creation_lock = threading.RLock()
+_MAX_RETRY_FOR_GET_SUBSCRIPTION_ID = 5
 
 
 @common.load_lazy_modules(modules=_LAZY_MODULES)
+@functools.lru_cache()
 def get_subscription_id() -> str:
     """Get the default subscription id."""
     from azure.common import credentials
-    return credentials.get_cli_profile().get_subscription_id()
+    retry = 0
+    backoff = common_utils.Backoff(initial_backoff=0.5, max_backoff_factor=4)
+    while True:
+        try:
+            return credentials.get_cli_profile().get_subscription_id()
+        except Exception as e:
+            if ('Please run \'az login\' to setup account.' in str(e) and
+                    retry < _MAX_RETRY_FOR_GET_SUBSCRIPTION_ID):
+                # When there are multiple processes trying to get the
+                # subscription id, it may fail with the above error message.
+                # Retry will fix the issue.
+                retry += 1
+
+                time.sleep(backoff.current_backoff())
+                continue
+            raise
 
 
 @common.load_lazy_modules(modules=_LAZY_MODULES)
@@ -36,8 +55,8 @@ def exceptions():
     return azure_exceptions
 
 
-@functools.lru_cache()
 @common.load_lazy_modules(modules=_LAZY_MODULES)
+@functools.lru_cache()
 def get_client(name: str, subscription_id: str):
     # Sky only supports Azure CLI credential for now.
     # Increase the timeout to fix the Azure get-access-token timeout issue.

--- a/sky/skylet/providers/azure/config.py
+++ b/sky/skylet/providers/azure/config.py
@@ -140,8 +140,8 @@ def _configure_resource_group(config):
         deployment_exists = False
 
     if not deployment_exists:
-        # TODO (skypilot): this takes a long time (> 40 seconds) for stopping an
-        # azure VM, and this can be called twice during ray down.
+        # This takes a long time (> 40 seconds), we should be careful calling
+        # this function.
         outputs = (
             create_or_update(
                 resource_group_name=resource_group,

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -11,11 +11,11 @@ from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 from azure.mgmt.resource.resources.models import DeploymentMode
 
+from sky.adaptors import azure
 from sky.skylet.providers.azure.config import (
     bootstrap_azure,
     get_azure_sdk_function,
 )
-from sky.skylet import autostop_lib
 from sky.skylet.providers.command_runner import SkyDockerCommandRunner
 from sky.provision import docker_utils
 
@@ -62,23 +62,7 @@ class AzureNodeProvider(NodeProvider):
 
     def __init__(self, provider_config, cluster_name):
         NodeProvider.__init__(self, provider_config, cluster_name)
-        if not autostop_lib.get_is_autostopping():
-            # TODO(suquark): This is a temporary patch for resource group.
-            # By default, Ray autoscaler assumes the resource group is still
-            # here even after the whole cluster is destroyed. However, now we
-            # deletes the resource group after tearing down the cluster. To
-            # comfort the autoscaler, we need to create/update it here, so the
-            # resource group always exists.
-            #
-            # We should not re-configure the resource group again, when it is
-            # running on the remote VM and the autostopping is in progress,
-            # because the VM is running which guarantees the resource group
-            # exists.
-            from sky.skylet.providers.azure.config import _configure_resource_group
 
-            _configure_resource_group(
-                {"cluster_name": cluster_name, "provider": provider_config}
-            )
         subscription_id = provider_config["subscription_id"]
         self.cache_stopped_nodes = provider_config.get("cache_stopped_nodes", True)
         # Sky only supports Azure CLI credential for now.
@@ -106,9 +90,15 @@ class AzureNodeProvider(NodeProvider):
                     return False
             return True
 
-        vms = self.compute_client.virtual_machines.list(
-            resource_group_name=self.provider_config["resource_group"]
-        )
+        try:
+            vms = self.compute_client.virtual_machines.list(
+                resource_group_name=self.provider_config["resource_group"]
+            )
+        except azure.exceptions().HttpResponseError as e:
+            if e.reason == "ResourceGroupNotFound":
+                vms = {}
+            else:
+                raise
 
         nodes = [self._extract_metadata(vm) for vm in filter(match_tags, vms)]
         self.cached_nodes = {node["name"]: node for node in nodes}

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -98,7 +98,8 @@ class AzureNodeProvider(NodeProvider):
             )
         except azure.exceptions().ResourceNotFoundError as e:
             if "Code: ResourceGroupNotFound" in e.exc_msg:
-                logger.debug("Resource group not found. VMs should be terminated.")
+                logger.debug("Resource group not found. VMs should have been "
+                             "terminated.")
                 vms = []
             else:
                 raise

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -83,6 +83,7 @@ class AzureNodeProvider(NodeProvider):
     def _get_filtered_nodes(self, tag_filters):
         # add cluster name filter to only get nodes from this cluster
         cluster_tag_filters = {**tag_filters, TAG_RAY_CLUSTER_NAME: self.cluster_name}
+
         def match_tags(vm):
             for k, v in cluster_tag_filters.items():
                 if vm.tags.get(k) != v:
@@ -90,9 +91,11 @@ class AzureNodeProvider(NodeProvider):
             return True
 
         try:
-            vms = list(self.compute_client.virtual_machines.list(
-                resource_group_name=self.provider_config["resource_group"]
-            ))
+            vms = list(
+                self.compute_client.virtual_machines.list(
+                    resource_group_name=self.provider_config["resource_group"]
+                )
+            )
         except azure.exceptions().ResourceNotFoundError as e:
             if "Code: ResourceGroupNotFound" in e.exc_msg:
                 logger.debug("Resource group not found. VMs should be terminated.")

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -98,8 +98,9 @@ class AzureNodeProvider(NodeProvider):
             )
         except azure.exceptions().ResourceNotFoundError as e:
             if "Code: ResourceGroupNotFound" in e.exc_msg:
-                logger.debug("Resource group not found. VMs should have been "
-                             "terminated.")
+                logger.debug(
+                    "Resource group not found. VMs should have been terminated."
+                )
                 vms = []
             else:
                 raise

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -96,6 +96,8 @@ class AzureNodeProvider(NodeProvider):
             )
         except azure.exceptions().HttpResponseError as e:
             if e.reason == "ResourceGroupNotFound":
+                logger.debug("Resource group not found. VMs should be "
+                            "terminated.")
                 vms = {}
             else:
                 raise

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -83,7 +83,6 @@ class AzureNodeProvider(NodeProvider):
     def _get_filtered_nodes(self, tag_filters):
         # add cluster name filter to only get nodes from this cluster
         cluster_tag_filters = {**tag_filters, TAG_RAY_CLUSTER_NAME: self.cluster_name}
-
         def match_tags(vm):
             for k, v in cluster_tag_filters.items():
                 if vm.tags.get(k) != v:
@@ -91,13 +90,13 @@ class AzureNodeProvider(NodeProvider):
             return True
 
         try:
-            vms = self.compute_client.virtual_machines.list(
+            vms = list(self.compute_client.virtual_machines.list(
                 resource_group_name=self.provider_config["resource_group"]
-            )
-        except azure.exceptions().HttpResponseError as e:
-            if e.reason == "ResourceGroupNotFound":
-                logger.debug("Resource group not found. VMs should be " "terminated.")
-                vms = {}
+            ))
+        except azure.exceptions().ResourceNotFoundError as e:
+            if "Code: ResourceGroupNotFound" in e.exc_msg:
+                logger.debug("Resource group not found. VMs should be terminated.")
+                vms = []
             else:
                 raise
 

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -96,8 +96,7 @@ class AzureNodeProvider(NodeProvider):
             )
         except azure.exceptions().HttpResponseError as e:
             if e.reason == "ResourceGroupNotFound":
-                logger.debug("Resource group not found. VMs should be "
-                            "terminated.")
+                logger.debug("Resource group not found. VMs should be " "terminated.")
                 vms = {}
             else:
                 raise

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -233,7 +233,7 @@ class Backoff:
     MULTIPLIER = 1.6
     JITTER = 0.4
 
-    def __init__(self, initial_backoff: int = 5, max_backoff_factor: int = 5):
+    def __init__(self, initial_backoff: float = 5, max_backoff_factor: int = 5):
         self._initial = True
         self._backoff = 0.0
         self._initial_backoff = initial_backoff


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Mitigates #3695. 

This PR avoids an additional configuration which causes a significant slow down.

## Single Node (1.6x faster)
```
multitme -n 5 sky launch --cloud azure -y
            Mean        Std.Dev.    Min         Median      Max
real        214.837     11.941      203.255     211.937     237.772
user        9.281       0.455       8.990       9.093       10.186
sys         2.748       0.080       2.641       2.761       2.873
```

## Single Node on existing cluster (5.8x faster)

```
multitime -n 5 sky launch -c test-azure-skip-deploy --cloud azure --cpus 2 -y
            Mean        Std.Dev.    Min         Median      Max
real        28.327      0.950       27.159      28.309      29.676      
user        10.261      0.166       10.113      10.187      10.582      
sys         1.497       0.066       1.442       1.472       1.623 
```

## Multi Node (1.24x faster)
```
multitime -n 5 sky launch --cloud azure -y --cpus 2 --num-nodes 2
            Mean        Std.Dev.    Min         Median      Max
real        541.261     284.335     385.725     402.150     1109.727
user        21.173      2.179       19.834      19.920      25.469
sys         5.746       0.293       5.519       5.640       6.322
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky autostop -i 0 --down test-azure`
  - [x] Wait until the cluster terminated, and `sky launch -c test-azure echo hi`
  - [x] `sky launch -c test-azure --cloud azure --cpus 2 echo hi`; manually terminate the cluster; `sky down test-azure`
  - [x] `sky launch -c test-azure --cloud azure --cpus 2 echo hi`; manually delete resource group on the portal; `sky stop test-azure` (our error handling works)
- [x] All smoke tests: `pytest tests/test_smoke.py --azure` (except for tests related to GPUs due to the quota limit and the issue with A10 #3707)
```
FAILED tests/test_smoke.py::test_managed_jobs - Exception: test failed: less /var/tmp/managed-jobs-i8368hll.log
FAILED tests/test_smoke.py::test_skyserve_large_readiness_timeout - Exception: test failed: less /var/tmp/test-skyserve-large-readiness-timeout-xcoph374.log
FAILED tests/test_smoke.py::test_huggingface - Exception: test failed: less /var/tmp/huggingface_glue_imdb_app-fool8shv.log
FAILED tests/test_smoke.py::test_multi_echo - Exception: test failed: less /var/tmp/multi_echo-sz1vyxl_.log
FAILED tests/test_smoke.py::test_job_queue - Exception: test failed: less /var/tmp/job_queue-51ns08vv.log
FAILED tests/test_smoke.py::test_job_queue_with_docker[docker:continuumio/miniconda3:latest] - Exception: test failed: less /var/tmp/job_queue_with_docker-4m7keo3r.log
FAILED tests/test_smoke.py::test_cancel_pytorch - Exception: test failed: less /var/tmp/cancel-pytorch-w43a0mbm.log
FAILED tests/test_smoke.py::test_job_queue_with_docker[docker:nvidia/cuda:11.8.0-devel-ubuntu18.04] - Exception: test failed: less /var/tmp/job_queue_with_docker-bxu6ez58.log
FAILED tests/test_smoke.py::test_job_queue_with_docker[docker:ubuntu:18.04] - Exception: test failed: less /var/tmp/job_queue_with_docker-q6o1kwco.log
FAILED tests/test_smoke.py::test_job_queue_with_docker[docker:winglian/axolotl:main-latest] - Exception: test failed: less /var/tmp/job_queue_with_docker-e0xabtb2.log
FAILED tests/test_smoke.py::test_sky_bench - Exception: test failed: less /var/tmp/sky-bench-exgbfdgp.log
FAILED tests/test_smoke.py::test_job_queue_multinode - Exception: test failed: less /var/tmp/job_queue_multinode-cd29qwwe.log
FAILED tests/test_smoke.py::test_job_queue_with_docker[docker:continuumio/miniconda3:24.1.2-0] - Exception: test failed: less /var/tmp/job_queue_with_docker-n1agtcv7.log
FAILED tests/test_smoke.py::test_skyserve_readiness_timeout_fail - Exception: test failed: less /var/tmp/test-skyserve-readiness-timeout-fail-y1wcupuq.log
FAILED tests/test_smoke.py::test_skyserve_base_ondemand_fallback - Exception: test failed: less /var/tmp/test-skyserve-base-ondemand-fallback-h887u0t1.log
FAILED tests/test_smoke.py::test_skyserve_update - Exception: test failed: less /var/tmp/test-skyserve-update-wigafrh6.log
FAILED tests/test_smoke.py::test_skyserve_llm - Exception: test failed: less /var/tmp/test-skyserve-llm-smothj9l.log
FAILED tests/test_smoke.py::test_skyserve_new_autoscaler_update[blue_green] - Exception: test failed: less /var/tmp/test-skyserve-new-autoscaler-update-5pof25gf.log
FAILED tests/test_smoke.py::test_skyserve_new_autoscaler_update[rolling] - Exception: test failed: less /var/tmp/test-skyserve-new-autoscaler-update-kg7w6usv.log
```
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
