### PR TITLE
[k8s] Remove `lsof` dependence for tailing logs

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -324,6 +324,8 @@ available_node_types:
           command: ["/bin/bash", "-c", "--"]
           args: 
             - |
+              function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
+
               # Tails file and checks every 5 sec for
               # open file handlers with write access
               # closes if none exist
@@ -333,7 +335,7 @@ available_node_types:
                 while kill -0 $TAIL_PID 2> /dev/null; do
                   # only two PIDs should be accessing the file
                   # the log appender and log tailer
-                  if [ $(lsof -w $file | wc -l) -lt 3 ]; then
+                  if [ $(mylsof $file | wc -l) -lt 2 ]; then
                     kill $TAIL_PID
                     break
                   fi


### PR DESCRIPTION
Many images (e.g., ubuntu, nemo) don't have `lsof` installed by default, which would cause our log tailing to k8s container output to fail.

This PR removes the dependence on lsof by using our own minimal version of lsof. 

Tested:
- [x] `sky launch -c test --cloud kubernetes -- 'seq 1 10 | xargs -I {} sh -c "echo {}; sleep 1"'` 
- [x] `sky launch -c test --cloud kubernetes --image-id docker:ubuntu:18.04 -- 'seq 1 10 | xargs -I {} sh -c "echo {}; sleep 1"'`

In both cases verified logs are written to container stdout and can be read with `kubectl logs -f`. Also made sure the `tail` process is terminated after the task completes. 