### PR TITLE
[Test] Fix unittest for region infer

### DIFF
--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -663,7 +663,8 @@ def test_infer_cloud_from_region_or_zone(monkeypatch):
     _test_resources_launch(monkeypatch, zone='us-west2-a')
 
     # Maps to AWS.
-    _test_resources_launch(monkeypatch, region='us-east-2')
+    # Not use us-east-2 or us-west-1 as it is also supported by Lambda.
+    _test_resources_launch(monkeypatch, region='eu-south-1')
     _test_resources_launch(monkeypatch, zone='us-west-2a')
 
     # `sky launch`


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Lambda recently added us-east-1 region #4291  which conflicts with the name of AWS causing our unittest to fail for inferring cloud from region/zone. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
