### PR TITLE
[k8s][GKE] distinguish between h100 and h100-mega on gke

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -111,7 +111,8 @@ def get_gke_accelerator_name(accelerator: str) -> str:
         # H100 is named as H100-80GB in GKE.
         accelerator = 'H100-80GB'
     if accelerator in ('A100-80GB', 'L4', 'H100-80GB', 'H100-MEGA-80GB'):
-        # A100-80GB, L4, H100-80GB and H100-MEGA-80GB have a different name pattern.
+        # A100-80GB, L4, H100-80GB and H100-MEGA-80GB
+        # have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
         return 'nvidia-tesla-{}'.format(accelerator.lower())

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -110,7 +110,7 @@ def get_gke_accelerator_name(accelerator: str) -> str:
     if accelerator == 'H100':
         # H100 is named as H100-80GB in GKE.
         accelerator = 'H100-80GB'
-    if accelerator in ('A100-80GB', 'L4', 'H100-80GB'):
+    if accelerator in ('A100-80GB', 'L4', 'H100-80GB', 'H100-MEGA-80GB'):
         # A100-80GB, L4 and H100-80GB have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
@@ -194,13 +194,10 @@ class GKELabelFormatter(GPULabelFormatter):
             return value.replace('nvidia-tesla-', '').upper()
         elif value.startswith('nvidia-'):
             acc = value.replace('nvidia-', '').upper()
-            if acc in ['H100-80GB', 'H100-MEGA-80GB']:
-                # H100 is named H100-80GB or H100-MEGA-80GB in GKE,
-                # where the latter has improved bandwidth.
-                # See a3-mega instances on GCP.
-                # TODO: we do not distinguish the two GPUs for simplicity,
-                # but we can evaluate whether we should distinguish
-                # them based on users' requests.
+            if acc == 'H100-80GB':
+                # H100 can be either H100-80GB or H100-MEGA-80GB in GKE
+                # we map H100 ---> H100-80GB and keep H100-MEGA-80GB
+                # to distinguish between a3-high and a3-mega instances
                 return 'H100'
             return acc
         else:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -111,7 +111,7 @@ def get_gke_accelerator_name(accelerator: str) -> str:
         # H100 is named as H100-80GB in GKE.
         accelerator = 'H100-80GB'
     if accelerator in ('A100-80GB', 'L4', 'H100-80GB', 'H100-MEGA-80GB'):
-        # A100-80GB, L4 and H100-80GB have a different name pattern.
+        # A100-80GB, L4, H100-80GB and H100-MEGA-80GB have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
     else:
         return 'nvidia-tesla-{}'.format(accelerator.lower())


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This distinguishes between `H100` and `H100-MEGA-80GB` on GKE. Closes #3890 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

List gpus `H100` and `H100-MEGA-80GB` with `sky show-gpus --cloud kubernetes`
schedule a skypilot cluster on `H100` and `H100-MEGA-80GB` with `sky launch --cloud kubernetes --gpus {H100,H100-MEGA-80GB}`
Test output [here](https://gist.github.com/asaiacai/be2a95c31c4057fc10b5c47dc8866e57)
