### PR TITLE
[k8s] Fix generate_kubeconfig.sh when ingress is not used

### DIFF
--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -169,6 +169,9 @@ roleRef:
   kind: Role
   name: skypilot-system-service-account-role
   apiGroup: rbac.authorization.k8s.io
+EOF
+# Apply optional ingress-related roles, but don't make the script fail if it fails
+kubectl apply -f - <<EOF || true
 ---
 # Optional: Role for accessing ingress resources
 apiVersion: rbac.authorization.k8s.io/v1

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -171,8 +171,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 EOF
 # Apply optional ingress-related roles, but don't make the script fail if it fails
-kubectl apply -f - <<EOF || true
----
+kubectl apply -f - <<EOF || echo "Failed to apply optional ingress-related roles. Nginx ingress is likely not installed. This is not critical and the script will continue."
 # Optional: Role for accessing ingress resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
generate_kubeconfig.sh would fail when a cluster doesn't have ingress:
```
Error from server (NotFound): error when creating "STDIN": namespaces "ingress-nginx" not found
Error from server (NotFound): error when creating "STDIN": namespaces "ingress-nginx" not found
```
This PR makes it optional, and any errors due to ingress not being present are ignored.