### PR TITLE
[docs]: OCI key_file path clarrification

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -264,7 +264,7 @@ The :code:`~/.oci/config` file should contain the following fields:
   fingerprint=aa:bb:cc:dd:ee:ff:gg:hh:ii:jj:kk:ll:mm:nn:oo:pp
   tenancy=ocid1.tenancy.oc1..aaaaaaaa
   region=us-sanjose-1
-  # Note that we should avoid using full home path for the key_file configuration, e.g. use `~/.oci` instead of `/home/username/.oci`
+  # Note that we should avoid using full home path for the key_file configuration, e.g. use ~/.oci instead of /home/username/.oci
   key_file=~/.oci/oci_api_key.pem
 
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -264,6 +264,7 @@ The :code:`~/.oci/config` file should contain the following fields:
   fingerprint=aa:bb:cc:dd:ee:ff:gg:hh:ii:jj:kk:ll:mm:nn:oo:pp
   tenancy=ocid1.tenancy.oc1..aaaaaaaa
   region=us-sanjose-1
+  # Note that we should avoid using full home path for the key_file configuration, e.g. use `~/.oci` instead of `/home/username/.oci`
   key_file=~/.oci/oci_api_key.pem
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR is to clarrify the key_file path configuration in the oci config file.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
