### PR TITLE
[test] update default clouds for smoke tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 # to mark a test as slow and to skip by default.
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
 
-# By default, only run generic tests and cloud-specific tests for GCP and Azure,
+# By default, only run generic tests and cloud-specific tests for AWS and Azure,
 # due to the cloud credit limit for the development account.
 #
 # A "generic test" tests a generic functionality (e.g., autostop) that
@@ -24,7 +24,7 @@ all_clouds_in_smoke_tests = [
     'aws', 'gcp', 'azure', 'lambda', 'cloudflare', 'ibm', 'scp', 'oci',
     'kubernetes', 'vsphere', 'cudo', 'fluidstack', 'paperspace'
 ]
-default_clouds_to_run = ['gcp', 'azure']
+default_clouds_to_run = ['aws', 'azure']
 
 # Translate cloud name to pytest keyword. We need this because
 # @pytest.mark.lambda is not allowed, so we use @pytest.mark.lambda_cloud
@@ -72,7 +72,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--generic-cloud',
         type=str,
-        default='gcp',
+        default='aws',
         choices=all_clouds_in_smoke_tests,
         help='Cloud to use for generic tests. If the generic cloud is '
         'not within the clouds to be run, it will be reset to the first '
@@ -138,8 +138,8 @@ def pytest_collection_modifyitems(config, items):
         for cloud in all_clouds_in_smoke_tests:
             cloud_keyword = cloud_to_pytest_keyword[cloud]
             if (cloud_keyword in item.keywords and cloud not in cloud_to_run):
-                # Need to check both conditions as 'gcp' is added to cloud_to_run
-                # when tested for cloudflare
+                # Need to check both conditions as the first default cloud is
+                # added to cloud_to_run when tested for cloudflare
                 if config.getoption('--cloudflare') and cloud == 'cloudflare':
                     continue
                 item.add_marker(skip_marks[cloud])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
generic_cloud default gcp -> aws
default enabled clouds [gcp, azure] -> [aws, azure]

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] `bash format.sh`
- [x] `pytest tests/test_smoke.py::test_minimal`
- [x] Will do more smoke tests on #4159 later today with this patch.