### PR TITLE
[k8s] Fix in-cluster auth namespace fetching

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1045,11 +1045,14 @@ def get_kube_config_context_namespace(
             the default namespace.
     """
     k8s = kubernetes.kubernetes
-    # Get namespace if using in-cluster config
     ns_path = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
-    if os.path.exists(ns_path):
-        with open(ns_path, encoding='utf-8') as f:
-            return f.read().strip()
+    # If using in-cluster context, get the namespace from the service account
+    # namespace file.
+    if (context_name == kubernetes.in_cluster_context_name() or
+            context_name is None):
+        if os.path.exists(ns_path):
+            with open(ns_path, encoding='utf-8') as f:
+                return f.read().strip()
     # If not in-cluster, get the namespace from kubeconfig
     try:
         contexts, current_context = k8s.config.list_kube_config_contexts()

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1047,7 +1047,8 @@ def get_kube_config_context_namespace(
     k8s = kubernetes.kubernetes
     ns_path = '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
     # If using in-cluster context, get the namespace from the service account
-    # namespace file.
+    # namespace file. Uses the same logic as adaptors.kubernetes._load_config()
+    # to stay consistent with in-cluster config loading.
     if (context_name == kubernetes.in_cluster_context_name() or
             context_name is None):
         if os.path.exists(ns_path):


### PR DESCRIPTION
SkyPilot, when run inside a k8s pod, does not respect the namespace configured in the kubeconfig context. This PR fixes that by using the same logic for namespace loading as for load_config(). 

Tested
- [x] `sky launch` when running in a pod without any kubeconfig file
- [x] `sky launch` when running in a pod with kubeconfig file using a custom namespace