### PR TITLE
[AWS] Avoid quota check when reservation is specified

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -858,6 +858,12 @@ class AWS(clouds.Cloud):
             # Quota code not found in the catalog for the chosen instance_type, try provisioning anyway
             return True
 
+        if aws_utils.use_reservations():
+            # When reservations are used, it is possible that a user has
+            # reservations for an instance type, but does not have the quota
+            # for that instance type. Skipping the quota check in this case.
+            return True
+
         client = aws.client('service-quotas', region_name=region)
         try:
             response = client.get_service_quota(ServiceCode='ec2',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that even if they have capacity reservation for a specific GPU, they cannot utilize them with SkyPilot because they have 0 on-demand quota for that GPU and our optimization for quota skips that region.

This PR skips the quota check when reservations are used.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
