### PR TITLE
[docs] use k8s instead of kubernetes in the CLI

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 rm -rf build docs
-script -q /tmp/build_docs.txt bash -c "make html"
+
+# MacOS and GNU `script` have different usages
+if [ "$(uname -s)" = "Linux" ]; then
+  script -q /tmp/build_docs.txt -c "make html"
+else
+  # Assume MacOS (uname -s = Darwin)
+  script -q /tmp/build_docs.txt bash -c "make html"
+fi
 
 # Check if the output contains "ERROR:" or "WARNING:"
 if grep -q -E "ERROR:|WARNING:" /tmp/build_docs.txt; then

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -142,11 +142,11 @@ Deploying on Google Cloud GKE
 
      $ sky check
 
-5. [If using GPUs] Check available GPUs in the kubernetes cluster with :code:`sky show-gpus --cloud kubernetes`
+5. [If using GPUs] Check available GPUs in the kubernetes cluster with :code:`sky show-gpus --cloud k8s`
 
    .. code-block:: console
 
-       $ sky show-gpus --cloud kubernetes
+       $ sky show-gpus --cloud k8s
        GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
        L4    1, 2, 4                   8           6
        A100  1, 2                      4           2
@@ -197,11 +197,11 @@ Deploying on Amazon EKS
 
      $ sky check
 
-5. [If using GPUs] Check available GPUs in the kubernetes cluster with :code:`sky show-gpus --cloud kubernetes`
+5. [If using GPUs] Check available GPUs in the kubernetes cluster with :code:`sky show-gpus --cloud k8s`
 
    .. code-block:: console
 
-       $ sky show-gpus --cloud kubernetes
+       $ sky show-gpus --cloud k8s
        GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
        A100  1, 2                      4           2
 

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -150,11 +150,11 @@ Unlike :code:`sky status` which lists only the SkyPilot resources launched by th
     bob      2   -     failjob   1x[CPU:1+]  1 day ago   54s            9s            0            FAILED
     bob      1   -     shortjob  1x[CPU:1+]  2 days ago  1h 1m 19s      1h 16s        0            SUCCEEDED
 
-You can also inspect the real-time GPU usage on the cluster with :code:`sky show-gpus --cloud kubernetes`.
+You can also inspect the real-time GPU usage on the cluster with :code:`sky show-gpus --cloud kubernetes` (or :code:`--cloud k8s`).
 
 .. code-block:: console
 
-    $ sky show-gpus --cloud kubernetes
+    $ sky show-gpus --cloud k8s
     Kubernetes GPUs
     GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
     L4    1, 2, 4                   12          12

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -150,7 +150,7 @@ Unlike :code:`sky status` which lists only the SkyPilot resources launched by th
     bob      2   -     failjob   1x[CPU:1+]  1 day ago   54s            9s            0            FAILED
     bob      1   -     shortjob  1x[CPU:1+]  2 days ago  1h 1m 19s      1h 16s        0            SUCCEEDED
 
-You can also inspect the real-time GPU usage on the cluster with :code:`sky show-gpus --cloud kubernetes` (or :code:`--cloud k8s`).
+You can also inspect the real-time GPU usage on the cluster with :code:`sky show-gpus --cloud k8s`.
 
 .. code-block:: console
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -260,7 +260,7 @@ You can also check the GPUs available on your nodes by running:
 
 .. code-block:: console
 
-    $ sky show-gpus --cloud kubernetes
+    $ sky show-gpus --cloud k8s
     Kubernetes GPUs
     GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
     L4    1, 2, 4                   12          12

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -87,7 +87,7 @@ Next, try running a simple hello world task to verify that SkyPilot can launch t
 
 .. code-block:: bash
 
-    $ sky launch -y -c mycluster --cloud kubernetes -- "echo hello world"
+    $ sky launch -y -c mycluster --cloud k8s -- "echo hello world"
     # Task should run and print "hello world" to the console
 
     # Once you have verified that the task runs, you can delete it
@@ -174,7 +174,7 @@ Run :code:`sky check` to verify that SkyPilot can see your GPUs.
     # Should show `Kubernetes: Enabled` and should not print any warnings about GPU support.
 
     # List the available GPUs in your cluster
-    $ sky show-gpus --cloud kubernetes
+    $ sky show-gpus --cloud k8s
 
 Step B4 - Try launching a dummy GPU task
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +184,7 @@ Next, try running a simple GPU task to verify that SkyPilot can launch GPU tasks
 .. code-block:: bash
 
     # Replace the GPU type from the sky show-gpus output in the task launch command
-    $ sky launch -y -c mygpucluster --cloud kubernetes --gpu <gpu-type>:1 -- "nvidia-smi"
+    $ sky launch -y -c mygpucluster --cloud k8s --gpu <gpu-type>:1 -- "nvidia-smi"
 
     # Task should run and print the nvidia-smi output to the console
 
@@ -298,7 +298,7 @@ Next, try running a simple task with a service to verify that SkyPilot can launc
 
 .. code-block:: bash
 
-    $ sky launch -y -c myserver --cloud kubernetes --ports 8080 -- "python -m http.server 8080"
+    $ sky launch -y -c myserver --cloud k8s --ports 8080 -- "python -m http.server 8080"
 
     # Obtain the endpoint of the service
     $ sky status --endpoint 8080 myserver

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -106,7 +106,7 @@ Deploying SkyPilot
 
    .. code-block:: console
 
-      $ sky show-gpus --cloud kubernetes
+      $ sky show-gpus --cloud k8s
       Kubernetes GPUs
       GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
       L4    1, 2, 4                   12          12
@@ -121,7 +121,7 @@ Deploying SkyPilot
       my-cluster-4               H100      8           8
       my-cluster-5               H100      8           8
 
-      $ sky launch --cloud kubernetes --gpus H100:1 -- nvidia-smi
+      $ sky launch --cloud k8s --gpus H100:1 -- nvidia-smi
 
    .. tip::
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3025,9 +3025,9 @@ def show_gpus(
     and spot instances. There may be multiple regions with the same lowest
     price.
 
-    If ``--cloud kubernetes`` is specified, it will show the maximum quantities
-    of the GPU available on a single node and the real-time availability of
-    the GPU across all nodes in the Kubernetes cluster.
+    If ``--cloud kubernetes`` or ``--cloud k8s`` is specified, it will show the
+    maximum quantities of the GPU available on a single node and the real-time
+    availability of the GPU across all nodes in the Kubernetes cluster.
 
     Definitions of certain fields:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Update the docs after #4151.

We may want to wait until after 0.7 release to merge.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
