### PR TITLE
[dev] restrict pylint to changed files

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -131,7 +131,7 @@ elif [[ "$1" == '--all' ]]; then
     pylint "${PYLINT_FLAGS[@]}" sky
 else
     # Pylint only files in sky/ that have changed in last commit.
-    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/**/*.py' 'sky/**/*.pyi')
+    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi')
     if [[ -n "$changed_files" ]]; then
         echo "$changed_files" | xargs -d '\n' pylint "${PYLINT_FLAGS[@]}"
     else

--- a/format.sh
+++ b/format.sh
@@ -81,8 +81,9 @@ format_changed() {
     MERGEBASE="$(git merge-base origin/master HEAD)"
 
     if ! git diff --diff-filter=ACM --quiet --exit-code "$MERGEBASE" -- '*.py' '*.pyi' &>/dev/null; then
-        git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.py' '*.pyi' | xargs -P 5 -d '\n' \
-             yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
+        git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.py' '*.pyi' | \
+            tr '\n' '\0' | xargs -P 5 -0 \
+            yapf --in-place "${YAPF_EXCLUDES[@]}" "${YAPF_FLAGS[@]}"
     fi
 
 }
@@ -133,7 +134,7 @@ else
     # Pylint only files in sky/ that have changed in last commit.
     changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi')
     if [[ -n "$changed_files" ]]; then
-        echo "$changed_files" | xargs -d '\n' pylint "${PYLINT_FLAGS[@]}"
+        echo "$changed_files" | tr '\n' '\0' | xargs -0 pylint "${PYLINT_FLAGS[@]}"
     else
         echo 'Pylint skipped: no files changed in sky/.'
     fi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Use a similar approach to what we do with yapf to limit pylint to only files that have changed from master.

On my machine this shaves about a minute off pylint runtime, making pylint 7-8x faster and format.sh 3-4x faster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh` :)
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`