### PR TITLE
 [ux] re-provision cluster if --fast but skypilot wheel is outdated 

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2897,7 +2897,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 self._update_after_cluster_provisioned(
                     handle, to_provision_config.prev_handle, task,
                     prev_cluster_status, handle.external_ips(),
-                    handle.external_ssh_ports(), lock_path)
+                    handle.external_ssh_ports(), lock_path, wheel_hash)
                 return handle
 
             cluster_config_file = config_dict['ray']
@@ -2968,8 +2968,14 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                  source_bashrc=True)
 
             self._update_after_cluster_provisioned(
-                handle, to_provision_config.prev_handle, task,
-                prev_cluster_status, ip_list, ssh_port_list, lock_path)
+                handle,
+                to_provision_config.prev_handle,
+                task,
+                prev_cluster_status,
+                ip_list,
+                ssh_port_list,
+                lock_path,
+                wheel_hash=wheel_hash)
             return handle
 
     def _open_ports(self, handle: CloudVmRayResourceHandle) -> None:
@@ -2983,12 +2989,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                  provider_config)
 
     def _update_after_cluster_provisioned(
-            self, handle: CloudVmRayResourceHandle,
+            self,
+            handle: CloudVmRayResourceHandle,
             prev_handle: Optional[CloudVmRayResourceHandle],
             task: task_lib.Task,
             prev_cluster_status: Optional[status_lib.ClusterStatus],
-            ip_list: List[str], ssh_port_list: List[int],
-            lock_path: str) -> None:
+            ip_list: List[str],
+            ssh_port_list: List[int],
+            lock_path: str,
+            wheel_hash: Optional[str] = None) -> None:
         usage_lib.messages.usage.update_cluster_resources(
             handle.launched_nodes, handle.launched_resources)
         usage_lib.messages.usage.update_final_cluster_status(
@@ -3048,6 +3057,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 handle,
                 set(task.resources),
                 ready=True,
+                wheel_hash=wheel_hash,
             )
             usage_lib.messages.usage.update_final_cluster_status(
                 status_lib.ClusterStatus.UP)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2737,7 +2737,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 (e.g., cluster name invalid) or a region/zone throwing
                 resource unavailability.
             exceptions.CommandError: any ssh command error.
-            RuntimeErorr: raised when 'rsync' is not installed.
+            RuntimeError: raised when 'rsync' is not installed.
             # TODO(zhwu): complete the list of exceptions.
         """
         # FIXME: ray up for Azure with different cluster_names will overwrite

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -549,7 +549,7 @@ def _launch_with_confirm(
     retry_until_up: bool = False,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
-    skip_setup: bool = False,
+    fast: bool = False,
 ):
     """Launch a cluster with a Task."""
     if cluster is None:
@@ -614,7 +614,7 @@ def _launch_with_confirm(
         retry_until_up=retry_until_up,
         no_setup=no_setup,
         clone_disk_from=clone_disk_from,
-        skip_setup=skip_setup,
+        fast=fast,
     )
 
 
@@ -1037,7 +1037,7 @@ def cli():
           'a new one. This is useful when the new cluster needs to have '
           'the same data on the boot disk as an existing cluster.'))
 @click.option(
-    '--skip-setup',
+    '--fast',
     is_flag=True,
     default=False,
     required=False,
@@ -1074,7 +1074,7 @@ def launch(
     yes: bool,
     no_setup: bool,
     clone_disk_from: Optional[str],
-    skip_setup: bool,
+    fast: bool,
 ):
     """Launch a cluster or task.
 
@@ -1144,7 +1144,7 @@ def launch(
                          retry_until_up=retry_until_up,
                          no_setup=no_setup,
                          clone_disk_from=clone_disk_from,
-                         skip_setup=skip_setup)
+                         fast=fast)
 
 
 @cli.command(cls=_DocumentedCodeCommand)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -549,6 +549,7 @@ def _launch_with_confirm(
     retry_until_up: bool = False,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
+    skip_setup: bool = False,
 ):
     """Launch a cluster with a Task."""
     if cluster is None:
@@ -613,6 +614,7 @@ def _launch_with_confirm(
         retry_until_up=retry_until_up,
         no_setup=no_setup,
         clone_disk_from=clone_disk_from,
+        skip_setup=skip_setup,
     )
 
 
@@ -1034,6 +1036,13 @@ def cli():
     help=('[Experimental] Clone disk from an existing cluster to launch '
           'a new one. This is useful when the new cluster needs to have '
           'the same data on the boot disk as an existing cluster.'))
+@click.option(
+    '--skip-setup',
+    is_flag=True,
+    default=False,
+    required=False,
+    help=('[Experimental] If the cluster is already up and available, skip'
+          'provisioning and setup steps.'))
 @usage_lib.entrypoint
 def launch(
     entrypoint: Tuple[str, ...],
@@ -1065,6 +1074,7 @@ def launch(
     yes: bool,
     no_setup: bool,
     clone_disk_from: Optional[str],
+    skip_setup: bool,
 ):
     """Launch a cluster or task.
 
@@ -1133,7 +1143,8 @@ def launch(
                          down=down,
                          retry_until_up=retry_until_up,
                          no_setup=no_setup,
-                         clone_disk_from=clone_disk_from)
+                         clone_disk_from=clone_disk_from,
+                         skip_setup=skip_setup)
 
 
 @cli.command(cls=_DocumentedCodeCommand)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -15,6 +15,7 @@ from sky import global_user_state
 from sky import optimizer
 from sky import sky_logging
 from sky.backends import backend_utils
+from sky.exceptions import ClusterNotUpError
 from sky.usage import usage_lib
 from sky.utils import admin_policy_utils
 from sky.utils import controller_utils
@@ -451,15 +452,47 @@ def launch(
         controller_utils.check_cluster_name_not_controller(
             cluster_name, operation_str='sky.launch')
 
+    handle = None
+    stages = None
+    # Check if cluster exists
+    if cluster_name is not None:
+        maybe_handle = global_user_state.get_handle_from_cluster_name(
+            cluster_name)
+        if maybe_handle is not None:
+            try:
+                # This will throw if the cluster is not available
+                backend_utils.check_cluster_available(
+                    cluster_name,
+                    operation='executing tasks',
+                    check_cloud_vm_ray_backend=False,
+                    dryrun=dryrun)
+                # If the cluster is available, restrict stages
+                handle = maybe_handle
+                stages = [
+                    # Stage.CLONE_DISK,
+                    # Stage.PROVISION,
+                    # Stage.OPTIMIZE,
+                    Stage.SYNC_WORKDIR,
+                    Stage.SYNC_FILE_MOUNTS,
+                    # Stage.SETUP,
+                    Stage.PRE_EXEC,
+                    Stage.EXEC,
+                    Stage.DOWN
+                ]
+            except ClusterNotUpError:
+                # Proceed with normal provisioning
+                pass
+
     return _execute(
         entrypoint=entrypoint,
         dryrun=dryrun,
         down=down,
         stream_logs=stream_logs,
-        handle=None,
+        handle=handle,
         backend=backend,
         retry_until_up=retry_until_up,
         optimize_target=optimize_target,
+        stages=stages,
         cluster_name=cluster_name,
         detach_setup=detach_setup,
         detach_run=detach_run,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -356,7 +356,7 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
-    skip_setup: bool = False,
+    fast: bool = False,
     # Internal only:
     # pylint: disable=invalid-name
     _is_launched_by_jobs_controller: bool = False,
@@ -411,7 +411,7 @@ def launch(
         clone_disk_from: [Experimental] if set, clone the disk from the
             specified cluster. This is useful to migrate the cluster to a
             different availability zone or region.
-        skip_setup: [Experimental] If the cluster is already up and available,
+        fast: [Experimental] If the cluster is already up and available,
             skip provisioning and setup steps.
 
     Example:
@@ -458,8 +458,8 @@ def launch(
 
     handle = None
     stages = None
-    # Check if cluster exists and we have skip_setup
-    if skip_setup and cluster_name is not None:
+    # Check if cluster exists and we are doing fast provisioning
+    if fast and cluster_name is not None:
         maybe_handle = global_user_state.get_handle_from_cluster_name(
             cluster_name)
         if maybe_handle is not None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -216,7 +216,8 @@ def _execute(
                             '(after all jobs finish).'
                             f'{colorama.Style.RESET_ALL}')
                 idle_minutes_to_autostop = 1
-            stages.remove(Stage.DOWN)
+            if Stage.DOWN in stages:
+                stages.remove(Stage.DOWN)
             if idle_minutes_to_autostop >= 0:
                 requested_features.add(
                     clouds.CloudImplementationFeatures.AUTO_TERMINATE)
@@ -355,6 +356,7 @@ def launch(
     detach_run: bool = False,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
+    skip_setup: bool = False,
     # Internal only:
     # pylint: disable=invalid-name
     _is_launched_by_jobs_controller: bool = False,
@@ -409,6 +411,8 @@ def launch(
         clone_disk_from: [Experimental] if set, clone the disk from the
             specified cluster. This is useful to migrate the cluster to a
             different availability zone or region.
+        skip_setup: [Experimental] If the cluster is already up and available,
+            skip provisioning and setup steps.
 
     Example:
         .. code-block:: python
@@ -454,8 +458,8 @@ def launch(
 
     handle = None
     stages = None
-    # Check if cluster exists
-    if cluster_name is not None:
+    # Check if cluster exists and we have skip_setup
+    if skip_setup and cluster_name is not None:
         maybe_handle = global_user_state.get_handle_from_cluster_name(
             cluster_name)
         if maybe_handle is not None:
@@ -473,11 +477,11 @@ def launch(
                     # Stage.PROVISION,
                     # Stage.OPTIMIZE,
                     Stage.SYNC_WORKDIR,
-                    Stage.SYNC_FILE_MOUNTS,
+                    # Stage.SYNC_FILE_MOUNTS,
                     # Stage.SETUP,
-                    Stage.PRE_EXEC,
+                    # Stage.PRE_EXEC,
                     Stage.EXEC,
-                    Stage.DOWN
+                    # Stage.DOWN
                 ]
             except ClusterNotUpError:
                 # Proceed with normal provisioning


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
based on #4159 - draft PR until that is merged


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Code formatting: `bash format.sh`
- [x] Manually tested happy path, wheel upgrade, autostop/autodown
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_launch_fast,test_launch_fast_with_autostop`
  - Unfortunately we don't have a good way to smoke test a wheel update outside of backward compatibility tests. 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
