### PR TITLE
[AWS] Fix opening ports

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -728,9 +728,11 @@ def open_ports(
             # For AWS, IpProtocol = -1 means all traffic
             for group_pairs in existing_rule['UserIdGroupPairs']:
                 if group_pairs['GroupId'] != sg.id:
-                    # We only skpi the port opening when the rule allows access
-                    # from other security groups. Otherwise, it will always fail
-                    # to open any port.
+                    # We skip the port opening when the rule allows access from 
+                    # other security groups, as that is likely added by a user
+                    # manually and satisfy their requirement.
+                    # The security group created by SkyPilot allows all traffic
+                    # from the same security group, which should not be skipped.
                     existing_ports.add(-1)
                     break
             break

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -726,7 +726,13 @@ def open_ports(
                 range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))
         elif existing_rule['IpProtocol'] == '-1':
             # For AWS, IpProtocol = -1 means all traffic
-            existing_ports.add(-1)
+            for group_pairs in existing_rule['UserIdGroupPairs']:
+                if group_pairs['GroupId'] != sg.id:
+                    # We only skpi the port opening when the rule allows access
+                    # from other security groups. Otherwise, it will always fail
+                    # to open any port.
+                    existing_ports.add(-1)
+                    break
             break
 
     ports_to_open = []

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -728,7 +728,7 @@ def open_ports(
             # For AWS, IpProtocol = -1 means all traffic
             for group_pairs in existing_rule['UserIdGroupPairs']:
                 if group_pairs['GroupId'] != sg.id:
-                    # We skip the port opening when the rule allows access from 
+                    # We skip the port opening when the rule allows access from
                     # other security groups, as that is likely added by a user
                     # manually and satisfy their requirement.
                     # The security group created by SkyPilot allows all traffic


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a bug introduced by #3637: AWS skip the ports opening for all the instances.

To reproduce:
1. `sky launch -c test-aws-port --cloud aws --cpus 2 --ports 8000 "python -m http.server 8000"
2. `curl $(sky status --endpoint 8000 test-aws-port)`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Reproducible code above.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
