### PR TITLE
[Docs] Add docs for disk encrypted

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -191,7 +191,7 @@ Available fields and semantics:
     # SkyPilot. This is useful for compliance with data protection regulations.
     #
     # Default: false.
-    disk_encrypted: true
+    disk_encrypted: false
 
     # Identity to use for AWS instances (optional).
     #

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -185,6 +185,14 @@ Available fields and semantics:
     #         - "*": my-default-security-group
     security_group_name: my-security-group
 
+    # Encrypted boot disk (optional).
+    #
+    # Set to true to encrypt the boot disk of all AWS instances launched by
+    # SkyPilot. This is useful for compliance with data protection regulations.
+    #
+    # Default: false.
+    disk_encrypted: true
+
     # Identity to use for AWS instances (optional).
     #
     # LOCAL_CREDENTIALS: The user's local credential files will be uploaded to


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is to add the docs for encrypted disk introduced by #2483 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
