### PR TITLE
[DAG] Add Edge-Based Data Flow Support

### DIFF
--- a/sky/dag.py
+++ b/sky/dag.py
@@ -16,32 +16,48 @@ TaskOrName = Union['task.Task', str]
 
 
 @dataclasses.dataclass
+class TaskData:
+    """Represents data transfer information between tasks.
+
+    Attributes:
+        source_path: Path where data is stored on the source node.
+        target_path: Path where data will be stored on the target node.
+        size_gb: Estimated size of the data in gigabytes.
+    """
+    source_path: str
+    target_path: str
+    size_gb: float
+
+
+@dataclasses.dataclass
 class TaskEdge:
     """Represents an edge between two tasks in a DAG.
 
     Attributes:
         source: The upstream task.
         target: The downstream task.
-        data_path: Path where data will be stored on the target node.
-        data_size_gb: Estimated size of the data in gigabytes.
+        data: Optional data transfer information between tasks.
+               If None, only represents task dependency.
     """
     source: 'task.Task'
     target: 'task.Task'
-    data_path: Optional[str] = None
-    data_size_gb: Optional[float] = None
+    data: Optional[TaskData] = None
 
-    def with_data(self, path: str, size_gb: float) -> 'TaskEdge':
-        """Specifies data transfer path and size for this edge.
+    def with_data(self, source_path: str, target_path: str,
+                  size_gb: float) -> 'TaskEdge':
+        """Specifies data transfer information for this edge.
 
         Args:
-            path: Path where data will be stored on the target node.
+            source_path: Path where data is stored on the source node.
+            target_path: Path where data will be stored on the target node.
             size_gb: Estimated size of the data in gigabytes.
 
         Returns:
             self: The current edge for chaining.
         """
-        self.data_path = path
-        self.data_size_gb = size_gb
+        self.data = TaskData(source_path=source_path,
+                             target_path=target_path,
+                             size_gb=size_gb)
         return self
 
 

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -1,4 +1,5 @@
 """DAGs: user applications to be run."""
+import dataclasses
 import threading
 import typing
 from typing import Dict, List, Optional, Set, Union
@@ -12,6 +13,36 @@ if typing.TYPE_CHECKING:
     from sky import task
 
 TaskOrName = Union['task.Task', str]
+
+
+@dataclasses.dataclass
+class TaskEdge:
+    """Represents an edge between two tasks in a DAG.
+
+    Attributes:
+        source: The upstream task.
+        target: The downstream task.
+        data_path: Path where data will be stored on the target node.
+        data_size_gb: Estimated size of the data in gigabytes.
+    """
+    source: 'task.Task'
+    target: 'task.Task'
+    data_path: Optional[str] = None
+    data_size_gb: Optional[float] = None
+
+    def with_data(self, path: str, size_gb: float) -> 'TaskEdge':
+        """Specifies data transfer path and size for this edge.
+
+        Args:
+            path: Path where data will be stored on the target node.
+            size_gb: Estimated size of the data in gigabytes.
+
+        Returns:
+            self: The current edge for chaining.
+        """
+        self.data_path = path
+        self.data_size_gb = size_gb
+        return self
 
 
 class Dag:
@@ -113,12 +144,15 @@ class Dag:
         assert task.name is not None
         self._task_name_lookup.pop(task.name, None)
 
-    def add_edge(self, source: TaskOrName, target: TaskOrName) -> None:
+    def add_edge(self, source: TaskOrName, target: TaskOrName) -> 'TaskEdge':
         """Add an edge from source task to target task.
 
         Args:
             source: The upstream task.
             target: The downstream task to be added.
+
+        Returns:
+            A TaskEdge object representing the edge.
 
         Raises:
             ValueError: If a task is set as its own downstream task or if the
@@ -132,14 +166,20 @@ class Dag:
                 raise ValueError(f'Task {source.name} should not be its own '
                                  'downstream task.')
 
-        self.graph.add_edge(source, target)
+        edge = TaskEdge(source, target)
+        self.graph.add_edge(source, target, edge=edge)
+        return edge
 
-    def add_downstream(self, source: TaskOrName, target: TaskOrName) -> None:
-        """Add downstream tasks for a source task.
+    def add_downstream(self, source: TaskOrName,
+                       target: TaskOrName) -> 'TaskEdge':
+        """Add downstream tasks for a source task. Equivalent to add_edge.
 
         Args:
             source: The upstream task.
             target: The downstream task to be added.
+
+        Returns:
+            A TaskEdge object representing the edge.
         """
         return self.add_edge(source, target)
 
@@ -197,6 +237,32 @@ class Dag:
         """
         task = self._get_task(task)
         return set(self.graph.successors(task))
+
+    def get_edge(self, source: TaskOrName,
+                 target: TaskOrName) -> Optional[TaskEdge]:
+        """Get the edge between two tasks if it exists.
+
+        Args:
+            source: The upstream task.
+            target: The downstream task.
+
+        Returns:
+            The TaskEdge object if the edge exists, None otherwise.
+        """
+        source = self._get_task(source)
+        target = self._get_task(target)
+        try:
+            return self.graph[source][target]['edge']
+        except KeyError:
+            return None
+
+    def get_edges(self) -> List[TaskEdge]:
+        """Get all edges in the DAG.
+
+        Returns:
+            A list of TaskEdge objects.
+        """
+        return [data['edge'] for _, _, data in self.graph.edges(data=True)]
 
     def __len__(self) -> int:
         """Return the number of tasks in the DAG."""

--- a/sky/task.py
+++ b/sky/task.py
@@ -1156,14 +1156,25 @@ class Task:
 
         return required_features
 
-    def __rshift__(self, b):
+    def __rshift__(self, b: 'Task') -> 'sky.dag.TaskEdge':
+        """Creates a directed edge from this task to another task.
+
+        Args:
+            b: The downstream task.
+
+        Returns:
+            A TaskEdge object representing the edge.
+
+        Raises:
+            ValueError: If no current DAG context is found.
+        """
         current_dag = sky.dag.get_current_dag()
         if current_dag is None:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError('No current DAG context found. '
                                  'Use `with sky.Dag() as dag: ...` '
                                  'to define a DAG.')
-        current_dag.add_edge(self, b)
+        return current_dag.add_edge(self, b)
 
     def __repr__(self):
         if isinstance(self.run, str):

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -136,7 +136,9 @@ def load_dag_from_yaml(
             task_edge = dag.add_edge(source, target)
             if 'data' in edge:
                 data = edge['data']
-                task_edge.with_data(data['path'], data['size_gb'])
+                task_edge.with_data(source_path=data['source_path'],
+                                    target_path=data['target_path'],
+                                    size_gb=data['size_gb'])
     else:
         # Implicit dependency
         for i in range(len(tasks) - 1):
@@ -158,17 +160,17 @@ def dump_dag_to_yaml(dag: dag_lib.Dag, path: str) -> None:
     """
     header: Dict[str, Any] = {'name': dag.name}
 
-    # Collect all edge information
     edges: List[Dict[str, Any]] = []
     for edge in dag.get_edges():
         edge_dict: Dict[str, Any] = {
             'source': edge.source.name,
             'target': edge.target.name
         }
-        if edge.data_path is not None and edge.data_size_gb is not None:
+        if edge.data is not None:
             edge_dict['data'] = {
-                'path': edge.data_path,
-                'size_gb': edge.data_size_gb
+                'source_path': edge.data.source_path,
+                'target_path': edge.data.target_path,
+                'size_gb': edge.data.size_gb
             }
         edges.append(edge_dict)
 


### PR DESCRIPTION
Closes #4254 

## Description

This PR introduces edge-based data flow support in DAGs, allowing users to specify data transfer paths and sizes between tasks. This provides a more explicit and flexible way to define data dependencies between tasks.

### Changes

1. Added `TaskEdge` dataclass to represent edges between tasks:
   - Stores source task, target task, data path, and data size
   - Provides `with_data()` method for fluent API

2. Enhanced DAG implementation:
   - Store edge metadata in networkx graph
   - Added methods to get/manipulate edges and their properties

3. Updated YAML format:
   - Replaced `downstream` with new `edges` field for explicit edge definition
   - Added support for data transfer specifications on edges

### Example Usage

Python API:
```python
with sky.Dag() as dag:
    preprocess = sky.Task(name='preprocess', run='python preprocess.py')
    train_a = sky.Task(name='train_a', run='python train.py')
    train_b = sky.Task(name='train_b', run='python train.py')

    (preprocess >> train_a).with_data('/data/model_a', '/train', size_gb=2.0)
    (preprocess >> train_b).with_data('/data/model_b', '/train', size_gb=2.0)
```

YAML format:
```
name: example-pipeline
edges:
  - source: preprocess
    target: train_a
    data:
      source_path: /data/raw/model_a
      target_path: /data/processed/model_a
      size_gb: 2.0
  - source: preprocess 
    target: train_b
    data:
      source_path: /data/raw/model_b
      target_path: /data/processed/model_b
      size_gb: 2.0

---
name: preprocess
run: python preprocess.py
---
name: train_a
run: python train.py
---
name: train_b
run: python train.py
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
