### PR TITLE
[Jobs] Managed jobs database use WAL mode

### DIFF
--- a/sky/clouds/service_catalog/images/aws_utils/image_gen.py
+++ b/sky/clouds/service_catalog/images/aws_utils/image_gen.py
@@ -1,4 +1,4 @@
-"""Copy SkyPilot AMI to multiple regions, make them public, and generate images.csv
+"""Copy SkyPilot AMI to multi regions, make them public, and generate images.csv
 
 Example Usage:
   python aws_image_gen.py  --source-image-id ami-00000 --processor gpu
@@ -63,7 +63,7 @@ ALL_REGIONS = [
 
 
 def make_image_public(image_id, region):
-    unblock_command = f"aws ec2 disable-image-block-public-access --region {region}"
+    unblock_command = (f'aws ec2 disable-image-block-public-access --region {region}')
     subprocess.run(unblock_command, shell=True, check=True)
     public_command = (
         f'aws ec2 modify-image-attribute --image-id {image_id} '
@@ -75,10 +75,12 @@ def make_image_public(image_id, region):
 
 def copy_image_and_make_public(target_region):
     # Copy the AMI to the target region
+    ami_name = f'skypilot-aws-{args.processor}-{args.os_type}-{time.strftime("%y%m%d")}'
     copy_command = (
-        f"aws ec2 copy-image --source-region {args.region} "
-        f"--source-image-id {args.image_id} --region {target_region} "
-        f"--name 'skypilot-aws-{args.processor}-{args.os_type}-{time.strftime('%y%m%d')}'  --output json"
+        f'aws ec2 copy-image --source-region {args.region} '
+        f'--source-image-id {args.image_id} --region {target_region} '
+        f'--name "{ami_name}"  '
+        '--output json'
     )
     print(copy_command)
     result = subprocess.run(copy_command,
@@ -88,11 +90,12 @@ def copy_image_and_make_public(target_region):
                             text=True)
     print(result.stdout)
     new_image_id = json.loads(result.stdout)['ImageId']
-    print(f"Copied image to {target_region} with new image ID: {new_image_id}")
+    print(f'Copied image to {target_region} with new image ID: {new_image_id}')
 
     # Wait for the image to be available
-    print(f"Waiting for {new_image_id} to be available...")
-    wait_command = f"aws ec2 wait image-available --image-ids {new_image_id} --region {target_region}"
+    print(f'Waiting for {new_image_id} to be available...')
+    wait_command = (f'aws ec2 wait image-available --image-ids {new_image_id} '
+                   f'--region {target_region}')
     subprocess.run(wait_command, shell=True, check=True)
 
     make_image_public(new_image_id, target_region)
@@ -115,7 +118,7 @@ def write_image_to_csv(image_id, region):
 def main():
     make_image_public(args.image_id, args.region)
     if not os.path.exists(args.output_csv):
-        with open(args.output_csv, 'w', newline='') as csvfile:
+        with open(args.output_csv, 'w', newline='', encoding='utf-8') as csvfile:
             writer = csv.writer(csvfile)
             writer.writerow([
                 'Tag', 'Region', 'OS', 'OSVersion', 'ImageId', 'CreationDate',
@@ -127,11 +130,11 @@ def main():
     image_cache = [(args.image_id, args.region)]
 
     def process_region(copy_to_region):
-        print(f"Start copying image to {copy_to_region}...")
+        print(f'Start copying image to {copy_to_region}...')
         try:
             new_image_id = copy_image_and_make_public(copy_to_region)
         except Exception as e:
-            print(f"Error generating image to {copy_to_region}: {str(e)}")
+            print(f'Error generating image to {copy_to_region}: {str(e)}')
             new_image_id = 'NEED_FALLBACK'
         image_cache.append((new_image_id, copy_to_region))
 
@@ -144,8 +147,8 @@ def main():
     for new_image_id, copy_to_region in sorted_image_cache:
         write_image_to_csv(new_image_id, copy_to_region)
 
-    print("All done!")
+    print('All done!')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/sky/jobs/dashboard/dashboard.py
+++ b/sky/jobs/dashboard/dashboard.py
@@ -26,7 +26,8 @@ def _is_running_on_jobs_controller() -> bool:
     """
     if pathlib.Path('~/.sky/sky_ray.yml').expanduser().exists():
         config = yaml.safe_load(
-            pathlib.Path('~/.sky/sky_ray.yml').expanduser().read_text(encoding='utf-8'))
+            pathlib.Path('~/.sky/sky_ray.yml').expanduser().read_text(
+                encoding='utf-8'))
         cluster_name = config.get('cluster_name', '')
         candidate_controller_names = (
             controller_utils.Controllers.JOBS_CONTROLLER.value.

--- a/sky/jobs/dashboard/dashboard.py
+++ b/sky/jobs/dashboard/dashboard.py
@@ -26,7 +26,7 @@ def _is_running_on_jobs_controller() -> bool:
     """
     if pathlib.Path('~/.sky/sky_ray.yml').expanduser().exists():
         config = yaml.safe_load(
-            pathlib.Path('~/.sky/sky_ray.yml').expanduser().read_text())
+            pathlib.Path('~/.sky/sky_ray.yml').expanduser().read_text(encoding='utf-8'))
         cluster_name = config.get('cluster_name', '')
         candidate_controller_names = (
             controller_utils.Controllers.JOBS_CONTROLLER.value.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -23,19 +23,6 @@ CallbackType = Callable[[str], None]
 logger = sky_logging.init_logger(__name__)
 
 
-def _get_db_path() -> str:
-    """Workaround to collapse multi-step Path ops for type checker.
-    Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
-    """
-    path = pathlib.Path('~/.sky/spot_jobs.db')
-    path = path.expanduser().absolute()
-    path.parents[0].mkdir(parents=True, exist_ok=True)
-    return str(path)
-
-
-_DB_PATH = _get_db_path()
-
-
 # === Database schema ===
 # `spot` table contains all the finest-grained tasks, including all the
 # tasks of a managed job (called spot for legacy reason, as it is generalized
@@ -128,6 +115,17 @@ def create_table(cursor, conn):
 
 # Module-level connection/cursor; thread-safe as the module is only imported
 # once.
+def _get_db_path() -> str:
+    """Workaround to collapse multi-step Path ops for type checker.
+    Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
+    """
+    path = pathlib.Path('~/.sky/spot_jobs.db')
+    path = path.expanduser().absolute()
+    path.parents[0].mkdir(parents=True, exist_ok=True)
+    return str(path)
+
+
+_DB_PATH = _get_db_path()
 db_utils.SQLiteConn(_DB_PATH, create_table)
 
 # job_duration is the time a job actually runs (including the

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -35,6 +35,7 @@ def _get_db_path() -> str:
 
 _DB_PATH = _get_db_path()
 
+
 # === Database schema ===
 # `spot` table contains all the finest-grained tasks, including all the
 # tasks of a managed job (called spot for legacy reason, as it is generalized
@@ -87,34 +88,34 @@ def create_table(cursor, conn):
     # The original `job_id` no longer has an actual meaning, but only a legacy
     # identifier for all tasks in database.
     db_utils.add_column_to_table(cursor,
-                                conn,
-                                'spot',
-                                'spot_job_id',
-                                'INTEGER',
-                                copy_from='job_id')
+                                 conn,
+                                 'spot',
+                                 'spot_job_id',
+                                 'INTEGER',
+                                 copy_from='job_id')
     db_utils.add_column_to_table(cursor,
-                                conn,
-                                'spot',
-                                'task_id',
-                                'INTEGER DEFAULT 0',
-                                value_to_replace_existing_entries=0)
+                                 conn,
+                                 'spot',
+                                 'task_id',
+                                 'INTEGER DEFAULT 0',
+                                 value_to_replace_existing_entries=0)
     db_utils.add_column_to_table(cursor,
-                                conn,
-                                'spot',
-                                'task_name',
-                                'TEXT',
-                                copy_from='job_name')
+                                 conn,
+                                 'spot',
+                                 'task_name',
+                                 'TEXT',
+                                 copy_from='job_name')
 
     # Specs is some useful information about the task, e.g., the
     # max_restarts_on_errors value. It is stored in JSON format.
     db_utils.add_column_to_table(cursor,
-                                conn,
-                                'spot',
-                                'specs',
-                                'TEXT',
-                                value_to_replace_existing_entries=json.dumps({
-                                    'max_restarts_on_errors': 0,
-                                }))
+                                 conn,
+                                 'spot',
+                                 'specs',
+                                 'TEXT',
+                                 value_to_replace_existing_entries=json.dumps({
+                                     'max_restarts_on_errors': 0,
+                                 }))
 
     # `job_info` contains the mapping from job_id to the job_name.
     # In the future, it may contain more information about each job.
@@ -123,6 +124,7 @@ def create_table(cursor, conn):
         spot_job_id INTEGER PRIMARY KEY AUTOINCREMENT,
         name TEXT)""")
     conn.commit()
+
 
 # Module-level connection/cursor; thread-safe as the module is only imported
 # once.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

WAL is more robust for more parallel access, as we have done for #3863 #3923 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Launch 1000 jobs with a 64 core CPU controller.
    ```
    import subprocess
    from multiprocessing.pool import ThreadPool
    
    def run_task(task):
        print(f'Running task {task}')
        subprocess.run(
            f'sky jobs launch -n job-{task} -dy --fast --cloud aws -t t3.medium --use-spot "echo hi {task}; sleep 3600"',
            shell=True
        )
    
    with ThreadPool(8) as pool:
        pool.map(run_task, range(1000))
    
    ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
