### PR TITLE
[Core][RunPod] Fix list instances in RunPod Provisioner

### DIFF
--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -80,7 +80,8 @@ def list_instances() -> Dict[str, Dict[str, Any]]:
         # Sometimes when the cluster is in the process of being created,
         # the `port` field in the runtime is None and we need to check for it.
         if (instance['desiredStatus'] == 'RUNNING' and
-                instance.get('runtime', {}).get('ports')):
+                instance.get('runtime') and
+                instance.get('runtime').get('ports')):
             for port in instance['runtime']['ports']:
                 if port['isIpPublic']:
                     if port['privatePort'] == 22:

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -80,8 +80,7 @@ def list_instances() -> Dict[str, Dict[str, Any]]:
         # Sometimes when the cluster is in the process of being created,
         # the `port` field in the runtime is None and we need to check for it.
         if (instance['desiredStatus'] == 'RUNNING' and
-                instance.get('runtime') and
-                instance.get('runtime').get('ports')):
+                instance.get('runtime', {}).get('ports')):
             for port in instance['runtime']['ports']:
                 if port['isIpPublic']:
                     if port['privatePort'] == 22:

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -77,7 +77,11 @@ def list_instances() -> Dict[str, Dict[str, Any]]:
         info['name'] = instance['name']
         info['port2endpoint'] = {}
 
-        if instance['desiredStatus'] == 'RUNNING' and instance.get('runtime'):
+        # Sometimes when the cluster is in the process of being created,
+        # the `port` field in the runtime is None and we need to check for it.
+        if (instance['desiredStatus'] == 'RUNNING' and
+                instance.get('runtime') and
+                instance.get('runtime').get('ports')):
             for port in instance['runtime']['ports']:
                 if port['isIpPublic']:
                     if port['privatePort'] == 22:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Sometimes when the RunPod cluster is in the process of being created, the `port` field in the runtime is None and that causes some problems (see logs below). This PR fixes the issue.

```bash
Traceback (most recent call last):
  File “/home/memory/install/miniconda3/envs/sky/bin/sky”, line 8, in <module>
    sys.exit(cli())
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/site-packages/click/core.py”, line 1157, in __call__
    return self.main(*args, **kwargs)
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/site-packages/click/core.py”, line 1078, in main
    rv = self.invoke(ctx)
  File “/home/memory/skypilot/sky/utils/common_utils.py”, line 367, in _record
    return f(*args, **kwargs)
  File “/home/memory/skypilot/sky/cli.py”, line 806, in invoke
    return super().invoke(ctx)
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/site-packages/click/core.py”, line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/site-packages/click/core.py”, line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/site-packages/click/core.py”, line 783, in invoke
    return __callback(*args, **kwargs)
  File “/home/memory/skypilot/sky/utils/common_utils.py”, line 388, in _record
    return f(*args, **kwargs)
  File “/home/memory/skypilot/sky/cli.py”, line 2563, in down
    _down_or_stop_clusters(clusters,
  File “/home/memory/skypilot/sky/cli.py”, line 2881, in _down_or_stop_clusters
    subprocess_utils.run_in_parallel(_down_or_stop, clusters)
  File “/home/memory/skypilot/sky/utils/subprocess_utils.py”, line 65, in run_in_parallel
    return list(p.imap(func, args))
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/multiprocessing/pool.py”, line 870, in next
    raise value
  File “/home/memory/install/miniconda3/envs/sky/lib/python3.9/multiprocessing/pool.py”, line 125, in worker
    result = (True, func(*args, **kwds))
  File “/home/memory/skypilot/sky/cli.py”, line 2853, in _down_or_stop
    core.down(name, purge=purge)
  File “/home/memory/skypilot/sky/utils/common_utils.py”, line 388, in _record
    return f(*args, **kwargs)
  File “/home/memory/skypilot/sky/core.py”, line 404, in down
    backend.teardown(handle, terminate=True, purge=purge)
  File “/home/memory/skypilot/sky/utils/common_utils.py”, line 388, in _record
    return f(*args, **kwargs)
  File “/home/memory/skypilot/sky/utils/common_utils.py”, line 367, in _record
    return f(*args, **kwargs)
  File “/home/memory/skypilot/sky/backends/backend.py”, line 116, in teardown
    self._teardown(handle, terminate, purge)
  File “/home/memory/skypilot/sky/backends/cloud_vm_ray_backend.py”, line 3480, in _teardown
    self.teardown_no_lock(
  File “/home/memory/skypilot/sky/backends/cloud_vm_ray_backend.py”, line 3809, in teardown_no_lock
    provisioner.teardown_cluster(repr(cloud),
  File “/home/memory/skypilot/sky/provision/provisioner.py”, line 228, in teardown_cluster
    provision.terminate_instances(cloud_name, cluster_name.name_on_cloud,
  File “/home/memory/skypilot/sky/provision/__init__.py”, line 47, in _wrapper
    return impl(*args, **kwargs)
  File “/home/memory/skypilot/sky/provision/runpod/instance.py”, line 143, in terminate_instances
    instances = _filter_instances(cluster_name_on_cloud, None)
  File “/home/memory/skypilot/sky/provision/runpod/instance.py”, line 22, in _filter_instances
    instances = utils.list_instances()
  File “/home/memory/skypilot/sky/provision/runpod/utils.py”, line 83, in list_instances
    for port in instance[‘runtime’][‘ports’]:
TypeError: ‘NoneType’ object is not iterable
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
