### PR TITLE
[k8s] Nimbus backward compatibility

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -218,7 +218,7 @@ RAY_INSTALLATION_COMMANDS = (
 SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
     f'{SET_SKY_PIP} '
     f'{{ SKY_PIP list | grep "skypilot " && '
-    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || ' # pylint: disable=line-too-long
+    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '  # pylint: disable=line-too-long
     f'{{ SKY_PIP uninstall skypilot; '
     f'SKY_PIP install "$(echo ~/.sky/wheels/{{sky_wheel_hash}}/'
     f'skypilot-{_sky_version}*.whl)[{{cloud}}, remote]" && '

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -52,7 +52,6 @@ SKY_REMOTE_PYTHON_ENV = f'~/{SKY_REMOTE_PYTHON_ENV_NAME}'
 ACTIVATE_SKY_REMOTE_PYTHON_ENV = f'source {SKY_REMOTE_PYTHON_ENV}/bin/activate'
 # Deleting the SKY_REMOTE_PYTHON_ENV_NAME from the PATH to deactivate the
 # environment. `deactivate` command does not work when conda is used.
-
 DEACTIVATE_SKY_REMOTE_PYTHON_ENV = (
     'export PATH='
     f'$(echo $PATH | sed "s|$(echo ~)/{SKY_REMOTE_PYTHON_ENV_NAME}/bin:||")')

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -208,10 +208,14 @@ RAY_INSTALLATION_COMMANDS = (
     f'which ray > {SKY_RAY_PATH_FILE} || exit 1; }}; ')
 
 SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
-    f'{{ {SKY_UV_PIP_CMD} list | grep "skypilot " && '
-    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '  # pylint: disable=line-too-long
-    f'{{ {SKY_UV_PIP_CMD} uninstall skypilot; '
-    f'{SKY_UV_PIP_CMD} install "$(echo ~/.sky/wheels/{{sky_wheel_hash}}/'
+    # Try uv first, fall back to regular pip if uv is not available.
+    # This is only for backwards compatibility with pre-nimbus SkyPilot versions.
+    # TODO(romilb): Change to using SKY_UV_PIP_CMD after v0.10.0.
+    f'PIP_CMD=$(which uv >/dev/null 2>&1 && echo "{SKY_UV_PIP_CMD}" || echo "{SKY_PIP_CMD}"); '
+    f'{{ $PIP_CMD list | grep "skypilot " && '
+    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '
+    f'{{ $PIP_CMD uninstall skypilot; '
+    f'$PIP_CMD install "$(echo ~/.sky/wheels/{{sky_wheel_hash}}/'
     f'skypilot-{_sky_version}*.whl)[{{cloud}}, remote]" && '
     'echo "{sky_wheel_hash}" > ~/.sky/wheels/current_sky_wheel_hash || '
     'exit 1; }; ')

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -54,7 +54,7 @@ ACTIVATE_SKY_REMOTE_PYTHON_ENV = f'source {SKY_REMOTE_PYTHON_ENV}/bin/activate'
 # uv is used for venv and pip, much faster than python implementations.
 SKY_UV_INSTALL_DIR = '"$HOME/.local/bin"'
 SKY_UV_CMD = f'{SKY_UV_INSTALL_DIR}/uv'
-SKY_UV_PIP_CMD = f'VIRTUAL_ENV={SKY_REMOTE_PYTHON_ENV} {SKY_UV_CMD} pip'
+SKY_UV_PIP_CMD = f'env VIRTUAL_ENV={SKY_REMOTE_PYTHON_ENV} {SKY_UV_CMD} pip'
 # Deleting the SKY_REMOTE_PYTHON_ENV_NAME from the PATH to deactivate the
 # environment. `deactivate` command does not work when conda is used.
 DEACTIVATE_SKY_REMOTE_PYTHON_ENV = (
@@ -211,9 +211,9 @@ SKYPILOT_WHEEL_INSTALLATION_COMMANDS = (
     # Try uv first, fall back to regular pip if uv is not available.
     # This is only for backwards compatibility with pre-nimbus SkyPilot versions.
     # TODO(romilb): Change to using SKY_UV_PIP_CMD after v0.10.0.
-    f'PIP_CMD=$(which uv >/dev/null 2>&1 && echo "{SKY_UV_PIP_CMD}" || echo "{SKY_PIP_CMD}"); '
+    f'PIP_CMD=$(which uv >/dev/null 2>&1 && echo "{SKY_UV_PIP_CMD}" || echo "{SKY_PIP_CMD}"); ' # pylint: disable=line-too-long
     f'{{ $PIP_CMD list | grep "skypilot " && '
-    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || '
+    '[ "$(cat ~/.sky/wheels/current_sky_wheel_hash)" == "{sky_wheel_hash}" ]; } || ' # pylint: disable=line-too-long
     f'{{ $PIP_CMD uninstall skypilot; '
     f'$PIP_CMD install "$(echo ~/.sky/wheels/{{sky_wheel_hash}}/'
     f'skypilot-{_sky_version}*.whl)[{{cloud}}, remote]" && '

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -53,12 +53,6 @@ ACTIVATE_SKY_REMOTE_PYTHON_ENV = f'source {SKY_REMOTE_PYTHON_ENV}/bin/activate'
 # Deleting the SKY_REMOTE_PYTHON_ENV_NAME from the PATH to deactivate the
 # environment. `deactivate` command does not work when conda is used.
 
-# Define SKY_GET_PIP_CMD to try uv first, fall back to regular pip if uv is not
-# available. This is only for backwards compatibility with pre-nimbus SkyPilot
-# versions.
-# TODO(romilb): Change to using SKY_UV_PIP_CMD after v0.10.0.
-SET_SKY_PIP = f'SKY_PIP() {{ which uv >/dev/null 2>&1 && {SKY_UV_PIP_CMD} "$@" || {SKY_PIP_CMD} "$@"; }};'  # pylint: disable=line-too-long
-
 DEACTIVATE_SKY_REMOTE_PYTHON_ENV = (
     'export PATH='
     f'$(echo $PATH | sed "s|$(echo ~)/{SKY_REMOTE_PYTHON_ENV_NAME}/bin:||")')

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -329,7 +329,9 @@ available_node_types:
             - |
               # For backwards compatibility, we put a marker file in the pod
               # to indicate that the pod is running with the changes introduced 
-              # in project nimbus: https://github.com/skypilot-org/skypilot/pull/4393 
+              # in project nimbus: https://github.com/skypilot-org/skypilot/pull/4393
+              # TODO: Remove this marker file and it's usage in setup_commands
+              # after v0.10.0 release.
               touch /tmp/skypilot_is_nimbus
               
               # Helper function to conditionally use sudo

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -327,6 +327,11 @@ available_node_types:
           command: ["/bin/bash", "-c", "--"]
           args: 
             - |
+              # For backwards compatibility, we put a marker file in the pod
+              # to indicate that the pod is running with the changes introduced 
+              # in project nimbus: https://github.com/skypilot-org/skypilot/pull/4393 
+              touch /tmp/skypilot_is_nimbus
+              
               # Helper function to conditionally use sudo
               # TODO(zhwu): consolidate the two prefix_cmd and sudo replacements
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
@@ -575,9 +580,12 @@ setup_commands:
     STEPS=("apt-ssh-setup" "runtime-setup" "env-setup")
     start_epoch=$(date +%s);
     echo "=== Logs for asynchronous ray and skypilot installation ===";
-    [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log || 
-    { tail -f -n +1 /tmp/${STEPS[1]}.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
-    [ -f /tmp/${STEPS[1]}.failed ] && { echo "Error: ${STEPS[1]} failed. Exiting."; exit 1; } || true;
+    if [ -f /tmp/skypilot_is_nimbus ]; then
+      echo "=== Logs for asynchronous ray and skypilot installation ===";
+      [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log || 
+      { tail -f -n +1 /tmp/${STEPS[1]}.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
+      [ -f /tmp/${STEPS[1]}.failed ] && { echo "Error: ${STEPS[1]} failed. Exiting."; exit 1; } || true;
+    fi
     end_epoch=$(date +%s);
     echo "=== Ray and skypilot dependencies installation completed in $(($end_epoch - $start_epoch)) secs ===";
     start_epoch=$(date +%s);


### PR DESCRIPTION
Closes #4397.

Fixes backward compatibility by:
* Adding a marker file to distinguish newer nimbus clusters vs older clusters.
* Waiting/checking log files only this marker exists
* UV/pip handling depending on what's installed

Note that this is partial backward compatibility - if a user launches a cluster with older version, upgrades, and sky launches again, we will not re-run some provisioning steps (e.g., ray setup). Supporting full backward compatibility would require maintaining two very different code paths in the k8s provisioning pipeline, and probably not a good idea. If users need to re-initialize the cluster, they can do `sky down` and `sky launch` again. 

Tested:
- [x] `sky launch -c test` on old branch, switch to this branch and `sky launch -c test` again 
- [x] `sky launch -c test` on old branch, switch to this branch and `sky exec test` 
- [x] `sky launch -c test` twice on this branch 