### PR TITLE
[UX] Show log after failure and fix the color issue with narrow window

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2843,10 +2843,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         attempt_cnt += 1
                         time.sleep(gap_seconds)
                         continue
-                    logger.error(
-                        f'{colorama.Fore.RED}⨯{colorama.Style.RESET_ALL} '
+                    logger.error(ux_utils.error_message(
                         'Failed to provision resources. '
-                        f'{ux_utils.log_path_hint(log_path)}')
+                        f'{ux_utils.log_path_hint(log_path)}'))
                     error_message += (
                         '\nTo keep retrying until the cluster is up, use '
                         'the `--retry-until-up` flag.')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2843,9 +2843,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         attempt_cnt += 1
                         time.sleep(gap_seconds)
                         continue
-                    logger.error(ux_utils.error_message(
-                        'Failed to provision resources. '
-                        f'{ux_utils.log_path_hint(log_path)}'))
+                    logger.error(
+                        ux_utils.error_message(
+                            'Failed to provision resources. '
+                            f'{ux_utils.log_path_hint(log_path)}'))
                     error_message += (
                         '\nTo keep retrying until the cluster is up, use '
                         'the `--retry-until-up` flag.')

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -573,7 +573,7 @@ def post_provision_runtime_setup(
         except Exception:  # pylint: disable=broad-except
             logger.error(
                 ux_utils.error_message(
-                    f'Failed to set up SkyPilot runtime on cluster.',
+                    'Failed to set up SkyPilot runtime on cluster.',
                     provision_logging.config.log_path))
             logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -571,7 +571,7 @@ def post_provision_runtime_setup(
                                          provision_record=provision_record,
                                          custom_resource=custom_resource)
         except Exception:  # pylint: disable=broad-except
-            logger.error('*** Failed setting up cluster. ***')
+            logger.error(ux_utils.error_message(f'Failed to set up SkyPilot runtime on cluster.', provision_logging.config.log_path))
             logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():
                 raise

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -571,7 +571,10 @@ def post_provision_runtime_setup(
                                          provision_record=provision_record,
                                          custom_resource=custom_resource)
         except Exception:  # pylint: disable=broad-except
-            logger.error(ux_utils.error_message(f'Failed to set up SkyPilot runtime on cluster.', provision_logging.config.log_path))
+            logger.error(
+                ux_utils.error_message(
+                    f'Failed to set up SkyPilot runtime on cluster.',
+                    provision_logging.config.log_path))
             logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():
                 raise

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -121,9 +121,6 @@ class RedirectOutputForProcess:
                 raise
 
 
-def starting_message(message: str) -> str:
-    """Gets the starting message for the given message."""
-    return f'⚙︎ {message}'
 
 
 def log_path_hint(log_path: Union[str, 'pathlib.Path']) -> str:
@@ -134,17 +131,31 @@ def log_path_hint(log_path: Union[str, 'pathlib.Path']) -> str:
         log_path = '~' + log_path[len(expanded_home):]
     return _LOG_PATH_HINT.format(log_path=log_path)
 
+def starting_message(message: str) -> str:
+    """Gets the starting message for the given message."""
+    return f'{colorama.Style.RESET_ALL}⚙︎ {message}'
 
 def finishing_message(
         message: str,
         log_path: Optional[Union[str, 'pathlib.Path']] = None) -> str:
     """Gets the finishing message for the given message."""
-    success_prefix = (f'{colorama.Fore.GREEN}✓ {message}'
-                      f'{colorama.Style.RESET_ALL}')
+    # We have to reset the color before the message, because sometimes if a
+    # previous spinner with dimmed color overflows in a narrow terminal, the
+    # color might be messed up.
+    success_prefix = (f'{colorama.Style.RESET_ALL}{colorama.Fore.GREEN}✓ '
+                      f'{message}{colorama.Style.RESET_ALL}')
     if log_path is None:
         return success_prefix
     path_hint = log_path_hint(log_path)
     return f'{success_prefix}  {path_hint}'
+
+def error_message(message: str, log_path: Optional[Union[str, 'pathlib.Path']] = None) -> str:
+    """Gets the error message for the given message."""
+    error_prefix = f'{colorama.Style.RESET_ALL}{colorama.Fore.RED}⨯{colorama.Style.RESET_ALL} {message}'
+    if log_path is None:
+        return error_prefix
+    path_hint = log_path_hint(log_path)
+    return f'{error_prefix}  {path_hint}'
 
 
 def retry_message(message: str) -> str:

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -121,8 +121,6 @@ class RedirectOutputForProcess:
                 raise
 
 
-
-
 def log_path_hint(log_path: Union[str, 'pathlib.Path']) -> str:
     """Gets the log path hint for the given log path."""
     log_path = str(log_path)
@@ -131,9 +129,11 @@ def log_path_hint(log_path: Union[str, 'pathlib.Path']) -> str:
         log_path = '~' + log_path[len(expanded_home):]
     return _LOG_PATH_HINT.format(log_path=log_path)
 
+
 def starting_message(message: str) -> str:
     """Gets the starting message for the given message."""
     return f'{colorama.Style.RESET_ALL}⚙︎ {message}'
+
 
 def finishing_message(
         message: str,
@@ -149,7 +149,9 @@ def finishing_message(
     path_hint = log_path_hint(log_path)
     return f'{success_prefix}  {path_hint}'
 
-def error_message(message: str, log_path: Optional[Union[str, 'pathlib.Path']] = None) -> str:
+
+def error_message(message: str,
+                  log_path: Optional[Union[str, 'pathlib.Path']] = None) -> str:
     """Gets the error message for the given message."""
     error_prefix = f'{colorama.Style.RESET_ALL}{colorama.Fore.RED}⨯{colorama.Style.RESET_ALL} {message}'
     if log_path is None:

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -132,6 +132,9 @@ def log_path_hint(log_path: Union[str, 'pathlib.Path']) -> str:
 
 def starting_message(message: str) -> str:
     """Gets the starting message for the given message."""
+    # We have to reset the color before the message, because sometimes if a
+    # previous spinner with dimmed color overflows in a narrow terminal, the
+    # color might be messed up.
     return f'{colorama.Style.RESET_ALL}⚙︎ {message}'
 
 
@@ -153,7 +156,11 @@ def finishing_message(
 def error_message(message: str,
                   log_path: Optional[Union[str, 'pathlib.Path']] = None) -> str:
     """Gets the error message for the given message."""
-    error_prefix = f'{colorama.Style.RESET_ALL}{colorama.Fore.RED}⨯{colorama.Style.RESET_ALL} {message}'
+    # We have to reset the color before the message, because sometimes if a
+    # previous spinner with dimmed color overflows in a narrow terminal, the
+    # color might be messed up.
+    error_prefix = (f'{colorama.Style.RESET_ALL}{colorama.Fore.RED}⨯'
+                    f'{colorama.Style.RESET_ALL} {message}')
     if log_path is None:
         return error_prefix
     path_hint = log_path_hint(log_path)
@@ -162,7 +169,11 @@ def error_message(message: str,
 
 def retry_message(message: str) -> str:
     """Gets the retry message for the given message."""
-    return f'{colorama.Fore.YELLOW}↺{colorama.Style.RESET_ALL} {message}'
+    # We have to reset the color before the message, because sometimes if a
+    # previous spinner with dimmed color overflows in a narrow terminal, the
+    # color might be messed up.
+    return (f'{colorama.Style.RESET_ALL}{colorama.Fore.YELLOW}↺'
+            f'{colorama.Style.RESET_ALL} {message}')
 
 
 def spinner_message(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when the window is narrow the logger output can be messed up due to the overflow of the status.

Also, in this PR, we should the log path after failure happens for skypilot runtime setup

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
