### PR TITLE
[Core] Turn on WAL mode for cluster job table

### DIFF
--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -8,10 +8,10 @@ import json
 import os
 import pathlib
 import shlex
+import sqlite3
 import subprocess
 import time
 import typing
-import sqlite3
 from typing import Any, Dict, List, Optional, Tuple
 
 import colorama

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -11,6 +11,7 @@ import shlex
 import subprocess
 import time
 import typing
+import sqlite3
 from typing import Any, Dict, List, Optional, Tuple
 
 import colorama
@@ -55,6 +56,20 @@ os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
 
 
 def create_table(cursor, conn):
+    # Enable WAL mode to avoid locking issues.
+    # See: issue #3863, #1441 and PR #1509
+    # https://github.com/microsoft/WSL/issues/2395
+    # TODO(romilb): We do not enable WAL for WSL because of known issue in WSL.
+    #  This may cause the database locked problem from WSL issue #1441.
+    if not common_utils.is_wsl():
+        try:
+            cursor.execute('PRAGMA journal_mode=WAL')
+        except sqlite3.OperationalError as e:
+            if 'database is locked' not in str(e):
+                raise
+            # If the database is locked, it is OK to continue, as the WAL mode
+            # is not critical and is likely to be enabled by other processes.
+
     cursor.execute("""\
         CREATE TABLE IF NOT EXISTS jobs (
         job_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -336,17 +351,13 @@ def get_status_no_lock(job_id: int) -> Optional[JobStatus]:
     the status in a while loop as in `log_lib._follow_job_logs`. Otherwise, use
     `get_status`.
     """
-
-    def db_operation():
-        rows = _CURSOR.execute('SELECT status FROM jobs WHERE job_id=(?)',
-                               (job_id,))
-        for (status,) in rows:
-            if status is None:
-                return None
-            return JobStatus(status)
-        return None
-
-    return db_utils.retry_on_database_locked(db_operation)
+    rows = _CURSOR.execute('SELECT status FROM jobs WHERE job_id=(?)',
+                           (job_id,))
+    for (status,) in rows:
+        if status is None:
+            return None
+        return JobStatus(status)
+    return None
 
 
 def get_status(job_id: int) -> Optional[JobStatus]:

--- a/sky/utils/db_utils.py
+++ b/sky/utils/db_utils.py
@@ -2,7 +2,6 @@
 import contextlib
 import sqlite3
 import threading
-import time
 from typing import Any, Callable, Optional
 
 

--- a/sky/utils/db_utils.py
+++ b/sky/utils/db_utils.py
@@ -74,28 +74,6 @@ def rename_column(
     conn.commit()
 
 
-def retry_on_database_locked(func: Callable,
-                             max_retries: int = 5,
-                             retry_delay: float = 0.1):
-    """Retry a database operation if it fails due to database lock."""
-    for attempt in range(max_retries):
-        try:
-            return func()
-        except sqlite3.OperationalError as e:
-            if 'database is locked' in str(e) and attempt < max_retries - 1:
-                time.sleep(retry_delay)
-            else:
-                raise
-    raise sqlite3.OperationalError(
-        'Database operation failed after maximum retries')
-
-
-def enable_wal_mode(conn: 'sqlite3.Connection'):
-    """Enable WAL mode for the given SQLite connection."""
-    conn.execute('PRAGMA journal_mode=WAL;')
-    conn.commit()
-
-
 class SQLiteConn(threading.local):
     """Thread-local connection to the sqlite3 database."""
 
@@ -106,5 +84,4 @@ class SQLiteConn(threading.local):
         # errors. This is a hack, but it works.
         self.conn = sqlite3.connect(db_path, timeout=10)
         self.cursor = self.conn.cursor()
-        enable_wal_mode(self.conn)  # Enable WAL mode
         create_table(self.cursor, self.conn)


### PR DESCRIPTION
Issues Addressed
- #3863 

Changes Made
- [x] Enable WAL mode for the given SQLite connection.
- [x] Add a wrapper to retry a database operation if it fails due to database lock.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
