### PR TITLE
[Serve] Make controller regions/ choose from replica resources

### DIFF
--- a/examples/serve/http_server/task.yaml
+++ b/examples/serve/http_server/task.yaml
@@ -15,6 +15,7 @@ service:
 resources:
   ports: 8080
   cpus: 2+
+  cloud: gcp
 
 workdir: examples/serve/http_server
 

--- a/examples/serve/http_server/task.yaml
+++ b/examples/serve/http_server/task.yaml
@@ -15,7 +15,6 @@ service:
 resources:
   ports: 8080
   cpus: 2+
-  cloud: gcp
 
 workdir: examples/serve/http_server
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -529,7 +529,8 @@ def get_controller_resources(
     # Filter regions and zones and construct the result
     result = set()
     for cloud_name in filtered_clouds:
-        regions = requested_clouds_with_region_zone.get(cloud_name, {})
+        regions = requested_clouds_with_region_zone.get(cloud_name,
+                                                        {None: {None}})
 
         # Filter regions if controller_resources_to_use.region is specified
         filtered_regions = ({controller_region}

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -528,7 +528,7 @@ def get_controller_resources(
                        requested_clouds_with_region_zone.keys())
 
     # Filter regions and zones and construct the result.
-    result = set()
+    result: Set[resources.Resources] = set()
     for cloud_name in filtered_clouds:
         regions = requested_clouds_with_region_zone.get(cloud_name,
                                                         {None: {None}})

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -515,14 +515,16 @@ def get_controller_resources(
             break
     if not requested_clouds_with_region_zone:
         return {controller_resources_to_use}
-    return {
-        controller_resources_to_use.copy(
-            cloud=clouds.CLOUD_REGISTRY.from_str(cloud_name),
-            region=region,
-            zone=zone)
-        for cloud_name, regions in requested_clouds_with_region_zone.items()
-        for region, zones in regions.items() for zone in zones
-    }
+    result = set()
+    for cloud_name, regions in requested_clouds_with_region_zone.items():
+        for region, zones in regions.items():
+            for zone in zones:
+                resource_copy = controller_resources_to_use.copy(
+                    cloud=clouds.CLOUD_REGISTRY.from_str(cloud_name),
+                    region=region,
+                    zone=zone)
+                result.add(resource_copy)
+    return result
 
 
 def _setup_proxy_command_on_controller(

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -474,8 +474,7 @@ def get_controller_resources(
     # TODO(tian): Consider respecting the regions/zones specified for the
     # resources as well.
 
-    sky_logging.print("task_resources", task_resources)
-    requested_clouds_with_region_zone: Dict[str, Dict[str, set[str]]] = {}
+    requested_clouds_with_region_zone: Dict[str, Dict[str, Set[str]]] = {}
     for resource in task_resources:
         cloud_name = str(resource.cloud) if resource.cloud is not None else None
         if cloud_name is not None:
@@ -489,14 +488,22 @@ def get_controller_resources(
                     continue
                 requested_clouds_with_region_zone[cloud_name] = {}
             if resource.region is None:
-                requested_clouds_with_region_zone[cloud_name] = {"_allow_any_region": {"_allow_any_zone"}}
-            elif "_allow_any_region" not in requested_clouds_with_region_zone[cloud_name]:
-                if resource.region not in requested_clouds_with_region_zone[cloud_name]:
-                    requested_clouds_with_region_zone[cloud_name][resource.region] = set()
+                requested_clouds_with_region_zone[cloud_name] = {
+                    '_allow_any_region': {'_allow_any_zone'}
+                }
+            elif '_allow_any_region' not in requested_clouds_with_region_zone[
+                    cloud_name]:
+                if resource.region not in requested_clouds_with_region_zone[
+                        cloud_name]:
+                    requested_clouds_with_region_zone[cloud_name][
+                        resource.region] = set()
                 if resource.zone is None:
-                    requested_clouds_with_region_zone[cloud_name][resource.region] = {"_allow_any_zone"}
-                elif "_allow_any_zone" not in requested_clouds_with_region_zone[cloud_name][resource.region]:
-                    requested_clouds_with_region_zone[cloud_name][resource.region].add(resource.zone)
+                    requested_clouds_with_region_zone[cloud_name][
+                        resource.region] = {'_allow_any_zone'}
+                elif '_allow_any_zone' not in requested_clouds_with_region_zone[
+                        cloud_name][resource.region]:
+                    requested_clouds_with_region_zone[cloud_name][
+                        resource.region].add(resource.zone)
         else:
             # if one of the resource.cloud is None, this could represent user
             # does not know which cloud is best for the specified resources.
@@ -513,12 +520,10 @@ def get_controller_resources(
     return {
         controller_resources_to_use.copy(
             cloud=cloud,
-            region=(None if region == "_allow_any_region" else region),
-            zone=(None if zone == "_allow_any_zone" else zone)
-        )
+            region=(None if region == '_allow_any_region' else region),
+            zone=(None if zone == '_allow_any_zone' else zone))
         for cloud_name, regions in requested_clouds_with_region_zone.items()
-        for region, zones in regions.items()
-        for zone in zones
+        for region, zones in regions.items() for zone in zones
         for cloud in [clouds.CLOUD_REGISTRY.from_str(cloud_name)]
     }
 

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -189,7 +189,7 @@ def test_get_controller_resources_with_task_resources(
         assert config == default_controller_resources, config
     assert not expected_combinations
 
-    # 7. Mixed case: Some resources have clouds and regions or zones, others do not.
+    # 6. Mixed case: Some resources have clouds and regions or zones, others do not.
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -105,7 +105,9 @@ def test_get_controller_resources_with_task_resources(
         assert config == default_controller_resources, config
     assert not all_cloud_names
 
-    # 2. Some resources cannot host controllers.
+    # 2. All resources has cloud specified. Some of them
+    # could NOT host controllers. Return a set, only
+    # containing those could host controllers.
     all_clouds = {
         sky.AWS(),
         sky.GCP(),
@@ -139,7 +141,8 @@ def test_get_controller_resources_with_task_resources(
         assert config == default_controller_resources, config
     assert not all_cloud_names_expected
 
-    # 3. Some resources do not have cloud specified.
+    # 3. Some resources does not have cloud specified.
+    # Return the default resources.
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[
@@ -151,6 +154,9 @@ def test_get_controller_resources_with_task_resources(
     assert config == default_controller_resources, config
 
     # 4. All resources have clouds, regions, and zones specified.
+    # Return a set of controller resources for all combinations of clouds,
+    # regions, and zones. Each combination should contain the default resources
+    # along with the cloud, region, and zone.
     all_cloud_regions_zones = [
         sky.Resources(cloud=sky.AWS(), region='us-east-1', zone='us-east-1a'),
         sky.Resources(cloud=sky.AWS(), region='ap-south-1', zone='ap-south-1b'),
@@ -171,7 +177,10 @@ def test_get_controller_resources_with_task_resources(
     _check_controller_resources(controller_resources, expected_combinations,
                                 default_controller_resources)
 
-    # 5. Clouds and regions specified but zones partially specified.
+    # 5. Clouds and regions are specified, but zones are partially specified.
+    # Return a set containing combinations where the zone is None
+    # when not all zones are specified in the input for the given region. The default
+    # resources should be returned along with the cloud and region, and the zone (if specified).
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[
@@ -189,6 +198,9 @@ def test_get_controller_resources_with_task_resources(
                                 default_controller_resources)
 
     # 6. Mixed case: Some resources have clouds and regions or zones, others do not.
+    # For clouds where regions or zones are not specified in the input, return None
+    # for those fields. The default resources should be returned along with the cloud,
+    # region (if specified), and zone (if specified).
     controller_resources = controller_utils.get_controller_resources(
         controller=controller_utils.Controllers.from_type(controller_type),
         task_resources=[

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -138,3 +138,81 @@ def test_get_controller_resources_with_task_resources(
     assert len(controller_resources) == 1
     config = list(controller_resources)[0].to_yaml_config()
     assert config == default_controller_resources, config
+
+    # 4. All resources have clouds, regions, and zones specified.
+    # Return a set with all combinations.
+    all_cloud_regions_zones = [
+        sky.Resources(cloud=sky.AWS(), region='us-east-1', zone='us-east-1a'),
+        sky.Resources(cloud=sky.AWS(), region='ap-south-1', zone='ap-south-1b'),
+        sky.Resources(cloud=sky.GCP(),
+                      region='us-central1',
+                      zone='us-central1-a'),
+        sky.Resources(cloud=sky.GCP(),
+                      region='europe-west1',
+                      zone='europe-west1-b')
+    ]
+    controller_resources = controller_utils.get_controller_resources(
+        controller=controller_utils.Controllers.from_type(controller_type),
+        task_resources=all_cloud_regions_zones)
+    expected_combinations = {('AWS', 'us-east-1', 'us-east-1a'),
+                             ('AWS', 'ap-south-1', 'ap-south-1b'),
+                             ('GCP', 'us-central1', 'us-central1-a'),
+                             ('GCP', 'europe-west1', 'europe-west1-b')}
+    for r in controller_resources:
+        config = r.to_yaml_config()
+        cloud = config.pop('cloud')
+        region = config.pop('region')
+        zone = config.pop('zone')
+        assert (cloud, region, zone) in expected_combinations
+        expected_combinations.remove((cloud, region, zone))
+        assert config == default_controller_resources, config
+    assert not expected_combinations
+
+    # 5. Clouds and regions are specified but zones are only partially specified.
+    controller_resources = controller_utils.get_controller_resources(
+        controller=controller_utils.Controllers.from_type(controller_type),
+        task_resources=[
+            sky.Resources(cloud=sky.AWS(), region='us-west-2'),
+            sky.Resources(cloud=sky.GCP(),
+                          region='us-central1',
+                          zone='us-central1-a')
+        ])
+    expected_combinations = {('AWS', 'us-west-2', None),
+                             ('GCP', 'us-central1', 'us-central1-a')}
+    for r in controller_resources:
+        config = r.to_yaml_config()
+        cloud = config.pop('cloud')
+        region = config.pop('region')
+        zone = config.pop('zone', None)
+        assert (cloud, region, zone) in expected_combinations
+        expected_combinations.remove((cloud, region, zone))
+        assert config == default_controller_resources, config
+    assert not expected_combinations
+
+    # 7. Mixed case: Some resources have clouds and regions or zones, others do not.
+    controller_resources = controller_utils.get_controller_resources(
+        controller=controller_utils.Controllers.from_type(controller_type),
+        task_resources=[
+            sky.Resources(cloud=sky.GCP(), region='europe-west1'),
+            sky.Resources(cloud=sky.GCP()),
+            sky.Resources(cloud=sky.AWS(),
+                          region='eu-north-1',
+                          zone='eu-north-1a'),
+            sky.Resources(cloud=sky.AWS(), region='eu-north-1'),
+            sky.Resources(cloud=sky.Azure()),
+        ])
+    expected_combinations = {
+        ('AWS', 'eu-north-1', None),
+        ('GCP', None, None),
+        ('Azure', None, None),
+    }
+    assert len(controller_resources) == len(expected_combinations)
+    for r in controller_resources:
+        config = r.to_yaml_config()
+        cloud = config.pop('cloud')
+        region = config.pop('region', None)
+        zone = config.pop('zone', None)
+        assert (cloud, region, zone) in expected_combinations
+        expected_combinations.remove((cloud, region, zone))
+        assert config == default_controller_resources, config
+    assert not expected_combinations


### PR DESCRIPTION
Fixes #3364 .

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Unit test for the case where all resources are specified with clouds, regions and zones.
  - [x] Unit test for the case where all resources are specified with clouds and regions, only part of them have zones.
  - [x] Unit test for mixed cases: some resources have clouds, regions and zones; some don't have regions or zones. 
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
