### PR TITLE
[Docs] Use `--fast` for job submission in tutorials

### DIFF
--- a/docs/source/running-jobs/many-jobs.rst
+++ b/docs/source/running-jobs/many-jobs.rst
@@ -294,10 +294,12 @@ Then, submit all jobs by iterating over the config files and calling ``sky jobs 
 
   for config_file in configs/*; do
     job_name=$(basename $config_file)
+    # --fast: allows SkyPilot to skip the pre-checks for controller and
+    #         speed up the submission.
     # -y: yes to all prompts.
     # -d: detach from the job's logging, so the next job can be submitted
     #      without waiting for the previous job to finish.
-    sky jobs launch -n train-$job_name -y -d train-template.yaml \
+    sky jobs launch --fast -n train-$job_name -y -d train-template.yaml \
       --env-file $config_file \
       --env WANDB_API_KEY
   done
@@ -342,5 +344,6 @@ To have more customized control over generation of job variants, you can also us
         name=f'train-job{job_idx}',
         detach_run=True,
         retry_until_up=True,
+        fast=True
       )
       job_idx += 1


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

TODO:
- [ ] Add `--fast` in the managed jobs / managed spot pages.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
