### PR TITLE
[k8s] Allow per-context identity configuration + in-cluster auth fixes

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -380,8 +380,8 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     secret_field_name = clouds.Kubernetes().ssh_key_secret_field_name
     context = config['provider'].get(
         'context', kubernetes_utils.get_current_kube_config_context_name())
-    if context == kubernetes_utils.IN_CLUSTER_REGION:
-        # If the context is set to IN_CLUSTER_REGION, we are running in a pod
+    if context == kubernetes_utils.get_in_cluster_context_name():
+        # If the context is a in-cluster context name, we are running in a pod
         # with in-cluster configuration. We need to set the context to None
         # to use the mounted service account.
         context = None

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -16,6 +16,7 @@ from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import common_utils
 from sky.utils import resources_utils
 from sky.utils import schemas
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     # Renaming to avoid shadowing variables.
@@ -180,8 +181,8 @@ class Kubernetes(clouds.Cloud):
         regions = []
         for context in existing_contexts:
             if context is None:
-                # If running in-cluster, we allow the region to be set to the
-                # singleton region since there is no context name available.
+                # If running in-cluster, we look up the context name and
+                # fetch it from the environment, if available.
                 in_cluster_region = (
                     kubernetes_utils.get_in_cluster_context_name())
                 regions.append(clouds.Region(in_cluster_region))
@@ -385,7 +386,8 @@ class Kubernetes(clouds.Cloud):
             if k8s_service_account_name is None:
                 err_msg = (f'Context {context!r} not found in '
                            'remote identities from config.yaml')
-                raise ValueError(err_msg)
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(err_msg)
         else:
             # If remote_identity is not a dict, use
             k8s_service_account_name = remote_identity

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -182,7 +182,8 @@ class Kubernetes(clouds.Cloud):
             if context is None:
                 # If running in-cluster, we allow the region to be set to the
                 # singleton region since there is no context name available.
-                in_cluster_region = kubernetes_utils.get_in_cluster_context_name()
+                in_cluster_region = (
+                    kubernetes_utils.get_in_cluster_context_name())
                 regions.append(clouds.Region(in_cluster_region))
             else:
                 regions.append(clouds.Region(context))
@@ -376,24 +377,29 @@ class Kubernetes(clouds.Cloud):
         remote_identity = skypilot_config.get_nested(
             ('kubernetes', 'remote_identity'),
             schemas.get_default_remote_identity('kubernetes'))
-        
+
         if isinstance(remote_identity, dict):
-            # If remote_identity is a dict, use the service account for the current context
+            # If remote_identity is a dict, use the service account for the
+            # current context
             k8s_service_account_name = remote_identity.get(context, None)
             if k8s_service_account_name is None:
-                err_msg = f'Context {context!r} not found in remote identities from config.yaml'
+                err_msg = (f'Context {context!r} not found in '
+                           'remote identities from config.yaml')
                 raise ValueError(err_msg)
         else:
-            # If remote_identity is not a dict, use 
+            # If remote_identity is not a dict, use
             k8s_service_account_name = remote_identity
 
-        if k8s_service_account_name == schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value:
+        if (k8s_service_account_name ==
+                schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value):
             # SA name doesn't matter since automounting credentials is disabled
             k8s_service_account_name = 'default'
             k8s_automount_sa_token = 'false'
-        elif k8s_service_account_name == schemas.RemoteIdentityOptions.SERVICE_ACCOUNT.value:
+        elif (k8s_service_account_name ==
+              schemas.RemoteIdentityOptions.SERVICE_ACCOUNT.value):
             # Use the default service account
-            k8s_service_account_name = kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME
+            k8s_service_account_name = (
+                kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME)
             k8s_automount_sa_token = 'true'
         else:
             # User specified a custom service account
@@ -421,7 +427,9 @@ class Kubernetes(clouds.Cloud):
         # Set environment variables for the pod. Note that SkyPilot env vars
         # are set separately when the task is run. These env vars are
         # independent of the SkyPilot task to be run.
-        k8s_env_vars = {kubernetes_utils.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context}
+        k8s_env_vars = {
+            kubernetes_utils.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context
+        }
 
         deploy_vars = {
             'instance_type': resources.instance_type,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2150,5 +2150,5 @@ def get_in_cluster_context_name() -> Optional[str]:
     If the environment variable is not set, returns the default in-cluster
     context name.
     """
-    return (os.environ.get(IN_CLUSTER_CONTEXT_NAME_ENV_VAR)
-            or DEFAULT_IN_CLUSTER_REGION)
+    return (os.environ.get(IN_CLUSTER_CONTEXT_NAME_ENV_VAR) or
+            DEFAULT_IN_CLUSTER_REGION)

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -36,7 +36,13 @@ if typing.TYPE_CHECKING:
 
 # TODO(romilb): Move constants to constants.py
 DEFAULT_NAMESPACE = 'default'
-IN_CLUSTER_REGION = 'in-cluster'
+DEFAULT_IN_CLUSTER_REGION = 'in-cluster'
+
+# The name for the environment variable that stores the in-cluster context name
+# for Kubernetes clusters. This is used to associate a name with the current
+# context when running with in-cluster auth. If not set, the context name is
+# set to DEFAULT_IN_CLUSTER_REGION.
+IN_CLUSTER_CONTEXT_NAME_ENV_VAR = 'SKYPILOT_IN_CLUSTER_CONTEXT_NAME'
 
 DEFAULT_SERVICE_ACCOUNT_NAME = 'skypilot-service-account'
 
@@ -1996,9 +2002,9 @@ def set_autodown_annotations(handle: 'backends.CloudVmRayResourceHandle',
 def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
     context = provider_config.get('context',
                                   get_current_kube_config_context_name())
-    if context == IN_CLUSTER_REGION:
-        # If the context (also used as the region) is set to IN_CLUSTER_REGION
-        # we need to use in-cluster auth.
+    if context == get_in_cluster_context_name():
+        # If the context (also used as the region) is in-cluster, we need to
+        # we need to use in-cluster auth by setting the context to None.
         context = None
     return context
 
@@ -2136,3 +2142,13 @@ def process_skypilot_pods(
         num_pods = len(cluster.pods)
         cluster.resources_str = f'{num_pods}x {cluster.resources}'
     return list(clusters.values()), jobs_controllers, serve_controllers
+
+
+def get_in_cluster_context_name() -> Optional[str]:
+    """Returns the name of the in-cluster context from the environment.
+
+    If the environment variable is not set, returns the default in-cluster
+    context name.
+    """
+    return (os.environ.get(IN_CLUSTER_CONTEXT_NAME_ENV_VAR)
+            or DEFAULT_IN_CLUSTER_REGION)

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -370,6 +370,14 @@ available_node_types:
               }
               trap : TERM INT; log_tail || sleep infinity & wait
 
+          {% if k8s_env_vars is not none %}
+          env:
+          {% for key, value in k8s_env_vars.items() %}
+          - name: {{ key }}
+            value: {{ value }}
+          {% endfor %}
+          {% endif %}
+
           ports:
           - containerPort: 22  # Used for SSH
           - containerPort: {{ray_port}}  # Redis port

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -668,7 +668,13 @@ _REMOTE_IDENTITY_SCHEMA = {
 
 _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
     'remote_identity': {
-        'type': 'string'
+        'anyOf': [
+            {'type': 'string'},
+            {
+                'type': 'object',
+                'additionalProperties': {'type': 'string'}
+            }
+        ]
     },
 }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -668,13 +668,14 @@ _REMOTE_IDENTITY_SCHEMA = {
 
 _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
     'remote_identity': {
-        'anyOf': [
-            {'type': 'string'},
-            {
-                'type': 'object',
-                'additionalProperties': {'type': 'string'}
+        'anyOf': [{
+            'type': 'string'
+        }, {
+            'type': 'object',
+            'additionalProperties': {
+                'type': 'string'
             }
-        ]
+        }]
     },
 }
 


### PR DESCRIPTION
Closes #4131. Also updates how in-cluster auth/context detection works. Instead of using `in-cluster`, we now pass the context name so that the remote_identity specified in config.yaml can be parsed correctly.

Tested:
- [x] Manual tests with `sky jobs launch` on a `sky local up` and GKE cluster, with both clusters configured in allowed_contexts.