### PR TITLE
[GCP] Cluster info respects `use_internal_ips`

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2248,9 +2248,7 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
         """
         if cluster_info is not None:
             self.cached_cluster_info = cluster_info
-            use_internal_ips = self._use_internal_ips()
-            cluster_feasible_ips = self.cached_cluster_info.get_feasible_ips(
-                use_internal_ips)
+            cluster_feasible_ips = self.cached_cluster_info.get_feasible_ips()
             cluster_internal_ips = self.cached_cluster_info.get_feasible_ips(
                 force_internal_ips=True)
         else:

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -205,7 +205,13 @@ class ClusterInfo:
 
     def get_feasible_ips(self, force_internal_ips: bool = False) -> List[str]:
         """Get external IPs if they exist, otherwise get internal ones."""
-        return self._get_ips(not self.has_external_ips() or force_internal_ips)
+        if self.provider_config is not None:
+            use_internal_ips = self.provider_config.get('use_internal_ips',
+                                                        False)
+        else:
+            use_internal_ips = False
+        return self._get_ips(use_internal_ips or not self.has_external_ips() or
+                             force_internal_ips)
 
     def get_ssh_ports(self) -> List[int]:
         """Get the SSH port of all the instances."""

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -204,7 +204,8 @@ class ClusterInfo:
         return ip_list
 
     def get_feasible_ips(self, force_internal_ips: bool = False) -> List[str]:
-        """Get external IPs if they exist, otherwise get internal ones."""
+        """Get internal IPs if provider config specifies to, external IPs if
+        they exist, otherwise get internal ones."""
         if self.provider_config is not None:
             use_internal_ips = self.provider_config.get('use_internal_ips',
                                                         False)

--- a/sky/provision/common.py
+++ b/sky/provision/common.py
@@ -204,8 +204,7 @@ class ClusterInfo:
         return ip_list
 
     def get_feasible_ips(self, force_internal_ips: bool = False) -> List[str]:
-        """Get internal IPs if provider config specifies to, external IPs if
-        they exist, otherwise get internal ones."""
+        """Get internal or external IPs depends on the settings."""
         if self.provider_config is not None:
             use_internal_ips = self.provider_config.get('use_internal_ips',
                                                         False)


### PR DESCRIPTION
Follow up to https://github.com/skypilot-org/skypilot/pull/3699, which introduced the `gcp.force_enable_external_ips` setting to the skypilot configuration. E.g.
```
gcp:
  vpc_name: default
  use_internal_ips: true
  force_enable_external_ips: true
```

With this configuration, however, skypilot will attempt to communicate with the VMs via the external ips, despite `use_internal_ips: true`, since the existence of external ips is implicitly interpreted to mean `use_internal_ips = false`; this assumption was broken in https://github.com/skypilot-org/skypilot/pull/3699.

This PR fixes by having `ClusterInfo.get_feasible_ips` check the `provider_config` for `use_internal_ips` respecting it's setting if found.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
