### PR TITLE
[Core] Make ssh connection more robust with custom proxy

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -276,16 +276,6 @@ def get_mounting_command(
     script = get_mounting_script(mount_path, mount_cmd, install_cmd,
                                  version_check_cmd)
 
-    # TODO(romilb): Get direct bash script to work like so:
-    # command = f'bash <<-\EOL' \
-    #           f'{script}' \
-    #           'EOL'
-
-    # TODO(romilb): This heredoc should have EOF after script, but it
-    #  fails with sky's ssh pipeline. Instead, we don't use EOF and use )
-    #  as the end of heredoc. This raises a warning (here-document delimited
-    #  by end-of-file) that can be safely ignored.
-
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.
     script_path = f'~/.sky/mount_{random.randint(0, 1000000)}.sh'

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -289,10 +289,8 @@ def get_mounting_command(
     # While these commands are run sequentially for each storage object,
     # we add random int to be on the safer side and avoid collisions.
     script_path = f'~/.sky/mount_{random.randint(0, 1000000)}.sh'
-    first_line = r'(cat <<-\EOF > {}'.format(script_path)
-    command = (f'{first_line}'
-               f'{script}'
-               f') && chmod +x {script_path}'
-               f' && bash {script_path}'
-               f' && rm {script_path}')
+    command = (f'echo {shlex.quote(script)} > {script_path} && '
+               f'chmod +x {script_path} && '
+               f'bash {script_path} && '
+               f'rm {script_path}')
     return command

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -3,6 +3,8 @@ import enum
 import typing
 from typing import List, Optional, Sequence
 
+from sky.utils import env_options
+
 if typing.TYPE_CHECKING:
     from sky import status_lib
     from sky.backends import backend
@@ -104,7 +106,8 @@ class CommandError(Exception):
         if not command:
             message = error_msg
         else:
-            if len(command) > 100:
+            if (len(command) > 100 and
+                    not env_options.Options.SHOW_DEBUG_INFO.get()):
                 # Chunck the command to avoid overflow.
                 command = command[:100] + '...'
             message = (f'Command {command} failed with return code '

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -104,6 +104,7 @@ def ssh_options_list(
     }
     # SSH Control will have a severe delay when using docker_ssh_proxy_command.
     # TODO(tian): Investigate why.
+    #
     # We disable ControlMaster when ssh_proxy_command is used, because the
     # master connection will be idle although the connection might be shared
     # by other ssh commands that is not idle. In that case, user's custom proxy
@@ -111,6 +112,7 @@ def ssh_options_list(
     # see the idle master connection. It is an issue even with the
     # ServerAliveInterval set, since the keepalive message may not be recognized
     # by the custom proxy command, such as AWS SSM Session Manager.
+    #
     # We also do not use ControlMaster when we use `kubectl port-forward`
     # to access Kubernetes pods over SSH+Proxycommand. This is because the
     # process running ProxyCommand is kept running as long as the ssh session

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -424,7 +424,7 @@ class SSHCommandRunner(CommandRunner):
         ssh_control_name: Optional[str] = '__default__',
         ssh_proxy_command: Optional[str] = None,
         docker_user: Optional[str] = None,
-        disable_control_master: Optional[bool] = False,
+        disable_control_master: Optional[bool] = True,
     ):
         """Initialize SSHCommandRunner.
 
@@ -595,6 +595,7 @@ class SSHCommandRunner(CommandRunner):
                                                skip_num_lines=skip_num_lines,
                                                source_bashrc=source_bashrc)
         command = base_ssh_command + [shlex.quote(command_str)]
+        # DEBUG: simulate the command being too long
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
         os.makedirs(log_dir, exist_ok=True)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -117,6 +117,14 @@ def ssh_options_list(
             'ControlMaster': 'auto',
             'ControlPath': f'{_ssh_control_path(ssh_control_name)}/%C',
             'ControlPersist': '300s',
+            # Send a keepalive message every 60 seconds to prevent the
+            # connection from being closed by the server. This is useful when
+            # a custom ssh_proxy_command is used, which may drop the connection
+            # if it is idle for the first master connection.
+            'ServerAliveInterval': 60,
+            # If no keepalive message is received within 5 * 60 seconds,
+            # the connection will be closed.
+            'ServerAliveCountMax': 5,
         })
     ssh_key_option = [
         '-i',
@@ -424,7 +432,7 @@ class SSHCommandRunner(CommandRunner):
         ssh_control_name: Optional[str] = '__default__',
         ssh_proxy_command: Optional[str] = None,
         docker_user: Optional[str] = None,
-        disable_control_master: Optional[bool] = True,
+        disable_control_master: Optional[bool] = False,
     ):
         """Initialize SSHCommandRunner.
 

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -104,27 +104,26 @@ def ssh_options_list(
     }
     # SSH Control will have a severe delay when using docker_ssh_proxy_command.
     # TODO(tian): Investigate why.
+    # We disable ControlMaster when ssh_proxy_command is used, because the
+    # master connection will be idle although the connection might be shared
+    # by other ssh commands that is not idle. In that case, user's custom proxy
+    # command may drop the connection due to idle timeout, since it will only
+    # see the idle master connection. It is an issue even with the
+    # ServerAliveInterval set, since the keepalive message may not be recognized
+    # by the custom proxy command, such as AWS SSM Session Manager.
     # We also do not use ControlMaster when we use `kubectl port-forward`
     # to access Kubernetes pods over SSH+Proxycommand. This is because the
     # process running ProxyCommand is kept running as long as the ssh session
     # is running and the ControlMaster keeps the session, which results in
     # 'ControlPersist' number of seconds delay per ssh commands ran.
     if (ssh_control_name is not None and docker_ssh_proxy_command is None and
-            not disable_control_master):
+            ssh_proxy_command is None and not disable_control_master):
         arg_dict.update({
             # Control path: important optimization as we do multiple ssh in one
             # sky.launch().
             'ControlMaster': 'auto',
             'ControlPath': f'{_ssh_control_path(ssh_control_name)}/%C',
             'ControlPersist': '300s',
-            # Send a keepalive message every 60 seconds to prevent the
-            # connection from being closed by the server. This is useful when
-            # a custom ssh_proxy_command is used, which may drop the connection
-            # if it is idle for the first master connection.
-            'ServerAliveInterval': 60,
-            # If no keepalive message is received within 5 * 60 seconds,
-            # the connection will be closed.
-            'ServerAliveCountMax': 5,
         })
     ssh_key_option = [
         '-i',

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -603,7 +603,6 @@ class SSHCommandRunner(CommandRunner):
                                                skip_num_lines=skip_num_lines,
                                                source_bashrc=source_bashrc)
         command = base_ssh_command + [shlex.quote(command_str)]
-        # DEBUG: simulate the command being too long
 
         log_dir = os.path.expanduser(os.path.dirname(log_path))
         os.makedirs(log_dir, exist_ok=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

User's custom proxy may drop the connection for idleness. Since we are using the SSH control master, the master connection (the first connection made with the remote machine) can be idle even though the later connection is doing work. We now disable the control master for custom ssh proxy command.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_aws_with_ssh_proxy_command`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
