### PR TITLE
[RunPod] Fix assertion in ports query.

### DIFF
--- a/sky/provision/runpod/instance.py
+++ b/sky/provision/runpod/instance.py
@@ -232,7 +232,12 @@ def query_ports(
         instances = _filter_instances(cluster_name_on_cloud,
                                       None,
                                       head_only=True)
-        assert len(instances) == 1
+        assert len(instances) <= 1
+        # It is possible that the instance is terminated on console by
+        # the user. In this case, the instance will not be found and we
+        # should return an empty dict.
+        if not instances:
+            return {}
         head_inst = list(instances.values())[0]
         ready_ports: Dict[int, List[common.Endpoint]] = {
             port: [common.SocketEndpoint(**endpoint)]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4286.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] `sky serve up` a service on runpod replica, and manually terminate it. all `sky serve` commands works properly and a restart is triggered.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
