### PR TITLE
[Azure blob] fix `test_private_bucket` for azure blob

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -186,7 +186,7 @@ def get_client(name: str,
                     if 'ERROR: AADSTS50020' in str(e):
                         with ux_utils.print_exception_no_traceback():
                             raise sky_exceptions.StorageBucketGetError(
-                                'Attempted to fetch a non-existant public '
+                                'Attempted to fetch a non-existent public '
                                 'container name: '
                                 f'{container_client.container_name}. '
                                 'Please check if the name is correct.')

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2537,7 +2537,7 @@ class AzureBlobStore(AbstractStore):
             if 'Name or service not known' in error_message:
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.StorageBucketGetError(
-                        'Attempted to fetch the container from non-existant '
+                        'Attempted to fetch the container from non-existent '
                         'storage account '
                         f'name: {self.storage_account_name}. Please check '
                         'if the name is correct.')

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4895,10 +4895,15 @@ class TestStorageWithCredentials:
                 private_bucket).path.strip('/')
         else:
             private_bucket_name = urllib.parse.urlsplit(private_bucket).netloc
+        match_str = storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
+                    name=private_bucket_name)
+        if store_type == 'https':
+            # Azure blob uses a different error string since container may
+            # not exist even though the bucket name is ok.
+            match_str = 'Attempted to fetch a non-existent public container'
         with pytest.raises(
                 sky.exceptions.StorageBucketGetError,
-                match=storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
-                    name=private_bucket_name)):
+                match=match_str):
             storage_obj = storage_lib.Storage(source=private_bucket)
 
     @pytest.mark.no_fluidstack

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4896,14 +4896,13 @@ class TestStorageWithCredentials:
         else:
             private_bucket_name = urllib.parse.urlsplit(private_bucket).netloc
         match_str = storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
-                    name=private_bucket_name)
+            name=private_bucket_name)
         if store_type == 'https':
             # Azure blob uses a different error string since container may
             # not exist even though the bucket name is ok.
             match_str = 'Attempted to fetch a non-existent public container'
-        with pytest.raises(
-                sky.exceptions.StorageBucketGetError,
-                match=match_str):
+        with pytest.raises(sky.exceptions.StorageBucketGetError,
+                           match=match_str):
             storage_obj = storage_lib.Storage(source=private_bucket)
 
     @pytest.mark.no_fluidstack


### PR DESCRIPTION
`pytest tests/test_smoke.py::TestStorageWithCredentials::test_private_bucket --azure` has been failing.

Tested (run the relevant ones):

- [x] `pytest tests/test_smoke.py::TestStorageWithCredentials::test_private_bucket --azure`
