### PR TITLE
Update Lambda Cloud regions

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -20,7 +20,6 @@ DEFAULT_LAMBDA_KEYS_PATH = os.path.expanduser('~/.lambda_cloud/lambda_keys')
 
 # List of all possible regions.
 REGIONS = [
-    'australia-southeast-1',
     'europe-central-1',
     'asia-south-1',
     'me-west-1',
@@ -28,9 +27,12 @@ REGIONS = [
     'asia-northeast-1',
     'asia-northeast-2',
     'us-east-1',
+    'us-east-2',
     'us-west-2',
     'us-west-1',
     'us-south-1',
+    'us-south-2',
+    'us-south-3',
     'us-west-3',
     'us-midwest-1',
 ]


### PR DESCRIPTION
This PR updates Lambda Cloud's regions:

- `us-east-2` → Washington DC, USA
- `us-south-2` → North Texas, USA
- `us-south-3` → Central Texas, USA