### PR TITLE
[GCP] assign labels to buckets managed by skypilot

### DIFF
--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -55,6 +55,13 @@ def forbidden_exception():
 
 
 @common.load_lazy_modules(_LAZY_MODULES)
+def bad_request_exception():
+    """BadRequest exception."""
+    from google.api_core import exceptions as gcs_exceptions
+    return gcs_exceptions.BadRequest
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
 def http_error_exception():
     """HttpError exception."""
     from googleapiclient import errors

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4609,6 +4609,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # Get the first store and use it to mount
             store = list(storage_obj.stores.values())[0]
             mount_cmd = store.mount_command(dst)
+            if store.is_sky_managed:
+                # Only add labels to buckets managed by sky pilot
+                if not store.update_labels(
+                    {'used_by_skypilot_cluster': handle.cluster_name}):
+                    logger.warning(
+                        f'{style.DIM}\tCan not assign labels to backing store. '
+                        'Please check logs for further details.'
+                        f'{style.RESET_ALL}')
+
             src_print = (storage_obj.source
                          if storage_obj.source else storage_obj.name)
             if isinstance(src_print, list):

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1580,7 +1580,7 @@ class GcsStore(AbstractStore):
             self.is_sky_managed = is_new_bucket
 
         if self.is_sky_managed:
-            self.update_labels({'is_sky_managed': 'true'})
+            self.update_labels({'managedby': 'skypilot'})
 
     def upload(self):
         """Uploads source to store bucket.

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -166,6 +166,12 @@ class StorageUploadError(StorageError):
     pass
 
 
+class StorageBucketLabelNameError(StorageError):
+    # Error raised when bucket is successfully initialized, but labeling fails,
+    # due to key value labeling limitations.
+    pass
+
+
 class StorageSourceError(StorageSpecError):
     # Error raised when the source of the storage is invalid. E.g., does not
     # exist, malformed path, or other reasons.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To be able to clean up the lingering buckets we need to assign labels to the buckets managed by skypilot only.

The change is minimal and not a breaking change for the other providers.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
