### PR TITLE
[smoke] if --generic-cloud is set, force enable that cloud 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to SkyPilot
 
-Thank you for your interest in contributing to SkyPilot! We welcome and value 
-all contributions to the project, including but not limited to: 
+Thank you for your interest in contributing to SkyPilot! We welcome and value
+all contributions to the project, including but not limited to:
 
 * [Bug reports](https://github.com/skypilot-org/skypilot/issues) and [discussions](https://github.com/skypilot-org/skypilot/discussions)
 * [Pull requests](https://github.com/skypilot-org/skypilot/pulls) for bug fixes and new features
@@ -26,7 +26,7 @@ pip install -r requirements-dev.txt
 ### Testing
 To run smoke tests (NOTE: Running all smoke tests launches ~20 clusters):
 ```
-# Run all tests except for AWS and Lambda Cloud
+# Run all tests on AWS and Azure (default smoke test clouds)
 pytest tests/test_smoke.py
 
 # Terminate a test's cluster even if the test failed (default is to keep it around for debugging)
@@ -41,11 +41,11 @@ pytest tests/test_smoke.py::test_minimal
 # Only run managed spot tests
 pytest tests/test_smoke.py --managed-spot
 
-# Only run test for AWS + generic tests
-pytest tests/test_smoke.py --aws
+# Only run test for GCP + generic tests
+pytest tests/test_smoke.py --gcp
 
-# Change cloud for generic tests to aws
-pytest tests/test_smoke.py --generic-cloud aws
+# Change cloud for generic tests to Azure
+pytest tests/test_smoke.py --generic-cloud azure
 ```
 
 For profiling code, use:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import common  # TODO(zongheng): for some reason isort places it here.
 import pytest
@@ -73,7 +73,6 @@ def pytest_addoption(parser):
     parser.addoption(
         '--generic-cloud',
         type=str,
-        default='aws',
         choices=all_clouds_in_smoke_tests,
         help='Cloud to use for generic tests. If the generic cloud is '
         'not within the clouds to be run, it will be reset to the first '
@@ -102,14 +101,21 @@ def pytest_configure(config):
 
 def _get_cloud_to_run(config) -> List[str]:
     cloud_to_run = []
+
     for cloud in all_clouds_in_smoke_tests:
         if config.getoption(f'--{cloud}'):
             if cloud == 'cloudflare':
                 cloud_to_run.append(default_clouds_to_run[0])
             else:
                 cloud_to_run.append(cloud)
-    if not cloud_to_run:
+
+    generic_cloud_option = config.getoption('--generic-cloud')
+    if generic_cloud_option is not None and generic_cloud_option not in cloud_to_run:
+        cloud_to_run.append(generic_cloud_option)
+
+    if len(cloud_to_run) == 0:
         cloud_to_run = default_clouds_to_run
+
     return cloud_to_run
 
 
@@ -187,11 +193,10 @@ def _is_generic_test(item) -> bool:
 
 
 def _generic_cloud(config) -> str:
-    c = config.getoption('--generic-cloud')
-    cloud_to_run = _get_cloud_to_run(config)
-    if c not in cloud_to_run:
-        c = cloud_to_run[0]
-    return c
+    generic_cloud_option = config.getoption('--generic-cloud')
+    if generic_cloud_option is not None:
+        return generic_cloud_option
+    return default_clouds_to_run[0]
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before, if GCP was not enabled for smoke tests, `pytest tests/test_smoke.py --generic-cloud gcp` would just completely ignore the `--generic-cloud` option and force the test to use the first enabled cloud (currently AWS).

Now, if the cloud provided to `--generic-cloud` isn't enabled for smoke tests, just enable it, since that's probably what was intended.

Fixes #4327.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
