### PR TITLE
[serve] fix aws s3 sync in other regions

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1291,8 +1291,12 @@ class S3Store(AbstractStore):
                 for file_name in file_names
             ])
             base_dir_path = shlex.quote(base_dir_path)
-            sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
-                            f'{includes} {base_dir_path} '
+            if self.region is not None and self.region != 'us-east-1':
+                region_arg = f'--region {self.region}'
+            else:
+                region_arg = ''
+            sync_command = (f'aws s3 sync {region_arg} --no-follow-symlinks '
+                            f'--exclude="*" {includes} {base_dir_path} '
                             f's3://{self.name}')
             return sync_command
 
@@ -1304,9 +1308,13 @@ class S3Store(AbstractStore):
                 f'--exclude {shlex.quote(file_name)}'
                 for file_name in excluded_list
             ])
+            if self.region is not None and self.region != 'us-east-1':
+                region_arg = f'--region {self.region}'
+            else:
+                region_arg = ''
             src_dir_path = shlex.quote(src_dir_path)
-            sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
-                            f'{src_dir_path} '
+            sync_command = (f'aws s3 sync {region_arg} --no-follow-symlinks '
+                            f'{excludes} {src_dir_path} '
                             f's3://{self.name}/{dest_dir_name}')
             return sync_command
 


### PR DESCRIPTION
Previously you could get
```
fatal error: An error occurred (IllegalLocationConstraintException) when calling the ListObjectsV2 operation: The <region-name> location constraint is incompatible for the region specific endpoint this request was sent to.
```
in certain regions such as eu-south-1.

Repro:
```
$ sky serve up -n serve-eu-south-1 --cloud aws --region eu-south-1 -y tests/skyserve/spot/base_ondemand_fallback.yaml
```

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Fixes #3405.


Tested (run the relevant ones):
TODO
- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
