### PR TITLE
add how to use EFA to faq.rst

### DIFF
--- a/docs/source/reference/faq.rst
+++ b/docs/source/reference/faq.rst
@@ -235,7 +235,7 @@ How Can I Use Elastic Fiber Adapter (EFA) with a Capacity Reservation on AWS?
 
 1. Install the aws cli tool
 
-2. Download `this cloud formation input json <https://gist.github.com/jasonkrone/7e6a446b24e1bc93ed0c25869e5353ff>`__ and `this cloud formation template <https://gist.github.com/jasonkrone/7e6a446b24e1bc93ed0c25869e5353ff>`__.
+2. Download `this cloud formation input json <https://gist.github.com/jasonkrone/7e6a446b24e1bc93ed0c25869e5353ff>`__ and `this cloud formation template <https://gist.github.com/jasonkrone/fc3e5f10d549b0d91b7a0061792afb80>`__.
     - Credit to Sean Smith at AWS for creating the cloud formation template.
 
 3. Edit the coudformation input json to specify the values for VPCName, PrimarySubnetAZ, and CreateS3Endpoint


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Added instructions for how to use elastic fiber adapter (EFA) with a capacity reservation on AWS to faq.rst.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Regarding tests, I only confirmed via a local .rst render tool that the text was formatting correctly. Note: for some reason the text for items number 5 and 6 in my FAQ answer are italicized and I couldn't figure out how to fix it. 
