### PR TITLE
[Job] Support DAG execution by replacing `is_chain` with `is_dag` check

### DIFF
--- a/sky/dag.py
+++ b/sky/dag.py
@@ -242,9 +242,15 @@ class Dag:
                 (all(degree <= 1 for degree in out_degrees) and
                  sum(degree == 0 for degree in out_degrees) == 1))
 
-    def is_dag(self) -> bool:
-        """Check if the DAG is a DAG."""
-        return nx.is_directed_acyclic_graph(self.graph)
+    def is_connected_dag(self) -> bool:
+        """Check if the graph is a connected directed acyclic graph (DAG).
+
+        Returns:
+            True if the graph is a connected DAG (weakly connected,
+            directed and acyclic), False otherwise.
+        """
+        return (nx.is_directed_acyclic_graph(self.graph) and
+                nx.is_weakly_connected(self.graph))
 
 
 class _DagContext(threading.local):

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -249,8 +249,14 @@ class Dag:
             True if the graph is a connected DAG (weakly connected,
             directed and acyclic), False otherwise.
         """
-        return (nx.is_directed_acyclic_graph(self.graph) and
-                nx.is_weakly_connected(self.graph))
+
+        # A graph is weakly connected if replacing all directed edges with
+        # undirected edges produces a connected graph, i.e., any two nodes
+        # can reach each other ignoring edge directions.
+        if not nx.is_weakly_connected(self.graph):
+            return False
+
+        return nx.is_directed_acyclic_graph(self.graph)
 
 
 class _DagContext(threading.local):

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -242,6 +242,10 @@ class Dag:
                 (all(degree <= 1 for degree in out_degrees) and
                  sum(degree == 0 for degree in out_degrees) == 1))
 
+    def is_dag(self) -> bool:
+        """Check if the DAG is a DAG."""
+        return nx.is_directed_acyclic_graph(self.graph)
+
 
 class _DagContext(threading.local):
     """A thread-local stack of Dags."""

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -59,7 +59,7 @@ def launch(
     dag = dag_utils.convert_entrypoint_to_dag(entrypoint)
     dag, mutated_user_config = admin_policy_utils.apply(
         dag, use_mutated_config_in_current_request=False)
-    if not dag.is_dag():
+    if not dag.is_connected_dag():
         with ux_utils.print_exception_no_traceback():
             raise ValueError(f'Only DAG is allowed for job_launch. Dag: {dag}')
 

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -61,7 +61,7 @@ def launch(
         dag, use_mutated_config_in_current_request=False)
     if not dag.is_connected_dag():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'Only DAG is allowed for job_launch. Dag: {dag}')
+            raise ValueError(f'Only connected DAG is allowed for job_launch. If your dag contains multiple subgraph that is a connected dag, please separate them into multiple dag. Get: {dag}')
 
     dag_utils.maybe_infer_and_fill_dag_and_task_names(dag)
 

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -59,10 +59,9 @@ def launch(
     dag = dag_utils.convert_entrypoint_to_dag(entrypoint)
     dag, mutated_user_config = admin_policy_utils.apply(
         dag, use_mutated_config_in_current_request=False)
-    if not dag.is_chain():
+    if not dag.is_dag():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError('Only single-task or chain DAG is '
-                             f'allowed for job_launch. Dag: {dag}')
+            raise ValueError(f'Only DAG is allowed for job_launch. Dag: {dag}')
 
     dag_utils.maybe_infer_and_fill_dag_and_task_names(dag)
 

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -61,7 +61,10 @@ def launch(
         dag, use_mutated_config_in_current_request=False)
     if not dag.is_connected_dag():
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'Only connected DAG is allowed for job_launch. If your dag contains multiple subgraph that is a connected dag, please separate them into multiple dag. Get: {dag}')
+            raise ValueError(
+                f'Only connected DAG is allowed for job_launch. If your dag '
+                f'contains multiple subgraph that is a connected dag, please '
+                f'separate them into multiple dag. Get: {dag}')
 
     dag_utils.maybe_infer_and_fill_dag_and_task_names(dag)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Replace `is_chain()` with `is_dag()` check to:
1. Enable future DAG execution support
2. Validate DAG structure before job launch

              Also, Lets create another PR to check the inputt graph is a connected DAG?

_Originally posted by @cblmemo in https://github.com/skypilot-org/skypilot/pull/4128#discussion_r1817400139_

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
