### PR TITLE
[k8s] Update waiting logic for init containers

### DIFF
--- a/llm/axolotl/axolotl-spot.yaml
+++ b/llm/axolotl/axolotl-spot.yaml
@@ -29,5 +29,3 @@ run: |
 envs:
   HF_TOKEN: # TODO: Fill with your own huggingface token, or use --env to pass.
   BUCKET: # TODO: Fill with your unique bucket name, or use --env to pass.
-
-4

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -223,7 +223,7 @@ def _wait_for_pods_to_run(namespace, new_nodes):
     creation.
     """
 
-    def _check_init_containers(pod: 'kubernetes.client.V1Pod'):
+    def _check_init_containers(pod):
         # Check if any of the init containers failed
         # to start. Could be because the init container
         # command failed or failed to pull image etc.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -236,10 +236,12 @@ def _wait_for_pods_to_run(namespace, new_nodes):
                     raise config_lib.KubernetesError(
                         'Failed to run init container for pod '
                         f'{pod.metadata.name}. Error details: {msg}.')
-                return
+                continue
             init_waiting = init_status.state.waiting
             if (init_waiting is not None and init_waiting.reason
                     not in ['ContainerCreating', 'PodInitializing']):
+                # TODO(romilb): There may be more states to check for. Add
+                #  them as needed.
                 msg = init_waiting.message if (
                     init_waiting.message) else str(init_waiting)
                 raise config_lib.KubernetesError(


### PR DESCRIPTION
Closes #3702.

Tested with:

1. Base case - bad image, no init container, returns clear error message: `sky launch -c test --cloud kubernetes --image-id romilb/fakeimage -- echo hi`
```
run_instances: Error occurred when creating pods: Failed to create container while launching the node. Error details: failed to pull and unpack image "docker.io/romilb/fakeimage:latest": failed to resolve reference "docker.io/romilb/fakeimage:latest": pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed.
```

2. Healthy init container - `sky launch -c test --cloud kubernetes` with this config.yaml:
```
kubernetes:
  pod_config:
    spec:
      initContainers:
        - name: init-myservice
          image: busybox
          command: ['sh', '-c', 'echo hi']
```

3. Bad init container - `sky launch -c test --cloud kubernetes` with this config.yaml:
```
kubernetes:
  pod_config:
    spec:
      initContainers:
        - name: init-myservice
          image: busybox
          command: ['sh', '-c', 'exit 1']
```
```
W 07-18 11:55:11 instance.py:604] run_instances: Error occurred when creating pods: Failed to run init container for pod test-2ea4-head. Error details: {'container_id': 'containerd://88a2f346c4b2b5abc09493cb7204d1bcd91eca0fa35670d9142b5c6840e00610',
W 07-18 11:55:11 instance.py:604]  'exit_code': 1,
W 07-18 11:55:11 instance.py:604]  'finished_at': datetime.datetime(2024, 7, 18, 18, 55, 11, tzinfo=tzutc()),
W 07-18 11:55:11 instance.py:604]  'message': None,
W 07-18 11:55:11 instance.py:604]  'reason': 'Error',
W 07-18 11:55:11 instance.py:604]  'signal': None,
W 07-18 11:55:11 instance.py:604]  'started_at': datetime.datetime(2024, 7, 18, 18, 55, 11, tzinfo=tzutc())}.
```


