### PR TITLE
Fix OCI import issue

### DIFF
--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -468,7 +468,9 @@ class OCI(clouds.Cloud):
             api_key_file = oci_cfg[
                 'key_file'] if 'key_file' in oci_cfg else 'BadConf'
             sky_cfg_file = oci_utils.oci_config.get_sky_user_config_file()
-        except (ImportError, oci_adaptor.oci.exceptions.ConfigFileNotFound):
+        except ImportError:
+            return {}
+        except oci_adaptor.oci.exceptions.ConfigFileNotFound:
             return {}
 
         # OCI config and API key file are mandatory

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -470,6 +470,12 @@ class OCI(clouds.Cloud):
             sky_cfg_file = oci_utils.oci_config.get_sky_user_config_file()
         except ImportError:
             return {}
+        # This exception is explicitly separated from the line above, as this function
+        # can be called by `check.get_credential_file_mounts` even without oci
+        # dependencies installed. Having this exception in the same line as
+        # ImportError above can cause another error being raised, due to
+        # oci_adaptor.oci.exceptions.ConfigFileNotFound trying to import the oci
+        # dependencies again.
         except oci_adaptor.oci.exceptions.ConfigFileNotFound:
             return {}
 

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -468,14 +468,10 @@ class OCI(clouds.Cloud):
             api_key_file = oci_cfg[
                 'key_file'] if 'key_file' in oci_cfg else 'BadConf'
             sky_cfg_file = oci_utils.oci_config.get_sky_user_config_file()
+        # Must catch ImportError before any oci_adaptor.oci.exceptions
+        # because oci_adaptor.oci.exceptions can throw ImportError.
         except ImportError:
             return {}
-        # This exception is explicitly separated from the line above, as this function
-        # can be called by `check.get_credential_file_mounts` even without oci
-        # dependencies installed. Having this exception in the same line as
-        # ImportError above can cause another error being raised, due to
-        # oci_adaptor.oci.exceptions.ConfigFileNotFound trying to import the oci
-        # dependencies again.
         except oci_adaptor.oci.exceptions.ConfigFileNotFound:
             return {}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Putting ImportError and oci_adaptor.oci.exceptions.ConfigFileNotFound on the same line will fail to catch ImportError caused by oci_adaptor.oci.exceptions.ConfigFileNotFound

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual: tested `sky launch` when having OCI installed and uninstalled
