### PR TITLE
[GCP] Add H100 mega

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -483,7 +483,7 @@ class GCP(clouds.Cloud):
                 if acc in ('A100-80GB', 'L4'):
                     # A100-80GB and L4 have a different name pattern.
                     resources_vars['gpu'] = f'nvidia-{acc.lower()}'
-                elif acc == 'H100':
+                elif acc in ('H100', 'H100-MEGA'):
                     resources_vars['gpu'] = f'nvidia-{acc.lower()}-80gb'
                 else:
                     resources_vars['gpu'] = 'nvidia-tesla-{}'.format(

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -419,6 +419,11 @@ def _get_gpus_for_zone(zone: str) -> 'pd.DataFrame':
                 if count != 8:
                     # H100 only has 8 cards.
                     continue
+            if 'H100-MEGA-80GB' in gpu_name:
+                gpu_name = 'H100-MEGA'
+                if count != 8:
+                    # H100-MEGA only has 8 cards.
+                    continue
             if 'VWS' in gpu_name:
                 continue
             if gpu_name.startswith('TPU-'):
@@ -447,6 +452,7 @@ def _gpu_info_from_name(name: str) -> Optional[Dict[str, List[Dict[str, Any]]]]:
         'A100-80GB': 80 * 1024,
         'A100': 40 * 1024,
         'H100': 80 * 1024,
+        'H100-MEGA': 80 * 1024,
         'P4': 8 * 1024,
         'T4': 16 * 1024,
         'V100': 16 * 1024,
@@ -496,6 +502,8 @@ def get_gpu_df(skus: List[Dict[str, Any]],
                 gpu_name = 'A100 80GB'
             if gpu_name == 'H100':
                 gpu_name = 'H100 80GB'
+            if gpu_name == 'H100-MEGA':
+                gpu_name = 'H100 80GB Plus'
             if f'{gpu_name} GPU' not in sku['description']:
                 continue
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -497,14 +497,16 @@ def get_gpu_df(skus: List[Dict[str, Any]],
             if sku['category']['usageType'] != ondemand_or_spot:
                 continue
 
-            gpu_name = row['AcceleratorName']
-            if gpu_name == 'A100-80GB':
-                gpu_name = 'A100 80GB'
-            if gpu_name == 'H100':
-                gpu_name = 'H100 80GB'
-            if gpu_name == 'H100-MEGA':
-                gpu_name = 'H100 80GB Plus'
-            if f'{gpu_name} GPU' not in sku['description']:
+            gpu_names = [row['AcceleratorName']]
+            if gpu_names[0] == 'A100-80GB':
+                gpu_names = ['A100 80GB']
+            if gpu_names[0] == 'H100':
+                gpu_names = ['H100 80GB']
+            if gpu_names[0] == 'H100-MEGA':
+                # Seems that H100-MEGA has two different descriptions in SKUs in
+                # different regions: 'H100 80GB Mega' and 'H100 80GB Plus'.
+                gpu_names = ['H100 80GB Mega', 'H100 80GB Plus']
+            if not any(f'{gpu_name} GPU' in sku['description'] for gpu_name in gpu_names):
                 continue
 
             unit_price = _get_unit_price(sku)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -506,7 +506,8 @@ def get_gpu_df(skus: List[Dict[str, Any]],
                 # Seems that H100-MEGA has two different descriptions in SKUs in
                 # different regions: 'H100 80GB Mega' and 'H100 80GB Plus'.
                 gpu_names = ['H100 80GB Mega', 'H100 80GB Plus']
-            if not any(f'{gpu_name} GPU' in sku['description'] for gpu_name in gpu_names):
+            if not any(f'{gpu_name} GPU' in sku['description']
+                       for gpu_name in gpu_names):
                 continue
 
             unit_price = _get_unit_price(sku)

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -98,6 +98,9 @@ _ACC_INSTANCE_TYPE_DICTS = {
     },
     'H100': {
         8: ['a3-highgpu-8g'],
+    },
+    'H100-MEGA': {
+        8: ['a3-megagpu-8g'],
     }
 }
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] Fetches locally and checked the result, seems correct.
  - [x] `sky launch --gpus H100-mega --use-spot --down`
```
(sky-cmd, pid=13008) Thu Oct 17 01:47:13 2024       
(sky-cmd, pid=13008) +---------------------------------------------------------------------------------------+
(sky-cmd, pid=13008) | NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
(sky-cmd, pid=13008) |-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) | GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
(sky-cmd, pid=13008) | Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
(sky-cmd, pid=13008) |                                         |                      |               MIG M. |
(sky-cmd, pid=13008) |=========================================+======================+======================|
(sky-cmd, pid=13008) |   0  NVIDIA H100 80GB HBM3          On  | 00000000:04:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   32C    P0              70W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   1  NVIDIA H100 80GB HBM3          On  | 00000000:05:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   31C    P0              70W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   2  NVIDIA H100 80GB HBM3          On  | 00000000:0B:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   33C    P0              71W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   3  NVIDIA H100 80GB HBM3          On  | 00000000:0C:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   30C    P0              68W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   4  NVIDIA H100 80GB HBM3          On  | 00000000:84:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   32C    P0              68W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   5  NVIDIA H100 80GB HBM3          On  | 00000000:85:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   31C    P0              68W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   6  NVIDIA H100 80GB HBM3          On  | 00000000:8B:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   32C    P0              69W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008) |   7  NVIDIA H100 80GB HBM3          On  | 00000000:8C:00.0 Off |                    0 |
(sky-cmd, pid=13008) | N/A   31C    P0              72W / 700W |      0MiB / 81559MiB |      0%      Default |
(sky-cmd, pid=13008) |                                         |                      |             Disabled |
(sky-cmd, pid=13008) +-----------------------------------------+----------------------+----------------------+
(sky-cmd, pid=13008)                                                                                          
(sky-cmd, pid=13008) +---------------------------------------------------------------------------------------+
(sky-cmd, pid=13008) | Processes:                                                                            |
(sky-cmd, pid=13008) |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
(sky-cmd, pid=13008) |        ID   ID                                                             Usage      |
(sky-cmd, pid=13008) |=======================================================================================|
(sky-cmd, pid=13008) |  No running processes found                                                           |
(sky-cmd, pid=13008) +---------------------------------------------------------------------------------------+
✓ Job finished (status: SUCCEEDED).
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
