### PR TITLE
[AWS] Support EFA for P5/P5e instances

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -204,6 +204,20 @@ Available fields and semantics:
     # Default: false.
     disk_encrypted: false
 
+    # Enable EFA (optional).
+    #
+    # Set to true to enable EFA. Currently, it is only effective for P5/P5e
+    # instances.
+    #
+    # When enable_efa is set to true, use_internal_ips must also be set to true
+    # due to the limitation of EFA.
+    #
+    # This is useful for high-performance distributed training, see:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html
+    #
+    # Default: false.
+    enable_efa: false
+
     # Reserved capacity (optional).
     #
     # Whether to prioritize capacity reservations (considered as 0 cost) in the

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -440,15 +440,17 @@ class AWS(clouds.Cloud):
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
                     'in `~/.sky/config.yaml`.')
-                
+
         enable_efa = skypilot_config.get_nested(('aws', 'enable_efa'), False)
         efa_interface_count = 0
         if enable_efa:
             # AWS allows 32 EFA interfaces for P5/P5e, and 4 for G6e instances.
-            if r.instance_type.startswith('p5.') or r.instance_type.startswith('p5e.'):
+            if (r.instance_type.startswith('p5.') or
+                    r.instance_type.startswith('p5e.')):
                 efa_interface_count = 32
             elif r.instance_type.startswith('g6e'):
-                efa_interface_count = 4
+                logger.warning('EFA support for G6e instances is not yet '
+                               'implemented. Ignoring the setting.')
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -440,6 +440,15 @@ class AWS(clouds.Cloud):
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
                     'in `~/.sky/config.yaml`.')
+                
+        enable_efa = skypilot_config.get_nested(('aws', 'enable_efa'), False)
+        efa_interface_count = 0
+        if enable_efa:
+            # AWS allows 32 EFA interfaces for P5/P5e, and 4 for G6e instances.
+            if r.instance_type.startswith('p5.') or r.instance_type.startswith('p5e.'):
+                efa_interface_count = 32
+            elif r.instance_type.startswith('g6e'):
+                efa_interface_count = 4
 
         return {
             'instance_type': r.instance_type,
@@ -452,6 +461,7 @@ class AWS(clouds.Cloud):
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group != user_security_group).lower(),
+            'efa_interface_count': efa_interface_count,
             **AWS._get_disk_specs(r.disk_tier)
         }
 

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -244,10 +244,10 @@ def _create_instances(ec2_fail_fast, cluster_name: str,
                     'InterfaceType': 'efa',
                     'DeleteOnTermination': True,
                 }]
-                for _ in range(efa_interface_count):
+                for card_index in range(1, efa_interface_count):
                     network_interfaces.append({
                         'SubnetId': subnet_id,
-                        'NetworkCardIndex': len(network_interfaces),
+                        'NetworkCardIndex': card_index,
                         'DeviceIndex': 1,
                         'AssociatePublicIpAddress': False,
                         'Groups': security_group_ids,

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -134,6 +134,9 @@ available_node_types:
       # Use IDMSv2
       MetadataOptions:
         HttpTokens: required 
+      # Used for SkyPilot provisioner sky/provision/aws/instance.py to generate
+      # EFA network interface config for AWS EC2 SDK.
+      SkyPilotEfaInterfaceCount: {{efa_interface_count}}
 
 head_node_type: ray.head.default
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -592,6 +592,8 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
                                         f'{most_similar_field[0]!r}?')
                         else:
                             err_msg += f'Found unsupported field {field!r}.'
+        elif e.schema.get('errorMessage', None) is not None:
+            err_msg = err_msg_prefix + e.schema['errorMessage']
         else:
             message = e.message
             # Object in jsonschema is represented as dict in Python. Replace

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -726,22 +726,28 @@ def get_config_schema():
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },
-            'allOf': [
-                {
-                    'if': {
-                        'properties': {'enable_efa': {'const': True}},
-                        'required': ['enable_efa']
+            'allOf': [{
+                'if': {
+                    'properties': {
+                        'enable_efa': {
+                            'const': True
+                        }
                     },
-                    'then': {
-                        'properties': {'use_internal_ips': {'const': True}},
-                        'required': ['use_internal_ips'],
-                        'errorMessage': ('When `aws.enable_efa` is set to '
-                                        'true, `aws.use_internal_ips` '
-                                        'must also be set to true, as EFA '
-                                        'requires private IP addresses.')
-                    },
+                    'required': ['enable_efa']
                 },
-            ],
+                'then': {
+                    'properties': {
+                        'use_internal_ips': {
+                            'const': True
+                        }
+                    },
+                    'required': ['use_internal_ips'],
+                    'errorMessage': ('When `aws.enable_efa` is set to '
+                                     'true, `aws.use_internal_ips` '
+                                     'must also be set to true, as EFA '
+                                     'requires private IP addresses.')
+                },
+            },],
             **_check_not_both_fields_present('instance_tags', 'labels'),
         },
         'gcp': {

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -715,6 +715,9 @@ def get_config_schema():
                         'type': 'string',
                     },
                 },
+                'enable_efa': {
+                    'type': 'boolean',
+                },
                 'disk_encrypted': {
                     'type': 'boolean',
                 },
@@ -723,7 +726,23 @@ def get_config_schema():
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },
-            **_check_not_both_fields_present('instance_tags', 'labels')
+            'allOf': [
+                {
+                    'if': {
+                        'properties': {'enable_efa': {'const': True}},
+                        'required': ['enable_efa']
+                    },
+                    'then': {
+                        'properties': {'use_internal_ips': {'const': True}},
+                        'required': ['use_internal_ips'],
+                        'errorMessage': ('When `aws.enable_efa` is set to '
+                                        'true, `aws.use_internal_ips` '
+                                        'must also be set to true, as EFA '
+                                        'requires private IP addresses.')
+                    },
+                },
+            ],
+            **_check_not_both_fields_present('instance_tags', 'labels'),
         },
         'gcp': {
             'type': 'object',

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -156,6 +156,7 @@ def test_aws_make_deploy_variables(*mocks) -> None:
         'docker_container_name': 'sky_container',
         'docker_login_config': None,
         'docker_run_options': [],
+        'efa_interface_count': 0,
         'initial_setup_commands': [],
         'zones': 'fake-zone'
     }


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To enable EFA:
```yaml
aws:
    enable_efa: true
    use_internal_ips: true
    vpc_name: my-vpc
```

`sky launch --gpus A100:8 --num-nodes 2 -c test-efa` 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
