### PR TITLE
[k8s] Fix recursive decoration of kubernetes API methods

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -4,6 +4,7 @@
 
 import logging
 import os
+from typing import Any, Callable
 
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
@@ -30,14 +31,18 @@ _api_client = None
 API_TIMEOUT = 5
 
 
-def _decorate_methods(obj, decorator):
+def _decorate_methods(obj: Any, decorator: Callable, decoration_type: str):
     for attr_name in dir(obj):
         attr = getattr(obj, attr_name)
-        if callable(attr) and not attr_name.startswith('__') and not getattr(
-                attr, '_is_sky_decorated', False):
-            decorated_attr = decorator(attr)
-            decorated_attr._is_sky_decorated = True  # pylint: disable=protected-access
-            setattr(obj, attr_name, decorated_attr)
+        # Skip methods starting with '__' since they are invoked through one
+        # of the main methods, which are already decorated.
+        if callable(attr) and not attr_name.startswith('__'):
+            decorated_types = getattr(attr, '_sky_decorator_types', set())
+            if decoration_type not in decorated_types:
+                decorated_attr = decorator(attr)
+                decorated_attr._sky_decorator_types = (decorated_types |
+                                                       {decoration_type})
+                setattr(obj, attr_name, decorated_attr)
     return obj
 
 
@@ -52,7 +57,7 @@ def _api_logging_decorator(logger: str, level: int):
 
         def wrapped(*args, **kwargs):
             obj = api(*args, **kwargs)
-            _decorate_methods(obj, set_logging_level(logger, level))
+            _decorate_methods(obj, set_logging_level(logger, level), 'api_log')
             return obj
 
         return wrapped

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from typing import Any, Callable
+from typing import Any, Callable, Set
 
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
@@ -37,11 +37,12 @@ def _decorate_methods(obj: Any, decorator: Callable, decoration_type: str):
         # Skip methods starting with '__' since they are invoked through one
         # of the main methods, which are already decorated.
         if callable(attr) and not attr_name.startswith('__'):
-            decorated_types = getattr(attr, '_sky_decorator_types', set())
+            decorated_types: Set[str] = getattr(attr, '_sky_decorator_types',
+                                                set())
             if decoration_type not in decorated_types:
                 decorated_attr = decorator(attr)
-                decorated_attr._sky_decorator_types = (decorated_types |
-                                                       {decoration_type})
+                decorated_attr._sky_decorator_types = (  # pylint: disable=protected-access
+                    decorated_types | {decoration_type})
                 setattr(obj, attr_name, decorated_attr)
     return obj
 

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -33,8 +33,10 @@ API_TIMEOUT = 5
 def _decorate_methods(obj, decorator):
     for attr_name in dir(obj):
         attr = getattr(obj, attr_name)
-        if callable(attr) and not attr_name.startswith('__'):
-            setattr(obj, attr_name, decorator(attr))
+        if callable(attr) and not attr_name.startswith('__') and not getattr(attr, '_is_sky_decorated', False):
+            decorated_attr = decorator(attr)
+            decorated_attr._is_sky_decorated = True
+            setattr(obj, attr_name, decorated_attr)
     return obj
 
 

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -33,9 +33,10 @@ API_TIMEOUT = 5
 def _decorate_methods(obj, decorator):
     for attr_name in dir(obj):
         attr = getattr(obj, attr_name)
-        if callable(attr) and not attr_name.startswith('__') and not getattr(attr, '_is_sky_decorated', False):
+        if callable(attr) and not attr_name.startswith('__') and not getattr(
+                attr, '_is_sky_decorated', False):
             decorated_attr = decorator(attr)
-            decorated_attr._is_sky_decorated = True
+            decorated_attr._is_sky_decorated = True  # pylint: disable=protected-access
             setattr(obj, attr_name, decorated_attr)
     return obj
 


### PR DESCRIPTION
Closes #3774. This was a regression in https://github.com/skypilot-org/skypilot/pull/3674 which decorated the kubernetes API methods multiple times, blowing up the stack depth and causing the recursion error.

This PR fixes it by decorating methods only once.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual repro by terminating SkyServe replica and watching controller logs
- [x] `pytest tests/test_smoke.py::test_skyserve_update_autoscale --kubernetes`
