### PR TITLE
[Catalog] Fix GCP Fetcher

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -531,7 +531,8 @@ def _get_tpu_for_zone(zone: str) -> 'pd.DataFrame':
         parent=parent)
     try:
         tpus_response = tpus_request.execute()
-        for tpu in tpus_response['acceleratorTypes']:
+        # TODO(tian): Sometimes the response is empty ({}). Need to investigate.
+        for tpu in tpus_response.get('acceleratorTypes', []):
             tpus.append(tpu)
     except gcp.http_error_exception() as error:
         if error.resp.status == 403:

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -547,7 +547,7 @@ def _get_tpu_response_for_zone(zone: str) -> list:
         time_to_sleep = backoff.current_backoff()
         print(f'  Retry zone {zone!r} in {time_to_sleep} seconds...')
         time.sleep(time_to_sleep)
-    print(f'Failed to fetch TPUs for zone {zone!r}.')
+    print(f'ERROR: Failed to fetch TPUs for zone {zone!r}.')
     return []
 
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -545,7 +545,7 @@ def _get_tpu_response_for_zone(zone: str) -> list:
             # If error happens, fail early.
             return []
         time_to_sleep = backoff.current_backoff()
-        print(f'Retry zone {zone!r} in {time_to_sleep} seconds...')
+        print(f'  Retry zone {zone!r} in {time_to_sleep} seconds...')
         time.sleep(time_to_sleep)
     print(f'Failed to fetch TPUs for zone {zone!r}.')
     return []

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -41,7 +41,7 @@ TPU_SERVICE_ID = 'E000-3F24-B8AA'
 PRICE_ROUNDING = 5
 
 # The number of retries for the TPU API.
-TPU_RETRY_TIMES = 3
+TPU_RETRY_CNT = 3
 
 # This zone is only for TPU v4, and does not appear in the skus yet.
 TPU_V4_ZONES = ['us-central2-b']
@@ -528,14 +528,14 @@ def _get_tpu_response_for_zone(zone: str) -> list:
     # Sometimes the response is empty ({}) even for enabled zones. Here we
     # retry the request for a few times.
     backoff = common_utils.Backoff(initial_backoff=1)
-    for _ in range(TPU_RETRY_TIMES):
+    for _ in range(TPU_RETRY_CNT):
         tpus_request = (
             tpu_client.projects().locations().acceleratorTypes().list(
                 parent=parent))
         try:
             tpus_response = tpus_request.execute()
-            if tpus_response:
-                return tpus_response.get('acceleratorTypes', [])
+            if 'acceleratorTypes' in tpus_response:
+                return tpus_response['acceleratorTypes']
         except gcp.http_error_exception() as error:
             if error.resp.status == 403:
                 print('  TPU API is not enabled or you don\'t have TPU access '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Sometimes the return body of GCP is empty and that causes a key error in our fetcher. This happenes to zones that we does not have access to. This PR fixes the problem.

Reference: https://github.com/skypilot-org/skypilot-catalog/actions/runs/10800668225/job/29959644303

```bash
# For the same zone, sometime it will shows as the following 403 error:
WARNING:googleapiclient.http:Encountered 403 Forbidden with reason "PERMISSION_DENIED"
  TPU API is not enabled or you don't have TPU access to zone: 'asia-east1-a'.

# And sometimes it just returned an empty response.
Traceback (most recent call last):
  File "/home/txia/miniconda3/envs/sky-serve/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/txia/miniconda3/envs/sky-serve/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 740, in <module>
    catalog_df = get_catalog_df(region_prefix_filter)
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 690, in get_catalog_df
    tpu_df = get_tpu_df(gcp_skus, gcp_tpu_skus)
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 581, in get_tpu_df
    df = _get_tpus()
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 570, in _get_tpus
    all_tpu_dfs = [_get_tpu_for_zone(zone) for zone in zones]
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 570, in <listcomp>
    all_tpu_dfs = [_get_tpu_for_zone(zone) for zone in zones]
  File "/home/txia/skypilot/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 535, in _get_tpu_for_zone
    for tpu in tpus_response['acceleratorTypes']:
KeyError: 'acceleratorTypes'
```



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
