### PR TITLE
[Optimizer] List GPU Instances When a Large Number of CPUs are Requested

### DIFF
--- a/sky/clouds/service_catalog/aws_catalog.py
+++ b/sky/clouds/service_catalog/aws_catalog.py
@@ -238,7 +238,14 @@ def get_default_instance_type(
     instance_type_prefix = tuple(
         f'{family}.' for family in _DEFAULT_INSTANCE_FAMILY)
     df = _get_df()
-    df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
+
+    default_instance_type_df = df[df['InstanceType'].str.startswith(
+        instance_type_prefix)]
+    default_instance_type = common.get_instance_type_for_cpus_mem_impl(
+        default_instance_type_df, cpus, memory_gb_or_ratio)
+    if default_instance_type is not None:
+        return default_instance_type
+
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -106,14 +106,20 @@ def get_default_instance_type(
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
     else:
         memory_gb_or_ratio = memory
-    df = _df[_df['InstanceType'].apply(_get_instance_family).isin(
-        _DEFAULT_INSTANCE_FAMILY)]
 
     def _filter_disk_type(instance_type: str) -> bool:
         valid, _ = Azure.check_disk_tier(instance_type, disk_tier)
         return valid
 
-    df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
+    df = _df.loc[_df['InstanceType'].apply(_filter_disk_type)]
+
+    default_instance_type_df = _df[_df['InstanceType'].apply(
+        _get_instance_family).isin(_DEFAULT_INSTANCE_FAMILY)]
+    default_instance_type = common.get_instance_type_for_cpus_mem_impl(
+        default_instance_type_df, cpus, memory_gb_or_ratio)
+    if default_instance_type is not None:
+        return default_instance_type
+
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
 

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -253,13 +253,20 @@ def get_default_instance_type(
     instance_type_prefix = tuple(
         f'{family}-' for family in _DEFAULT_INSTANCE_FAMILY)
     df = _df[_df['InstanceType'].notna()]
-    df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
 
     def _filter_disk_type(instance_type: str) -> bool:
         valid, _ = GCP.check_disk_tier(instance_type, disk_tier)
         return valid
 
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
+
+    default_instance_type_df = df[df['InstanceType'].str.startswith(
+        instance_type_prefix)]
+    default_instance_type = common.get_instance_type_for_cpus_mem_impl(
+        default_instance_type_df, cpus, memory_gb_or_ratio)
+    if default_instance_type is not None:
+        return default_instance_type
+
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
 

--- a/sky/clouds/service_catalog/ibm_catalog.py
+++ b/sky/clouds/service_catalog/ibm_catalog.py
@@ -105,8 +105,15 @@ def get_default_instance_type(
     else:
         memory_gb_or_ratio = memory
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-'
-    df = _df[_df['InstanceType'].str.startswith(instance_type_prefix)]
-    return common.get_instance_type_for_cpus_mem_impl(df, cpus,
+
+    default_instance_type_df = _df[_df['InstanceType'].str.startswith(
+        instance_type_prefix)]
+    default_instance_type = common.get_instance_type_for_cpus_mem_impl(
+        default_instance_type_df, cpus, memory_gb_or_ratio)
+    if default_instance_type is not None:
+        return default_instance_type
+
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus,
                                                       memory_gb_or_ratio)
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Closes: https://github.com/skypilot-org/skypilot/issues/3597

This change adds logic to search for a matching GPU instance if there is no CPU instance that satisfies the requirements.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Manual Tests:
```
$ sky launch --cpus 192+
I 09-23 19:11:00 optimizer.py:719] == Optimizer ==
I 09-23 19:11:00 optimizer.py:730] Target: minimizing cost
I 09-23 19:11:00 optimizer.py:742] Estimated cost: $5.3 / hour
I 09-23 19:11:00 optimizer.py:742] 
I 09-23 19:11:00 optimizer.py:867] Considered resources (1 node):
I 09-23 19:11:00 optimizer.py:937] -------------------------------------------------------------------------------------------------
I 09-23 19:11:00 optimizer.py:937]  CLOUD   INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN   
I 09-23 19:11:00 optimizer.py:937] -------------------------------------------------------------------------------------------------
I 09-23 19:11:00 optimizer.py:937]  AWS     m6a.48xlarge       192     768       -              ap-south-1      5.33          ✔     
I 09-23 19:11:00 optimizer.py:937]  GCP     n2d-standard-224   224     896       -              asia-south1-a   6.25                
I 09-23 19:11:00 optimizer.py:937] -------------------------------------------------------------------------------------------------
I 09-23 19:11:00 optimizer.py:937] 
```
