### PR TITLE
[Tests] Fix public bucket tests

### DIFF
--- a/examples/managed_job_with_storage.yaml
+++ b/examples/managed_job_with_storage.yaml
@@ -26,8 +26,8 @@ file_mounts:
     name: sky-output-bucket
     mode: MOUNT
 
-  /imagenet-image:
-    source: s3://sky-imagenet-data
+  /public-bucket:
+    source: s3://fah-public-data-covid19-cryptic-pockets
   
   # File mounts for folder
   /tmp/workdir: ~/tmp-workdir
@@ -49,7 +49,7 @@ run: |
   set -ex
   ls ~/sky_workdir/managed_job_with_storage.yaml
   ls ~/bucket_workdir/managed_job_with_storage.yaml
-  ls -l /imagenet-image/datasets
+  ls -l /public-bucket
   
 
   mkdir -p /data/logs


### PR DESCRIPTION
sky-imagenet-data is no longer public. Changes to an actual public S3 bucket.

- [x] ` pytest tests/test_smoke.py::test_managed_jobs_storage --aws`