### PR TITLE
[Storage] Call `sync_file_mounts` when either rsync or storage file_mounts are specified 

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -296,7 +296,8 @@ def _execute(
         do_workdir = (Stage.SYNC_WORKDIR in stages and not dryrun and
                       task.workdir is not None)
         do_file_mounts = (Stage.SYNC_FILE_MOUNTS in stages and not dryrun and
-                          task.file_mounts is not None)
+                          (task.file_mounts is not None or
+                           task.storage_mounts is not None))
         if do_workdir or do_file_mounts:
             logger.info(ux_utils.starting_message('Mounting files.'))
 


### PR DESCRIPTION
Closes #4315, a regression recently introduced in #4023. `backend.sync_file_mounts` syncs both, rsync based file mounts and storage based file mounts, so it should be invoked if either of those are specified.

- [x] Snippet from original issue.
