### PR TITLE
fix the pylint hook for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,3 +70,5 @@ repos:
         args:
             - --rcfile=.pylintrc  # Use your custom pylint configuration
             - --load-plugins=pylint_quotes  # Load the pylint-quotes plugin
+        files: ^sky/  # Only include files from the 'sky/' directory
+        exclude: ^sky/skylet/providers/ibm/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     -   id: pylint
         additional_dependencies:
             - pylint-quotes==0.2.3  # Match the version from requirements
-        name: pylint-only-changed-files
+        name: pylint
         args:
             - --rcfile=.pylintrc  # Use your custom pylint configuration
             - --load-plugins=pylint_quotes  # Load the pylint-quotes plugin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,4 +70,3 @@ repos:
         args:
             - --rcfile=.pylintrc  # Use your custom pylint configuration
             - --load-plugins=pylint_quotes  # Load the pylint-quotes plugin
-        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,14 +67,7 @@ repos:
         additional_dependencies:
             - pylint-quotes==0.2.3  # Match the version from requirements
         name: pylint-only-changed-files
-        entry: >
-            bash -c '
-            MERGEBASE=$(git merge-base origin/main HEAD);
-            changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- "sky/*.py" "sky/*.pyi");
-            if [[ -n "$changed_files" ]]; then
-                echo "$changed_files" | tr "\n" "\0" | xargs -0 pylint --load-plugins=pylint_quotes --rcfile=.pylintrc;
-            else
-                echo "Pylint skipped: no files changed in sky/.";
-            fi'
-        pass_filenames: false
-        always_run: true
+        args:
+            - --rcfile=.pylintrc  # Use your custom pylint configuration
+            - --load-plugins=pylint_quotes  # Load the pylint-quotes plugin
+        pass_filenames: true


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The previous [PR](https://github.com/skypilot-org/skypilot/pull/4258) added the pre-commit configuration.

The Pylint hook was not set correctly; it is now properly configured and works the same as [format.sh](https://github.com/skypilot-org/skypilot/blob/master/format.sh).

## Pre commit

```bash
(sky) ➜  skypilot git:(dev/zeping/pre_commit_same_as_format) ✗ (sky) ➜  skypilot git:(dev/zeping/pre_commit_same_as_format) ✗ git commit -m "test"                                          
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
black (IBM specific).................................(no files to check)Skipped
isort (general)..........................................................Passed
isort (IBM specific).................................(no files to check)Skipped
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

sky/utils/controller_utils.py:907: error: Incompatible types in assignment (expression has type "Dict[<nothing>, <nothing>]", variable has type "str")  [assignment]
Found 1 error in 1 file (checked 232 source files)

yapf.....................................................................Passed
pylint...................................................................Failed
- hook id: pylint
- exit code: 20

************* Module sky.utils.controller_utils
sky/utils/controller_utils.py:908:0: W1405: Quote delimiter " is inconsistent with the rest of the file (inconsistent-quotes)
sky/utils/controller_utils.py:908:0: C4001: Invalid string quote ", should be ' (invalid-string-quote)
sky/utils/controller_utils.py:908:4: W0612: Unused variable 'b' (unused-variable)

-----------------------------------
Your code has been rated at 9.92/10

```

## format.sh -> mypy

```bash format.sh 
SkyPilot Black:
All done! ✨ 🍰 ✨
4 files left unchanged.
SkyPilot yapf: Done
SkyPilot isort:
Skipped 4 files
SkyPilot mypy:
sky/utils/controller_utils.py:907: error: Incompatible types in assignment (expression has type "Dict[<nothing>, <nothing>]", variable has type "str")  [assignment]
Found 1 error in 1 file (checked 232 source files)
```
## format.sh -> pylint

```bash
bash format.sh 
SkyPilot Black:
All done! ✨ 🍰 ✨
4 files left unchanged.
SkyPilot yapf: Done
SkyPilot isort:
Skipped 4 files
SkyPilot mypy:
Success: no issues found in 232 source files
Sky Pylint:
************* Module sky.utils.controller_utils
sky/utils/controller_utils.py:907:0: W1405: Quote delimiter " is inconsistent with the rest of the file (inconsistent-quotes)
sky/utils/controller_utils.py:907:0: C4001: Invalid string quote ", should be ' (invalid-string-quote)
sky/utils/controller_utils.py:907:4: W0612: Unused variable 'b' (unused-variable)

-----------------------------------
Your code has been rated at 9.92/10
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
