### PR TITLE
[k8s] Fix resources.image_id backward compatibility

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -41,6 +41,8 @@ class Kubernetes(clouds.Cloud):
     SKY_SSH_KEY_SECRET_NAME = 'sky-ssh-keys'
     SKY_SSH_JUMP_NAME = 'sky-ssh-jump-pod'
 
+    LEGACY_SINGLETON_REGION = 'kubernetes'
+
     # Limit the length of the cluster name to avoid exceeding the limit of 63
     # characters for Kubernetes resources. We limit to 42 characters (63-21) to
     # allow additional characters for creating ingress services to expose ports.
@@ -54,7 +56,6 @@ class Kubernetes(clouds.Cloud):
     _DEFAULT_MEMORY_CPU_RATIO = 1
     _DEFAULT_MEMORY_CPU_RATIO_WITH_GPU = 4  # Allocate more memory for GPU tasks
     _REPR = 'Kubernetes'
-    _LEGACY_SINGLETON_REGION = 'kubernetes'
     _CLOUD_UNSUPPORTED_FEATURES = {
         # TODO(romilb): Stopping might be possible to implement with
         #  container checkpointing introduced in Kubernetes v1.25. See:
@@ -630,7 +631,7 @@ class Kubernetes(clouds.Cloud):
             instance_type)
 
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        if region == self._LEGACY_SINGLETON_REGION:
+        if region == self.LEGACY_SINGLETON_REGION:
             # For backward compatibility, we allow the region to be set to the
             # legacy singleton region.
             # TODO: Remove this after 0.9.0.

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1616,7 +1616,7 @@ class Resources:
             legacy_region = clouds.Kubernetes().LEGACY_SINGLETON_REGION
             original_cloud = state.get('_cloud', None)
             original_region = state.get('_region', None)
-            if (clouds.Kubernetes().is_same_cloud(original_cloud) and
+            if (isinstance(original_cloud, clouds.Kubernetes) and
                     original_region == legacy_region):
                 current_context = (
                     kubernetes_utils.get_current_kube_config_context_name())

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1606,19 +1606,20 @@ class Resources:
         if version < 19:
             self._cluster_config_overrides = state.pop(
                 '_cluster_config_overrides', None)
-        
+
         if version < 20:
             # Pre-0.7.0, we used 'kubernetes' as the default region for
             # Kubernetes clusters. With the introduction of support for
             # multiple contexts, we now set the region to the context name.
-            # Since we do not have information on which context the cluster 
+            # Since we do not have information on which context the cluster
             # was run in, we default it to the current active context.
             legacy_region = clouds.Kubernetes().LEGACY_SINGLETON_REGION
             original_cloud = state.get('_cloud', None)
             original_region = state.get('_region', None)
             if (clouds.Kubernetes().is_same_cloud(original_cloud) and
-                original_region == legacy_region):
-                current_context = kubernetes_utils.get_current_kube_config_context_name()
+                    original_region == legacy_region):
+                current_context = (
+                    kubernetes_utils.get_current_kube_config_context_name())
                 state['_region'] = current_context
                 # Also update the image_id dict if it contains the old region
                 if isinstance(state['_image_id'], dict):


### PR DESCRIPTION
User reported upgrading from 0.6.1 to 0.7.0 broke `sky status` and other commands when state.db had a k8s cluster using a custom image:
```
$ sky status
ValueError: image_id {'kubernetes': 'docker:ubuntu:22.04'} should contain the image for the specified region
```

This happens because we renamed the default region for k8s from the constant `kubernetes` to the context name. 

This PR fixes backward compatibility for `sky.Resources` by replacing `kubernetes` in `_image_id` dict with the current active context when an older version is detected. Ideally we should use the context used in the previous launch, but that information is not available to us. 

Tested:
- [x] Manual backward compatibility - checkout 0.6.1, `sky launch --cloud kubernetes --image-id docker:ubuntu:22.04`, upgrade to this branch, `sky status`
- [x] `sky launch --cloud kubernetes --image-id docker:ubuntu:22.04` twice on this branch