### PR TITLE
[Lambda] Update multi-node timeout for lambda

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -82,7 +82,7 @@ _NODES_LAUNCHING_PROGRESS_TIMEOUT = {
     clouds.AWS: 90,
     clouds.Azure: 90,
     clouds.GCP: 240,
-    clouds.Lambda: 150,
+    clouds.Lambda: 300,
     clouds.IBM: 160,
     clouds.OCI: 300,
     clouds.Paperspace: 600,


### PR DESCRIPTION
Closes #3881. Our provisioner takes > 200s to provision multinode, which was causing this failure.
