### PR TITLE
Stop using deprecated `on_event()` decorator

### DIFF
--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -53,7 +53,7 @@ class SkyServeController:
         self._app = fastapi.FastAPI(lifespan=self.lifespan)
 
     @contextlib.asynccontextmanager
-    async def lifespan(self, _app: fastapi.FastAPI):
+    async def lifespan(self, _: fastapi.FastAPI):
         uvicorn_access_logger = logging.getLogger('uvicorn.access')
         for handler in uvicorn_access_logger.handlers:
             handler.setFormatter(sky_logging.FORMATTER)

--- a/sky/serve/controller.py
+++ b/sky/serve/controller.py
@@ -2,6 +2,7 @@
 
 Responsible for autoscaling and replica management.
 """
+import contextlib
 import logging
 import threading
 import time
@@ -51,7 +52,8 @@ class SkyServeController:
         self._port = port
         self._app = fastapi.FastAPI(lifespan=self.lifespan)
 
-    async def lifespan(self, app: fastapi.FastAPI):
+    @contextlib.asynccontextmanager
+    async def lifespan(self, _app: fastapi.FastAPI):
         uvicorn_access_logger = logging.getLogger('uvicorn.access')
         for handler in uvicorn_access_logger.handlers:
             handler.setFormatter(sky_logging.FORMATTER)


### PR DESCRIPTION
Fixes #3997

Replace deprecated `@app.on_event('startup')` decorator with lifespan event handler in `sky/serve/controller.py`.

* Remove the `@app.on_event('startup')` decorator.
* Add a lifespan event handler to configure the logger.
* Update the `SkyServeController` class to use the lifespan event handler.

