### PR TITLE
Don't require create namespace permission in cluster launch flow

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1529,6 +1529,14 @@ def create_namespace(namespace: str) -> None:
         namespace: Name of the namespace to create
     """
     kubernetes_client = kubernetes.kubernetes.client
+    try:
+        kubernetes.core_api().read_namespace(namespace)
+    except kubernetes.api_exception() as e:
+        if e.status != 404:
+            raise
+    else:
+        return
+
     ns_metadata = dict(name=namespace, labels={'parent': 'skypilot'})
     merge_custom_metadata(ns_metadata)
     namespace_obj = kubernetes_client.V1Namespace(metadata=ns_metadata)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently running `sky launch ...` against a K8S cluster requires the namespace.create permission even if the namespace already exists, because it checks existence using the create call. This changes it to use `read_namespace` instead to reduce the permissions surface area required to launch a cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

There are no existing unit tests for this functionality, as far as I can tell. For now, I just tried submitting a job using an account that only has read namespaces permission and it started working.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
