### PR TITLE
Release 0.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm -rf /var/lib/apt/lists/*
 
 # Install sky
-RUN pip install --no-cache-dir "skypilot[all]==0.6.0"
+RUN pip install --no-cache-dir "skypilot[all]==0.6.1"

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -35,7 +35,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.6.1'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
- [x] `pytest tests/test_smoke.py --aws`
- [x] `pytest tests/test_smoke.py --gcp` except `test_tpu_vm_pod` due to no availability.
- [x] `pytest tests/test_smoke.py --azure`
- [x] `pytest tests/test_smoke.py --kubernetes`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] `backward_compatibility_tests.sh` run against 0.6.0 on gcp
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky jobs launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky jobs logs --controller
        ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot 
    sky down dbg
    ```
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud gcp -y`
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud aws -y`
- [x] `sky show-gpus` manual tests