### PR TITLE
[k8s] Fix GPU labeling for EKS

### DIFF
--- a/sky/utils/kubernetes/k8s_gpu_labeler_job.yaml
+++ b/sky/utils/kubernetes/k8s_gpu_labeler_job.yaml
@@ -14,9 +14,10 @@ spec:
       containers:
       - name: gpu-labeler
         image: us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest # Using this image also serves as a way to "pre-pull" the image onto nodes
-        command:
-          - "python"
-          - "/label_gpus.py"
+        command: ["/bin/bash", "-i", "-c"]
+        args:
+          - |
+            python /label_gpus.py
         env:
         - name: MY_NODE_NAME
           valueFrom:


### PR DESCRIPTION
GPU labelling pods would fail on EKS with this error:
```
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  25m   default-scheduler  Successfully assigned kube-system/sky-gpu-labeler-6d605bbb187adc86ce55ad1b77759882-6nrsm to ip-192-168-55-105.ec2.internal
  Normal   Pulling    25m   kubelet            Pulling image "us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest"
  Normal   Pulled     24m   kubelet            Successfully pulled image "us-central1-docker.pkg.dev/skypilot-375900/skypilotk8s/skypilot-gpu:latest" in 55.832s (55.832s including waiting)
  Normal   Created    24m   kubelet            Created container gpu-labeler
  Warning  Failed     24m   kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "python": executable file not found in $PATH: unknown
```

We now invoke the script with `bash -i` which makes sure python is available in PATH. Tested on EKS.