### PR TITLE
[Core] Add `NO_UPLOAD` for `remote_identity`

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -244,9 +244,9 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account (IAM
     # role) for AWS instances.
     #
-    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
-    # the instances. Useful for avoiding overriding any existing credentials
-    # that may be automounted on the cluster.
+    # NO_UPLOAD: No credentials will be uploaded to the pods. Useful for
+    # avoiding overriding any existing credentials that may be automounted on
+    # the cluster.
     #
     # Customized service account (IAM role): <string> or <list of single-element dict>
     # - <string>: apply the service account with the specified name to all instances.
@@ -410,9 +410,9 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account for GCP
     # instances.
     #
-    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
-    # the instances. Useful for avoiding overriding any existing credentials
-    # that may be automounted on the cluster.
+    # NO_UPLOAD: No credentials will be uploaded to the pods. Useful for
+    # avoiding overriding any existing credentials that may be automounted on
+    # the cluster.
     #
     # Two caveats of SERVICE_ACCOUNT for multicloud users:
     #
@@ -499,9 +499,9 @@ Available fields and semantics:
     # SkyPilot will auto-create and reuse a service account with necessary roles
     # in the user's namespace.
     #
-    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
-    # the pods. Useful for avoiding overriding any existing credentials that may
-    # be automounted on the cluster.
+    # NO_UPLOAD: No credentials will be uploaded to the pods. Useful for
+    # avoiding overriding any existing credentials that may be automounted on
+    # the cluster.
     #
     # <string>: The name of a service account to use for all Kubernetes pods.
     # This service account must exist in the user's namespace and have all

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -244,6 +244,10 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account (IAM
     # role) for AWS instances.
     #
+    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
+    # the instances. Useful for avoiding overriding any existing credentials
+    # that may be automounted on the cluster.
+    #
     # Customized service account (IAM role): <string> or <list of single-element dict>
     # - <string>: apply the service account with the specified name to all instances.
     #    Example:
@@ -406,6 +410,10 @@ Available fields and semantics:
     # instances. SkyPilot will auto-create and reuse a service account for GCP
     # instances.
     #
+    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
+    # the instances. Useful for avoiding overriding any existing credentials
+    # that may be automounted on the cluster.
+    #
     # Two caveats of SERVICE_ACCOUNT for multicloud users:
     #
     # - This only affects GCP instances. Local GCP credentials will still be
@@ -490,6 +498,10 @@ Available fields and semantics:
     # SERVICE_ACCOUNT: Local ~/.kube/config is not uploaded to Kubernetes pods.
     # SkyPilot will auto-create and reuse a service account with necessary roles
     # in the user's namespace.
+    #
+    # SKIP: Skip setting the remote identity. No credentials will be uploaded to
+    # the pods. Useful for avoiding overriding any existing credentials that may
+    # be automounted on the cluster.
     #
     # <string>: The name of a service account to use for all Kubernetes pods.
     # This service account must exist in the user's namespace and have all

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -267,7 +267,8 @@ Available fields and semantics:
     #
     # - This only affects AWS instances. Local AWS credentials will still be
     #   uploaded to non-AWS instances (since those instances may need to access
-    #   AWS resources).
+    #   AWS resources). To fully disable credential upload, set
+    #   `remote_identity: NO_UPLOAD`.
     # - If the SkyPilot jobs/serve controller is on AWS, this setting will make
     #   non-AWS managed jobs / non-AWS service replicas fail to access any
     #   resources on AWS (since the controllers don't have AWS credential
@@ -418,7 +419,8 @@ Available fields and semantics:
     #
     # - This only affects GCP instances. Local GCP credentials will still be
     #   uploaded to non-GCP instances (since those instances may need to access
-    #   GCP resources).
+    #   GCP resources). To fully disable credential uploads, set
+    #   `remote_identity: NO_UPLOAD`.
     # - If the SkyPilot jobs/serve controller is on GCP, this setting will make
     #   non-GCP managed jobs / non-GCP service replicas fail to access any
     #   resources on GCP (since the controllers don't have GCP credential
@@ -511,7 +513,8 @@ Available fields and semantics:
     # Using SERVICE_ACCOUNT or a custom service account only affects Kubernetes
     # instances. Local ~/.kube/config will still be uploaded to non-Kubernetes
     # instances (e.g., a serve controller on GCP or AWS may need to provision
-    # Kubernetes resources).
+    # Kubernetes resources). To fully disable credential uploads, set
+    # `remote_identity: NO_UPLOAD`.
     #
     # Default: 'SERVICE_ACCOUNT'.
     remote_identity: my-k8s-service-account

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -706,6 +706,14 @@ def write_cluster_config(
                 'is not supported by this cloud. Remove the config or set: '
                 '`remote_identity: LOCAL_CREDENTIALS`.')
         excluded_clouds = [cloud]
+
+    for cloud_str, cloud_obj in cloud_registry.CLOUD_REGISTRY.items():
+        remote_identity_config = skypilot_config.get_nested(
+            (cloud_str.lower(), 'remote_identity'), None)
+        if remote_identity_config:
+            if remote_identity_config == schemas.RemoteIdentityOptions.SKIP.value:
+                excluded_clouds.append(cloud_obj)
+    
     credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
 
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -691,9 +691,9 @@ def write_cluster_config(
     # 2. SERVICE_ACCOUNT: SkyPilot creates and manages a service account
     # 3. Custom service account: Use specified service account
     # 4. NO_UPLOAD: Do not upload any credentials
-    # 
-    # We need to upload credentials only if LOCAL_CREDENTIALS is specified. In 
-    # other cases, we exclude the cloud from credential file uploads after 
+    #
+    # We need to upload credentials only if LOCAL_CREDENTIALS is specified. In
+    # other cases, we exclude the cloud from credential file uploads after
     # running required checks.
     assert cluster_name is not None
     excluded_clouds = set()
@@ -711,8 +711,8 @@ def write_cluster_config(
                 remote_identity = list(profile.values())[0]
                 break
     if remote_identity != schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value:
-        # If LOCAL_CREDENTIALS is not specified, we add the cloud to the 
-        # excluded_clouds set, but we must also check if the cloud supports 
+        # If LOCAL_CREDENTIALS is not specified, we add the cloud to the
+        # excluded_clouds set, but we must also check if the cloud supports
         # service accounts.
         if remote_identity == schemas.RemoteIdentityOptions.NO_UPLOAD.value:
             # If NO_UPLOAD is specified, fall back to default remote identity

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -705,13 +705,12 @@ def write_cluster_config(
             # credential file uploads.
             remote_identity = schemas.get_default_remote_identity(
                 str(cloud).lower())
-        else:
-            if not cloud.supports_service_account_on_remote():
-                raise exceptions.InvalidCloudConfigs(
-                    'remote_identity: SERVICE_ACCOUNT is specified in '
-                    f'{skypilot_config.loaded_config_path!r} for {cloud}, but it '
-                    'is not supported by this cloud. Remove the config or set: '
-                    '`remote_identity: LOCAL_CREDENTIALS`.')
+        elif not cloud.supports_service_account_on_remote():
+            raise exceptions.InvalidCloudConfigs(
+                'remote_identity: SERVICE_ACCOUNT is specified in '
+                f'{skypilot_config.loaded_config_path!r} for {cloud}, but it '
+                'is not supported by this cloud. Remove the config or set: '
+                '`remote_identity: LOCAL_CREDENTIALS`.')
         excluded_clouds.add(cloud)
 
     for cloud_str, cloud_obj in cloud_registry.CLOUD_REGISTRY.items():

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -711,9 +711,10 @@ def write_cluster_config(
         remote_identity_config = skypilot_config.get_nested(
             (cloud_str.lower(), 'remote_identity'), None)
         if remote_identity_config:
-            if remote_identity_config == schemas.RemoteIdentityOptions.SKIP.value:
+            if (remote_identity_config ==
+                    schemas.RemoteIdentityOptions.NO_UPLOAD.value):
                 excluded_clouds.append(cloud_obj)
-    
+
     credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
 
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -700,7 +700,7 @@ def write_cluster_config(
                 break
     if remote_identity != schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value:
         if remote_identity == schemas.RemoteIdentityOptions.NO_UPLOAD.value:
-            # If NO_UPLOAD is specified, fall back to default remote identity 
+            # If NO_UPLOAD is specified, fall back to default remote identity
             # for downstream logic but add it to excluded_clouds to skip
             # credential file uploads.
             remote_identity = schemas.get_default_remote_identity(
@@ -713,7 +713,6 @@ def write_cluster_config(
                     'is not supported by this cloud. Remove the config or set: '
                     '`remote_identity: LOCAL_CREDENTIALS`.')
         excluded_clouds.add(cloud)
-
 
     for cloud_str, cloud_obj in cloud_registry.CLOUD_REGISTRY.items():
         remote_identity_config = skypilot_config.get_nested(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -655,6 +655,7 @@ class RemoteIdentityOptions(enum.Enum):
     """
     LOCAL_CREDENTIALS = 'LOCAL_CREDENTIALS'
     SERVICE_ACCOUNT = 'SERVICE_ACCOUNT'
+    SKIP = 'SKIP'
 
 
 def get_default_remote_identity(cloud: str) -> str:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -655,7 +655,7 @@ class RemoteIdentityOptions(enum.Enum):
     """
     LOCAL_CREDENTIALS = 'LOCAL_CREDENTIALS'
     SERVICE_ACCOUNT = 'SERVICE_ACCOUNT'
-    SKIP = 'SKIP'
+    NO_UPLOAD = 'NO_UPLOAD'
 
 
 def get_default_remote_identity(cloud: str) -> str:


### PR DESCRIPTION
User reported they are using an external mechanism to inject AWS credentials in their k8s pods, which should be used for accessing buckets. However, we upload AWS credentials from the local machine if they exist, and as a result these local user credentials were overriding the injected credentials.

This PR adds a `NO_UPLOAD` flag to `remote_identity`, to explicitly skip uploading cloud credentials even if they exist on the local machine.

- [x] Tested on a SkyPilot cluster launched on k8s, with `aws.remote_identity: NO_UPLOAD` and verified AWS credentials are not uploaded. 