### PR TITLE
[AWS] Disable additional auto update services for ubuntu image with cloud-init

### DIFF
--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -123,12 +123,9 @@ available_node_types:
             content: |
               APT::Periodic::Enable "0";
         bootcmd:
-          - systemctl stop apt-daily.timer apt-daily-upgrade.timer
-          - systemctl disable apt-daily.timer apt-daily-upgrade.timer
-          - systemctl mask apt-daily.service apt-daily-upgrade.service
-          - systemctl stop unattended-upgrades.service
-          - systemctl disable unattended-upgrades.service
-          - systemctl mask unattended-upgrades.service
+          - systemctl stop apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service
+          - systemctl disable apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service
+          - systemctl mask apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
           - systemctl daemon-reload
       TagSpecifications:
         - ResourceType: instance

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -122,6 +122,14 @@ available_node_types:
           - path: /etc/apt/apt.conf.d/10cloudinit-disable
             content: |
               APT::Periodic::Enable "0";
+        bootcmd:
+          - systemctl stop apt-daily.timer apt-daily-upgrade.timer
+          - systemctl disable apt-daily.timer apt-daily-upgrade.timer
+          - systemctl mask apt-daily.service apt-daily-upgrade.service
+          - systemctl stop unattended-upgrades.service
+          - systemctl disable unattended-upgrades.service
+          - systemctl mask unattended-upgrades.service
+          - systemctl daemon-reload
       TagSpecifications:
         - ResourceType: instance
           Tags:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Related to #4246

Master:
```
multitime -n 5 sky launch --cpus 2 --use-spot -y --region us-east-2 --down
===> multitime results
1: sky launch --cpus 2 --use-spot -y --region us-east-2 --down
            Mean        Std.Dev.    Min         Median      Max
real        44.757      2.256       42.070      44.111      48.014      
user        4.977       0.757       4.574       4.605       6.490       
sys         0.482       0.053       0.442       0.454       0.585   
```

Current:
```
===> multitime results
1: sky launch --cpus 2 --use-spot -y --region us-east-2 --down
            Mean        Std.Dev.    Min         Median      Max
real        46.844      2.892       43.189      46.732      51.460      
user        4.856       0.579       4.508       4.587       6.013       
sys         0.511       0.070       0.437       0.496       0.645    
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
