### PR TITLE
Add a pre commit config to help format before pushing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,10 @@ repos:
     hooks:
     -   id: isort
         exclude: sky/skylet/providers/ibm/.*
-        args: [“--profile”, “google”]
+        args: ["--profile", "google"]
     -   id: isort
         files: sky/skylet/providers/ibm/.*
-        args: [“--profile”, “black”, “-l”, “88", “-m”, “3"]
+        args: ["--profile", "black", "-l", "88", "-m", "3"]
         stages: [pre-commit]
 
 -   repo: https://github.com/google/yapf
@@ -42,8 +42,8 @@ repos:
             - pylint==2.14.5
             - pylint-quotes==0.2.3
         args: [
-            “--load-plugins=pylint_quotes”,
-            “--rcfile=.pylintrc”
+            "--load-plugins=pylint_quotes",
+            "--rcfile=.pylintrc"
         ]
         exclude: ^(build/.*|sky/skylet/providers/ibm/.*)$
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
             "--load-plugins=pylint_quotes",
             "--rcfile=.pylintrc"
         ]
-        exclude: ^(build/.*|sky/skylet/providers/ibm/.*)$
+        exclude: ^(build/.*|sky/skylet/providers/ibm/.*|tests/test_smoke\.py)$
 
     -   id: mypy
         name: mypy
@@ -53,3 +53,4 @@ repos:
         language: system
         types: [python]
         require_serial: true
+        exclude: ^tests/test_smoke\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,9 +52,4 @@ repos:
         entry: mypy
         language: system
         types: [python]
-        files: |
-            (?x)^(
-                sky/global_user_state.py|
-                sky/serve/
-            )$
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+    -   id: black
+        files: sky/skylet/providers/ibm/.*
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+    -   id: isort
+        exclude: sky/skylet/providers/ibm/.*
+        args: ["--profile", "google"]
+    -   id: isort
+        files: sky/skylet/providers/ibm/.*
+        args: ["--profile", "black", "-l", "88", "-m", "3"]
+        stages: [pre-commit]
+
+-   repo: https://github.com/google/yapf
+    rev: v0.40.2
+    hooks:
+    -   id: yapf
+        exclude: (build/.*|sky/skylet/providers/ibm/.*)
+        additional_dependencies: [toml]
+
+-   repo: local
+    hooks:
+    -   id: pylint
+        name: pylint
+        entry: pylint
+        language: python
+        types: [python]
+        additional_dependencies:
+            - pylint==2.14.5
+            - pylint-quotes==0.2.3
+        args: [
+            "--load-plugins=pylint_quotes",
+            "--rcfile=.pylintrc"
+        ]
+        exclude: ^(build/.*|sky/skylet/providers/ibm/.*)$
+
+    -   id: mypy
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]
+        files: |
+            (?x)^(
+                sky/global_user_state.py|
+                sky/serve/
+            )$
+        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
     hooks:
     -   id: isort
         exclude: sky/skylet/providers/ibm/.*
-        args: ["--profile", "google"]
+        args: [“--profile”, “google”]
     -   id: isort
         files: sky/skylet/providers/ibm/.*
-        args: ["--profile", "black", "-l", "88", "-m", "3"]
+        args: [“--profile”, “black”, “-l”, “88", “-m”, “3"]
         stages: [pre-commit]
 
 -   repo: https://github.com/google/yapf
-    rev: v0.40.2
+    rev: v0.32.0
     hooks:
     -   id: yapf
         exclude: (build/.*|sky/skylet/providers/ibm/.*)
@@ -42,8 +42,8 @@ repos:
             - pylint==2.14.5
             - pylint-quotes==0.2.3
         args: [
-            "--load-plugins=pylint_quotes",
-            "--rcfile=.pylintrc"
+            “--load-plugins=pylint_quotes”,
+            “--rcfile=.pylintrc”
         ]
         exclude: ^(build/.*|sky/skylet/providers/ibm/.*)$
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# TODO(zpoint): Ensure it is synchronized with format.sh
+# Ensure this configuration aligns with format.sh and requirements.txt
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -9,49 +9,72 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 22.10.0  # Match the version from requirements
     hooks:
     -   id: black
-        files: sky/skylet/providers/ibm/.*
+        name: black (IBM specific)
+        files: "^sky/skylet/providers/ibm/.*"  # Match only files in the IBM directory
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 5.12.0  # Match the version from requirements
     hooks:
+    # First isort command
     -   id: isort
-        exclude: sky/skylet/providers/ibm/.*
-        args: ["--profile", "google"]
+        name: isort (general)
+        args:
+          - "--sg=build/**"  # Matches "${ISORT_YAPF_EXCLUDES[@]}"
+          - "--sg=sky/skylet/providers/ibm/**"
+        files: "^(sky|tests|examples|llm|docs)/.*"  # Only match these directories
+    # Second isort command
     -   id: isort
-        files: sky/skylet/providers/ibm/.*
-        args: ["--profile", "black", "-l", "88", "-m", "3"]
-        stages: [pre-commit]
+        name: isort (IBM specific)
+        args:
+          - "--profile=black"
+          - "-l=88"
+          - "-m=3"
+        files: "^sky/skylet/providers/ibm/.*"  # Only match IBM-specific directory
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991  # Match the version from requirements
+    hooks:
+    -   id: mypy
+        args:
+            # from tests/mypy_files.txt
+            - "sky"
+            - "--exclude"
+            - "sky/benchmark|sky/callbacks|sky/skylet/providers/azure|sky/resources.py|sky/backends/monkey_patches"
+        pass_filenames: false
+        additional_dependencies:
+            - types-PyYAML
+            - types-requests<2.31  # Match the condition in requirements.txt
+            - types-setuptools
+            - types-cachetools
+            - types-pyvmomi
 
 -   repo: https://github.com/google/yapf
-    rev: v0.32.0
+    rev: v0.32.0  # Match the version from requirements
     hooks:
     -   id: yapf
-        exclude: (build/.*|sky/skylet/providers/ibm/.*)
-        additional_dependencies: [toml]
+        name: yapf
+        exclude: (build/.*|sky/skylet/providers/ibm/.*)  # Matches exclusions from the script
+        args: ['--recursive', '--parallel']  # Only necessary flags
+        additional_dependencies: [toml==0.10.2]
 
--   repo: local
+-   repo: https://github.com/pylint-dev/pylint
+    rev: v2.14.5  # Match the version from requirements
     hooks:
     -   id: pylint
-        name: pylint
-        entry: pylint
-        language: python
-        types: [python]
         additional_dependencies:
-            - pylint==2.14.5
-            - pylint-quotes==0.2.3
-        args: [
-            "--load-plugins=pylint_quotes",
-            "--rcfile=.pylintrc"
-        ]
-        exclude: ^(build/.*|sky/skylet/providers/ibm/.*|tests/test_smoke\.py)$
-
-    -   id: mypy
-        name: mypy
-        entry: mypy
-        language: system
-        types: [python]
-        require_serial: true
-        exclude: ^tests/test_smoke\.py$
+            - pylint-quotes==0.2.3  # Match the version from requirements
+        name: pylint-only-changed-files
+        entry: >
+            bash -c '
+            MERGEBASE=$(git merge-base origin/main HEAD);
+            changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- "sky/*.py" "sky/*.pyi");
+            if [[ -n "$changed_files" ]]; then
+                echo "$changed_files" | tr "\n" "\0" | xargs -0 pylint --load-plugins=pylint_quotes --rcfile=.pylintrc;
+            else
+                echo "Pylint skipped: no files changed in sky/.";
+            fi'
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     hooks:
     -   id: mypy
         args:
-            # from tests/mypy_files.txt
+            # From tests/mypy_files.txt
             - "sky"
             - "--exclude"
             - "sky/benchmark|sky/callbacks|sky/skylet/providers/azure|sky/resources.py|sky/backends/monkey_patches"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# TODO(zpoint): Ensure it is synchronized with format.sh
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,8 @@ It has some convenience features which you might find helpful (see [Dockerfile](
 - Fork the SkyPilot repository and create a new branch for your changes.
 - If relevant, add tests for your changes. For changes that touch the core system, run the [smoke tests](#testing) and ensure they pass.
 - Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html).
-- Ensure code is properly formatted by running [`format.sh`](https://github.com/skypilot-org/skypilot/blob/master/format.sh). [Optional] You can also install pre-commit hooks by running `pre-commit install` to automatically format your code on commit.
+- Ensure code is properly formatted by running [`format.sh`](https://github.com/skypilot-org/skypilot/blob/master/format.sh).
+  - [Optional] You can also install pre-commit hooks by running `pre-commit install` to automatically format your code on commit.
 - Push your changes to your fork and open a pull request in the SkyPilot repository.
 - In the PR description, write a `Tested:` section to describe relevant tests performed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,7 @@ It has some convenience features which you might find helpful (see [Dockerfile](
 - Fork the SkyPilot repository and create a new branch for your changes.
 - If relevant, add tests for your changes. For changes that touch the core system, run the [smoke tests](#testing) and ensure they pass.
 - Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html).
-- [Optional] Install pre-commit hooks by running `pre-commit install` to automatically format your code on commit.
-- Ensure code is properly formatted by running [`format.sh`](https://github.com/skypilot-org/skypilot/blob/master/format.sh).
+- Ensure code is properly formatted by running [`format.sh`](https://github.com/skypilot-org/skypilot/blob/master/format.sh). [Optional] You can also install pre-commit hooks by running `pre-commit install` to automatically format your code on commit.
 - Push your changes to your fork and open a pull request in the SkyPilot repository.
 - In the PR description, write a `Tested:` section to describe relevant tests performed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to SkyPilot
 
-Thank you for your interest in contributing to SkyPilot! We welcome and value 
-all contributions to the project, including but not limited to: 
+Thank you for your interest in contributing to SkyPilot! We welcome and value
+all contributions to the project, including but not limited to:
 
 * [Bug reports](https://github.com/skypilot-org/skypilot/issues) and [discussions](https://github.com/skypilot-org/skypilot/discussions)
 * [Pull requests](https://github.com/skypilot-org/skypilot/pulls) for bug fixes and new features
@@ -77,6 +77,7 @@ It has some convenience features which you might find helpful (see [Dockerfile](
 - Fork the SkyPilot repository and create a new branch for your changes.
 - If relevant, add tests for your changes. For changes that touch the core system, run the [smoke tests](#testing) and ensure they pass.
 - Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html).
+- [Optional] Install pre-commit hooks by running `pre-commit install` to automatically format your code on commit.
 - Ensure code is properly formatted by running [`format.sh`](https://github.com/skypilot-org/skypilot/blob/master/format.sh).
 - Push your changes to your fork and open a pull request in the SkyPilot repository.
 - In the PR description, write a `Tested:` section to describe relevant tests performed.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Step 1 install pre-commit

```bash
pip install pre-commit
# in the project root of skypilot repo
pre-commit install
# Make sure the .pre-commit-config.yaml file is in your project root, as demonstrated in this PR.
```

Step 2, now just run `git commit`. The command will use the `pre-commit` hook, it will behave exactly the same as [format.sh](https://github.com/skypilot-org/skypilot/blob/master/format.sh)

<img width="594" alt="image" src="https://github.com/user-attachments/assets/728eb625-57b6-4076-9e02-18854c708ba8">


Refer to this [comment](https://github.com/skypilot-org/skypilot/pull/4258#issuecomment-2469513779) if you're using cursor/vscode and encounter env problem

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
