### PR TITLE
Raises error when user tries to update an existing service to Rolling…

### DIFF
--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -963,4 +963,7 @@ class ServeCodeGen:
             f'{version}, **mode_kwargs)',
             'print(msg, end="", flush=True)',
         ]
+        if mode == UpdateMode.ROLLING:
+            raise exceptions.NotSupportedError(
+                f'Rolling updates not supported on {service_name} service')
         return cls._build(code)


### PR DESCRIPTION
… mode. #4066

<!-- Describe the changes in this PR -->
Added a couple lines of code to disallow users from altering a service such as to put it in rolling mode. 


<!-- Describe the tests ran -->
format.sh
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
