### PR TITLE
Set minimum port number a Ray worker can listen on to 11002

### DIFF
--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -264,6 +264,7 @@ def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
         f'--disable-usage-stats '
         f'--port={constants.SKY_REMOTE_RAY_PORT} '
         f'--dashboard-port={constants.SKY_REMOTE_RAY_DASHBOARD_PORT} '
+        f'--min-worker-port 11002 '
         f'--object-manager-port=8076 '
         f'--temp-dir={constants.SKY_REMOTE_RAY_TEMPDIR}')
     if custom_resource:


### PR DESCRIPTION
This pull request sets the minimum port number a Ray worker can listen on to 11002. Without this change, when running [examples/k8s_cloud_deploy/launch_k8s.sh](https://github.com/skypilot-org/skypilot/blob/master/examples/k8s_cloud_deploy/launch_k8s.sh), k3s/containerd will fail with the error:

```
/var/lib/rancher/k3s/agent/containerd/containerd.log
time="2024-11-06T18:12:48.119844117Z" level=fatal msg="Failed to run CRI service" error="stream server error: listen tcp 127.0.0.1:10010: bind: address already in use"
```

See:

- https://github.com/skypilot-org/skypilot/pull/3929
- https://github.com/k3s-io/k3s/issues/4984