### PR TITLE
[UX] user-friendly message shown if Kubernetes is not enabled.

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -520,7 +520,11 @@ class Kubernetes(clouds.Cloud):
     @classmethod
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         # Test using python API
-        existing_allowed_contexts = cls._existing_allowed_contexts()
+        try:
+            existing_allowed_contexts = cls._existing_allowed_contexts()
+        except ImportError as e:
+            return (False,
+                    f'{common_utils.format_exception(e, use_bracket=True)}')
         if not existing_allowed_contexts:
             if skypilot_config.loaded_config_path() is None:
                 check_skypilot_config_msg = ''


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve [issue #4324](https://github.com/skypilot-org/skypilot/issues/4324)

Catch exceptions for the `sky check` command in Kubernetes.

Before:

```bash
  Kubernetes: disabled                              
    Reason: Traceback (most recent call last):
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 31, in load_module
    self._module = importlib.import_module(self._module_name)
  File "/Users/zepingguo/miniconda3/envs/sky/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'kubernetes'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zepingguo/Desktop/skypilot/sky/provision/kubernetes/utils.py", line 854, in get_all_kube_config_context_names
    all_contexts, _ = k8s.config.list_kube_config_contexts()
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 46, in __getattr__
    return getattr(self.load_module(), name)
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 36, in load_module
    raise ImportError(self._import_error_message) from e
ImportError: Failed to import dependencies for Kubernetes. Try running: pip install "skypilot[kubernetes]"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 31, in load_module
    self._module = importlib.import_module(self._module_name)
  File "/Users/zepingguo/miniconda3/envs/sky/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'kubernetes'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/zepingguo/Desktop/skypilot/sky/check.py", line 35, in check_one_cloud
    ok, reason = cloud.check_credentials()
  File "/Users/zepingguo/Desktop/skypilot/sky/clouds/kubernetes.py", line 523, in check_credentials
    existing_allowed_contexts = cls._existing_allowed_contexts()
  File "/Users/zepingguo/Desktop/skypilot/sky/clouds/kubernetes.py", line 138, in _existing_allowed_contexts
    all_contexts = kubernetes_utils.get_all_kube_config_context_names()
  File "/Users/zepingguo/Desktop/skypilot/sky/provision/kubernetes/utils.py", line 858, in get_all_kube_config_context_names
    except k8s.config.config_exception.ConfigException:
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 46, in __getattr__
    return getattr(self.load_module(), name)
  File "/Users/zepingguo/Desktop/skypilot/sky/adaptors/common.py", line 36, in load_module
    raise ImportError(self._import_error_message) from e
ImportError: Failed to import dependencies for Kubernetes. Try running: pip install "skypilot[kubernetes]"
```

After:

```bash
  Kubernetes: disabled                              
    Reason: [ImportError] Failed to import dependencies for Kubernetes. Try running: pip install "skypilot[kubernetes]"
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
