### PR TITLE
[k8s] Suppress insecure request warnings

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -18,7 +18,6 @@ kubernetes = common.LazyImport('kubernetes',
 urllib3 = common.LazyImport('urllib3',
                             import_error_message=_IMPORT_ERROR_MESSAGE)
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 _configured = False
 _core_api = None
@@ -72,6 +71,7 @@ def _load_config():
     global _configured
     if _configured:
         return
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     try:
         # Load in-cluster config if running in a pod
         # Kubernetes set environment variables for service discovery do not

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -18,6 +18,8 @@ kubernetes = common.LazyImport('kubernetes',
 urllib3 = common.LazyImport('urllib3',
                             import_error_message=_IMPORT_ERROR_MESSAGE)
 
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 _configured = False
 _core_api = None
 _auth_api = None

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -18,7 +18,6 @@ kubernetes = common.LazyImport('kubernetes',
 urllib3 = common.LazyImport('urllib3',
                             import_error_message=_IMPORT_ERROR_MESSAGE)
 
-
 _configured = False
 _core_api = None
 _auth_api = None


### PR DESCRIPTION
If user uses disables tls for k8s with `insecure-skip-tls-verify` in their kubeconfig, urllib3 prints warnings for each connection:
```
/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/urllib3/connectionpool.py:1103: InsecureRequestWarning: Unverified HTTPS request is being made to host '150.136.46.159'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
```

This PR disables warnings with the [method recommended](https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings) by urllib3.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual tests to verify warnings are no longer printed.