### PR TITLE
[AWS] Support capacity reservation with `open` matching metrics

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -193,6 +193,21 @@ Available fields and semantics:
     # Default: false.
     disk_encrypted: false
 
+    # Reserved capacity (optional).
+    #
+    # Whether to prioritize capacity reservations (considered as 0 cost) in the
+    # optimizer.
+    #
+    # If you have capacity reservations in your AWS project:
+    # Setting this to true guarantees the optimizer will pick any matching
+    # reservation within all regions and AWS will auto consume your reservations
+    # with instance match criteria to "open", and setting to false means
+    # optimizer uses regular, non-zero pricing in optimization (if by chance any
+    # matching reservation exists, AWS does NOT consume the reservation).
+    #
+    # Default: false.
+    prioritize_reservations: false
+
     # Identity to use for AWS instances (optional).
     #
     # LOCAL_CREDENTIALS: The user's local credential files will be uploaded to
@@ -307,8 +322,8 @@ Available fields and semantics:
     # Setting this to true guarantees the optimizer will pick any matching
     # reservation and GCP will auto consume your reservation, and setting to
     # false means optimizer uses regular, non-zero pricing in optimization (if
-    # by chance any matching reservation is selected, GCP still auto consumes
-    # the reservation).
+    # by chance any matching reservation exists, GCP still auto consumes the
+    # reservation).
     #
     # If you have "specifically targeted" reservations (set by the
     # `specific_reservations` field below): This field will automatically be set

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import time
 import typing
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from sky import clouds
 from sky import exceptions
@@ -17,6 +17,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import aws
 from sky.clouds import service_catalog
+from sky.clouds.utils import aws_utils
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import resources_utils
@@ -174,6 +175,10 @@ class AWS(clouds.Cloud):
         return regions
 
     @classmethod
+    def optimize_by_zone(cls) -> bool:
+        return aws_utils.use_reservations()
+
+    @classmethod
     def zones_provision_loop(
         cls,
         *,
@@ -197,11 +202,13 @@ class AWS(clouds.Cloud):
                                             zone=None)
         for r in regions:
             assert r.zones is not None, r
-            if num_nodes > 1:
+            if num_nodes > 1 or aws_utils.use_reservations():
                 # When num_nodes > 1, we shouldn't pass a list of zones to the
                 # AWS NodeProvider to try, because it may then place the nodes of
                 # the same cluster in different zones. This is an artifact of the
                 # current AWS NodeProvider implementation.
+                # Also, when using reservations, they are zone-specific, so we
+                # should return one zone at a time.
                 for z in r.zones:
                     yield [z]
             else:
@@ -855,6 +862,37 @@ class AWS(clouds.Cloud):
 
         # Quota found to be greater than zero, try provisioning
         return True
+
+    def get_reservations_available_resources(
+        self,
+        instance_type: str,
+        region: str,
+        zone: Optional[str],
+        specific_reservations: Set[str],
+    ) -> Dict[str, int]:
+        if zone is None:
+            # For backward compatibility, the cluster in INIT state launched
+            # before #2352 may not have zone information. In this case, we
+            # return 0 for all reservations.
+            return {reservation: 0 for reservation in specific_reservations}
+        reservations = aws_utils.list_reservations_for_instance_type(
+            instance_type, region)
+
+        filtered_reservations = []
+        for r in reservations:
+            if zone != r.zone:
+                continue
+            if r.targeted:
+                if r.name in specific_reservations:
+                    filtered_reservations.append(r)
+            else:
+                filtered_reservations.append(r)
+        reservation_available_resources = {
+            r.name: r.available_resources for r in filtered_reservations
+        }
+        logger.debug('Get AWS reservations available resources:'
+                     f'{reservation_available_resources}')
+        return reservation_available_resources
 
     @classmethod
     def query_status(cls, name: str, tag_filters: Dict[str, str],

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -178,6 +178,11 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
+    def optimize_by_zone(cls) -> bool:
+        """Returns whether the optimizer by zone."""
+        return False
+
+    @classmethod
     def zones_provision_loop(
         cls,
         *,

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -261,6 +261,10 @@ class GCP(clouds.Cloud):
         return regions
 
     @classmethod
+    def optimize_by_zone(cls) -> bool:
+        return True
+
+    @classmethod
     def zones_provision_loop(
         cls,
         *,

--- a/sky/clouds/utils/aws_utils.py
+++ b/sky/clouds/utils/aws_utils.py
@@ -1,0 +1,57 @@
+"""Utilities for AWS."""
+import dataclasses
+import time
+from typing import List
+
+import cachetools
+
+from sky import skypilot_config
+from sky.adaptors import aws
+
+
+@dataclasses.dataclass
+class AWSReservation:
+    name: str
+    instance_type: str
+    zone: str
+    available_resources: int
+    # Whether the reservation is targeted, i.e. can only be consumed when
+    # the reservation name is specified.
+    targeted: bool
+
+
+def use_reservations() -> bool:
+    prioritize_reservations = skypilot_config.get_nested(
+        ('aws', 'prioritize_reservations'), False)
+    return prioritize_reservations
+
+
+@cachetools.cached(cache=cachetools.TTLCache(maxsize=10,
+                                             ttl=300,
+                                             timer=time.time))
+def list_reservations_for_instance_type(
+    instance_type: str,
+    region: str,
+) -> List[AWSReservation]:
+    if not use_reservations():
+        return []
+    ec2 = aws.client('ec2', region_name=region)
+    # TODO(zhwu): We need to test the tenancy to make sure the current active
+    # user can consume the reservations.
+    response = ec2.describe_capacity_reservations(Filters=[{
+        'Name': 'instance-type',
+        'Values': [instance_type]
+    }, {
+        'Name': 'state',
+        'Values': ['active']
+    }])
+    reservations = response['CapacityReservations']
+    return [
+        AWSReservation(
+            name=r['CapacityReservationId'],
+            instance_type=r['InstanceType'],
+            zone=r['AvailabilityZone'],
+            available_resources=r['AvailableInstanceCount'],
+            targeted=r['InstanceMatchCriteria'] == 'targeted',
+        ) for r in reservations
+    ]

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -19,6 +19,8 @@ from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
 from sky.utils import env_options
 from sky.utils import log_utils
+from sky.utils import rich_utils
+from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
@@ -252,6 +254,26 @@ class Optimizer:
         # node -> cloud -> list of resources that satisfy user's requirements.
         node_to_candidate_map: _TaskToPerCloudCandidates = {}
 
+        def get_available_reservations(
+            launchable_resources: Dict[resources_lib.Resources,
+                                       List[resources_lib.Resources]]
+        ) -> Dict[resources_lib.Resources, int]:
+            num_available_reserved_nodes_per_resource = {}
+
+            def get_reservations_available_resources(
+                    resources: resources_lib.Resources):
+                num_available_reserved_nodes_per_resource[resources] = sum(
+                    resources.get_reservations_available_resources().values())
+
+            launchable_resources_list: List[resources_lib.Resources] = sum(
+                launchable_resources.values(), [])
+            with rich_utils.safe_status(
+                    '[cyan]Checking reserved resources...[/]'):
+                subprocess_utils.run_in_parallel(
+                    get_reservations_available_resources,
+                    launchable_resources_list)
+            return num_available_reserved_nodes_per_resource
+
         # Compute the estimated cost/time for each node.
         for node_i, node in enumerate(topo_order):
             if node_i == 0:
@@ -279,7 +301,11 @@ class Optimizer:
                     list(node.resources)[0]: list(node.resources)
                 }
 
+            # Fetch reservations in advance and in parallel to speed up the
+            # reservation info fetching.
             num_resources = len(list(node.resources))
+            num_available_reserved_nodes_per_resource = (
+                get_available_reservations(launchable_resources))
 
             for orig_resources, launchable_list in launchable_resources.items():
                 if num_resources == 1 and node.time_estimator_func is None:
@@ -302,15 +328,16 @@ class Optimizer:
                     else:
                         estimated_runtime = node.estimate_runtime(
                             orig_resources)
+
                 for resources in launchable_list:
                     if do_print:
                         logger.debug(f'resources: {resources}')
 
                     if minimize_cost:
                         cost_per_node = resources.get_cost(estimated_runtime)
-                        num_available_reserved_nodes = sum(
-                            resources.get_reservations_available_resources(
-                            ).values())
+                        num_available_reserved_nodes = (
+                            num_available_reserved_nodes_per_resource[resources]
+                        )
 
                         # We consider the cost of the unused reservation
                         # resources to be 0 since we are already paying for
@@ -1116,7 +1143,7 @@ def _make_launchables_for_valid_region_zones(
     regions = launchable_resources.get_valid_regions_for_launchable()
     for region in regions:
         if (launchable_resources.use_spot and region.zones is not None or
-                isinstance(launchable_resources.cloud, clouds.GCP)):
+                launchable_resources.cloud.optimize_by_zone()):
             # Spot instances.
             # Do not batch the per-zone requests.
             for zone in region.zones:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -706,6 +706,9 @@ def get_config_schema():
             'required': [],
             'additionalProperties': False,
             'properties': {
+                'prioritize_reservations': {
+                    'type': 'boolean',
+                },
                 'disk_encrypted': {
                     'type': 'boolean',
                 },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is the first step for #3039, where we support prioritizing the zone that has a reservation with matching criteria "open".

To check how it works:
1. create a capacity reservation in `us-west-2a` for `t3.large`
2. `sky launch -t t3.large`, will now go to `us-west-2a` first with the price == 0, if a user specifies the following in the `~/.sky/config.yaml`
```yaml
aws:
  prioritize_reservations: true
```

In the following PR, we will do:
1. Support `specific_reservations` to allow users to specify `target` reservations
4. Support capacity block

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c t3.large` with the configs and reservation above: skypilot automatically select the zone with the reservation and create an instance
  - [x] `sky launch -c t3.large` with the capacity reservation occupied above: skypilot will go to `us-east-1` instead for the resource as no available resources in capacity reservation.
  - [x] `sky down -a`, `sky launch -c t3.large --num-nodes 4`: a multi-node cluster with part of the cluster on reservation, others on normal on-demand (it takes a minutes until the reservation actually frees up)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
