### PR TITLE
[Core] Enable use docker image w/ non-default entrypoint as runtime env

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -161,6 +161,12 @@ Any GPUs assigned to the task will be automatically mapped to your Docker contai
 
     2. The container image must grant sudo permissions without requiring password authentication for the user. Having a root user is also acceptable.
 
+.. note::
+
+  When used as a runtime environment, the container's entrypoint will be
+  override by :code:`/bin/bash`. If you need to run a specific command, you can
+  do so in the :code:`setup` and :code:`run` sections of the task YAML file.
+
 Private Registries
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -163,9 +163,12 @@ Any GPUs assigned to the task will be automatically mapped to your Docker contai
 
 .. note::
 
-  When used as a runtime environment, the container's entrypoint will be
-  override by :code:`/bin/bash`. If you need to run a specific command, you can
-  do so in the :code:`setup` and :code:`run` sections of the task YAML file.
+  Using a container with a customized entrypoint as a runtime environment is
+  supported, with the container's entrypoint being overridden by :code:`/bin/bash`.
+  Specific commands can be executed in the :code:`setup` and :code:`run` sections
+  of the task YAML file. However, this approach is not compatible with RunPod due
+  to limitations in the RunPod API, so ensure that you choose a container with a
+  default entrypoint (i.e. :code:`/bin/bash`).
 
 Private Registries
 ^^^^^^^^^^^^^^^^^^

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -110,8 +110,8 @@ def docker_start_cmds(
         '--cap-add=SYS_ADMIN',
         '--device=/dev/fuse',
         '--security-opt=apparmor:unconfined',
+        '--entrypoint=/bin/bash',
         image,
-        'bash',
     ]
     return ' '.join(docker_run)
 

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -77,11 +77,7 @@ def list_instances() -> Dict[str, Dict[str, Any]]:
         info['name'] = instance['name']
         info['port2endpoint'] = {}
 
-        # Sometimes when the cluster is in the process of being created,
-        # the `port` field in the runtime is None and we need to check for it.
-        if (instance['desiredStatus'] == 'RUNNING' and
-                instance.get('runtime') and
-                instance.get('runtime').get('ports')):
+        if instance['desiredStatus'] == 'RUNNING' and instance.get('runtime'):
             for port in instance['runtime']['ports']:
                 if port['isIpPublic']:
                     if port['privatePort'] == 22:
@@ -142,7 +138,6 @@ def launch(name: str, instance_type: str, region: str, disk_size: int,
     if ports is not None:
         custom_ports_str = ''.join([f'{p}/tcp,' for p in ports])
 
-
     new_instance = runpod.runpod.create_pod(
         name=name,
         image_name=image_name,
@@ -159,7 +154,7 @@ def launch(name: str, instance_type: str, region: str, disk_size: int,
                f'{constants.SKY_REMOTE_RAY_PORT}/http'),
         support_public_ip=True,
         docker_args=
-        f'-c \'echo {encoded} | base64 --decode > init.sh; bash init.sh\'')
+        f'bash -c \'echo {encoded} | base64 --decode > init.sh; bash init.sh\'')
 
     return new_instance['id']
 

--- a/sky/skylet/providers/command_runner.py
+++ b/sky/skylet/providers/command_runner.py
@@ -65,8 +65,8 @@ def docker_start_cmds(
         '--cap-add=SYS_ADMIN',
         '--device=/dev/fuse',
         '--security-opt=apparmor:unconfined',
+        '--entrypoint=/bin/bash',
         image,
-        'bash',
     ]
     return ' '.join(docker_run)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, if the docker image had an entry point that was not default (`/bin/bash`), it would fail when running as runtime env on real clouds (in k8s it works since we have special handling for this), e.g. the vllm official docker uses `python3 -m vllm.entrypoints.openai.api_server` as entry point, as ref here: https://github.com/vllm-project/vllm/blob/9db93de20ca282feb4dfaabbc56032c9312bde7b/Dockerfile#L222

This PR fixed it by overriding the entry point to `/bin/bash`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] The following YAML successfully launch a vllm endpoint
```python
resources:
  cloud: aws
  image_id: docker:vllm/vllm-openai:latest
  accelerators: T4
run: |
  conda deactivate
  python3 -c "import huggingface_hub; huggingface_hub.login('$HF_TOKEN')"
  python3 -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-2-7b-chat-hf --tokenizer hf-internal-testing/llama-tokenizer --max-model-len 64
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests:
     - [x] `pytest tests/test_smoke.py::test_docker_storage_mounts`
     - [x] `pytest tests/test_smoke.py::test_job_queue_with_docker`
     - [x] `pytest tests/test_smoke.py::test_docker_preinstalled_package` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
