### PR TITLE
[AWS] Explicitly check credential and refresh if needed

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -85,7 +85,6 @@ def _assert_kwargs_builtin_type(kwargs):
         f'kwargs should not contain none built-in types: {kwargs}')
 
 
-
 # The LRU cache needs to be thread-local to avoid multiple threads sharing the
 # same session object, which is not guaranteed to be thread-safe.
 @_thread_local_lru_cache()
@@ -93,10 +92,10 @@ def session():
     """Create an AWS session."""
     return boto3.session.Session()
 
+
 def get_session():
     attempt = 0
-    backoff = common_utils.Backoff(initial_backoff=0.5,
-                                   max_backoff_factor=4)
+    backoff = common_utils.Backoff(initial_backoff=0.5, max_backoff_factor=4)
     while True:
         try:
             # Creating the boto3 objects are not thread-safe,

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -180,7 +180,7 @@ def _ec2_call_with_retry(
             if not credentials_refreshed:
                 cached_ec2 = ec2_recreation_fn()
                 logger.warning('AWS: Credentials refreshed for temporary '
-                            'NoCredentialsError.')
+                               'NoCredentialsError.')
                 credentials_refreshed = True
                 continue
             raise

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -730,7 +730,6 @@ def terminate_instances(
     sg_name = provider_config['security_group']['GroupName']
     managed_by_skypilot = provider_config['security_group'].get(
         'ManagedBySkyPilot', True)
-    ec2 = _default_ec2_resource(region)
     filters = [
         {
             'Name': 'instance-state-name',
@@ -745,11 +744,12 @@ def terminate_instances(
             'Values': ['worker'],
         })
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Instance
-    instances = _filter_instances(ec2,
+    instances = _filter_instances(region,
                                   filters,
                                   included_instances=None,
                                   excluded_instances=None)
     instance_ids = [inst.id for inst in instances]
+    ec2 = _default_ec2_resource(region)
     _ec2_call_with_retry(
         ec2,
         ec2_recreation_fn=lambda: _default_ec2_resource(region),

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -161,7 +161,8 @@ def _ec2_call_with_retry(
                 time.sleep(backoff.current_backoff())
                 logger.debug(f'create_instances: {error_code}, retrying.')
                 continue
-            if error_code == 'UnauthorizedOperation' and not credentials_refreshed:
+            if (error_code == 'UnauthorizedOperation' and
+                    not credentials_refreshed):
                 # Refresh the cached ec2 resource to get the latest credentials.
                 # We will retry until the credentials are refreshed in the
                 # underlying boto3 session.

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -167,7 +167,8 @@ def _ec2_call_with_retry(
                 # We will retry until the credentials are refreshed in the
                 # underlying boto3 session.
                 cached_ec2 = ec2_recreation_fn()
-                logger.debug('create_instances: Credentials refreshed.')
+                logger.warning('AWS: Credentials refreshed for temporary '
+                               'UnauthorizedOperation.')
                 credentials_refreshed = True
                 continue
             logger.log(log_level, f'create_instances: Attempt failed with {e}')
@@ -178,7 +179,8 @@ def _ec2_call_with_retry(
             # underlying boto3 session.
             if not credentials_refreshed:
                 cached_ec2 = ec2_recreation_fn()
-                logger.debug('create_instances: Credentials refreshed.')
+                logger.warning('AWS: Credentials refreshed for temporary '
+                            'NoCredentialsError.')
                 credentials_refreshed = True
                 continue
             raise

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -161,7 +161,7 @@ def _ec2_call_with_retry(
                 time.sleep(backoff.current_backoff())
                 logger.debug(f'create_instances: {error_code}, retrying.')
                 continue
-            if (error_code == 'UnauthorizedOperation' and
+            if (error_code in ['UnauthorizedOperation', 'ExpiredToken'] and
                     not credentials_refreshed):
                 # Refresh the cached ec2 resource to get the latest credentials.
                 # We will retry until the credentials are refreshed in the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4275.


TODO: performance impact

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [ ] ~~Submitting 1000 jobs and after 256 jobs running, cancel the jobs all together to trigger the parallel termination of clusters. (failed to reproduce the issue on master)~~
    ```
    import subprocess
    from multiprocessing.pool import ThreadPool
    
    def run_task(task):
        print(f'Running task {task}')
        subprocess.run(
            f'sky jobs launch -n job-{task} -dy --fast --cloud aws -t t3.medium --use-spot "echo hi {task}; sleep 7200"',
            shell=True
        )
    
    with ThreadPool(8) as pool:
        pool.map(run_task, range(1000))
    ```
  - [ ] ~~Simulate the list on master and this branch to test the assumed role refresh~~ Failed to reproduce on both master and this branch...
    - master
    ```
    # no retry
    import datetime
    import time
    
    from sky.adaptors import aws
    
    while True:
        ec2 = aws.resource('ec2', region_name='us-east-1')
        instances = list(ec2.instances.all())
        print(datetime.datetime.now(), len(instances))
        print('-' * 100)
        time.sleep(1)
    ```
    - this branch
    ```
    # with-retry
    
    import datetime
    import time
    
    from sky.adaptors import aws
    from sky.provision.aws import instance
    
    while True:
        ec2 = aws.resource('ec2', region_name='us-east-1')
        _, instances = instance._ec2_call_with_retry(ec2, lambda: aws.resource('ec2', region_name='us-east-1'), lambda ec2: list(ec2.instances.all()))
        print(datetime.datetime.now(), len(instances))
        print('-' * 100)
        time.sleep(1)
    ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
