### PR TITLE
[UX] remove deprecated `sky spot` CLI and `sky.spot_xxx` API

### DIFF
--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -106,12 +106,6 @@ from sky.data import StoreType
 from sky.execution import exec  # pylint: disable=redefined-builtin
 from sky.execution import launch
 from sky.jobs import ManagedJobStatus
-# TODO (zhwu): These imports are for backward compatibility, and spot APIs
-# should be called with `sky.spot.xxx` instead. Remove in release 0.8.0
-from sky.jobs.core import spot_cancel
-from sky.jobs.core import spot_launch
-from sky.jobs.core import spot_queue
-from sky.jobs.core import spot_tail_logs
 from sky.optimizer import Optimizer
 from sky.optimizer import OptimizeTarget
 from sky.resources import Resources
@@ -172,7 +166,6 @@ __all__ = [
     # execution APIs
     'launch',
     'exec',
-    'spot_launch',
     # core APIs
     'status',
     'start',
@@ -184,12 +177,8 @@ __all__ = [
     'queue',
     'cancel',
     'tail_logs',
-    'spot_tail_logs',
     'download_logs',
     'job_status',
-    # core APIs Spot Job Management
-    'spot_queue',
-    'spot_cancel',
     # core APIs Storage Management
     'storage_ls',
     'storage_delete',

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3997,25 +3997,6 @@ def jobs_dashboard(port: Optional[int]):
             click.echo('Exiting.')
 
 
-# TODO(zhwu): Backward compatibility for the old `sky spot launch` command.
-# It is now renamed to `sky jobs launch` and the old command is deprecated.
-# Remove in v0.8.0.
-@cli.group(cls=_NaturalOrderGroup)
-def spot():
-    """Alias for Managed Jobs CLI (default to managed spot jobs)."""
-    pass
-
-
-_add_command_alias(jobs,
-                   jobs_launch,
-                   new_group=spot,
-                   override_command_argument={'use_spot': True})
-_add_command_alias(jobs, jobs_queue, new_group=spot)
-_add_command_alias(jobs, jobs_logs, new_group=spot)
-_add_command_alias(jobs, jobs_cancel, new_group=spot)
-_add_command_alias(jobs, jobs_dashboard, new_group=spot)
-
-
 @cli.group(cls=_NaturalOrderGroup)
 def serve():
     """SkyServe CLI (multi-region, multi-cloud serving)."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
[The v0.6.0 release](https://github.com/skypilot-org/skypilot/releases/tag/v0.6.0) said these "will be removed in the next minor release", but the comments say v0.8.0. We will wait til 0.8.0.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [ ] /quicktest-core
- [ ] /smoke-test --managed-jobs