### PR TITLE
    [FluidStack] Fix provisioning and add new gpu types

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_fluidstack.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_fluidstack.py
@@ -15,6 +15,26 @@ ENDPOINT = 'https://platform.fluidstack.io/list_available_configurations'
 DEFAULT_FLUIDSTACK_API_KEY_PATH = os.path.expanduser('~/.fluidstack/api_key')
 
 plan_vcpus_memory = [{
+    'gpu_type': 'H100_SXM5_80GB',
+    'gpu_count': 1,
+    'min_cpu_count': 52,
+    'min_memory': 450
+}, {
+    'gpu_type': 'H100_SXM5_80GB',
+    'gpu_count': 2,
+    'min_cpu_count': 52,
+    'min_memory': 450
+}, {
+    'gpu_type': 'H100_SXM5_80GB',
+    'gpu_count': 4,
+    'min_cpu_count': 104,
+    'min_memory': 900
+}, {
+    'gpu_type': 'H100_SXM5_80GB',
+    'gpu_count': 8,
+    'min_cpu_count': 192,
+    'min_memory': 1800
+}, {
     'gpu_type': 'RTX_A6000_48GB',
     'gpu_count': 2,
     'min_cpu_count': 12,
@@ -150,7 +170,8 @@ GPU_MAP = {
     'H100_PCIE_80GB': 'H100',
     'H100_NVLINK_80GB': 'H100',
     'A100_NVLINK_80GB': 'A100-80GB',
-    'A100_SXM4_80GB': 'A100-80GB',
+    'A100_SXM4_80GB': 'A100-80GB-SXM',
+    'H100_SXM5_80GB': 'H100-SXM',
     'A100_PCIE_80GB': 'A100-80GB',
     'A100_SXM4_40GB': 'A100',
     'A100_PCIE_40GB': 'A100',

--- a/sky/provision/fluidstack/instance.py
+++ b/sky/provision/fluidstack/instance.py
@@ -79,9 +79,7 @@ def run_instances(region: str, cluster_name_on_cloud: str,
                   config: common.ProvisionConfig) -> common.ProvisionRecord:
     """Runs instances for the given cluster."""
 
-    pending_status = [
-        'pending',
-    ]
+    pending_status = ['pending', 'provisioning']
     while True:
         instances = _filter_instances(cluster_name_on_cloud, pending_status)
         if len(instances) > config.count:


### PR DESCRIPTION
    * Add new provisioning status to fix failed deployments

    * Add H100 SXM5 GPU mapping

<!-- Describe the changes in this PR -->
- Implement logic for new `provisioning` status
- Add H100 SXM5 mapping


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `sky launch --cloud fluidstack --gpus A6000:1`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - `pytest tests/test_smoke.py::test_minimal --fluidstack  --terminate-on-failure`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
