### PR TITLE
Fix AWS Route Table caching which causes invalid failures in other regions after an initial valid failure.

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -42,8 +42,9 @@ def _skypilot_log_error_and_exit_for_failover(error: str) -> None:
     Mainly used for handling VPC/subnet errors before nodes are launched.
     """
     # NOTE: keep. The backend looks for this to know no nodes are launched.
-    prefix = 'SKYPILOT_ERROR_NO_NODES_LAUNCHED: '
-    raise RuntimeError(prefix + error)
+    full_error = f'SKYPILOT_ERROR_NO_NODES_LAUNCHED: {error}'
+    logger.error(full_error)
+    raise RuntimeError(full_error)
 
 
 def bootstrap_instances(
@@ -222,10 +223,17 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
 
 
 @functools.lru_cache(maxsize=128)  # Keep bounded.
-def _get_route_tables(ec2, vpc_id: Optional[str], main: bool) -> List[Any]:
+def _get_route_tables(ec2, vpc_id: Optional[str], region: str,
+                      main: bool) -> List[Any]:
+    """Get route tables associated with a VPC and region
+    :param region: region is mandatory to allow the lru cache
+                   to return the corect results
+    """
     filters = [{'Name': 'association.main', 'Values': [str(main).lower()]}]
     if vpc_id is not None:
         filters.append({'Name': 'vpc-id', 'Values': [vpc_id]})
+    logger.debug(
+        f'Getting route tables with filters: {filters} in region: {region}')
     return ec2.meta.client.describe_route_tables(Filters=filters).get(
         'RouteTables', [])
 
@@ -238,7 +246,8 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
     https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html
     """
     # Get the route tables associated with the subnet
-    all_route_tables = _get_route_tables(ec2, vpc_id, main=False)
+    region = ec2.meta.client.meta.region_name
+    all_route_tables = _get_route_tables(ec2, vpc_id, region, main=False)
     route_tables = [
         rt for rt in all_route_tables
         # An RT can be associated with multiple subnets, i.e.,
@@ -267,7 +276,8 @@ def _is_subnet_public(ec2, subnet_id, vpc_id: Optional[str]) -> bool:
     # subnets. Since the associations are implicit, the filter above won't find
     # any. Check there exists a main route table with routes pointing to an IGW.
     logger.debug('Checking main route table')
-    main_route_tables = _get_route_tables(ec2, vpc_id, main=True)
+    region = ec2.meta.client.meta.region_name
+    main_route_tables = _get_route_tables(ec2, vpc_id, region, main=True)
     return _has_igw_route(main_route_tables)
 
 

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -226,9 +226,14 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
 def _get_route_tables(ec2, vpc_id: Optional[str], region: str,
                       main: bool) -> List[Any]:
     """Get route tables associated with a VPC and region
-    :param region: region is mandatory to allow the lru cache
+    
+    Args:
+        region: region is mandatory to allow the lru cache
                    to return the corect results
+    Returns:
+        A list of route tables associated with a VPC and region
     """
+    del region # not used.
     filters = [{'Name': 'association.main', 'Values': [str(main).lower()]}]
     if vpc_id is not None:
         filters.append({'Name': 'vpc-id', 'Values': [vpc_id]})

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -226,7 +226,7 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
 def _get_route_tables(ec2, vpc_id: Optional[str], region: str,
                       main: bool) -> List[Any]:
     """Get route tables associated with a VPC and region
-    
+
     Args:
         ec2: ec2 resource object
         vpc_id: vpc_id is optional, if not provided, all route tables in the

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -228,12 +228,17 @@ def _get_route_tables(ec2, vpc_id: Optional[str], region: str,
     """Get route tables associated with a VPC and region
     
     Args:
+        ec2: ec2 resource object
+        vpc_id: vpc_id is optional, if not provided, all route tables in the
+                region will be returned
         region: region is mandatory to allow the lru cache
                    to return the corect results
+        main: if True, only main route tables will be returned otherwise
+                only non-main route tables will be returned
+
     Returns:
-        A list of route tables associated with a VPC and region
+        A list of route tables associated with the options VPC and region
     """
-    del region # not used.
     filters = [{'Name': 'association.main', 'Values': [str(main).lower()]}]
     if vpc_id is not None:
         filters.append({'Name': 'vpc-id', 'Values': [vpc_id]})


### PR DESCRIPTION
Log error before throwing exception
<!-- Describe the changes in this PR -->
Route tables returned by the config.py _get_route_tables() function were incorrect after being called once because of the @functools.lru_cache defined on the function. I added region to the function call to keep the cache and have it return the correct results (switching regions before the change caused the issue).

Also added a logger.error() call to the _skypilot_log_error_and_exit_for_failover() function to actually log an error which shows up in stderr. Without this you get a generic error that does not tell you the actual cause of the error. You needed to go into the provision log to get the actual error.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [X] Code formatting: `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

Ran successful A10G:1 deploys and unsuccessful H100:8 deploys across all my regions in AWS and the appropriate messages are shown

CC: @concretevitamin 
