### PR TITLE
[docs] Update GPUs used in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Paste the following into a file `my_task.yaml`:
 
 ```yaml
 resources:
-  accelerators: H100:1  # 1x NVIDIA H100 GPU
+  accelerators: A100:8  # 8x NVIDIA A100 GPU
 
 num_nodes: 1  # Number of VMs to launch
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Paste the following into a file `my_task.yaml`:
 
 ```yaml
 resources:
-  accelerators: V100:1  # 1x NVIDIA V100 GPU
+  accelerators: H100:1  # 1x NVIDIA H100 GPU
 
 num_nodes: 1  # Number of VMs to launch
 

--- a/docs/source/cloud-setup/quota.rst
+++ b/docs/source/cloud-setup/quota.rst
@@ -5,7 +5,7 @@ Requesting Quota Increase
 
 
 Most cloud providers enforce a quota policy to limit the number of VM instances that can exist in a given region.
-Users may encounter `QuotaExceeded` or `VcpuLimitExceeded` errors during resources provisioning, especially for high end GPUs such as V100/A100.
+Users may encounter `QuotaExceeded` or `VcpuLimitExceeded` errors during resources provisioning, especially for high end GPUs such as H100/A100.
 To check or increase your quota limits, please follow the below instructions.
 After submitting the request, it will usually take a few days for the support team to review.
 To increase chances of being approved, you may respond their inquiry emails on how the requested resources will be used your projects.
@@ -34,7 +34,7 @@ Azure
   - For Deployment model, ensure **Resource Manager** is selected.
   - For Locations, select all regions in which you want to increase quotas.
   - For each region you selected, select one or more VM series from the Quotas drop-down list.
-  - For each VM Series you selected (e.g., ``NCSv3``, ``NDv2`` for V100 instances), enter the new vCPU limit that you want for this subscription. You may check `for more VM Series <https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu>`_.
+  - For each VM Series you selected (e.g., ``ND_H100_v5`` for H100 instances), enter the new vCPU limit that you want for this subscription. You may check `for more VM Series <https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu>`_.
   - When you're finished, select **Save and continue**.
 
 5. Enter or confirm your contact details, then select **Next**.
@@ -45,10 +45,11 @@ GCP
 
 1. In the Google Cloud Console, go to the `Quota page <https://console.cloud.google.com/iam-admin/quotas/>`_.
 2. Click **Filter** and select ``Service: Compute Engine API``.
-3. Choose ``Limit Name: instance_name``. (e.g., ``NVIDIA-V100-GPUS-per-project-region``). You may check the `the compute GPU list <https://cloud.google.com/compute/quotas#gpu_quota>`_.
-4. Select the checkbox of the region whose quota you want to change.
-5. Click **Edit Quotas** and fill out the new limit.
-6. Click **Submit Request**.
+3. For H100 GPUs: choose ``metric: GPUS_PER_GPU_FAMILY`` and select dimension ``gpu_family: NVIDIA_H100``.
+4. For all other GPUs: choose ``Limit Name: instance_name``. (e.g., ``NVIDIA-V100-GPUS-per-project-region``). You may check the `the compute GPU list <https://cloud.google.com/compute/quotas#gpu_quota>`_.
+5. Select the checkbox of the region whose quota you want to change.
+6. Click **Edit Quotas** and fill out the new limit.
+7. Click **Submit Request**.
 
 OCI
 -------------------------------

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -124,9 +124,9 @@ This may show multiple clusters, if you have created several:
 
 .. code-block::
 
-  NAME       LAUNCHED     RESOURCES             COMMAND                            STATUS
-  mygcp      1 day ago    1x GCP(n1-highmem-8)  sky launch -c mygcp --cloud gcp    STOPPED
-  mycluster  4 mins ago   1x AWS(p4d.24xlarge)  sky exec mycluster hello_sky.yaml  UP
+  NAME       LAUNCHED     RESOURCES                          COMMAND                            STATUS
+  mygcp      1 day ago    1x GCP(n1-highmem-8)               sky launch -c mygcp --cloud gcp    STOPPED
+  mycluster  4 mins ago   1x AWS(p4d.24xlarge, {'A100': 8})  sky exec mycluster hello_sky.yaml  UP
 
 See here for a list of all possible :ref:`cluster states <sky-status>`.
 

--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -31,8 +31,8 @@ Copy the following YAML into a ``hello_sky.yaml`` file:
   resources:
     # Optional; if left out, automatically pick the cheapest cloud.
     cloud: aws
-    # 1x NVIDIA V100 GPU
-    accelerators: V100:1
+    # 8x NVIDIA A100 GPU
+    accelerators: A100:8
 
   # Working directory (optional) containing the project codebase.
   # Its contents are synced to ~/sky_workdir/ on the cluster.
@@ -106,7 +106,7 @@ Bash commands are also supported, such as:
 .. code-block:: console
 
   $ sky exec mycluster python train_cpu.py
-  $ sky exec mycluster --gpus=V100:1 python train_gpu.py
+  $ sky exec mycluster --gpus=A100:8 python train_gpu.py
 
 For interactive/monitoring commands, such as ``htop`` or ``gpustat -i``, use ``ssh`` instead (see below) to avoid job submission overheads.
 
@@ -126,7 +126,7 @@ This may show multiple clusters, if you have created several:
 
   NAME       LAUNCHED     RESOURCES             COMMAND                            STATUS
   mygcp      1 day ago    1x GCP(n1-highmem-8)  sky launch -c mygcp --cloud gcp    STOPPED
-  mycluster  4 mins ago   1x AWS(p3.2xlarge)    sky exec mycluster hello_sky.yaml  UP
+  mycluster  4 mins ago   1x AWS(p4d.24xlarge)  sky exec mycluster hello_sky.yaml  UP
 
 See here for a list of all possible :ref:`cluster states <sky-status>`.
 

--- a/docs/source/reference/job-queue.rst
+++ b/docs/source/reference/job-queue.rst
@@ -57,14 +57,14 @@ First, create a :code:`cluster.yaml` to specify the desired cluster:
 
   num_nodes: 4
   resources:
-    accelerators: V100:8
+    accelerators: H100:8
 
   workdir: ...
   setup: |
     # Install dependencies.
     ...
 
-Use :code:`sky launch -c mycluster cluster.yaml` to provision a 4-node (each having 8 V100 GPUs) cluster.
+Use :code:`sky launch -c mycluster cluster.yaml` to provision a 4-node (each having 8 H100 GPUs) cluster.
 The :code:`num_nodes` field is used to specify how many nodes are required.
 
 Next, create a :code:`task.yaml` to specify each task:
@@ -73,13 +73,13 @@ Next, create a :code:`task.yaml` to specify each task:
 
   num_nodes: 2
   resources:
-    accelerators: V100:4
+    accelerators: H100:4
 
   run: |
     # Run training script.
     ...
 
-This specifies a task that needs to be run on 2 nodes, each of which must have 4 free V100s.
+This specifies a task that needs to be run on 2 nodes, each of which must have 4 free H100s.
 
 Use :code:`sky exec mycluster task.yaml` to submit this task, which will be scheduled correctly by the job queue.
 
@@ -107,18 +107,18 @@ To submit multiple trials with different hyperparameters to a cluster:
 
 .. code-block:: bash
 
-  $ sky exec mycluster --gpus V100:1 -d -- python train.py --lr 1e-3
-  $ sky exec mycluster --gpus V100:1 -d -- python train.py --lr 3e-3
-  $ sky exec mycluster --gpus V100:1 -d -- python train.py --lr 1e-4
-  $ sky exec mycluster --gpus V100:1 -d -- python train.py --lr 1e-2
-  $ sky exec mycluster --gpus V100:1 -d -- python train.py --lr 1e-6
+  $ sky exec mycluster --gpus H100:1 -d -- python train.py --lr 1e-3
+  $ sky exec mycluster --gpus H100:1 -d -- python train.py --lr 3e-3
+  $ sky exec mycluster --gpus H100:1 -d -- python train.py --lr 1e-4
+  $ sky exec mycluster --gpus H100:1 -d -- python train.py --lr 1e-2
+  $ sky exec mycluster --gpus H100:1 -d -- python train.py --lr 1e-6
 
 Options used:
 
 - :code:`--gpus`: specify the resource requirement for each job.
 - :code:`-d` / :code:`--detach`: detach the run and logging from the terminal, allowing multiple trials to run concurrently.
 
-If there are only 4 V100 GPUs on the cluster, SkyPilot will queue 1 job while the
+If there are only 4 H100 GPUs on the cluster, SkyPilot will queue 1 job while the
 other 4 run in parallel. Once a job finishes, the next job will begin executing
 immediately.
 See :ref:`below <scheduling-behavior>` for more details on SkyPilot's scheduling behavior.
@@ -131,12 +131,12 @@ Example: Fractional GPUs
 -------------------------
 
 To run multiple trials per GPU, use *fractional GPUs* in the resource requirement.
-For example, use :code:`--gpus V100:0.5` to make 2 trials share 1 GPU:
+For example, use :code:`--gpus H100:0.5` to make 2 trials share 1 GPU:
 
 .. code-block:: bash
 
-  $ sky exec mycluster --gpus V100:0.5 -d -- python train.py --lr 1e-3
-  $ sky exec mycluster --gpus V100:0.5 -d -- python train.py --lr 3e-3
+  $ sky exec mycluster --gpus H100:0.5 -d -- python train.py --lr 1e-3
+  $ sky exec mycluster --gpus H100:0.5 -d -- python train.py --lr 3e-3
   ...
 
 When sharing a GPU, ensure that the GPU's memory is not oversubscribed
@@ -168,12 +168,12 @@ In that tutorial, we have a task YAML that specifies these resource requirements
   # dnn.yaml
   ...
   resources:
-    accelerators: V100:4
+    accelerators: H100:4
   ...
 
 Since a new cluster was created when we ran :code:`sky launch -c lm-cluster
 dnn.yaml`, SkyPilot provisioned the cluster with exactly the same resources as those
-required for the task.  Thus, :code:`lm-cluster` has 4 V100 GPUs.
+required for the task.  Thus, :code:`lm-cluster` has 4 H100 GPUs.
 
 While this initial job is running, let us submit more tasks:
 
@@ -182,12 +182,12 @@ While this initial job is running, let us submit more tasks:
   $ # Launch 4 jobs, perhaps with different hyperparameters.
   $ # You can override the task name with `-n` (optional) and
   $ # the resource requirement with `--gpus` (optional).
-  $ sky exec lm-cluster dnn.yaml -d -n job2 --gpus=V100:1
-  $ sky exec lm-cluster dnn.yaml -d -n job3 --gpus=V100:1
-  $ sky exec lm-cluster dnn.yaml -d -n job4 --gpus=V100:4
-  $ sky exec lm-cluster dnn.yaml -d -n job5 --gpus=V100:2
+  $ sky exec lm-cluster dnn.yaml -d -n job2 --gpus=H100:1
+  $ sky exec lm-cluster dnn.yaml -d -n job3 --gpus=H100:1
+  $ sky exec lm-cluster dnn.yaml -d -n job4 --gpus=H100:4
+  $ sky exec lm-cluster dnn.yaml -d -n job5 --gpus=H100:2
 
-Because the cluster has only 4 V100 GPUs, we will see the following sequence of events:
+Because the cluster has only 4 H100 GPUs, we will see the following sequence of events:
 
 - The initial :code:`sky launch` job is running and occupies 4 GPUs; all other jobs are pending (no free GPUs).
 - The first two :code:`sky exec` jobs (job2, job3) then start running and occupy 1 GPU each.

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -182,7 +182,7 @@ Manually Labelling Nodes
 
 You can also manually label nodes, if required. Labels must be of the format ``skypilot.co/accelerator: <gpu_name>`` where ``<gpu_name>`` is the lowercase name of the GPU.
 
-For example, a node with V100 GPUs must have a label :code:`skypilot.co/accelerator: v100`.
+For example, a node with H100 GPUs must have a label :code:`skypilot.co/accelerator: h100`.
 
 Use the following command to label a node:
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -51,18 +51,18 @@ Available fields:
       #
       #   To specify a single type of accelerator:
       #     Format: <name>:<count> (or simply <name>, short for a count of 1).
-      #     accelerators: V100:4
+      #     accelerators: H100:4
       #
       #   To specify an ordered list of accelerators (try the accelerators in
       #   the specified order):
       #     Format: [<name>:<count>, ...]
-      #     accelerators: ['K80:1', 'V100:1', 'T4:1']
+      #     accelerators: ['L4:1', 'H100:1', 'A100:1']
       #
       #   To specify an unordered set of accelerators (optimize all specified
       #   accelerators together, and try accelerator with lowest cost first):
       #     Format: {<name>:<count>, ...}
-      #     accelerators: {'K80:1', 'V100:1', 'T4:1'}
-      accelerators: V100:4
+      #     accelerators: {'L4:1', 'H100:1', 'A100:1'}
+      accelerators: H100:8
 
       # Number of vCPUs per node (optional).
       #
@@ -249,9 +249,9 @@ Available fields:
       any_of:
         - cloud: aws
           region: us-west-2
-          acceraltors: V100
+          accelerators: H100
         - cloud: gcp
-          acceraltors: A100
+          accelerators: H100
 
 
     # Environment variables (optional). These values can be accessed in the

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -14,7 +14,7 @@ For example, here is a simple PyTorch Distributed training example:
    name: resnet-distributed-app
 
    resources:
-     accelerators: V100:4
+     accelerators: A100:8
 
    num_nodes: 2
 
@@ -42,7 +42,7 @@ For example, here is a simple PyTorch Distributed training example:
 
 In the above,
 
-- :code:`num_nodes: 2` specifies that this task is to be run on 2 nodes, with each node having 4 V100s;
+- :code:`num_nodes: 2` specifies that this task is to be run on 2 nodes, with each node having 8 A100s;
 - The highlighted lines in the ``run`` section show common environment variables that are useful for launching distributed training, explained below.
 
 .. note::

--- a/llm/vllm/README.md
+++ b/llm/vllm/README.md
@@ -29,9 +29,9 @@ Before you get started, you need to have access to the Llama-2 model weights on 
 ```bash
 sky launch -c vllm-llama2 serve-openai-api.yaml --env HF_TOKEN=YOUR_HUGGING_FACE_API_TOKEN
 ```
-**Optional**: Only GCP offers the specified L4 GPUs currently. To use other clouds, use the `--gpus` flag to request other GPUs. For example, to use V100 GPUs:
+**Optional**: Only GCP offers the specified L4 GPUs currently. To use other clouds, use the `--gpus` flag to request other GPUs. For example, to use H100 GPUs:
 ```bash
-sky launch -c vllm-llama2 serve-openai-api.yaml --gpus V100:1 --env HF_TOKEN=YOUR_HUGGING_FACE_API_TOKEN
+sky launch -c vllm-llama2 serve-openai-api.yaml --gpus H100:1 --env HF_TOKEN=YOUR_HUGGING_FACE_API_TOKEN
 ```
 **Tip**: You can also use the vLLM docker container for faster setup. Refer to [serve-openai-api-docker.yaml](https://github.com/skypilot-org/skypilot/tree/master/llm/vllm/serve-openai-api-docker.yaml) for more.
 


### PR DESCRIPTION
Updates GPUs used in our docs from V100 to A100 or H100. A100:8 is used at many places because it's a configuration that is available across all 3 hyperscalers (AWS, GCP, Az). Other places use H100 to showcase the use of latest GPUs.

`tutorial.rst` and `distributed-jobs.rst` will be updated in a separate PR with a newer example (newer than BERT).

`managed-jobs.rst` will stay with V100s for now because the plots use V100 BERT training. 
Similarly `benchmark/*.rst` will also continue to use V100s because the benchmark measurements shown in examples are based on V100s..