### PR TITLE
[UX] Show 0.25 on controller queue

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2500,8 +2500,7 @@ def get_task_resources_str(task: 'task_lib.Task',
     spot_str = ''
     is_controller_task = task.is_controller_task()
     task_cpu_demand = (str(constants.CONTROLLER_PROCESS_CPU_DEMAND)
-                       if is_controller_task else
-                       str(DEFAULT_TASK_CPU_DEMAND))
+                       if is_controller_task else str(DEFAULT_TASK_CPU_DEMAND))
     if is_controller_task:
         resources_str = f'CPU:{task_cpu_demand}'
     elif task.best_resources is not None:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2498,10 +2498,13 @@ def get_task_resources_str(task: 'task_lib.Task',
     the accelerator demands (if any). Otherwise, the CPU demand is shown.
     """
     spot_str = ''
+    is_controller_task = task.is_controller_task()
     task_cpu_demand = (str(constants.CONTROLLER_PROCESS_CPU_DEMAND)
-                       if task.is_controller_task() else
+                       if is_controller_task else
                        str(DEFAULT_TASK_CPU_DEMAND))
-    if task.best_resources is not None:
+    if is_controller_task:
+        resources_str = f'CPU:{task_cpu_demand}'
+    elif task.best_resources is not None:
         accelerator_dict = task.best_resources.accelerators
         if is_managed_job:
             if task.best_resources.use_spot:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously for controller process on the `sky queue sky-jobs-controller-<hash>`, we are showing `CPU:8` as the resources, it is a bit confusing for how many jobs can be run in parallel. This PR makes it `CPU:0.25` instead.

See job ID 10 (new) vs job ID 9 (old)

```bash
$ sky queue sky-jobs-controller-a37461fd 
Fetching and parsing job queue...

Job queue of cluster sky-jobs-controller-a37461fd
ID  NAME                         SUBMITTED    STARTED      DURATION    RESOURCES     STATUS     LOG                                        
10  test                         39 secs ago  34 secs ago  34s         1x[CPU:0.25]  RUNNING    ~/sky_logs/sky-2024-10-31-18-18-15-660126  
9   test                         5 mins ago   5 mins ago   1m 24s      1x[CPU:8.0]   SUCCEEDED  ~/sky_logs/sky-2024-10-31-18-12-39-221597  
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
