### PR TITLE
[Serve] Enable multiple ports in SkyServe replicas

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4089,7 +4089,10 @@ def _generate_task_with_service(
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
             # For the case when the user specified a port range like 10000-10010
-            service_port_str = service_port_str.split('-')[0]
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Port {service_port_str!r} is not a valid '
+                                 'port number. Please specify a single port '
+                                 f'as the main port. Got: {service_port_str!r}')
         # We request all the replicas using the same port for now, but it
         # should be fine to allow different replicas to use different ports
         # in the future.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4080,19 +4080,16 @@ def _generate_task_with_service(
                              'To fix, add a valid `service` field.')
     service_port: Optional[int] = None
     for requested_resources in list(task.resources):
-        if requested_resources.ports is None or len(
-                requested_resources.ports) != 1:
+        if requested_resources.ports is None :
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
-                    'Must only specify one port in resources. Each replica '
-                    'will use the port specified as application ingress port.')
+                    'Must specify at least one ports in resources. Each '
+                    'replica will use the port specified as application '
+                    'ingress port.')
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
             # For the case when the user specified a port range like 10000-10010
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Port {service_port_str!r} is not a valid '
-                                 'port number. Please specify a single port '
-                                 f'instead. Got: {service_port_str!r}')
+            service_port_str = service_port_str.split('-')[0]
         # We request all the replicas using the same port for now, but it
         # should be fine to allow different replicas to use different ports
         # in the future.

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4089,6 +4089,7 @@ def _generate_task_with_service(
         service_port_str = requested_resources.ports[0]
         if not service_port_str.isdigit():
             # For the case when the user specified a port range like 10000-10010
+            # in the first ports entry (i.e. the main port).
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Port {service_port_str!r} is not a valid '
                                  'port number. Please specify a single port '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4080,7 +4080,7 @@ def _generate_task_with_service(
                              'To fix, add a valid `service` field.')
     service_port: Optional[int] = None
     for requested_resources in list(task.resources):
-        if requested_resources.ports is None :
+        if requested_resources.ports is None:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     'Must specify at least one ports in resources. Each '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4105,6 +4105,8 @@ def _generate_task_with_service(
                     raise ValueError(f'Got multiple ports: {service_port} and '
                                      f'{resource_port} in different resources. '
                                      'Please specify single port instead.')
+        assert service_port is not None
+        task.service.set_port(service_port)
     else:
         port_set = set()
         for requested_resources in list(task.resources):

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -84,8 +84,8 @@ def _validate_service_task(task: 'sky.Task') -> None:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
                         'Must only specify one port in resources. Each replica '
-                        'will use the port specified as application ingress port.'
-                    )
+                        'will use the port specified as application ingress '
+                        'port.')
             service_port = requested_ports[0]
             if replica_ingress_port is None:
                 replica_ingress_port = service_port

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -68,7 +68,7 @@ def _validate_service_task(task: 'sky.Task') -> None:
                                  'SkyServe will replenish preempted spot '
                                  f'with {policy_description} instances.')
 
-    replica_ingress_port: Optional[int] = None
+    replica_ingress_port: Optional[int] = task.service.port
     for requested_resources in task.resources:
         if (task.service.use_ondemand_fallback and
                 not requested_resources.use_spot):
@@ -77,17 +77,24 @@ def _validate_service_task(task: 'sky.Task') -> None:
                     '`use_ondemand_fallback` is only supported '
                     'for spot resources. Please explicitly specify '
                     '`use_spot: true` in resources for on-demand fallback.')
-        requested_ports = list(
-            resources_utils.port_ranges_to_set(requested_resources.ports))
-        service_port = requested_ports[0]
-        if replica_ingress_port is None:
-            replica_ingress_port = service_port
-        elif service_port != replica_ingress_port:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    f'Got multiple ports: {service_port} and '
-                    f'{replica_ingress_port} in different resources. '
-                    'Please specify the same port instead.')
+        if task.service.port is None:
+            requested_ports = list(
+                resources_utils.port_ranges_to_set(requested_resources.ports))
+            if len(requested_ports) != 1:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        'Must only specify one port in resources. Each replica '
+                        'will use the port specified as application ingress port.'
+                    )
+            service_port = requested_ports[0]
+            if replica_ingress_port is None:
+                replica_ingress_port = service_port
+            elif service_port != replica_ingress_port:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(
+                        f'Got multiple ports: {service_port} and '
+                        f'{replica_ingress_port} in different resources. '
+                        'Please specify the same port instead.')
 
 
 def _rewrite_tls_credential_paths_and_get_tls_env_vars(

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -79,11 +79,6 @@ def _validate_service_task(task: 'sky.Task') -> None:
                     '`use_spot: true` in resources for on-demand fallback.')
         requested_ports = list(
             resources_utils.port_ranges_to_set(requested_resources.ports))
-        if len(requested_ports) != 1:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(
-                    'Must only specify one port in resources. Each replica '
-                    'will use the port specified as application ingress port.')
         service_port = requested_ports[0]
         if replica_ingress_port is None:
             replica_ingress_port = service_port

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -84,9 +84,11 @@ def _validate_service_task(task: 'sky.Task') -> None:
             if len(requested_ports) != 1:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError(
-                        'Must only specify one port in resources. Each replica '
-                        'will use the port specified as application ingress '
-                        'port.')
+                        'To open multiple ports on the replica, please set the '
+                        '`service.ports` field to specify a main service port. '
+                        'Must only specify one port in resources otherwise. '
+                        'Each replica will use the port specified as '
+                        'application ingress port.')
             service_port = requested_ports[0]
             if replica_ingress_port is None:
                 replica_ingress_port = service_port

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -68,7 +68,8 @@ def _validate_service_task(task: 'sky.Task') -> None:
                                  'SkyServe will replenish preempted spot '
                                  f'with {policy_description} instances.')
 
-    replica_ingress_port: Optional[int] = task.service.port
+    replica_ingress_port: Optional[int] = int(
+        task.service.ports) if (task.service.ports is not None) else None
     for requested_resources in task.resources:
         if (task.service.use_ondemand_fallback and
                 not requested_resources.use_spot):
@@ -77,7 +78,7 @@ def _validate_service_task(task: 'sky.Task') -> None:
                     '`use_ondemand_fallback` is only supported '
                     'for spot resources. Please explicitly specify '
                     '`use_spot: true` in resources for on-demand fallback.')
-        if task.service.port is None:
+        if task.service.ports is None:
             requested_ports = list(
                 resources_utils.port_ranges_to_set(requested_resources.ports))
             if len(requested_ports) != 1:

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -177,10 +177,7 @@ def _get_resources_ports(task_yaml: str) -> str:
     # Already checked the resources have and only have one port
     # before upload the task yaml.
     assert task_resources.ports is not None
-    service_port_str = task_resources.ports[0]
-    if not service_port_str.isdigit():
-        service_port_str = service_port_str.split('-')[0]
-    return service_port_str
+    return task_resources.ports[0]
 
 
 def _should_use_spot(task_yaml: str,

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -172,10 +172,10 @@ def _get_resources_ports(task_yaml: str) -> str:
     """Get the resources ports used by the task."""
     task = sky.Task.from_yaml(task_yaml)
     # Already checked all ports are valid in sky.serve.core.up
-    assert len(task.resources) >= 1, task
+    assert task.resources, task
     assert task.service is not None, task
-    assert task.service.port is not None, task
-    return str(task.service.port)
+    assert task.service.ports is not None, task
+    return task.service.ports
 
 
 def _should_use_spot(task_yaml: str,

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -171,8 +171,13 @@ def terminate_cluster(cluster_name: str,
 def _get_resources_ports(task_yaml: str) -> str:
     """Get the resources ports used by the task."""
     task = sky.Task.from_yaml(task_yaml)
-    # Already checked all ports are the same in sky.serve.core.up
-    assert task.resources, task
+    # Already checked all ports are valid in sky.serve.core.up
+    assert len(task.resources) >= 1, task
+    assert task.service is not None, task
+    # If the service has a specified main port
+    task_service_port = task.service.port
+    if task_service_port is not None:
+        return str(task_service_port)
     task_resources: 'resources.Resources' = list(task.resources)[0]
     # Already checked the resources have and only have one port
     # before upload the task yaml.

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -177,7 +177,10 @@ def _get_resources_ports(task_yaml: str) -> str:
     # Already checked the resources have and only have one port
     # before upload the task yaml.
     assert task_resources.ports is not None
-    return task_resources.ports[0]
+    service_port_str = task_resources.ports[0]
+    if not service_port_str.isdigit():
+        service_port_str = service_port_str.split('-')[0]
+    return service_port_str
 
 
 def _should_use_spot(task_yaml: str,

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -174,15 +174,8 @@ def _get_resources_ports(task_yaml: str) -> str:
     # Already checked all ports are valid in sky.serve.core.up
     assert len(task.resources) >= 1, task
     assert task.service is not None, task
-    # If the service has a specified main port
-    task_service_port = task.service.port
-    if task_service_port is not None:
-        return str(task_service_port)
-    task_resources: 'resources.Resources' = list(task.resources)[0]
-    # Already checked the resources have and only have one port
-    # before upload the task yaml.
-    assert task_resources.ports is not None
-    return task_resources.ports[0]
+    assert task.service.port is not None, task
+    return str(task.service.port)
 
 
 def _should_use_spot(task_yaml: str,

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -145,7 +145,7 @@ class SkyServiceSpec:
             if not 1 <= ports <= 65535:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError('Port must be between 1 and 65535.')
-        service_config['ports'] = str(ports)
+        service_config['ports'] = str(ports) if ports is not None else None
 
         policy_section = config.get('replica_policy', None)
         simplified_policy_section = config.get('replicas', None)

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -245,7 +245,7 @@ class SkyServiceSpec:
                         self.downscale_delay_seconds)
         add_if_not_none('load_balancing_policy', None,
                         self._load_balancing_policy)
-        add_if_not_none('ports', None, self.ports)
+        add_if_not_none('ports', None, int(self.ports) if self.ports else None)
         if self.tls_credential is not None:
             add_if_not_none('tls', 'keyfile', self.tls_credential.keyfile)
             add_if_not_none('tls', 'certfile', self.tls_credential.certfile)

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -141,16 +141,8 @@ class SkyServiceSpec:
 
         ports = config.get('ports', None)
         if ports is not None:
-            if isinstance(ports, list):
-                if len(ports) > 1:
-                    with ux_utils.print_exception_no_traceback():
-                        raise ValueError(
-                            'We only support one port as main port now.')
-                ports = ports[0]
-            if isinstance(ports, str) and not ports.isdigit():
-                with ux_utils.print_exception_no_traceback():
-                    raise ValueError('Port must be an integer.')
-            if not 1 <= int(ports) <= 65535:
+            assert isinstance(ports, int)
+            if not 1 <= ports <= 65535:
                 with ux_utils.print_exception_no_traceback():
                     raise ValueError('Port must be between 1 and 65535.')
         service_config['ports'] = str(ports)

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -295,6 +295,9 @@ class SkyServiceSpec:
                 f'replica{max_plural} (target QPS per replica: '
                 f'{self.target_qps_per_replica})')
 
+    def set_port(self, port: int) -> None:
+        self._port = port
+
     def tls_str(self):
         if self.tls_credential is None:
             return 'No TLS Enabled'

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -389,22 +389,7 @@ def get_service_schema():
                 }
             },
             'ports': {
-                'anyOf': [{
-                    'type': 'string',
-                }, {
-                    'type': 'integer',
-                }, {
-                    'type': 'array',
-                    'items': {
-                        'anyOf': [{
-                            'type': 'string',
-                        }, {
-                            'type': 'integer',
-                        }]
-                    }
-                }, {
-                    'type': 'null',
-                }],
+                'type': 'integer',
             },
             'replicas': {
                 'type': 'integer',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -388,6 +388,9 @@ def get_service_schema():
                     },
                 }
             },
+            'port': {
+                'type': 'integer',
+            },
             'replicas': {
                 'type': 'integer',
             },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -388,8 +388,23 @@ def get_service_schema():
                     },
                 }
             },
-            'port': {
-                'type': 'integer',
+            'ports': {
+                'anyOf': [{
+                    'type': 'string',
+                }, {
+                    'type': 'integer',
+                }, {
+                    'type': 'array',
+                    'items': {
+                        'anyOf': [{
+                            'type': 'string',
+                        }, {
+                            'type': 'integer',
+                        }]
+                    }
+                }, {
+                    'type': 'null',
+                }],
             },
             'replicas': {
                 'type': 'integer',

--- a/tests/skyserve/multi_ports.yaml
+++ b/tests/skyserve/multi_ports.yaml
@@ -1,0 +1,19 @@
+service:
+  readiness_probe:
+    path: /health
+    initial_delay_seconds: 20
+  replicas: 1
+  port: 8080
+
+resources:
+  ports:
+    - 8080
+    - 8081
+  cpus: 2+
+
+setup: |
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
+
+run: |
+  python3 server.py --port 8080 &
+  python3 server.py --port 8081

--- a/tests/skyserve/multi_ports.yaml
+++ b/tests/skyserve/multi_ports.yaml
@@ -3,7 +3,7 @@ service:
     path: /health
     initial_delay_seconds: 20
   replicas: 1
-  port: 8080
+  ports: 8080
 
 resources:
   ports:

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -850,6 +850,28 @@ def test_skyserve_https(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.serve
+def test_skyserve_multi_ports(generic_cloud: str):
+    """Test skyserve with multiple ports"""
+    name = _get_service_name()
+    test = smoke_tests_utils.Test(
+        f'test-skyserve-multi-ports',
+        [
+            f'sky serve up -n {name} --cloud {generic_cloud} -y tests/skyserve/multi_ports.yaml',
+            _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=1),
+            f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
+            f'export endpoint=$(sky serve status {name} | tail -n 1 | awk \'{{print $4}}\'); '
+            'export endpoint_alt=$(echo $endpoint | sed "s/8080/8081/"); '
+            'echo "Accessing endpoints $endpoint, $endpoint_alt"; '
+            'curl $endpoint | grep "Hi, SkyPilot here"; '
+            'curl $endpoint_alt | grep "Hi, SkyPilot here"',
+        ],
+        _TEARDOWN_SERVICE.format(name=name),
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # TODO(Ziming, Tian): Add tests for autoscaling.
 
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -860,11 +860,11 @@ def test_skyserve_multi_ports(generic_cloud: str):
             f'sky serve up -n {name} --cloud {generic_cloud} -y tests/skyserve/multi_ports.yaml',
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=1),
             f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
-            f'export endpoint=$(sky serve status {name} | tail -n 1 | awk \'{{print $4}}\'); '
-            'export endpoint_alt=$(echo $endpoint | sed "s/8080/8081/"); '
-            'echo "Accessing endpoints $endpoint, $endpoint_alt"; '
-            'curl $endpoint | grep "Hi, SkyPilot here"; '
-            'curl $endpoint_alt | grep "Hi, SkyPilot here"',
+            'curl $replica_endpoint | grep "Hi, SkyPilot here"; '
+            f'export replica_endpoint=$(sky serve status {name} | tail -n 1 | awk \'{{print $4}}\'); '
+            'export replica_endpoint_alt=$(echo $endpoint | sed "s/8080/8081/"); '
+            'curl $replica_endpoint | grep "Hi, SkyPilot here"; '
+            'curl $replica_endpoint_alt | grep "Hi, SkyPilot here"',
         ],
         _TEARDOWN_SERVICE.format(name=name),
         timeout=20 * 60,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Current implementation of SkyServe only allows the replicas to expose one port. In some cases, services may need to expose multiple ports for custom controller, GUI interface, etc. This PR adds support for it by allowing multiple ports, but requiring user to specify one as the main port in the service section, if multiple ports are provided.

```yaml
service:
  readiness_probe: /
  replicas: 2
  port: 8000

resources:
  ports:
  - 8000-8001
  - 3000
  cpus: 2
```
The output of `sky serve status` will look like:
```
Services
NAME              VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT            
sky-service-xxxx  1        28s     READY   2/2       xxxx:30001  

Service Replicas
SERVICE_NAME      ID  VERSION  ENDPOINT             LAUNCHED     RESOURCES       STATUS  REGION     
sky-service-xxxx  1   1        http://xxxx:8000     50 secs ago  1x AWS(vCPU=2)  READY   us-east-1  
sky-service-xxxx  2   1        http://xxxx:8000     1 min ago    1x AWS(vCPU=2)  READY   us-east-1 
```
while the other ports (8001, 3000) are still accessible.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `sky serve up`, `sky serve status` and accessing the service with config:
  ```yaml
  service:
    readiness_probe: /
    replicas: 2
    port: 8000

  resources:
    ports:
    - 8000-8001
    - 3000
    cpus: 2

  run: |
    python -m http.server 8000 &
    python -m http.server 8001 &
    python -m http.server 3000 &
  ```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
