### PR TITLE
Allow setting the workdir using environment variables

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -393,6 +393,11 @@ class Task:
             config['service'] = _fill_in_env_vars(config['service'],
                                                   config.get('envs', {}))
 
+        # Fill in any Task.envs into workdir
+        if config.get('workdir') is not None:
+            config['workdir'] = _fill_in_env_vars(config['workdir'],
+                                                  config.get('envs', {}))
+
         task = Task(
             config.pop('name', None),
             run=config.pop('run', None),

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -146,3 +146,13 @@ def test_invalid_empty_envs(tmp_path):
     with pytest.raises(ValueError) as e:
         Task.from_yaml(config_path)
     assert 'Environment variable \'env_key2\' is None.' in e.value.args[0]
+
+def test_replace_envs_in_path(tmpdir, tmp_path):
+    config_path = _create_config_file(
+        textwrap.dedent(f"""\
+            envs:
+                env_key1: {tmpdir}
+            workdir: $env_key1
+            """), tmp_path)
+    task = Task.from_yaml(config_path)
+    assert task.workdir == tmpdir

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -147,6 +147,7 @@ def test_invalid_empty_envs(tmp_path):
         Task.from_yaml(config_path)
     assert 'Environment variable \'env_key2\' is None.' in e.value.args[0]
 
+
 def test_replace_envs_in_path(tmpdir, tmp_path):
     config_path = _create_config_file(
         textwrap.dedent(f"""\

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -148,7 +148,7 @@ def test_invalid_empty_envs(tmp_path):
     assert 'Environment variable \'env_key2\' is None.' in e.value.args[0]
 
 
-def test_replace_envs_in_path(tmpdir, tmp_path):
+def test_replace_envs_in_workdir(tmpdir, tmp_path):
     config_path = _create_config_file(
         textwrap.dedent(f"""\
             envs:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Allows the workdir to be configured using environment variables.

Closes #3271 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
