### PR TITLE
[LLM] Add huggingface token due to recent change of Pixtral on HF

### DIFF
--- a/llm/pixtral/pixtral.yaml
+++ b/llm/pixtral/pixtral.yaml
@@ -1,5 +1,6 @@
 envs:
   MODEL_NAME: mistralai/Pixtral-12B-2409
+  HF_TOKEN:
 
 service:
   replicas: 2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Recent Pixtral model on HF requires login. This PR adds `HF_TOKEN` for the access.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
