### PR TITLE
[CI] Add trigger for merge group

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/mypy-generic.yml
+++ b/.github/workflows/mypy-generic.yml
@@ -13,6 +13,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   mypy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
 
 jobs:
   pylint:

--- a/.github/workflows/pytest-generic.yml
+++ b/.github/workflows/pytest-generic.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   python-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   python-test:
     strategy:

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-poetry-build.yml
+++ b/.github/workflows/test-poetry-build.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - master
       - 'releases/**'
+  merge_group:
+
 jobs:
   poetry-build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`merge_group` trigger is required for enabling merge group. Merge group could help us queue multiple PRs to be merged without waiting for the CI to finish.

Reference: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
