### PR TITLE
[k8s] Parallelize setup for faster multi-node provisioning

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -324,7 +324,9 @@ def _set_env_vars_in_pods(namespace: str, context: Optional[str],
     set_k8s_env_var_cmd = docker_utils.SETUP_ENV_VARS_CMD
 
     def _set_env_vars_thread(new_pod):
-        logger.info(f'{"-"*20}Start: Set up env vars in pod {new_pod.metadata.name!r} {"-"*20}')
+        logger.info(
+            f'{"-"*20}Start: Set up env vars in pod {new_pod.metadata.name!r} '
+            f'{"-"*20}')
         runner = command_runner.KubernetesCommandRunner(
             ((namespace, context), new_pod.metadata.name))
         rc, stdout, _ = runner.run(set_k8s_env_var_cmd,
@@ -332,7 +334,9 @@ def _set_env_vars_in_pods(namespace: str, context: Optional[str],
                                    stream_logs=False)
         _raise_command_running_error('set env vars', set_k8s_env_var_cmd,
                                      new_pod.metadata.name, rc, stdout)
-        logger.info(f'{"-"*20}End: Set up env vars in pod {new_pod.metadata.name!r} {"-"*20}')
+        logger.info(
+            f'{"-"*20}End: Set up env vars in pod {new_pod.metadata.name!r} '
+            f'{"-"*20}')
 
     subprocess_utils.run_in_parallel(_set_env_vars_thread, new_pods)
 
@@ -357,7 +361,8 @@ def _check_user_privilege(namespace: str, context: Optional[str],
     def _check_privilege_thread(new_node):
         runner = command_runner.KubernetesCommandRunner(
             ((namespace, context), new_node.metadata.name))
-        logger.info(f'{"-"*20}Start: Check user privilege in pod {new_node.metadata.name!r} {"-"*20}')
+        logger.info(f'{"-"*20}Start: Check user privilege in pod '
+                    f'{new_node.metadata.name!r} {"-"*20}')
         rc, stdout, stderr = runner.run(check_k8s_user_sudo_cmd,
                                         require_outputs=True,
                                         separate_stderr=True,
@@ -372,7 +377,8 @@ def _check_user_privilege(namespace: str, context: Optional[str],
                 'Ensure the default user has root access or '
                 '"sudo" is installed and the user is added to the sudoers '
                 'from the image.')
-        logger.info(f'{"-"*20}End: Check user privilege in pod {new_node.metadata.name!r} {"-"*20}')
+        logger.info(f'{"-"*20}End: Check user privilege in pod '
+                    f'{new_node.metadata.name!r} {"-"*20}')
 
     subprocess_utils.run_in_parallel(_check_privilege_thread, new_nodes)
 

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -25,6 +25,7 @@ from sky.utils import ux_utils
 POLL_INTERVAL = 2
 _TIMEOUT_FOR_POD_TERMINATION = 60  # 1 minutes
 _MAX_RETRIES = 3
+NUM_THREADS = subprocess_utils.get_parallel_threads() * 2
 
 logger = sky_logging.init_logger(__name__)
 TAG_RAY_CLUSTER_NAME = 'ray-cluster-name'
@@ -351,7 +352,7 @@ def _set_env_vars_in_pods(namespace: str, context: Optional[str],
             f'{"-"*20}End: Set up env vars in pod {new_pod.metadata.name!r} '
             f'{"-"*20}')
 
-    subprocess_utils.run_in_parallel(_set_env_vars_thread, new_pods)
+    subprocess_utils.run_in_parallel(_set_env_vars_thread, new_pods, NUM_THREADS)
 
 
 def _check_user_privilege(namespace: str, context: Optional[str],
@@ -464,7 +465,7 @@ def _setup_ssh_in_pods(namespace: str, context: Optional[str],
                     raise
         logger.info(f'{"-"*20}End: Set up SSH in pod {pod_name!r} {"-"*20}')
 
-    subprocess_utils.run_in_parallel(_setup_ssh_thread, new_nodes)
+    subprocess_utils.run_in_parallel(_setup_ssh_thread, new_nodes, NUM_THREADS)
 
 
 def _label_pod(namespace: str, context: Optional[str], pod_name: str,
@@ -825,7 +826,7 @@ def terminate_instances(
         _terminate_node(namespace, context, pod_name)
 
     # Run pod termination in parallel
-    subprocess_utils.run_in_parallel(_terminate_pod_thread, pods.items())
+    subprocess_utils.run_in_parallel(_terminate_pod_thread, pods.items(), NUM_THREADS)
 
 
 def get_cluster_info(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -334,15 +334,16 @@ def _set_env_vars_in_pods(namespace: str, context: Optional[str],
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 rc, stdout, _ = runner.run(set_k8s_env_var_cmd,
-                                       require_outputs=True,
-                                       stream_logs=False)
-                _raise_command_running_error('set env vars', set_k8s_env_var_cmd,
-                                         new_pod.metadata.name, rc, stdout)
+                                           require_outputs=True,
+                                           stream_logs=False)
+                _raise_command_running_error('set env vars',
+                                             set_k8s_env_var_cmd,
+                                             new_pod.metadata.name, rc, stdout)
                 break
             except Exception as e:
                 if attempt < _MAX_RETRIES:
                     logger.warning('Failed to set env vars in pod '
-                                 '- retrying in 5 seconds.')
+                                   '- retrying in 5 seconds.')
                     time.sleep(5)
                 else:
                     raise
@@ -379,15 +380,15 @@ def _check_user_privilege(namespace: str, context: Optional[str],
         for attempt in range(_MAX_RETRIES + 1):
             try:
                 rc, stdout, stderr = runner.run(check_k8s_user_sudo_cmd,
-                                              require_outputs=True,
-                                              separate_stderr=True,
-                                              stream_logs=False)
+                                                require_outputs=True,
+                                                separate_stderr=True,
+                                                stream_logs=False)
                 _raise_command_running_error('check user privilege',
-                                           check_k8s_user_sudo_cmd,
-                                           new_node.metadata.name, rc,
-                                           stdout + stderr)
+                                             check_k8s_user_sudo_cmd,
+                                             new_node.metadata.name, rc,
+                                             stdout + stderr)
                 break
-            except Exception as e: # config_lib.KubernetesError? 
+            except Exception as e:  # config_lib.KubernetesError?
                 if attempt < _MAX_RETRIES:
                     logger.warning('Failed to check user privilege in pod '
                                    '- retrying in 5 seconds.')
@@ -448,8 +449,8 @@ def _setup_ssh_in_pods(namespace: str, context: Optional[str],
                 rc, stdout, _ = runner.run(set_k8s_ssh_cmd,
                                            require_outputs=True,
                                            stream_logs=False)
-                _raise_command_running_error('setup ssh', set_k8s_ssh_cmd, pod_name, rc,
-                                             stdout)
+                _raise_command_running_error('setup ssh', set_k8s_ssh_cmd,
+                                             pod_name, rc, stdout)
                 break
             except Exception as e:
                 if attempt < _MAX_RETRIES:

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -245,7 +245,7 @@ class CommandRunner:
             while retries_left >= 0:
                 try:
                     return get_remote_home_dir()
-                except Exception as e:
+                except Exception:  # pylint: disable=broad-except
                     if retries_left == 0:
                         raise
                     sleep_time = backoff.current_backoff()

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -238,7 +238,8 @@ class CommandRunner:
         rsync_command += ['rsync', RSYNC_DISPLAY_OPTION]
 
         def _get_remote_home_dir_with_retry():
-            backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
+            backoff = common_utils.Backoff(initial_backoff=1,
+                                           max_backoff_factor=5)
             retries_left = max_retry
             assert retries_left > 0, f'max_retry {max_retry} must be positive.'
             while retries_left >= 0:
@@ -672,7 +673,7 @@ class SSHCommandRunner(CommandRunner):
 class KubernetesCommandRunner(CommandRunner):
     """Runner for Kubernetes commands."""
 
-    _MAX_RETRIES = 3
+    _MAX_RETRIES_FOR_RSYNC = 3
 
     def __init__(
         self,
@@ -816,7 +817,7 @@ class KubernetesCommandRunner(CommandRunner):
         # Advanced options.
         log_path: str = os.devnull,
         stream_logs: bool = True,
-        max_retry: int = _MAX_RETRIES,
+        max_retry: int = _MAX_RETRIES_FOR_RSYNC,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -237,6 +237,22 @@ class CommandRunner:
             rsync_command.append(prefix_command)
         rsync_command += ['rsync', RSYNC_DISPLAY_OPTION]
 
+        def _get_remote_home_dir_with_retry():
+            backoff = common_utils.Backoff(initial_backoff=5, max_backoff_factor=5)
+            retries_left = max_retry
+            assert retries_left > 0, f'max_retry {max_retry} must be positive.'
+            while retries_left >= 0:
+                try:
+                    return get_remote_home_dir()
+                except Exception as e:
+                    if retries_left == 0:
+                        raise
+                    sleep_time = backoff.current_backoff()
+                    logger.warning(f'Failed to get remote home dir '
+                                   f'- retrying in {sleep_time} seconds.')
+                    retries_left -= 1
+                    time.sleep(sleep_time)
+
         # --filter
         # The source is a local path, so we need to resolve it.
         resolved_source = pathlib.Path(source).expanduser().resolve()
@@ -261,7 +277,7 @@ class CommandRunner:
         if up:
             resolved_target = target
             if target.startswith('~'):
-                remote_home_dir = get_remote_home_dir()
+                remote_home_dir = _get_remote_home_dir_with_retry()
                 resolved_target = target.replace('~', remote_home_dir)
             full_source_str = str(resolved_source)
             if resolved_source.is_dir():
@@ -273,7 +289,7 @@ class CommandRunner:
         else:
             resolved_source = source
             if source.startswith('~'):
-                remote_home_dir = get_remote_home_dir()
+                remote_home_dir = _get_remote_home_dir_with_retry()
                 resolved_source = source.replace('~', remote_home_dir)
             rsync_command.extend([
                 f'{node_destination}:{resolved_source!r}',
@@ -656,6 +672,8 @@ class SSHCommandRunner(CommandRunner):
 class KubernetesCommandRunner(CommandRunner):
     """Runner for Kubernetes commands."""
 
+    _MAX_RETRIES = 3
+
     def __init__(
         self,
         node: Tuple[Tuple[str, Optional[str]], str],
@@ -798,7 +816,7 @@ class KubernetesCommandRunner(CommandRunner):
         # Advanced options.
         log_path: str = os.devnull,
         stream_logs: bool = True,
-        max_retry: int = 1,
+        max_retry: int = _MAX_RETRIES,
     ) -> None:
         """Uses 'rsync' to sync 'source' to 'target'.
 

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -50,17 +50,23 @@ def get_parallel_threads() -> int:
     return max(4, cpu_count - 1)
 
 
-def run_in_parallel(func: Callable, args: Iterable[Any]) -> List[Any]:
+def run_in_parallel(func: Callable, args: Iterable[Any], num_threads: Optional[int] = None) -> List[Any]:
     """Run a function in parallel on a list of arguments.
 
     The function 'func' should raise a CommandError if the command fails.
+
+    Args:
+        func: The function to run in parallel
+        args: Iterable of arguments to pass to func
+        num_threads: Optional number of threads to use. If None, uses get_parallel_threads()
 
     Returns:
       A list of the return values of the function func, in the same order as the
       arguments.
     """
     # Reference: https://stackoverflow.com/questions/25790279/python-multiprocessing-early-termination # pylint: disable=line-too-long
-    with pool.ThreadPool(processes=get_parallel_threads()) as p:
+    processes = num_threads if num_threads is not None else get_parallel_threads()
+    with pool.ThreadPool(processes=processes) as p:
         # Run the function in parallel on the arguments, keeping the order.
         return list(p.imap(func, args))
 

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -50,7 +50,9 @@ def get_parallel_threads() -> int:
     return max(4, cpu_count - 1)
 
 
-def run_in_parallel(func: Callable, args: Iterable[Any], num_threads: Optional[int] = None) -> List[Any]:
+def run_in_parallel(func: Callable,
+                    args: Iterable[Any],
+                    num_threads: Optional[int] = None) -> List[Any]:
     """Run a function in parallel on a list of arguments.
 
     The function 'func' should raise a CommandError if the command fails.
@@ -58,14 +60,16 @@ def run_in_parallel(func: Callable, args: Iterable[Any], num_threads: Optional[i
     Args:
         func: The function to run in parallel
         args: Iterable of arguments to pass to func
-        num_threads: Optional number of threads to use. If None, uses get_parallel_threads()
+        num_threads: Number of threads to use. If None, uses
+          get_parallel_threads()
 
     Returns:
       A list of the return values of the function func, in the same order as the
       arguments.
     """
     # Reference: https://stackoverflow.com/questions/25790279/python-multiprocessing-early-termination # pylint: disable=line-too-long
-    processes = num_threads if num_threads is not None else get_parallel_threads()
+    processes = num_threads if num_threads is not None else get_parallel_threads(
+    )
     with pool.ThreadPool(processes=processes) as p:
         # Run the function in parallel on the arguments, keeping the order.
         return list(p.imap(func, args))


### PR DESCRIPTION
Parallelizes env var init and privilege check steps in our k8s provisioning pipeline. 3x speedup for a 20 node cluster (and larger speedup for bigger clusters).

Measuring pod init time for `sky launch -c k8s --num-nodes 20 --cpus 1 -- echo hi`:

Master: 117s
This PR: 36s