### PR TITLE
[k8s] Autodown Serve controller on Kubernetes

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4147,10 +4147,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     idle_minutes_to_autostop >= 0):
                 # We should hit this code path only for the controllers on
                 # Kubernetes and RunPod clusters.
-                controller = controller_utils.Controllers.from_name(handle.cluster_name)
+                controller = controller_utils.Controllers.from_name(
+                    handle.cluster_name)
                 assert (controller is not None), handle.cluster_name
-                if (controller == controller_utils.Controllers.SKY_SERVE_CONTROLLER and
-                    isinstance(handle.launched_resources.cloud, clouds.Kubernetes)):
+                if (controller
+                        == controller_utils.Controllers.SKY_SERVE_CONTROLLER and
+                        isinstance(handle.launched_resources.cloud,
+                                   clouds.Kubernetes)):
                     # For SkyServe controllers on Kubernetes: override autostop
                     # behavior to force autodown (instead of no-op)
                     # to avoid dangling controllers.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4147,11 +4147,18 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     idle_minutes_to_autostop >= 0):
                 # We should hit this code path only for the controllers on
                 # Kubernetes and RunPod clusters.
-                assert (controller_utils.Controllers.from_name(
-                    handle.cluster_name) is not None), handle.cluster_name
-                logger.info('Auto-stop is not supported for Kubernetes '
-                            'and RunPod clusters. Skipping.')
-                return
+                controller = controller_utils.Controllers.from_name(handle.cluster_name)
+                assert (controller is not None), handle.cluster_name
+                if (controller == controller_utils.Controllers.SKY_SERVE_CONTROLLER and
+                    isinstance(handle.launched_resources.cloud, clouds.Kubernetes)):
+                    # For SkyServe controllers on Kubernetes: override autostop
+                    # behavior to force autodown (instead of no-op)
+                    # to avoid dangling controllers.
+                    down = True
+                else:
+                    logger.info('Auto-stop is not supported for Kubernetes '
+                                'and RunPod clusters. Skipping.')
+                    return
 
             # Check if we're stopping spot
             assert (handle.launched_resources is not None and


### PR DESCRIPTION
This PR sets the serve controller to autodown (instead of being left to run indefinitely) when running on Kubernetes. This is to avoid dangling controllers.


Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manually tested with `sky serve up` on Kubernetes and on GCP