### PR TITLE
[k8s] Add `sky status` flag to query global Kubernetes status

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -53,7 +53,6 @@ from sky import core
 from sky import exceptions
 from sky import global_user_state
 from sky import jobs as managed_jobs
-from sky import resources as resources_lib
 from sky import serve as serve_lib
 from sky import sky_logging
 from sky import status_lib
@@ -1501,8 +1500,8 @@ def _status_kubernetes(show_all: bool):
     click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                f'Kubernetes cluster state (context: {context})'
                f'{colorama.Style.RESET_ALL}')
-    status_utils.show_kubernetes_cluster_status_table(
-        unmanaged_clusters, show_all)
+    status_utils.show_kubernetes_cluster_status_table(unmanaged_clusters,
+                                                      show_all)
     if all_jobs:
         click.echo(f'\n{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                    f'Managed jobs from {len(jobs_controllers)} users'
@@ -1512,7 +1511,7 @@ def _status_kubernetes(show_all: bool):
     if serve_controllers:
         # TODO: Parse serve controllers and show services separately.
         #  Currently we show a hint that services are shown as clusters.
-        click.echo(f'\nHint: SkyServe controllers detected in the cluster. '
+        click.echo('\nHint: SkyServe controllers detected in the cluster. '
                    'SkyServe service replicas will be shown as SkyPilot '
                    'clusters')
 
@@ -1563,7 +1562,8 @@ def _status_kubernetes(show_all: bool):
               required=False,
               help='Also show sky serve services, if any.')
 @click.option(
-    '--kubernetes', '--k8s',
+    '--kubernetes',
+    '--k8s',
     default=False,
     is_flag=True,
     required=False,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1473,7 +1473,7 @@ def _process_skypilot_pods(
             '-', 1
         )[0]  # Remove the user hash to get cluster name (e.g., mycluster-2ea4)
 
-        # Check if name is name of a controller
+        # Check if cluster name is name of a controller
         # Can't use controller_utils.Controllers.from_name(cluster_name)
         # because hash is different across users
         if 'controller' in cluster_name_on_cloud:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1459,6 +1459,11 @@ def _get_services(service_names: Optional[List[str]],
 
 
 def _status_kubernetes(show_all: bool):
+    """Show all SkyPilot resources in the current Kubernetes context.
+
+    Args:
+        show_all (bool): Show all job information (e.g., start time, failures).
+    """
     context = kubernetes_utils.get_current_kube_config_context_name()
     try:
         pods = kubernetes_utils.get_skypilot_pods(context)
@@ -1479,7 +1484,8 @@ def _status_kubernetes(show_all: bool):
                 status_message += f's ({i+1}/{len(jobs_controllers)})'
             spinner.update(f'{status_message}[/]')
             try:
-                job_list = managed_jobs.queue_kubernetes(pod.metadata.name)
+                job_list = managed_jobs.queue_from_kubernetes_pod(
+                    pod.metadata.name)
             except RuntimeError as e:
                 logger.warning('Failed to get managed jobs from controller '
                                f'{pod.metadata.name}: {str(e)}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3185,8 +3185,8 @@ def show_gpus(
                     context = region
                 else:
                     # If region is not specified, we use the current context
-                    context = (kubernetes_utils.
-                               get_current_kube_config_context_name())
+                    context = (
+                        kubernetes_utils.get_current_kube_config_context_name())
                 try:
                     # If --cloud kubernetes is not specified, we want to catch
                     # the case where no GPUs are available on the cluster and

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1732,10 +1732,9 @@ def status(all: bool, refresh: bool, ip: bool, endpoints: bool,
             unmanaged_clusters, all)
 
         if all_jobs:
-            click.echo(
-                f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                f'Managed jobs from {len(jobs_controllers)} users'
-                f'{colorama.Style.RESET_ALL}')
+            click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+                       f'Managed jobs from {len(jobs_controllers)} users'
+                       f'{colorama.Style.RESET_ALL}')
             msg = managed_jobs.format_job_table(all_jobs, show_all=all)
             click.echo(msg)
         return

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3184,7 +3184,9 @@ def show_gpus(
                 if region:
                     context = region
                 else:
-                    context = kubernetes_utils.get_current_kube_config_context_name()
+                    # If region is not specified, we use the current context
+                    context = (kubernetes_utils.
+                               get_current_kube_config_context_name())
                 try:
                     # If --cloud kubernetes is not specified, we want to catch
                     # the case where no GPUs are available on the cluster and

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3181,7 +3181,10 @@ def show_gpus(
             print_section_titles = False
             # If cloud is kubernetes, we want to show real-time capacity
             if kubernetes_is_enabled and (cloud is None or cloud_is_kubernetes):
-                context = region
+                if region:
+                    context = region
+                else:
+                    context = kubernetes_utils.get_current_kube_config_context_name()
                 try:
                     # If --cloud kubernetes is not specified, we want to catch
                     # the case where no GPUs are available on the cluster and
@@ -3196,7 +3199,7 @@ def show_gpus(
                 else:
                     print_section_titles = True
                     yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                           f'Kubernetes GPUs (Context: {context})'
+                           f'Kubernetes GPUs (context: {context})'
                            f'{colorama.Style.RESET_ALL}\n')
                     yield from k8s_realtime_table.get_string()
                     k8s_node_table = _get_kubernetes_node_info_table(context)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1474,12 +1474,16 @@ def _status_kubernetes(show_all: bool):
         for i, (_, job_controller_info) in enumerate(jobs_controllers.items()):
             user = job_controller_info['user']
             pod = job_controller_info['pods'][0]
-            status_message = ('[bold cyan]Checking in-progress '
-                              f'managed jobs for {user}')
+            status_message = ('[bold cyan]Checking managed jobs controller')
             if len(jobs_controllers) > 1:
-                status_message += f' ({i+1}/{len(jobs_controllers)})'
+                status_message += f's ({i+1}/{len(jobs_controllers)})'
             spinner.update(f'{status_message}[/]')
-            job_list = managed_jobs.queue_kubernetes(pod.metadata.name)
+            try:
+                job_list = managed_jobs.queue_kubernetes(pod.metadata.name)
+            except RuntimeError as e:
+                logger.warning('Failed to get managed jobs from controller '
+                               f'{pod.metadata.name}: {str(e)}')
+                job_list = []
             # Add user field to jobs
             for job in job_list:
                 job['user'] = user

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1688,7 +1688,7 @@ def status(all: bool, refresh: bool, ip: bool, endpoints: bool,
                 raise ValueError(
                     f'Failed to get SkyPilot pods from Kubernetes: {str(e)}')
 
-        clusters, jobs_controllers, serve_controllers = _process_skypilot_pods(
+        all_clusters, jobs_controllers, serve_controllers = _process_skypilot_pods(
             pods, context)
 
         all_jobs = []
@@ -1720,7 +1720,7 @@ def status(all: bool, refresh: bool, ip: bool, endpoints: bool,
             managed_job_cluster_names.add(managed_cluster_name)
 
         unmanaged_clusters = [
-            c for c in clusters
+            c for c in all_clusters
             if c['cluster_name'] not in managed_job_cluster_names
         ]
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1463,7 +1463,6 @@ def _process_skypilot_pods(
     pods: List[Any],
     context: Optional[str] = None
 ) -> Tuple[List[Dict[Any, Any]], Dict[str, Any], Dict[str, Any]]:
-    """Process SkyPilot pods and group them by cluster."""
     clusters: Dict[str, Dict] = {}
     jobs_controllers: Dict[str, Dict] = {}
     serve_controllers: Dict[str, Dict] = {}

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1513,7 +1513,7 @@ def _status_kubernetes(show_all: bool):
         #  Currently we show a hint that services are shown as clusters.
         click.echo('\nHint: SkyServe controllers detected in the cluster. '
                    'SkyServe service replicas will be shown as SkyPilot '
-                   'clusters')
+                   'clusters.')
 
 
 @cli.command()

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -6,10 +6,11 @@ from typing import Any, Dict, List
 
 import colorama
 
+import sky.utils.common_utils
 from sky import exceptions
 from sky import sky_logging
+from sky.utils import common_utils
 from sky.utils import log_utils
-from sky.utils.cli_utils import status_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -43,8 +44,8 @@ def format_storage_table(storages: List[Dict[str, Any]],
         if show_all:
             command = row['last_use']
         else:
-            command = status_utils.truncate_long_string(
-                row['last_use'], status_utils.COMMAND_TRUNC_LENGTH)
+            command = sky.utils.common_utils.truncate_long_string(
+                row['last_use'], common_utils.COMMAND_TRUNC_LENGTH)
         storage_table.add_row([
             # NAME
             row['name'],

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -21,7 +21,7 @@ _FILE_EXCLUSION_FROM_GITIGNORE_FAILURE_MSG = (
     'to the cloud storage for {path!r}'
     'due to the following error: {error_msg!r}')
 
-LAST_USE_TRUNC_LENGTH = 25
+_LAST_USE_TRUNC_LENGTH = 25
 
 
 def format_storage_table(storages: List[Dict[str, Any]],
@@ -48,7 +48,7 @@ def format_storage_table(storages: List[Dict[str, Any]],
             command = row['last_use']
         else:
             command = common_utils.truncate_long_string(row['last_use'],
-                                                        LAST_USE_TRUNC_LENGTH)
+                                                        _LAST_USE_TRUNC_LENGTH)
         storage_table.add_row([
             # NAME
             row['name'],

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List
 
 import colorama
 
-import sky.utils.common_utils
 from sky import exceptions
 from sky import sky_logging
 from sky.utils import common_utils
@@ -19,6 +18,8 @@ _FILE_EXCLUSION_FROM_GITIGNORE_FAILURE_MSG = (
     'specified in .gitignore will be uploaded '
     'to the cloud storage for {path!r}'
     'due to the following error: {error_msg!r}')
+
+LAST_USE_TRUNC_LENGTH = 25
 
 
 def format_storage_table(storages: List[Dict[str, Any]],
@@ -44,8 +45,8 @@ def format_storage_table(storages: List[Dict[str, Any]],
         if show_all:
             command = row['last_use']
         else:
-            command = sky.utils.common_utils.truncate_long_string(
-                row['last_use'], common_utils.COMMAND_TRUNC_LENGTH)
+            command = common_utils.truncate_long_string(row['last_use'],
+                                                        LAST_USE_TRUNC_LENGTH)
         storage_table.add_row([
             # NAME
             row['name'],

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -8,6 +8,7 @@ from sky.jobs.constants import JOBS_TASK_YAML_PREFIX
 from sky.jobs.core import cancel
 from sky.jobs.core import launch
 from sky.jobs.core import queue
+from sky.jobs.core import queue_kubernetes
 from sky.jobs.core import tail_logs
 from sky.jobs.recovery_strategy import DEFAULT_RECOVERY_STRATEGY
 from sky.jobs.recovery_strategy import RECOVERY_STRATEGIES
@@ -34,6 +35,7 @@ __all__ = [
     'cancel',
     'launch',
     'queue',
+    'queue_kubernetes',
     'tail_logs',
     # utils
     'ManagedJobCodeGen',

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -8,7 +8,7 @@ from sky.jobs.constants import JOBS_TASK_YAML_PREFIX
 from sky.jobs.core import cancel
 from sky.jobs.core import launch
 from sky.jobs.core import queue
-from sky.jobs.core import queue_kubernetes
+from sky.jobs.core import queue_from_kubernetes_pod
 from sky.jobs.core import tail_logs
 from sky.jobs.recovery_strategy import DEFAULT_RECOVERY_STRATEGY
 from sky.jobs.recovery_strategy import RECOVERY_STRATEGIES
@@ -35,7 +35,7 @@ __all__ = [
     'cancel',
     'launch',
     'queue',
-    'queue_kubernetes',
+    'queue_from_kubernetes_pod',
     'tail_logs',
     # utils
     'ManagedJobCodeGen',

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -168,7 +168,7 @@ def queue_kubernetes(pod_name: str,
         ]
 
     Raises:
-        RuntimeError: If there's an error fetching the managed jobs from the Kubernetes cluster.
+        RuntimeError: If there's an error fetching the managed jobs.
     """
     # Create dummy cluster info to get the command runner.
     provider_config = {'context': context}

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -153,15 +153,24 @@ def queue_kubernetes(pod_name: str,
     Returns:
 
     """
-    from sky.provision import common
     from sky import provision as provision_lib
+    from sky.provision import common
     cluster_name = pod_name.strip('-head').rsplit('-', 1)[0]
 
+    # Create dummy cluster info to get the command runner.
     provider_config = {'context': context}
-    instances = {pod_name: None}
-    cluster_info = common.ClusterInfo(provider_name='kubernetes', head_instance_id=pod_name, provider_config=provider_config, instances=instances)
-    managed_jobs_runner = provision_lib.get_command_runners('kubernetes',
-                                                            cluster_info)[0]
+    instances = {
+        pod_name: common.InstanceInfo(instance_id=pod_name,
+                                      internal_ip='',
+                                      external_ip='',
+                                      tags={})
+    }  # Internal IP is not required for Kubernetes
+    cluster_info = common.ClusterInfo(provider_name='kubernetes',
+                                      head_instance_id=pod_name,
+                                      provider_config=provider_config,
+                                      instances=instances)
+    managed_jobs_runner = provision_lib.get_command_runners(
+        'kubernetes', cluster_info)[0]
 
     code = managed_job_utils.ManagedJobCodeGen.get_job_table()
     returncode, job_table_payload, stderr = managed_jobs_runner.run(

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -140,9 +140,10 @@ def launch(
                    _disable_controller_check=True)
 
 
-def queue_kubernetes(pod_name: str,
-                     context: Optional[str] = None,
-                     skip_finished: bool = False) -> List[Dict[str, Any]]:
+def queue_from_kubernetes_pod(
+        pod_name: str,
+        context: Optional[str] = None,
+        skip_finished: bool = False) -> List[Dict[str, Any]]:
     """Gets the jobs queue from a specific controller pod.
 
     Args:

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -160,10 +160,12 @@ def queue_kubernetes(pod_name: str,
     # Create dummy cluster info to get the command runner.
     provider_config = {'context': context}
     instances = {
-        pod_name: common.InstanceInfo(instance_id=pod_name,
-                                      internal_ip='',
-                                      external_ip='',
-                                      tags={})
+        pod_name: [
+            common.InstanceInfo(instance_id=pod_name,
+                                internal_ip='',
+                                external_ip='',
+                                tags={})
+        ]
     }  # Internal IP is not required for Kubernetes
     cluster_info = common.ClusterInfo(provider_name='kubernetes',
                                       head_instance_id=pod_name,

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -147,8 +147,9 @@ def queue_kubernetes(pod_name: str,
 
     Args:
         pod_name (str): The name of the controller pod to query for jobs.
-        context (Optional[str]): The Kubernetes context to use. If None, the current context is used.
-        skip_finished (bool): If True, exclude finished jobs from the returned list.
+        context (Optional[str]): The Kubernetes context to use. If None, the
+            current context is used.
+        skip_finished (bool): If True, does not return finished jobs.
 
     Returns:
         [

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -138,12 +138,16 @@ def launch(
                    _disable_controller_check=True)
 
 
-def queue_kubernetes(pod_name: str, refresh: bool, skip_finished: bool = False) -> List[Dict[str, Any]]:
+def queue_kubernetes(pod_name: str,
+                     refresh: bool,
+                     context: Optional[str] = None,
+                     skip_finished: bool = False) -> List[Dict[str, Any]]:
     """Gets the jobs queue from the kubernetes cluster by reconstructing a cluster handle and running the appropriate code on the head node.
 
     Args:
         pod_name:
         refresh:
+        context: Kubernetes context to use
         skip_finished:
 
     Returns:
@@ -153,7 +157,7 @@ def queue_kubernetes(pod_name: str, refresh: bool, skip_finished: bool = False) 
     from sky import provision as provision_lib
     cluster_name = pod_name.strip('-head').rsplit('-', 1)[0]
 
-    provider_config = {} # TODO: Specify context and namespace here.
+    provider_config = {'context': context}
     instances = {pod_name: None}
     cluster_info = common.ClusterInfo(provider_name='kubernetes', head_instance_id=pod_name, provider_config=provider_config, instances=instances)
     managed_jobs_runner = provision_lib.get_command_runners('kubernetes',

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -143,16 +143,31 @@ def launch(
 def queue_kubernetes(pod_name: str,
                      context: Optional[str] = None,
                      skip_finished: bool = False) -> List[Dict[str, Any]]:
-    """Gets the jobs queue from the kubernetes cluster.
+    """Gets the jobs queue from a specific controller pod.
 
     Args:
-        pod_name:
-        refresh:
-        context: Kubernetes context to use
-        skip_finished:
+        pod_name (str): The name of the controller pod to query for jobs.
+        context (Optional[str]): The Kubernetes context to use. If None, the current context is used.
+        skip_finished (bool): If True, exclude finished jobs from the returned list.
 
     Returns:
+        [
+            {
+                'job_id': int,
+                'job_name': str,
+                'resources': str,
+                'submitted_at': (float) timestamp of submission,
+                'end_at': (float) timestamp of end,
+                'duration': (float) duration in seconds,
+                'recovery_count': (int) Number of retries,
+                'status': (sky.jobs.ManagedJobStatus) of the job,
+                'cluster_resources': (str) resources of the cluster,
+                'region': (str) region of the cluster,
+            }
+        ]
 
+    Raises:
+        RuntimeError: If there's an error fetching the managed jobs from the Kubernetes cluster.
     """
     # Create dummy cluster info to get the command runner.
     provider_config = {'context': context}

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -9,6 +9,7 @@ import colorama
 import sky
 from sky import backends
 from sky import exceptions
+from sky import provision as provision_lib
 from sky import sky_logging
 from sky import status_lib
 from sky import task as task_lib
@@ -16,6 +17,7 @@ from sky.backends import backend_utils
 from sky.clouds.service_catalog import common as service_catalog_common
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import utils as managed_job_utils
+from sky.provision import common
 from sky.skylet import constants as skylet_constants
 from sky.usage import usage_lib
 from sky.utils import admin_policy_utils
@@ -139,10 +141,9 @@ def launch(
 
 
 def queue_kubernetes(pod_name: str,
-                     refresh: bool,
                      context: Optional[str] = None,
                      skip_finished: bool = False) -> List[Dict[str, Any]]:
-    """Gets the jobs queue from the kubernetes cluster by reconstructing a cluster handle and running the appropriate code on the head node.
+    """Gets the jobs queue from the kubernetes cluster.
 
     Args:
         pod_name:
@@ -153,10 +154,6 @@ def queue_kubernetes(pod_name: str,
     Returns:
 
     """
-    from sky import provision as provision_lib
-    from sky.provision import common
-    cluster_name = pod_name.strip('-head').rsplit('-', 1)[0]
-
     # Create dummy cluster info to get the command runner.
     provider_config = {'context': context}
     instances = {

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -680,9 +680,9 @@ def format_job_table(
             if not managed_job_status.is_terminal():
                 status_str += f' (task: {current_task_id})'
 
+            job_id = job_hash[1] if tasks_have_user else job_hash
             job_values = [
-                job_hash[1]
-                if tasks_have_user else job_hash,  # TODO: Clean this up
+                job_id,
                 '',
                 job_name,
                 '-',

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -620,11 +620,6 @@ def format_job_table(
         if not managed_job_status.is_terminal():
             status_counts[managed_job_status.value] += 1
 
-    if max_jobs is not None:
-        job_ids = sorted(jobs.keys(), reverse=True)
-        job_ids = job_ids[:max_jobs]
-        jobs = {job_id: jobs[job_id] for job_id in job_ids}
-
     columns = [
         'ID', 'TASK', 'NAME', 'RESOURCES', 'SUBMITTED', 'TOT. DURATION',
         'JOB DURATION', '#RECOVERIES', 'STATUS'

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -613,7 +613,6 @@ def format_job_table(
         # The tasks within the same job_id are already sorted
         # by the task_id.
         jobs[get_hash(task)].append(task)
-    jobs = dict(jobs)
 
     status_counts: Dict[str, int] = collections.defaultdict(int)
     for job_tasks in jobs.values():

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -599,10 +599,20 @@ def format_job_table(
       a list of "rows" (each of which is a list of str).
     """
     jobs = collections.defaultdict(list)
+    # Check if the tasks have user information.
+    tasks_have_user = any([task.get('user') for task in tasks])
+    if max_jobs and tasks_have_user:
+        raise ValueError('max_jobs is not supported when tasks have user info.')
+
+    def get_hash(task):
+        if tasks_have_user:
+            return (task['user'], task['job_id'])
+        return task['job_id']
+
     for task in tasks:
         # The tasks within the same job_id are already sorted
         # by the task_id.
-        jobs[task['job_id']].append(task)
+        jobs[get_hash(task)].append(task)
     jobs = dict(jobs)
 
     status_counts: Dict[str, int] = collections.defaultdict(int)
@@ -622,6 +632,8 @@ def format_job_table(
     ]
     if show_all:
         columns += ['STARTED', 'CLUSTER', 'REGION', 'FAILURE']
+    if tasks_have_user:
+        columns.insert(0, 'USER')
     job_table = log_utils.create_table(columns)
 
     status_counts: Dict[str, int] = collections.defaultdict(int)
@@ -636,9 +648,9 @@ def format_job_table(
     for task in all_tasks:
         # The tasks within the same job_id are already sorted
         # by the task_id.
-        jobs[task['job_id']].append(task)
+        jobs[get_hash(task)].append(task)
 
-    for job_id, job_tasks in jobs.items():
+    for job_hash, job_tasks in jobs.items():
         if len(job_tasks) > 1:
             # Aggregate the tasks into a new row in the table.
             job_name = job_tasks[0]['job_name']
@@ -675,7 +687,7 @@ def format_job_table(
                 status_str += f' (task: {current_task_id})'
 
             job_values = [
-                job_id,
+                job_hash[1] if tasks_have_user else job_hash, # TODO: Clean this up
                 '',
                 job_name,
                 '-',
@@ -692,6 +704,8 @@ def format_job_table(
                     '-',
                     failure_reason if failure_reason is not None else '-',
                 ])
+            if tasks_have_user:
+                job_values.insert(0, job_tasks[0].get('user', '-'))
             job_table.add_row(job_values)
 
         for task in job_tasks:
@@ -724,6 +738,8 @@ def format_job_table(
                     task['failure_reason']
                     if task['failure_reason'] is not None else '-',
                 ])
+            if tasks_have_user:
+                values.insert(0, task.get('user', '-'))
             job_table.add_row(values)
 
         if len(job_tasks) > 1:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -687,7 +687,8 @@ def format_job_table(
                 status_str += f' (task: {current_task_id})'
 
             job_values = [
-                job_hash[1] if tasks_have_user else job_hash, # TODO: Clean this up
+                job_hash[1]
+                if tasks_have_user else job_hash,  # TODO: Clean this up
                 '',
                 job_name,
                 '-',

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2004,7 +2004,7 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
     """Gets all SkyPilot pods in the Kubernetes cluster.
 
     Args:
-        context: The Kubernetes context to use. If None, uses the current context.
+        context: Kubernetes context to use. If None, uses the current context.
 
     Returns:
         A list of Kubernetes pod objects.
@@ -2018,7 +2018,7 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
             _request_timeout=kubernetes.API_TIMEOUT).items
     except kubernetes.max_retry_error():
         raise exceptions.ResourcesUnavailableError(
-            'Timed out when trying to get SkyPilot pod info from Kubernetes cluster. '
+            'Timed out trying to get SkyPilot pods from Kubernetes cluster. '
             'Please check if the cluster is healthy and retry. To debug, run: '
             'kubectl get pods --selector=skypilot-cluster --all-namespaces'
         ) from None

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1998,3 +1998,26 @@ def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
         # we need to use in-cluster auth.
         context = None
     return context
+
+def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
+    """Gets all SkyPilot pods in the Kubernetes cluster.
+
+    Args:
+        context: The Kubernetes context to use. If None, uses the current context.
+
+    Returns:
+        A list of Kubernetes pod objects.
+    """
+    if context is None:
+        context = get_current_kube_config_context_name()
+
+    try:
+        pods = kubernetes.core_api(context).list_pod_for_all_namespaces(
+            label_selector='skypilot-cluster',
+            _request_timeout=kubernetes.API_TIMEOUT).items
+    except kubernetes.max_retry_error():
+        raise exceptions.ResourcesUnavailableError(
+            'Timed out when trying to get SkyPilot pod info from Kubernetes cluster. '
+            'Please check if the cluster is healthy and retry. To debug, run: '
+            'kubectl get pods --selector=skypilot-cluster --all-namespaces') from None
+    return pods

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1999,6 +1999,7 @@ def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
         context = None
     return context
 
+
 def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
     """Gets all SkyPilot pods in the Kubernetes cluster.
 
@@ -2019,5 +2020,6 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
         raise exceptions.ResourcesUnavailableError(
             'Timed out when trying to get SkyPilot pod info from Kubernetes cluster. '
             'Please check if the cluster is healthy and retry. To debug, run: '
-            'kubectl get pods --selector=skypilot-cluster --all-namespaces') from None
+            'kubectl get pods --selector=skypilot-cluster --all-namespaces'
+        ) from None
     return pods

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,13 +5,14 @@ import click
 import colorama
 
 from sky import backends
-from sky import status_lib
+from sky import clouds as sky_clouds
 from sky import resources as resources_lib
+from sky import status_lib
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import log_utils
 from sky.utils import resources_utils
-from sky.provision.kubernetes import utils as kubernetes_utils
 
 COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
@@ -345,8 +346,8 @@ def show_kubernetes_cluster_status_table(clusters: List[Any],
 
 
 def process_skypilot_pods(
-        pods: List[Any],
-        context: Optional[str] = None
+    pods: List[Any],
+    context: Optional[str] = None
 ) -> Tuple[List[Dict[Any, Any]], Dict[str, Any], Dict[str, Any]]:
     clusters: Dict[str, Dict] = {}
     jobs_controllers: Dict[str, Dict] = {}
@@ -429,7 +430,7 @@ def process_skypilot_pods(
             if pod_start_time is not None:
                 pod_start_time = pod_start_time.timestamp()
                 if pod_start_time < clusters[cluster_name_on_cloud][
-                    'launched_at']:
+                        'launched_at']:
                     clusters[cluster_name_on_cloud][
                         'launched_at'] = pod_start_time
         clusters[cluster_name_on_cloud]['pods'].append(pod)

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -318,7 +318,8 @@ def _get_estimated_cost_for_cost_report(
     return f'$ {cost:.2f}'
 
 
-def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
+def show_kubernetes_cluster_status_table(clusters: List[Any],
+                                         show_all: bool) -> None:
     """Compute cluster table values and display for Kubernetes clusters."""
     status_columns = [
         StatusColumn('USER', lambda c: c['user']),

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -323,7 +323,7 @@ def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
     """Compute cluster table values and display for Kubernetes clusters."""
     status_columns = [
         StatusColumn('USER', lambda c: c['user']),
-        StatusColumn('NAME', lambda c: c['name']),
+        StatusColumn('NAME', lambda c: c['cluster_name']),
         StatusColumn('LAUNCHED', lambda c: log_utils.readable_time_duration(c['launched_at'])),
         StatusColumn('RESOURCES', lambda c: c['resources_str'], trunc_length=70 if not show_all else 0),
         # StatusColumn('PODS', lambda c: len(c['pods'])),

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -342,13 +342,35 @@ def show_kubernetes_cluster_status_table(clusters: List[Any],
                    f'{colorama.Style.RESET_ALL}')
         click.echo(cluster_table)
     else:
-        click.echo('No existing SkyPilot clusters on Kubernetes.')
+        click.echo('No SkyPilot resources found in the '
+                   'active Kubernetes context.')
 
 
 def process_skypilot_pods(
     pods: List[Any],
     context: Optional[str] = None
 ) -> Tuple[List[Dict[Any, Any]], Dict[str, Any], Dict[str, Any]]:
+    """Process SkyPilot pods on k8s to extract cluster and controller info.
+
+    Args:
+        pods: List of Kubernetes pod objects.
+        context: Kubernetes context name, used to detect GPU label formatter.
+
+    Returns:
+        A tuple containing:
+        - List of dictionaries with cluster information.
+        - Dictionary of job controller information.
+        - Dictionary of serve controller information.
+
+        Each dictionary contains the following keys:
+            'cluster_name_on_cloud': The cluster_name_on_cloud used by SkyPilot
+            'cluster_name': The cluster name without the user hash
+            'user': The user who created the cluster. Fetched from pod label
+            'status': The cluster status (assumed UP if pod exists)
+            'pods': List of pod objects in the cluster
+            'launched_at': Timestamp of when the cluster was launched
+            'resources': sky.Resources object for the cluster
+    """
     clusters: Dict[str, Dict] = {}
     jobs_controllers: Dict[str, Dict] = {}
     serve_controllers: Dict[str, Dict] = {}

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -6,9 +6,11 @@ import colorama
 
 from sky import backends
 from sky import status_lib
+from sky import clouds
 from sky.skylet import constants
 from sky.utils import log_utils
 from sky.utils import resources_utils
+from sky.provision.kubernetes import utils as kubernetes_utils
 
 COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
@@ -316,3 +318,86 @@ def _get_estimated_cost_for_cost_report(
         return '-'
 
     return f'$ {cost:.2f}'
+
+def process_skypilot_pods(pods: List[Any]) -> List[Dict[str, Any]]:
+    """Process SkyPilot pods and group them by cluster."""
+    # pylint: disable=import-outside-toplevel
+    from sky import resources as resources_lib
+    clusters = {}
+    for pod in pods:
+        cluster_name = pod.metadata.labels.get('skypilot-cluster')
+        if cluster_name not in clusters:
+            # Parse the earliest start time for the cluster
+            start_time = pod.status.start_time
+            if start_time:
+                # Parse to unix timestamp and convert to int
+                start_time = start_time.timestamp()
+
+            # Parse resources
+            cpu_request = kubernetes_utils.parse_cpu_or_gpu_resource(pod.spec.containers[0].resources.requests.get('cpu', '0'))
+            memory_request = kubernetes_utils.parse_memory_resource(pod.spec.containers[0].resources.requests.get('memory', '0')) / 1073741824  # Convert to GiB
+            gpu_count = kubernetes_utils.parse_cpu_or_gpu_resource(pod.spec.containers[0].resources.requests.get('nvidia.com/gpu', '0'))
+            if gpu_count > 0:
+                # TODO: We should pass context here
+                context = None
+                label_formatter, _ = kubernetes_utils.detect_gpu_label_formatter(context)
+                gpu_label = label_formatter.get_label_key()
+                # Get GPU name from pod node selector
+                if pod.spec.node_selector is not None:
+                    gpu_name = label_formatter.get_accelerator_from_label_value(
+                        pod.spec.node_selector.get(gpu_label))
+            
+            resources = resources_lib.Resources(
+                cloud=clouds.Kubernetes(),
+                cpus=float(cpu_request),
+                memory=memory_request,
+                accelerators=(f'{gpu_name}:{gpu_count}' if gpu_count > 0 else None)
+            )
+
+            clusters[cluster_name] = {
+                'name': cluster_name,
+                'user': pod.metadata.labels.get('skypilot-user'),
+                'status': status_lib.ClusterStatus.UP,  # Assuming UP if pod exists
+                'pods': [],
+                'launched_at': start_time,
+                'resources': resources,
+                'resources_str': f'{len(pods)}x {resources}',
+            }
+        else:
+            # Update start_time if this pod started earlier
+            pod_start_time = pod.status.start_time
+            if pod_start_time:
+                pod_start_time = pod_start_time.replace(tzinfo=None)
+                if pod_start_time < clusters[cluster_name]['launched_at']:
+                    clusters[cluster_name]['launched_at'] = pod_start_time
+
+        clusters[cluster_name]['pods'].append(pod)
+    return list(clusters.values())
+
+def show_kubernetes_status_table(pods: List[Any], show_all: bool) -> None:
+    """Compute cluster table values and display for Kubernetes clusters."""
+    status_columns = [
+        StatusColumn('NAME', lambda c: c['name']),
+        StatusColumn('USER', lambda c: c['user']),
+        StatusColumn('LAUNCHED', lambda c: log_utils.readable_time_duration(c['launched_at'])),
+        StatusColumn('RESOURCES', lambda c: c['resources_str'], trunc_length=70 if not show_all else 0),
+        # StatusColumn('PODS', lambda c: len(c['pods'])),
+        StatusColumn('STATUS', lambda c: c['status'].colored_str()),
+        # Add more columns as needed
+    ]
+
+    clusters = process_skypilot_pods(pods)
+    columns = [col.name for col in status_columns if col.show_by_default or show_all]
+    cluster_table = log_utils.create_table(columns)
+
+    for cluster in clusters:
+        row = []
+        for status_column in status_columns:
+            if status_column.show_by_default or show_all:
+                row.append(status_column.calc(cluster))
+        cluster_table.add_row(row)
+
+    if clusters:
+        click.echo(cluster_table)
+    else:
+        click.echo('No existing SkyPilot clusters on Kubernetes.')

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -319,6 +319,7 @@ def _get_estimated_cost_for_cost_report(
 
     return f'$ {cost:.2f}'
 
+
 def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
     """Compute cluster table values and display for Kubernetes clusters."""
     status_columns = [
@@ -328,13 +329,17 @@ def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
         StatusColumn('RESOURCES', lambda c: c['resources_str'], trunc_length=70 if not show_all else 0),
         # StatusColumn('PODS', lambda c: len(c['pods'])),
         StatusColumn('STATUS', lambda c: c['status'].colored_str()),
-        # Add more columns as needed
+        # TODO(romilb): We should consider adding POD_NAME field here when --all
+        #  is passed to help users fetch pod name programmatically.
     ]
 
     columns = [col.name for col in status_columns if col.show_by_default or show_all]
     cluster_table = log_utils.create_table(columns)
 
-    for cluster in clusters:
+    # Sort table by user, then by cluster name
+    sorted_clusters = sorted(clusters, key=lambda c: (c['user'], c['cluster_name']))
+
+    for cluster in sorted_clusters:
         row = []
         for status_column in status_columns:
             if status_column.show_by_default or show_all:

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -329,7 +329,6 @@ def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
         StatusColumn('RESOURCES',
                      lambda c: c['resources_str'],
                      trunc_length=70 if not show_all else 0),
-        # StatusColumn('PODS', lambda c: len(c['pods'])),
         StatusColumn('STATUS', lambda c: c['status'].colored_str()),
         # TODO(romilb): We should consider adding POD_NAME field here when --all
         #  is passed to help users fetch pod name programmatically.

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,9 +5,7 @@ import click
 import colorama
 
 from sky import backends
-from sky import clouds
 from sky import status_lib
-from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
 from sky.utils import log_utils
 from sky.utils import resources_utils

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -5,12 +5,12 @@ import click
 import colorama
 
 from sky import backends
-from sky import status_lib
 from sky import clouds
+from sky import status_lib
+from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
 from sky.utils import log_utils
 from sky.utils import resources_utils
-from sky.provision.kubernetes import utils as kubernetes_utils
 
 COMMAND_TRUNC_LENGTH = 25
 NUM_COST_REPORT_LINES = 5
@@ -325,19 +325,26 @@ def show_kubernetes_status_table(clusters: List[Any], show_all: bool) -> None:
     status_columns = [
         StatusColumn('USER', lambda c: c['user']),
         StatusColumn('NAME', lambda c: c['cluster_name']),
-        StatusColumn('LAUNCHED', lambda c: log_utils.readable_time_duration(c['launched_at'])),
-        StatusColumn('RESOURCES', lambda c: c['resources_str'], trunc_length=70 if not show_all else 0),
+        StatusColumn(
+            'LAUNCHED',
+            lambda c: log_utils.readable_time_duration(c['launched_at'])),
+        StatusColumn('RESOURCES',
+                     lambda c: c['resources_str'],
+                     trunc_length=70 if not show_all else 0),
         # StatusColumn('PODS', lambda c: len(c['pods'])),
         StatusColumn('STATUS', lambda c: c['status'].colored_str()),
         # TODO(romilb): We should consider adding POD_NAME field here when --all
         #  is passed to help users fetch pod name programmatically.
     ]
 
-    columns = [col.name for col in status_columns if col.show_by_default or show_all]
+    columns = [
+        col.name for col in status_columns if col.show_by_default or show_all
+    ]
     cluster_table = log_utils.create_table(columns)
 
     # Sort table by user, then by cluster name
-    sorted_clusters = sorted(clusters, key=lambda c: (c['user'], c['cluster_name']))
+    sorted_clusters = sorted(clusters,
+                             key=lambda c: (c['user'], c['cluster_name']))
 
     for cluster in sorted_clusters:
         row = []

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -679,3 +679,22 @@ def deprecated_function(
         return func(*args, **kwargs)
 
     return new_func
+
+
+def truncate_long_string(s: str, max_length: int = 35) -> str:
+    if len(s) <= max_length:
+        return s
+    splits = s.split(' ')
+    if len(splits[0]) > max_length:
+        return splits[0][:max_length] + '...'  # Use '…'?
+    # Truncate on word boundary.
+    i = 0
+    total = 0
+    for i, part in enumerate(splits):
+        total += len(part)
+        if total >= max_length:
+            break
+    prefix = ' '.join(splits[:i])
+    if len(prefix) < max_length:
+        prefix += s[len(prefix):max_length]
+    return prefix + '...'

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -682,6 +682,7 @@ def deprecated_function(
 
 
 def truncate_long_string(s: str, max_length: int = 35) -> str:
+    """Truncate a string to a maximum length, preserving whole words."""
     if len(s) <= max_length:
         return s
     splits = s.split(' ')


### PR DESCRIPTION
Adds a `--kubernetes` flag to `sky status` to show the global state of the Kubernetes cluster, including SkyPilot clusters created by other users. Helps users see the current state of the Kubernetes cluster.

Example:

```
(base) ➜  sky-experiments git:(k8s_global_status) ✗ sky status --kubernetes
SkyPilot Clusters on Kubernetes
NAME        USER    LAUNCHED     RESOURCES                                      STATUS  
test-2ea4   romilb  45 secs ago  2x Kubernetes(cpus=2.0, mem=2.0)               UP      
train-j49a  test    1 min ago    2x Kubernetes(cpus=2.0, mem=8.0, {'H100': 1})  UP     
```

TODO:
- [x] Handle multiple contexts
- [x] Decide whether to poll current namespace or all namespaces
- [x] Remove user hash from cluster name
- [x] Cleaner code

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
