### PR TITLE
[Core][Disk] High disk tier on Azure

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -61,9 +61,8 @@ class Azure(clouds.Cloud):
     _BEST_DISK_TIER = resources_utils.DiskTier.HIGH
     _DEFAULT_DISK_TIER = resources_utils.DiskTier.MEDIUM
     # Azure does not support high disk and ultra disk tier.
-    _SUPPORTED_DISK_TIERS = (
-        set(resources_utils.DiskTier) -
-        {resources_utils.DiskTier.ULTRA})
+    _SUPPORTED_DISK_TIERS = (set(resources_utils.DiskTier) -
+                             {resources_utils.DiskTier.ULTRA})
 
     _INDENT_PREFIX = ' ' * 4
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -643,12 +643,3 @@ class Azure(clouds.Cloud):
             resources_utils.DiskTier.LOW: 'Standard_LRS',
         }
         return tier2name[tier]
-
-    @classmethod
-    def _get_disk_performance_tier(
-            cls,
-            disk_tier: Optional[resources_utils.DiskTier]) -> Optional[str]:
-        tier = cls._translate_disk_tier(disk_tier)
-        if tier == resources_utils.DiskTier.HIGH:
-            return 'P50'
-        return None

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -281,6 +281,7 @@ def _create_instances(
         disks = compute_client.disks.list_by_resource_group(resource_group)
         for disk in disks:
             name = disk.name
+            # TODO(tian): Investigate if we can use Python SDK to update this.
             subprocess_utils.run_no_outputs(
                 f'az disk update -n {name} -g {resource_group} '
                 f'--set tier={performance_tier}')

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -276,8 +276,8 @@ def _create_instances(
         parameters=parameters,
     ).wait()
 
-    if 'disk_performance_tier' in provider_config:
-        performance_tier = provider_config['disk_performance_tier']
+    performance_tier = node_config.get('disk_performance_tier', None)
+    if performance_tier is not None:
         disks = compute_client.disks.list_by_resource_group(resource_group)
         for disk in disks:
             name = disk.name

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -45,6 +45,9 @@ provider:
   # The upper-level SkyPilot code has make sure there will not be resource
   # leakage.
   disable_launch_config_check: true
+  {%- if disk_performance_tier is not none %}
+  disk_performance_tier: {{disk_performance_tier}}
+  {%- endif %}
 
 
 auth:

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -45,9 +45,6 @@ provider:
   # The upper-level SkyPilot code has make sure there will not be resource
   # leakage.
   disable_launch_config_check: true
-  {%- if disk_performance_tier is not none %}
-  disk_performance_tier: {{disk_performance_tier}}
-  {%- endif %}
 
 
 auth:
@@ -84,6 +81,9 @@ available_node_types:
               {{ cmd }}
               {%- endfor %}
         need_nvidia_driver_extension: {{need_nvidia_driver_extension}}
+        {%- if disk_performance_tier is not none %}
+        disk_performance_tier: {{disk_performance_tier}}
+        {%- endif %}
         # TODO: attach disk
 
 head_node_type: ray.head.default

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -765,12 +765,12 @@ def test_optimize_disk_tier(enable_all_clouds):
         map(clouds.CLOUD_REGISTRY.get,
             ['aws', 'gcp', 'azure', 'oci'])), low_tier_candidates
 
-    # Only AWS, GCP, OCI supports HIGH disk tier.
+    # Only AWS, GCP, Azure, OCI supports HIGH disk tier.
     high_tier_resources = sky.Resources(disk_tier=resources_utils.DiskTier.HIGH)
     high_tier_candidates = _get_all_candidate_cloud(high_tier_resources)
     assert high_tier_candidates == set(
         map(clouds.CLOUD_REGISTRY.get,
-            ['aws', 'gcp', 'oci'])), high_tier_candidates
+            ['aws', 'gcp', 'azure', 'oci'])), high_tier_candidates
 
     # Only AWS, GCP supports ULTRA disk tier.
     ultra_tier_resources = sky.Resources(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Added a high disk tier for Azure. The new tier uses P50 on Premium_LRS.

Discussions
- [ ] For disk size >= 4096, it will automatically select P50 and this does not make any difference b/t `medium` and `high` tier.
- [ ] Investigate if update the disk performance can be done on python API.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `sky launch --cloud azure --disk-tier high` and manually check the console
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
