### PR TITLE
[Performance] Use new GCP custom images

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -95,9 +95,10 @@ _IMAGE_NOT_FOUND_UX_MESSAGE = (
 )
 
 # Image ID tags
-DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-2204'
-DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
-DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
+_DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-2204'
+# For GPU-related package version, see sky/clouds/service_catalog/images/provisioners/cuda.sh
+_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
+_DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
 
 
 def _run_output(cmd):
@@ -427,7 +428,7 @@ class GCP(clouds.Cloud):
         # --no-standard-images
         # We use the debian image, as the ubuntu image has some connectivity
         # issue when first booted.
-        image_id = DEFAULT_CPU_IMAGE_ID
+        image_id = _DEFAULT_CPU_IMAGE_ID
 
         def _failover_disk_tier() -> Optional[resources_utils.DiskTier]:
             if (r.disk_tier is not None and
@@ -492,10 +493,10 @@ class GCP(clouds.Cloud):
                     # Though the image is called cu113, it actually has later
                     # versions of CUDA as noted below.
                     # CUDA driver version 470.57.02, CUDA Library 11.4
-                    image_id = DEFAULT_GPU_K80_IMAGE_ID
+                    image_id = _DEFAULT_GPU_K80_IMAGE_ID
                 else:
                     # CUDA driver version 535.86.10, CUDA Library 12.2
-                    image_id = DEFAULT_GPU_IMAGE_ID
+                    image_id = _DEFAULT_GPU_IMAGE_ID
 
         if (resources.image_id is not None and
                 resources.extract_docker_image() is None):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -94,6 +94,11 @@ _IMAGE_NOT_FOUND_UX_MESSAGE = (
     f'\nTo query common AI images: {colorama.Style.BRIGHT}gcloud compute images list --project deeplearning-platform-release | less{colorama.Style.RESET_ALL}'
 )
 
+# Image ID tags
+DEFAULT_CPU_IMAGE_ID = 'skypilot:cpu-debian-11'
+DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
+DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-debian-11'
+
 
 def _run_output(cmd):
     proc = subprocess.run(cmd,
@@ -422,7 +427,7 @@ class GCP(clouds.Cloud):
         # --no-standard-images
         # We use the debian image, as the ubuntu image has some connectivity
         # issue when first booted.
-        image_id = 'skypilot:cpu-debian-11'
+        image_id = DEFAULT_CPU_IMAGE_ID
 
         def _failover_disk_tier() -> Optional[resources_utils.DiskTier]:
             if (r.disk_tier is not None and
@@ -487,10 +492,10 @@ class GCP(clouds.Cloud):
                     # Though the image is called cu113, it actually has later
                     # versions of CUDA as noted below.
                     # CUDA driver version 470.57.02, CUDA Library 11.4
-                    image_id = 'skypilot:k80-debian-10'
+                    image_id = DEFAULT_GPU_K80_IMAGE_ID
                 else:
                     # CUDA driver version 535.86.10, CUDA Library 12.2
-                    image_id = 'skypilot:gpu-debian-11'
+                    image_id = DEFAULT_GPU_IMAGE_ID
 
         if (resources.image_id is not None and
                 resources.extract_docker_image() is None):

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -95,9 +95,9 @@ _IMAGE_NOT_FOUND_UX_MESSAGE = (
 )
 
 # Image ID tags
-DEFAULT_CPU_IMAGE_ID = 'skypilot:cpu-debian-11'
+DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-2204'
 DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
-DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-debian-11'
+DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
 
 
 def _run_output(cmd):

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -153,8 +153,8 @@ CONDA_INSTALLATION_COMMANDS = (
     # We use --system-site-packages to reuse the system site packages to avoid
     # the overhead of installing the same packages in the new environment.
     f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || '
-    f'{{ {SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages && '
-    f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE}; }};'
+    f'{SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages;'
+    f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE};'
 )
 
 _sky_version = str(version.parse(sky.__version__))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Use the new custom image for GCP's GPU VM creation. 

Benchmark results:
|  VM Type 💻   | Old Provision 🕐                 | New Provision 🕐     | % Improvement ✅ |
| --------------- | ---------------------------- | ----------- | ----------- |
| GCP GPU      | 3min 35s      | 1min 15s    | 65% |
| AWS GPU       | 3min 30s     | 2min 20s | 30% |
| GCP CPU       | 1min 45s   | 1min 10s | 32% |
* Provision Time = from start of launching an instance to instance setup and ready to run any user workloads (does not include time to search for the available instance)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x]  [GCP] Run all smoke tests `pytest tests/test_smoke.py --gcp`
