### PR TITLE
[GCP][Disk] Add supported instance type check for disk tier ultra

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -433,7 +433,7 @@ class GCP(clouds.Cloud):
             start_index = all_tiers.index(GCP._translate_disk_tier(r.disk_tier))
             while start_index < len(all_tiers):
                 disk_tier = all_tiers[start_index]
-                ok, _ = GCP.check_disk_tier(r.instance_type, disk_tier)
+                ok, _ = GCP._check_disk_tier(r.instance_type, disk_tier)
                 if ok:
                     return disk_tier
                 start_index += 1
@@ -932,7 +932,7 @@ class GCP(clouds.Cloud):
             'gcp')
 
     @classmethod
-    def check_disk_tier(
+    def _check_disk_tier(
             cls, instance_type: Optional[str],
             disk_tier: Optional[resources_utils.DiskTier]) -> Tuple[bool, str]:
         if disk_tier != resources_utils.DiskTier.ULTRA or instance_type is None:
@@ -956,7 +956,7 @@ class GCP(clouds.Cloud):
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: Optional[str],
                                 disk_tier: resources_utils.DiskTier) -> None:
-        ok, msg = cls.check_disk_tier(instance_type, disk_tier)
+        ok, msg = cls._check_disk_tier(instance_type, disk_tier)
         if not ok:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(msg)

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -428,7 +428,7 @@ class GCP(clouds.Cloud):
             if (r.disk_tier is not None and
                     r.disk_tier != resources_utils.DiskTier.BEST):
                 return r.disk_tier
-            # Failover disk tier from high to low.
+            # Failover disk tier from ultra to low.
             all_tiers = list(reversed(resources_utils.DiskTier))
             start_index = all_tiers.index(GCP._translate_disk_tier(r.disk_tier))
             while start_index < len(all_tiers):

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional, Tuple
 from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
+from sky.clouds import GCP
 from sky.clouds.service_catalog import common
 from sky.utils import resources_utils
 from sky.utils import ux_utils
@@ -243,7 +244,6 @@ def get_default_instance_type(
         cpus: Optional[str] = None,
         memory: Optional[str] = None,
         disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
-    del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:
@@ -254,6 +254,12 @@ def get_default_instance_type(
         f'{family}-' for family in _DEFAULT_INSTANCE_FAMILY)
     df = _df[_df['InstanceType'].notna()]
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
+
+    def _filter_disk_type(instance_type: str) -> bool:
+        valid, _ = GCP.check_disk_tier(instance_type, disk_tier)
+        return valid
+
+    df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://cloud.google.com/compute/docs/disks/extreme-persistent-disk#machine_shape_support

On GCP, disk tier ultra only supports handful of instance type. This PR adds the check and fixes #3933.

From the documentation, it seems like we could still attach the pd-extreme disk to some instance type but will get a degraded performance. We should benchmark and see how severe the degradation is, as the instance type that officially supports the ultra tier is too small (no GPU instance types is officially supported).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `sky launch --cloud gcp --disk-tier best --gpus L4`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
