### PR TITLE
[TPU] Add docker support

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -451,6 +451,9 @@ class GCP(clouds.Cloud):
                     'runtime_version']
                 resources_vars['tpu_node_name'] = r.accelerator_args.get(
                     'tpu_name')
+                # TPU VMs require privileged mode for docker containers to
+                # access TPU devices.
+                resources_vars['docker_run_options'] = ['--privileged']
             else:
                 # Convert to GCP names:
                 # https://cloud.google.com/compute/docs/gpus

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -137,6 +137,7 @@ class DockerInitializer:
         self.initialized = False
         # podman is not fully tested yet.
         use_podman = docker_config.get('use_podman', False)
+        # TODO(zhwu): Only add sudo when required
         self.docker_cmd = 'podman' if use_podman else 'sudo docker'
         self.log_path = log_path
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1037,7 +1037,8 @@ class Resources:
         cloud_specific_variables = self.cloud.make_deploy_resources_variables(
             self, cluster_name, region, zones, dryrun)
         if 'docker_run_options' in cloud_specific_variables:
-            docker_run_options.extend(cloud_specific_variables['docker_run_options'])
+            docker_run_options.extend(
+                cloud_specific_variables['docker_run_options'])
         return dict(
             cloud_specific_variables,
             **{

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -835,12 +835,6 @@ class Resources:
 
         if self.extract_docker_image() is not None:
             # TODO(tian): validate the docker image exists / of reasonable size
-            if self.accelerators is not None:
-                for acc in self.accelerators.keys():
-                    if acc.lower().startswith('tpu'):
-                        with ux_utils.print_exception_no_traceback():
-                            raise ValueError(
-                                'Docker image is not supported for TPU VM.')
             if self.cloud is not None:
                 self.cloud.check_features_are_supported(
                     self, {clouds.CloudImplementationFeatures.DOCKER_IMAGE})
@@ -1042,6 +1036,8 @@ class Resources:
         # Cloud specific variables
         cloud_specific_variables = self.cloud.make_deploy_resources_variables(
             self, cluster_name, region, zones, dryrun)
+        if 'docker_run_options' in cloud_specific_variables:
+            docker_run_options.extend(cloud_specific_variables['docker_run_options'])
         return dict(
             cloud_specific_variables,
             **{


### PR DESCRIPTION
<!-- Describe the changes in this PR -->


The following dockerfile (from [vLLM](https://github.com/vllm-project/vllm/blob/main/Dockerfile.tpu)) can be used on TPU

```Dockerfile
ARG NIGHTLY_DATE="20240726"
ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"

FROM $BASE_IMAGE
WORKDIR /workspace

# Install aiohttp separately to avoid build errors.
RUN pip install aiohttp
# Install NumPy 1 instead of NumPy 2.
RUN pip install "numpy<2"
# Install the TPU and Pallas dependencies.
RUN pip install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
RUN pip install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html

# Fix FastAPI dependence
RUN pip install "starlette<0.38.0"

# Build vLLM.
COPY . /workspace/vllm
ENV VLLM_TARGET_DEVICE="tpu"
RUN cd /workspace/vllm && python setup.py develop

CMD ["/bin/bash"]

```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-tpu-docker --gpus tpu-v3-8 --image-id docker:michaelvll/tpu-test`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
