### PR TITLE
[UX] Support --tail parameter for sky logs

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3708,7 +3708,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                   handle: CloudVmRayResourceHandle,
                   job_id: Optional[int],
                   managed_job_id: Optional[int] = None,
-                  follow: bool = True) -> int:
+                  follow: bool = True,
+                  number_of_lines: int = 0) -> int:
         """Tail the logs of a job.
 
         Args:
@@ -3716,10 +3717,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             job_id: The job ID to tail the logs of.
             managed_job_id: The managed job ID for display purpose only.
             follow: Whether to follow the logs.
+            number_of_lines: The number of lines to display from the end of the
+                log file. If 0, print all lines.
         """
         code = job_lib.JobLibCodeGen.tail_logs(job_id,
                                                managed_job_id=managed_job_id,
-                                               follow=follow)
+                                               follow=follow,
+                                               number_of_lines=number_of_lines)
         if job_id is None and managed_job_id is None:
             logger.info(
                 'Job ID not provided. Streaming the logs of the latest job.')

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3709,7 +3709,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                   job_id: Optional[int],
                   managed_job_id: Optional[int] = None,
                   follow: bool = True,
-                  number_of_lines: int = 0) -> int:
+                  tail: int = 0) -> int:
         """Tail the logs of a job.
 
         Args:
@@ -3717,13 +3717,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             job_id: The job ID to tail the logs of.
             managed_job_id: The managed job ID for display purpose only.
             follow: Whether to follow the logs.
-            number_of_lines: The number of lines to display from the end of the
+            tail: The number of lines to display from the end of the
                 log file. If 0, print all lines.
         """
         code = job_lib.JobLibCodeGen.tail_logs(job_id,
                                                managed_job_id=managed_job_id,
                                                follow=follow,
-                                               number_of_lines=number_of_lines)
+                                               tail=tail)
         if job_id is None and managed_job_id is None:
             logger.info(
                 'Job ID not provided. Streaming the logs of the latest job.')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2016,7 +2016,8 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
     '-n',
     default=0,
     type=int,
-    help='The number of lines to display from the end of the log file. If 0, print all lines.'
+    help=
+    'The number of lines to display from the end of the log file. If 0, print all lines.'
 )
 @click.argument('cluster',
                 required=True,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2017,8 +2017,8 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
     default=0,
     type=int,
     help=
-    'The number of lines to display from the end of the log file. If 0, print all lines.'
-)
+    'The number of lines to display from the end of the log file. '
+    'If 0, print all lines.')
 @click.argument('cluster',
                 required=True,
                 type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2012,12 +2012,12 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
           'If --no-follow is specified, print the log so far and exit. '
           '[default: --follow]'))
 @click.option(
-    '--number-of-lines',
+    '--tail',
     '-n',
     default=0,
     type=int,
     help=('The number of lines to display from the end of the log file. '
-          'If 0, print all lines.'))
+          'Default is 0, which means print all lines.'))
 @click.argument('cluster',
                 required=True,
                 type=str,
@@ -2031,7 +2031,7 @@ def logs(
     sync_down: bool,
     status: bool,  # pylint: disable=redefined-outer-name
     follow: bool,
-    number_of_lines: int,
+    tail: int,
 ):
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the log of a job.
@@ -2098,7 +2098,7 @@ def logs(
                 click.secho(f'Job {id_str}not found', fg='red')
             sys.exit(1)
 
-    core.tail_logs(cluster, job_id, follow, number_of_lines)
+    core.tail_logs(cluster, job_id, follow, tail)
 
 
 @cli.command()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2016,9 +2016,8 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
     '-n',
     default=0,
     type=int,
-    help=
-    'The number of lines to display from the end of the log file. '
-    'If 0, print all lines.')
+    help=('The number of lines to display from the end of the log file. '
+          'If 0, print all lines.'))
 @click.argument('cluster',
                 required=True,
                 type=str,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2011,6 +2011,13 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
     help=('Follow the logs of a job. '
           'If --no-follow is specified, print the log so far and exit. '
           '[default: --follow]'))
+@click.option(
+    '--number-of-lines',
+    '-n',
+    default=0,
+    type=int,
+    help='The number of lines to display from the end of the log file. If 0, print all lines.'
+)
 @click.argument('cluster',
                 required=True,
                 type=str,
@@ -2024,6 +2031,7 @@ def logs(
     sync_down: bool,
     status: bool,  # pylint: disable=redefined-outer-name
     follow: bool,
+    number_of_lines: int,
 ):
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the log of a job.
@@ -2090,7 +2098,7 @@ def logs(
                 click.secho(f'Job {id_str}not found', fg='red')
             sys.exit(1)
 
-    core.tail_logs(cluster, job_id, follow)
+    core.tail_logs(cluster, job_id, follow, number_of_lines)
 
 
 @cli.command()

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -2013,7 +2013,6 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
           '[default: --follow]'))
 @click.option(
     '--tail',
-    '-n',
     default=0,
     type=int,
     help=('The number of lines to display from the end of the log file. '

--- a/sky/core.py
+++ b/sky/core.py
@@ -743,7 +743,7 @@ def cancel(
 def tail_logs(cluster_name: str,
               job_id: Optional[int],
               follow: bool = True,
-              number_of_lines: int = 0) -> None:
+              tail: int = 0) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the logs of a job.
 
@@ -779,7 +779,7 @@ def tail_logs(cluster_name: str,
     backend.tail_logs(handle,
                       job_id,
                       follow=follow,
-                      number_of_lines=number_of_lines)
+                      tail=tail)
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -776,7 +776,10 @@ def tail_logs(cluster_name: str,
         f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.tail_logs(handle, job_id, follow=follow, number_of_lines=number_of_lines)
+    backend.tail_logs(handle, 
+                      job_id, 
+                      follow=follow, 
+                      number_of_lines=number_of_lines)
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -776,9 +776,9 @@ def tail_logs(cluster_name: str,
         f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.tail_logs(handle, 
-                      job_id, 
-                      follow=follow, 
+    backend.tail_logs(handle,
+                      job_id,
+                      follow=follow,
                       number_of_lines=number_of_lines)
 
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -742,7 +742,8 @@ def cancel(
 @usage_lib.entrypoint
 def tail_logs(cluster_name: str,
               job_id: Optional[int],
-              follow: bool = True) -> None:
+              follow: bool = True,
+              number_of_lines: int = 0) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail the logs of a job.
 
@@ -775,7 +776,7 @@ def tail_logs(cluster_name: str,
         f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.tail_logs(handle, job_id, follow=follow)
+    backend.tail_logs(handle, job_id, follow=follow, number_of_lines=number_of_lines)
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -776,10 +776,7 @@ def tail_logs(cluster_name: str,
         f'{colorama.Style.RESET_ALL}')
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.tail_logs(handle,
-                      job_id,
-                      follow=follow,
-                      tail=tail)
+    backend.tail_logs(handle, job_id, follow=follow, tail=tail)
 
 
 @usage_lib.entrypoint

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -82,7 +82,7 @@ SKYLET_VERSION = '8'
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.
-SKYLET_LIB_VERSION = 1
+SKYLET_LIB_VERSION = 2
 SKYLET_VERSION_FILE = '~/.sky/skylet_version'
 
 # `sky jobs dashboard`-related

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -886,9 +886,9 @@ class JobLibCodeGen:
             f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
-            f'log_lib.tail_logs(job_id=job_id, log_dir=log_dir, '
-            f'managed_job_id={managed_job_id!r}, follow={follow}, '
-            f'tail={tail})',
+            f'tail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',
+            f'if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
+            'log_lib.tail_logs(**tail_log_kwargs)',
         ]
         return cls._build(code)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -882,6 +882,7 @@ class JobLibCodeGen:
                   follow: bool = True,
                   tail: int = 0) -> str:
         # pylint: disable=line-too-long
+
         code = [
             f'job_id = {job_id} if {job_id} is not None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -576,8 +576,8 @@ def update_job_status(job_ids: List[int],
                 # the pending table until appearing in ray jobs. For jobs
                 # submitted outside of the grace period, we will consider the
                 # ray job status.
-                if not (pending_job['submit'] > 0 and pending_job['submit'] <
-                        ray_job_query_time - _PENDING_SUBMIT_GRACE_PERIOD):
+                if not (pending_job['submit'] > 0 and pending_job['submit']
+                        < ray_job_query_time - _PENDING_SUBMIT_GRACE_PERIOD):
                     # Reset the job status to PENDING even though it may not
                     # appear in the ray jobs, so that it will not be considered
                     # as stale.

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -880,7 +880,7 @@ class JobLibCodeGen:
                   job_id: Optional[int],
                   managed_job_id: Optional[int],
                   follow: bool = True,
-                  number_of_lines: int = 0) -> str:
+                  tail: int = 0) -> str:
         # pylint: disable=line-too-long
         code = [
             f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
@@ -888,7 +888,7 @@ class JobLibCodeGen:
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
             f'log_lib.tail_logs(job_id=job_id, log_dir=log_dir, '
             f'managed_job_id={managed_job_id!r}, follow={follow}, '
-            f'number_of_lines={number_of_lines})',
+            f'tail={tail})',
         ]
         return cls._build(code)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -879,14 +879,16 @@ class JobLibCodeGen:
     def tail_logs(cls,
                   job_id: Optional[int],
                   managed_job_id: Optional[int],
-                  follow: bool = True) -> str:
+                  follow: bool = True,
+                  number_of_lines: int = 0) -> str:
         # pylint: disable=line-too-long
         code = [
             f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
             f'log_lib.tail_logs(job_id=job_id, log_dir=log_dir, '
-            f'managed_job_id={managed_job_id!r}, follow={follow})',
+            f'managed_job_id={managed_job_id!r}, follow={follow}, '
+            f'number_of_lines={number_of_lines})',
         ]
         return cls._build(code)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -883,9 +883,11 @@ class JobLibCodeGen:
                   follow: bool = True,
                   tail: int = 0) -> str:
         # pylint: disable=line-too-long
+        # We use != instead of is not because 1 is not None will print a warning:
+        # <stdin>:1: SyntaxWarning: "is not" with a literal. Did you mean "!="?
 
         code = [
-            f'job_id = {job_id} if {job_id} is not None else job_lib.get_latest_job_id()',
+            f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
             f'tail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -883,12 +883,12 @@ class JobLibCodeGen:
                   tail: int = 0) -> str:
         # pylint: disable=line-too-long
         code = [
-            f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
+            f'job_id = {job_id} if {job_id} is not None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
             f'tail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',
-            f'if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
-            'log_lib.tail_logs(**tail_log_kwargs)',
+            f'\nif getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
+            '\nlog_lib.tail_logs(**tail_log_kwargs)',
         ]
         return cls._build(code)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -29,6 +29,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
+_LINUX_NEW_LINE = '\n'
 _JOB_STATUS_LOCK = '~/.sky/locks/.job_{}.lock'
 
 
@@ -883,16 +884,16 @@ class JobLibCodeGen:
                   follow: bool = True,
                   tail: int = 0) -> str:
         # pylint: disable=line-too-long
+
         code = [
             # We use != instead of is not because 1 is not None will print a warning:
             # <stdin>:1: SyntaxWarning: "is not" with a literal. Did you mean "!="?
-
             f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',
             f'tail_log_kwargs = {{"job_id": job_id, "log_dir": log_dir, "managed_job_id": {managed_job_id!r}, "follow": {follow}}}',
-            f'\nif getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
-            '\nlog_lib.tail_logs(**tail_log_kwargs)',
+            f'{_LINUX_NEW_LINE}if getattr(constants, "SKYLET_LIB_VERSION", 1) > 1: tail_log_kwargs["tail"] = {tail}',
+            f'{_LINUX_NEW_LINE}log_lib.tail_logs(**tail_log_kwargs)',
         ]
         return cls._build(code)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -883,10 +883,10 @@ class JobLibCodeGen:
                   follow: bool = True,
                   tail: int = 0) -> str:
         # pylint: disable=line-too-long
-        # We use != instead of is not because 1 is not None will print a warning:
-        # <stdin>:1: SyntaxWarning: "is not" with a literal. Did you mean "!="?
-
         code = [
+            # We use != instead of is not because 1 is not None will print a warning:
+            # <stdin>:1: SyntaxWarning: "is not" with a literal. Did you mean "!="?
+
             f'job_id = {job_id} if {job_id} != None else job_lib.get_latest_job_id()',
             'run_timestamp = job_lib.get_run_timestamp(job_id)',
             f'log_dir = None if run_timestamp is None else os.path.join({constants.SKY_LOGS_DIRECTORY!r}, run_timestamp)',

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -576,8 +576,9 @@ def update_job_status(job_ids: List[int],
                 # the pending table until appearing in ray jobs. For jobs
                 # submitted outside of the grace period, we will consider the
                 # ray job status.
-                if not (pending_job['submit'] > 0 and pending_job['submit']
-                        < ray_job_query_time - _PENDING_SUBMIT_GRACE_PERIOD):
+
+                if not (pending_job['submit'] > 0 and pending_job['submit'] <
+                        ray_job_query_time - _PENDING_SUBMIT_GRACE_PERIOD):
                     # Reset the job status to PENDING even though it may not
                     # appear in the ray jobs, so that it will not be considered
                     # as stale.

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -484,16 +484,16 @@ def tail_logs(job_id: Optional[int],
         with open(log_path, 'r', newline='', encoding='utf-8') as log_file:
             # Using `_follow` instead of `tail -f` to streaming the whole
             # log and creating a new process for tail.
-            start_stream = False
+            start_streaming = False
             if tail > 0:
                 head_lines_of_log_file = _peek_head_lines(log_file)
-                lines = collections.deque(log_file.readlines(), maxlen=tail)
-                start_stream = _should_stream_the_whole_tail_lines(
+                lines = collections.deque(log_file, maxlen=tail)
+                start_streaming = _should_stream_the_whole_tail_lines(
                     head_lines_of_log_file, lines, start_stream_at)
                 for line in lines:
                     if start_stream_at in line:
-                        start_stream = True
-                    if start_stream:
+                        start_streaming = True
+                    if start_streaming:
                         print(line, end='')
                 # Flush the last n lines
                 print(end='', flush=True)
@@ -501,26 +501,26 @@ def tail_logs(job_id: Optional[int],
             # if tail > 0
             for line in _follow_job_logs(log_file,
                                          job_id=job_id,
-                                         start_streaming=start_stream,
+                                         start_streaming=start_streaming,
                                          start_streaming_at=start_stream_at):
                 print(line, end='', flush=True)
     else:
         try:
-            start_stream = False
+            start_streaming = False
             with open(log_path, 'r', encoding='utf-8') as log_file:
                 if tail > 0:
                     # If tail > 0, we need to read the last n lines.
                     # We use double ended queue to rotate the last n lines.
                     head_lines_of_log_file = _peek_head_lines(log_file)
-                    lines = collections.deque(log_file.readlines(), maxlen=tail)
-                    start_stream = _should_stream_the_whole_tail_lines(
+                    lines = collections.deque(log_file, maxlen=tail)
+                    start_streaming = _should_stream_the_whole_tail_lines(
                         head_lines_of_log_file, lines, start_stream_at)
                 else:
-                    lines = log_file.readlines()
+                    lines = log_file
                 for line in lines:
                     if start_stream_at in line:
-                        start_stream = True
-                    if start_stream:
+                        start_streaming = True
+                    if start_streaming:
                         print(line, end='', flush=True)
         except FileNotFoundError:
             print(f'{colorama.Fore.RED}ERROR: Logs for job {job_id} (status:'

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -383,7 +383,7 @@ def tail_logs(job_id: Optional[int],
               log_dir: Optional[str],
               managed_job_id: Optional[int] = None,
               follow: bool = True,
-              number_of_lines: int = 0) -> None:
+              tail: int = 0) -> None:
     """Tail the logs of a job.
 
     Args:
@@ -392,8 +392,8 @@ def tail_logs(job_id: Optional[int],
         managed_job_id: The managed job id (for logging info only to avoid
             confusion).
         follow: Whether to follow the logs or print the logs so far and exit.
-        number_of_lines: The number of lines to display from the end of the
-            log file, if 0, print all lines.
+        tail: The number of lines to display from the end of the log file,
+            if 0, print all lines.
     """
     if job_id is None:
         # This only happens when job_lib.get_latest_job_id() returns None,
@@ -444,8 +444,8 @@ def tail_logs(job_id: Optional[int],
         with open(log_path, 'r', newline='', encoding='utf-8') as log_file:
             # Using `_follow` instead of `tail -f` to streaming the whole
             # log and creating a new process for tail.
-            if number_of_lines > 0:
-                lines = deque(log_file.readlines(), maxlen=number_of_lines)
+            if tail > 0:
+                lines = deque(log_file.readlines(), maxlen=tail)
                 for line in lines:
                     print(line, end='')
                 # Flush the last n lines
@@ -460,8 +460,8 @@ def tail_logs(job_id: Optional[int],
         try:
             start_stream = False
             with open(log_path, 'r', encoding='utf-8') as f:
-                if number_of_lines > 0:
-                    lines = deque(f.readlines(), maxlen=number_of_lines)
+                if tail > 0:
+                    lines = deque(f.readlines(), maxlen=tail)
                     start_stream = True
                 else:
                     lines = f.readlines()

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -396,7 +396,7 @@ def _peek_head_lines(log_file: TextIO) -> List[str]:
 def _should_stream_the_whole_tail_lines(head_lines_of_log_file: List[str],
                                         tail_lines: Deque[str],
                                         start_stream_at: str) -> bool:
-    """Determine if start_stream_at is found before the tail_lines."""
+    """Check if the entire tail lines should be streamed."""
     # See comment:
     # https://github.com/skypilot-org/skypilot/pull/4241#discussion_r1833611567
     # for more details.

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -388,9 +388,9 @@ def _peek_head_lines(log_file: TextIO) -> List[str]:
     lines = [
         log_file.readline() for _ in range(PEEK_HEAD_LINES_FOR_START_STREAM)
     ]
-    # eset the file pointer to the beginning
+    # Reset the file pointer to the beginning
     log_file.seek(0, os.SEEK_SET)
-    return [line for line in lines if line != '' and line is not None]
+    return [line for line in lines if line]
 
 
 def _should_stream_the_whole_tail_lines(head_lines_of_log_file: List[str],

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -392,7 +392,8 @@ def tail_logs(job_id: Optional[int],
         managed_job_id: The managed job id (for logging info only to avoid
             confusion).
         follow: Whether to follow the logs or print the logs so far and exit.
-        number_of_lines: The number of lines to display from the end of the log file, if 0, print all lines.
+        number_of_lines: The number of lines to display from the end of the
+            log file, if 0, print all lines.
     """
     if job_id is None:
         # This only happens when job_lib.get_latest_job_id() returns None,
@@ -449,7 +450,8 @@ def tail_logs(job_id: Optional[int],
                     print(line, end='')
                 # Flush the last n lines
                 print(end='', flush=True)
-            # Now, the cursor is at the end of the last lines if tail_f_lines > 0
+            # Now, the cursor is at the end of the last lines
+            # if tail_f_lines > 0
             for line in _follow_job_logs(log_file,
                                          job_id=job_id,
                                          start_streaming_at=start_stream_at):

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -485,6 +485,7 @@ def tail_logs(job_id: Optional[int],
         with open(log_path, 'r', newline='', encoding='utf-8') as log_file:
             # Using `_follow` instead of `tail -f` to streaming the whole
             # log and creating a new process for tail.
+            start_stream = False
             if tail > 0:
                 head_lines_of_log_file = _peek_head_lines(log_file)
                 lines = collections.deque(log_file.readlines(), maxlen=tail)
@@ -507,7 +508,7 @@ def tail_logs(job_id: Optional[int],
     else:
         try:
             start_stream = False
-            with open(log_path, 'r', encoding='utf-8') as f:
+            with open(log_path, 'r', encoding='utf-8') as log_file:
                 if tail > 0:
                     # If tail > 0, we need to read the last n lines.
                     # We use double ended queue to rotate the last n lines.
@@ -516,7 +517,7 @@ def tail_logs(job_id: Optional[int],
                     start_stream = _start_stream_before_tail_lines(
                         head_lines_of_log_file, lines, start_stream_at)
                 else:
-                    lines = f.readlines()
+                    lines = log_file.readlines()
                 for line in lines:
                     if start_stream_at in line:
                         start_stream = True


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Trying to add this feature: https://github.com/skypilot-org/skypilot/issues/4222

<!-- Describe the tests ran -->

Config file:

```bash
(sky) ➜  skypilot git:(dev/zeping/support_tail_n) cat ~/Desktop/hello-sky/long_log.yaml 
# SkyPilot YAML configuration for a cluster with one node
workdir: .

resources:
  cloud: aws
  instance_type: t3.small

num_nodes: 1

setup: |
  echo "Running setup."

run: |
  i=1
  while [ $i -le 1000 ]; do
    echo "This is test log line number $i"
    i=$((i + 1))
  done
```

Launch command:

```bash
# Below are the output from this branching: sky/skylet/log_lib.py:436    if follow and status in [job_lib.JobStatus.SETTING_UP, job_lib.JobStatus.PENDING, job_lib.JobStatus.RUNNING, ]:
sky launch -c long_log_small ~/Desktop/hello-sky/long_log.yaml

...
(task, pid=1789) This is test log line number 985
(task, pid=1789) This is test log line number 986
(task, pid=1789) This is test log line number 987
(task, pid=1789) This is test log line number 988
(task, pid=1789) This is test log line number 989
(task, pid=1789) This is test log line number 990
(task, pid=1789) This is test log line number 991
(task, pid=1789) This is test log line number 992
(task, pid=1789) This is test log line number 993
(task, pid=1789) This is test log line number 994
(task, pid=1789) This is test log line number 995
(task, pid=1789) This is test log line number 996
(task, pid=1789) This is test log line number 997
(task, pid=1789) This is test log line number 998
(task, pid=1789) This is test log line number 999
(task, pid=1789) This is test log line number 1000
✓ Job finished (status: SUCCEEDED).

📋 Useful Commands
Job ID: 1
├── To cancel the job:          sky cancel long_log_small 1
├── To stream job logs:         sky logs long_log_small 1
└── To view job queue:          sky queue long_log_small

Cluster name: long_log_small
├── To log into the head VM:    ssh long_log_small
├── To submit a job:            sky exec long_log_small yaml_file
├── To stop the cluster:        sky stop long_log_small
└── To teardown the cluster:    sky down long_log_small
```

log command 1:

```bash
(sky) ➜  skypilot git:(dev/zeping/support_tail_n) ✗ sky logs long_log_small 1 --tail 10
Tailing logs of job 1 on cluster 'long_log_small'...
(task, pid=1789) This is test log line number 991
(task, pid=1789) This is test log line number 992
(task, pid=1789) This is test log line number 993
(task, pid=1789) This is test log line number 994
(task, pid=1789) This is test log line number 995
(task, pid=1789) This is test log line number 996
(task, pid=1789) This is test log line number 997
(task, pid=1789) This is test log line number 998
(task, pid=1789) This is test log line number 999
(task, pid=1789) This is test log line number 1000
```

log command 2:
```
(sky) ➜  skypilot git:(dev/zeping/support_tail_n) ✗ sky logs long_log_small 1 --tail 20
Tailing logs of job 1 on cluster 'long_log_small'...
(task, pid=1789) This is test log line number 981
(task, pid=1789) This is test log line number 982
(task, pid=1789) This is test log line number 983
(task, pid=1789) This is test log line number 984
(task, pid=1789) This is test log line number 985
(task, pid=1789) This is test log line number 986
(task, pid=1789) This is test log line number 987
(task, pid=1789) This is test log line number 988
(task, pid=1789) This is test log line number 989
(task, pid=1789) This is test log line number 990
(task, pid=1789) This is test log line number 991
(task, pid=1789) This is test log line number 992
(task, pid=1789) This is test log line number 993
(task, pid=1789) This is test log line number 994
(task, pid=1789) This is test log line number 995
(task, pid=1789) This is test log line number 996
(task, pid=1789) This is test log line number 997
(task, pid=1789) This is test log line number 998
(task, pid=1789) This is test log line number 999
(task, pid=1789) This is test log line number 1000
```

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
