### PR TITLE
[Tests] Add missing changes from #3966 for fast service update test

### DIFF
--- a/tests/skyserve/update/bump_version_after.yaml
+++ b/tests/skyserve/update/bump_version_after.yaml
@@ -20,9 +20,8 @@ resources:
   cpus: 2+
 
 setup: |
-  git clone https://github.com/skypilot-org/skypilot.git
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
 
 run: |
-  cd skypilot/examples/serve/http_server
   python3 server.py --port 8081
   

--- a/tests/skyserve/update/bump_version_before.yaml
+++ b/tests/skyserve/update/bump_version_before.yaml
@@ -20,9 +20,8 @@ resources:
   cpus: 2+
 
 setup: |
-  git clone https://github.com/skypilot-org/skypilot.git
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
 
 run: |
-  cd skypilot/examples/serve/http_server
   python3 server.py --port 8081
   


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

git cloning SkyPilot repo takes too long for the test, making the test fail due to initial delay exceed.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
