### PR TITLE
[Azure][Disk] Ultra tier on Azure with disk bursting.

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -638,13 +638,14 @@ class Cloud:
 
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: Optional[str],
+                                disk_size: int,
                                 disk_tier: resources_utils.DiskTier) -> None:
         """Errors out if the disk tier is not supported by the cloud provider.
 
         Raises:
             exceptions.NotSupportedError: If the disk tier is not supported.
         """
-        del instance_type  # unused
+        del instance_type, disk_size  # unused
         if disk_tier not in cls._SUPPORTED_DISK_TIERS:
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.NotSupportedError(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -965,7 +965,9 @@ class GCP(clouds.Cloud):
 
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: Optional[str],
+                                disk_size: int,
                                 disk_tier: resources_utils.DiskTier) -> None:
+        del disk_size  # Unused.
         ok, msg = cls.check_disk_tier(instance_type, disk_tier)
         if not ok:
             with ux_utils.print_exception_no_traceback():

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -920,12 +920,13 @@ class Resources:
         if self.cloud is not None:
             try:
                 self.cloud.check_disk_tier_enabled(self.instance_type,
+                                                   self.disk_size,
                                                    self.disk_tier)
-            except exceptions.NotSupportedError:
+            except exceptions.NotSupportedError as e:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         f'Disk tier {self.disk_tier.value} is not supported '
-                        f'for instance type {self.instance_type}.') from None
+                        f'for instance type {self.instance_type}.') from e
 
     def _try_validate_ports(self) -> None:
         """Try to validate the ports attribute.

--- a/sky/templates/azure-ray.yml.j2
+++ b/sky/templates/azure-ray.yml.j2
@@ -84,6 +84,9 @@ available_node_types:
         {%- if disk_performance_tier is not none %}
         disk_performance_tier: {{disk_performance_tier}}
         {%- endif %}
+        {%- if enable_disk_bursting is not none %}
+        enable_disk_bursting: {{enable_disk_bursting}}
+        {%- endif %}
         # TODO: attach disk
 
 head_node_type: ray.head.default


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds `ultra` tier on Azure, leveraging [Azure disk bursting](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-bursting?tabs=azure-cli).

Since configure the disk bursting requires restarting the VM, which introduces ~44s overhead to the provisioning stage, we still set the best disk tier to `high` on Azure for now. We should investigate the attached data disk which could support Premium SSD v2 & ultra disk.

```bash
I 09-13 14:20:25 instance.py:306] Stopped instances to enable disk bursting in 23.10 seconds.
I 09-13 14:20:37 instance.py:318] Enabled disk bursting for {len(disks)} disks in 12.44 seconds.
I 09-13 14:20:46 instance.py:324] Started instances to enable disk bursting in 8.56 seconds.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `sky launch --cloud azure --disk-tier ultra --disk-size 1024` launches successfully.
     - [x] `sky launch --cloud azure --disk-tier ultra` outputs error `Azure Ultra SSD requires a disk size greater than 512GB.`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
