### PR TITLE
[k8s] Fix `show-gpus` availability map when nvidia drivers are not installed

### DIFF
--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -243,7 +243,7 @@ def _list_accelerators(
                     quantized_availability = min_quantity_filter * (
                         accelerators_available // min_quantity_filter)
                     total_accelerators_available[accelerator_name] = (
-                        total_accelerators_available.get(accelerator_name, 0) + 
+                        total_accelerators_available.get(accelerator_name, 0) +
                         quantized_availability)
 
     result = []

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -239,13 +239,12 @@ def _list_accelerators(
 
                 accelerators_available = accelerator_count - allocated_qty
 
-                if accelerator_name not in total_accelerators_available:
-                    total_accelerators_available[accelerator_name] = 0
                 if accelerators_available >= min_quantity_filter:
                     quantized_availability = min_quantity_filter * (
                         accelerators_available // min_quantity_filter)
-                    total_accelerators_available[
-                        accelerator_name] += quantized_availability
+                    total_accelerators_available[accelerator_name] = (
+                        total_accelerators_available.get(accelerator_name, 0) + 
+                        quantized_availability)
 
     result = []
 


### PR DESCRIPTION
When nvidia drivers are not installed, `sky show-gpus --cloud kubernetes` would fail with:

```
AssertionError: Keys of counts ([]), capacity ([]), and available (['T4']) must be same.
```

This is because we were adding GPUs to the available table if the label was present, even if the resource did not exist. This PR fixes it by adding a GPU to available only if both conditions are satisfied - resource exists and labels are present.

Tested:
- [x] GKE cluster with and without GPU drivers.