### PR TITLE
feat: add flux provisioner

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -91,7 +91,10 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = {
 }
 
 # Kubernetes type clouds
-_KUBERNETES_CLOUDS = (clouds.Kubernetes, clouds.Flux,)
+_KUBERNETES_CLOUDS = (
+    clouds.Kubernetes,
+    clouds.Flux,
+)
 
 # Time gap between retries after failing to provision in all possible places.
 # Used only if --retry-until-up is set.
@@ -3769,9 +3772,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
 
         # TODO: bug (error) if this file was manually removed
         if not os.path.exists(handle.cluster_yaml):
-            logger.warning(
-                f'Cluster {handle.cluster_name!r} config file. '
-                'is missing. Skipped.')
+            logger.warning(f'Cluster {handle.cluster_name!r} config file. '
+                           'is missing. Skipped.')
             return
         config = common_utils.read_yaml(handle.cluster_yaml)
         cluster_name = handle.cluster_name

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -175,6 +175,7 @@ def _get_cluster_config_template(cloud):
         clouds.OCI: 'oci-ray.yml.j2',
         clouds.Paperspace: 'paperspace-ray.yml.j2',
         clouds.RunPod: 'runpod-ray.yml.j2',
+        clouds.Flux: 'kubernetes-ray.yml.j2',
         clouds.Kubernetes: 'kubernetes-ray.yml.j2',
         clouds.Vsphere: 'vsphere-ray.yml.j2',
         clouds.Fluidstack: 'fluidstack-ray.yml.j2'

--- a/sky/clouds/__init__.py
+++ b/sky/clouds/__init__.py
@@ -15,6 +15,7 @@ from sky.clouds.aws import AWS
 from sky.clouds.azure import Azure
 from sky.clouds.cudo import Cudo
 from sky.clouds.fluidstack import Fluidstack
+from sky.clouds.flux import Flux
 from sky.clouds.gcp import GCP
 from sky.clouds.ibm import IBM
 from sky.clouds.kubernetes import Kubernetes
@@ -31,6 +32,7 @@ __all__ = [
     'Azure',
     'Cloud',
     'Cudo',
+    'Flux',
     'GCP',
     'Lambda',
     'Paperspace',

--- a/sky/clouds/flux.py
+++ b/sky/clouds/flux.py
@@ -46,7 +46,7 @@ class Flux(Kubernetes):
             zones,
             dryrun)
         # Disabled until provision module is added
-        # deploy_vars['module'] = 'sky.provision.flux'
+        deploy_vars['module'] = 'sky.provision.flux'
         return deploy_vars
 
     def _get_feasible_launchable_resources(

--- a/sky/clouds/flux.py
+++ b/sky/clouds/flux.py
@@ -1,0 +1,67 @@
+"""Flux Framework.
+
+Flux is implemented via the Flux Operator in Kubernetes. To make
+it maximally flexible to deploy to different clouds, we use the
+same Kubernetes abstractions, but also deploy the Flux Operator.
+We do this because it is unlikely to have a cluster with Flux
+already running to provision to.
+"""
+import typing
+from typing import List, Optional, Tuple, Dict
+
+from sky.clouds.kubernetes import Kubernetes
+
+from sky import clouds
+from sky import sky_logging
+from sky.utils import resources_utils
+
+if typing.TYPE_CHECKING:
+    # Renaming to avoid shadowing variables.
+    from sky import resources as resources_lib
+
+logger = sky_logging.init_logger(__name__)
+
+@clouds.CLOUD_REGISTRY.register
+class Flux(Kubernetes):
+    """Flux Framework"""
+
+    _REPR = 'Flux'
+
+    def make_deploy_resources_variables(
+            self,
+            resources: 'resources_lib.Resources',
+            cluster_name: resources_utils.ClusterName,
+            region: Optional['clouds.Region'],
+            zones: Optional[List['clouds.Zone']],
+            dryrun: bool = False) -> Dict[str, Optional[str]]:
+        """Make deployment YAML variables
+
+        The "module" parameter needs to be populated with the custom
+        Flux provisioner, tweaking from Kubernetes.
+        """
+        deploy_vars = super(Flux, self).make_deploy_resources_variables(
+            resources,
+            cluster_name,
+            region,
+            zones,
+            dryrun)
+        # Disabled until provision module is added
+        # deploy_vars['module'] = 'sky.provision.flux'
+        return deploy_vars
+
+    def _get_feasible_launchable_resources(
+        self, resources: 'resources_lib.Resources'
+    ) -> Tuple[List['resources_lib.Resources'], List[str]]:
+        """Get feasible launchable resources
+
+        This function sets the cloud on the resources, so we need
+        to retrieve from Kubernetes and update "Kubernetes" to "Flux"
+        """
+        # This returns a tuple with feasible resources/candidate list, unwrap
+        res = super(Flux, self)._get_feasible_launchable_resources(resources)
+        (feasible_resources, fuzzy_candidate_list) = res
+
+        # Update the cloud, Kubernetes -> Flux since will be printed in UI
+        for item in feasible_resources:
+            item.set_cloud(self)
+        return (feasible_resources, fuzzy_candidate_list)

--- a/sky/clouds/flux.py
+++ b/sky/clouds/flux.py
@@ -7,12 +7,11 @@ We do this because it is unlikely to have a cluster with Flux
 already running to provision to.
 """
 import typing
-from typing import List, Optional, Tuple, Dict
-
-from sky.clouds.kubernetes import Kubernetes
+from typing import Dict, List, Optional, Tuple
 
 from sky import clouds
 from sky import sky_logging
+from sky.clouds.kubernetes import Kubernetes
 from sky.utils import resources_utils
 
 if typing.TYPE_CHECKING:
@@ -20,6 +19,7 @@ if typing.TYPE_CHECKING:
     from sky import resources as resources_lib
 
 logger = sky_logging.init_logger(__name__)
+
 
 @clouds.CLOUD_REGISTRY.register
 class Flux(Kubernetes):
@@ -40,11 +40,7 @@ class Flux(Kubernetes):
         Flux provisioner, tweaking from Kubernetes.
         """
         deploy_vars = super(Flux, self).make_deploy_resources_variables(
-            resources,
-            cluster_name,
-            region,
-            zones,
-            dryrun)
+            resources, cluster_name, region, zones, dryrun)
         # Disabled until provision module is added
         deploy_vars['module'] = 'sky.provision.flux'
         return deploy_vars

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -312,6 +312,7 @@ class Kubernetes(clouds.Cloud):
             10,
             override_configs=resources.cluster_config_overrides)
         deploy_vars = {
+            'module': 'sky.provision.kubernetes',
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
             'region': region.name,

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -267,6 +267,8 @@ class Optimizer:
             fuzzy_candidates: List[str] = []
             if node_i < len(topo_order) - 1:
                 # Convert partial resource labels to launchable resources.
+                # Note: this is where the cloud object gets populated with
+                # resource names, e.g., Flux(): [Kubernetes(2CPU--2GB)]
                 launchable_resources, cloud_candidates, fuzzy_candidates = (
                     _fill_in_launchable_resources(
                         task=node,

--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -17,6 +17,7 @@ from sky.provision import azure
 from sky.provision import common
 from sky.provision import cudo
 from sky.provision import fluidstack
+from sky.provision import flux
 from sky.provision import gcp
 from sky.provision import kubernetes
 from sky.provision import runpod

--- a/sky/provision/flux/__init__.py
+++ b/sky/provision/flux/__init__.py
@@ -1,0 +1,13 @@
+"""Flux provisioner for SkyPilot."""
+
+from sky.provision.kubernetes.config import bootstrap_instances
+from sky.provision.flux.instance import get_cluster_info
+from sky.provision.kubernetes.instance import get_command_runners
+from sky.provision.kubernetes.instance import query_instances
+from sky.provision.flux.instance import run_instances
+from sky.provision.kubernetes.instance import stop_instances
+from sky.provision.flux.instance import terminate_instances
+from sky.provision.kubernetes.instance import wait_instances
+from sky.provision.kubernetes.network import cleanup_ports
+from sky.provision.kubernetes.network import open_ports
+from sky.provision.kubernetes.network import query_ports

--- a/sky/provision/flux/__init__.py
+++ b/sky/provision/flux/__init__.py
@@ -1,12 +1,12 @@
 """Flux provisioner for SkyPilot."""
 
-from sky.provision.kubernetes.config import bootstrap_instances
 from sky.provision.flux.instance import get_cluster_info
+from sky.provision.flux.instance import run_instances
+from sky.provision.flux.instance import terminate_instances
+from sky.provision.kubernetes.config import bootstrap_instances
 from sky.provision.kubernetes.instance import get_command_runners
 from sky.provision.kubernetes.instance import query_instances
-from sky.provision.flux.instance import run_instances
 from sky.provision.kubernetes.instance import stop_instances
-from sky.provision.flux.instance import terminate_instances
 from sky.provision.kubernetes.instance import wait_instances
 from sky.provision.kubernetes.network import cleanup_ports
 from sky.provision.kubernetes.network import open_ports

--- a/sky/provision/flux/instance.py
+++ b/sky/provision/flux/instance.py
@@ -1,0 +1,404 @@
+"""Flux MiniCluster provisioning."""
+import copy
+import time
+from typing import Any, Dict, Optional
+
+from kubernetes.client import ApiException
+from sky import exceptions
+from sky import sky_logging
+from sky import status_lib
+from sky.adaptors import kubernetes
+from sky.provision import common
+from sky.provision.kubernetes import network_utils
+from sky.provision.kubernetes import config as config_lib
+from sky.provision.kubernetes import utils as kubernetes_utils
+import sky.provision.kubernetes.instance as instance_utils
+from sky.utils import common_utils
+from sky.utils import kubernetes_enums
+from sky.utils import subprocess_utils
+from sky.utils import ux_utils
+
+POLL_INTERVAL = 2
+
+# Flux Operator install
+# TODO(vsoch): could someone want arm support here?
+FLUX_OPERATOR_INSTALL = (
+    'https://raw.githubusercontent.com/' +
+    'flux-framework/flux-operator/' +
+    'main/examples/dist/flux-operator.yaml'
+)
+
+# Flux Operator Metadata
+_FLUX_OPERATOR_GROUP='flux-framework.org'
+_FLUX_OPERATOR_VERSION='v1alpha2'
+_MINICLUSTER_PLURAL='miniclusters'
+_MINICLUSTER_KIND='MiniCluster'
+_FLUX_OPERATOR_API_VERSION=f'{_FLUX_OPERATOR_GROUP}/{_FLUX_OPERATOR_VERSION}'
+
+logger = sky_logging.init_logger(__name__)
+TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'
+TAG_SKYPILOT_CLUSTER_NAME = 'skypilot-cluster-name'
+TAG_POD_INITIALIZED = 'skypilot-initialized'
+
+# Identifier in indexed job for "head"
+_HEAD_INDEX_LABEL = 'job-index'
+_HEAD_INDEX = '0'
+
+POD_STATUSES = {
+    'Pending', 'Running', 'Succeeded', 'Failed', 'Unknown', 'Terminating'
+}
+
+def _run_kubectl(command: str, args: str):
+    """Run a kubectl command, check return"""
+    p = subprocess_utils.run(f'kubectl {command} {args}')
+    assert p.returncode == 0
+
+def _get_namespace(provider_config: Dict[str, Any]) -> str:
+    return provider_config.get(
+        'namespace',
+        kubernetes_utils.get_current_kube_config_context_namespace())
+
+
+def terminate_instances(
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    worker_only: bool = False,
+) -> None:
+    """See sky/provision/__init__.py"""
+    namespace = _get_namespace(provider_config)
+    tag_filters = {
+        TAG_RAY_CLUSTER_NAME: cluster_name_on_cloud,
+    }
+    pods = instance_utils.filter_pods(namespace, tag_filters, None)
+
+    def _is_head(pod) -> bool:
+        return pod.metadata.labels[_HEAD_INDEX_LABEL] == _HEAD_INDEX
+
+    for pod_name, pod in pods.items():
+        logger.debug(f'Terminating instance {pod_name}: {pod}')
+        if _is_head(pod) and worker_only:
+            continue
+        _terminate_node(namespace, pod_name)
+
+
+def _ensure_flux_operator_installed():
+    """Check that the Flux Operator is installed, install if not."""
+    # The flux operator lives in the operator-system namespace
+    ns = 'operator-system'
+    selector = 'control-plane=controller-manager'
+    pod_list = kubernetes.core_api().list_namespaced_pod(
+        ns, label_selector=selector)
+
+    # If we have items, the operator is installed
+    if pod_list.items:
+        return
+
+    # Easiest means to interact with complex apply is with subprocess
+    _run_kubectl('apply', f'-f {FLUX_OPERATOR_INSTALL}')
+
+    # Wait for pods to be running
+    _run_kubectl('wait', f'-n {ns} --for condition=Ready pod -l {selector}')
+
+
+def head_service_selector(cluster_name: str) -> Dict[str, str]:
+    """Selector for Operator-configured head service."""
+    return {'component': f'{cluster_name}-head'}
+
+
+def _raise_command_running_error(message: str, command: str, pod_name: str,
+                                 rc: int, stdout: str) -> None:
+    if rc == 0:
+        return
+    raise config_lib.KubernetesError(
+        f'Failed to {message} for pod {pod_name} with return '
+        f'code {rc}: {command!r}\nOutput: {stdout}.')
+
+
+def _create_minicluster(region: str, cluster_name_on_cloud: str,
+                 config: common.ProvisionConfig) -> common.ProvisionRecord:
+    """Create pods based on the config."""
+    provider_config = config.provider_config
+    namespace = _get_namespace(provider_config)
+    pod_spec = copy.deepcopy(config.node_config)
+    tags = {
+        TAG_RAY_CLUSTER_NAME: cluster_name_on_cloud,
+    }
+
+    # No support for jump pod - ssh directly into the lead broker!
+    mode = config.provider_config.get('networking_mode')
+    networking_mode = network_utils.get_networking_mode(mode)
+    if networking_mode == kubernetes_enums.KubernetesNetworkingMode.NODEPORT:
+        raise ValueError('run_instances: node with jump pod is not supported')
+
+    # Here we need to convert the provider config into a MiniCluster config
+    # We use the custom objects api
+    crd_api = kubernetes.custom_objects_api()
+
+    # First see if we have an existing cluster of this name
+    try:
+        crd_api.get_namespaced_custom_object(
+            name=cluster_name_on_cloud,
+            group=_FLUX_OPERATOR_GROUP,
+            version=_FLUX_OPERATOR_VERSION,
+            namespace=namespace,
+            plural=_MINICLUSTER_PLURAL,
+        )
+        # Assume for now we want to delete it. We could eventually
+        # just change the size (update it) but I need to be more
+        # familiar with skypilot first.
+        logger.warning('run_instances: Cleaning up existing MiniCluster.')
+        crd_api.delete_namespaced_custom_object(
+            group=_FLUX_OPERATOR_GROUP,
+            version=_FLUX_OPERATOR_VERSION,
+            namespace=namespace,
+            plural=_MINICLUSTER_PLURAL,
+            name=cluster_name_on_cloud,
+        )
+    except ApiException as exc:
+        if exc.status != 404:
+            raise exc
+
+    # Always wait for any potentially terminating pods
+    instance_utils.wait_for_termination(namespace, tags)
+
+    # Volumes are shared by the pod, create a lookup for containers to see here
+    volumes = {}
+    for volume in pod_spec['spec'].get('volumes', []):
+        volumes[volume['name']] = volume
+
+    # Here is our main container for the MiniCluster
+    containers = []
+    run_flux = True
+    for i, container in enumerate(pod_spec['spec']['containers']):
+        if i > 0:
+            run_flux = False
+
+        # Prepare volume mounts for the container
+        mounts = {}
+        for mount in container['volumeMounts']:
+            volume = volumes[mount['name']]
+            if 'secret' in volume:
+                mounts[volume['name']] = {
+                    'secretName': volume['secret']['secretName'],
+                    'path': mount['mountPath'],
+                }
+
+            # Assuming for now emptyDir always means memory, so will have Medium
+            elif 'emptyDir' in volume:
+                mounts[volume['name']] = {
+                    'emptyDir': True,
+                    'emptyDirMedium': volume['emptyDir']['medium'],
+                    'path': mount['mountPath'],
+                }
+
+            elif 'hostPath' in volume:
+                mounts[volume['name']] = {'path': volume['hostPath']['path']}
+
+        # Container ports
+        ports = []
+        for port in container['ports']:
+            ports.append(port['containerPort'])
+
+        # Prepare the container for the set. It looks like the pull policy is
+        # if not present, let's leave the default and not set here. Note
+        # That we don't need a command to keep it running with interactive
+        containers.append({
+            'image': container['image'],
+            'run_flux': run_flux,
+            'volumes': mounts,
+            'ports': ports,
+            'resources': container['resources'],
+        })
+
+
+    # Prepare labels for the podspec
+    # Note that I'm not adding constants.HEAD_NODE_TAGS, and
+    # constants.WORKER_NODE_TAGS - no quick way with indexed job.
+    labels = pod_spec['metadata'].get('labels') or {}
+    labels.update(tags)
+    labels.update({TAG_SKYPILOT_CLUSTER_NAME: cluster_name_on_cloud})
+
+    # flux view image must match container with sky
+    view_image = 'ghcr.io/converged-computing/flux-view-ubuntu:tag-focal'
+
+    # minicluster spec inherits from the pod_spec
+    # If we are updating one (in terms of size) it will update
+    # We could also explicitly terminate / recreate, will need
+    # testing. Interactive must be true to keep it running.
+    spec = {
+        'size': config.count,
+        'containers': containers,
+        'interactive': True,
+        'pod': {
+            'labels': labels,
+            'serviceAccountName': pod_spec['spec']['serviceAccountName'],
+            'restartPolicy': pod_spec['spec']['restartPolicy']
+        },
+
+        # Skypilot base images seem to be ubuntu bases (bullseye, so sid)
+        'flux': {
+            'container': {
+                'image': view_image,
+            }
+        }
+    }
+
+    # Add nvidia runtime class if it exists
+    if instance_utils.nvidia_runtime_exists():
+        spec['pod']['runtimeClassName'] = 'nvidia'
+
+    # Wrap the spec in the MiniCluster
+    minicluster = {
+        'kind':_MINICLUSTER_KIND,
+        'apiVersion': _FLUX_OPERATOR_API_VERSION,
+        'metadata': {
+            'name': cluster_name_on_cloud,
+            'namespace': namespace,
+        },
+        'spec': spec,
+    }
+    crd_api.create_namespaced_custom_object(
+        group=_FLUX_OPERATOR_GROUP,
+        version=_FLUX_OPERATOR_VERSION,
+        namespace=namespace,
+        plural=_MINICLUSTER_PLURAL,
+        body=minicluster,
+    )
+    # Get list of pods to wait for readiness.
+    # If we eventually support ssh pod, should be -0 and not -head
+    ssh_name = pod_spec['metadata']['labels']['skypilot-ssh-jump']
+    instance_utils.wait_pods_running(
+        config, provider_config, namespace, tags, ssh_name)
+    created_pods = instance_utils.initialize_pods(namespace, tags)
+
+    # Add created pod names to config - a hack to update ssh pod later
+    config.provider_config['created_pods'] = list(created_pods.keys())
+
+    # Update the config to have the correct selector name for ssh
+    return common.ProvisionRecord(
+        provider_name='flux',
+        region=region,
+        zone=None,
+        cluster_name=cluster_name_on_cloud,
+        head_instance_id=cluster_name_on_cloud+'-0',
+        resumed_instance_ids=[],
+        created_instance_ids=list(created_pods.keys()),
+    )
+
+def run_instances(region: str, cluster_name_on_cloud: str,
+                  config: common.ProvisionConfig) -> common.ProvisionRecord:
+    """Runs instances for the given cluster."""
+    try:
+        _ensure_flux_operator_installed()
+        return _create_minicluster(region, cluster_name_on_cloud, config)
+    except (kubernetes.api_exception(), config_lib.KubernetesError) as e:
+        logger.warning(f'run_instances: Error occurred when creating pods: {e}')
+        raise
+
+def stop_instances(
+    cluster_name_on_cloud: str,
+    provider_config: Optional[Dict[str, Any]] = None,
+    worker_only: bool = False,
+) -> None:
+    raise NotImplementedError()
+
+def _terminate_node(namespace: str, pod_name: str) -> None:
+    """Terminate a pod (node).
+    In the future we likely want to decrease the size of the cluster, but here
+    we are going to delete the entire thing.
+    """
+    logger.debug('terminate_instances: calling delete_namespaced_pod')
+    crd_api = kubernetes.custom_objects_api()
+    cluster_name = pod_name.rsplit('-0-', 1)[0]
+
+    # First see if we have an existing cluster of this name
+    try:
+        crd_api.delete_namespaced_custom_object(
+            group=_FLUX_OPERATOR_GROUP,
+            version=_FLUX_OPERATOR_VERSION,
+            namespace=namespace,
+            plural=_MINICLUSTER_PLURAL,
+            name=cluster_name,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning('terminate_instances: Error occurred when analyzing '
+                       f'SSH Jump pod: {e}')
+
+    tags = {TAG_RAY_CLUSTER_NAME: cluster_name}
+    instance_utils.wait_for_termination(namespace, tags)
+    # TODO(vsoch): do we need to add back services deletion here?
+
+def get_cluster_info(
+        region: str,
+        cluster_name_on_cloud: str,
+        provider_config: Optional[Dict[str, Any]] = None) -> common.ClusterInfo:
+    del region  # unused
+    assert provider_config is not None
+    namespace = _get_namespace(provider_config)
+    tags = {
+        TAG_RAY_CLUSTER_NAME: cluster_name_on_cloud,
+    }
+
+    # Wait until pods are running, they go from init->pod initializing->running
+    running_pods = {}
+    while not running_pods:
+        running_pods = instance_utils.filter_pods(namespace, tags, ['Running'])
+        if running_pods:
+            break
+        logger.warning('get_cluster_info: pods not in running state yet.')
+        time.sleep(10)
+
+    return instance_utils.query_cluster_info(
+        running_pods,
+        namespace,
+        _HEAD_INDEX_LABEL,
+        _HEAD_INDEX,
+        cluster_name_on_cloud,
+        provider_config,
+    )
+
+def query_instances(
+    cluster_name_on_cloud: str,
+    provider_config: Optional[Dict[str, Any]] = None,
+    non_terminated_only: bool = True
+) -> Dict[str, Optional[status_lib.ClusterStatus]]:
+
+    del provider_config  # unused
+    status_map = {
+        'Pending': status_lib.ClusterStatus.INIT,
+        'Running': status_lib.ClusterStatus.UP,
+        'Failed': None,
+        'Unknown': None,
+        'Succeeded': None,
+        'Terminating': None,
+    }
+
+    namespace = kubernetes_utils.get_current_kube_config_context_namespace()
+
+    # Get all the pods with the label skypilot-cluster: <cluster_name>
+    try:
+        pods = kubernetes.core_api().list_namespaced_pod(
+            namespace,
+            label_selector=f'skypilot-cluster={cluster_name_on_cloud}',
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.max_retry_error():
+        with ux_utils.print_exception_no_traceback():
+            ctx = kubernetes_utils.get_current_kube_config_context_name()
+            raise exceptions.ClusterStatusFetchingError(
+                f'Failed to query cluster {cluster_name_on_cloud!r} status. '
+                'Network error - check if the Kubernetes cluster in '
+                f'context {ctx} is up and accessible.') from None
+    except Exception as e:  # pylint: disable=broad-except
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.ClusterStatusFetchingError(
+                f'Failed to query Kubernetes cluster {cluster_name_on_cloud!r} '
+                f'status: {common_utils.format_exception(e)}')
+
+    # Check if the pods are running or pending
+    cluster_status = {}
+    for pod in pods:
+        pod_status = status_map[pod.status.phase]
+        if non_terminated_only and pod_status is None:
+            continue
+        cluster_status[pod.metadata.name] = pod_status
+    return cluster_status

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -47,8 +47,9 @@ def _get_namespace(provider_config: Dict[str, Any]) -> str:
         'namespace',
         kubernetes_utils.get_current_kube_config_context_namespace())
 
-def wait_pods_running(config, provider_config,
-                       namespace: str, tags: List[str], ssh_jump_pod_name: str):
+
+def wait_pods_running(config, provider_config, namespace: str,
+                      tags: Dict[str, str], ssh_jump_pod_name: str):
     """Wait for all pods to schedule and run (including the ssh jump pod)
     """
     wait_pods_dict = filter_pods(namespace, tags, ['Pending'])
@@ -83,7 +84,8 @@ def wait_pods_running(config, provider_config,
                  f'{list(wait_pods_dict.keys())}')
     return wait_pods
 
-def wait_for_termination(namespace: str, tags: List[str]):
+
+def wait_for_termination(namespace: str, tags: Dict[str, str]):
     """Wait for termination of pods"""
     # Wait for any terminating minicluster pods
     terminating_pods = filter_pods(namespace, tags, ['Terminating'])
@@ -111,11 +113,12 @@ def wait_for_termination(namespace: str, tags: List[str]):
                 _request_timeout=config_lib.DELETION_TIMEOUT,
                 grace_period_seconds=0)
 
-def initialize_pods(namespace: str, tags: List[str]):
+
+def initialize_pods(namespace: str, tags: Dict[str, str]):
     """For pods not tagged as initialized, run init steps"""
 
     # Wait until pods are running, they can go from init->pod init->running
-    running_pods = {}
+    running_pods: Dict[str, Any] = {}
     while not running_pods:
         running_pods = filter_pods(namespace, tags, ['Running'])
         if running_pods:
@@ -155,6 +158,7 @@ def initialize_pods(namespace: str, tags: List[str]):
 
     return running_pods
 
+
 def nvidia_runtime_exists() -> bool:
     """Determine if nvidia runtime exists"""
     try:
@@ -170,8 +174,9 @@ def nvidia_runtime_exists() -> bool:
                        'For more details, refer to https://skypilot.readthedocs.io/en/latest/reference/config.html')  # pylint: disable=line-too-long
     return runtime_exists
 
+
 def filter_pods(namespace: str, tag_filters: Dict[str, str],
-                 status_filters: Optional[List[str]]) -> Dict[str, Any]:
+                status_filters: Optional[List[str]]) -> Dict[str, Any]:
     """Filters pods by tags and status.
     Public function, as is shared by flux provisioner.
     """
@@ -702,11 +707,15 @@ def get_cluster_info(
         provider_config,
     )
 
-def query_cluster_info(running_pods, namespace: str,
-                       head_index_label: str, head_index: str,
-                       cluster_name_on_cloud: str,
-                       provider_config: Optional[Dict[str, Any]] = None,
-                       ) -> common.ClusterInfo:
+
+def query_cluster_info(
+    running_pods,
+    namespace: str,
+    head_index_label: str,
+    head_index: str,
+    cluster_name_on_cloud: str,
+    provider_config: Optional[Dict[str, Any]] = None,
+) -> common.ClusterInfo:
     """Get the head pod name and cpu_resources based on labels"""
     pods: Dict[str, List[common.InstanceInfo]] = {}
     head_pod_name = None
@@ -717,7 +726,7 @@ def query_cluster_info(running_pods, namespace: str,
         network_mode_str)
     external_ip = kubernetes_utils.get_external_ip(network_mode)
     port = 22
-    if not provider_config.get('use_internal_ips', False):
+    if provider_config and not provider_config.get('use_internal_ips', False):
         port = kubernetes_utils.get_head_ssh_port(cluster_name_on_cloud,
                                                   namespace)
     head_pod_name = None
@@ -769,6 +778,7 @@ def query_cluster_info(running_pods, namespace: str,
         },
         provider_name='kubernetes',
         provider_config=provider_config)
+
 
 def query_instances(
     cluster_name_on_cloud: str,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1452,6 +1452,8 @@ def combine_pod_config_fields(
         kubernetes_config,
         yaml_obj['available_node_types']['ray_head_default']['node_config'])
 
+    # Hack for flux to add current running pods
+
     # Write the updated YAML back to the file
     common_utils.dump_yaml(cluster_yaml_path, yaml_obj)
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -57,7 +57,8 @@ def _bulk_provision(
     else:
         zone_str = ','.join(z.name for z in zones)
 
-    if isinstance(cloud, clouds.Kubernetes):
+    # TODO(vsoch): there should be a special set of Kubernetes based "clouds"
+    if isinstance(cloud, (clouds.Kubernetes, clouds.Flux)):
         # Omit the region name for Kubernetes.
         logger.info(f'{style.BRIGHT}Launching on {cloud}{style.RESET_ALL} '
                     f'{cluster_name!r}.')
@@ -66,6 +67,7 @@ def _bulk_provision(
                     f'{region_name}{style.RESET_ALL} ({zone_str})')
 
     start = time.time()
+
     with rich_utils.safe_status('[bold cyan]Launching[/]') as status:
         try:
             # TODO(suquark): Should we cache the bootstrapped result?

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -67,7 +67,6 @@ def _bulk_provision(
                     f'{region_name}{style.RESET_ALL} ({zone_str})')
 
     start = time.time()
-
     with rich_utils.safe_status('[bold cyan]Launching[/]') as status:
         try:
             # TODO(suquark): Should we cache the bootstrapped result?
@@ -94,6 +93,7 @@ def _bulk_provision(
         backoff = common_utils.Backoff(initial_backoff=1, max_backoff_factor=3)
         logger.debug(
             f'\nWaiting for instances of {cluster_name!r} to be ready...')
+
         status.update('[bold cyan]Launching - Checking instance status[/]')
         # AWS would take a very short time (<<1s) updating the state of the
         # instance.
@@ -444,7 +444,10 @@ def _post_provision_setup(
 
         logger.debug(
             f'\nWaiting for SSH to be available for {cluster_name!r} ...')
-        wait_for_ssh(cluster_info, ssh_credentials)
+
+        # We don't need ssh for kubectl accessed clouds like flux
+        if provider_config['module'] != 'sky.provision.flux':
+            wait_for_ssh(cluster_info, ssh_credentials)
         logger.debug(f'SSH Conection ready for {cluster_name!r}')
         plural = '' if len(cluster_info.instances) == 1 else 's'
         logger.info(f'{colorama.Fore.GREEN}Successfully provisioned '

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -446,9 +446,10 @@ def _post_provision_setup(
             f'\nWaiting for SSH to be available for {cluster_name!r} ...')
 
         # We don't need ssh for kubectl accessed clouds like flux
-        if provider_config['module'] != 'sky.provision.flux':
+        if provider_config is not None and provider_config[
+                'module'] != 'sky.provision.flux':
             wait_for_ssh(cluster_info, ssh_credentials)
-        logger.debug(f'SSH Conection ready for {cluster_name!r}')
+        logger.debug(f'SSH Connection ready for {cluster_name!r}')
         plural = '' if len(cluster_info.instances) == 1 else 's'
         logger.info(f'{colorama.Fore.GREEN}Successfully provisioned '
                     f'or found existing instance{plural}.'

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -461,6 +461,14 @@ class Resources:
     def requires_fuse(self, value: Optional[bool]) -> None:
         self._requires_fuse = value
 
+    def set_cloud(self, cloud):
+        """Set the cloud to a different class
+
+        This is used for Kubernetes-based clouds.
+        """
+        if hasattr(self, '_cloud') and self._cloud is not None:
+            self._cloud = cloud
+
     def _set_cpus(
         self,
         cpus: Union[None, int, float, str],

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -208,6 +208,9 @@ aws_dependencies = [
     'colorama < 0.4.5',
 ]
 
+# Flux requires the same as kubernetes
+kubernetes_requires = ['kubernetes>=20.0.0']
+
 extras_require: Dict[str, List[str]] = {
     'aws': aws_dependencies,
     # TODO(zongheng): azure-cli is huge and takes a long time to install.
@@ -231,7 +234,8 @@ extras_require: Dict[str, List[str]] = {
     'cloudflare': aws_dependencies,
     'scp': local_ray,
     'oci': ['oci'] + local_ray,
-    'kubernetes': ['kubernetes>=20.0.0'],
+    'kubernetes': kubernetes_requires,
+    "flux": kubernetes_requires,
     'remote': remote,
     'runpod': ['runpod>=1.5.1'],
     'fluidstack': [],  # No dependencies needed for fluidstack

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -14,7 +14,7 @@ idle_timeout_minutes: 60
 # created by your cluster administrator.
 provider:
     type: external
-    module: sky.provision.kubernetes
+    module: {{module}}
 
     region: kubernetes
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I am opening this pull request to start discussion around adding Flux Framework as a cloud and provisioner. This first stage allows for deployment of the MiniCluster, and running the cowsay example, and then bringing it down. I have done a lot of the work but this needs quite a bit of work before it gets into a more finished state.

## Details

### "Kubernetes Cloud" should be supported for operator-derived clusters

This adds a new design idea, that we can have a "Kubernetes Cloud" or any kind of operator that deploys an entire cluster via Kubernetes. This means, design wise, that we add a new cloud and provisioner, each of which shares a lot of functionality with Kubernetes, and so a lot of the current private functions I exposed to be public for Flux to use. At a high level, I think sharing logic will help to organize the Kubernetes functions/code. I started on this a bit and would be happy to continue.

### Need to easily customize the -head node

I first want to clarify the use for the ssh pod. Should this be considered separate to the cluster entirely, or can it be the head node of the cluster? I am thinking the latter, and in this case, the ideal head node is the flux operator index 0 pod (the Flux Operator deploys an indexed job) because this is where you'd typically shell in to interact with the flux queue. For my limited look at the code thus far, this seems relevant for setting up the ssh pod. I got this mostly working, but it was done via a hack to pass forward a different pod for the head node, and then add custom logic to use it in the provisioner. My question:

> Can we more generalize the name of the ssh pod for different environments? And if not, what is the best way to pass that forward? It's not a predictable name, it will be in the format `sky-xxxx-vanessa-0-xxxx` and I typically get it by way of running `filter_pods` with Running status.

Once this is easy to do, I can go back and debug the ssh issue, which came down to some invalid identification string [reported here](https://github.com/skypilot-org/skypilot/issues/3751#issuecomment-2244020281). After that is resolved, the ssh should work.

### Next steps

I'm developing this mostly based on knowing the commands that need to be run, and then tracing them / reading the code to understand how it works, and then working on it for Flux. In addition to ssh above, I'd like to ask for examples of interacting with the cluster that need to be afforded. I'm guessing we will want to issue commands to flux directly, which can either be done via a service (I can expose either grpc or standard restful) or it could even be done with ssh, as long as the broker socket is targeted. 

@romilbhardwaj if you can give me direction for each of ssh and the next stage of work to do, that would be greatly appreciated! And we can move into discussion of the PR needs (e.g., tests) after this development stage is done. If we need to discuss details of the Kubernetes cloud idea beyond this issue, I'm thinking maybe we could schedule a small slot in an upcoming batch meeting.

Issues addressed:

- https://github.com/skypilot-org/skypilot/issues/3751

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
