### PR TITLE
Remove outdated pylint disabling comments

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3585,9 +3585,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             backend_utils.CLUSTER_STATUS_LOCK_PATH.format(cluster_name))
 
         try:
-            # TODO(mraheja): remove pylint disabling when filelock
-            # version updated
-            # pylint: disable=abstract-class-instantiated
             with filelock.FileLock(
                     lock_path,
                     backend_utils.CLUSTER_STATUS_LOCK_TIMEOUT_SECONDS):


### PR DESCRIPTION
This PR removes the outdated pylint disabling comments related to `abstract-class-instantiated` in the `cloud_vm_ray_backend.py` file. The comments were no longer necessary as the filelock version has been updated.