### PR TITLE
[Jobs] Remove assertion for one single controller resources.

### DIFF
--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -133,7 +133,6 @@ def launch(
         controller_task.set_resources(controller_resources)
 
         controller_task.managed_job_dag = dag
-        assert len(controller_task.resources) == 1, controller_task
 
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reports when launch a managed jobs, following assertion error appears:

```bash
  File "sky/jobs/core.py", line 128, in launch
    assert len(controller_task.resources) == 1, controller_task
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is due to the multi-controller resources we introduces in #4053. Fixed now

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
