### PR TITLE
update image generation to use uv

### DIFF
--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -34,11 +34,12 @@ ENV HOME /home/sky
 WORKDIR /home/sky
 
 # Install skypilot dependencies
-RUN conda init && export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-    python3 -m venv ~/skypilot-runtime && \
-    PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
-    $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
+RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=$HOME/.local/bin sh && \
+    export PATH=$PATH:$HOME/.local/bin && \
+    conda init && uv venv --seed ~/skypilot-runtime && \
+    UV_PIP_EXEC="env VIRTUAL_ENV=$(echo ~/skypilot-runtime) uv pip" && \
+    $UV_PIP_EXEC install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+    $UV_PIP_EXEC uninstall skypilot-nightly && \
     curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl" && \
     sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -42,11 +42,12 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x8
     eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true && conda activate base && \
     grep "# >>> conda initialize >>>" ~/.bashrc || { conda init && source ~/.bashrc; } && \
     rm Miniconda3-Linux-x86_64.sh && \
-    export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-    python3 -m venv ~/skypilot-runtime && \
-    PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
-    $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
+    curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=$HOME/.local/bin sh && \
+    export PATH=$PATH:$HOME/.local/bin && \
+    uv venv --seed ~/skypilot-runtime && \
+    UV_PIP_EXEC="env VIRTUAL_ENV=$(echo ~/skypilot-runtime) uv pip" && \
+    $UV_PIP_EXEC install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+    $UV_PIP_EXEC uninstall skypilot-nightly && \
     curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl" && \
     sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -270,7 +270,7 @@ FAQs
 * **Are autoscaling Kubernetes clusters supported?**
 
   To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/config.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
-  This will direct SkyPilot to wait for the cluster to scale up before failing over to the next candidate resource (e.g., next cloud). 
+  This will direct SkyPilot to wait for the cluster to scale up before failing over to the next candidate resource (e.g., next cloud).
 
   If you are using GPUs in a scale-to-zero setting, you should also set the :code:`autoscaler` key to the autoscaler type of your cluster. More details in :ref:`config-yaml`.
 
@@ -344,12 +344,12 @@ FAQs
         eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true && conda activate base && \
         grep "# >>> conda initialize >>>" ~/.bashrc || { conda init && source ~/.bashrc; } && \
         rm Miniconda3-Linux-x86_64.sh && \
-        export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-        python3 -m venv ~/skypilot-runtime && \
-        PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
-        $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-        $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
+        curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=$HOME/.local/bin sh && \
+        export PATH=$PATH:$HOME/.local/bin && \
+        uv venv --seed ~/skypilot-runtime && \
+        UV_PIP_EXEC="env VIRTUAL_ENV=$(echo ~/skypilot-runtime) uv pip" && \
+        $UV_PIP_EXEC install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+        $UV_PIP_EXEC uninstall skypilot-nightly && \
         curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl" && \
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
         echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
-

--- a/sky/clouds/service_catalog/images/README.md
+++ b/sky/clouds/service_catalog/images/README.md
@@ -7,8 +7,9 @@ You only need to do this once.
 ```bash
 packer init plugins.pkr.hcl
 ```
-3. Setup cloud credentials
-4. `cd sky/clouds/service_catalog/images`
+3. Check that docker buildx is installed: `docker buildx` should show a help page. buildx is installed with Docker Desktop but you may have to install separately on Linux.
+4. Setup cloud credentials
+5. `cd sky/clouds/service_catalog/images`
 
 ## Generate Images
 FYI time to packer build images:

--- a/sky/clouds/service_catalog/images/plugins.pkr.hcl
+++ b/sky/clouds/service_catalog/images/plugins.pkr.hcl
@@ -15,3 +15,12 @@ packer {
     }
   }
 }
+
+packer {
+  required_plugins {
+    azure = {
+      source  = "github.com/hashicorp/azure"
+      version = "~> 2"
+    }
+  }
+}

--- a/sky/clouds/service_catalog/images/provisioners/user-toolkit.sh
+++ b/sky/clouds/service_catalog/images/provisioners/user-toolkit.sh
@@ -3,10 +3,12 @@
 
 eval "$(~/miniconda3/bin/conda shell.bash hook)"
 conda activate base
-pip install numpy
-pip install pandas
+
+export PATH=$PATH:$HOME/.local/bin
+uv pip install numpy
+uv pip install pandas
 
 if [ "$AZURE_GRID_DRIVER" = 1 ]; then
     # Need PyTorch X.X.X+cu121 version to be compatible with older NVIDIA driver (535.161.08 or lower)
-    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
+    uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 fi

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -154,7 +154,7 @@ CONDA_INSTALLATION_COMMANDS = (
     f'conda create -y -n {SKY_REMOTE_PYTHON_ENV_NAME} python=3.10 && '
     f'conda activate {SKY_REMOTE_PYTHON_ENV_NAME};'
     # Install uv for venv management and pip installation.
-    'which uv >/dev/null 2>&1 || '
+    f'{SKY_UV_INSTALL_DIR}/uv --version >/dev/null 2>&1 || '
     'curl -LsSf https://astral.sh/uv/install.sh '
     f'| UV_INSTALL_DIR={SKY_UV_INSTALL_DIR} sh;'
     # Create a separate conda environment for SkyPilot dependencies.
@@ -162,7 +162,7 @@ CONDA_INSTALLATION_COMMANDS = (
     # Do NOT use --system-site-packages here, because if users upgrade any
     # packages in the base env, they interfere with skypilot dependencies.
     # Reference: https://github.com/skypilot-org/skypilot/issues/4097
-    f'{SKY_UV_CMD} venv {SKY_REMOTE_PYTHON_ENV};'
+    f'{SKY_UV_CMD} venv --seed {SKY_REMOTE_PYTHON_ENV};'
     f'echo "$(echo {SKY_REMOTE_PYTHON_ENV})/bin/python" > {SKY_PYTHON_PATH_FILE};'
 )
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Also, update runtime_setup to use `uv venv --seed`, which will ensure pip and setuptools are installed in the venv for compatibility.

Once this is approved and merged I will do a final build of all the images on master and open a catalog PR.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
