### PR TITLE
[k8s] Handle apt update log not existing

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -430,7 +430,7 @@ def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
         'start_time=$(date +%s); '
         'while ! grep -q "Fetched" /tmp/apt-update.log 2>/dev/null; do '
         '  echo "apt update still running. Logs:"; '
-        '  cat /tmp/apt-update.log; '
+        '  cat /tmp/apt-update.log || true; '
         '  current_time=$(date +%s); '
         '  elapsed=$((current_time - start_time)); '
         '  if [ $elapsed -ge $timeout_secs ]; then '


### PR DESCRIPTION
`apt update` log from container init may not be written by the time we check it in our provisioner. This PR handles that by retrying till the timeout is hit. PR tested/verified by user running into the bug.