### PR TITLE
[k8s] Use default runtime on k3s for CPU tasks

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -530,7 +530,9 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                        'override runtimeClassName in ~/.sky/config.yaml. '
                        'For more details, refer to https://skypilot.readthedocs.io/en/latest/reference/config.html')  # pylint: disable=line-too-long
 
-    if nvidia_runtime_exists:
+    needs_gpus = (pod_spec['spec']['containers'][0].get('resources', {}).
+                  get('limits', {}).get('nvidia.com/gpu', 0) > 0)
+    if nvidia_runtime_exists and needs_gpus:
         pod_spec['spec']['runtimeClassName'] = 'nvidia'
 
     created_pods = {}

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -530,8 +530,8 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                        'override runtimeClassName in ~/.sky/config.yaml. '
                        'For more details, refer to https://skypilot.readthedocs.io/en/latest/reference/config.html')  # pylint: disable=line-too-long
 
-    needs_gpus = (pod_spec['spec']['containers'][0].get('resources', {}).
-                  get('limits', {}).get('nvidia.com/gpu', 0) > 0)
+    needs_gpus = (pod_spec['spec']['containers'][0].get('resources', {}).get(
+        'limits', {}).get('nvidia.com/gpu', 0) > 0)
     if nvidia_runtime_exists and needs_gpus:
         pod_spec['spec']['runtimeClassName'] = 'nvidia'
 


### PR DESCRIPTION
Launching a CPU cluster on k3s cluster with the Nvidia GPU runtime class installed but no Nvidia GPU operator would stay stuck on launching with this error in `k describe pods`:

```
Warning  FailedCreatePodSandBox  0s (x3 over 28s)  kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to get sandbox runtime: no runtime for "nvidia" is configured
```

This PR adds a check for to add the nvidia runtime only if the Nvidia GPU operator is installed.