### PR TITLE
[k8s] Surface provisioning errors + handling for fuse failures

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -113,7 +113,7 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
         # Returns a formatted string of node selectors for a pod.
         node_selectors = []
         if pod.spec.node_selector is None:
-            return
+            return None
         for label_key, label_value in pod.spec.node_selector.items():
             node_selectors.append(f'{label_key}={label_value}')
         return ', '.join(node_selectors)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -109,9 +109,11 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
         return ', '.join(f'{resource}={value}'
                          for resource, value in resource_requirements.items())
 
-    def _formatted_node_selector(pod):
+    def _formatted_node_selector(pod) -> Optional[str]:
         # Returns a formatted string of node selectors for a pod.
         node_selectors = []
+        if pod.spec.node_selector is None:
+            return
         for label_key, label_value in pod.spec.node_selector.items():
             node_selectors.append(f'{label_key}={label_value}')
         return ', '.join(node_selectors)
@@ -123,7 +125,7 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
             node_selectors) else ''
         msg = (
             f'Insufficient {resource} capacity on the cluster. '
-            f'Required resources({resource_requirements}){node_selector_str} '
+            f'Required resources ({resource_requirements}){node_selector_str} '
             'were not found in a single node. Other SkyPilot tasks or pods may '
             'be using resources. Check resource usage by running '
             '`kubectl describe nodes`.')

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -119,7 +119,7 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
         return ', '.join(node_selectors)
 
     def _lack_resource_msg(resource: str,
-                           pod: 'kubernetes.kubernetes.client.V1Pod',
+                           pod,
                            extra_msg: Optional[str] = None,
                            details: Optional[str] = None) -> str:
         resource_requirements = _formatted_resource_requirements(pod)

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -119,7 +119,8 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
     def lack_resource_msg(resource, pod, extra_msg=None, details=None) -> str:
         resource_requirements = _formatted_resource_requirements(pod)
         node_selectors = _formatted_node_selector(pod)
-        node_selector_str = f' and labels ({node_selectors})' if node_selectors else ''
+        node_selector_str = f' and labels ({node_selectors})' if (
+            node_selectors) else ''
         msg = (
             f'Insufficient {resource} capacity on the cluster. '
             f'Required resources({resource_requirements}){node_selector_str} '
@@ -176,7 +177,7 @@ def _raise_pod_scheduling_errors(namespace, new_nodes):
                     raise config_lib.KubernetesError(
                         'Something went wrong with FUSE device daemonset.'
                         ' Try restarting your FUSE pods by running '
-                        '`kubectl delete pods -n skypilot-system -l name=smarter-device-manager`.'
+                        '`kubectl delete pods -n skypilot-system -l name=smarter-device-manager`.'  # pylint: disable=line-too-long
                         f' Full error: {event_message}')
                 gpu_lf_keys = [
                     lf.get_label_key()


### PR DESCRIPTION
This PR adds logging for surfacing errors during pod provisioning due to insufficient resources.

Previously, any non-cpu/memory related failure would be shown as insufficient GPU, even though other resources may be missing.

We now surface the underlying error message and add special handling for when FUSE device is unavailable (reported by users).


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manually by exhausting resources (CPU, mem, fuse, GPU) and running `sky launch`