### PR TITLE
[k8s] Handle @ in context name

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -836,8 +836,9 @@ class KubernetesCommandRunner(CommandRunner):
         # default delimiter for options and arguments.
         # rsync_helper.sh will parse the namespace_context by reverting the
         # encoding and pass it to kubectl exec.
-        encoded_namespace_context = namespace_context.replace(
-            ':', '%3A').replace('/', '%2F').replace('+', '%2B')
+        encoded_namespace_context = (namespace_context.replace(
+            '@', '%40').replace(':', '%3A').replace('/',
+                                                    '%2F').replace('+', '%2B'))
         self._rsync(
             source,
             target,

--- a/sky/utils/kubernetes/rsync_helper.sh
+++ b/sky/utils/kubernetes/rsync_helper.sh
@@ -7,7 +7,7 @@ shift
 echo "pod: $pod" >&2
 encoded_namespace_context=$1
 # Revert the encoded namespace+context to the original string.
-namespace_context=$(echo "$encoded_namespace_context" | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
+namespace_context=$(echo "$encoded_namespace_context" | sed 's|%40|@|g' | sed 's|%3A|:|g' | sed 's|%2B|+|g' | sed 's|%2F|/|g')
 echo "namespace_context: $namespace_context" >&2
 namespace=$(echo $namespace_context | cut -d+ -f1)
 echo "namespace: $namespace" >&2


### PR DESCRIPTION
eksctl generates context names like `romildev@my-cluster.us-east-1.eksctl.io`. 

The `@` in the context name causes our rsync pipeline to crash.

This PR adds handling for `@` in context name. 