### PR TITLE
[k8s] fix managed job issue on k8s

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1693,6 +1693,8 @@ def merge_dicts(source: Dict[Any, Any], destination: Dict[Any, Any]):
             else:
                 destination[key].extend(value)
         else:
+            if destination is None:
+                destination = {}
             destination[key] = value
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. initialize a new dict if the destination is None, and add the source key/value to it
2. use the cpu/memory to k8s resources limits, or the pod will fail to create if there is LimitRange configured in the namespace, as the default cpu/memory maybe smaller than the requests.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
