### PR TITLE
[Tests] Fix smoke tests for new job creation log format

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -288,13 +288,13 @@ _VALIDATE_LAUNCH_OUTPUT = (
     # (min, pid=1277)
     # (min, pid=1277) task run finish
     # ✓ Job finished (status: SUCCEEDED).
-
-    # 📋 Useful Commands
+    #
     # Job ID: 1
+    # 📋 Useful Commands
     # ├── To cancel the job:          sky cancel test 1
     # ├── To stream job logs:         sky logs test 1
     # └── To view job queue:          sky queue test
-
+    #
     # Cluster name: test
     # ├── To log into the head VM:    ssh test
     # ├── To submit a job:            sky exec test yaml_file
@@ -314,8 +314,8 @@ _VALIDATE_LAUNCH_OUTPUT = (
     'grep "Job finished (status: SUCCEEDED)" && '
     'echo "==Validating task output ending 2==" && '
     'echo "$s" | grep -A 5 "Job finished (status: SUCCEEDED)" | '
-    'grep "Useful Commands" && '
-    'echo "$s" | grep -A 1 "Useful Commands" | grep "Job ID:"')
+    'grep "Job ID:" && '
+    'echo "$s" | grep -A 1 "Job ID:" | grep "Useful Commands"')
 
 
 # ---------- A minimal task ----------


### PR DESCRIPTION
Fix smoke tests that were broken by #4198 which changed the job creation log format. The following tests were updated:

- test_minimal
- test_launch_fast  
- test_launch_fast_with_autostop

The tests now validate the new log format where "Job ID" appears before "Useful Commands".

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
    - `pytest tests/test_smoke.py::test_minimal --gcp -v -s`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`