### PR TITLE
aws: use IDMSv2 in zone shell cmd

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -303,8 +303,8 @@ class AWS(clouds.Cloud):
             '-H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && '
             'curl -H "X-aws-ec2-metadata-token: $TOKEN" -s '
             'http://169.254.169.254/latest/dynamic/instance-identity/document'
-	     f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
-	     'print(json.load(sys.stdin)[\'availabilityZone\'])"')
+            f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
+            'print(json.load(sys.stdin)[\'availabilityZone\'])"')
         return command_str
 
     #### Normal methods ####

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -299,9 +299,13 @@ class AWS(clouds.Cloud):
         # The command for getting the current zone is from:
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html  # pylint: disable=line-too-long
         command_str = (
-            'curl -s http://169.254.169.254/latest/dynamic/instance-identity/document'  # pylint: disable=line-too-long
-            f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
-            'print(json.load(sys.stdin)[\'availabilityZone\'])"')
+            'TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" '
+            '-H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && '
+            'curl -H "X-aws-ec2-metadata-token: $TOKEN" -s '
+            'http://169.254.169.254/latest/dynamic/instance-identity/document'
+	     f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
+	     'print(json.load(sys.stdin)[\'availabilityZone\'])"'
+        )
         return command_str
 
     #### Normal methods ####

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -304,8 +304,7 @@ class AWS(clouds.Cloud):
             'curl -H "X-aws-ec2-metadata-token: $TOKEN" -s '
             'http://169.254.169.254/latest/dynamic/instance-identity/document'
 	     f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
-	     'print(json.load(sys.stdin)[\'availabilityZone\'])"'
-        )
+	     'print(json.load(sys.stdin)[\'availabilityZone\'])"')
         return command_str
 
     #### Normal methods ####

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -131,6 +131,9 @@ available_node_types:
             - Key: {{ label_key }}
               Value: {{ label_value|tojson }}
             {%- endfor %}
+      # Use IDMSv2
+      MetadataOptions:
+        HttpTokens: required 
 
 head_node_type: ray.head.default
 


### PR DESCRIPTION
Usage of IDMSv2 is considered a best practice for security. To facilitate [fully disabling IDMSv1](https://aws.amazon.com/blogs/security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure/) we should switch to using v2 everywhere.

This change was tested manually on an ec2 instance using this test script:

```
import subprocess
from typing import Optional

class Constants:
    SKY_PYTHON_CMD = "python3"  # Assuming this is what constants.SKY_PYTHON_CMD refers to

constants = Constants()

class EC2InstanceMetadata:
    @classmethod
    def get_zone_shell_cmd(cls) -> Optional[str]:
        # The command for getting the current zone is from:
        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html  # pylint: disable=line-too-long
        command_str = (
            'TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" '
            '-H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && '
            'curl -H "X-aws-ec2-metadata-token: $TOKEN" -s '
            'http://169.254.169.254/latest/dynamic/instance-identity/document'
            f' | {constants.SKY_PYTHON_CMD} -u -c "import sys, json; '
            'print(json.load(sys.stdin)[\'availabilityZone\'])"'
        )
        return command_str

    @classmethod
    def get_availability_zone(cls) -> str:
        cmd = cls.get_zone_shell_cmd()
        if cmd is None:
            return "Error: Unable to generate command"
        try:
            result = subprocess.run(cmd, shell=True, check=True, capture_output=True, text=True)
            return result.stdout.strip()
        except subprocess.CalledProcessError as e:
            return f"Error executing command: {e}"

def main():
    ec2_metadata = EC2InstanceMetadata()
    zone = ec2_metadata.get_availability_zone()
    print(f"Result: {zone}")

if __name__ == "__main__":
    main()
```

This prints: `Result: us-east-1a`