### PR TITLE
[Docs] Add gcloud auth login in GCP setup instruction

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -213,9 +213,13 @@ Google Cloud Platform (GCP)
 
   gcloud init
 
-  # Run this if you don't have a credentials file.
+  # Generate credentials for cloud API access
   # This will generate ~/.config/gcloud/application_default_credentials.json.
   gcloud auth application-default login
+
+  # Generate credentials for the gcloud CLI access
+  # This will generate ~/.config/gcloud/credentials.db
+  gcloud auth login
 
 .. tip::
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Without user running `gcloud auth login`, they cannot run `sky jobs launch` as sky will use gcloud CLI such as gsutil in the code.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

