### PR TITLE
Ensure AWS labels are appropriately validated

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -973,7 +973,7 @@ class AWS(clouds.Cloud):
     @classmethod
     def is_label_valid(cls, label_key: str,
                        label_value: str) -> Tuple[bool, Optional[str]]:
-        key_regex = re.compile(r'^[^aws:][\S]{0,127}$')
+        key_regex = re.compile(r'^(?!aws:)[\S]{0,127}$')
         value_regex = re.compile(r'^[\S]{0,255}$')
         key_valid = bool(key_regex.match(label_key))
         value_valid = bool(value_regex.match(label_value))

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -973,7 +973,7 @@ class AWS(clouds.Cloud):
     @classmethod
     def is_label_valid(cls, label_key: str,
                        label_value: str) -> Tuple[bool, Optional[str]]:
-        key_regex = re.compile(r'^(?!aws:)[\S]{0,127}$')
+        key_regex = re.compile(r'^(?!aws:)[\S]{1,127}$')
         value_regex = re.compile(r'^[\S]{0,255}$')
         key_valid = bool(key_regex.match(label_key))
         value_valid = bool(value_regex.match(label_value))

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+import pytest
+
+from sky.clouds.aws import AWS
+
+
+def test_aws_label():
+    aws = AWS()
+    # Invalid - AWS prefix
+    assert aws.is_label_valid("aws:whatever", "value")[0] == False
+    # Valid - valid prefix
+    assert aws.is_label_valid("any:whatever", "value")[0] == True
+    # Invalid - Too long
+    assert (aws.is_label_valid(
+        "sprinto:thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing",
+        "value",
+    )[0] == False)
+    # Invalid - Too long
+    assert (aws.is_label_valid(
+        "sprinto:short",
+        "thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing",
+    )[0] == False)

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -8,16 +8,16 @@ from sky.clouds.aws import AWS
 def test_aws_label():
     aws = AWS()
     # Invalid - AWS prefix
-    assert aws.is_label_valid("aws:whatever", "value")[0] == False
+    assert not aws.is_label_valid('aws:whatever', 'value')[0]
     # Valid - valid prefix
-    assert aws.is_label_valid("any:whatever", "value")[0] == True
+    assert aws.is_label_valid('any:whatever', 'value')[0]
     # Invalid - Too long
-    assert (aws.is_label_valid(
-        "sprinto:thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing",
-        "value",
-    )[0] == False)
+    assert not (aws.is_label_valid(
+        'sprinto:thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',
+        'value',
+    )[0])
     # Invalid - Too long
-    assert (aws.is_label_valid(
-        "sprinto:short",
-        "thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing",
-    )[0] == False)
+    assert not (aws.is_label_valid(
+        'sprinto:short',
+        'thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thingthisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',
+    )[0])

--- a/tests/unit_tests/test_aws.py
+++ b/tests/unit_tests/test_aws.py
@@ -11,6 +11,8 @@ def test_aws_label():
     assert not aws.is_label_valid('aws:whatever', 'value')[0]
     # Valid - valid prefix
     assert aws.is_label_valid('any:whatever', 'value')[0]
+    # Valid - valid prefix
+    assert aws.is_label_valid('Owner', 'username-1')[0]
     # Invalid - Too long
     assert not (aws.is_label_valid(
         'sprinto:thisiexample_string_with_123_characters_length_thing_thing_thing_thing_thing_thing_thing_thin_thing_thing_thing_thing_thing_thing',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix #3733

Oneline code fix + new unit tests to properly validate labels for AWS launches.

<!-- Describe the tests ran -->
Created new unit tests with several cases.  Ensured `aws:` is prejected and not `aws:` is accepted.

Skipped running any other tests due to the unit-tests and narrowly scoped changes.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Ran `tests/unit_tests/test_resources.py` and `tests/unit_tests/test_aws.py`