### PR TITLE
[DAG] Add DAG Visualization with Jupyter Support

### DIFF
--- a/sky/dag.py
+++ b/sky/dag.py
@@ -323,9 +323,8 @@ class Dag:
         try:
             # Try to display the image in Jupyter Notebook
             # pylint: disable=import-outside-toplevel
-            from IPython.display import display
-            from IPython.display import Image
-            display(Image(filename=to_file))
+            from IPython import display
+            display.display(display.Image(filename=to_file))
             return None
         except ImportError:
             pass


### PR DESCRIPTION
Resolve #4277.

Adds a `plot` method to the `Dag` class to visualize task dependencies. Automatically displays inline in Jupyter or saves to a file in other environments.

#### Example:
```python
from sky import Dag, Task

with Dag() as dag:
    task_a = Task(name="A")
    task_b = Task(name="B")
    task_c = Task(name="C")
    task_a >> task_b >> task_c

dag.plot()
```

**Notes:**
- Requires `matplotlib` and `networkx`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - Tested in Jupyter Notebook (`.ipynb`)
    - Tested in regular Python environment
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
