### PR TITLE
Add cli for opening VSCode against a cluster

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5260,9 +5260,14 @@ def code(
     if not cluster:
         raise click.UsageError('Please specify a cluster with ---cluster/-c.')
 
+    handle = global_user_state.get_handle_from_cluster_name(cluster)
+    if handle is None:
+        raise click.BadParameter(f'Cluster {cluster!r} not found. '
+                                 'Use `sky launch` to provision first.')
+
     code_bin = shutil.which("code")
     if not code_bin:
-        raise RuntimeError(
+        raise click.UsageError(
             '"code" is not available in your path. Ensure VSCode in installed and the shell command is available on '
             'your path https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line'
         )

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5265,21 +5265,22 @@ def code(
         raise click.BadParameter(f'Cluster {cluster!r} not found. '
                                  'Use `sky launch` to provision first.')
 
-    code_bin = shutil.which("code")
+    code_bin = shutil.which('code')
     if not code_bin:
         raise click.UsageError(
-            '"code" is not available in your path. Ensure VSCode in installed and the shell command is available on '
-            'your path https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line'
+            '"code" is not available in your path. Ensure VSCode in installed'
+            ' and the shell command is available on your path '
+            'https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line'
         )
 
     command = [
-        code_bin, "--disable-workspace-trust",
-        f"--folder-uri=vscode-remote://ssh-remote+{cluster}{workdir}"
+        code_bin, '--disable-workspace-trust',
+        f'--folder-uri=vscode-remote://ssh-remote+{cluster}{workdir}'
     ]
     if new_window:
-        command.append("--new-window")
+        command.append('--new-window')
     if profile:
-        command += ["--profile", profile]
+        command += ['--profile', profile]
 
     subprocess.check_call(command)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adds a CLI command that opens VSCode against a target cluster

Issues:

* Can't default open to SKY_WORKDIR since actual path is dynamic and changes based on the parent image. 
* Failures will probably be unintuitive if code isn't installed with the ssh-remote extension. Should improve validation to check it's installed.
* Users should be able to select from a list of clusters if they don't specify one. [Questionary](https://pypi.org/project/questionary/) is a good library for this, but I didn't want to add a new dependency 

<!-- Describe the tests ran -->

sky code -c spot-test --workdir /home/sky/sky_workdir

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
