### PR TITLE
[GCP DWS] Fix None issue when no provision timeout is provided

### DIFF
--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -1081,6 +1081,9 @@ class GCPManagedInstanceGroup(GCPComputeInstance):
                 run_duration=managed_instance_group_config['run_duration'])
             cls.wait_for_operation(operation, project_id, zone=zone)
 
+        provision_timeout = managed_instance_group_config.get('provision_timeout')
+        if provision_timeout is None:
+            provision_timeout = constants.DEFAULT_MANAGED_INSTANCE_GROUP_PROVISION_TIMEOUT
         # This will block the provisioning until the nodes are ready, which
         # makes the failover not effective. We rely on the request timeout set
         # by user to trigger failover.
@@ -1088,9 +1091,7 @@ class GCPManagedInstanceGroup(GCPComputeInstance):
             project_id,
             zone,
             managed_instance_group_name,
-            timeout=managed_instance_group_config.get(
-                'provision_timeout',
-                constants.DEFAULT_MANAGED_INSTANCE_GROUP_PROVISION_TIMEOUT))
+            timeout=provision_timeout)
 
         pending_running_instance_names = cls._add_labels_and_find_head(
             cluster_name, project_id, zone, labels, potential_head_instances)

--- a/sky/provision/gcp/instance_utils.py
+++ b/sky/provision/gcp/instance_utils.py
@@ -1081,9 +1081,6 @@ class GCPManagedInstanceGroup(GCPComputeInstance):
                 run_duration=managed_instance_group_config['run_duration'])
             cls.wait_for_operation(operation, project_id, zone=zone)
 
-        provision_timeout = managed_instance_group_config.get('provision_timeout')
-        if provision_timeout is None:
-            provision_timeout = constants.DEFAULT_MANAGED_INSTANCE_GROUP_PROVISION_TIMEOUT
         # This will block the provisioning until the nodes are ready, which
         # makes the failover not effective. We rely on the request timeout set
         # by user to trigger failover.
@@ -1091,7 +1088,9 @@ class GCPManagedInstanceGroup(GCPComputeInstance):
             project_id,
             zone,
             managed_instance_group_name,
-            timeout=provision_timeout)
+            timeout=managed_instance_group_config.get(
+                'provision_timeout',
+                constants.DEFAULT_MANAGED_INSTANCE_GROUP_PROVISION_TIMEOUT))
 
         pending_running_instance_names = cls._add_labels_and_find_head(
             cluster_name, project_id, zone, labels, potential_head_instances)

--- a/sky/provision/gcp/mig_utils.py
+++ b/sky/provision/gcp/mig_utils.py
@@ -207,3 +207,4 @@ def wait_for_managed_group_to_be_stable(project_id: str, zone: str,
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.decode('ascii')
         logger.info(stderr)
+        raise

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -88,7 +88,9 @@ available_node_types:
       {%- if gcp_use_managed_instance_group %}
       managed-instance-group:
         run_duration: {{ run_duration }}
+        {%- if provision_timeout is defined and provision_timeout is not none %}
         provision_timeout: {{ provision_timeout }}
+        {%- endif %}
       {%- endif %}
       {%- if specific_reservations %}
       reservationAffinity:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

It is possible that the `provision_timeout` is set to None in our cluster yaml, which will cause a wrong CLI to wait for MIG.

To reproduce:
```
experimental:
  config_overrides:
    gcp:
      managed_instance_group:
        # Setup the DWS config
        run_duration: 36000
        # Failover to other regions after 30 minutes.
        provision_timeout: 1800
resources:
  accelerators: H100:8
  cpus: 32+
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
