### PR TITLE
[Azure][Storage] Update Error response for accessing private container without access

### DIFF
--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -193,7 +193,8 @@ def get_client(name: str,
                     # upstream.
                     # Reference: https://learn.microsoft.com/en-us/troubleshoot/azure/entra/entra-id/app-integration/error-code-aadsts50020-user-account-identity-provider-does-not-exist # pylint: disable=line-too-long
                     if 'ERROR: AADSTS50020' in str(e):
-                        raise e
+                        with ux_utils.print_exception_no_traceback():
+                            raise e
                     with ux_utils.print_exception_no_traceback():
                         raise sky_exceptions.StorageBucketGetError(
                             'Failed to retreive the container client for the '

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -178,7 +178,7 @@ def get_client(name: str,
                     container_url, credential)
                 try:
                     # Suppress noisy logs from Azure SDK when attempting
-                    # to run exists() on public container with credentials.
+                    # to run exists() on private container without access.
                     # Reference:
                     # https://github.com/Azure/azure-sdk-for-python/issues/9422
                     azure_logger = logging.getLogger('azure')

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -189,7 +189,8 @@ def get_client(name: str,
                     return container_client
                 except exceptions().ClientAuthenticationError as e:
                     # Caught when user attempted to use private container
-                    # without access rights. This is handled at upper steam.
+                    # without access rights. Raised error is handled at the
+                    # upstream.
                     # Reference: https://learn.microsoft.com/en-us/troubleshoot/azure/entra/entra-id/app-integration/error-code-aadsts50020-user-account-identity-provider-does-not-exist # pylint: disable=line-too-long
                     if 'ERROR: AADSTS50020' in str(e):
                         raise e

--- a/sky/adaptors/azure.py
+++ b/sky/adaptors/azure.py
@@ -177,19 +177,22 @@ def get_client(name: str,
                 container_client = blob.ContainerClient.from_container_url(
                     container_url, credential)
                 try:
+                    # Suppress noisy logs from Azure SDK when attempting
+                    # to run exists() on public container with credentials.
+                    # Reference:
+                    # https://github.com/Azure/azure-sdk-for-python/issues/9422
+                    azure_logger = logging.getLogger('azure')
+                    original_level = azure_logger.getEffectiveLevel()
+                    azure_logger.setLevel(logging.CRITICAL)
                     container_client.exists()
+                    azure_logger.setLevel(original_level)
                     return container_client
                 except exceptions().ClientAuthenticationError as e:
                     # Caught when user attempted to use private container
-                    # without access rights.
+                    # without access rights. This is handled at upper steam.
                     # Reference: https://learn.microsoft.com/en-us/troubleshoot/azure/entra/entra-id/app-integration/error-code-aadsts50020-user-account-identity-provider-does-not-exist # pylint: disable=line-too-long
                     if 'ERROR: AADSTS50020' in str(e):
-                        with ux_utils.print_exception_no_traceback():
-                            raise sky_exceptions.StorageBucketGetError(
-                                'Attempted to fetch a non-existent public '
-                                'container name: '
-                                f'{container_client.container_name}. '
-                                'Please check if the name is correct.')
+                        raise e
                     with ux_utils.print_exception_no_traceback():
                         raise sky_exceptions.StorageBucketGetError(
                             'Failed to retreive the container client for the '

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2517,6 +2517,16 @@ class AzureBlobStore(AbstractStore):
                                     name=self.name))
                 raise
             if container_client.exists():
+                is_private = (True if
+                              container_client.get_container_properties().get(
+                                  'public_access', None) is None else False)
+                # when user attempts to use private container without
+                # access rights
+                if self.resource_group_name is None and is_private:
+                    with ux_utils.print_exception_no_traceback():
+                        raise exceptions.StorageBucketGetError(
+                            _BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
+                                name=self.name))
                 self._validate_existing_bucket()
                 return container_client.container_name, False
             # when the container name does not exist under the provided

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2508,6 +2508,8 @@ class AzureBlobStore(AbstractStore):
                     resource_group_name=self.resource_group_name)
             except azure.exceptions().ClientAuthenticationError as e:
                 if 'ERROR: AADSTS50020' in str(e):
+                    # Caught when failing to obtain container client due to
+                    # lack of permission to passed given private container.
                     if self.resource_group_name is None:
                         with ux_utils.print_exception_no_traceback():
                             raise exceptions.StorageBucketGetError(

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2562,7 +2562,6 @@ class AzureBlobStore(AbstractStore):
             raise exceptions.StorageExternalDeletionError(
                 f'Attempted to fetch a non-existent container: {self.name}')
 
-
     def mount_command(self, mount_path: str) -> str:
         """Returns the command to mount the container to the mount_path.
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4896,14 +4896,10 @@ class TestStorageWithCredentials:
                 private_bucket).path.strip('/')
         else:
             private_bucket_name = urllib.parse.urlsplit(private_bucket).netloc
-        match_str = storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
-            name=private_bucket_name)
-        if store_type == 'https':
-            # Azure blob uses a different error string since container may
-            # not exist even though the bucket name is ok.
-            match_str = 'Attempted to fetch a non-existent public container'
-        with pytest.raises(sky.exceptions.StorageBucketGetError,
-                           match=match_str):
+        with pytest.raises(
+                sky.exceptions.StorageBucketGetError,
+                match=storage_lib._BUCKET_FAIL_TO_CONNECT_MESSAGE.format(
+                    name=private_bucket_name)):
             storage_obj = storage_lib.Storage(source=private_bucket)
 
     @pytest.mark.no_fluidstack


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This updates the temporary solution implemented at #3791 

Error was incorrectly handled when the user attempted to access a private container without access. This PR fixes with correct error response.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Manually try to use private container without access as a source from `task.yaml` raises:
```
sky.exceptions.StorageBucketGetError: Failed to access existing bucket 'test'. This is likely because it is a private bucket you do not have access to.
To fix:
  1. If you are trying to create a new bucket: use a different name.
  2. If you are trying to connect to an existing bucket: make sure your cloud credentials have access to it.
```
- [x] All smoke tests:
  - [x] `pytest tests/test_smoke.py::TestStorageWithCredentials --azure`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
