### PR TITLE
[SkyBench] Allow only s3 for sky benchmark

### DIFF
--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -173,8 +173,9 @@ def _create_benchmark_bucket() -> Tuple[str, str]:
         raise_if_no_cloud_access=True)
     # Sky Benchmark only supports S3 (see _download_remote_dir and
     # _delete_remote_dir).
-    enabled_clouds = [cloud for cloud in enabled_clouds
-                      if cloud in [str(clouds.AWS())]]
+    enabled_clouds = [
+        cloud for cloud in enabled_clouds if cloud in [str(clouds.AWS())]
+    ]
     assert enabled_clouds, ('No enabled cloud storage found. Sky Benchmark '
                             'requires GCP or AWS to store logs.')
     bucket_type = data.StoreType.from_cloud(enabled_clouds[0]).value

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -20,6 +20,7 @@ from rich import progress as rich_progress
 
 import sky
 from sky import backends
+from sky import clouds
 from sky import data
 from sky import global_user_state
 from sky import sky_logging
@@ -170,8 +171,12 @@ def _create_benchmark_bucket() -> Tuple[str, str]:
     # Select the bucket type.
     enabled_clouds = storage_lib.get_cached_enabled_storage_clouds_or_refresh(
         raise_if_no_cloud_access=True)
-    # Already checked by raise_if_no_cloud_access=True.
-    assert enabled_clouds
+    # Sky Benchmark only supports GCS and S3 (see _download_remote_dir and
+    # _delete_remote_dir).
+    enabled_clouds = [cloud for cloud in enabled_clouds
+                      if cloud in [str(clouds.AWS()), str(clouds.GCP())]]
+    assert enabled_clouds, ('No enabled cloud storage found. Sky Benchmark '
+                            'requires GCP or AWS to store logs.')
     bucket_type = data.StoreType.from_cloud(enabled_clouds[0]).value
 
     # Create a benchmark bucket.

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -171,10 +171,10 @@ def _create_benchmark_bucket() -> Tuple[str, str]:
     # Select the bucket type.
     enabled_clouds = storage_lib.get_cached_enabled_storage_clouds_or_refresh(
         raise_if_no_cloud_access=True)
-    # Sky Benchmark only supports GCS and S3 (see _download_remote_dir and
+    # Sky Benchmark only supports S3 (see _download_remote_dir and
     # _delete_remote_dir).
     enabled_clouds = [cloud for cloud in enabled_clouds
-                      if cloud in [str(clouds.AWS()), str(clouds.GCP())]]
+                      if cloud in [str(clouds.AWS())]]
     assert enabled_clouds, ('No enabled cloud storage found. Sky Benchmark '
                             'requires GCP or AWS to store logs.')
     bucket_type = data.StoreType.from_cloud(enabled_clouds[0]).value
@@ -247,14 +247,8 @@ def _download_remote_dir(remote_dir: str, local_dir: str,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=True)
-    elif bucket_type == data.StoreType.GCS:
-        remote_dir = f'gs://{remote_dir}'
-        subprocess.run(['gsutil', '-m', 'cp', '-r', remote_dir, local_dir],
-                       stdout=subprocess.DEVNULL,
-                       stderr=subprocess.DEVNULL,
-                       check=True)
     else:
-        raise RuntimeError('Azure Blob Storage is not supported yet.')
+        raise RuntimeError(f'{bucket_type} is not supported yet.')
 
 
 def _delete_remote_dir(remote_dir: str, bucket_type: data.StoreType) -> None:
@@ -265,20 +259,8 @@ def _delete_remote_dir(remote_dir: str, bucket_type: data.StoreType) -> None:
                        stdout=subprocess.DEVNULL,
                        stderr=subprocess.DEVNULL,
                        check=True)
-    elif bucket_type == data.StoreType.GCS:
-        remote_dir = f'gs://{remote_dir}'
-        proc = subprocess.run(['gsutil', '-m', 'rm', '-r', remote_dir],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE,
-                              check=False)
-        if proc.returncode != 0:
-            stderr = proc.stderr.decode('utf-8')
-            if 'BucketNotFoundException: 404' in stderr:
-                logger.warning(f'Bucket {remote_dir} does not exist. Skip')
-            else:
-                raise RuntimeError(f'Failed to delete {remote_dir}: {stderr}')
     else:
-        raise RuntimeError('Azure Blob Storage is not supported yet.')
+        raise RuntimeError(f'{bucket_type} is not supported yet.')
 
 
 def _read_timestamp(path: str) -> float:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5268,6 +5268,7 @@ def test_multiple_resources():
 @pytest.mark.no_fluidstack  # Requires other clouds to be enabled
 @pytest.mark.no_paperspace  # Requires other clouds to be enabled
 @pytest.mark.no_kubernetes
+@pytest.mark.aws  # SkyBenchmark requires S3 access
 def test_sky_bench(generic_cloud: str):
     name = _get_cluster_name()
     test = Test(


### PR DESCRIPTION
Closes #3731.

Sky Benchmark works reliably only with S3. If the object store is created on GCS, it fails (possibly related to https://github.com/GoogleCloudPlatform/gsutil/issues/417, but special casing for the error seems to break other parts of sky benchmark code). 

`test_sky_bench` has been restricted now to run only if AWS is used for the test.

- [x] Code formatting: `bash format.sh`
- [x] `pytest tests/test_smoke.py::test_sky_bench --aws`