### PR TITLE
[Performance] Use new Azure custom images

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -39,9 +39,9 @@ _DEFAULT_AZURE_UBUNTU_HPC_IMAGE_GB = 30
 _DEFAULT_AZURE_UBUNTU_2004_IMAGE_GB = 150
 _DEFAULT_SKYPILOT_IMAGE_GB = 30
 
-_DEFAULT_CPU_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
-_DEFAULT_GPU_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
-_DEFAULT_V1_IMAGE_ID = 'skypilot:v1-ubuntu-2004'
+_DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-v2'
+_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-v2'
+_DEFAULT_V1_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-v1'
 _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-ubuntu-2004'
 _FALLBACK_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
 

--- a/sky/clouds/service_catalog/azure_catalog.py
+++ b/sky/clouds/service_catalog/azure_catalog.py
@@ -6,7 +6,8 @@ instance types and pricing information for Azure.
 import re
 from typing import Dict, List, Optional, Tuple
 
-from sky import clouds as cloud_lib, sky_logging
+from sky import clouds as cloud_lib
+from sky import sky_logging
 from sky.clouds import Azure
 from sky.clouds.service_catalog import common
 from sky.utils import resources_utils


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Use the new custom image for Azure's VM creation. 

Example performance change (with fixed region):
|  VM Type 💻   | Old Provision 🕐                 | New Provision 🕐     | % Speedup ✅ |
| --------------- | ---------------------------- | ----------- | ----------- |
| Azure GPU      |   4min    | 2min 40s   | 35% (1.5x) |
| Azure CPU       |  4min  | 2min |  50% (2x) |

Example benchmark commands:
CPU: `time sky launch --cloud=azure --region=centralus -y`
GPU: `time sky launch --cloud=azure --region=centralus -y --gpus=A100-80GB:1`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Relevant individual smoke tests: 
`pytest tests/test_smoke.py::test_minimal --azure`
`pytest tests/test_smoke.py::test_huggingface --azure`
`pytest tests/test_smoke.py::test_job_queue_with_docker --azure`
`pytest tests/test_smoke.py::test_cancel_azure`
