### PR TITLE
[Core] NoCloudAccessError check is escaped from storage sync

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -818,8 +818,9 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
                                      '[dim]View storages: sky storage ls'))
     try:
         task.sync_storage_mounts()
-    except ValueError as e:
-        if 'No enabled cloud for storage' in str(e):
+    except (ValueError, exceptions.NoCloudAccessError) as e:
+        if 'No enabled cloud for storage' in str(e) or isinstance(
+                e, exceptions.NoCloudAccessError):
             data_src = None
             if has_local_source_paths_file_mounts:
                 data_src = 'file_mounts'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve the issue #4367  

After fix, the message shown:

Launching a new service 'http-server'. Proceed? [Y/n]:
⚙︎ Translating workdir to SkyPilot Storage...
  Workdir: 'examples/serve/http_server' -> storage: 'skypilot-workdir-hysunhe-f650b5f9'.
sky.exceptions.NotSupportedError: Unable to use workdir - no cloud with object store is enabled. Please enable at least one cloud with object store support (AWS, GCP, Azure, IBM, Cloudflare) by running `sky check`, or remove workdir from your task.
Hint: If you do not have any cloud access, you may still download data and code over the network using curl or other tools in the `setup` section of the task.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
