### PR TITLE
[docs] Add docs for internal load balancers on k8s

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -55,14 +55,14 @@ These load balancers will be automatically terminated when the cluster is delete
 Internal Load Balancers
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `Internal Load Balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
+To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `internal load balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
 
 Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/config.yaml``):
 
 .. tab-set::
 
     .. tab-item:: GKE
-        :sync: internal-service-gke
+        :sync: internal-lb-gke
 
         .. code-block:: yaml
 
@@ -73,7 +73,7 @@ Depending on your cloud, set the appropriate annotation in the SkyPilot config f
                    networking.gke.io/load-balancer-type: "Internal"
 
     .. tab-item:: AWS
-        :sync: internal-service-gke
+        :sync: internal-lb-aws
 
         .. code-block:: yaml
 
@@ -84,7 +84,7 @@ Depending on your cloud, set the appropriate annotation in the SkyPilot config f
                   service.beta.kubernetes.io/aws-load-balancer-internal: "true"
 
     .. tab-item:: Azure
-        :sync: internal-service-gke
+        :sync: internal-lb-azure
 
         .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -52,10 +52,10 @@ These load balancers will be automatically terminated when the cluster is delete
 
     To work around this issue, make sure all your ports have services running behind them.
 
-Internal LoadBalancers
-^^^^^^^^^^^^^^^^^^^^^^
+Internal Load Balancers
+^^^^^^^^^^^^^^^^^^^^^^^
 
-To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `Internal LoadBalancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
+To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `Internal Load Balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
 
 Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/config.yaml``):
 

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -1,7 +1,7 @@
 .. _kubernetes-ports:
 
 Exposing Services on Kubernetes
--------------------------------
+===============================
 
 .. note::
     This is a guide on how to configure an existing Kubernetes cluster (along with the caveats involved) to successfully expose ports and services externally through SkyPilot.
@@ -23,7 +23,7 @@ If your cluster does not support LoadBalancer services, SkyPilot can also use `a
 .. _kubernetes-loadbalancer:
 
 LoadBalancer Service
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 This mode exposes ports through a Kubernetes `LoadBalancer Service <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`__. This is the default mode used by SkyPilot.
 
@@ -52,11 +52,53 @@ These load balancers will be automatically terminated when the cluster is delete
 
     To work around this issue, make sure all your ports have services running behind them.
 
+Internal LoadBalancers
+^^^^^^^^^^^^^^^^^^^^^^
+
+To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `Internal LoadBalancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
+
+Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/config.yaml``):
+
+.. tab-set::
+
+    .. tab-item:: GKE
+        :sync: internal-service-gke
+
+        .. code-block:: yaml
+
+          # ~/.sky/config.yaml
+          kubernetes:
+            custom_metadata:
+                annotations:
+                   networking.gke.io/load-balancer-type: "Internal"
+
+    .. tab-item:: AWS
+        :sync: internal-service-gke
+
+        .. code-block:: yaml
+
+          # ~/.sky/config.yaml
+          kubernetes:
+            custom_metadata:
+                annotations:
+                  service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+
+    .. tab-item:: Azure
+        :sync: internal-service-gke
+
+        .. code-block:: yaml
+
+          # ~/.sky/config.yaml
+          kubernetes:
+            custom_metadata:
+                annotations:
+                  service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+
 
 .. _kubernetes-ingress:
 
 Nginx Ingress
-^^^^^^^^^^^^^
+-------------
 
 This mode exposes ports by creating a Kubernetes `Ingress <https://kubernetes.io/docs/concepts/services-networking/ingress/>`_ backed by an existing `Nginx Ingress Controller <https://kubernetes.github.io/ingress-nginx/>`_.
 

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -61,7 +61,7 @@ Depending on your cloud, set the appropriate annotation in the SkyPilot config f
 
 .. tab-set::
 
-    .. tab-item:: GKE
+    .. tab-item:: GCP
         :sync: internal-lb-gke
 
         .. code-block:: yaml


### PR DESCRIPTION
Adds docs for internal load balancers for AWS, GCP and Azure. 

- [x] Docs rendered locally.