### PR TITLE
[Core] Inform user if bash too old for shell completion

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -371,7 +371,6 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
                f'([[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd}) || '
                f'(echo "Bash must be version 4 or above." && exit 1))')
 
-               
         reload_cmd = _RELOAD_BASH_CMD
 
     elif value == 'fish':

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -368,7 +368,10 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
                 echo "{bashrc_diff}" >> ~/.bashrc'
 
         cmd = (f'(grep -q "SkyPilot" ~/.bashrc) || '
-               f'[[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd})')
+               f'([[ ${{BASH_VERSINFO[0]}} -ge 4 ]] && ({install_cmd}) || '
+               f'(echo "Bash must be version 4 or above." && exit 1))')
+
+               
         reload_cmd = _RELOAD_BASH_CMD
 
     elif value == 'fish':


### PR DESCRIPTION
As discussed in #3885.

I extend the bash command that installs the shell completion to explain to the user that their bash is too old, if the version check added in #2433 fails.


Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] ~Any manual or new tests for this PR (please specify below)~ not needed
- [ ] ~All smoke tests: `pytest tests/test_smoke.py`~ none relevant
- [ ] ~Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name`~ none relevant
- [ ] ~Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`~ not relevant
