### PR TITLE
[Serve] Refactor replica record handling using enum

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1,8 +1,6 @@
 """ReplicaManager: handles the creation and deletion of endpoint replicas."""
 import dataclasses
 import enum
-from enum import auto
-from enum import Enum
 import functools
 import multiprocessing
 from multiprocessing import pool as mp_pool
@@ -821,14 +819,14 @@ class SkyPilotReplicaManager(ReplicaManager):
     # ReplicaManager Daemon Threads #
     #################################
 
-    class ReplicaRecordAction(Enum):
-        KEEP = auto()
-        REMOVE_SCALE_DOWN = auto()
-        REMOVE_PREEMPTION = auto()
-        REMOVE_VERSION_MISMATCH = auto()
+    class ReplicaRecordAction(str, enum.Enum):
+        KEEP = 'keep the error record'
+        REMOVE_SCALE_DOWN = 'for scale down normally'
+        REMOVE_PREEMPTION = 'for preemption recovery'
+        REMOVE_VERSION_MISMATCH = 'remove_version_mismatch'
 
-    def get_replica_record_action(self,
-                                  info: ReplicaInfo) -> ReplicaRecordAction:
+    def _get_replica_record_action(self,
+                                   info: ReplicaInfo) -> ReplicaRecordAction:
         if info.status_property.is_scale_down:
             # This means the cluster is deleted due to an autoscaler
             # decision or the cluster is recovering from preemption.
@@ -919,7 +917,7 @@ class SkyPilotReplicaManager(ReplicaManager):
                 # TODO(tian): Currently, restart replicas that failed within
                 # initial_delay_seconds is not supported. We should add it
                 # later when we support `sky serve update`.
-                action = self.get_replica_record_action(info)
+                action = self._get_replica_record_action(info)
                 if action == self.ReplicaRecordAction.KEEP:
                     logger.info(f'Termination of replica {replica_id} '
                                 'finished. Replica info is kept since some '

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1,6 +1,8 @@
 """ReplicaManager: handles the creation and deletion of endpoint replicas."""
 import dataclasses
 import enum
+from enum import auto
+from enum import Enum
 import functools
 import multiprocessing
 from multiprocessing import pool as mp_pool
@@ -10,7 +12,6 @@ import time
 import traceback
 import typing
 from typing import Any, Dict, List, Optional, Tuple
-from enum import auto, Enum
 
 import colorama
 import psutil
@@ -826,7 +827,8 @@ class SkyPilotReplicaManager(ReplicaManager):
         REMOVE_PREEMPTION = auto()
         REMOVE_VERSION_MISMATCH = auto()
 
-    def get_replica_record_action(self, info: ReplicaInfo) -> ReplicaRecordAction:
+    def get_replica_record_action(self,
+                                  info: ReplicaInfo) -> ReplicaRecordAction:
         if info.status_property.is_scale_down:
             # This means the cluster is deleted due to an autoscaler
             # decision or the cluster is recovering from preemption.
@@ -839,7 +841,6 @@ class SkyPilotReplicaManager(ReplicaManager):
             # since user should fixed the error before update.
             return self.ReplicaRecordAction.REMOVE_VERSION_MISMATCH
         return self.ReplicaRecordAction.KEEP
-
 
     @with_lock
     def _refresh_process_pool(self) -> None:


### PR DESCRIPTION
This PR introduces the following improvements:

1. Replaces the unclear condition:
   ```python
   if removal_reason is not None:
   ```
   with a more explicit enum-based approach. 
2. Adds a `ReplicaRecordAction` enum to clearly define possible actions for replica records.
3. Refactors the logic for determining replica record actions into a separate function.
4. Simplifies the main code flow by using the new enum and function.

These changes make the replica management process more explicit and easier to extend in the future.