### PR TITLE
[Core] Avoid PENDING job to be set to FAILED and speed up job scheduling

### DIFF
--- a/examples/multi_echo.py
+++ b/examples/multi_echo.py
@@ -31,13 +31,13 @@ def run(cluster: Optional[str] = None, cloud: Optional[str] = None):
 
     # Submit multiple tasks in parallel to trigger queueing behaviors.
     def _exec(i):
-        task = sky.Task(run=f'echo {i}; sleep 5')
-        resources = sky.Resources(accelerators={'T4': 0.5})
+        task = sky.Task(run=f'echo {i}; sleep 60')
+        resources = sky.Resources(accelerators={'T4': 0.05})
         task.set_resources(resources)
         sky.exec(task, cluster_name=cluster, detach_run=True)
 
     with pool.ThreadPool(8) as p:
-        list(p.imap(_exec, range(32)))
+        list(p.imap(_exec, range(150)))
 
 
 if __name__ == '__main__':

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -65,7 +65,6 @@ class JobSchedulerEvent(SkyletEvent):
 
     def _run(self):
         job_lib.scheduler.schedule_step(force_update_jobs=True)
-        logger.info('Triggerred job status update and scheduling.')
 
 
 class ManagedJobUpdateEvent(SkyletEvent):

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -65,6 +65,7 @@ class JobSchedulerEvent(SkyletEvent):
 
     def _run(self):
         job_lib.scheduler.schedule_step(force_update_jobs=True)
+        logger.info('Triggerred job status update and scheduling.')
 
 
 class ManagedJobUpdateEvent(SkyletEvent):

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -155,7 +155,7 @@ class JobStatus(enum.Enum):
 # to avoid race condition with `ray job` to make sure it job has been
 # correctly updated.
 # TODO(zhwu): This number should be tuned based on heuristics.
-_PENDING_SUBMIT_GRACE_PERIOD = 90
+_PENDING_SUBMIT_GRACE_PERIOD = 60
 
 _PRE_RESOURCE_STATUSES = [JobStatus.PENDING]
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -627,6 +627,7 @@ def update_job_status(job_ids: List[int],
                 # DB) would already have that value. So we take the max here to
                 # keep it at later status.
                 status = max(status, original_status)
+                assert status is not None, (job_id, status, original_status)
                 if status != original_status:  # Prevents redundant update.
                     _set_status_no_lock(job_id, status)
                     if not silent:

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1824,6 +1824,7 @@ def test_multi_echo(generic_cloud: str):
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "RUNNING" | wc -l | awk \'{{if ($1 < 10) exit 1}}\'',
             'sleep 30',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
+            f'until sky logs {name} 32 --status; do echo "Waiting for job 32 to finish..."; sleep 1; done',
         ] +
         # Ensure jobs succeeded.
         [f'sky logs {name} {i + 1} --status' for i in range(32)] +

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1813,7 +1813,17 @@ def test_multi_echo(generic_cloud: str):
         'multi_echo',
         [
             f'python examples/multi_echo.py {name} {generic_cloud}',
-            'sleep 120',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
+            'sleep 10',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
+            'sleep 30',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
+            'sleep 30',
+            # Make sure that our job scheduler is fast enough to have at least
+            # 10 RUNNING jobs in parallel.
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "RUNNING" | wc -l | awk \'{{if ($1 < 10) exit 1}}\'',
+            'sleep 30',
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
         ] +
         # Ensure jobs succeeded.
         [f'sky logs {name} {i + 1} --status' for i in range(32)] +

--- a/tests/test_yamls/pipeline_aws.yaml
+++ b/tests/test_yamls/pipeline_aws.yaml
@@ -5,7 +5,7 @@ name: a
 
 resources:
   cloud: aws
-  region: us-west-2
+  region: us-east-2
   cpus: 2+
 
 run: |


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4263 

It also speed up the job scheduling by avoid update status for all the jobs:
Previously, gap between jobs to be scheduled is ~4-5s, ie with 60s duration of a task, there will be 12 jobs running in parallel (the additional RUNNING (with more than 1 min job duration) ones below are invoking the scheduling step for jobs which takes a long time waiting for the job scheduler to finish).
```
221  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-10-870719  
220  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-09-092916  
219  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-07-104709  
218  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-06-950815  
217  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-06-835127  
216  sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-19-30-04-966880  
215  sky-cmd  11 mins ago  a few secs ago  1s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-30-04-499591  
214  sky-cmd  11 mins ago  a few secs ago  5s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-30-03-997782  
213  sky-cmd  11 mins ago  a few secs ago  9s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-30-03-401201  
212  sky-cmd  11 mins ago  14 secs ago     14s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-30-02-683537  
211  sky-cmd  11 mins ago  18 secs ago     18s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-58-437107  
210  sky-cmd  11 mins ago  22 secs ago     22s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-58-121545  
209  sky-cmd  11 mins ago  27 secs ago     27s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-58-030503  
208  sky-cmd  11 mins ago  30 secs ago     30s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-55-595568  
207  sky-cmd  11 mins ago  36 secs ago     36s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-55-308832  
206  sky-cmd  11 mins ago  41 secs ago     41s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-54-752160  
205  sky-cmd  11 mins ago  46 secs ago     46s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-54-840566  
204  sky-cmd  11 mins ago  52 secs ago     52s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-54-647147  
203  sky-cmd  11 mins ago  56 secs ago     56s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-51-826498  
202  sky-cmd  11 mins ago  1 min ago       1m        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-51-525987  
201  sky-cmd  11 mins ago  1 min ago       1m 4s     1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-51-529238  
200  sky-cmd  11 mins ago  1 min ago       1m 12s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-49-392753  
199  sky-cmd  11 mins ago  1 min ago       1m 16s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-48-211998  
198  sky-cmd  11 mins ago  1 min ago       1m 20s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-47-018499  
197  sky-cmd  11 mins ago  1 min ago       1m 24s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-46-732420  
196  sky-cmd  11 mins ago  1 min ago       1m 29s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-46-527903  
195  sky-cmd  11 mins ago  1 min ago       1m 34s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-44-218424  
194  sky-cmd  11 mins ago  1 min ago       1m 40s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-43-986796  
193  sky-cmd  11 mins ago  1 min ago       1m 44s    1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-19-29-44-039565  
192  sky-cmd  11 mins ago  1 min ago       1m 45s    1x[CPU:1+]  SUCCEEDED  ~/sky_logs/sky-2024-11-05-19-29-42-571895 
```

Now, it takes ~2-3 seconds for each job to be submitted, so there can be 21 parallel jobs, and there are no jobs with duration significantly longer than 1 minute.
```
339   sky-cmd  11 mins ago  -               -         1x[CPU:1+]  PENDING    ~/sky_logs/sky-2024-11-05-23-31-46-294901  
338   sky-cmd  11 mins ago  a few secs ago  2s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-46-151382  
337   sky-cmd  11 mins ago  a few secs ago  5s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-44-053912  
336   sky-cmd  11 mins ago  a few secs ago  8s        1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-41-961098  
335   sky-cmd  11 mins ago  11 secs ago     11s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-41-919819  
334   sky-cmd  11 mins ago  14 secs ago     14s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-41-611173  
333   sky-cmd  11 mins ago  16 secs ago     16s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-41-550143  
332   sky-cmd  11 mins ago  19 secs ago     19s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-41-136605  
331   sky-cmd  11 mins ago  22 secs ago     22s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-40-268279  
330   sky-cmd  11 mins ago  25 secs ago     25s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-40-298456  
329   sky-cmd  11 mins ago  28 secs ago     28s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-38-036070  
328   sky-cmd  11 mins ago  30 secs ago     30s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-35-625810  
327   sky-cmd  11 mins ago  33 secs ago     33s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-35-368378  
326   sky-cmd  11 mins ago  36 secs ago     36s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-35-547889  
325   sky-cmd  11 mins ago  39 secs ago     39s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-35-271033  
324   sky-cmd  11 mins ago  41 secs ago     41s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-34-871366  
323   sky-cmd  11 mins ago  44 secs ago     44s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-34-202901  
322   sky-cmd  11 mins ago  47 secs ago     47s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-34-022552  
321   sky-cmd  11 mins ago  50 secs ago     50s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-31-843038  
320   sky-cmd  11 mins ago  53 secs ago     53s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-29-105083  
319   sky-cmd  11 mins ago  56 secs ago     56s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-29-240834  
318   sky-cmd  11 mins ago  58 secs ago     58s       1x[CPU:1+]  RUNNING    ~/sky_logs/sky-2024-11-05-23-31-28-474097  
317   sky-cmd  11 mins ago  1 min ago       1m        1x[CPU:1+]  SUCCEEDED  ~/sky_logs/sky-2024-11-05-23-31-28-665341
```



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Reproducible script in #4263 
- [x] All smoke tests: `pytest tests/test_smoke.py --aws` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_multi_echo`
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
