### PR TITLE
Remove --system-site-packages when setup sky cluster

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -150,6 +150,9 @@ CONDA_INSTALLATION_COMMANDS = (
     f'conda activate {SKY_REMOTE_PYTHON_ENV_NAME};'
     # Create a separate conda environment for SkyPilot dependencies.
     f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || '
+    # Do NOT use --system-site-packages here, because if users upgrade any
+    # packages in the base env, they interfere with skypilot dependencies.
+    # Reference: https://github.com/skypilot-org/skypilot/issues/4097
     f'{SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV};'
     f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE};'
 )

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -44,9 +44,6 @@ SKY_PIP_CMD = f'{SKY_PYTHON_CMD} -m pip'
 # We need to add SKY_PYTHON_CMD before ray executable because:
 # The ray executable is a python script with a header like:
 #   #!/opt/conda/bin/python3
-# When we create the skypilot-runtime venv, the previously installed ray
-# executable will be reused (due to --system-site-packages), and that will cause
-# running ray CLI commands to use the wrong python executable.
 SKY_RAY_CMD = (f'{SKY_PYTHON_CMD} $([ -s {SKY_RAY_PATH_FILE} ] && '
                f'cat {SKY_RAY_PATH_FILE} 2> /dev/null || which ray)')
 # Separate env for SkyPilot runtime dependencies.
@@ -152,10 +149,8 @@ CONDA_INSTALLATION_COMMANDS = (
     f'conda create -y -n {SKY_REMOTE_PYTHON_ENV_NAME} python=3.10 && '
     f'conda activate {SKY_REMOTE_PYTHON_ENV_NAME};'
     # Create a separate conda environment for SkyPilot dependencies.
-    # We use --system-site-packages to reuse the system site packages to avoid
-    # the overhead of installing the same packages in the new environment.
     f'[ -d {SKY_REMOTE_PYTHON_ENV} ] || '
-    f'{SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV} --system-site-packages;'
+    f'{SKY_PYTHON_CMD} -m venv {SKY_REMOTE_PYTHON_ENV};'
     f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE};'
 )
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Solve https://github.com/skypilot-org/skypilot/issues/4097
Remove the flag so that sky's venv won't link to the global (system) site-packages directory which can be modified by users.

No regression on latency for all clouds.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_minimal`
- [x] Performance compare before and after on all 4 major clouds, the setup time improved 0-3s across clouds
