### PR TITLE
Resolve param credential typo

### DIFF
--- a/sky/provision/__init__.py
+++ b/sky/provision/__init__.py
@@ -186,12 +186,12 @@ def get_cluster_info(
 def get_command_runners(
     provider_name: str,
     cluster_info: common.ClusterInfo,
-    **crednetials: Dict[str, Any],
+    **credentials: Dict[str, Any],
 ) -> List[command_runner.CommandRunner]:
     """Get a command runner for the given cluster."""
     ip_list = cluster_info.get_feasible_ips()
     port_list = cluster_info.get_ssh_ports()
     return command_runner.SSHCommandRunner.make_runner_list(
         node_list=zip(ip_list, port_list),
-        **crednetials,
+        **credentials,
     )


### PR DESCRIPTION
Issues addressed
- #3813 

Changes made
- [x] Resolve the typo in credentials param

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
