### PR TITLE
[k8s] Add debug message for timeout

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -351,7 +351,8 @@ def get_kubernetes_nodes() -> List[Any]:
     except kubernetes.max_retry_error():
         raise exceptions.ResourcesUnavailableError(
             'Timed out when trying to get node info from Kubernetes cluster. '
-            'Please check if the cluster is healthy and retry.') from None
+            'Please check if the cluster is healthy and retry. To debug, run: '
+            'kubectl get nodes') from None
     return nodes
 
 
@@ -363,7 +364,8 @@ def get_kubernetes_pods() -> List[Any]:
     except kubernetes.max_retry_error():
         raise exceptions.ResourcesUnavailableError(
             'Timed out when trying to get pod info from Kubernetes cluster. '
-            'Please check if the cluster is healthy and retry.') from None
+            'Please check if the cluster is healthy and retry. To debug, run: '
+            'kubectl get pods') from None
     return pods
 
 


### PR DESCRIPTION
Adds  a debugging hint to run `kubectl` when get_nodes or get_pods fails. This is usually caused by network issues, and running `kubectl` for debugging will assure the user the issue is related to k8s reachability, not SkyPilot. 


Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`=