### PR TITLE
[Performance] Add script for GCP custom OS image generation

### DIFF
--- a/sky/clouds/service_catalog/os_image/README.md
+++ b/sky/clouds/service_catalog/os_image/README.md
@@ -2,7 +2,7 @@
 
 ## GCP
 The following is an example of generating a custom skypilot image for GPU instance running Debian 11 OS.
-1. Use SkyPilot to launch a VM \
+1. Use SkyPilot to launch a VM
 <!-- `sky launch sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml` -->
 ```bash
 CLUSTER_NAME="image-creation"
@@ -10,7 +10,7 @@ ZONE="us-west1-a"
 sky launch -c $CLUSTER_NAME --zone $ZONE sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
 ```
 
-2. Stop the VM, create a custom image and make it public \
+2. Stop the VM, create a custom image and make it public
 ```
 sky stop $CLUSTER_NAME -y
 IMAGE_NAME="skypilot-gcp-gpu-debian-11-v$(date +'%y%m%d')"
@@ -24,12 +24,15 @@ gcloud compute images add-iam-policy-binding ${IMAGE_NAME} --member='allAuthenti
 echo "Image ID projects/sky-dev-465/global/images/${IMAGE_NAME} is created and public."
 ```
 
-3. [Optional] Test the image: change default image ID in `sky/clouds/gcp.py` to the new image ID and run \
+3. [Optional] Test the image: change default image ID in `sky/clouds/gcp.py` to the new image ID and run
 ```bash
 pytest tests/test_smoke.py::test_huggingface --gcp
 ```
 
-4. Clean up: delete deprecated images and stop sky cluster \
-`sky down -y ${CLUSTER_NAME}`
+4. Clean up: delete deprecated images and stop sky cluster
+```bash
+sky down -y ${CLUSTER_NAME}
+```
 
 5. Create a PR to update SkyPilot Catalog's latest version of [`images.csv`](https://github.com/skypilot-org/skypilot-catalog/blob/master/catalogs/v5/gcp/images.csv): update row for tag `skypilot:custom-gpu-debian-11`.
+

--- a/sky/clouds/service_catalog/os_image/README.md
+++ b/sky/clouds/service_catalog/os_image/README.md
@@ -1,0 +1,17 @@
+# Custom OS Image Generation for SkyPilot
+
+## GCP
+The following is an example of generating a custom skypilot image for GPU instance running Debian 11 OS.
+1. Use SkyPilot to launch a VM \
+`sky launch sky/clouds/os_image/skypilot-gcp-gpu-debian-11.yaml`
+
+2. Stop the VM and create a custom image with name *skypilot-gcp-gpu-debian-11-v{YYMMDD}* \
+`gcloud compute images create ${IMAGE_NAME} --source-disk=${VM_BOOT_DISK_NAME} --source-disk-zone=${VM_ZONE} --family=skypilot-gpu --storage-location=us`
+
+3. Make image public so that any authenticated GCP user can use it \
+`gcloud compute images add-iam-policy-binding ${IMAGE_NAME} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'`
+
+4. Create a PR to update SkyPilot Catalog's latest version of [`images.csv`](https://github.com/skypilot-org/skypilot-catalog/blob/master/catalogs/v5/gcp/images.csv): update the ImageId for tag `skypilot:custom-gpu-debian-11`.
+
+5. Clean up: delete deprecated images and stop sky cluster \
+`sky stop ${CLUSTER_NAME}`

--- a/sky/clouds/service_catalog/os_image/README.md
+++ b/sky/clouds/service_catalog/os_image/README.md
@@ -3,15 +3,33 @@
 ## GCP
 The following is an example of generating a custom skypilot image for GPU instance running Debian 11 OS.
 1. Use SkyPilot to launch a VM \
-`sky launch sky/clouds/os_image/skypilot-gcp-gpu-debian-11.yaml`
+<!-- `sky launch sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml` -->
+```bash
+CLUSTER_NAME="image-creation"
+ZONE="us-west1-a"
+sky launch -c $CLUSTER_NAME --zone $ZONE sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
+```
 
-2. Stop the VM and create a custom image with name *skypilot-gcp-gpu-debian-11-v{YYMMDD}* \
-`gcloud compute images create ${IMAGE_NAME} --source-disk=${VM_BOOT_DISK_NAME} --source-disk-zone=${VM_ZONE} --family=skypilot-gpu --storage-location=us`
+2. Stop the VM, create a custom image and make it public \
+```
+sky stop $CLUSTER_NAME -y
+IMAGE_NAME="skypilot-gcp-gpu-debian-11-v$(date +'%y%m%d')"
+VM_BOOT_DISK_NAME=$(gcloud compute instances list --filter="labels.skypilot-cluster-name=$CLUSTER_NAME" --format="value(name)")
+gcloud compute images create ${IMAGE_NAME} \
+  --source-disk=${VM_BOOT_DISK_NAME} \
+  --source-disk-zone=${ZONE} \
+  --family=skypilot-gpu \
+  --storage-location=us
+gcloud compute images add-iam-policy-binding ${IMAGE_NAME} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+echo "Image ID projects/sky-dev-465/global/images/${IMAGE_NAME} is created and public."
+```
 
-3. Make image public so that any authenticated GCP user can use it \
-`gcloud compute images add-iam-policy-binding ${IMAGE_NAME} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'`
+3. [Optional] Test the image: change default image ID in `sky/clouds/gcp.py` to the new image ID and run \
+```bash
+pytest tests/test_smoke.py::test_huggingface --gcp
+```
 
-4. Create a PR to update SkyPilot Catalog's latest version of [`images.csv`](https://github.com/skypilot-org/skypilot-catalog/blob/master/catalogs/v5/gcp/images.csv): update the ImageId for tag `skypilot:custom-gpu-debian-11`.
+4. Clean up: delete deprecated images and stop sky cluster \
+`sky down -y ${CLUSTER_NAME}`
 
-5. Clean up: delete deprecated images and stop sky cluster \
-`sky stop ${CLUSTER_NAME}`
+5. Create a PR to update SkyPilot Catalog's latest version of [`images.csv`](https://github.com/skypilot-org/skypilot-catalog/blob/master/catalogs/v5/gcp/images.csv): update row for tag `skypilot:custom-gpu-debian-11`.

--- a/sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
+++ b/sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
@@ -1,10 +1,13 @@
 resources:
   cloud: gcp
   accelerators: L4:1
-  use_spot: True
   disk_size: 50
+  # This is the base image, need to keep it up to date.
   image_id: projects/deeplearning-platform-release/global/images/common-cu121-v20231105-debian-11-py310
 
 setup: |
-  sudo rm -rf /home/gcpuser/.config/gcloud/
-  sudo rm /home/gcpuser/.sky/user_hash
+  sudo rm -rf /home/gcpuser/.config/gcloud
+  sudo rm -rf /home/gcpuser/.sky
+  sudo rm -rf /home/gcpuser/.aws
+  sudo rm -rf /home/gcpuser/.azure
+  sudo rm -rf /home/gcpuser/.ssh

--- a/sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
+++ b/sky/clouds/service_catalog/os_image/skypilot-gcp-gpu-debian-11.yaml
@@ -1,0 +1,10 @@
+resources:
+  cloud: gcp
+  accelerators: L4:1
+  use_spot: True
+  disk_size: 50
+  image_id: projects/deeplearning-platform-release/global/images/common-cu121-v20231105-debian-11-py310
+
+setup: |
+  sudo rm -rf /home/gcpuser/.config/gcloud/
+  sudo rm /home/gcpuser/.sky/user_hash

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -154,9 +154,8 @@ CONDA_INSTALLATION_COMMANDS = (
     # Create a separate conda environment for SkyPilot dependencies.
     # We use --system-site-packages to reuse the system site packages to avoid
     # the overhead of installing the same packages in the new environment.
-    f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || '
-    f'{{ {SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages && '
-    f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE}; }};'
+    f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || {SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages;'
+    f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE};'
 )
 
 _sky_version = str(version.parse(sky.__version__))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. Create script and guide on how to generate a skypilot custom image for GCP
2. Edit setup command to generate `~/.sky/python_path` regardless of whether `~/skypilot-runtime` exists

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] E2e testing: followed the README to create image
- [x] E2e testing: use the new image to run smoke test: `pytest tests/test_smoke.py::test_huggingface --gcp`
