### PR TITLE
[AWS] Add tags on bucket creation time

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -90,7 +90,7 @@ Available fields and semantics:
   # Advanced AWS configurations (optional).
   # Apply to all new instances but not existing ones.
   aws:
-    # Tags to assign to all instances launched by SkyPilot (optional).
+    # Tags to assign to all instances and buckets created by SkyPilot (optional).
     #
     # Example use case: cost tracking by user/team/project.
     #

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1447,6 +1447,19 @@ class S3Store(AbstractStore):
             s3_client.create_bucket(**create_bucket_config)
             logger.info(
                 f'Created S3 bucket {bucket_name!r} in {region or "us-east-1"}')
+
+            # add tags to the bucket
+            bucket_tags = skypilot_config.get_nested(('aws', 'labels'), {})
+            if bucket_tags:
+                s3_client.put_bucket_tagging(
+                    Bucket=bucket_name,
+                    Tagging={
+                        'TagSet': [{
+                            'Key': k,
+                            'Value': v
+                        } for k, v in bucket_tags.items()]
+                    })
+
         except aws.botocore_exceptions().ClientError as e:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1448,7 +1448,8 @@ class S3Store(AbstractStore):
             logger.info(
                 f'Created S3 bucket {bucket_name!r} in {region or "us-east-1"}')
 
-            # add tags to the bucket
+            # Add AWS tags configured in config.yaml to the bucket.
+            # This is useful for cost tracking and external cleanup.
             bucket_tags = skypilot_config.get_nested(('aws', 'labels'), {})
             if bucket_tags:
                 s3_client.put_bucket_tagging(


### PR DESCRIPTION
Adding ability to add tags from global config to buckets created 


- [x] Code formatting: `bash format.sh`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
