### PR TITLE
[k8s] Fix show-gpus when limited permissions are available

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -96,7 +96,29 @@ SkyPilot requires permissions equivalent to the following roles to be able to ma
 
 These roles must apply to both the user account configured in the kubeconfig file and the service account used by SkyPilot (if configured).
 
-If your tasks use object store mounting or require access to ingress resources, you will need to grant additional permissions as described below.
+If you need to view real-time GPU availability with ``sky show-gpus``, your tasks use object store mounting or your tasks require access to ingress resources, you will need to grant additional permissions as described below.
+
+Permissions for ``sky show-gpus``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``sky show-gpus`` needs to list all pods across all namespaces to calculate GPU availability. To do this, SkyPilot needs the ``get`` and ``list`` permissions for pods in a ``ClusterRole``:
+
+.. code-block:: yaml
+
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+        name: sky-sa-cluster-role-pod-reader
+    rules:
+      - apiGroups: [""]
+        resources: ["pods"]
+        verbs: ["get", "list"]
+
+
+.. tip::
+
+    If this role is not granted to the service account, ``sky show-gpus`` will still work but it will only show the total GPUs on the nodes, not the number of free GPUs.
+
 
 Permissions for Object Store Mounting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -225,6 +247,9 @@ To create a service account that has all necessary permissions for SkyPilot (inc
       - apiGroups: ["networking.k8s.io"]   # Required for exposing services through ingresses
         resources: ["ingressclasses"]
         verbs: ["get", "list", "watch"]
+      - apiGroups: [""]                 # Required for `sky show-gpus` command
+        resources: ["pods"]
+        verbs: ["get", "list"]
     ---
     # ClusterRoleBinding for the service account
     apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -296,6 +296,11 @@ FAQs
                 volumeMounts:       # Custom volume mounts for the pod
                   - mountPath: /foo
                     name: example-volume
+                resources:          # Custom resource requests and limits
+                  requests:
+                    rdma/rdma_shared_device_a: 1
+                  limits:
+                    rdma/rdma_shared_device_a: 1
             volumes:
               - name: example-volume
                 hostPath:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3073,6 +3073,7 @@ def show_gpus(
     kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type() is not None
     kubernetes_is_enabled = sky_clouds.cloud_in_iterable(
         sky_clouds.Kubernetes(), global_user_state.get_cached_enabled_clouds())
+    no_permissions_str = '<no permissions>'
 
     def _list_to_str(lst):
         return ', '.join([str(e) for e in lst])
@@ -3117,7 +3118,8 @@ def show_gpus(
                             debug_msg)
             raise ValueError(full_err_msg)
         for gpu, _ in sorted(counts.items()):
-            available_qty = available[gpu] if available[gpu] != -1 else 'NA'
+            available_qty = available[gpu] if available[gpu] != -1 else (
+                no_permissions_str)
             realtime_gpu_table.add_row([
                 gpu,
                 _list_to_str(counts.pop(gpu)), capacity[gpu], available_qty
@@ -3131,7 +3133,7 @@ def show_gpus(
         node_info_dict = kubernetes_utils.get_kubernetes_node_info(context)
         for node_name, node_info in node_info_dict.items():
             available = node_info.free['nvidia.com/gpu'] if node_info.free[
-                'nvidia.com/gpu'] != -1 else 'NA'
+                'nvidia.com/gpu'] != -1 else no_permissions_str
             node_table.add_row([
                 node_name, node_info.gpu_type,
                 node_info.total['nvidia.com/gpu'], available

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3117,9 +3117,10 @@ def show_gpus(
                             debug_msg)
             raise ValueError(full_err_msg)
         for gpu, _ in sorted(counts.items()):
+            available = available[gpu] if available[gpu] != -1 else 'NA'
             realtime_gpu_table.add_row([
                 gpu,
-                _list_to_str(counts.pop(gpu)), capacity[gpu], available[gpu]
+                _list_to_str(counts.pop(gpu)), capacity[gpu], available
             ])
         return realtime_gpu_table
 
@@ -3129,10 +3130,11 @@ def show_gpus(
 
         node_info_dict = kubernetes_utils.get_kubernetes_node_info(context)
         for node_name, node_info in node_info_dict.items():
+            available = node_info.free['nvidia.com/gpu'] if node_info.free['nvidia.com/gpu'] != -1 else 'NA'
             node_table.add_row([
                 node_name, node_info.gpu_type,
                 node_info.total['nvidia.com/gpu'],
-                node_info.free['nvidia.com/gpu']
+                available
             ])
         return node_table
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3117,10 +3117,10 @@ def show_gpus(
                             debug_msg)
             raise ValueError(full_err_msg)
         for gpu, _ in sorted(counts.items()):
-            available = available[gpu] if available[gpu] != -1 else 'NA'
+            available_qty = available[gpu] if available[gpu] != -1 else 'NA'
             realtime_gpu_table.add_row([
                 gpu,
-                _list_to_str(counts.pop(gpu)), capacity[gpu], available
+                _list_to_str(counts.pop(gpu)), capacity[gpu], available_qty
             ])
         return realtime_gpu_table
 
@@ -3130,11 +3130,11 @@ def show_gpus(
 
         node_info_dict = kubernetes_utils.get_kubernetes_node_info(context)
         for node_name, node_info in node_info_dict.items():
-            available = node_info.free['nvidia.com/gpu'] if node_info.free['nvidia.com/gpu'] != -1 else 'NA'
+            available = node_info.free['nvidia.com/gpu'] if node_info.free[
+                'nvidia.com/gpu'] != -1 else 'NA'
             node_table.add_row([
                 node_name, node_info.gpu_type,
-                node_info.total['nvidia.com/gpu'],
-                available
+                node_info.total['nvidia.com/gpu'], available
             ])
         return node_table
 

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -16,12 +16,10 @@ from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
 from sky.provision.kubernetes import utils as kubernetes_utils
 
-
 if typing.TYPE_CHECKING:
     import pandas as pd
 else:
     pd = adaptors_common.LazyImport('pandas')
-
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1807,7 +1807,18 @@ def get_kubernetes_node_info(
     """
     nodes = get_kubernetes_nodes(context)
     # Get the pods to get the real-time resource usage
-    pods = get_all_pods_in_kubernetes_cluster(context)
+    try:
+        pods = get_all_pods_in_kubernetes_cluster(context)
+    except kubernetes.api_exception() as e:
+        if e.status == 403:
+            #TODO(romilb): This warning shows up twice
+            logger.warning('Failed to get pods in the Kubernetes cluster. '
+                           'Please check if the user has the necessary '
+                           'permissions to list pods. Realtime GPU usage '
+                           'information may be incorrect.')
+            pods = []
+        else:
+            raise
 
     label_formatter, _ = detect_gpu_label_formatter(context)
     if not label_formatter:

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -112,6 +112,9 @@ rules:
   - apiGroups: ["networking.k8s.io"]   # Required for exposing services through ingresses
     resources: ["ingressclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]                 # Required for sky show-gpus command
+    resources: ["pods"]
+    verbs: ["get", "list"]
 ---
 # ClusterRoleBinding for the service account
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Updates our minimal permissions doc to add permissions required by show-gpus, and updates show-gpus to work with limited permissions:

```
W 10-29 18:36:09 kubernetes_catalog.py:112] Failed to get pods in the Kubernetes cluster (forbidden). Please check if your account has necessary permissions to list pods. Realtime GPU availability information may be incorrect.
Kubernetes GPUs (context: gke_sky-dev-465_us-central1-c_gkeusc6)
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
H100  1, 2, 4, 8                8           NA

Kubernetes per node GPU availability
NODE_NAME                               GPU_NAME  TOTAL_GPUS  FREE_GPUS
gke-gkeusc6-default-pool-db727de5-62gm  H100      8           NA
```

Also adds a quick snippet for specifying custom resources in pod_config.