### PR TITLE
Allow smarter device manager to schedule on all nodes

### DIFF
--- a/sky/provision/kubernetes/manifests/smarter-device-manager-daemonset.yaml
+++ b/sky/provision/kubernetes/manifests/smarter-device-manager-daemonset.yaml
@@ -26,6 +26,9 @@ spec:
       hostname: smarter-device-management
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
       containers:
       - name: smarter-device-manager
         image: us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/smarter-device-manager:v1.1.2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently smarter-device-manager isn't running on spot or queued-provisioning nodes that have tolerations applied to them, which makes it impossible to schedule pods with file_mounts enabled. This tells it to run on all nodes, regardless of taints.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
