### PR TITLE
[ux] display human-readable name for controller

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -272,7 +272,8 @@ def _execute(
                         cluster_name)
                     if controller is not None:
                         logger.info(
-                            f'Choosing resources for {controller.name}...')
+                            f'Choosing resources for {controller.value.name}...'
+                        )
                     dag = sky.optimize(dag, minimize=optimize_target)
                     task = dag.tasks[0]  # Keep: dag may have been deep-copied.
                     assert task.best_resources is not None, task


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
> Choosing resources for JOBS_CONTROLLER...

After:
> Choosing resources for managed jobs controller...

This was what was intended in #4341, but it broke during PR review and I didn't notice.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
