### PR TITLE
Update `--env-file` to sky doc

### DIFF
--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -27,7 +27,7 @@ You can specify environment variables to be made available to a task in two ways
 
 - ``--env`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
 
-- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (lowest precedence over the above)
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a dotenv file (lowest precedence over the above)
 
   .. code-block:: text
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -28,7 +28,7 @@ You can specify environment variables to be made available to a task in several 
     WANDB_API_KEY=MY_WANDB_API_KEY
     HF_TOKEN=MY_HF_TOKEN
 
-- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>`: (takes precedence over the above)
+- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>` (takes precedence over the above):
 
   .. code-block:: yaml
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -18,7 +18,7 @@ User-specified environment variables are useful for passing secrets and any argu
 
 You can specify environment variables to be made available to a task in several ways:
 
-- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a `dotenv` file:
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, which is a path to a `dotenv` file:
 
   .. code-block:: text
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -18,7 +18,7 @@ User-specified environment variables are useful for passing secrets and any argu
 
 You can specify environment variables to be made available to a task in several ways:
 
-- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a dotenv file:
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a `dotenv` file:
 
   .. code-block:: text
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -18,7 +18,15 @@ User-specified environment variables are useful for passing secrets and any argu
 
 You can specify environment variables to be made available to a task in several ways:
 
-- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, which is a path to a `dotenv` file:
+- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>`:
+
+  .. code-block:: yaml
+
+    envs:
+      MYVAR: val
+
+
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, which is a path to a `dotenv` file (takes precedence over the above):
 
   .. code-block:: text
 
@@ -27,13 +35,6 @@ You can specify environment variables to be made available to a task in several 
     MYVAR=val
     WANDB_API_KEY=MY_WANDB_API_KEY
     HF_TOKEN=MY_HF_TOKEN
-
-- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>` (takes precedence over the above):
-
-  .. code-block:: yaml
-
-    envs:
-      MYVAR: val
 
 - ``--env`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -31,8 +31,8 @@ You can specify environment variables to be made available to a task in two ways
 
   .. code-block:: text
 
+    # sky launch example.yaml --env-file my_app.env
     # cat my_app.env
-    # --env-file my_app.env
     MYVAR=val
     WANDB_API_KEY=MY_WANDB_API_KEY
     HF_TOKEN=MY_HF_TOKEN

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -16,18 +16,9 @@ User-specified environment variables
 
 User-specified environment variables are useful for passing secrets and any arguments or configurations needed for your tasks. They are made available in ``file_mounts``, ``setup``, and ``run``.
 
-You can specify environment variables to be made available to a task in two ways:
+You can specify environment variables to be made available to a task in several ways:
 
-- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>`:
-
-  .. code-block:: yaml
-
-    envs:
-      MYVAR: val
-
-- ``--env`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
-
-- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a dotenv file (lowest precedence over the above)
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>`, path to a dotenv file:
 
   .. code-block:: text
 
@@ -36,6 +27,15 @@ You can specify environment variables to be made available to a task in two ways
     MYVAR=val
     WANDB_API_KEY=MY_WANDB_API_KEY
     HF_TOKEN=MY_HF_TOKEN
+
+- ``envs`` field (dict) in a :ref:`task YAML <yaml-spec>`: (takes precedence over the above)
+
+  .. code-block:: yaml
+
+    envs:
+      MYVAR: val
+
+- ``--env`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
 
 .. tip::
 

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -24,8 +24,18 @@ You can specify environment variables to be made available to a task in two ways
 
     envs:
       MYVAR: val
-  
+
 - ``--env`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (takes precedence over the above)
+
+- ``--env-file`` flag in ``sky launch/exec`` :ref:`CLI <cli>` (lowest precedence over the above)
+
+  .. code-block:: text
+
+    # cat my_app.env
+    # --env-file my_app.env
+    MYVAR=val
+    WANDB_API_KEY=MY_WANDB_API_KEY
+    HF_TOKEN=MY_HF_TOKEN
 
 .. tip::
 
@@ -145,9 +155,9 @@ Environment variables for ``setup``
      - 0
    * - ``SKYPILOT_SETUP_NODE_IPS``
      - A string of IP addresses of the nodes in the cluster with the same order as the node ranks, where each line contains one IP address.
-     
+
        Note that this is not necessarily the same as the nodes in ``run`` stage: the ``setup`` stage runs on all nodes of the cluster, while the ``run`` stage can run on a subset of nodes.
-     -      
+     -
        .. code-block:: text
 
          1.2.3.4
@@ -158,19 +168,19 @@ Environment variables for ``setup``
      - 2
    * - ``SKYPILOT_TASK_ID``
      - A unique ID assigned to each task.
-       
-       This environment variable is available only when the task is submitted 
+
+       This environment variable is available only when the task is submitted
        with :code:`sky launch --detach-setup`, or run as a managed spot job.
-       
+
        Refer to the description in the :ref:`environment variables for run <env-vars-for-run>`.
      - sky-2023-07-06-21-18-31-563597_myclus_1
-     
+
        For managed spot jobs: sky-managed-2023-07-06-21-18-31-563597_my-job-name_1-0
    * - ``SKYPILOT_CLUSTER_INFO``
      - A JSON string containing information about the cluster. To access the information, you could parse the JSON string in bash ``echo $SKYPILOT_CLUSTER_INFO | jq .cloud`` or in Python :
 
        .. code-block:: python
-         
+
          import json
          json.loads(
            os.environ['SKYPILOT_CLUSTER_INFO']
@@ -200,7 +210,7 @@ Environment variables for ``run``
      - 0
    * - ``SKYPILOT_NODE_IPS``
      - A string of IP addresses of the nodes reserved to execute the task, where each line contains one IP address. Read more :ref:`here <dist-jobs>`.
-     - 
+     -
        .. code-block:: text
 
          1.2.3.4
@@ -221,13 +231,13 @@ Environment variables for ``run``
        If a task is run as a :ref:`managed spot job <spot-jobs>`, then all
        recoveries of that job will have the same ID value. The ID is in the format "sky-managed-<timestamp>_<job-name>(_<task-name>)_<job-id>-<task-id>", where ``<task-name>`` will appear when a pipeline is used, i.e., more than one task in a managed spot job. Read more :ref:`here <spot-jobs-end-to-end>`.
      - sky-2023-07-06-21-18-31-563597_myclus_1
-     
+
        For managed spot jobs: sky-managed-2023-07-06-21-18-31-563597_my-job-name_1-0
    * - ``SKYPILOT_CLUSTER_INFO``
      - A JSON string containing information about the cluster. To access the information, you could parse the JSON string in bash ``echo $SKYPILOT_CLUSTER_INFO | jq .cloud``  or in Python :
 
        .. code-block:: python
-         
+
          import json
          json.loads(
            os.environ['SKYPILOT_CLUSTER_INFO']


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Add the parameter `--env-file` to `environment-variables.rst` to complete the doc and example.
* Trailing-whitespace hook automatically fixes some white spaces.

<!-- Describe the tests ran -->

Tested [here](https://github.com/skypilot-org/skypilot/pull/4345#discussion_r1841531611)

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
