### PR TITLE
[Test] Resolve version compatibility issues in `tests/test_smoke.py`

### DIFF
--- a/examples/resnet_distributed_torch.yaml
+++ b/examples/resnet_distributed_torch.yaml
@@ -11,7 +11,7 @@ setup: |
     git clone https://github.com/michaelzhiluo/pytorch-distributed-resnet
     cd pytorch-distributed-resnet
     # SkyPilot's default image on AWS/GCP has CUDA 11.6 (Azure 11.5).
-    pip3 install -r requirements.txt torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
+    pip3 install -r requirements.txt numpy==1.26.4 torch==1.12.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
     mkdir -p data  && mkdir -p saved_models && cd data && \
     wget -c --quiet https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
     tar -xvzf cifar-10-python.tar.gz

--- a/examples/tpu/tpuvm_mnist.yaml
+++ b/examples/tpu/tpuvm_mnist.yaml
@@ -14,10 +14,11 @@ setup: |
     conda create -n flax python=3.10 -y
     conda activate flax
     # Make sure to install TPU related packages in a conda env to avoid package conflicts.
-    pip install "jax[tpu]==0.4.26" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
-    pip install clu
+    pip install \
+      -f https://storage.googleapis.com/jax-releases/libtpu_releases.html "jax[tpu]==0.4.25" \
+      clu \
+      tensorflow tensorflow-datasets
     pip install -e flax
-    pip install tensorflow tensorflow-datasets
   fi
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The test scripts has not been updated for long and there are some version compatibility issues. When running `tests/test_smoke.py::test_tpu_vm`, I encountered
```
Traceback (most recent call last):
  File "/home/gcpuser/sky_workdir/flax/examples/mnist/main.py", line 29, in <module>
    import train
  File "/home/gcpuser/sky_workdir/flax/examples/mnist/train.py", line 25, in <module>
    from flax import linen as nn
  File "/home/gcpuser/sky_workdir/flax/flax/__init__.py", line 24, in <module>
    from flax import core
  File "/home/gcpuser/sky_workdir/flax/flax/core/__init__.py", line 24, in <module>
    from .lift import (
  File "/home/gcpuser/sky_workdir/flax/flax/core/lift.py", line 44, in <module>
    from . import axes_scan, meta
  File "/home/gcpuser/sky_workdir/flax/flax/core/meta.py", line 31, in <module>
    from jax.experimental import maps
ImportError: cannot import name 'maps' from 'jax.experimental' (/home/gcpuser/miniconda3/envs/flax/lib/python3.10/site-packages/jax/experimental/__init__.py)
```
which is because `jax.experimental.maps` is deprecated in jax 0.4.26. And when running `tests/test_smoke.py::test_cancel_pytorch`, there are also similar bugs because of newer numpy version. This PR fixes those two issues by specifying the correct version in test configuration.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `tests/test_smoke.py::test_tpu_vm`,  `tests/test_smoke.py::test_cancel_pytorch`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
