### PR TITLE
[Core] Fix A10 GPU on Azure

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2020,8 +2020,16 @@ class RetryingVmProvisioner(object):
         failover_history: List[Exception] = list()
 
         style = colorama.Style
+        fore = colorama.Fore
         # Retrying launchable resources.
         while True:
+            if (isinstance(to_provision.cloud, clouds.Azure) and
+                    to_provision.accelerators is not None and
+                    'A10' in to_provision.accelerators):
+                logger.warning(f'{style.BRIGHT}{fore.YELLOW}Trying to launch '
+                               'an A10 cluster on Azure. This may take ~20 '
+                               'minutes due to driver installation.'
+                               f'{style.RESET_ALL}')
             try:
                 # Recheck cluster name as the 'except:' block below may
                 # change the cloud assignment.

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -315,8 +315,8 @@ class Azure(clouds.Cloud):
         }
 
         # Setup the A10 nvidia driver.
-        need_nvidia_driver_extension = (resources.accelerators is not None and
-                                        'A10' in resources.accelerators)
+        need_nvidia_driver_extension = (acc_dict is not None and
+                                        'A10' in acc_dict)
 
         # Setup commands to eliminate the banner and restart sshd.
         # This script will modify /etc/ssh/sshd_config and add a bash script

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -333,6 +333,7 @@ class AzureNodeProvider(NodeProvider):
                             },
                         },
                     ]
+                    break
 
         parameters = {
             "properties": {

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -329,8 +329,15 @@ class AzureNodeProvider(NodeProvider):
         )
         poller.wait()
 
+        # pylint: disable=import-outside-toplevel
+        from sky.clouds.service_catalog import azure_catalog
+
+        instance_type = node_config["azure_arm_parameters"].get("vmSize", "")
+        accs = azure_catalog.get_accelerators_from_instance_type(instance_type)
+        if accs is None or "A10" not in accs:
+            return
+
         # Configure driver extension for A10 GPUs
-        # TODO(tian): Only do this for A10 vms.
         create_result = poller.result().as_dict()
         output_resources = create_result.get("properties", {}).get(
             "output_resources", []

--- a/sky/skylet/providers/azure/node_provider.py
+++ b/sky/skylet/providers/azure/node_provider.py
@@ -303,12 +303,7 @@ class AzureNodeProvider(NodeProvider):
         template_params["nsg"] = self.provider_config["nsg"]
         template_params["subnet"] = self.provider_config["subnet"]
 
-        # pylint: disable=import-outside-toplevel
-        from sky.clouds.service_catalog import azure_catalog
-
-        instance_type = node_config["azure_arm_parameters"].get("vmSize", "")
-        accs = azure_catalog.get_accelerators_from_instance_type(instance_type)
-        if accs is not None and "A10" in accs:
+        if node_config.get("need_nvidia_driver_extension", False):
             # Configure driver extension for A10 GPUs. A10 GPUs requires a
             # special type of drivers which is available at Microsoft HPC
             # extension. Reference: https://forums.developer.nvidia.com/t/ubuntu-22-04-installation-driver-error-nvidia-a10/285195/2

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -80,6 +80,7 @@ available_node_types:
             # billingProfile:
             #     maxPrice: -1
             {%- endif %}
+        need_nvidia_driver_extension: {{need_nvidia_driver_extension}}
         # TODO: attach disk
 {% if num_nodes > 1 %}
     ray.worker.default:
@@ -108,6 +109,7 @@ available_node_types:
             # billingProfile:
             #     maxPrice: -1
           {%- endif %}
+        need_nvidia_driver_extension: {{need_nvidia_driver_extension}}
 {%- endif %}
 
 head_node_type: ray.head.default


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3651. [A10 GPUs require a special type of driver, Grid Driver](https://forums.developer.nvidia.com/t/ubuntu-22-04-installation-driver-error-nvidia-a10/285195/2), which is [suggested to be installed by enabling the `NvidiaGpuDriverLinux` extension](https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/hpccompute-gpu-linux). This PR added this extension for A10 instances.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] The YAML in the issue and `nvidia-smi` works well. 
     - [x] The YAML in the issue, Qwen model e2e.
     - [x] `sky launch --cloud azure -c az-wo-a10` and checked that the drivers is not installed
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
