### PR TITLE
[Core] Update subprocess_daemon.py to terminate all child processes from ray job when 'sky cancel' is ran 

### DIFF
--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -208,10 +208,10 @@ def run_with_log(
                 str(proc.pid),
             ]
 
-            # We do not need to set `start_new_session=True` here, as the daemon
-            # script will detach itself from the parent process with fork to avoid being
-            # killed by ray job. See the reason we daemonize the process in
-            # `sky/skylet/subprocess_daemon.py`
+            # We do not need to set `start_new_session=True` here, as the
+            # daemon script will detach itself from the parent process with
+            # fork to avoid being killed by ray job. See the reason we
+            # daemonize the process in `sky/skylet/subprocess_daemon.py`.
             subprocess.Popen(
                 daemon_cmd,
                 # Suppress output

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -210,7 +210,6 @@ def run_with_log(
 
             subprocess.Popen(
                 daemon_cmd,
-                start_new_session=True,
                 # Suppress output
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -208,6 +208,10 @@ def run_with_log(
                 str(proc.pid),
             ]
 
+            # We do not need to set `start_new_session=True` here, as the daemon
+            # script will detach itself from the parent process with fork to avoid being
+            # killed by ray job. See the reason we daemonize the process in
+            # `sky/skylet/subprocess_daemon.py`
             subprocess.Popen(
                 daemon_cmd,
                 # Suppress output

--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -11,7 +11,7 @@ import psutil
 
 
 def daemonize():
-    """Separates the process from parent process with double-forking."""
+    """Separates the process from its parent process with double-forking."""
     # First fork
     if os.fork() > 0:
         # original process terminates.

--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -14,7 +14,7 @@ def daemonize():
     """Detaches the process from its parent process with double-forking.
     
     This detachment is crucial in the context of SkyPilot and Ray job. When
-    'sky cancel' is executed, it uses Ray's stop_job API to terminate the job.
+    'sky cancel' is executed, it uses Ray's stop job API to terminate the job.
     Without daemonization, this subprocess_daemon process would be terminated
     along with its parent process, ray::task, which is launched with Ray job.
     Daemonization ensures this process survives the 'sky cancel' command, 
@@ -62,7 +62,7 @@ if __name__ == '__main__':
             try:
                 # process.children() must be called while the target process
                 # is alive, as it will return an empty list if the target
-                # process has already terminated. 
+                # process has already terminated.
                 tmp_children = process.children(recursive=True)
                 if tmp_children:
                     children = tmp_children

--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -60,8 +60,9 @@ if __name__ == '__main__':
         # Wait for either parent or target process to exit.
         while process.is_running() and parent_process.is_running():
             try:
-                # if process is terminated by the time reaching this line,
-                # it returns an empty list.
+                # process.children() must be called while the target process
+                # is alive, as it will return an empty list if the target
+                # process has already terminated. 
                 tmp_children = process.children(recursive=True)
                 if tmp_children:
                     children = tmp_children

--- a/sky/skylet/subprocess_daemon.py
+++ b/sky/skylet/subprocess_daemon.py
@@ -12,12 +12,12 @@ import psutil
 
 def daemonize():
     """Detaches the process from its parent process with double-forking.
-    
+
     This detachment is crucial in the context of SkyPilot and Ray job. When
     'sky cancel' is executed, it uses Ray's stop job API to terminate the job.
     Without daemonization, this subprocess_daemon process would be terminated
     along with its parent process, ray::task, which is launched with Ray job.
-    Daemonization ensures this process survives the 'sky cancel' command, 
+    Daemonization ensures this process survives the 'sky cancel' command,
     allowing it to prevent orphaned processes of Ray job.
     """
     # First fork: Creates a child process identical to the parent
@@ -66,10 +66,10 @@ if __name__ == '__main__':
                 tmp_children = process.children(recursive=True)
                 if tmp_children:
                     children = tmp_children
-                    children.append(process)
             except psutil.NoSuchProcess:
                 pass
             time.sleep(1)
+    children.append(process)
 
     for child in children:
         try:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2388,8 +2388,6 @@ def _get_cancel_task_with_cloud(name, cloud, timeout=15 * 60):
 
 # ---------- Testing `sky cancel` ----------
 @pytest.mark.aws
-@pytest.mark.skip(
-    reason='The resnet_app is flaky, due to TF failing to detect GPUs.')
 def test_cancel_aws():
     name = _get_cluster_name()
     test = _get_cancel_task_with_cloud(name, 'aws')
@@ -2397,8 +2395,6 @@ def test_cancel_aws():
 
 
 @pytest.mark.gcp
-@pytest.mark.skip(
-    reason='The resnet_app is flaky, due to TF failing to detect GPUs.')
 def test_cancel_gcp():
     name = _get_cluster_name()
     test = _get_cancel_task_with_cloud(name, 'gcp')
@@ -2406,8 +2402,6 @@ def test_cancel_gcp():
 
 
 @pytest.mark.azure
-@pytest.mark.skip(
-    reason='The resnet_app is flaky, due to TF failing to detect GPUs.')
 def test_cancel_azure():
     name = _get_cluster_name()
     test = _get_cancel_task_with_cloud(name, 'azure', timeout=30 * 60)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This resolves #3898.

We completely separate the `subprocess_daemony.py` process from `ray::task` process. Originally, `subprocess_daemon.py` was ran as child process of `ray::task` process, and this resulted in termination of the `subprocess_daemon.py` process as well when ray's `stop_job` API was ran to terminate `ray::task` process. And this resulted in failing to terminate all of `ray::task` process's child processes in the tree.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] manually check if the process running `subprocess_daemon.py` is not child of `ray::task` process and have different session group: https://github.com/skypilot-org/skypilot/pull/3919#discussion_r1748906461
- [x] All smoke tests: `pytest tests/test_smoke.py` besides the ones that are failing from `master` branch:
  - `test_managed_jobs_storage`
  - `test_multiple_accelerators_unordered_with_default`
  - `test_tpu_vm_pod`
  - `test_skyserve_fast_update`
  - `test_tpu_vm`
  - `test_managed_jobs_tpu`
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
