### PR TITLE
[GCP] Add gcp.force_enable_external_ips configuration

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -94,7 +94,7 @@ User
     resourcemanager.projects.getIamPolicy
 
 .. note::
-    
+
     For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/config.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
 
 .. note::
@@ -145,7 +145,7 @@ User
 8. **Optional**: If the user needs to use custom machine images with ``sky launch --image-id``, you can additionally add the following permissions:
 
 .. code-block:: text
-    
+
     compute.disks.get
     compute.disks.resize
     compute.images.get
@@ -297,7 +297,7 @@ To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to sp
       use_internal_ips: true
       # VPC with NAT setup, see below
       vpc_name: my-vpc-name
-      ssh_proxy_command: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.proxy      
+      ssh_proxy_command: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.proxy
 
 The ``gcp.ssh_proxy_command`` field is optional. If SkyPilot is run on a machine that can directly access the internal IPs of the instances, it can be omitted. Otherwise, it should be set to a command that can be used to proxy SSH connections to the internal IPs of the instances.
 
@@ -338,3 +338,16 @@ If proxy is not needed, but the regions need to be limited, you can set the ``gc
       ssh_proxy_command:
         us-west1: null
         us-east1: null
+
+
+Force Enable Exteral IPs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+An alternative to setting up cloud NAT for instances that need to access the public internet but are in a VPC and communicated with via their internal IP is to force them to be created with an external IP address.
+
+.. code-block:: yaml
+
+    gcp:
+      use_internal_ips: true
+      vpc_name: my-vpc-name
+      force_enable_external_ips: true

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -341,7 +341,7 @@ If proxy is not needed, but the regions need to be limited, you can set the ``gc
 
 
 Force Enable Exteral IPs
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 An alternative to setting up cloud NAT for instances that need to access the public internet but are in a VPC and communicated with via their internal IP is to force them to be created with an external IP address.
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -245,6 +245,16 @@ Available fields and semantics:
     #
     # Default: false.
     use_internal_ips: true
+
+    # Should instances in a vpc where communicated with via internal IPs still
+    # have an external IP? (optional)
+    #
+    # Set to true to force VMs to be assigned an exteral IP even when vpc_name
+    # and use_internal_ips are set.
+    #
+    # Default: false
+    force_enable_external_ips: true
+
     # SSH proxy command (optional).
     #
     # Please refer to the aws.ssh_proxy_command section above for more details.
@@ -312,7 +322,7 @@ Available fields and semantics:
       #
       # Default: 900
       provision_timeout: 900
-      
+
 
     # Identity to use for all GCP instances (optional).
     #

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -515,9 +515,9 @@ class GCP(clouds.Cloud):
             int(use_mig))
         if use_mig:
             resources_vars.update(managed_instance_group_config)
-        resources_vars['force_enable_external_ips'] = skypilot_config.get_nested(
-            ('gcp', 'force_enable_external_ips'), False
-        )
+        resources_vars[
+            'force_enable_external_ips'] = skypilot_config.get_nested(
+                ('gcp', 'force_enable_external_ips'), False)
         return resources_vars
 
     def _get_feasible_launchable_resources(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -515,6 +515,9 @@ class GCP(clouds.Cloud):
             int(use_mig))
         if use_mig:
             resources_vars.update(managed_instance_group_config)
+        resources_vars['force_enable_external_ips'] = skypilot_config.get_nested(
+            ('gcp', 'force_enable_external_ips'), False
+        )
         return resources_vars
 
     def _get_feasible_launchable_resources(

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -672,7 +672,8 @@ def _configure_subnet(region: str, cluster_name: str,
             'type': 'ONE_TO_ONE_NAT',
         }],
     }]
-    if config.provider_config.get('use_internal_ips', False):
+    enable_external_ips = _enable_exteral_ips(config)
+    if not enable_external_ips:
         # Removing this key means the VM will not be assigned an external IP.
         default_interfaces[0].pop('accessConfigs')
 
@@ -686,12 +687,18 @@ def _configure_subnet(region: str, cluster_name: str,
         node_config['networkConfig'] = copy.deepcopy(default_interfaces)[0]
         # TPU doesn't have accessConfigs
         node_config['networkConfig'].pop('accessConfigs', None)
-        if config.provider_config.get('use_internal_ips', False):
-            node_config['networkConfig']['enableExternalIps'] = False
-        else:
-            node_config['networkConfig']['enableExternalIps'] = True
+        node_config['networkConfig']['enableExternalIps'] = enable_external_ips
 
     return config
+
+
+def _enable_exteral_ips(config: common.ProvisionConfig) -> bool:
+    force_enable_external_ips = config.provider_config.get(
+        'force_enable_external_ips', False
+    )
+    use_internal_ips = config.provider_config.get('use_internal_ips', False)
+
+    return force_enable_external_ips or not use_internal_ips
 
 
 def _delete_firewall_rule(project_id: str, compute, name):

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -694,8 +694,7 @@ def _configure_subnet(region: str, cluster_name: str,
 
 def _enable_exteral_ips(config: common.ProvisionConfig) -> bool:
     force_enable_external_ips = config.provider_config.get(
-        'force_enable_external_ips', False
-    )
+        'force_enable_external_ips', False)
     use_internal_ips = config.provider_config.get('use_internal_ips', False)
 
     return force_enable_external_ips or not use_internal_ips

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -672,7 +672,7 @@ def _configure_subnet(region: str, cluster_name: str,
             'type': 'ONE_TO_ONE_NAT',
         }],
     }]
-    enable_external_ips = _enable_exteral_ips(config)
+    enable_external_ips = _enable_external_ips(config)
     if not enable_external_ips:
         # Removing this key means the VM will not be assigned an external IP.
         default_interfaces[0].pop('accessConfigs')
@@ -692,7 +692,7 @@ def _configure_subnet(region: str, cluster_name: str,
     return config
 
 
-def _enable_exteral_ips(config: common.ProvisionConfig) -> bool:
+def _enable_external_ips(config: common.ProvisionConfig) -> bool:
     force_enable_external_ips = config.provider_config.get(
         'force_enable_external_ips', False)
     use_internal_ips = config.provider_config.get('use_internal_ips', False)

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -50,6 +50,7 @@ provider:
   firewall_rule: {{firewall_rule}}
 {% endif %}
   use_internal_ips: {{use_internal_ips}}
+  force_enable_external_ips: {{force_enable_external_ips}}
 {%- if tpu_vm %}
   _has_tpus: True
 {%- endif %}

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -32,7 +32,7 @@ docker:
 provider:
   # We use a custom node provider for GCP to create, stop and reuse instances.
   type: external  # type: gcp
-  module: sky.skylet.providers.gcp.GCPNodeProvider
+  module: sky.provision.gcp
   region: {{region}}
   availability_zone: {{zones}}
   # Keep (otherwise cannot reuse when re-provisioning).

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -664,7 +664,7 @@ def get_config_schema():
                         }
                     }
                 },
-                'force_enable_exteral_ips': {
+                'force_enable_external_ips': {
                     'type': 'boolean'
                 },
                 **_LABELS_SCHEMA,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -664,6 +664,9 @@ def get_config_schema():
                         }
                     }
                 },
+                'force_enable_exteral_ips': {
+                    'type': 'boolean'
+                },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -798,31 +798,6 @@ def test_gcp_mig():
 
 
 @pytest.mark.gcp
-def test_gcp_use_internal_ips():
-    name = _get_cluster_name()
-    test_commands = [
-        # Launch in background because internal ips will prevent sshing for setup
-        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml &',
-        # Wait for the vm to be up
-        'sleep 30',
-        # Check network of vm is "default"
-        (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.network)" | grep "networks/default"'),
-        # Check no entries in network interfaces access configs,
-        # where external ips would be
-        (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.accessConfigs)" | wc -w | grep 0'),
-        f'sky down -y {name}',
-    ]
-    test = Test(
-        'gcp_use_internal_ips',
-        test_commands,
-        f'sky down -y {name}',
-        env={'SKYPILOT_CONFIG': 'tests/test_yamls/use_internal_ips_config.yaml'})
-    run_one_test(test)
-
-
-@pytest.mark.gcp
 def test_gcp_force_enable_external_ips():
     name = _get_cluster_name()
     test_commands = [

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -797,6 +797,29 @@ def test_gcp_mig():
     run_one_test(test)
 
 
+@pytest.mark.gcp
+def test_gcp_force_enable_external_ips():
+    name = _get_cluster_name()
+    test_commands = [
+        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
+        (
+            f'gcloud compute instances list --filter=name~"{name}" --format='
+            '"value(networkInterfaces.subnetwork)" | grep "subnetworks/default"'
+        ),
+        (
+            f'gcloud compute instances list --filter=name~"{name}" --format='
+            '"value(networkInterfaces.accessConfigs[0].name)" | grep "External"'
+        ),
+        f'sky down -y {name}',
+    ]
+    test = Test(
+        'gcp_force_enable_external_ips',
+        test_commands,
+        f'sky down -y {name}',
+        env={'SKYPILOT_CONFIG': 'tests/test_yamls/force_enable_external_ips_config.yaml'})
+    run_one_test(test)
+
+
 @pytest.mark.aws
 def test_image_no_conda():
     name = _get_cluster_name()
@@ -3302,7 +3325,7 @@ def _check_replica_in_status(name: str, check_tuples: List[Tuple[int, bool,
     """Check replicas' status and count in sky serve status
 
     We will check vCPU=2, as all our tests use vCPU=2.
-    
+
     Args:
         name: the name of the service
         check_tuples: A list of replica property to check. Each tuple is

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -801,11 +801,17 @@ def test_gcp_mig():
 def test_gcp_use_internal_ips():
     name = _get_cluster_name()
     test_commands = [
-        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
+        # Launch detached because internal ips will prevent sshing for setup
+        f'(sky launch -y -s -c {name} tests/test_yamls/minimal.yaml)',
+        # Wait for the vm to be up
+        'sleep 20',
+        # Check network of vm is "default"
         (f'gcloud compute instances list --filter=name~"{name}" --format='
          '"value(networkInterfaces.network)" | grep "networks/default"'),
+        # Check no entries in network interfaces access configs,
+        # where external ips would be
         (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.accessConfigs[0].name)" | wc -w  | grep 0'),
+         '"value(networkInterfaces.accessConfigs)" | wc -w  | grep 0'),
         f'sky down -y {name}',
     ]
     test = Test(
@@ -821,10 +827,12 @@ def test_gcp_force_enable_external_ips():
     name = _get_cluster_name()
     test_commands = [
         f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
+        # Check network of vm is "default"
         (f'gcloud compute instances list --filter=name~"{name}" --format='
          '"value(networkInterfaces.network)" | grep "networks/default"'),
+        # Check External NAT in network access configs, corresponds to external ip
         (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.accessConfigs[0].name)" | grep "External"'),
+         '"value(networkInterfaces.accessConfigs[0].name)" | grep "External NAT"'),
         f'sky down -y {name}',
     ]
     skypilot_config = 'tests/test_yamls/force_enable_external_ips_config.yaml'

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -801,17 +801,17 @@ def test_gcp_mig():
 def test_gcp_use_internal_ips():
     name = _get_cluster_name()
     test_commands = [
-        # Launch detached because internal ips will prevent sshing for setup
-        f'(sky launch -y -s -c {name} tests/test_yamls/minimal.yaml)',
+        # Launch in background because internal ips will prevent sshing for setup
+        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml &',
         # Wait for the vm to be up
-        'sleep 20',
+        'sleep 30',
         # Check network of vm is "default"
         (f'gcloud compute instances list --filter=name~"{name}" --format='
          '"value(networkInterfaces.network)" | grep "networks/default"'),
         # Check no entries in network interfaces access configs,
         # where external ips would be
         (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.accessConfigs)" | wc -w  | grep 0'),
+         '"value(networkInterfaces.accessConfigs)" | wc -w | grep 0'),
         f'sky down -y {name}',
     ]
     test = Test(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -801,7 +801,7 @@ def test_gcp_mig():
 def test_gcp_force_enable_external_ips():
     name = _get_cluster_name()
     test_commands = [
-        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
+        f'sky launch -y -c {name} --cloud gcp --cpus 2 tests/test_yamls/minimal.yaml',
         # Check network of vm is "default"
         (f'gcloud compute instances list --filter=name~"{name}" --format='
          '"value(networkInterfaces.network)" | grep "networks/default"'),

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -798,25 +798,41 @@ def test_gcp_mig():
 
 
 @pytest.mark.gcp
+def test_gcp_use_internal_ips():
+    name = _get_cluster_name()
+    test_commands = [
+        f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
+        (f'gcloud compute instances list --filter=name~"{name}" --format='
+         '"value(networkInterfaces.network)" | grep "networks/default"'),
+        (f'gcloud compute instances list --filter=name~"{name}" --format='
+         '"value(networkInterfaces.accessConfigs[0].name)" | wc -w  | grep 0'),
+        f'sky down -y {name}',
+    ]
+    test = Test(
+        'gcp_use_internal_ips',
+        test_commands,
+        f'sky down -y {name}',
+        env={'SKYPILOT_CONFIG': 'tests/test_yamls/use_internal_ips_config.yaml'})
+    run_one_test(test)
+
+
+@pytest.mark.gcp
 def test_gcp_force_enable_external_ips():
     name = _get_cluster_name()
     test_commands = [
         f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
-        (
-            f'gcloud compute instances list --filter=name~"{name}" --format='
-            '"value(networkInterfaces.network)" | grep "networks/default"'
-        ),
-        (
-            f'gcloud compute instances list --filter=name~"{name}" --format='
-            '"value(networkInterfaces.accessConfigs[0].name)" | grep "External"'
-        ),
+        (f'gcloud compute instances list --filter=name~"{name}" --format='
+         '"value(networkInterfaces.network)" | grep "networks/default"'),
+        (f'gcloud compute instances list --filter=name~"{name}" --format='
+         '"value(networkInterfaces.accessConfigs[0].name)" | grep "External"'),
         f'sky down -y {name}',
     ]
+    skypilot_config = 'tests/test_yamls/force_enable_external_ips_config.yaml'
     test = Test(
         'gcp_force_enable_external_ips',
         test_commands,
         f'sky down -y {name}',
-        env={'SKYPILOT_CONFIG': 'tests/test_yamls/force_enable_external_ips_config.yaml'})
+        env={'SKYPILOT_CONFIG': skypilot_config})
     run_one_test(test)
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -804,7 +804,7 @@ def test_gcp_force_enable_external_ips():
         f'sky launch -y -c {name} tests/test_yamls/minimal.yaml',
         (
             f'gcloud compute instances list --filter=name~"{name}" --format='
-            '"value(networkInterfaces.subnetwork)" | grep "subnetworks/default"'
+            '"value(networkInterfaces.network)" | grep "networks/default"'
         ),
         (
             f'gcloud compute instances list --filter=name~"{name}" --format='

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -807,15 +807,15 @@ def test_gcp_force_enable_external_ips():
          '"value(networkInterfaces.network)" | grep "networks/default"'),
         # Check External NAT in network access configs, corresponds to external ip
         (f'gcloud compute instances list --filter=name~"{name}" --format='
-         '"value(networkInterfaces.accessConfigs[0].name)" | grep "External NAT"'),
+         '"value(networkInterfaces.accessConfigs[0].name)" | grep "External NAT"'
+        ),
         f'sky down -y {name}',
     ]
     skypilot_config = 'tests/test_yamls/force_enable_external_ips_config.yaml'
-    test = Test(
-        'gcp_force_enable_external_ips',
-        test_commands,
-        f'sky down -y {name}',
-        env={'SKYPILOT_CONFIG': skypilot_config})
+    test = Test('gcp_force_enable_external_ips',
+                test_commands,
+                f'sky down -y {name}',
+                env={'SKYPILOT_CONFIG': skypilot_config})
     run_one_test(test)
 
 

--- a/tests/test_yamls/force_enable_external_ips_config.yaml
+++ b/tests/test_yamls/force_enable_external_ips_config.yaml
@@ -1,0 +1,4 @@
+gcp:
+  vpc_name: default
+  use_internal_ips: true
+  force_enable_external_ips: true

--- a/tests/test_yamls/use_internal_ips_config.yaml
+++ b/tests/test_yamls/use_internal_ips_config.yaml
@@ -1,0 +1,3 @@
+gcp:
+  vpc_name: default
+  use_internal_ips: true


### PR DESCRIPTION
This PR adds a new configuration to the `~/.sky/config.yaml` for gcp, `force_enable_external_ips`. Setting this configuration to `true` (default is `false` for backwards compatibility) will cause the gcp subnet provisioner to create VMs with a public ip address even if `use_internal_ips` is set to `true`; this is useful when communication within a vcp is desired _and_ the VM needs to make calls to the public internet.

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_gcp_force_enable_external_ips` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
