### PR TITLE
[OCI] lazy import 

### DIFF
--- a/sky/adaptors/oci.py
+++ b/sky/adaptors/oci.py
@@ -11,6 +11,7 @@ oci = common.LazyImport(
     'oci',
     import_error_message='Failed to import dependencies for OCI. '
     'Try running: pip install "skypilot[oci]"')
+_LAZY_MODULES = (oci,)
 
 
 def get_config_file() -> str:
@@ -21,6 +22,7 @@ def get_config_file() -> str:
     return conf_file_path
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_oci_config(region=None, profile='DEFAULT'):
     conf_file_path = get_config_file()
     oci_config = oci.config.from_file(file_location=conf_file_path,
@@ -30,23 +32,28 @@ def get_oci_config(region=None, profile='DEFAULT'):
     return oci_config
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_core_client(region=None, profile='DEFAULT'):
     return oci.core.ComputeClient(get_oci_config(region, profile))
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_net_client(region=None, profile='DEFAULT'):
     return oci.core.VirtualNetworkClient(get_oci_config(region, profile))
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_search_client(region=None, profile='DEFAULT'):
     return oci.resource_search.ResourceSearchClient(
         get_oci_config(region, profile))
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def get_identity_client(region=None, profile='DEFAULT'):
     return oci.identity.IdentityClient(get_oci_config(region, profile))
 
 
+@common.load_lazy_modules(modules=_LAZY_MODULES)
 def service_exception():
     """OCI service exception."""
     return oci.exceptions.ServiceError


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Ran into this while testing digital ocean. These imports shouldn't be breaking `serve`/`jobs` when I've only enabled clouds other than `oci`. this fixes that.
```
Traceback (most recent call last):
  File "/root/skypilot-runtime/lib/python3.10/site-packages/sky/clouds/oci.py", line 466, in get_credential_file_mounts
    oci_cfg = oci_adaptor.get_oci_config(
  File "/root/skypilot-runtime/lib/python3.10/site-packages/sky/adaptors/oci.py", line 26, in get_oci_config
    oci_config = oci.config.from_file(file_location=conf_file_path,
  File "/root/skypilot-runtime/lib/python3.10/site-packages/sky/adaptors/common.py", line 46, in __getattr__
    return getattr(self.load_module(), name)
  File "/root/skypilot-runtime/lib/python3.10/site-packages/sky/adaptors/common.py", line 36, in load_module
    raise ImportError(self._import_error_message) from e
ImportError: Failed to import dependencies for OCI. Try running: pip install "skypilot[oci]"
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
