### PR TITLE
[Admin Policy] Apply policy in CLI

### DIFF
--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -113,6 +113,9 @@ The ``sky.Config`` and ``sky.RequestOptions`` classes are defined as follows:
     :pyobject: RequestOptions
     :caption: `RequestOptions Class <https://github.com/skypilot-org/skypilot/blob/master/sky/admin_policy.py>`_
 
+.. note::
+
+    The ``sky.AdminPolicy`` should be idempotent. In other words, it should be safe to apply the policy multiple times to the same user request.
 
 Example Policies    
 ----------------

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -77,6 +77,8 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 from sky.utils.cli_utils import status_utils
+from sky import admin_policy
+from sky.utils import admin_policy_utils
 
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
@@ -582,6 +584,15 @@ def _launch_with_confirm(
             with ux_utils.print_exception_no_traceback():
                 raise RuntimeError(f'{colorama.Fore.YELLOW}{e}'
                                    f'{colorama.Style.RESET_ALL}') from e
+        dag, _ = admin_policy_utils.apply(
+            dag,
+            request_options=admin_policy.RequestOptions(
+                cluster_name=cluster,
+                idle_minutes_to_autostop=idle_minutes_to_autostop,
+                down=down,
+                dryrun=dryrun,
+            ),
+        )
         dag = sky.optimize(dag)
     task = dag.tasks[0]
 
@@ -3667,6 +3678,8 @@ def jobs_launch(
 
     click.secho(f'Managed job {dag.name!r} will be launched on (estimated):',
                 fg='cyan')
+    dag, _ = admin_policy_utils.apply(
+        dag, use_mutated_config_in_current_request=False)
     dag = sky.optimize(dag)
 
     if not yes:
@@ -4145,6 +4158,7 @@ def serve_up(
                 fg='cyan')
     with sky.Dag() as dag:
         dag.add(task)
+    dag, _ = admin_policy_utils.apply(dag, use_mutated_config_in_current_request=False)
     sky.optimize(dag)
 
     if not yes:
@@ -4261,6 +4275,7 @@ def serve_update(
                 fg='cyan')
     with sky.Dag() as dag:
         dag.add(task)
+    dag, _ = admin_policy_utils.apply(dag, use_mutated_config_in_current_request=False)
     sky.optimize(dag)
 
     if not yes:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -46,6 +46,7 @@ from rich import progress as rich_progress
 import yaml
 
 import sky
+from sky import admin_policy
 from sky import backends
 from sky import check as sky_check
 from sky import clouds as sky_clouds
@@ -67,6 +68,7 @@ from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
 from sky.usage import usage_lib
+from sky.utils import admin_policy_utils
 from sky.utils import common_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
@@ -77,8 +79,6 @@ from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
 from sky.utils.cli_utils import status_utils
-from sky import admin_policy
-from sky.utils import admin_policy_utils
 
 if typing.TYPE_CHECKING:
     from sky.backends import backend as backend_lib
@@ -4158,7 +4158,8 @@ def serve_up(
                 fg='cyan')
     with sky.Dag() as dag:
         dag.add(task)
-    dag, _ = admin_policy_utils.apply(dag, use_mutated_config_in_current_request=False)
+    dag, _ = admin_policy_utils.apply(
+        dag, use_mutated_config_in_current_request=False)
     sky.optimize(dag)
 
     if not yes:
@@ -4275,7 +4276,8 @@ def serve_update(
                 fg='cyan')
     with sky.Dag() as dag:
         dag.add(task)
-    dag, _ = admin_policy_utils.apply(dag, use_mutated_config_in_current_request=False)
+    dag, _ = admin_policy_utils.apply(
+        dag, use_mutated_config_in_current_request=False)
     sky.optimize(dag)
 
     if not yes:

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -23,6 +23,7 @@ class Dag:
 
         self.graph = nx.DiGraph()
         self.name: Optional[str] = None
+        self.policy_applied: bool = False
 
     def add(self, task: 'task.Task') -> None:
         self.graph.add_node(task)

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -160,14 +160,16 @@ def _execute(
     """
 
     dag = dag_utils.convert_entrypoint_to_dag(entrypoint)
-    dag, _ = admin_policy_utils.apply(
-        dag,
-        request_options=admin_policy.RequestOptions(
-            cluster_name=cluster_name,
-            idle_minutes_to_autostop=idle_minutes_to_autostop,
-            down=down,
-            dryrun=dryrun,
-        ))
+    if not dag.policy_applied:
+        dag, _ = admin_policy_utils.apply(
+            dag,
+            request_options=admin_policy.RequestOptions(
+                cluster_name=cluster_name,
+                idle_minutes_to_autostop=idle_minutes_to_autostop,
+                down=down,
+                    dryrun=dryrun,
+                ),
+        )
     assert len(dag) == 1, f'We support 1 task for now. {dag}'
     task = dag.tasks[0]
 

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -167,8 +167,8 @@ def _execute(
                 cluster_name=cluster_name,
                 idle_minutes_to_autostop=idle_minutes_to_autostop,
                 down=down,
-                    dryrun=dryrun,
-                ),
+                dryrun=dryrun,
+            ),
         )
     assert len(dag) == 1, f'We support 1 task for now. {dag}'
     task = dag.tasks[0]

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -59,8 +59,10 @@ def launch(
     """
     entrypoint = task
     dag_uuid = str(uuid.uuid4().hex[:4])
-
     dag = dag_utils.convert_entrypoint_to_dag(entrypoint)
+    # Always apply the policy again here, even though it might have been applied
+    # in the CLI. This is to ensure that we apply the policy to the final DAG
+    # and get the mutated config.
     dag, mutated_user_config = admin_policy_utils.apply(
         dag, use_mutated_config_in_current_request=False)
     if not dag.is_chain():

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -124,7 +124,9 @@ def up(
                              f'{constants.CLUSTER_NAME_VALID_REGEX}')
 
     _validate_service_task(task)
-
+    # Always apply the policy again here, even though it might have been applied
+    # in the CLI. This is to ensure that we apply the policy to the final DAG
+    # and get the mutated config.
     dag, mutated_user_config = admin_policy_utils.apply(
         task, use_mutated_config_in_current_request=False)
     task = dag.tasks[0]
@@ -319,6 +321,11 @@ def update(
         service_name: Name of the service.
     """
     _validate_service_task(task)
+    # Always apply the policy again here, even though it might have been applied
+    # in the CLI. This is to ensure that we apply the policy to the final DAG
+    # and get the mutated config.
+    dag, _ = admin_policy_utils.apply(task, use_mutated_config_in_current_request=False)
+    task = dag.tasks[0]
     handle = backend_utils.is_controller_accessible(
         controller=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
         stopped_message=

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -324,6 +324,8 @@ def update(
     # Always apply the policy again here, even though it might have been applied
     # in the CLI. This is to ensure that we apply the policy to the final DAG
     # and get the mutated config.
+    # TODO(cblmemo,zhwu): If a user sets a new skypilot_config, the update
+    # will not apply the config.
     dag, _ = admin_policy_utils.apply(
         task, use_mutated_config_in_current_request=False)
     task = dag.tasks[0]

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -324,7 +324,8 @@ def update(
     # Always apply the policy again here, even though it might have been applied
     # in the CLI. This is to ensure that we apply the policy to the final DAG
     # and get the mutated config.
-    dag, _ = admin_policy_utils.apply(task, use_mutated_config_in_current_request=False)
+    dag, _ = admin_policy_utils.apply(
+        task, use_mutated_config_in_current_request=False)
     task = dag.tasks[0]
     handle = backend_utils.is_controller_accessible(
         controller=controller_utils.Controllers.SKY_SERVE_CONTROLLER,

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -142,4 +142,5 @@ def apply(
             importlib.reload(skypilot_config)
 
     logger.debug(f'Mutated user request: {mutated_user_request}')
+    mutated_dag.policy_applied = True
     return mutated_dag, mutated_config


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the admin policy is only applied in the backend, which will cause wrong output of the optimizer table in the CLI. We now apply the policy to dag in CLI as well.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `sky launch -c test-aws --cloud aws --cpus 2 echo hi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
