### PR TITLE
[Azure] Allow different prices in a same region

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -352,7 +352,17 @@ def get_hourly_cost_impl(
         price_str = 'Price'
         # For AWS/Azure/GCP on-demand instances, the price is the same across
         # all the zones in the same region.
-        assert region is None or len(set(df[price_str])) == 1, df
+        # We do not assert this as for Azure, it seems we can have different
+        # prices for specific instance types in the same region. This is to
+        # unblock our users from using those specific instance types:
+        #    Standard_D2as_v5, Standard_D2ads_v5
+        # TODO(Tian): investigate this.
+        if region is not None and len(set(df[price_str])) > 1:
+            logger.debug(f'Found multiple prices for instance type '
+                         f'{instance_type!r} in region {region!r}. '
+                         'This is unexpected. Please report this to the '
+                         'SkyPilot team.')
+        # assert region is None or len(set(df[price_str])) == 1, df
 
     if pd.isna(df[price_str]).all():
         with ux_utils.print_exception_no_traceback():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Mitigate the issue #3750. We should investigate the root cause of it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch --cloud azure -t Standard_D2ads_v5`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
