### PR TITLE
[Catalog] Remove fractional A10 instance types in catalog

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -95,7 +95,7 @@ DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
 # Some A10 instance types only contains a fractional of GPU. We temporarily
 # filter them out here to avoid using it as a whole A10 GPU.
-# TODO(zhwu,cbmemo): support fractional GPUs, which can be done on
+# TODO(zhwu,tian): support fractional GPUs, which can be done on
 # kubernetes as well.
 # Ref: https://learn.microsoft.com/en-us/azure/virtual-machines/nva10v5-series
 FILTERED_A10_INSTANCE_TYPES = [

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -93,6 +93,13 @@ def get_regions() -> List[str]:
 # We have to manually remove it.
 DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
+# Some A10 instance types only contains a fractional of GPU. We filter them out
+# here to avoid using it as a whole A10 GPU and causing memory out of capacity.
+# Ref: https://learn.microsoft.com/en-us/azure/virtual-machines/nva10v5-series
+FILTERED_A10_INSTANCE_TYPES = [
+    f'Standard_NV{vcpu}ads_A10_v5' for vcpu in [6, 12, 18]
+]
+
 USEFUL_COLUMNS = [
     'InstanceType', 'AcceleratorName', 'AcceleratorCount', 'vCPUs', 'MemoryGiB',
     'GpuInfo', 'Price', 'SpotPrice', 'Region', 'Generation'
@@ -285,6 +292,10 @@ def get_all_regions_instance_types_df(region_set: Set[str]):
     df_ret.dropna(subset=['InstanceType'], inplace=True, how='all')
     after_drop_len = len(df_ret)
     print(f'Dropped {before_drop_len - after_drop_len} duplicated rows')
+
+    # Filter out instance types that only contain a fractional of GPU.
+    df_ret = df_ret.loc[~df_ret['InstanceType'].isin(FILTERED_A10_INSTANCE_TYPES
+                                                    )]
 
     # Filter out deprecated families
     df_ret = df_ret.loc[~df_ret['family'].isin(DEPRECATED_FAMILIES)]

--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -93,8 +93,10 @@ def get_regions() -> List[str]:
 # We have to manually remove it.
 DEPRECATED_FAMILIES = ['standardNVSv2Family']
 
-# Some A10 instance types only contains a fractional of GPU. We filter them out
-# here to avoid using it as a whole A10 GPU and causing memory out of capacity.
+# Some A10 instance types only contains a fractional of GPU. We temporarily
+# filter them out here to avoid using it as a whole A10 GPU.
+# TODO(zhwu,cbmemo): support fractional GPUs, which can be done on
+# kubernetes as well.
 # Ref: https://learn.microsoft.com/en-us/azure/virtual-machines/nva10v5-series
 FILTERED_A10_INSTANCE_TYPES = [
     f'Standard_NV{vcpu}ads_A10_v5' for vcpu in [6, 12, 18]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolves (partially) #3718 by removing those fractional types

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] Running the fetcher and make sure the output does not contain any fractional GPU instance types.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
