### PR TITLE
[AWS/Azure] Avoid error out during image size check

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -280,12 +280,12 @@ class AWS(clouds.Cloud):
         if image_id.startswith('skypilot:'):
             return DEFAULT_AMI_GB
         assert region is not None, (image_id, region)
-        client = aws.client('ec2', region_name=region)
         image_not_found_message = (
             f'Image {image_id!r} not found in AWS region {region}.\n'
             f'\nTo find AWS AMI IDs: https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html#examples\n'  # pylint: disable=line-too-long
             'Example: ami-0729d913a335efca7')
         try:
+            client = aws.client('ec2', region_name=region)
             image_info = client.describe_images(ImageIds=[image_id])
             image_info = image_info.get('Images', [])
             if not image_info:
@@ -294,7 +294,8 @@ class AWS(clouds.Cloud):
             image_info = image_info[0]
             image_size = image_info['BlockDeviceMappings'][0]['Ebs'][
                 'VolumeSize']
-        except aws.botocore_exceptions().NoCredentialsError:
+        except (aws.botocore_exceptions().NoCredentialsError,
+                aws.botocore_exceptions().ProfileNotFound):
             # Fallback to default image size if no credentials are available.
             # The credentials issue will be caught when actually provisioning
             # the instance and appropriate errors will be raised there.

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -177,7 +177,7 @@ class Azure(clouds.Cloud):
         azure_utils.validate_image_id(image_id)
         try:
             compute_client = azure.get_client('compute', cls.get_project_id())
-        except (azure.exceptions().AzureError, RuntimeError) as e:
+        except (azure.exceptions().AzureError, RuntimeError):
             # Fallback to default image size if no credentials are available.
             return 0.0
 

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -175,7 +175,11 @@ class Azure(clouds.Cloud):
 
         # Process user-specified images.
         azure_utils.validate_image_id(image_id)
-        compute_client = azure.get_client('compute', cls.get_project_id())
+        try:
+            compute_client = azure.get_client('compute', cls.get_project_id())
+        except (azure.exceptions().AzureError, RuntimeError) as e:
+            # Fallback to default image size if no credentials are available.
+            return 0.0
 
         # Community gallery image.
         if image_id.startswith(_COMMUNITY_IMAGE_PREFIX):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reported that a error occurs during the resource cleanup on jobs controller triggered by `sky jobs cancel`, and the cleanup of the resources did not complete, although we have the retry setup for teardown: https://github.com/skypilot-org/skypilot/blob/17a1fee67d2daa38f48509a1f90d19b99b5aad56/sky/jobs/controller.py#L465
```
botocore.exceptions.NoCredentialsError: Unable to locate credentials
```
The credential issue could be caused by the assumed role of the controller being rotated, and our dag creation from yaml causes an issue with the resource validation (when `image_id` is specified), even before we get to the teardown retries:
https://github.com/skypilot-org/skypilot/blob/17a1fee67d2daa38f48509a1f90d19b99b5aad56/sky/jobs/controller.py#L460-L469

This PR gets rid of the requirement of credentials when creating the resources, so that the controller can still trying to teardown the clusters.

To reproduce the credential issue during resource creation:
```
export AWS_PROFILE='non-exist'
python -c "import sky; sky.Resources.from_yaml({'cloud': 'aws', 'instance_type': 'm6i.xlarge', 'image_id': 'ami-05e78ef8c273a78cf', 'region': 'us-east-1'})"
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
   - [x] remove GCP credential: `python -c "import sky; sky.Resources.from_yaml_config({'cloud'
: 'gcp', 'image_id': 'projects/sky-dev-465/global/images/skypilot-gcp-gpu-ubuntu-20241029144645', 'region': 'us-central1'})"`
  - [x] remove AWS credential: `python -c "import sky; sky.Resources.from_yaml({'cloud': 'aws', 'instance_type': 'm6i.xlarge', 'image_id': 'ami-05e78ef8c273a78cf', 'region': 'us-east-1'})"`
  - [x] remove Azure credential: `python -c "import sky; sky.Resources.from_yaml_config({'cloud': 'azure', 'image_id': '/CommunityGalleries/skypilot-fc3311ab-d34c-4589-b2fb-a95b8a84ceb1/Images/skypilot-gpu-gen2', 'region': 'eastus'})"`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
