### PR TITLE
Add force option to sky down

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2768,13 +2768,14 @@ def _down_or_stop_clusters(
                 hint_or_raise = _CONTROLLER_TO_HINT_OR_RAISE[controller]
                 if not force:
                     try:
-                        # TODO(zhwu): This hint or raise is not transactional, which
-                        # means even if it passed the check with no in-progress spot
-                        # or service and prompt the confirmation for termination,
-                        # a user could still do a `sky jobs launch` or a
-                        # `sky serve up` before typing the delete, causing a leaked
-                        # managed job or service. We should make this check atomic
-                        # with the termination.
+                        # TODO(zhwu): This hint or raise is not transactional,
+                        # which means even if it passed the check with no
+                        # in-progress spot or service and prompt the
+                        # confirmation for termination, a user could still
+                        # do a `sky jobs launch` or a `sky serve up` before
+                        # typing the delete, causing a leaked managed job or
+                        # service. We should make this check atomic with the
+                        # termination.
                         hint_or_raise(controller_name)
                     except (exceptions.ClusterOwnerIdentityMismatchError,
                             RuntimeError) as e:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #4059 

Add a `--force` option to the `sky down` command to handle services stuck in the `SHUTTING_DOWN` state.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
