### PR TITLE
[AWS] Fix best disk tier on AWS to use the best IOPS

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -799,7 +799,7 @@ class AWS(clouds.Cloud):
             disk_tier: Optional[resources_utils.DiskTier]) -> Dict[str, Any]:
         tier = cls._translate_disk_tier(disk_tier)
         tier2iops = {
-            resources_utils.DiskTier.HIGH: 7000,
+            resources_utils.DiskTier.HIGH: 16000,
             resources_utils.DiskTier.MEDIUM: 3500,
             resources_utils.DiskTier.LOW: 0,  # only gp3 is required to set iops
         }


### PR DESCRIPTION
AWS supports upto 16000 IOPS and 1000MB/s throughput on [GP3](https://aws.amazon.com/ebs/general-purpose/). We should use those specs for `high` disk tier. Makes a significant difference for reading models/datasets.

[Benchmarks](https://github.com/skypilot-org/skypilot/blob/master/examples/perf/storage_rawperf.yaml):
Before, `--disk-tier best` on AWS:
```
(storage-demo, pid=29191) ##### Sequential Read Results #####
(storage-demo, pid=29191) EBS:  498.37 MB/s     7604.55 IOPS
(storage-demo, pid=29191) 
(storage-demo, pid=29191) ##### Sequential Write Results #####
(storage-demo, pid=29191) EBS:  485.97 MB/s     7415.25 IOPS
```

After, `--disk-tier best` on AWS:
```
(storage-demo, pid=30375) ##### Sequential Read Results #####
(storage-demo, pid=30375) EBS:  1395.38 MB/s    21291.75 IOPS
(storage-demo, pid=30375) 
(storage-demo, pid=30375) ##### Sequential Write Results #####
(storage-demo, pid=30375) EBS:  1215.33 MB/s    18544.43 IOPS
```