### PR TITLE
[Storage] Add region argument for AWS s3 upload command

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1216,6 +1216,12 @@ class S3Store(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        region_arg = ''
+        if self.region == 'eu-south-1':
+            # We have to specify the region for eu-south-1, as AWS s3 uses
+            # a different endpoint for this region, and will error out if
+            # the region is not specified.
+            region_arg = f'--region {self.region}'
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join([
@@ -1224,6 +1230,7 @@ class S3Store(AbstractStore):
             ])
             base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
+                            f'{region_arg}'
                             f'{includes} {base_dir_path} '
                             f's3://{self.name}')
             return sync_command
@@ -1239,6 +1246,7 @@ class S3Store(AbstractStore):
             ])
             src_dir_path = shlex.quote(src_dir_path)
             sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
+                            f'{region_arg}'
                             f'{src_dir_path} '
                             f's3://{self.name}/{dest_dir_name}')
             return sync_command

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1216,12 +1216,7 @@ class S3Store(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
-        region_arg = ''
-        if self.region == 'eu-south-1':
-            # We have to specify the region for eu-south-1, as AWS s3 uses
-            # a different endpoint for this region, and will error out if
-            # the region is not specified.
-            region_arg = f'--region {self.region}'
+        region_arg = f'--region {self.region}'
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join([
@@ -1230,7 +1225,7 @@ class S3Store(AbstractStore):
             ])
             base_dir_path = shlex.quote(base_dir_path)
             sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
-                            f'{region_arg}'
+                            f'{region_arg} '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name}')
             return sync_command
@@ -1246,7 +1241,7 @@ class S3Store(AbstractStore):
             ])
             src_dir_path = shlex.quote(src_dir_path)
             sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
-                            f'{region_arg}'
+                            f'{region_arg} '
                             f'{src_dir_path} '
                             f's3://{self.name}/{dest_dir_name}')
             return sync_command


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In some of AWS regions, such as `eu-south-1`, `--region` has to be provided to upload to those regions.

Fixes #3405

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud aws --region us-west-2 test.yaml --env STORAGE_NAME=test-s3-zhwu-us-west-2`
  - [x] `sky launch --cloud aws --region us-east-1 test.yaml  --env STORAGE_NAME=test-s3-zhwu-us-east-1`
  - [x] `sky launch --cloud aws --region eu-south-1 test.yaml --env STORAGE_NAME=test-s3-zhwu-eu-south-1`
  - [x] `sky launch --cloud aws --use-spot test.yaml --env STORAGE_NAME=test-s3-zhwu-spot` (goes to `eu-south-1` by default)
  - [x] `sky launch --cloud aws test.yaml --env STORAGE_NAME=test-s3-zhwu-on-demand` (goes to `us-east-1` by default)
  ```yaml
  envs:
    STORAGE_NAME:
  
  file_mounts:
    /dst:
      name: $STORAGE_NAME
      source: examples
      mode: MOUNT
  
  resources:
    cloud: aws
    cpus: 2
  
  run: |
    ls -al /dst | grep tpu
  
  ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
