### PR TITLE
[k8s] Move setup and ray start to pod args to make them async

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -844,7 +844,11 @@ def write_cluster_config(
                         '{sky_wheel_hash}',
                         wheel_hash).replace('{cloud}',
                                             str(cloud).lower())),
-
+                'skypilot_wheel_installation_commands':
+                    constants.SKYPILOT_WHEEL_INSTALLATION_COMMANDS.replace(
+                        '{sky_wheel_hash}',
+                        wheel_hash).replace('{cloud}',
+                                            str(cloud).lower()),
                 # Port of Ray (GCS server).
                 # Ray's default port 6379 is conflicted with Redis.
                 'ray_port': constants.SKY_REMOTE_RAY_PORT,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -423,7 +423,7 @@ class Kubernetes(clouds.Cloud):
             override_configs=resources.cluster_config_overrides)
         custom_ray_options = {
             'object-store-memory': 500000000,
-            'num-cpus': str(cpus),
+            'num-cpus': str(int(cpus)),
         }
         deploy_vars = {
             'instance_type': resources.instance_type,
@@ -451,6 +451,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_topology_label_value': k8s_topology_label_value,
             'k8s_resource_key': k8s_resource_key,
             'image_id': image_id,
+            'ray_installation_commands': constants.RAY_INSTALLATION_COMMANDS,
             'ray_head_start_command': instance_setup.ray_head_start_command(
                 custom_resources, custom_ray_options),
             'skypilot_ray_port': constants.SKY_REMOTE_RAY_PORT,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -422,6 +422,10 @@ class Kubernetes(clouds.Cloud):
             ('kubernetes', 'provision_timeout'),
             30,
             override_configs=resources.cluster_config_overrides)
+        # We specify object-store-memory to be 500MB to avoid taking up too
+        # much memory on the head node. 'num-cpus' should be set to limit
+        # the CPU usage on the head pod, otherwise the ray cluster will use the
+        # CPU resources on the node instead within the pod.
         custom_ray_options = {
             'object-store-memory': 500000000,
             'num-cpus': str(int(cpus)),

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -10,8 +10,10 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes
 from sky.clouds import service_catalog
+from sky.provision import instance_setup
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import resources_utils
 from sky.utils import schemas
@@ -419,6 +421,10 @@ class Kubernetes(clouds.Cloud):
             ('kubernetes', 'provision_timeout'),
             10,
             override_configs=resources.cluster_config_overrides)
+        custom_ray_options = {
+            'object-store-memory': 500000000,
+            'num-cpus': str(cpus),
+        }
         deploy_vars = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
@@ -445,6 +451,11 @@ class Kubernetes(clouds.Cloud):
             'k8s_topology_label_value': k8s_topology_label_value,
             'k8s_resource_key': k8s_resource_key,
             'image_id': image_id,
+            'ray_head_start_command': instance_setup.ray_head_start_command(
+                custom_resources, custom_ray_options),
+            'skypilot_ray_port': constants.SKY_REMOTE_RAY_PORT,
+            'ray_worker_start_command': instance_setup.ray_worker_start_command(
+                custom_resources, custom_ray_options, no_restart=False),
         }
 
         # Add kubecontext if it is set. It may be None if SkyPilot is running

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -333,8 +333,6 @@ def ray_worker_start_command(custom_resource: Optional[str],
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
 
-    logger.info(f'Running command on worker nodes: {cmd}')
-
 
 @common.log_function_start_end
 @_auto_retry()

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -326,9 +326,10 @@ def ray_worker_start_command(custom_resource: Optional[str],
         # will return 0, i.e., we don't know skypilot's ray cluster is running.
         # Instead, we check whether the raylet process is running on gcs address
         # that is connected to the head with the correct port.
-        cmd = (f'ps aux | grep "ray/raylet/raylet" | '
-               'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" '
-               f'|| {{ {cmd} }}')
+        cmd = (
+            f'ps aux | grep "ray/raylet/raylet" | '
+            'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" '
+            f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
     return cmd

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -328,8 +328,8 @@ def ray_worker_start_command(custom_resource: Optional[str],
         # that is connected to the head with the correct port.
         cmd = (
             f'ps aux | grep "ray/raylet/raylet" | '
-            'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" || '
-            f'{{ {cmd} }}')
+            'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" '
+            f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
     return cmd

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -20,8 +20,8 @@ from sky.utils import accelerator_registry
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
-from sky.utils import ux_utils
 from sky.utils import timeline
+from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
 
@@ -247,21 +247,9 @@ def _ray_gpu_options(custom_resource: str) -> str:
     return f' --num-gpus={acc_count}'
 
 
-@common.log_function_start_end
-@_auto_retry()
-@timeline.event
-def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
-                           cluster_info: common.ClusterInfo,
-                           ssh_credentials: Dict[str, Any]) -> None:
-    """Start Ray on the head node."""
-    runners = provision.get_command_runners(cluster_info.provider_name,
-                                            cluster_info, **ssh_credentials)
-    head_runner = runners[0]
-    assert cluster_info.head_instance_id is not None, (cluster_name,
-                                                       cluster_info)
-
-    # Log the head node's output to the provision.log
-    log_path_abs = str(provision_logging.get_log_path())
+def ray_head_start_command(custom_resource: Optional[str],
+                           custom_ray_options: Optional[Dict[str, Any]]) -> str:
+    """Returns the command to start Ray on the head node."""
     ray_options = (
         # --disable-usage-stats in `ray start` saves 10 seconds of idle wait.
         f'--disable-usage-stats '
@@ -273,22 +261,20 @@ def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
     if custom_resource:
         ray_options += f' --resources=\'{custom_resource}\''
         ray_options += _ray_gpu_options(custom_resource)
-
-    if cluster_info.custom_ray_options:
-        if 'use_external_ip' in cluster_info.custom_ray_options:
-            cluster_info.custom_ray_options.pop('use_external_ip')
-        for key, value in cluster_info.custom_ray_options.items():
+    if custom_ray_options:
+        if 'use_external_ip' in custom_ray_options:
+            custom_ray_options.pop('use_external_ip')
+        for key, value in custom_ray_options.items():
             ray_options += f' --{key}={value}'
-
-    # Unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY to avoid using credentials
-    # from environment variables set by user. SkyPilot's ray cluster should use
-    # the `~/.aws/` credentials, as that is the one used to create the cluster,
-    # and the autoscaler module started by the `ray start` command should use
-    # the same credentials. Otherwise, `ray status` will fail to fetch the
-    # available nodes.
-    # Reference: https://github.com/skypilot-org/skypilot/issues/2441
     cmd = (
         f'{constants.SKY_RAY_CMD} stop; '
+        # Unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY to avoid using
+        # credentials from environment variables set by user. SkyPilot's ray
+        # cluster should use the `~/.aws/` credentials, as that is the one used
+        # to create the cluster, and the autoscaler module started by the
+        # `ray start` command should use the same credentials. Otherwise,
+        # `ray status` will fail to fetch the available nodes.
+        # Reference: https://github.com/skypilot-org/skypilot/issues/2441
         'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
         'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
         # worker_maximum_startup_concurrency controls the maximum number of
@@ -308,6 +294,65 @@ def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
         'RAY_worker_maximum_startup_concurrency=$(( 3 * $(nproc --all) )) '
         f'{constants.SKY_RAY_CMD} start --head {ray_options} || exit 1;' +
         _RAY_PRLIMIT + _DUMP_RAY_PORTS + RAY_HEAD_WAIT_INITIALIZED_COMMAND)
+    return cmd
+
+
+def ray_worker_start_command(custom_resource: Optional[str],
+                             custom_ray_options: Optional[Dict[str, Any]],
+                             no_restart: bool) -> str:
+    """Returns the command to start Ray on the worker node."""
+    ray_options = (
+        f'--address=${{SKYPILOT_RAY_HEAD_IP}}:{constants.SKY_REMOTE_RAY_PORT} '
+        f'--object-manager-port=8076')
+
+    if custom_resource:
+        ray_options += f' --resources=\'{custom_resource}\''
+        ray_options += _ray_gpu_options(custom_resource)
+
+    if custom_ray_options:
+        for key, value in custom_ray_options.items():
+            ray_options += f' --{key}={value}'
+
+    # Unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY, see the comment in
+    # `start_ray_on_head_node`.
+    cmd = (
+        f'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
+        'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
+        f'{constants.SKY_RAY_CMD} start --disable-usage-stats {ray_options} || '
+        'exit 1;' + _RAY_PRLIMIT)
+    if no_restart:
+        # We do not use ray status to check whether ray is running, because
+        # on worker node, if the user started their own ray cluster, ray status
+        # will return 0, i.e., we don't know skypilot's ray cluster is running.
+        # Instead, we check whether the raylet process is running on gcs address
+        # that is connected to the head with the correct port.
+        cmd = (
+            f'ps aux | grep "ray/raylet/raylet" | '
+            'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" || '
+            f'{{ {cmd} }}')
+    else:
+        cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
+
+    logger.info(f'Running command on worker nodes: {cmd}')
+
+
+@common.log_function_start_end
+@_auto_retry()
+@timeline.event
+def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
+                           cluster_info: common.ClusterInfo,
+                           ssh_credentials: Dict[str, Any]) -> None:
+    """Start Ray on the head node."""
+    runners = provision.get_command_runners(cluster_info.provider_name,
+                                            cluster_info, **ssh_credentials)
+    head_runner = runners[0]
+    assert cluster_info.head_instance_id is not None, (cluster_name,
+                                                       cluster_info)
+
+    # Log the head node's output to the provision.log
+    log_path_abs = str(provision_logging.get_log_path())
+    cmd = ray_head_start_command(custom_resource,
+                                 cluster_info.custom_ray_options)
     logger.info(f'Running command on head node: {cmd}')
     # TODO(zhwu): add the output to log files.
     returncode, stdout, stderr = head_runner.run(
@@ -362,43 +407,17 @@ def start_ray_on_worker_nodes(cluster_name: str, no_restart: bool,
     head_ip = (head_instance.internal_ip
                if not use_external_ip else head_instance.external_ip)
 
-    ray_options = (f'--address={head_ip}:{constants.SKY_REMOTE_RAY_PORT} '
-                   f'--object-manager-port=8076')
+    ray_cmd = ray_worker_start_command(custom_resource,
+                                       cluster_info.custom_ray_options,
+                                       no_restart)
 
-    if custom_resource:
-        ray_options += f' --resources=\'{custom_resource}\''
-        ray_options += _ray_gpu_options(custom_resource)
-
-    if cluster_info.custom_ray_options:
-        for key, value in cluster_info.custom_ray_options.items():
-            ray_options += f' --{key}={value}'
-
-    # Unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY, see the comment in
-    # `start_ray_on_head_node`.
-    cmd = (
-        f'unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; '
-        'RAY_SCHEDULER_EVENTS=0 RAY_DEDUP_LOGS=0 '
-        f'{constants.SKY_RAY_CMD} start --disable-usage-stats {ray_options} || '
-        'exit 1;' + _RAY_PRLIMIT)
-    if no_restart:
-        # We do not use ray status to check whether ray is running, because
-        # on worker node, if the user started their own ray cluster, ray status
-        # will return 0, i.e., we don't know skypilot's ray cluster is running.
-        # Instead, we check whether the raylet process is running on gcs address
-        # that is connected to the head with the correct port.
-        cmd = (f'RAY_PORT={ray_port}; ps aux | grep "ray/raylet/raylet" | '
-               f'grep "gcs-address={head_ip}:${{RAY_PORT}}" || '
-               f'{{ {cmd} }}')
-    else:
-        cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
+    cmd = (f'export SKYPILOT_RAY_HEAD_IP="{head_ip}"; '
+           f'export SKYPILOT_RAY_PORT={ray_port}; ' + ray_cmd)
 
     logger.info(f'Running command on worker nodes: {cmd}')
 
     def _setup_ray_worker(runner_and_id: Tuple[command_runner.CommandRunner,
                                                str]):
-        # for cmd in config_from_yaml['worker_start_ray_commands']:
-        #     cmd = cmd.replace('$RAY_HEAD_IP', ip_list[0][0])
-        #     runner.run(cmd)
         runner, instance_id = runner_and_id
         log_dir = metadata_utils.get_instance_log_dir(cluster_name, instance_id)
         log_path_abs = str(log_dir / ('ray_cluster' + '.log'))

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -21,6 +21,7 @@ from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.utils import timeline
 
 logger = sky_logging.init_logger(__name__)
 
@@ -170,6 +171,7 @@ def initialize_docker(cluster_name: str, docker_config: Dict[str, Any],
 
 
 @common.log_function_start_end
+@timeline.event
 def setup_runtime_on_cluster(cluster_name: str, setup_commands: List[str],
                              cluster_info: common.ClusterInfo,
                              ssh_credentials: Dict[str, Any]) -> None:
@@ -247,6 +249,7 @@ def _ray_gpu_options(custom_resource: str) -> str:
 
 @common.log_function_start_end
 @_auto_retry()
+@timeline.event
 def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
                            cluster_info: common.ClusterInfo,
                            ssh_credentials: Dict[str, Any]) -> None:
@@ -324,6 +327,7 @@ def start_ray_on_head_node(cluster_name: str, custom_resource: Optional[str],
 
 @common.log_function_start_end
 @_auto_retry()
+@timeline.event
 def start_ray_on_worker_nodes(cluster_name: str, no_restart: bool,
                               custom_resource: Optional[str], ray_port: int,
                               cluster_info: common.ClusterInfo,
@@ -421,6 +425,7 @@ def start_ray_on_worker_nodes(cluster_name: str, no_restart: bool,
 
 @common.log_function_start_end
 @_auto_retry()
+@timeline.event
 def start_skylet_on_head_node(cluster_name: str,
                               cluster_info: common.ClusterInfo,
                               ssh_credentials: Dict[str, Any]) -> None:
@@ -504,6 +509,7 @@ def _max_workers_for_file_mounts(common_file_mounts: Dict[str, str]) -> int:
 
 
 @common.log_function_start_end
+@timeline.event
 def internal_file_mounts(cluster_name: str, common_file_mounts: Dict[str, str],
                          cluster_info: common.ClusterInfo,
                          ssh_credentials: Dict[str, str]) -> None:

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -326,10 +326,9 @@ def ray_worker_start_command(custom_resource: Optional[str],
         # will return 0, i.e., we don't know skypilot's ray cluster is running.
         # Instead, we check whether the raylet process is running on gcs address
         # that is connected to the head with the correct port.
-        cmd = (
-            f'ps aux | grep "ray/raylet/raylet" | '
-            'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" '
-            f'|| {{ {cmd} }}')
+        cmd = (f'ps aux | grep "ray/raylet/raylet" | '
+               'grep "gcs-address=.*:${SKYPILOT_RAY_PORT}" '
+               f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
     return cmd

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -332,6 +332,7 @@ def ray_worker_start_command(custom_resource: Optional[str],
             f'{{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd
+    return cmd
 
 
 @common.log_function_start_end

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -327,7 +327,7 @@ def ray_worker_start_command(custom_resource: Optional[str],
         # Instead, we check whether the raylet process is running on gcs address
         # that is connected to the head with the correct port.
         cmd = (f'ps aux | grep "ray/raylet/raylet" | '
-               'grep "gcs-address=.*:${SKYPILOT_RAY_PORT}" '
+               'grep "gcs-address=${SKYPILOT_RAY_HEAD_IP}:${SKYPILOT_RAY_PORT}" '
                f'|| {{ {cmd} }}')
     else:
         cmd = f'{constants.SKY_RAY_CMD} stop; ' + cmd

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -832,40 +832,6 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     logger.debug(f'run_instances: all pods are scheduled and running: '
                  f'{[pod.metadata.name for pod in pods]}')
 
-    # running_pods = kubernetes_utils.filter_pods(namespace, context, tags,
-    #                                             ['Running'])
-    # initialized_pods = kubernetes_utils.filter_pods(namespace, context, {
-    #     TAG_POD_INITIALIZED: 'true',
-    #     **tags
-    # }, ['Running'])
-    # uninitialized_pods = {
-    #     pod_name: pod
-    #     for pod_name, pod in running_pods.items()
-    #     if pod_name not in initialized_pods
-    # }
-    # if len(uninitialized_pods) > 0:
-    #     logger.debug(f'run_instances: Initializing {len(uninitialized_pods)} '
-    #                  f'pods: {list(uninitialized_pods.keys())}')
-    #     uninitialized_pods_list = list(uninitialized_pods.values())
-
-    #     # Run pre-init steps in the pod.
-    #     pre_init(namespace, context, uninitialized_pods_list)
-
-    #     def _label_pod_thread(pod):
-    #         """Thread function to label a single pod."""
-    #         _label_pod(namespace,
-    #                    context,
-    #                    pod.metadata.name,
-    #                    label={
-    #                        TAG_POD_INITIALIZED: 'true',
-    #                        **pod.metadata.labels
-    #                    })
-
-    #     # Label pods in parallel
-    #     subprocess_utils.run_in_parallel(_label_pod_thread,
-    #                                      uninitialized_pods.values(),
-    #                                      NUM_THREADS)
-
     assert head_pod_name is not None, 'head_instance_id should not be None'
     return common.ProvisionRecord(
         provider_name='kubernetes',

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -232,7 +232,7 @@ def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int):
     If timeout is set to a negative value, this method will wait indefinitely.
     """
     # Create a set of pod names we're waiting for
-    if len(new_nodes) == 0:
+    if not new_nodes:
         return
     pod_names = {node.metadata.name for node in new_nodes}
     start_time = time.time()
@@ -293,7 +293,7 @@ def _wait_for_pods_to_run(namespace, context, new_nodes):
     Pods may be pulling images or may be in the process of container
     creation.
     """
-    if len(new_nodes) == 0:
+    if not new_nodes:
         return
 
     # Create a set of pod names we're waiting for
@@ -664,7 +664,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     terminating_pods = kubernetes_utils.filter_pods(namespace, context, tags,
                                                     ['Terminating'])
     start_time = time.time()
-    while (len(terminating_pods) > 0 and
+    while (terminating_pods and
            time.time() - start_time < _TIMEOUT_FOR_POD_TERMINATION):
         logger.debug(f'run_instances: Found {len(terminating_pods)} '
                      'terminating pods. Waiting them to finish: '
@@ -673,7 +673,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
         terminating_pods = kubernetes_utils.filter_pods(namespace, context,
                                                         tags, ['Terminating'])
 
-    if len(terminating_pods) > 0:
+    if terminating_pods:
         # If there are still terminating pods, we force delete them.
         logger.debug(f'run_instances: Found {len(terminating_pods)} '
                      'terminating pods still in terminating state after '

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -20,6 +20,7 @@ from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import kubernetes_enums
 from sky.utils import subprocess_utils
+from sky.utils import timeline
 from sky.utils import ux_utils
 
 POLL_INTERVAL = 2
@@ -219,6 +220,7 @@ def _raise_command_running_error(message: str, command: str, pod_name: str,
         f'code {rc}: {command!r}\nOutput: {stdout}.')
 
 
+@timeline.event
 def _wait_for_pods_to_schedule(namespace, context, new_nodes, timeout: int):
     """Wait for all pods to be scheduled.
 
@@ -366,7 +368,7 @@ def _run_function_with_retries(func: Callable,
             else:
                 raise
 
-
+@timeline.event
 def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
     """Pre-initialization step for SkyPilot pods.
 
@@ -527,7 +529,7 @@ def _label_pod(namespace: str, context: Optional[str], pod_name: str,
         }},
         _request_timeout=kubernetes.API_TIMEOUT)
 
-
+@timeline.event
 def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
                                         context: Optional[str]) -> Any:
     """Attempts to create a Kubernetes Pod and handle any errors.
@@ -605,7 +607,7 @@ def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
             # Re-raise the exception if it's a different error
             raise e
 
-
+@timeline.event
 def _create_pods(region: str, cluster_name_on_cloud: str,
                  config: common.ProvisionConfig) -> common.ProvisionRecord:
     """Create pods based on the config."""

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -804,7 +804,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
         uninitialized_pods_list = list(uninitialized_pods.values())
 
         # Run pre-init steps in the pod.
-        pre_init(namespace, context, uninitialized_pods_list)
+        # pre_init(namespace, context, uninitialized_pods_list)
 
         for pod in uninitialized_pods.values():
             _label_pod(namespace,

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -368,6 +368,7 @@ def _run_function_with_retries(func: Callable,
             else:
                 raise
 
+
 @timeline.event
 def pre_init(namespace: str, context: Optional[str], new_nodes: List) -> None:
     """Pre-initialization step for SkyPilot pods.
@@ -529,6 +530,7 @@ def _label_pod(namespace: str, context: Optional[str], pod_name: str,
         }},
         _request_timeout=kubernetes.API_TIMEOUT)
 
+
 @timeline.event
 def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
                                         context: Optional[str]) -> Any:
@@ -606,6 +608,7 @@ def _create_namespaced_pod_with_retries(namespace: str, pod_spec: dict,
         else:
             # Re-raise the exception if it's a different error
             raise e
+
 
 @timeline.event
 def _create_pods(region: str, cluster_name_on_cloud: str,
@@ -787,33 +790,33 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
     logger.debug(f'run_instances: all pods are scheduled and running: '
                  f'{list(wait_pods_dict.keys())}')
 
-    running_pods = kubernetes_utils.filter_pods(namespace, context, tags,
-                                                ['Running'])
-    initialized_pods = kubernetes_utils.filter_pods(namespace, context, {
-        TAG_POD_INITIALIZED: 'true',
-        **tags
-    }, ['Running'])
-    uninitialized_pods = {
-        pod_name: pod
-        for pod_name, pod in running_pods.items()
-        if pod_name not in initialized_pods
-    }
-    if len(uninitialized_pods) > 0:
-        logger.debug(f'run_instances: Initializing {len(uninitialized_pods)} '
-                     f'pods: {list(uninitialized_pods.keys())}')
-        uninitialized_pods_list = list(uninitialized_pods.values())
+    # running_pods = kubernetes_utils.filter_pods(namespace, context, tags,
+    #                                             ['Running'])
+    # initialized_pods = kubernetes_utils.filter_pods(namespace, context, {
+    #     TAG_POD_INITIALIZED: 'true',
+    #     **tags
+    # }, ['Running'])
+    # uninitialized_pods = {
+    #     pod_name: pod
+    #     for pod_name, pod in running_pods.items()
+    #     if pod_name not in initialized_pods
+    # }
+    # if len(uninitialized_pods) > 0:
+    #     logger.debug(f'run_instances: Initializing {len(uninitialized_pods)} '
+    #                  f'pods: {list(uninitialized_pods.keys())}')
+    #     # uninitialized_pods_list = list(uninitialized_pods.values())
 
-        # Run pre-init steps in the pod.
-        # pre_init(namespace, context, uninitialized_pods_list)
+    # Run pre-init steps in the pod.
+    # pre_init(namespace, context, uninitialized_pods_list)
 
-        for pod in uninitialized_pods.values():
-            _label_pod(namespace,
-                       context,
-                       pod.metadata.name,
-                       label={
-                           TAG_POD_INITIALIZED: 'true',
-                           **pod.metadata.labels
-                       })
+    # for pod in uninitialized_pods.values():
+    #     _label_pod(namespace,
+    #                context,
+    #                pod.metadata.name,
+    #                label={
+    #                    TAG_POD_INITIALIZED: 'true',
+    #                    **pod.metadata.labels
+    #                })
 
     assert head_pod_name is not None, 'head_instance_id should not be None'
     return common.ProvisionRecord(

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -536,9 +536,9 @@ def _post_provision_setup(
                 stream_logs=False,
                 require_outputs=True)
             if returncode:
-                logger.debug('Ray cluster on head is not up. Restarting...')
+                logger.debug('Ray cluster on head is not ready.')
             else:
-                logger.debug('Ray cluster on head is up.')
+                logger.debug('Ray cluster on head is ready.')
                 ray_port = common_utils.decode_payload(stdout)['ray_port']
             head_ray_needs_restart = bool(returncode)
             ray_cluster_healthy = is_ray_cluster_healthy(
@@ -560,14 +560,16 @@ def _post_provision_setup(
             timeout = 60  # 1-min maximum timeout
             start = time.time()
             while True:
-                # Wait until Ray cluster is healthy
+                # Wait until Ray cluster is ready
                 (ray_port, ray_cluster_healthy,
                  head_ray_needs_restart) = check_ray_port_and_cluster_healthy()
                 if ray_cluster_healthy:
                     break
                 if time.time() - start > timeout:
                     raise RuntimeError(
-                        f'Ray cluster on head is not up after {timeout}s.')
+                        f'Ray cluster on head is not ready after {timeout}s.')
+                logger.debug('Ray cluster is not ready yet, waiting for the '
+                             'async setup to complete...')
                 time.sleep(1)
 
         if head_ray_needs_restart:

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -433,11 +433,13 @@ def _post_provision_setup(
             ux_utils.spinner_message(
                 'Launching - Waiting for SSH access',
                 provision_logging.config.log_path)) as status:
-
-        logger.debug(
-            f'\nWaiting for SSH to be available for {cluster_name!r} ...')
-        wait_for_ssh(cluster_info, ssh_credentials)
-        logger.debug(f'SSH Connection ready for {cluster_name!r}')
+        # If on Kubernetes, skip SSH check since the pods are guaranteed to be
+        # ready by the provisioner.
+        if cloud_name.lower() != 'kubernetes':
+            logger.debug(
+                f'\nWaiting for SSH to be available for {cluster_name!r} ...')
+            wait_for_ssh(cluster_info, ssh_credentials)
+            logger.debug(f'SSH Connection ready for {cluster_name!r}')
         vm_str = 'Instance' if cloud_name.lower() != 'kubernetes' else 'Pod'
         plural = '' if len(cluster_info.instances) == 1 else 's'
         verb = 'is' if len(cluster_info.instances) == 1 else 'are'

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -30,6 +30,7 @@ from sky.utils import resources_utils
 from sky.utils import rich_utils
 from sky.utils import subprocess_utils
 from sky.utils import ux_utils
+from sky.utils import timeline
 
 # Do not use __name__ as we do not want to propagate logs to sky.provision,
 # which will be customized in sky.provision.logging.
@@ -342,7 +343,7 @@ def _wait_ssh_connection_indirect(ip: str,
         return False, stderr
     return True, ''
 
-
+@timeline.event
 def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
                  ssh_credentials: Dict[str, str]):
     """Wait until SSH is ready.
@@ -552,7 +553,7 @@ def _post_provision_setup(
                                    provision_logging.config.log_path))
     return cluster_info
 
-
+@timeline.event
 def post_provision_runtime_setup(
         cloud_name: str, cluster_name: resources_utils.ClusterName,
         cluster_yaml: str, provision_record: provision_common.ProvisionRecord,

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -557,7 +557,7 @@ def _post_provision_setup(
             (ray_port, ray_cluster_healthy,
              head_ray_needs_restart) = check_ray_port_and_cluster_healthy()
         elif cloud_name.lower() == 'kubernetes':
-            timeout = 60  # 1-min maximum timeout
+            timeout = 90  # 1.5-min maximum timeout
             start = time.time()
             while True:
                 # Wait until Ray cluster is ready
@@ -568,8 +568,10 @@ def _post_provision_setup(
                                  'node ray cluster setup.')
                     break
                 if time.time() - start > timeout:
-                    raise RuntimeError(
-                        f'Ray cluster on head is not ready after {timeout}s.')
+                    # In most cases, the ray cluster will be ready after a few
+                    # seconds. Trigger ray start on head or worker nodes to be
+                    # safe, if the ray cluster is not ready after timeout.
+                    break
                 logger.debug('Ray cluster is not ready yet, waiting for the '
                              'async setup to complete...')
                 time.sleep(1)

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -513,7 +513,7 @@ def _post_provision_setup(
                 if line.strip() and not line.startswith('Active:')
             ])
             return active_nodes
-        
+
         def check_ray_port_and_cluster_healthy() -> Tuple[int, bool, bool]:
             # Check if head node Ray is alive
             returncode, stdout, _ = head_runner.run(
@@ -536,17 +536,20 @@ def _post_provision_setup(
         if (not provision_record.is_instance_just_booted(
                 head_instance.instance_id)):
             # Check if head node Ray is alive
-            ray_port, ray_cluster_healthy, need_full_ray_setup = check_ray_port_and_cluster_healthy()
+            ray_port, ray_cluster_healthy, need_full_ray_setup = check_ray_port_and_cluster_healthy(
+            )
         elif cloud_name.lower() == 'kubernetes':
             timeout = 60  # 1-min maximum timeout
             start = time.time()
             while True:
                 # Wait until Ray cluster is healthy
-                (ray_port, ray_cluster_healthy, need_full_ray_setup) = check_ray_port_and_cluster_healthy()
+                (ray_port, ray_cluster_healthy,
+                 need_full_ray_setup) = check_ray_port_and_cluster_healthy()
                 if ray_cluster_healthy:
                     break
                 if time.time() - start > timeout:
-                    raise RuntimeError(f'Ray cluster on head is not up after {timeout}s.')
+                    raise RuntimeError(
+                        f'Ray cluster on head is not up after {timeout}s.')
                 time.sleep(1)
 
         # We don't start ray on Kubernetes, as it has been started in the

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -505,7 +505,6 @@ def _post_provision_setup(
         need_full_ray_setup = True
 
         def parse_num_active_nodes(stdout: str) -> int:
-            # Extract active nodes using list comprehension and string manipulation
             start = stdout.find('Active:')
             end = stdout.find('Pending:', start)
             active_nodes = len([

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -536,8 +536,8 @@ def _post_provision_setup(
         if (not provision_record.is_instance_just_booted(
                 head_instance.instance_id)):
             # Check if head node Ray is alive
-            ray_port, ray_cluster_healthy, need_full_ray_setup = check_ray_port_and_cluster_healthy(
-            )
+            (ray_port, ray_cluster_healthy,
+             need_full_ray_setup) = check_ray_port_and_cluster_healthy()
         elif cloud_name.lower() == 'kubernetes':
             timeout = 60  # 1-min maximum timeout
             start = time.time()

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -564,6 +564,8 @@ def _post_provision_setup(
                 (ray_port, ray_cluster_healthy,
                  head_ray_needs_restart) = check_ray_port_and_cluster_healthy()
                 if ray_cluster_healthy:
+                    logger.debug('Ray cluster is ready. Skip head and worker '
+                                 'node ray cluster setup.')
                     break
                 if time.time() - start > timeout:
                     raise RuntimeError(

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -202,15 +202,9 @@ RAY_INSTALLATION_COMMANDS = (
     # Writes ray path to file if it does not exist or the file is empty.
     f'[ -s {SKY_RAY_PATH_FILE} ] || '
     f'{{ {ACTIVATE_SKY_REMOTE_PYTHON_ENV} && '
-    f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; '
-)
+    f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; ')
 
-# Install ray and skypilot on the remote cluster if they are not already
-# installed. {var} will be replaced with the actual value in
-# backend_utils.write_cluster_config.
-RAY_SKYPILOT_INSTALLATION_COMMANDS = (
-    f'{RAY_INSTALLATION_COMMANDS} '
-    # END ray package check and installation
+SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
     'start_epoch=$(date +%s.%N); '
     f'{{ {SKY_PIP_CMD} list | grep "skypilot " && '
     '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '  # pylint: disable=line-too-long
@@ -221,8 +215,14 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     'exit 1; }; '
     'end_epoch=$(date +%s.%N); '
     'echo "=== Installed skypilot: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
-    # END SkyPilot package check and installation
+)
 
+# Install ray and skypilot on the remote cluster if they are not already
+# installed. {var} will be replaced with the actual value in
+# backend_utils.write_cluster_config.
+RAY_SKYPILOT_INSTALLATION_COMMANDS = (
+    f'{RAY_INSTALLATION_COMMANDS} '
+    f'{SKYPILOT_WHEEL_INSTALLATION_COMMANDS} '
     # Only patch ray when the ray version is the same as the expected version.
     # The ray installation above can be skipped due to the existing ray cluster
     # for backward compatibility. In this case, we should not patch the ray

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -183,13 +183,10 @@ RAY_INSTALLATION_COMMANDS = (
     # latest ray port 6380, but those existing cluster launched before #1790
     # that has ray cluster on the default port 6379 will be upgraded and
     # restarted.
-    'start_epoch=$(date +%s); '
     f'{SKY_PIP_CMD} list | grep "ray " | '
     f'grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null '
     f'|| {RAY_STATUS} || '
     f'{SKY_PIP_CMD} install --exists-action w -U ray[default]=={SKY_REMOTE_RAY_VERSION}; '  # pylint: disable=line-too-long
-    'end_epoch=$(date +%s); '
-    'echo "== Installed ray: $(($end_epoch - $start_epoch)) secs =="; '
     # In some envs, e.g. pip does not have permission to write under /opt/conda
     # ray package will be installed under ~/.local/bin. If the user's PATH does
     # not include ~/.local/bin (the pip install will have the output: `WARNING:
@@ -205,16 +202,13 @@ RAY_INSTALLATION_COMMANDS = (
     f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; ')
 
 SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
-    'start_epoch=$(date +%s); '
     f'{{ {SKY_PIP_CMD} list | grep "skypilot " && '
     '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '  # pylint: disable=line-too-long
     f'{{ {SKY_PIP_CMD} uninstall skypilot -y; '
     f'{SKY_PIP_CMD} install "$(echo ~/.sky/wheels/{{sky_wheel_hash}}/'
     f'skypilot-{_sky_version}*.whl)[{{cloud}}, remote]" && '
     'echo "{sky_wheel_hash}" > ~/.sky/wheels/current_sky_wheel_hash || '
-    'exit 1; }; '
-    'end_epoch=$(date +%s); '
-    'echo "== Installed skypilot: $(($end_epoch - $start_epoch)) secs =="; ')
+    'exit 1; }; ')
 
 # Install ray and skypilot on the remote cluster if they are not already
 # installed. {var} will be replaced with the actual value in
@@ -226,13 +220,10 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     # The ray installation above can be skipped due to the existing ray cluster
     # for backward compatibility. In this case, we should not patch the ray
     # files.
-    'start_epoch=$(date +%s); '
     f'{SKY_PIP_CMD} list | grep "ray " | '
     f'grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null && '
     f'{{ {SKY_PYTHON_CMD} -c '
-    '"from sky.skylet.ray_patches import patch; patch()" || exit 1; }; '
-    'end_epoch=$(date +%s); '
-    'echo "== Patched ray: $(($end_epoch - $start_epoch)) secs =="; ')
+    '"from sky.skylet.ray_patches import patch; patch()" || exit 1; }; ')
 
 # The name for the environment variable that stores SkyPilot user hash, which
 # is mainly used to make sure sky commands runs on a VM launched by SkyPilot

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -204,7 +204,6 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     #
     # Here, we add ~/.local/bin to the end of the PATH to make sure the issues
     # mentioned above are resolved.
-    
     'export PATH=$PATH:$HOME/.local/bin; '
     # Writes ray path to file if it does not exist or the file is empty.
     f'[ -s {SKY_RAY_PATH_FILE} ] || '
@@ -232,7 +231,8 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     f'&& {{ {SKY_PYTHON_CMD} -c "from sky.skylet.ray_patches import patch; patch()" '
     '|| exit 1; }; '
     'end_epoch=$(date +%s.%N); '
-    'echo "=== Patched ray: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; ')
+    'echo "=== Patched ray: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
+)
 
 # The name for the environment variable that stores SkyPilot user hash, which
 # is mainly used to make sure sky commands runs on a VM launched by SkyPilot

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -183,13 +183,13 @@ RAY_INSTALLATION_COMMANDS = (
     # latest ray port 6380, but those existing cluster launched before #1790
     # that has ray cluster on the default port 6379 will be upgraded and
     # restarted.
-    'start_epoch=$(date +%s.%N); '
+    'start_epoch=$(date +%s); '
     f'{SKY_PIP_CMD} list | grep "ray " | '
     f'grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null '
     f'|| {RAY_STATUS} || '
     f'{SKY_PIP_CMD} install --exists-action w -U ray[default]=={SKY_REMOTE_RAY_VERSION}; '  # pylint: disable=line-too-long
-    'end_epoch=$(date +%s.%N); '
-    'echo "=== Installed ray: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
+    'end_epoch=$(date +%s); '
+    'echo "== Installed ray: $(($end_epoch - $start_epoch)) secs =="; '
     # In some envs, e.g. pip does not have permission to write under /opt/conda
     # ray package will be installed under ~/.local/bin. If the user's PATH does
     # not include ~/.local/bin (the pip install will have the output: `WARNING:
@@ -205,7 +205,7 @@ RAY_INSTALLATION_COMMANDS = (
     f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; ')
 
 SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
-    'start_epoch=$(date +%s.%N); '
+    'start_epoch=$(date +%s); '
     f'{{ {SKY_PIP_CMD} list | grep "skypilot " && '
     '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '  # pylint: disable=line-too-long
     f'{{ {SKY_PIP_CMD} uninstall skypilot -y; '
@@ -213,8 +213,8 @@ SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
     f'skypilot-{_sky_version}*.whl)[{{cloud}}, remote]" && '
     'echo "{sky_wheel_hash}" > ~/.sky/wheels/current_sky_wheel_hash || '
     'exit 1; }; '
-    'end_epoch=$(date +%s.%N); '
-    'echo "=== Installed skypilot: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
+    'end_epoch=$(date +%s); '
+    'echo "== Installed skypilot: $(($end_epoch - $start_epoch)) secs =="; '
 )
 
 # Install ray and skypilot on the remote cluster if they are not already
@@ -227,13 +227,13 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     # The ray installation above can be skipped due to the existing ray cluster
     # for backward compatibility. In this case, we should not patch the ray
     # files.
-    'start_epoch=$(date +%s.%N); '
-    f'{SKY_PIP_CMD} list | grep "ray " | grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null '
-    f'&& {{ {SKY_PYTHON_CMD} -c "from sky.skylet.ray_patches import patch; patch()" '
-    '|| exit 1; }; '
-    'end_epoch=$(date +%s.%N); '
-    'echo "=== Patched ray: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
-)
+    'start_epoch=$(date +%s); '
+    f'{SKY_PIP_CMD} list | grep "ray " | '
+    f'grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null && '
+    f'{{ {SKY_PYTHON_CMD} -c '
+    '"from sky.skylet.ray_patches import patch; patch()" || exit 1; }; '
+    'end_epoch=$(date +%s); '
+    'echo "== Patched ray: $(($end_epoch - $start_epoch)) secs =="; ')
 
 # The name for the environment variable that stores SkyPilot user hash, which
 # is mainly used to make sure sky commands runs on a VM launched by SkyPilot

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -159,10 +159,7 @@ CONDA_INSTALLATION_COMMANDS = (
 
 _sky_version = str(version.parse(sky.__version__))
 RAY_STATUS = f'RAY_ADDRESS=127.0.0.1:{SKY_REMOTE_RAY_PORT} {SKY_RAY_CMD} status'
-# Install ray and skypilot on the remote cluster if they are not already
-# installed. {var} will be replaced with the actual value in
-# backend_utils.write_cluster_config.
-RAY_SKYPILOT_INSTALLATION_COMMANDS = (
+RAY_INSTALLATION_COMMANDS = (
     'mkdir -p ~/sky_workdir && mkdir -p ~/.sky/sky_app;'
     # Disable the pip version check to avoid the warning message, which makes
     # the output hard to read.
@@ -187,9 +184,6 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     # that has ray cluster on the default port 6379 will be upgraded and
     # restarted.
     'start_epoch=$(date +%s.%N); '
-    'end_epoch=$(date +%s.%N); '
-    'echo "=== Waiting for Kubernetes args: $(echo "$end_epoch - $start_epoch" | bc) seconds ==="; '
-    'start_epoch=$(date +%s.%N); '
     f'{SKY_PIP_CMD} list | grep "ray " | '
     f'grep {SKY_REMOTE_RAY_VERSION} 2>&1 > /dev/null '
     f'|| {RAY_STATUS} || '
@@ -209,6 +203,13 @@ RAY_SKYPILOT_INSTALLATION_COMMANDS = (
     f'[ -s {SKY_RAY_PATH_FILE} ] || '
     f'{{ {ACTIVATE_SKY_REMOTE_PYTHON_ENV} && '
     f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; '
+)
+
+# Install ray and skypilot on the remote cluster if they are not already
+# installed. {var} will be replaced with the actual value in
+# backend_utils.write_cluster_config.
+RAY_SKYPILOT_INSTALLATION_COMMANDS = (
+    f'{RAY_INSTALLATION_COMMANDS} '
     # END ray package check and installation
     'start_epoch=$(date +%s.%N); '
     f'{{ {SKY_PIP_CMD} list | grep "skypilot " && '

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -214,8 +214,7 @@ SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
     'echo "{sky_wheel_hash}" > ~/.sky/wheels/current_sky_wheel_hash || '
     'exit 1; }; '
     'end_epoch=$(date +%s); '
-    'echo "== Installed skypilot: $(($end_epoch - $start_epoch)) secs =="; '
-)
+    'echo "== Installed skypilot: $(($end_epoch - $start_epoch)) secs =="; ')
 
 # Install ray and skypilot on the remote cluster if they are not already
 # installed. {var} will be replaced with the actual value in

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -337,15 +337,15 @@ available_node_types:
               
               (
                 {{ conda_installation_commands }}
-                ~/skypilot-runtime/bin/python -m pip install ray[default]==2.9.3 skypilot-nightly[kubernetes,remote]
-                ~/skypilot-runtime/bin/python -c "from sky.skylet.ray_patches import patch; patch()"
+                {{ ray_installation_commands }}
+                ~/skypilot-runtime/bin/python -m pip install skypilot-nightly[kubernetes,remote]
+                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly --no-deps
                 touch /tmp/ray_skypilot_installation_complete
-                # TODO: start ray here.
+                echo "=== Ray and skypilot installation completed ==="
                 if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
                   {{ ray_head_start_command }}
                   touch /tmp/ray_started
                 fi
-                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly
               ) &
 
               if [ "$SKYPILOT_POD_NODE_TYPE" == "worker" ]; then
@@ -354,7 +354,7 @@ available_node_types:
                   set -ex
                   # Wait until the head pod is available with an IP address
                   while [ -z "$SKYPILOT_RAY_HEAD_IP" ]; do
-                    export SKYPILOT_RAY_HEAD_IP=$(kubectl get pods -l ray-node-type=head,skypilot-cluster={{cluster_name_on_cloud}} -o jsonpath='{.items[0].status.podIP}')
+                    export SKYPILOT_RAY_HEAD_IP=$(nslookup {{cluster_name_on_cloud}}.{{k8s_namespace}}.pod.cluster.local)
                     sleep 1
                   done
 
@@ -523,8 +523,13 @@ setup_commands:
     start_epoch_conda=$(date +%s.%N);
     end_epoch_conda=$(date +%s.%N);
     echo "=== Installed conda: $(echo "$end_epoch_conda - $start_epoch_conda" | bc) seconds ===";
+    start_epoch=$(date +%s.%N);
+    ls -l /tmp/ray_skypilot_installation_complete;
+    # TODO(zhwu): Stream the logs from the current pod's args while waiting for the installation to complete.
+    until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for ray and skypilot installation to complete..."; done;
+    end_epoch=$(date +%s.%N);
+    echo "=== Waiting ray and skypilot installation: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
     start_epoch_ray_skypilot=$(date +%s.%N);
-    until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for conda, ray and SkyPilot installation to complete..."; done;
     {{ ray_skypilot_installation_commands }}
     end_epoch_ray_skypilot=$(date +%s.%N);
     echo "=== Installed ray and skypilot: $(echo "$end_epoch_ray_skypilot - $start_epoch_ray_skypilot" | bc) seconds ===";

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -576,6 +576,7 @@ setup_commands:
     [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log || 
     { tail -f -n +1 /tmp/${STEPS[1]}.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
     [ -f /tmp/${STEPS[1]}.failed ] && { echo "Error: ${STEPS[1]} failed. Exiting."; exit 1; } || true;
+    end_epoch=$(date +%s);
     echo "=== Ray and skypilot dependencies installation completed in $(($end_epoch - $start_epoch)) secs ===";
     start_epoch=$(date +%s);
     {{ skypilot_wheel_installation_commands }}

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -329,6 +329,7 @@ available_node_types:
               (
                 mkdir -p ~/.sky
                 {{ conda_installation_commands }}
+                # TODO(zhwu): dedup setting somehow get discarded.
                 {{ ray_installation_commands }}
                 source ~/skypilot-runtime/bin/activate
                 pip install skypilot[kubernetes,remote]

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -330,8 +330,6 @@ available_node_types:
               (
                 mkdir -p ~/.sky
                 {{ conda_installation_commands }}
-                # TODO(zhwu): dedup setting somehow get discarded.
-                echo Nproc: $(( 3 * $(nproc --all) ))
                 {{ ray_installation_commands }}
                 ~/skypilot-runtime/bin/python -m pip install skypilot[kubernetes,remote]
                 touch /tmp/ray_skypilot_installation_complete

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -505,6 +505,8 @@ setup_commands:
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
+  # Line 'for failure_indicator in ..': check if any failure indicator exists for the setup done in pod args and print the error message. This is only a best effort, as the
+  # commands in pod args are asynchronous and we cannot guarantee the failure indicators are created before the setup commands finish.
   - |
     start_epoch=$(date +%s);
     end_epoch=$(date +%s);

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -508,35 +508,29 @@ setup_commands:
   # Line 'for failure_indicator in ..': check if any failure indicator exists for the setup done in pod args and print the error message. This is only a best effort, as the
   # commands in pod args are asynchronous and we cannot guarantee the failure indicators are created before the setup commands finish.
   - |
-    start_epoch=$(date +%s);
-    end_epoch=$(date +%s);
-    echo "=== Installed packages: $(($end_epoch - $start_epoch)) secs ===";
-    start_epoch=$(date +%s);
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {%- for initial_setup_command in initial_setup_commands %}
     {{ initial_setup_command }}
     {%- endfor %}
-    end_epoch=$(date +%s);
-    echo "=== Initial setup: $(($end_epoch - $start_epoch)) secs ===";
     start_epoch=$(date +%s);
-    ls -l /tmp/ray_skypilot_installation_complete;
-    # TODO(zhwu): Stream the logs from the current pod's args while waiting for the installation to complete.
-    until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for ray and skypilot installation to complete..."; done;
+    echo "=== Logs for asynchronous ray and skypilot installation ===";
+    [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/runtime-setup.log || 
+    { tail -f -n +1 /tmp/runtime-setup.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
+    [ -f /tmp/runtime-setup.failed ] && { echo "Error: runtime-setup failed. Exiting."; exit 1; } || true;
     end_epoch=$(date +%s);
-    echo "=== Waiting ray and skypilot installation: $(($end_epoch - $start_epoch)) secs ===";
+    echo "=== Waiting for asynchronous ray and skypilot installation: $(($end_epoch - $start_epoch)) secs ===";
     start_epoch_ray_skypilot=$(date +%s);
     {{ skypilot_wheel_installation_commands }}
-    end_epoch_ray_skypilot=$(date +%s);
-    echo "=== Installed ray and skypilot: $(($end_epoch_ray_skypilot - $start_epoch_ray_skypilot)) secs ===";
     start_epoch=$(date +%s);
     sudo touch ~/.sudo_as_admin_successful;
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
-    sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
+    sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf');
+    ulimit -n 1048576;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `goofys`;
     end_epoch=$(date +%s);
-    echo "=== Setup fuse: $(($end_epoch - $start_epoch)) secs ===";
-    FAILURE_INDICATORS="/tmp/apt-ssh-setup /tmp/runtime-setup /tmp/env-setup";
+    echo "=== Setup system configs and fuse: $(($end_epoch - $start_epoch)) secs ===";
+    FAILURE_INDICATORS="/tmp/apt-ssh-setup /tmp/env-setup /tmp/runtime-setup";
     for failure_indicator in $FAILURE_INDICATORS; do [ -f "$failure_indicator.failed" ] && { echo "Error: $failure_indicator.failed found:"; cat $failure_indicator.log; exit 1; } || true; done;
     {% if tpu_requested %}
     # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -320,7 +320,6 @@ available_node_types:
                   fieldPath: metadata.labels['ray-node-type']
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
-          # We need to use -i to make sure the environment variables are set.
           command: ["/bin/bash", "-c", "--"]
           args: 
             - |

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -329,11 +329,47 @@ available_node_types:
             - |
               # Helper function to conditionally use sudo
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
+              
+              (
+                {{ conda_installation_commands }}
+                ~/skypilot-runtime/bin/python -m pip install ray[default]==2.9.3 skypilot-nightly[kubernetes,remote]
+                ~/skypilot-runtime/bin/python -c "from sky.skylet.ray_patches import patch; patch()"
+                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly
+                touch /tmp/ray_skypilot_installation_complete
+                # TODO: start ray here.
+              ) &
 
-              # Run apt update in background and log to a file
+              # Run apt update in background and log to a file and install missing packages
               (
                 DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update > /tmp/apt-update.log 2>&1 || \
                 echo "Warning: apt-get update failed. Continuing anyway..." >> /tmp/apt-update.log
+                PACKAGES="gcc patch pciutils rsync fuse curl openssh-server rsync";
+                MISSING_PACKAGES="";
+                for pkg in $PACKAGES; do
+                  if ! dpkg -l | grep -q "^ii  $pkg "; then
+                    MISSING_PACKAGES="$MISSING_PACKAGES $pkg";
+                  fi
+                done;
+                if [ ! -z "$MISSING_PACKAGES" ]; then
+                  echo "Installing missing packages: $MISSING_PACKAGES";
+                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $MISSING_PACKAGES;
+                fi;
+                $(prefix_cmd) mkdir -p /var/run/sshd;
+                $(prefix_cmd) sed -i "s/PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config;
+                $(prefix_cmd) sed "s@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g" -i /etc/pam.d/sshd;
+                cd /etc/ssh/ && $(prefix_cmd) ssh-keygen -A;
+                $(prefix_cmd) mkdir -p ~/.ssh;
+                $(prefix_cmd) chown -R $(whoami) ~/.ssh;
+                $(prefix_cmd) chmod 700 ~/.ssh;
+                $(prefix_cmd) cat /etc/secret-volume/ssh-publickey* > ~/.ssh/authorized_keys;
+                $(prefix_cmd) chmod 644 ~/.ssh/authorized_keys;
+                $(prefix_cmd) service ssh restart;
+                $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
+              ) &
+
+              (
+                set -ex;if [ $(id -u) -eq 0 ]; then  echo 'alias sudo=""' >> ~/.bashrc; echo succeed;else   if command -v sudo >/dev/null 2>&1; then     timeout 2 sudo -l >/dev/null 2>&1 && echo succeed ||     ( echo 52;       exit 52; );   else     ( echo 52;       exit 52; );   fi; fi; 
+                printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
               ) &
 
               function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
@@ -442,41 +478,46 @@ setup_commands:
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - |
-    PACKAGES="gcc patch pciutils rsync fuse curl";
-    MISSING_PACKAGES="";
-    for pkg in $PACKAGES; do
-      if ! dpkg -l | grep -q "^ii  $pkg "; then
-        MISSING_PACKAGES="$MISSING_PACKAGES $pkg";
-      fi
-    done;
-    if [ ! -z "$MISSING_PACKAGES" ]; then
-      echo "Installing missing packages: $MISSING_PACKAGES";
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $MISSING_PACKAGES;
-    fi;
+    sudo DEBIAN_FRONTEND=noninteractive apt install -y bc;
+    start_epoch=$(date +%s.%N);
+    end_epoch=$(date +%s.%N);
+    echo "=== Installed packages: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
+    start_epoch=$(date +%s.%N);
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {%- for initial_setup_command in initial_setup_commands %}
     {{ initial_setup_command }}
     {%- endfor %}
-    {{ conda_installation_commands }}
+    end_epoch=$(date +%s.%N);
+    echo "=== Initial setup: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
+    start_epoch_conda=$(date +%s.%N);
+    end_epoch_conda=$(date +%s.%N);
+    echo "=== Installed conda: $(echo "$end_epoch_conda - $start_epoch_conda" | bc) seconds ===";
+    start_epoch_ray_skypilot=$(date +%s.%N);
+    f'until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for conda, ray and SkyPilot installation to complete..."; done; '
     {{ ray_skypilot_installation_commands }}
+    end_epoch_ray_skypilot=$(date +%s.%N);
+    echo "=== Installed ray and skypilot: $(echo "$end_epoch_ray_skypilot - $start_epoch_ray_skypilot" | bc) seconds ===";
+    start_epoch=$(date +%s.%N);
     sudo touch ~/.sudo_as_admin_successful;
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `goofys`;
-  {% if tpu_requested %}
-  # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from
-  # the TPU runtime, are written. These capture runtime information about the
-  # TPU execution, including any warnings, errors, or general activity of
-  # the TPU driver. By default, the /tmp/tpu_logs directory is created with
-  # 755 permissions, and the user of the provisioned pod is not necessarily
-  # a root. Hence, we need to update the write permission so the logs can be
-  # properly written.
-  # TODO(Doyoung): Investigate to see why TPU workload fails to run without
-  # execution permission, such as granting 766 to log file. Check if it's a
-  # must and see if there's a workaround to grant minimum permission. 
-  - sudo chmod 777 /tmp/tpu_logs;
-  {% endif %}
+    end_epoch=$(date +%s.%N);
+    echo "=== Setup fuse: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
+    {% if tpu_requested %}
+    # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from
+    # the TPU runtime, are written. These capture runtime information about the
+    # TPU execution, including any warnings, errors, or general activity of
+    # the TPU driver. By default, the /tmp/tpu_logs directory is created with
+    # 755 permissions, and the user of the provisioned pod is not necessarily
+    # a root. Hence, we need to update the write permission so the logs can be
+    # properly written.
+    # TODO(Doyoung): Investigate to see why TPU workload fails to run without
+    # execution permission, such as granting 766 to log file. Check if it's a
+    # must and see if there's a workaround to grant minimum permission. 
+    sudo chmod 777 /tmp/tpu_logs;
+    {% endif %}
 
 # Format: `REMOTE_PATH : LOCAL_PATH`
 file_mounts: {

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -497,35 +497,34 @@ setup_commands:
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
   - |
-    sudo DEBIAN_FRONTEND=noninteractive apt install -y bc;
-    start_epoch=$(date +%s.%N);
-    end_epoch=$(date +%s.%N);
-    echo "=== Installed packages: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
-    start_epoch=$(date +%s.%N);
+    start_epoch=$(date +%s);
+    end_epoch=$(date +%s);
+    echo "=== Installed packages: $(($end_epoch - $start_epoch)) secs ===";
+    start_epoch=$(date +%s);
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {%- for initial_setup_command in initial_setup_commands %}
     {{ initial_setup_command }}
     {%- endfor %}
-    end_epoch=$(date +%s.%N);
-    echo "=== Initial setup: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
-    start_epoch=$(date +%s.%N);
+    end_epoch=$(date +%s);
+    echo "=== Initial setup: $(($end_epoch - $start_epoch)) secs ===";
+    start_epoch=$(date +%s);
     ls -l /tmp/ray_skypilot_installation_complete;
     # TODO(zhwu): Stream the logs from the current pod's args while waiting for the installation to complete.
     until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for ray and skypilot installation to complete..."; done;
-    end_epoch=$(date +%s.%N);
-    echo "=== Waiting ray and skypilot installation: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
-    start_epoch_ray_skypilot=$(date +%s.%N);
+    end_epoch=$(date +%s);
+    echo "=== Waiting ray and skypilot installation: $(($end_epoch - $start_epoch)) secs ===";
+    start_epoch_ray_skypilot=$(date +%s);
     {{ skypilot_wheel_installation_commands }}
-    end_epoch_ray_skypilot=$(date +%s.%N);
-    echo "=== Installed ray and skypilot: $(echo "$end_epoch_ray_skypilot - $start_epoch_ray_skypilot" | bc) seconds ===";
-    start_epoch=$(date +%s.%N);
+    end_epoch_ray_skypilot=$(date +%s);
+    echo "=== Installed ray and skypilot: $(($end_epoch_ray_skypilot - $start_epoch_ray_skypilot)) secs ===";
+    start_epoch=$(date +%s);
     sudo touch ~/.sudo_as_admin_successful;
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
     sudo grep -e '^DefaultTasksMax' /etc/systemd/system.conf || (sudo bash -c 'echo "DefaultTasksMax=infinity" >> /etc/systemd/system.conf'); sudo systemctl set-property user-$(id -u $(whoami)).slice TasksMax=infinity; sudo systemctl daemon-reload;
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `goofys`;
-    end_epoch=$(date +%s.%N);
-    echo "=== Setup fuse: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
+    end_epoch=$(date +%s);
+    echo "=== Setup fuse: $(($end_epoch - $start_epoch)) secs ===";
     {% if tpu_requested %}
     # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from
     # the TPU runtime, are written. These capture runtime information about the

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -326,51 +326,43 @@ available_node_types:
             - |
               # Helper function to conditionally use sudo
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
-              
-              (
-                {
-                mkdir -p ~/.sky
-                {{ conda_installation_commands }}
-                {{ ray_installation_commands }}
-                ~/skypilot-runtime/bin/python -m pip install skypilot[kubernetes,remote]
-                touch /tmp/ray_skypilot_installation_complete
-                echo "=== Ray and skypilot installation completed ==="
-                
-                if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
-                  {{ ray_head_start_command }}
-                  touch /tmp/ray_started
-                else
-                  # Start ray worker on the worker pod.
-                  # Wait until the head pod is available with an IP address
-                  export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
-                  export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
-                  # Wait until the ray cluster is started on the head pod
-                  until nc -z -w 1 ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
-                    sleep 0.1
-                  done
-
-                  {{ ray_worker_start_command }}
-                  touch /tmp/ray_started
-                fi
-                } | tee /tmp/runtime-setup.log 2>&1
-              ) &
-
 
               # Run apt update in background and log to a file, install missing packages, and set up ssh
               (
                 {
                 DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update > /tmp/apt-update.log 2>&1 || \
                 echo "Warning: apt-get update failed. Continuing anyway..." >> /tmp/apt-update.log
-                PACKAGES="gcc patch pciutils rsync fuse curl openssh-server rsync";
+                PACKAGES="rsync curl netcat gcc patch pciutils fuse openssh-server";
+
+                # Separate packages into two groups: packages that are installed first
+                # so that curl and rsync are available sooner to unblock the following
+                # conda installation and rsync.
+                set -e
+                INSTALL_FIRST="";
                 MISSING_PACKAGES="";
                 for pkg in $PACKAGES; do
-                  if ! dpkg -l | grep -q "^ii  $pkg "; then
-                    MISSING_PACKAGES="$MISSING_PACKAGES $pkg";
+                  if [ "$pkg" == "netcat" ]; then
+                    if ! dpkg -l | grep -q "^ii  \(netcat\|netcat-openbsd\|netcat-traditional\) "; then
+                      INSTALL_FIRST="$INSTALL_FIRST netcat-openbsd";
+                    fi
+                  elif ! dpkg -l | grep -q "^ii  $pkg "; then
+                    if [ "$pkg" == "curl" ] || [ "$pkg" == "rsync" ]; then
+                      INSTALL_FIRST="$INSTALL_FIRST $pkg";
+                    else
+                      MISSING_PACKAGES="$MISSING_PACKAGES $pkg";
+                    fi
                   fi
                 done;
+                if [ ! -z "$INSTALL_FIRST" ]; then
+                  echo "Installing core packages: $INSTALL_FIRST";
+                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y $INSTALL_FIRST;
+                fi;
+                # SSH and other packages are not necessary, so we disable set -e
+                set +e
+                
                 if [ ! -z "$MISSING_PACKAGES" ]; then
                   echo "Installing missing packages: $MISSING_PACKAGES";
-                  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $MISSING_PACKAGES;
+                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y $MISSING_PACKAGES;
                 fi;
                 $(prefix_cmd) mkdir -p /var/run/sshd;
                 $(prefix_cmd) sed -i "s/PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config;
@@ -383,19 +375,78 @@ available_node_types:
                 $(prefix_cmd) chmod 644 ~/.ssh/authorized_keys;
                 $(prefix_cmd) service ssh restart;
                 $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
-                } | tee /tmp/apt-ssh-setup.log 2>&1 || {
+                } > /tmp/apt-ssh-setup.log 2>&1 || {
                   echo "Error: apt-ssh-setup failed. Continuing anyway..." > /tmp/apt-ssh-setup.failed
+                  cat /tmp/apt-ssh-setup.log
                   exit 1
                 }
               ) &
 
+              (
+                {
+                set -e
+                mkdir -p ~/.sky
+                # Wait for `curl` package to be installed before installing conda
+                # and ray.
+                until dpkg -l | grep -q "^ii  curl "; do
+                  sleep 0.1
+                  echo "Waiting for curl package to be installed..."
+                done
+                {{ conda_installation_commands }}
+                {{ ray_installation_commands }}
+                ~/skypilot-runtime/bin/python -m pip install skypilot[kubernetes,remote]
+                touch /tmp/ray_skypilot_installation_complete
+                echo "=== Ray and skypilot installation completed ==="
+
+                # Disable set -e, as we have some commands that are ok to fail
+                # after the ray start.
+                # TODO(zhwu): this is a hack, we should fix the commands that are
+                # ok to fail.
+                if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
+                  set +e
+                  {{ ray_head_start_command }}
+                else
+                  # Start ray worker on the worker pod.
+                  # Wait until the head pod is available with an IP address
+                  export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
+                  export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
+                  # Wait until the ray cluster is started on the head pod
+                  until dpkg -l | grep -q "^ii  \(netcat\|netcat-openbsd\|netcat-traditional\) "; do
+                    sleep 0.1
+                    echo "Waiting for netcat package to be installed..."
+                  done
+                  until nc -z -w 1 ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
+                    sleep 0.1
+                  done
+
+                  set +e
+                  {{ ray_worker_start_command }}
+                fi
+                } > /tmp/runtime-setup.log 2>&1 || {
+                  echo "Error: runtime-setup failed. Continuing anyway..." > /tmp/runtime-setup.failed
+                  cat /tmp/runtime-setup.log
+                  exit 1
+                }
+              ) &
+
+
               # Set up environment variables; this should be relatively fast, we don't explicitly wait for it.
               (
                 {
-                set -ex;if [ $(id -u) -eq 0 ]; then  echo 'alias sudo=""' >> ~/.bashrc; echo succeed;else   if command -v sudo >/dev/null 2>&1; then     timeout 2 sudo -l >/dev/null 2>&1 && echo succeed ||     ( echo 52;       exit 52; );   else     ( echo 52;       exit 52; );   fi; fi; 
+                set -e
+                if [ $(id -u) -eq 0 ]; then
+                  echo 'alias sudo=""' >> ~/.bashrc; echo succeed;
+                else
+                  if command -v sudo >/dev/null 2>&1; then
+                    timeout 2 sudo -l >/dev/null 2>&1 && echo succeed || ( echo 52; exit 52; );
+                  else
+                    ( echo 52; exit 52; );
+                  fi;
+                fi;
                 printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
-                } | tee /tmp/env-setup.log 2>&1 || {
+                } > /tmp/env-setup.log 2>&1 || {
                   echo "Error: env-setup failed. Continuing anyway..." > /tmp/env-setup.failed
+                  cat /tmp/env-setup.log
                   exit 1
                 }
               ) &

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -236,17 +236,9 @@ provider:
             name: {{cluster_name_on_cloud}}-head
         spec:
             # This selector must match the head node pod's selector below.
+            clusterIP: None
             selector:
                 component: {{cluster_name_on_cloud}}-head
-            ports:
-                - name: client
-                  protocol: TCP
-                  port: 10001
-                  targetPort: 10001
-                - name: dashboard
-                  protocol: TCP
-                  port: 8265
-                  targetPort: 8265
 
 # Specify the pod type for the ray head node (as configured below).
 head_node_type: ray_head_default
@@ -280,7 +272,6 @@ available_node_types:
         # serviceAccountName: skypilot-service-account
         serviceAccountName: {{k8s_service_account_name}}
         automountServiceAccountToken: {{k8s_automount_sa_token}}
-
         restartPolicy: Never
 
         # Add node selector if GPU/TPUs are requested:
@@ -336,10 +327,11 @@ available_node_types:
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
               
               (
+                mkdir -p ~/.sky
                 {{ conda_installation_commands }}
                 {{ ray_installation_commands }}
-                ~/skypilot-runtime/bin/python -m pip install skypilot-nightly[kubernetes,remote]
-                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly --no-deps
+                source ~/skypilot-runtime/bin/activate
+                pip install skypilot[kubernetes,remote]
                 touch /tmp/ray_skypilot_installation_complete
                 echo "=== Ray and skypilot installation completed ==="
                 if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
@@ -353,15 +345,11 @@ available_node_types:
                 (
                   set -ex
                   # Wait until the head pod is available with an IP address
-                  while [ -z "$SKYPILOT_RAY_HEAD_IP" ]; do
-                    export SKYPILOT_RAY_HEAD_IP=$(nslookup {{cluster_name_on_cloud}}.{{k8s_namespace}}.pod.cluster.local)
-                    sleep 1
-                  done
-
+                  export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
                   # Wait until the ray cluster is started on the head pod
-                  until nc -z ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
-                    sleep 1
+                  until nc -z -w 1 ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
+                    sleep 0.1
                   done
 
                   {{ ray_worker_start_command }}
@@ -520,9 +508,6 @@ setup_commands:
     {%- endfor %}
     end_epoch=$(date +%s.%N);
     echo "=== Initial setup: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
-    start_epoch_conda=$(date +%s.%N);
-    end_epoch_conda=$(date +%s.%N);
-    echo "=== Installed conda: $(echo "$end_epoch_conda - $start_epoch_conda" | bc) seconds ===";
     start_epoch=$(date +%s.%N);
     ls -l /tmp/ray_skypilot_installation_complete;
     # TODO(zhwu): Stream the logs from the current pod's args while waiting for the installation to complete.
@@ -530,7 +515,7 @@ setup_commands:
     end_epoch=$(date +%s.%N);
     echo "=== Waiting ray and skypilot installation: $(echo "$end_epoch - $start_epoch" | bc) seconds ===";
     start_epoch_ray_skypilot=$(date +%s.%N);
-    {{ ray_skypilot_installation_commands }}
+    {{ skypilot_wheel_installation_commands }}
     end_epoch_ray_skypilot=$(date +%s.%N);
     echo "=== Installed ray and skypilot: $(echo "$end_epoch_ray_skypilot - $start_epoch_ray_skypilot" | bc) seconds ===";
     start_epoch=$(date +%s.%N);

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -322,6 +322,11 @@ available_node_types:
         - name: ray-node
           imagePullPolicy: IfNotPresent
           image: {{image_id}}
+          env:
+            - name: SKYPILOT_POD_NODE_TYPE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['ray-node-type']
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
@@ -334,10 +339,35 @@ available_node_types:
                 {{ conda_installation_commands }}
                 ~/skypilot-runtime/bin/python -m pip install ray[default]==2.9.3 skypilot-nightly[kubernetes,remote]
                 ~/skypilot-runtime/bin/python -c "from sky.skylet.ray_patches import patch; patch()"
-                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly
                 touch /tmp/ray_skypilot_installation_complete
                 # TODO: start ray here.
+                if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
+                  {{ ray_head_start_command }}
+                  touch /tmp/ray_started
+                fi
+                ~/skypilot-runtime/bin/python -m pip uninstall -y skypilot-nightly
               ) &
+
+              if [ "$SKYPILOT_POD_NODE_TYPE" == "worker" ]; then
+                # Start ray worker on the worker pod.
+                (
+                  set -ex
+                  # Wait until the head pod is available with an IP address
+                  while [ -z "$SKYPILOT_RAY_HEAD_IP" ]; do
+                    export SKYPILOT_RAY_HEAD_IP=$(kubectl get pods -l ray-node-type=head,skypilot-cluster={{cluster_name_on_cloud}} -o jsonpath='{.items[0].status.podIP}')
+                    sleep 1
+                  done
+
+                  export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
+                  # Wait until the ray cluster is started on the head pod
+                  until nc -z ${SKYPILOT_RAY_HEAD_IP} ${SKYPILOT_RAY_PORT}; do
+                    sleep 1
+                  done
+
+                  {{ ray_worker_start_command }}
+                  touch /tmp/ray_started
+                ) &
+              fi
 
               # Run apt update in background and log to a file and install missing packages
               (
@@ -367,6 +397,7 @@ available_node_types:
                 $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
               ) &
 
+              # Set up environment variables; this should be relatively fast, we don't explicitly wait for it.
               (
                 set -ex;if [ $(id -u) -eq 0 ]; then  echo 'alias sudo=""' >> ~/.bashrc; echo succeed;else   if command -v sudo >/dev/null 2>&1; then     timeout 2 sudo -l >/dev/null 2>&1 && echo succeed ||     ( echo 52;       exit 52; );   else     ( echo 52;       exit 52; );   fi; fi; 
                 printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
@@ -493,7 +524,7 @@ setup_commands:
     end_epoch_conda=$(date +%s.%N);
     echo "=== Installed conda: $(echo "$end_epoch_conda - $start_epoch_conda" | bc) seconds ===";
     start_epoch_ray_skypilot=$(date +%s.%N);
-    f'until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for conda, ray and SkyPilot installation to complete..."; done; '
+    until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 1; echo "Waiting for conda, ray and SkyPilot installation to complete..."; done;
     {{ ray_skypilot_installation_commands }}
     end_epoch_ray_skypilot=$(date +%s.%N);
     echo "=== Installed ray and skypilot: $(echo "$end_epoch_ray_skypilot - $start_epoch_ray_skypilot" | bc) seconds ===";

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -320,6 +320,7 @@ available_node_types:
                   fieldPath: metadata.labels['ray-node-type']
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
+          # We need to use -i to make sure the environment variables are set.
           command: ["/bin/bash", "-c", "--"]
           args: 
             - |
@@ -330,20 +331,19 @@ available_node_types:
                 mkdir -p ~/.sky
                 {{ conda_installation_commands }}
                 # TODO(zhwu): dedup setting somehow get discarded.
+                echo Nproc: $(( 3 * $(nproc --all) ))
                 {{ ray_installation_commands }}
                 source ~/skypilot-runtime/bin/activate
-                pip install skypilot[kubernetes,remote]
+                ~/skypilot-runtime/bin/python -m pip install skypilot[kubernetes,remote]
                 touch /tmp/ray_skypilot_installation_complete
                 echo "=== Ray and skypilot installation completed ==="
+                
                 if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
+                  set -ex
                   {{ ray_head_start_command }}
                   touch /tmp/ray_started
-                fi
-              ) &
-
-              if [ "$SKYPILOT_POD_NODE_TYPE" == "worker" ]; then
-                # Start ray worker on the worker pod.
-                (
+                else
+                  # Start ray worker on the worker pod.
                   set -ex
                   # Wait until the head pod is available with an IP address
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
@@ -355,8 +355,9 @@ available_node_types:
 
                   {{ ray_worker_start_command }}
                   touch /tmp/ray_started
-                ) &
-              fi
+                fi
+              ) &
+
 
               # Run apt update in background and log to a file and install missing packages
               (

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -333,7 +333,6 @@ available_node_types:
                 # TODO(zhwu): dedup setting somehow get discarded.
                 echo Nproc: $(( 3 * $(nproc --all) ))
                 {{ ray_installation_commands }}
-                source ~/skypilot-runtime/bin/activate
                 ~/skypilot-runtime/bin/python -m pip install skypilot[kubernetes,remote]
                 touch /tmp/ray_skypilot_installation_complete
                 echo "=== Ray and skypilot installation completed ==="

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -328,6 +328,7 @@ available_node_types:
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
               
               (
+                {
                 mkdir -p ~/.sky
                 {{ conda_installation_commands }}
                 {{ ray_installation_commands }}
@@ -336,12 +337,10 @@ available_node_types:
                 echo "=== Ray and skypilot installation completed ==="
                 
                 if [ "$SKYPILOT_POD_NODE_TYPE" == "head" ]; then
-                  set -ex
                   {{ ray_head_start_command }}
                   touch /tmp/ray_started
                 else
                   # Start ray worker on the worker pod.
-                  set -ex
                   # Wait until the head pod is available with an IP address
                   export SKYPILOT_RAY_HEAD_IP="{{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local"
                   export SKYPILOT_RAY_PORT={{skypilot_ray_port}}
@@ -353,11 +352,13 @@ available_node_types:
                   {{ ray_worker_start_command }}
                   touch /tmp/ray_started
                 fi
+                } | tee /tmp/runtime-setup.log 2>&1
               ) &
 
 
-              # Run apt update in background and log to a file and install missing packages
+              # Run apt update in background and log to a file, install missing packages, and set up ssh
               (
+                {
                 DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update > /tmp/apt-update.log 2>&1 || \
                 echo "Warning: apt-get update failed. Continuing anyway..." >> /tmp/apt-update.log
                 PACKAGES="gcc patch pciutils rsync fuse curl openssh-server rsync";
@@ -382,12 +383,21 @@ available_node_types:
                 $(prefix_cmd) chmod 644 ~/.ssh/authorized_keys;
                 $(prefix_cmd) service ssh restart;
                 $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
+                } | tee /tmp/apt-ssh-setup.log 2>&1 || {
+                  echo "Error: apt-ssh-setup failed. Continuing anyway..." > /tmp/apt-ssh-setup.failed
+                  exit 1
+                }
               ) &
 
               # Set up environment variables; this should be relatively fast, we don't explicitly wait for it.
               (
+                {
                 set -ex;if [ $(id -u) -eq 0 ]; then  echo 'alias sudo=""' >> ~/.bashrc; echo succeed;else   if command -v sudo >/dev/null 2>&1; then     timeout 2 sudo -l >/dev/null 2>&1 && echo succeed ||     ( echo 52;       exit 52; );   else     ( echo 52;       exit 52; );   fi; fi; 
                 printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
+                } | tee /tmp/env-setup.log 2>&1 || {
+                  echo "Error: env-setup failed. Continuing anyway..." > /tmp/env-setup.failed
+                  exit 1
+                }
               ) &
 
               function mylsof { p=$(for pid in /proc/{0..9}*; do i=$(basename "$pid"); for file in "$pid"/fd/*; do link=$(readlink -e "$file"); if [ "$link" = "$1" ]; then echo "$i"; fi; done; done); echo "$p"; };
@@ -524,6 +534,8 @@ setup_commands:
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `goofys`;
     end_epoch=$(date +%s);
     echo "=== Setup fuse: $(($end_epoch - $start_epoch)) secs ===";
+    FAILURE_INDICATORS="/tmp/apt-ssh-setup /tmp/runtime-setup /tmp/env-setup";
+    for failure_indicator in $FAILURE_INDICATORS; do [ -f "$failure_indicator.failed" ] && { echo "Error: $failure_indicator.failed found:"; cat $failure_indicator.log; exit 1; } || true; done;
     {% if tpu_requested %}
     # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from
     # the TPU runtime, are written. These capture runtime information about the

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -222,7 +222,9 @@ provider:
             - protocol: TCP
               port: 22
               targetPort: 22
-      # Service that maps to the head node of the Ray cluster.
+      # Service that maps to the head node of the Ray cluster, so that the
+      # worker nodes can find the head node using
+      # {{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local
       - apiVersion: v1
         kind: Service
         metadata:
@@ -235,8 +237,10 @@ provider:
             # names.
             name: {{cluster_name_on_cloud}}-head
         spec:
-            # This selector must match the head node pod's selector below.
+            # Create a headless service so that the head node can be reached by
+            # the worker nodes with any port number.
             clusterIP: None
+            # This selector must match the head node pod's selector below.
             selector:
                 component: {{cluster_name_on_cloud}}-head
 

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -330,9 +330,11 @@ available_node_types:
               # Helper function to conditionally use sudo
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
 
-              # Run apt update in background and log to a file, install missing packages, and set up ssh
+              STEPS=("apt-ssh-setup" "runtime-setup" "env-setup")
+
+              # STEP 1: Run apt update, install missing packages, and set up ssh.
               (
-                {
+                (
                 DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get update > /tmp/apt-update.log 2>&1 || \
                 echo "Warning: apt-get update failed. Continuing anyway..." >> /tmp/apt-update.log
                 PACKAGES="rsync curl netcat gcc patch pciutils fuse openssh-server";
@@ -378,15 +380,17 @@ available_node_types:
                 $(prefix_cmd) chmod 644 ~/.ssh/authorized_keys;
                 $(prefix_cmd) service ssh restart;
                 $(prefix_cmd) sed -i "s/mesg n/tty -s \&\& mesg n/" ~/.profile;
-                } > /tmp/apt-ssh-setup.log 2>&1 || {
-                  echo "Error: apt-ssh-setup failed. Continuing anyway..." > /tmp/apt-ssh-setup.failed
-                  cat /tmp/apt-ssh-setup.log
+                ) > /tmp/${STEPS[0]}.log 2>&1 || {
+                  echo "Error: ${STEPS[0]} failed. Continuing anyway..." > /tmp/${STEPS[0]}.failed
+                  cat /tmp/${STEPS[0]}.log
                   exit 1
                 }
               ) &
 
+              # STEP 2: Install conda, ray and skypilot (for dependencies); start
+              # ray cluster.
               (
-                {
+                (
                 set -e
                 mkdir -p ~/.sky
                 # Wait for `curl` package to be installed before installing conda
@@ -425,31 +429,31 @@ available_node_types:
                   set +e
                   {{ ray_worker_start_command }}
                 fi
-                } > /tmp/runtime-setup.log 2>&1 || {
-                  echo "Error: runtime-setup failed. Continuing anyway..." > /tmp/runtime-setup.failed
-                  cat /tmp/runtime-setup.log
+                ) > /tmp/${STEPS[1]}.log 2>&1 || {
+                  echo "Error: ${STEPS[1]} failed. Continuing anyway..." > /tmp/${STEPS[1]}.failed
+                  cat /tmp/${STEPS[1]}.log
                   exit 1
                 }
               ) &
 
 
-              # Set up environment variables; this should be relatively fast, we don't explicitly wait for it.
+              # STEP 3: Set up environment variables; this should be relatively fast.
               (
-                {
+                (
                 set -e
                 if [ $(id -u) -eq 0 ]; then
                   echo 'alias sudo=""' >> ~/.bashrc; echo succeed;
                 else
                   if command -v sudo >/dev/null 2>&1; then
-                    timeout 2 sudo -l >/dev/null 2>&1 && echo succeed || ( echo 52; exit 52; );
+                    timeout 2 sudo -l >/dev/null 2>&1 && echo succeed || { echo 52; exit 52; };
                   else
-                    ( echo 52; exit 52; );
+                    { echo 52; exit 52; };
                   fi;
                 fi;
                 printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
-                } > /tmp/env-setup.log 2>&1 || {
-                  echo "Error: env-setup failed. Continuing anyway..." > /tmp/env-setup.failed
-                  cat /tmp/env-setup.log
+                ) > /tmp/${STEPS[2]}.log 2>&1 || {
+                  echo "Error: ${STEPS[2]} failed. Continuing anyway..." > /tmp/${STEPS[2]}.failed
+                  cat /tmp/${STEPS[2]}.log
                   exit 1
                 }
               ) &
@@ -559,22 +563,24 @@ setup_commands:
   # Line 'sudo grep ..': set the number of threads per process to unlimited to avoid ray job submit stucking issue when the number of running ray jobs increase.
   # Line 'mkdir -p ..': disable host key check
   # Line 'python3 -c ..': patch the buggy ray files and enable `-o allow_other` option for `goofys`
-  # Line 'for failure_indicator in ..': check if any failure indicator exists for the setup done in pod args and print the error message. This is only a best effort, as the
+  # Line 'for step in ..': check if any failure indicator exists for the setup done in pod args and print the error message. This is only a best effort, as the
   # commands in pod args are asynchronous and we cannot guarantee the failure indicators are created before the setup commands finish.
   - |
     mkdir -p ~/.ssh; touch ~/.ssh/config;
     {%- for initial_setup_command in initial_setup_commands %}
     {{ initial_setup_command }}
     {%- endfor %}
+    STEPS=("apt-ssh-setup" "runtime-setup" "env-setup")
     start_epoch=$(date +%s);
     echo "=== Logs for asynchronous ray and skypilot installation ===";
-    [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/runtime-setup.log || 
-    { tail -f -n +1 /tmp/runtime-setup.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
-    [ -f /tmp/runtime-setup.failed ] && { echo "Error: runtime-setup failed. Exiting."; exit 1; } || true;
-    end_epoch=$(date +%s);
-    echo "=== Waiting for asynchronous ray and skypilot installation: $(($end_epoch - $start_epoch)) secs ===";
-    start_epoch_ray_skypilot=$(date +%s);
+    [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log || 
+    { tail -f -n +1 /tmp/${STEPS[1]}.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
+    [ -f /tmp/${STEPS[1]}.failed ] && { echo "Error: ${STEPS[1]} failed. Exiting."; exit 1; } || true;
+    echo "=== Ray and skypilot dependencies installation completed in $(($end_epoch - $start_epoch)) secs ===";
+    start_epoch=$(date +%s);
     {{ skypilot_wheel_installation_commands }}
+    end_epoch=$(date +%s);
+    echo "=== Skypilot wheel installation completed in $(($end_epoch - $start_epoch)) secs ===";
     start_epoch=$(date +%s);
     sudo touch ~/.sudo_as_admin_successful;
     sudo bash -c 'rm -rf /etc/security/limits.d; echo "* soft nofile 1048576" >> /etc/security/limits.conf; echo "* hard nofile 1048576" >> /etc/security/limits.conf';
@@ -583,9 +589,8 @@ setup_commands:
     mkdir -p ~/.ssh; (grep -Pzo -q "Host \*\n  StrictHostKeyChecking no" ~/.ssh/config) || printf "Host *\n  StrictHostKeyChecking no\n" >> ~/.ssh/config;
     [ -f /etc/fuse.conf ] && sudo sed -i 's/#user_allow_other/user_allow_other/g' /etc/fuse.conf || (sudo sh -c 'echo "user_allow_other" > /etc/fuse.conf'); # This is needed for `-o allow_other` option for `goofys`;
     end_epoch=$(date +%s);
-    echo "=== Setup system configs and fuse: $(($end_epoch - $start_epoch)) secs ===";
-    FAILURE_INDICATORS="/tmp/apt-ssh-setup /tmp/env-setup /tmp/runtime-setup";
-    for failure_indicator in $FAILURE_INDICATORS; do [ -f "$failure_indicator.failed" ] && { echo "Error: $failure_indicator.failed found:"; cat $failure_indicator.log; exit 1; } || true; done;
+    echo "=== Setup system configs and fuse completed in $(($end_epoch - $start_epoch)) secs ===";
+    for step in $STEPS; do [ -f "/tmp/${step}.failed" ] && { echo "Error: /tmp/${step}.failed found:"; cat /tmp/${step}.log; exit 1; } || true; done;
     {% if tpu_requested %}
     # The /tmp/tpu_logs directory is where TPU-related logs, such as logs from
     # the TPU runtime, are written. These capture runtime information about the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Moved setup/ray start to the kubernetes pod args to make them async

TODO:
- [x] Better observability: the current logs are in `kubectl logs` instead of the provision.log as before which makes it harder to debug for users. (We now have a best effort for printing out the failed logs if we detect it during setup).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
