### PR TITLE
[Catalog] Fix Azure catalog duplications

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_azure.py
@@ -140,8 +140,12 @@ def get_pricing_df(region: Optional[str] = None) -> 'pd.DataFrame':
     print(f'Done fetching pricing {region}')
     df = pd.DataFrame(all_items)
     assert 'productName' in df.columns, (region, df.columns)
-    return df[(~df['productName'].str.contains(' Windows')) &
-              (df['unitPrice'] > 0)]
+    # Filter out the cloud services and windows products.
+    # Some H100 series use ' Win' instead of ' Windows', e.g.
+    # Virtual Machines NCCadsv5 Srs Win
+    return df[
+        (~df['productName'].str.contains(' Win| Cloud Services| CloudServices'))
+        & (df['unitPrice'] > 0)]
 
 
 def get_sku_df(region_set: Set[str]) -> 'pd.DataFrame':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #3750.

In Azure SKU, there is a cloud service series that we should filter out.

Reference: https://learn.microsoft.com/en-us/azure/cloud-services/cloud-services-choose-me

Also, for some H100 series, the windows product description is `Win` instead of `Windows`. This PR also fixes that.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] Following scripts, which checks if there are any duplicate rows, return `[]`
```python
import pandas as pd
import os
file_path = os.path.expanduser('~/.sky/catalogs/v5/azure/vms.csv')
df = pd.read_csv(file_path)
grouped = df.groupby(['InstanceType', 'Region']).size().reset_index(name='count')
filtered_instances = grouped[grouped['count'] >= 2]
instance_types = filtered_instances['InstanceType'].unique()
print(instance_types)
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
