### PR TITLE
[Paperspace] increase timeout

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -85,6 +85,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = {
     clouds.Lambda: 150,
     clouds.IBM: 160,
     clouds.OCI: 300,
+    clouds.Paperspace: 600,
     clouds.Kubernetes: 300,
     clouds.Vsphere: 240,
 }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Users were reporting instances being terminated before they fully booted up. From the paperspace console it looks like some of the larger instances can take up to 10 minutes. This bumps up the timeout to 10 minutes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
```
sky launch --gpus A100-80GB:1 --cloud paperspace
```
