### PR TITLE
[Core] Install completion using whichever bash in PATH

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -390,7 +390,7 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         ctx.exit()
 
     try:
-        subprocess.run(cmd, shell=True, check=True, executable='/bin/bash')
+        subprocess.run(cmd, shell=True, check=True, executable=shutil.which('bash'))
         click.secho(f'Shell completion installed for {value}', fg='green')
         click.echo(
             'Completion will take effect once you restart the terminal: ' +

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -391,7 +391,10 @@ def _install_shell_completion(ctx: click.Context, param: click.Parameter,
         ctx.exit()
 
     try:
-        subprocess.run(cmd, shell=True, check=True, executable=shutil.which('bash'))
+        subprocess.run(cmd,
+                       shell=True,
+                       check=True,
+                       executable=shutil.which('bash'))
         click.secho(f'Shell completion installed for {value}', fg='green')
         click.echo(
             'Completion will take effect once you restart the terminal: ' +

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -28,8 +28,8 @@ import datetime
 import functools
 import multiprocessing
 import os
-import shutil
 import shlex
+import shutil
 import signal
 import subprocess
 import sys

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -28,6 +28,7 @@ import datetime
 import functools
 import multiprocessing
 import os
+import shutil
 import shlex
 import signal
 import subprocess


### PR DESCRIPTION
With this pull request, `sky --install-shell-completion` searches the PATH for `bash` and rruns that version when it comes to installing shell completion, rather than systematically using `/bin/bash`.

Indeed we cannot assume that `/bin/bash` is the active bash. For example the system bash on macOS in `/bin/bash` is quite old (v3), so some users install bash v5 with homebrew, which installs in `/opt`, leaving `/bin` untouched.`

This matters because bash completion for skypilot requires bash >= v4.

Fixes https://github.com/skypilot-org/skypilot/issues/3885

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] ~Any manual or new tests for this PR (please specify below)~ not relevant
- [ ] ~All smoke tests: `pytest tests/test_smoke.py`~ not relevant
- [ ] ~Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name`~ not relevant
- [ ] ~Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`~ not relevant
