### PR TITLE
Refactor `stream_logs_by_id` to extract single task monitoring logic

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -528,6 +528,24 @@ def get_num_tasks(job_id: int) -> int:
     return len(_get_all_task_ids_statuses(job_id))
 
 
+def get_task_status(job_id: int, task_id: int) -> Optional[ManagedJobStatus]:
+    """Returns the status of a specific task in a job.
+
+    Args:
+        job_id: The ID of the job
+        task_id: The ID of the task within the job
+
+    Returns:
+        The status of the task, or None if not found
+    """
+    with db_utils.safe_cursor(_DB_PATH) as cursor:
+        row = cursor.execute(
+            """\
+            SELECT status FROM spot
+            WHERE spot_job_id=(?) AND task_id=(?)""",
+            (job_id, task_id)).fetchone()
+        return ManagedJobStatus(row[0]) if row else None
+
 def get_latest_task_id_status(
         job_id: int) -> Union[Tuple[int, ManagedJobStatus], Tuple[None, None]]:
     """Returns the (task id, status) of the latest task of a job.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -546,6 +546,7 @@ def get_task_status(job_id: int, task_id: int) -> Optional[ManagedJobStatus]:
             (job_id, task_id)).fetchone()
         return ManagedJobStatus(row[0]) if row else None
 
+
 def get_latest_task_id_status(
         job_id: int) -> Union[Tuple[int, ManagedJobStatus], Tuple[None, None]]:
     """Returns the (task id, status) of the latest task of a job.

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -311,8 +311,7 @@ def wait_for_task_completion(
         Optional[str]: Status message to display, or None when streaming logs
 
     Returns:
-        bool: True if task completed successfully, False if task failed or
-        cancelled
+        bool: True if task completed successfully, False if tailing logs failed
     """
     while True:
         # Get latest status
@@ -442,13 +441,13 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
             time.sleep(1)
 
         if managed_job_status.is_terminal():
+            failure_reason = (('\nFailure reason: '
+                               f'{managed_job_state.get_failure_reason(job_id)}'
+                              ) if managed_job_status.is_failed() else '')
             return (f'{colorama.Fore.YELLOW}'
                     f'Job {job_id} is already in terminal state '
                     f'{managed_job_status.value}. Logs will not be shown.'
-                    f'{colorama.Style.RESET_ALL}') + (
-                        ('\nFailure reason: '
-                         f'{managed_job_state.get_failure_reason(job_id)}')
-                        if managed_job_status.is_failed() else '')
+                    f'{colorama.Style.RESET_ALL}') + failure_reason
 
         backend = backends.CloudVmRayBackend()
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -320,8 +320,7 @@ def wait_for_task_completion(
         cluster_name = generate_managed_job_cluster_name(task_name, job_id)
         handle = global_user_state.get_handle_from_cluster_name(cluster_name)
 
-        _, managed_job_status = managed_job_state.get_latest_task_id_status(
-            job_id)
+        managed_job_status = managed_job_state.get_task_status(job_id, task_id)
         assert managed_job_status is not None
 
         logger.info('=== Checking the job status... ===')
@@ -388,8 +387,7 @@ def wait_for_task_completion(
 
         # Finish early if the managed job status is already in terminal
         # state.
-        _, managed_job_status = managed_job_state.get_latest_task_id_status(
-            job_id)
+        managed_job_status = managed_job_state.get_task_status(job_id, task_id)
         assert managed_job_status is not None, job_id
         if managed_job_status.is_terminal():
             return False


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Refactor `stream_logs_by_id` to separate task iteration from status management:

- Extract `wait_for_task_completion` generator to handle single task monitoring
- Leverage the fact that task_id only increases by 1
- Use `Optional[str]` as yield type for cleaner status display control
- Keep all logging and retry logic intact

The refactoring makes the code structure better match the execution model, where outer loop handles task iteration and inner generator manages status transitions.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
