### PR TITLE
[Docs] Refactor pod_config docs

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -283,7 +283,7 @@ For example, to set custom environment variables and use GPUDirect RDMA, you can
                   rdma/rdma_shared_device_a: 1
 
 
-Similarly, you can attach `Kubernetes volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`_ (e.g., a `NFS volume <https://kubernetes.io/docs/concepts/storage/volumes/#nfs>`_) directly to your SkyPilot pods:
+Similarly, you can attach `Kubernetes volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`_ (e.g., an `NFS volume <https://kubernetes.io/docs/concepts/storage/volumes/#nfs>`_) directly to your SkyPilot pods:
 
 .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -304,7 +304,7 @@ Similarly, you can attach `Kubernetes volumes <https://kubernetes.io/docs/concep
 
 .. tip::
 
-    You can set the ``pod_config`` on a per-task basis directly in your task YAML with the ``config_overrides`` :ref:`field <task-yaml-experimental>`.
+    As an alternative to setting ``pod_config`` globally, you can also set it on a per-task basis directly in your task YAML with the ``config_overrides`` :ref:`field <task-yaml-experimental>`.
 
     .. code-block:: yaml
 


### PR DESCRIPTION
Makes kubernetes.pod_config it's own subsection for easier referencing, adds NFS example.

- [x] Rendered locally.