### PR TITLE
[Jobs] Limit number of concurrent jobs & launches.

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -15,6 +15,9 @@ JOBS_TASK_YAML_PREFIX = '~/.sky/managed_jobs'
 # We use 50 GB disk size to reduce the cost.
 CONTROLLER_RESOURCES = {'cpus': '8+', 'memory': '3x', 'disk_size': 50}
 
+# Accordingly, we reserve 0.75 GB memory for each controller process.
+CONTROLLER_MEMORY_USAGE_GB = 0.75
+
 # Max length of the cluster name for GCP is 35, the user hash to be attached is
 # 4+1 chars, and we assume the maximum length of the job id is 4+1, so the max
 # length of the cluster name prefix is 25 to avoid the cluster name being too

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import colorama
 import filelock
+import psutil
 from typing_extensions import Literal
 
 from sky import backends
@@ -48,10 +49,19 @@ JOB_CONTROLLER_NAME: str = (
     f'sky-jobs-controller-{common_utils.get_user_hash()}')
 LEGACY_JOB_CONTROLLER_NAME: str = (
     f'sky-spot-controller-{common_utils.get_user_hash()}')
+
+_SYSTEM_MEMORY_GB = psutil.virtual_memory().total // (1024**3)
+NUM_JOBS_THRESHOLD = (_SYSTEM_MEMORY_GB //
+                      managed_job_constants.CONTROLLER_MEMORY_USAGE_GB)
+
 SIGNAL_FILE_PREFIX = '/tmp/sky_jobs_controller_signal_{}'
 LEGACY_SIGNAL_FILE_PREFIX = '/tmp/sky_spot_controller_signal_{}'
 # Controller checks its job's status every this many seconds.
 JOB_STATUS_CHECK_GAP_SECONDS = 20
+
+# Controller checks if the job is valid to start every this many seconds.
+# Jobs will be started only if the controller has enough resources.
+JOB_STARTING_STATUS_CHECK_GAP_SECONDS = 5
 
 # Controller checks if its job has started every this many seconds.
 JOB_STARTED_STATUS_CHECK_GAP_SECONDS = 5


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4243.

This PR adds memory limitations for the number of concurrently running jobs, and CPU limitations for the number of concurrent `sky launch` by the jobs controller.

I followed SkyServe's implementation to only apply CPU limit to concurrent launches, as IIRC `sky.launch` consumes more compute than memory. Also, only apply memory limits to the number of concurrent jobs as ray jobs consume more memory.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
