### PR TITLE
[k8s] Minor: fix dictionary merging logic

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1710,8 +1710,6 @@ def merge_dicts(source: Dict[Any, Any], destination: Dict[Any, Any]):
             else:
                 destination[key].extend(value)
         else:
-            if destination is None:
-                destination = {}
             destination[key] = value
 
 


### PR DESCRIPTION
Merge dict logic had some redundant code - destination can (and should) never be None, so this code path would never be reached. 

Tested:
TODO: Add unit tests.