### PR TITLE
[Catalog] Silently ignore TPU price not found.

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -681,9 +681,11 @@ def get_tpu_df(gce_skus: List[Dict[str, Any]],
             spot_str = 'spot ' if spot else ''
             print(f'The {spot_str}price of {tpu_name} in {tpu_region} is '
                   'not found in SKUs or hidden TPU price DF.')
-        if not spot and tpu_price is None:
-            # TODO(tian): Hack. Sometimes the price is not available.
-            # Should investigate why.
+        # TODO(tian): Hack. Should investigate how to retrieve the price
+        # for TPU-v6e.
+        if not tpu_name.startswith('tpu-v6e'):
+            assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
+        else:
             tpu_price = 0.0
         return tpu_price
 

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -681,7 +681,10 @@ def get_tpu_df(gce_skus: List[Dict[str, Any]],
             spot_str = 'spot ' if spot else ''
             print(f'The {spot_str}price of {tpu_name} in {tpu_region} is '
                   'not found in SKUs or hidden TPU price DF.')
-        assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
+        if not spot and tpu_price is None:
+            # TODO(tian): Hack. Sometimes the price is not available.
+            # Should investigate why.
+            tpu_price = 0.0
         return tpu_price
 
     df['Price'] = df.apply(lambda row: get_tpu_price(row, spot=False), axis=1)

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -684,7 +684,8 @@ def get_tpu_df(gce_skus: List[Dict[str, Any]],
         # TODO(tian): Hack. Should investigate how to retrieve the price
         # for TPU-v6e.
         if not tpu_name.startswith('tpu-v6e'):
-            assert spot or tpu_price is not None, (row, hidden_tpu, HIDDEN_TPU_DF)
+            assert spot or tpu_price is not None, (row, hidden_tpu,
+                                                   HIDDEN_TPU_DF)
         else:
             tpu_price = 0.0
         return tpu_price


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Our GCP fetcher fails again. Silently ignore this before we figured out why.

https://github.com/skypilot-org/skypilot-catalog/actions/runs/11449564946/job/31855393437

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
