### PR TITLE
[k8s] Fix rsync for context name with `:` and `/`

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -258,6 +258,10 @@ class CommandRunner:
 
         rsync_command.append(f'-e {shlex.quote(rsh_option)}')
 
+        # Avoid rsync interpreting :, /, and + in node_destination as the
+        # default delimiter for options and arguments.
+        encoded_node_destination = node_destination.replace(':', '%3A').replace(
+            '/', '%2F').replace('+', '%2B')
         if up:
             resolved_target = target
             if target.startswith('~'):
@@ -268,7 +272,7 @@ class CommandRunner:
                 full_source_str = os.path.join(full_source_str, '')
             rsync_command.extend([
                 f'{full_source_str!r}',
-                f'{node_destination}:{resolved_target!r}',
+                f'{encoded_node_destination}:{resolved_target!r}',
             ])
         else:
             resolved_source = source
@@ -276,7 +280,7 @@ class CommandRunner:
                 remote_home_dir = get_remote_home_dir()
                 resolved_source = source.replace('~', remote_home_dir)
             rsync_command.extend([
-                f'{node_destination}:{resolved_source!r}',
+                f'{encoded_node_destination}:{resolved_source!r}',
                 f'{os.path.expanduser(target)!r}',
             ])
         command = ' '.join(rsync_command)

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -4,9 +4,14 @@
 shift
 pod=$1
 shift
-namespace_context=$1
+echo "pod: $pod" >&2
+encoded_namespace_context=$1
+namespace_context=$(echo "$encoded_namespace_context" | sed 's|%3A|:/|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
+echo "namespace_context: $namespace_context" >&2
 namespace=$(echo $namespace_context | cut -d+ -f1)
+echo "namespace: $namespace" >&2
 context=$(echo $namespace_context | grep '+' >/dev/null && echo $namespace_context | cut -d+ -f2- || echo "")
+echo "context: $context" >&2
 context_lower=$(echo "$context" | tr '[:upper:]' '[:lower:]')
 shift
 if [ -z "$context" ] || [ "$context_lower" = "none" ]; then

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -6,6 +6,7 @@ pod=$1
 shift
 echo "pod: $pod" >&2
 encoded_namespace_context=$1
+# Revert the encoded namespace+context to the original string.
 namespace_context=$(echo "$encoded_namespace_context" | sed 's|%3A|:/|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
 echo "namespace_context: $namespace_context" >&2
 namespace=$(echo $namespace_context | cut -d+ -f1)

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -7,7 +7,7 @@ shift
 echo "pod: $pod" >&2
 encoded_namespace_context=$1
 # Revert the encoded namespace+context to the original string.
-namespace_context=$(echo "$encoded_namespace_context" | sed 's|%3A|:/|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
+namespace_context=$(echo "$encoded_namespace_context" | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
 echo "namespace_context: $namespace_context" >&2
 namespace=$(echo $namespace_context | cut -d+ -f1)
 echo "namespace: $namespace" >&2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, when context name contains `:` or `/`, rsync can wrongly parse the string to be passed to our rsync_helper. We now escape those special characters.

Tested with a context and namespace: `arn:xxx:xxx:xx-xxx-x:xxx:cluster/xxx` and `test-namespace`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
