### PR TITLE
[Docs] GKE Nvidia Driver installation instructions update

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -114,8 +114,8 @@ Deploying on Google Cloud GKE
      # Example:
      # gcloud container clusters get-credentials testcluster --region us-central1-c
 
-3. [If using GPUs] If your GKE nodes have GPUs, you may need to to
-   `manually install <https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/>`_
+3. [If using GPUs] If your GKE nodes have GPUs and you are using GKE version 1.30.1-gke.115600 or older, you may need to to
+   `manually install <https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers>`_
    nvidia drivers. You can do so by deploying the daemonset
    depending on the GPU and OS on your nodes:
 

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -114,9 +114,9 @@ Deploying on Google Cloud GKE
      # Example:
      # gcloud container clusters get-credentials testcluster --region us-central1-c
 
-3. [If using GPUs] If you are using GKE version 1.30.1-gke.115600 or older, you may need to to
+3. [If using GPUs] For GKE versions newer than 1.30.1-gke.115600, NVIDIA drivers are pre-installed and no additional setup is required. If you are using an older GKE version, you may need to
    `manually install <https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers>`_
-   nvidia drivers for GPU support. You can do so by deploying the daemonset
+   NVIDIA drivers for GPU support. You can do so by deploying the daemonset
    depending on the GPU and OS on your nodes:
 
    .. code-block:: console

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -114,9 +114,9 @@ Deploying on Google Cloud GKE
      # Example:
      # gcloud container clusters get-credentials testcluster --region us-central1-c
 
-3. [If using GPUs] If your GKE nodes have GPUs and you are using GKE version 1.30.1-gke.115600 or older, you may need to to
+3. [If using GPUs] If you are using GKE version 1.30.1-gke.115600 or older, you may need to to
    `manually install <https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#installing_drivers>`_
-   nvidia drivers. You can do so by deploying the daemonset
+   nvidia drivers for GPU support. You can do so by deploying the daemonset
    depending on the GPU and OS on your nodes:
 
    .. code-block:: console
@@ -133,7 +133,8 @@ Deploying on Google Cloud GKE
      # For Ubuntu based nodes with L4 GPUs:
      $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded-R525.yaml
 
-   To verify if GPU drivers are set up, run ``kubectl describe nodes`` and verify that ``nvidia.com/gpu`` is listed under the ``Capacity`` section.
+   .. tip::
+      To verify if GPU drivers are set up, run ``kubectl describe nodes`` and verify that ``nvidia.com/gpu`` resource is listed under the ``Capacity`` section.
 
 4. Verify your kubernetes cluster is correctly set up for SkyPilot by running :code:`sky check`:
 


### PR DESCRIPTION
GKE no longer requires manual driver installation for [1.30.1-gke.1156000](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create-gpu-pool-auto-drivers) and later. Updating our docs to reflect this