### PR TITLE
[Performance] Allow users to pass in Azure community images at --image-id

### DIFF
--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -12,6 +12,21 @@ from sky.clouds.service_catalog import common
 from sky.utils import resources_utils
 from sky.utils import ux_utils
 
+# This list should match the list of regions in
+# skypilot image generation Packer script's replication_regions
+# sky/clouds/service_catalog/images/skypilot-azure-cpu-ubuntu.pkr.hcl
+COMMUNITY_IMAGE_AVAILABLE_REGIONS = {
+    'centralus',
+    'eastus',
+    'eastus2',
+    'northcentralus',
+    'southcentralus',
+    'westcentralus',
+    'westus',
+    'westus2',
+    'westus3',
+}
+
 # The frequency of pulling the latest catalog from the cloud provider.
 # Though the catalog update is manual in our skypilot-catalog repo, we
 # still want to pull the latest catalog periodically to make sure the

--- a/sky/clouds/utils/azure_utils.py
+++ b/sky/clouds/utils/azure_utils.py
@@ -1,0 +1,77 @@
+"""Utilies for Azure"""
+
+import typing
+
+from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    from azure.mgmt import compute as azure_compute
+    from azure.mgmt.compute import models as azure_compute_models
+
+
+def validate_image_id(image_id: str):
+    """Check if the image ID has a valid format.
+
+    Raises:
+        ValueError: If the image ID is invalid.
+    """
+    image_id_colon_splitted = image_id.split(':')
+    image_id_slash_splitted = image_id.split('/')
+    if len(image_id_slash_splitted) != 5 and len(image_id_colon_splitted) != 4:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'Invalid image id for Azure: {image_id}. Expected format: \n'
+                '* Marketplace image ID: <publisher>:<offer>:<sku>:<version>\n'
+                '* Community image ID: '
+                '/CommunityGalleries/<gallery-name>/Images/<image-name>')
+    if len(image_id_slash_splitted) == 5:
+        _, gallery_type, _, image_type, _ = image_id.split('/')
+        if gallery_type != 'CommunityGalleries' or image_type != 'Images':
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'Invalid community image id for Azure: {image_id}.\n'
+                    'Expected format: '
+                    '/CommunityGalleries/<gallery-name>/Images/<image-name>')
+
+
+def get_community_image(
+        compute_client: 'azure_compute.ComputeManagementClient', image_id: str,
+        region: str) -> 'azure_compute_models.CommunityGalleryImage':
+    """Get community image from cloud.
+
+    Args:
+        image_id: /CommunityGalleries/<gallery-name>/Images/<image-name>
+    Raises:
+        azure.core.exceptions.ResourceNotFoundError
+    """
+    _, _, gallery_name, _, image_name = image_id.split('/')
+    return compute_client.community_gallery_images.get(
+        location=region,
+        public_gallery_name=gallery_name,
+        gallery_image_name=image_name)
+
+
+def get_community_image_size(
+        compute_client: 'azure_compute.ComputeManagementClient',
+        gallery_name: str, image_name: str, region: str) -> float:
+    """Get the size of the community image from cloud.
+
+    Args:
+        image_id: /CommunityGalleries/<gallery-name>/Images/<image-name>
+    Raises:
+        azure.core.exceptions.ResourceNotFoundError
+    """
+    image_versions = compute_client.community_gallery_image_versions.list(
+        location=region,
+        public_gallery_name=gallery_name,
+        gallery_image_name=image_name,
+    )
+    image_versions = list(image_versions)
+    latest_version = image_versions[-1].name
+
+    image_details = compute_client.community_gallery_image_versions.get(
+        location=region,
+        public_gallery_name=gallery_name,
+        gallery_image_name=image_name,
+        gallery_image_version_name=latest_version)
+    return image_details.storage_profile.os_disk_image.disk_size_gb

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -225,6 +225,7 @@ class Resources:
         self._set_memory(memory)
         self._set_accelerators(accelerators, accelerator_args)
 
+        # TODO: move these out of init to prevent repeated calls.
         self._try_validate_instance_type()
         self._try_validate_cpus_mem()
         self._try_validate_managed_job_attributes()

--- a/tests/unit_tests/test_azure_utils.py
+++ b/tests/unit_tests/test_azure_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from sky.clouds.utils import azure_utils
+
+
+def test_validate_image_id():
+    # Valid marketplace image ID
+    azure_utils.validate_image_id("publisher:offer:sku:version")
+
+    # Valid community image ID
+    azure_utils.validate_image_id(
+        "/CommunityGalleries/gallery-name/Images/image-name")
+
+    # Invalid format (neither marketplace nor community)
+    with pytest.raises(ValueError):
+        azure_utils.validate_image_id(
+            "CommunityGalleries/gallery-name/Images/image-name")
+
+    # Invalid marketplace image ID (too few parts)
+    with pytest.raises(ValueError):
+        azure_utils.validate_image_id("publisher:offer:sku")


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
You can pass an Azure community gallery image as `image-id` arg at `sky launch`.
You can find all available community images in Azure console: https://portal.azure.com/?feature.msaljs=true#browse/Microsoft.Compute%2Flocations%2FcommunityGalleries%2Fimages 

```
sky launch --cloud=azure --region <region> --image-id=/CommunityGalleries/<gallery-name>/Images/<image-definition-name>
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual: sky launch normally with default marketplace image and sky launch with community image 
Invalid image ID: `sky launch --cloud=azure -y --image-id=xx`
Valid community image: `sky launch --cloud=azure -y -t Standard_B2s --region centralus --image-id=/CommunityGalleries/skypilot-fc3311ab-d34c-4589-b2fb-a95b8a84ceb1/Images/skypilot-cpu-gen2`
Invalid community image: `sky launch --cloud=azure -y -t Standard_DS1_v2 --region westus2 --image-id=/CommunityGalleries/skypilot-fe1926f1-7aff-4300-90d6-51fe7a190de7/Images/skypilot-cpu`
- [x] Smoke tests: `pytest tests/test_smoke.py::test_minimal --azure` 
- [x] Unit tests: `pytest tests/unit_tests/test_azure_utils.py`
