### PR TITLE
Up paperspace MAX_POLLS_FOR_UP_OR_STOP

### DIFF
--- a/sky/provision/paperspace/instance.py
+++ b/sky/provision/paperspace/instance.py
@@ -14,7 +14,7 @@ from sky.utils import ux_utils
 POLL_INTERVAL = 5
 MAX_POLLS = 60 // POLL_INTERVAL
 # Stopping instances can take several minutes, so we increase the timeout
-MAX_POLLS_FOR_UP_OR_STOP = MAX_POLLS * 8
+MAX_POLLS_FOR_UP_OR_STOP = MAX_POLLS * 16
 
 logger = sky_logging.init_logger(__name__)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Increases the paperspace `MAX_POLLS_FOR_UP_OR_STOP` from 8 to 16 minutes.

Spawning a larger number of CPU instances on paperspace can be quite slow. I've had to manually monkeypatch this limit several times to spawn a C8 clusters on paperspace. This is definitely set too low.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
