### PR TITLE
Supporting encrypted disks for AWS

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -399,6 +399,8 @@ class AWS(clouds.Cloud):
         image_id = self._get_image_id(image_id_to_use, region_name,
                                       r.instance_type)
 
+        disk_encrypted = skypilot_config.get_nested(('aws', 'disk_encrypted'),
+                                                    False)
         user_security_group_config = skypilot_config.get_nested(
             ('aws', 'security_group_name'), None)
         user_security_group = None
@@ -429,6 +431,7 @@ class AWS(clouds.Cloud):
         return {
             'instance_type': r.instance_type,
             'custom_resources': custom_resources,
+            'disk_encrypted': disk_encrypted,
             'use_spot': r.use_spot,
             'region': region_name,
             'zones': ','.join(zone_names),

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -75,6 +75,7 @@ available_node_types:
           Ebs:
             VolumeSize: {{disk_size}}
             VolumeType: {{disk_tier}}
+            Encrypted: {{disk_encrypted}}
             {% if custom_disk_perf %}
             Iops: {{disk_iops}}
             Throughput: {{disk_throughput}}

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -706,6 +706,9 @@ def get_config_schema():
             'required': [],
             'additionalProperties': False,
             'properties': {
+                'disk_encrypted': {
+                    'type': 'boolean',
+                },
                 'security_group_name':
                     (_PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
                 **_LABELS_SCHEMA,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import kubernetes_enums
 
+DISK_ENCRYPTED = True
 VPC_NAME = 'vpc-12345678'
 PROXY_COMMAND = 'ssh -W %h:%p -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no'
 NODEPORT_MODE_NAME = kubernetes_enums.KubernetesNetworkingMode.NODEPORT.value
@@ -42,6 +43,7 @@ def _create_config_file(config_file_path: pathlib.Path) -> None:
                 vpc_name: {VPC_NAME}
                 use_internal_ips: true
                 ssh_proxy_command: {PROXY_COMMAND}
+                disk_encrypted: {DISK_ENCRYPTED}
 
             gcp:
                 vpc_name: {VPC_NAME}
@@ -215,6 +217,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     # Check that the config is loaded with the expected values
     assert skypilot_config.loaded()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
+    assert skypilot_config.get_nested(('aws', 'disk_encrypted'), None)
     assert skypilot_config.get_nested(('aws', 'use_internal_ips'), None)
     assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
                                       None) == PROXY_COMMAND

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -121,6 +121,7 @@ def test_aws_make_deploy_variables(*mocks) -> None:
         'use_spot': False,
         'region': 'fake-region',
         'image_id': 'fake-image',
+        'disk_encrypted': False,
         'disk_tier': 'gp3',
         'disk_throughput': 218,
         'disk_iops': 3500,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes https://github.com/skypilot-org/skypilot/issues/2483

Users can now specify a disk_encrypted option under the resources stanza to enable disk encryption at rest. This is currently only setup for AWS but can easily be extended for other providers given their capability.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_config.py` and `tests/unit_tests/test_resources.py`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Manually updated my `~/.sky/config` with 

```
aws:
  disk_encrypted: true
```

Then launched 

```
sky launch -c minimal examples/minimal.yaml
```

and confirmed that the attached EBS disks were encrypted.