### PR TITLE
[AWS] Fix catalog folder not exists issue

### DIFF
--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -58,7 +58,9 @@ class InstanceTypeInfo(NamedTuple):
 
 
 def get_catalog_path(filename: str) -> str:
-    return os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, filename)
+    catalog_path = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR, filename)
+    os.makedirs(os.path.dirname(catalog_path), exist_ok=True)
+    return catalog_path
 
 
 def is_catalog_modified(filename: str) -> bool:
@@ -225,7 +227,7 @@ def read_catalog(filename: str,
                         with open(meta_path + '.md5', 'w',
                                   encoding='utf-8') as f:
                             f.write(hashlib.md5(r.text.encode()).hexdigest())
-                logger.info(f'Updated {cloud} catalog.')
+                logger.debug(f'Updated {cloud} catalog {filename}.')
 
     return LazyDataFrame(catalog_path, update_func=_update_catalog)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To reproduce,
```
rm -r ~/.sky/catalogs/v5/aws
sky launch -c test-aws --cloud aws
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
