### PR TITLE
Remove A10 warning when re-launching on existing cluster

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1933,7 +1933,7 @@ class RetryingVmProvisioner(object):
         while True:
             if (isinstance(to_provision.cloud, clouds.Azure) and
                     to_provision.accelerators is not None and
-                    'A10' in to_provision.accelerators):
+                    'A10' in to_provision.accelerators and prev_handle is None):
                 logger.warning(f'{style.BRIGHT}{fore.YELLOW}Trying to launch '
                                'an A10 cluster on Azure. This may take ~20 '
                                'minutes due to driver installation.'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We have a message on A10 driver installation takes a lot of time and it keeps appearing every time launching on the cluster, even if it is launching on an existing cluster and the driver installation won't actually be executed. This PR fixes that.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
