### PR TITLE
Renamed sky storage ls to sky storage status, users can now specify bucket name to list only that bucket

### DIFF
--- a/docs/source/reference/cli.rst
+++ b/docs/source/reference/cli.rst
@@ -107,9 +107,9 @@ SkyServe CLI
 Storage CLI
 ------------
 
-.. _sky-storage-ls:
-.. click:: sky.cli:storage_ls
-   :prog: sky storage ls
+.. _sky-storage-status:
+.. click:: sky.cli:storage_status
+   :prog: sky storage status
    :nested: full
 
 .. _sky-storage-delete:

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -242,13 +242,13 @@ Using SkyPilot Storage CLI
 --------------------------------
 
 To manage buckets created by SkyPilot, the sky CLI provides two commands:
-:code:`sky storage ls` and :code:`sky storage delete`.
+:code:`sky storage status` and :code:`sky storage delete`.
 
-1.  :code:`sky storage ls` shows buckets created by SkyPilot.
+1.  :code:`sky storage status` shows buckets created by SkyPilot.
 
 .. code-block:: console
 
-    $ sky storage ls
+    $ sky storage status
     NAME               CREATED     STORE  COMMAND                                        STATUS
     sky-dataset        3 mins ago  S3     sky launch -c demo examples/storage_demo.yaml  READY
 
@@ -263,9 +263,9 @@ To manage buckets created by SkyPilot, the sky CLI provides two commands:
     I 04-02 19:42:26 storage.py:683] Deleting S3 Bucket sky-dataset
 
 .. note::
-    :code:`sky storage ls` only shows storage that were created
+    :code:`sky storage status` only shows storage that were created
     by SkyPilot. Externally created buckets or public buckets are not listed
-    in :code:`sky storage ls` and cannot be managed through SkyPilot.
+    in :code:`sky storage status` and cannot be managed through SkyPilot.
 
 Storage YAML reference
 ----------------------

--- a/examples/docker/echo_app.py
+++ b/examples/docker/echo_app.py
@@ -48,6 +48,6 @@ with sky.Dag() as dag:
 sky.launch(dag)
 
 print('Remember to clean up resources after this script is done!\n'
-      'Run sky status and sky storage ls to list current resources.\n'
+      'Run sky status and sky storage status to list current resources.\n'
       'Run sky down <cluster_name> and sky storage delete <storage_name> to '
       'delete resources.')

--- a/examples/storage_demo.yaml
+++ b/examples/storage_demo.yaml
@@ -155,5 +155,5 @@ run: |
   pwd
   ls -la /
 
-# Remember to run `sky storage ls` and `sky storage delete` to delete the
+# Remember to run `sky storage status` and `sky storage delete` to delete the
 # created storage objects!

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -94,7 +94,7 @@ from sky.core import start
 from sky.core import status
 from sky.core import stop
 from sky.core import storage_delete
-from sky.core import storage_ls
+from sky.core import storage_status
 from sky.core import tail_logs
 from sky.dag import Dag
 from sky.data import Storage
@@ -183,6 +183,6 @@ __all__ = [
     'spot_queue',
     'spot_cancel',
     # core APIs Storage Management
-    'storage_ls',
+    'storage_status',
     'storage_delete',
 ]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3364,7 +3364,7 @@ def storage_status(all: bool, bucket_name: Optional[str] = None):
 
 
 # TODO(aseriesof-tubes) Add command storage_ls that shows contents of bucket
-# like gsutil ls 
+# like gsutil ls
 
 
 @storage.command('delete', cls=_DocumentedCodeCommand)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3358,11 +3358,14 @@ def storage_status(all: bool, bucket_name: Optional[str] = None):
         if not storages:
             click.echo(f'No storage object found with name: {bucket_name}')
             return
-        
+
     storage_table = storage_utils.format_storage_table(storages, show_all=all)
     click.echo(storage_table)
 
-# TODO(aseriesof-tubes) Add command storage_ls that shows contents of specified bucket, like gsutil ls.
+
+# TODO(aseriesof-tubes) Add command storage_ls that shows contents of bucket
+# like gsutil ls 
+
 
 @storage.command('delete', cls=_DocumentedCodeCommand)
 @click.argument('names',

--- a/sky/core.py
+++ b/sky/core.py
@@ -797,7 +797,7 @@ def job_status(cluster_name: str,
 # = Storage Management =
 # ======================
 @usage_lib.entrypoint
-def storage_ls() -> List[Dict[str, Any]]:
+def storage_status() -> List[Dict[str, Any]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Get the storages.
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -697,7 +697,7 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
         # There may be existing (non-translated) storage mounts, so log this
         # whenever task.storage_mounts is non-empty.
         logger.info(f'{colorama.Fore.YELLOW}Uploading sources to cloud storage.'
-                    f'{colorama.Style.RESET_ALL} See: sky storage ls')
+                    f'{colorama.Style.RESET_ALL} See: sky storage status')
     try:
         task.sync_storage_mounts()
     except ValueError as e:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4956,7 +4956,8 @@ class TestStorageWithCredentials:
         storage_name = tmp_copy_mnt_existing_storage_obj.name
 
         # Check `sky storage status` to ensure storage object exists
-        out = subprocess.check_output(['sky', 'storage', 'status']).decode('utf-8')
+        out = subprocess.check_output(['sky', 'storage',
+                                       'status']).decode('utf-8')
         assert storage_name in out, f'Storage {storage_name} not found in sky storage status.'
 
     @pytest.mark.no_fluidstack

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4643,7 +4643,7 @@ class TestStorageWithCredentials:
         tmp_local_storage_obj.add_store(store_type)
 
         # Run sky storage status to check if storage object exists in the output
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_local_storage_obj.name in out.decode('utf-8')
 
         # Run sky storage delete to delete the storage object
@@ -4651,7 +4651,7 @@ class TestStorageWithCredentials:
             ['sky', 'storage', 'delete', tmp_local_storage_obj.name, '--yes'])
 
         # Run sky storage status to check if storage object is deleted
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_local_storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.no_fluidstack
@@ -4673,7 +4673,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage status to check if all storage objects exists in the
         # output filtered by store type
-        out_all = subprocess.check_output(['sky', 'storage', 'ls'])
+        out_all = subprocess.check_output(['sky', 'storage', 'status'])
         out = [
             item.split()[0]
             for item in out_all.decode('utf-8').splitlines()
@@ -4688,7 +4688,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage status to check if all storage objects filtered by store
         # type are deleted
-        out_all = subprocess.check_output(['sky', 'storage', 'ls'])
+        out_all = subprocess.check_output(['sky', 'storage', 'status'])
         out = [
             item.split()[0]
             for item in out_all.decode('utf-8').splitlines()
@@ -4714,7 +4714,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage status to check if all storage objects exists in the
         # output filtered by store type
-        out_all = subprocess.check_output(['sky', 'storage', 'ls'])
+        out_all = subprocess.check_output(['sky', 'storage', 'status'])
         out = [
             item.split()[0]
             for item in out_all.decode('utf-8').splitlines()
@@ -4736,7 +4736,7 @@ class TestStorageWithCredentials:
         tmp_scratch_storage_obj.add_store(store_type)
 
         # Run sky storage status to check if storage object exists in the output
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_scratch_storage_obj.name in out.decode('utf-8')
 
         # Delete bucket externally
@@ -4750,7 +4750,7 @@ class TestStorageWithCredentials:
         assert 'created' not in out.decode('utf-8').lower()
 
         # Run sky storage status to check if storage object is deleted
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_scratch_storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.no_fluidstack
@@ -4769,7 +4769,7 @@ class TestStorageWithCredentials:
             'sky', 'storage', 'delete', tmp_bulk_del_storage_obj.name, '--yes'
         ])
 
-        output = subprocess.check_output(['sky', 'storage', 'ls'])
+        output = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_bulk_del_storage_obj.name not in output.decode('utf-8')
 
     @pytest.mark.no_fluidstack
@@ -4789,7 +4789,7 @@ class TestStorageWithCredentials:
         tmp_public_storage_obj.add_store(store_type)
 
         # Run sky storage status to check if storage object exists in the output
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.no_fluidstack
@@ -4944,7 +4944,7 @@ class TestStorageWithCredentials:
 
         # Run sky storage status to check if storage object exists in the output.
         # It should not exist because the bucket was created externally.
-        out = subprocess.check_output(['sky', 'storage', 'ls'])
+        out = subprocess.check_output(['sky', 'storage', 'status'])
         assert storage_obj.name not in out.decode('utf-8')
 
     @pytest.mark.no_fluidstack
@@ -4956,7 +4956,7 @@ class TestStorageWithCredentials:
         storage_name = tmp_copy_mnt_existing_storage_obj.name
 
         # Check `sky storage status` to ensure storage object exists
-        out = subprocess.check_output(['sky', 'storage', 'ls']).decode('utf-8')
+        out = subprocess.check_output(['sky', 'storage', 'status']).decode('utf-8')
         assert storage_name in out, f'Storage {storage_name} not found in sky storage status.'
 
     @pytest.mark.no_fluidstack

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4642,7 +4642,7 @@ class TestStorageWithCredentials:
         # and deletes it.
         tmp_local_storage_obj.add_store(store_type)
 
-        # Run sky storage ls to check if storage object exists in the output
+        # Run sky storage status to check if storage object exists in the output
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_local_storage_obj.name in out.decode('utf-8')
 
@@ -4650,7 +4650,7 @@ class TestStorageWithCredentials:
         subprocess.check_output(
             ['sky', 'storage', 'delete', tmp_local_storage_obj.name, '--yes'])
 
-        # Run sky storage ls to check if storage object is deleted
+        # Run sky storage status to check if storage object is deleted
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_local_storage_obj.name not in out.decode('utf-8')
 
@@ -4671,7 +4671,7 @@ class TestStorageWithCredentials:
             store_obj.add_store(store_type)
             storage_obj_name.append(store_obj.name)
 
-        # Run sky storage ls to check if all storage objects exists in the
+        # Run sky storage status to check if all storage objects exists in the
         # output filtered by store type
         out_all = subprocess.check_output(['sky', 'storage', 'ls'])
         out = [
@@ -4686,7 +4686,7 @@ class TestStorageWithCredentials:
         delete_cmd += storage_obj_name
         subprocess.check_output(delete_cmd)
 
-        # Run sky storage ls to check if all storage objects filtered by store
+        # Run sky storage status to check if all storage objects filtered by store
         # type are deleted
         out_all = subprocess.check_output(['sky', 'storage', 'ls'])
         out = [
@@ -4712,7 +4712,7 @@ class TestStorageWithCredentials:
             storage_obj.add_store(store_type)
             storage_obj_names.append(storage_obj.name)
 
-        # Run sky storage ls to check if all storage objects exists in the
+        # Run sky storage status to check if all storage objects exists in the
         # output filtered by store type
         out_all = subprocess.check_output(['sky', 'storage', 'ls'])
         out = [
@@ -4735,7 +4735,7 @@ class TestStorageWithCredentials:
         # and then tries to delete it using sky storage delete.
         tmp_scratch_storage_obj.add_store(store_type)
 
-        # Run sky storage ls to check if storage object exists in the output
+        # Run sky storage status to check if storage object exists in the output
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_scratch_storage_obj.name in out.decode('utf-8')
 
@@ -4749,7 +4749,7 @@ class TestStorageWithCredentials:
         # Make sure bucket was not created during deletion (see issue #1322)
         assert 'created' not in out.decode('utf-8').lower()
 
-        # Run sky storage ls to check if storage object is deleted
+        # Run sky storage status to check if storage object is deleted
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_scratch_storage_obj.name not in out.decode('utf-8')
 
@@ -4788,7 +4788,7 @@ class TestStorageWithCredentials:
         # added to global_user_state.
         tmp_public_storage_obj.add_store(store_type)
 
-        # Run sky storage ls to check if storage object exists in the output
+        # Run sky storage status to check if storage object exists in the output
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert tmp_public_storage_obj.name not in out.decode('utf-8')
 
@@ -4942,7 +4942,7 @@ class TestStorageWithCredentials:
             'Symlink found in bucket - ls output was : {}'.format(
                 out.decode('utf-8')))
 
-        # Run sky storage ls to check if storage object exists in the output.
+        # Run sky storage status to check if storage object exists in the output.
         # It should not exist because the bucket was created externally.
         out = subprocess.check_output(['sky', 'storage', 'ls'])
         assert storage_obj.name not in out.decode('utf-8')
@@ -4955,9 +4955,9 @@ class TestStorageWithCredentials:
         tmp_copy_mnt_existing_storage_obj.add_store(storage_lib.StoreType.S3)
         storage_name = tmp_copy_mnt_existing_storage_obj.name
 
-        # Check `sky storage ls` to ensure storage object exists
+        # Check `sky storage status` to ensure storage object exists
         out = subprocess.check_output(['sky', 'storage', 'ls']).decode('utf-8')
-        assert storage_name in out, f'Storage {storage_name} not found in sky storage ls.'
+        assert storage_name in out, f'Storage {storage_name} not found in sky storage status.'
 
     @pytest.mark.no_fluidstack
     @pytest.mark.parametrize('store_type', [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This resolves issue #2284. By suggestion of the original issue, I renamed `sky storage ls` to `sky storage status`, and changed all mentions of `sky storage ls` to `status`, including the documentation. 

An issue came up while testing for this (only was able to test gcs). The test `test_gcs_regions` fails on the parameter `me-central2`, and after a quick look into this, it seems like there are some location restrictions on this. I'm not sure if this is just on my side but thought it was worth bringing up. 

I have also added a #TODO to implement a new `sky storage ls` CLI command that mimics the functionality of `gsutil ls`, which displays actual bucket contents. I can go ahead and implement that if needed. 

I have also changed the storage smoke tests so they use the command `sky storage status` instead of `sky storage ls`. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::TestStorageWithCredentials` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
