### PR TITLE
[Core] Skip worker ray start for multinode

### DIFF
--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -499,20 +499,27 @@ def _post_provision_setup(
         def is_ray_cluster_healthy(ray_status_output: str,
                                    expected_num_nodes: int) -> bool:
             """Parse the output of `ray status` to get #active nodes.
-            
-            The output of `ray status` looks like:
 
+            The output of `ray status` looks like:
+            Node status
+            ---------------------------------------------------------------
+            Active:
+              1 node_291a8b849439ad6186387c35dc76dc43f9058108f09e8b68108cf9ec
+              1 node_0945fbaaa7f0b15a19d2fd3dc48f3a1e2d7c97e4a50ca965f67acbfd
+            Pending:
+            (no pending nodes)
+            Recent failures:
+            (no failures)
             """
             start = ray_status_output.find('Active:')
             end = ray_status_output.find('Pending:', start)
             if start == -1 or end == -1:
                 return False
-            active_nodes = len([
-                line.split()[-1]
-                for line in ray_status_output[start:end].split('\n')
-                if line.strip() and not line.startswith('Active:')
-            ])
-            return active_nodes == expected_num_nodes
+            num_active_nodes = 0
+            for line in ray_status_output[start:end].split('\n'):
+                if line.strip() and not line.startswith('Active:'):
+                    num_active_nodes += 1
+            return num_active_nodes == expected_num_nodes
 
         status.update(
             runtime_preparation_str.format(step=3, step_name='runtime'))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

If the ray cluster is healthy, this skips the worker node `ray start` command, i.e. save N-1 ssh connections, each taking 2 seconds (divided by the parallelism).

This optimization comes from #4389 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
