### PR TITLE
Propagate kubernetes custom metadata annotations to sub-services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ sky/clouds/service_catalog/data_fetchers/*.csv
 .vscode/
 .idea/
 .env
+
+# For editor files
+*.swp

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -77,6 +77,8 @@ def fill_loadbalancer_template(namespace: str, service_name: str,
         template = fin.read()
     annotations = skypilot_config.get_nested(
         ('kubernetes', 'custom_metadata', 'annotations'), {})
+    labels = skypilot_config.get_nested(
+        ('kubernetes', 'custom_metadata', 'labels'), {})
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
@@ -85,6 +87,7 @@ def fill_loadbalancer_template(namespace: str, service_name: str,
         selector_key=selector_key,
         selector_value=selector_value,
         annotations=annotations,
+        labels=labels,
     )
     content = yaml.safe_load(cont)
     return content
@@ -103,6 +106,8 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
         template = fin.read()
     annotations = skypilot_config.get_nested(
         ('kubernetes', 'custom_metadata', 'annotations'), {})
+    labels = skypilot_config.get_nested(
+        ('kubernetes', 'custom_metadata', 'labels'), {})
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
@@ -115,6 +120,7 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
         selector_key=selector_key,
         selector_value=selector_value,
         annotations=annotations,
+        labels=labels,
     )
     content = yaml.safe_load(cont)
 

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -75,6 +75,8 @@ def fill_loadbalancer_template(namespace: str, service_name: str,
 
     with open(template_path, 'r', encoding='utf-8') as fin:
         template = fin.read()
+    annotations = skypilot_config.get_nested(
+        ('kubernetes', 'custom_metadata', 'annotations'), {})
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
@@ -82,6 +84,7 @@ def fill_loadbalancer_template(namespace: str, service_name: str,
         ports=ports,
         selector_key=selector_key,
         selector_value=selector_value,
+        annotations=annotations,
     )
     content = yaml.safe_load(cont)
     return content

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -101,6 +101,8 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
             f'Template "{_INGRESS_TEMPLATE_NAME}" does not exist.')
     with open(template_path, 'r', encoding='utf-8') as fin:
         template = fin.read()
+    annotations = skypilot_config.get_nested(
+        ('kubernetes', 'custom_metadata', 'annotations'), {})
     j2_template = jinja2.Template(template)
     cont = j2_template.render(
         namespace=namespace,
@@ -112,6 +114,7 @@ def fill_ingress_template(namespace: str, service_details: List[Tuple[str, int,
         ingress_name=ingress_name,
         selector_key=selector_key,
         selector_value=selector_value,
+        annotations=annotations,
     )
     content = yaml.safe_load(cont)
 

--- a/sky/templates/kubernetes-ingress.yml.j2
+++ b/sky/templates/kubernetes-ingress.yml.j2
@@ -2,6 +2,10 @@ ingress_spec:
   apiVersion: networking.k8s.io/v1
   kind: Ingress
   metadata:
+    labels:
+      {%- for label_key, label_value in labels.items() %}
+      {{ label_key }}: {{ label_value|tojson }}
+      {%- endfor %}
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/sky/templates/kubernetes-ingress.yml.j2
+++ b/sky/templates/kubernetes-ingress.yml.j2
@@ -5,6 +5,9 @@ ingress_spec:
     annotations:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/rewrite-target: /$2
+      {%- for key, value in annotations.items() %}
+      {{ key }}: {{ value|tojson }}
+      {%- endfor %}
     name: {{ ingress_name }}
     namespace: {{ namespace }}
   spec:

--- a/sky/templates/kubernetes-loadbalancer.yml.j2
+++ b/sky/templates/kubernetes-loadbalancer.yml.j2
@@ -5,6 +5,10 @@ service_spec:
     name: {{ service_name }}
     labels:
       parent: skypilot
+    annotations:
+      {%- for key, value in annotations.items() %}
+      {{ key }}: {{ value|tojson }}
+      {%- endfor %}
   spec:
     type: LoadBalancer
     selector:

--- a/sky/templates/kubernetes-loadbalancer.yml.j2
+++ b/sky/templates/kubernetes-loadbalancer.yml.j2
@@ -5,6 +5,9 @@ service_spec:
     name: {{ service_name }}
     labels:
       parent: skypilot
+      {%- for label_key, label_value in labels.items() %}
+      {{ label_key }}: {{ label_value|tojson }}
+      {%- endfor %}
     annotations:
       {%- for key, value in annotations.items() %}
       {{ key }}: {{ value|tojson }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This forwards kubernetes annotation values in the `~/.sky/config` to sub services such as the load balancer.  This ensures users can set custom annotations, such as for AWS, to ensure load balancers are internet facing.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Manually update my `~/.sky/config` to have the following contents:

```
kubernetes:
  ports: loadbalancer
  custom_metadata:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
```

And ran sky launch with this config:

```
service:
  readiness_probe: /v1/models

resources:
  # Can change to use more via `--gpus A100:N`.  N can be 1 to 8.
  accelerators: A100:2
  cpus: 22
  memory: 500
  # Note: Big models need LOTS of disk space, especially if saved in float32.
  # So specify a lot of disk.
  disk_size: 400
  # Keep fixed.
  cloud: kubernetes
  ports: 8000
  image_id: docker:vllm/vllm-openai:latest

envs:
  # Specify the training config via `--env MODEL=collinear-ai/model-repo-name`
  MODEL: ""

setup: |
  conda deactivate
  python3 -c "import huggingface_hub; huggingface_hub.login('${HUGGINGFACE_TOKEN}')"

run: |
  conda deactivate
  python3 -u -m vllm.entrypoints.openai.api_server \
    --host 0.0.0.0 \
    --port 8000 \
    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
    --trust-remote-code \
    --model $MODEL
```

I verified that my EKS cluster in AWS launched a standard network load balancer that was internet facing.