### PR TITLE
[Serve] Refactor to Fix Type Checking Errors

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -22,8 +22,7 @@ logger = sky_logging.init_logger(__name__)
 
 
 def _get_db_path() -> str:
-    """
-    Workaround to collapse multi-step Path ops for type checker.
+    """Workaround to collapse multi-step Path ops for type checker.
     Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
     """
     path = pathlib.Path('~/.sky/spot_jobs.db')

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -20,10 +20,19 @@ CallbackType = Callable[[str], None]
 
 logger = sky_logging.init_logger(__name__)
 
-_DB_PATH = pathlib.Path('~/.sky/spot_jobs.db')
-_DB_PATH = _DB_PATH.expanduser().absolute()
-_DB_PATH.parents[0].mkdir(parents=True, exist_ok=True)
-_DB_PATH = str(_DB_PATH)
+
+def _get_db_path() -> str:
+    """
+    Workaround to collapse multi-step Path ops for type checker.
+    Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
+    """
+    path = pathlib.Path('~/.sky/spot_jobs.db')
+    path = path.expanduser().absolute()
+    path.parents[0].mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+_DB_PATH = _get_db_path()
 
 # Module-level connection/cursor; thread-safe as the module is only imported
 # once.

--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -131,6 +131,10 @@ class Autoscaler:
         """Load dynamic states to autoscaler."""
         raise NotImplementedError
 
+    def get_decision_interval(self) -> int:
+        """Get the decision interval for the autoscaler."""
+        raise NotImplementedError
+
     def load_dynamic_states(self, dynamic_states: Dict[str, Any]) -> None:
         """Load dynamic states to autoscaler."""
         self.latest_version_ever_ready = dynamic_states.pop(

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -153,7 +153,7 @@ class SkyServeController:
         logger.info('SkyServe Controller started on '
                     f'http://{self._host}:{self._port}')
 
-        uvicorn.run(self._app, host={self._host}, port=self._port)
+        uvicorn.run(self._app, host=self._host, port=self._port)
 
 
 # TODO(tian): Probably we should support service that will stop the VM in

--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -79,7 +79,7 @@ class SkyServeLoadBalancer:
                                 'request_aggregator':
                                     self._request_aggregator.to_dict()
                             },
-                            timeout=5,
+                            timeout=aiohttp.ClientTimeout(5),
                     ) as response:
                         # Clean up after reporting request info to avoid OOM.
                         self._request_aggregator.clear()

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -174,7 +174,7 @@ def _get_resources_ports(task_yaml: str) -> str:
     task = sky.Task.from_yaml(task_yaml)
     # Already checked all ports are the same in sky.serve.core.up
     assert len(task.resources) >= 1, task
-    task_resources: Resources = list(task.resources)[0]
+    task_resources: 'resources.Resources' = list(task.resources)[0]
     # Already checked the resources have and only have one port
     # before upload the task yaml.
     assert task_resources.ports is not None

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -23,7 +23,8 @@ from sky import global_user_state
 from sky import sky_logging
 from sky import status_lib
 from sky.backends import backend_utils
-from sky.resources import Resources
+if typing.TYPE_CHECKING:
+    from sky import resources
 from sky.serve import constants as serve_constants
 from sky.serve import serve_state
 from sky.serve import serve_utils

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -23,8 +23,10 @@ from sky import global_user_state
 from sky import sky_logging
 from sky import status_lib
 from sky.backends import backend_utils
+
 if typing.TYPE_CHECKING:
     from sky import resources
+
 from sky.serve import constants as serve_constants
 from sky.serve import serve_state
 from sky.serve import serve_utils

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -23,10 +23,6 @@ from sky import global_user_state
 from sky import sky_logging
 from sky import status_lib
 from sky.backends import backend_utils
-
-if typing.TYPE_CHECKING:
-    from sky import resources
-
 from sky.serve import constants as serve_constants
 from sky.serve import serve_state
 from sky.serve import serve_utils
@@ -40,6 +36,7 @@ from sky.utils import env_options
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    from sky import resources
     from sky.serve import service_spec
 
 logger = sky_logging.init_logger(__name__)

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -23,6 +23,7 @@ from sky import global_user_state
 from sky import sky_logging
 from sky import status_lib
 from sky.backends import backend_utils
+from sky.resources import Resources
 from sky.serve import constants as serve_constants
 from sky.serve import serve_state
 from sky.serve import serve_utils
@@ -172,9 +173,10 @@ def _get_resources_ports(task_yaml: str) -> str:
     task = sky.Task.from_yaml(task_yaml)
     # Already checked all ports are the same in sky.serve.core.up
     assert len(task.resources) >= 1, task
-    task_resources = list(task.resources)[0]
+    task_resources: Resources = list(task.resources)[0]
     # Already checked the resources have and only have one port
     # before upload the task yaml.
+    assert task_resources.ports is not None
     return task_resources.ports[0]
 
 

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -19,8 +19,7 @@ if typing.TYPE_CHECKING:
 
 
 def _get_db_path() -> str:
-    """
-    Workaround to collapse multi-step Path ops for type checker.
+    """Workaround to collapse multi-step Path ops for type checker.
     Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
     """
     path = pathlib.Path(constants.SKYSERVE_METADATA_DIR) / 'services.db'

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -17,10 +17,15 @@ if typing.TYPE_CHECKING:
     from sky.serve import replica_managers
     from sky.serve import service_spec
 
-_DB_PATH = pathlib.Path(constants.SKYSERVE_METADATA_DIR) / 'services.db'
-_DB_PATH = _DB_PATH.expanduser().absolute()
-_DB_PATH.parents[0].mkdir(parents=True, exist_ok=True)
-_DB_PATH = str(_DB_PATH)
+
+def _get_db_path() -> str:
+    path = pathlib.Path(constants.SKYSERVE_METADATA_DIR) / 'services.db'
+    path = path.expanduser().absolute()
+    path.parents[0].mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+_DB_PATH: str = _get_db_path()
 
 
 def create_table(cursor: 'sqlite3.Cursor', conn: 'sqlite3.Connection') -> None:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -19,6 +19,10 @@ if typing.TYPE_CHECKING:
 
 
 def _get_db_path() -> str:
+    """
+    Workaround to collapse multi-step Path ops for type checker.
+    Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
+    """
     path = pathlib.Path(constants.SKYSERVE_METADATA_DIR) / 'services.db'
     path = path.expanduser().absolute()
     path.parents[0].mkdir(parents=True, exist_ok=True)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -241,12 +241,12 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     finally:
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
-        process_to_kill = [
-            proc for proc in [load_balancer_process, controller_process]
+        pids_to_kill = [
+            proc.pid for proc in [load_balancer_process, controller_process]
             if proc is not None
         ]
         subprocess_utils.kill_children_processes(
-            [process.pid for process in process_to_kill], force=True)
+            pids_to_kill, force=True)
         for process in process_to_kill:
             process.join()
         failed = _cleanup(service_name)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -241,8 +241,9 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     finally:
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
-        process_to_kill = filter(lambda proc: proc is not None,
-                                 [load_balancer_process, controller_process])
+        process_to_kill = filter(None,
+                                 [load_balancer_process, controller_process
+                                 ])  # filter out None from the list
         subprocess_utils.kill_children_processes(
             [process.pid for process in process_to_kill], force=True)
         for process in process_to_kill:

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -241,12 +241,12 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     finally:
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
-        pids_to_kill = [
-            proc.pid for proc in [load_balancer_process, controller_process]
+        process_to_kill = [
+            proc for proc in [load_balancer_process, controller_process]
             if proc is not None
         ]
         subprocess_utils.kill_children_processes(
-            pids_to_kill, force=True)
+            [process.pid for process in process_to_kill], force=True)
         for process in process_to_kill:
             process.join()
         failed = _cleanup(service_name)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -241,9 +241,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     finally:
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
-        process_to_kill = filter(None,
-                                 [load_balancer_process, controller_process
-                                 ])  # filter out None from the list
+        process_to_kill = [
+            proc for proc in [load_balancer_process, controller_process]
+            if proc is not None
+        ]
         subprocess_utils.kill_children_processes(
             [process.pid for process in process_to_kill], force=True)
         for process in process_to_kill:

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -241,7 +241,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     finally:
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
-        process_to_kill = filter(None,
+        process_to_kill = filter(lambda proc: proc is not None,
                                  [load_balancer_process, controller_process])
         subprocess_utils.kill_children_processes(
             [process.pid for process in process_to_kill], force=True)

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -9,7 +9,7 @@ import pathlib
 import shutil
 import time
 import traceback
-from typing import Dict, List
+from typing import Dict
 
 import filelock
 
@@ -116,15 +116,17 @@ def _cleanup(service_name: str) -> bool:
             logger.error(f'Replica {info.replica_id} failed to terminate.')
     versions = serve_state.get_service_versions(service_name)
     serve_state.remove_service_versions(service_name)
-    success = True
-    for version in versions:
+
+    def cleanup_version_storage(version: int) -> bool:
         task_yaml: str = serve_utils.generate_task_yaml_file_name(
             service_name, version)
         logger.info(f'Cleaning up storage for version {version}, '
                     f'task_yaml: {task_yaml}')
-        success = success and cleanup_storage(task_yaml)
-    if not success:
+        return cleanup_storage(task_yaml)
+
+    if not all(map(cleanup_version_storage, versions)):
         failed = True
+
     return failed
 
 
@@ -213,6 +215,7 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
 
             # TODO(tian): Support HTTPS.
             controller_addr = f'http://{controller_host}:{controller_port}'
+
             load_balancer_port = common_utils.find_free_port(
                 constants.LOAD_BALANCER_PORT_START)
 
@@ -236,13 +239,10 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
         serve_state.set_service_status_and_active_versions(
             service_name, serve_state.ServiceStatus.SHUTTING_DOWN)
     finally:
-        process_to_kill: List[multiprocessing.Process] = []
-        if load_balancer_process is not None:
-            process_to_kill.append(load_balancer_process)
-        if controller_process is not None:
-            process_to_kill.append(controller_process)
         # Kill load balancer process first since it will raise errors if failed
         # to connect to the controller. Then the controller process.
+        process_to_kill = filter(None,
+                                 [load_balancer_process, controller_process])
         subprocess_utils.kill_children_processes(
             [process.pid for process in process_to_kill], force=True)
         for process in process_to_kill:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR refactors multiple files within the Serve module to address type-checking errors and improve type annotations. Key changes include:

- Adjustments to method signatures and variable types in modules like autoscalers.py and replica_managers.py for better type safety.
- Modifications to ensure consistent use of `aiohttp.ClientTimeout` in load_balancer.py to prevent timeouts.
- Refactoring of methods in serve_state.py to make paths considered as `str` rather than `str | Path` using helper functions.
- Cleaning up and streamlining processes in service.py for managing service states and cleanup tasks.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
