### PR TITLE
[Release] Release 0.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm -rf /var/lib/apt/lists/*
 
 # Install sky
-RUN pip install --no-cache-dir "skypilot[all]==0.6.0"
+RUN pip install --no-cache-dir "skypilot[all]==0.7.0"

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -35,7 +35,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.7.0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3039,7 +3039,7 @@ def test_managed_jobs_cancellation_aws(aws_config_region):
             # Test cancellation during spot cluster being launched.
             f'sky jobs launch --cloud aws --region {region} -n {name} --use-spot "sleep 1000"  -y -d',
             'sleep 60',
-            f'{_GET_JOB_QUEUE} | grep {name} | head -n1 | grep "STARTING"',
+            f'{_GET_JOB_QUEUE} | grep {name} | head -n1 | grep "STARTING\|RUNNING"',
             f'sky jobs cancel -y -n {name}',
             'sleep 5',
             f'{_GET_JOB_QUEUE} | grep {name} | head -n1 | grep "CANCELLING\|CANCELLED"',


### PR DESCRIPTION
- [x] `pytest tests/test_smoke.py --aws`
- [x] `pytest tests/test_smoke.py --gcp` except `test_tpu_vm` and `test_tpu_vm_pod` #4236
- [x] `pytest tests/test_smoke.py --azure` (had to switch to different account for CPU quotas required for `test_azure_best_tier_failover`)
- [x] `pytest tests/test_smoke.py --kubernetes`
- [x] locally build docs, open `docs/build/index.html`, scroll over “CLI Reference” (ideally, every page) to see if there are missing sections (we once caught the CLI page completely missing due to an import error; and once it has weird blockquotes displayed)
- [x] Check `sky -v`
- [x] `backward_compatibility_tests.sh` run against 0.6.0 on gcp
- [x] Run manual stress tests (see subsection below)
   - [x] following script
        ```
        sky jobs launch --gpus A100:8 --cloud aws echo hi -y
        # Check we are properly failing over the zones:
        sky jobs logs --controller
        ```
  - [x] following script
    ```
    sky launch -c dbg --cloud aws --num-nodes 16 --gpus T4 --down --use-spot 
    sky down dbg
    ```
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud gcp -y`
  - [x] `sky launch --num-nodes=75 -c dbg --cpus 2+ --use-spot --down --cloud aws -y`
- [x] `sky show-gpus` manual tests