### PR TITLE
[OCI]: Bug fix: 1. sky config file path resolution. 2. fill in image_id as ocid in task YAML

### DIFF
--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -4,6 +4,15 @@ History:
  - Hysun He (hysun.he@oracle.com) @ Apr, 2023: Initial implementation
  - Hysun He (hysun.he@oracle.com) @ May 4, 2023: Support use the default
    image_id (configurable) if no image_id specified in the task yaml.
+ - Hysun He (hysun.he@oracle.com) @ Oct 12, 2024: 
+   get_credential_file_mounts(): bug fix for sky config
+   file path resolution (by os.path.expanduser) when construct the file 
+   mounts. This bug will cause the created workder nodes located in different
+   compartment and VCN than the header node if user specifies compartment_id 
+   in the sky config file, because the ~/.sky/config is not sync-ed to the
+   remote machine. 
+   The workaround is set the sky config file path using ENV before running
+   the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml 
 """
 import json
 import logging
@@ -447,7 +456,7 @@ class OCI(clouds.Cloud):
         credential_files = [oci_cfg_file, api_key_file]
 
         # Sky config file is optional
-        if os.path.exists(sky_cfg_file):
+        if os.path.exists(os.path.expanduser(sky_cfg_file)):
             credential_files.append(sky_cfg_file)
 
         file_mounts = {

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -4,15 +4,15 @@ History:
  - Hysun He (hysun.he@oracle.com) @ Apr, 2023: Initial implementation
  - Hysun He (hysun.he@oracle.com) @ May 4, 2023: Support use the default
    image_id (configurable) if no image_id specified in the task yaml.
- - Hysun He (hysun.he@oracle.com) @ Oct 12, 2024: 
+ - Hysun He (hysun.he@oracle.com) @ Oct 12, 2024:
    get_credential_file_mounts(): bug fix for sky config
-   file path resolution (by os.path.expanduser) when construct the file 
+   file path resolution (by os.path.expanduser) when construct the file
    mounts. This bug will cause the created workder nodes located in different
-   compartment and VCN than the header node if user specifies compartment_id 
+   compartment and VCN than the header node if user specifies compartment_id
    in the sky config file, because the ~/.sky/config is not sync-ed to the
-   remote machine. 
+   remote machine.
    The workaround is set the sky config file path using ENV before running
-   the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml 
+   the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml
 """
 import json
 import logging

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -13,6 +13,10 @@ History:
    remote machine.
    The workaround is set the sky config file path using ENV before running
    the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml
+ - Hysun He (hysun.he@oracle.com) @ Oct 12, 2024:
+   make_deploy_resources_variables(): Bug fix for specify the image_id as
+   the ocid of the image in the task.yaml file, in this case the image_id
+   for the node config should be set to the ocid instead of a dict.
 """
 import json
 import logging
@@ -220,7 +224,9 @@ class OCI(clouds.Cloud):
             listing_id = image_cols[1]
             res_ver = image_cols[2]
         else:
-            image_id = resources.image_id
+            # Oct.12,2024 by HysunHe: Bug fix - resources.image_id is an
+            # dict. The image_id here should be the ocid format.
+            image_id = image_str
             listing_id = None
             res_ver = None
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

1.  Bug fix for sky config file path resolution:

This bug will cause the created workder nodes located in different compartment and VCN than the header node if user specifies compartment_id in the sky config file, because the ~/.sky/config is not sync-ed to the remote machine. 
   The workaround is to set the sky config file path using ENV before running
   the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml 

2.  Bug fix for image_id in task YAML:
    We can specify the image to use for node provision by setting the image_id parameter in the task YAML.  The image_id in the task YAML can be an tag in the images.csv catalog file such as skypilot:gpu-ubuntu-2004. 
    Some customers would also perfer to specify the ocid of the image in the image_id field, and we already supported this in the skypilot[oci], but this does not works due to the bug here. 

3.  Doc update: The image_id section of the task YAML would be updated for OCI. After this PR merged, I'll update the doc then.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [v] Code formatting: `bash format.sh`
- [v] Any manual or new tests for this PR (please specify below)
       1. create a cluster with 2+ nodes
       2. specify the compartment and vcn in ~/.sky/config.yaml
       5. sky launch
       6. check the created VMs: header and worker nodes are in different compartment & VCN. If the VCNs are not inter-accessible, the cluster will never success till timeout, though nodes are created.
       7. run export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml, then sky launch can workaround this issue.

       Specify the image_id as the ocid of the image, and run 1~6 again.
       
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
