### PR TITLE
[Paperspace] add A4000, P4000, GPU+

### DIFF
--- a/sky/provision/paperspace/constants.py
+++ b/sky/provision/paperspace/constants.py
@@ -19,6 +19,12 @@ INSTANCE_TO_TEMPLATEID = {
     'V100-32Gx2': 'twnlo3zj',
     'V100-32G': 'twnlo3zj',
     'V100': 'twnlo3zj',
+    'GPU+': 'twnlo3zj',
+    'P4000': 'twnlo3zj',
+    'P4000x2': 'twnlo3zj',
+    'A4000': 'twnlo3zj',
+    'A4000x2': 'twnlo3zj',
+    'A4000x4': 'twnlo3zj',
     **CPU_INSTANCES_TEMPLATEID
 }
 NVLINK_INSTANCES = {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

adds some new paperspace gpus. closes #3988 and depends on skypilot-org/skypilot-catalog#85

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

```
sky launch --cloud paperspace --gpus {M4000,P4000,P4000:2,A4000,A4000:2,A4000:4} -y -d
```
