### PR TITLE
[Docs] Clarify k8s private registry usage in docs

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -20,7 +20,7 @@ Running Containers as Tasks
 
 .. note::
 
-    On Kubernetes, running docker runtime in a pod is not recommended. Instead, :ref:`use your container as a runtime environment <docker-containers-as-runtime-environments>`.
+    On Kubernetes, running Docker runtime in a pod is not recommended. Instead, :ref:`use your container as a runtime environment <docker-containers-as-runtime-environments>`.
 
 SkyPilot can run containerized applications directly as regular tasks. The default VM images provided by SkyPilot already have the Docker runtime pre-configured.
 
@@ -179,7 +179,7 @@ Private Registries
 
 .. note::
 
-    These instructions do not apply to Kubernetes clusters. See :ref:`Using Images from Private Repositories in Kubernetes<kubernetes-custom-images-private-repos>` for more.
+    These instructions do not apply if you use SkyPilot to launch on Kubernetes clusters. Instead, see :ref:`Using Images from Private Repositories in Kubernetes<kubernetes-custom-images-private-repos>` for more.
 
 When using this mode, to access Docker images hosted on private registries,
 you can provide the registry authentication details using :ref:`task environment variables <env-vars>`:

--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -18,6 +18,10 @@ SkyPilot can run a container either as a task, or as the runtime environment of 
 Running Containers as Tasks
 ---------------------------
 
+.. note::
+
+    On Kubernetes, running docker runtime in a pod is not recommended. Instead, :ref:`use your container as a runtime environment <docker-containers-as-runtime-environments>`.
+
 SkyPilot can run containerized applications directly as regular tasks. The default VM images provided by SkyPilot already have the Docker runtime pre-configured.
 
 To launch a containerized application, you can directly invoke :code:`docker run` in the :code:`run` section of your task.
@@ -172,6 +176,10 @@ Any GPUs assigned to the task will be automatically mapped to your Docker contai
 
 Private Registries
 ^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+    These instructions do not apply to Kubernetes clusters. See :ref:`Using Images from Private Repositories in Kubernetes<kubernetes-custom-images-private-repos>` for more.
 
 When using this mode, to access Docker images hosted on private registries,
 you can provide the registry authentication details using :ref:`task environment variables <env-vars>`:

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -119,6 +119,8 @@ Once your cluster administrator has :ref:`setup a Kubernetes cluster <kubernetes
     $ kubectl config set-context --current --namespace=mynamespace
 
 
+.. _kubernetes-custom-images:
+
 Using Custom Images
 -------------------
 By default, we use and maintain a SkyPilot container image that has conda and a few other basic tools installed.
@@ -139,6 +141,8 @@ Your image must satisfy the following requirements:
 .. note::
 
     If your cluster runs on non-x86_64 architecture (e.g., Apple Silicon), your image must be built natively for that architecture. Otherwise, your job may get stuck at :code:`Start streaming logs ...`. See `GitHub issue <https://github.com/skypilot-org/skypilot/issues/3035>`_ for more.
+
+.. _kubernetes-custom-images-private-repos:
 
 Using Images from Private Repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Current docs are confusing because private registry instructions don't apply to k8s. This PR adds a note for k8s with appropriate pointers. 