### PR TITLE
[k8s] Add resource limits only if they exist

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -560,6 +560,7 @@ available_node_types:
               # https://gitlab.com/arm-research/smarter/smarter-device-manager
               smarter-devices/fuse: "1"
               {% endif %}
+            {% if k8s_resource_key is not none or k8s_fuse_device_required %}
             limits:
               # Limits need to be defined for GPU/TPU requests
               {% if k8s_resource_key is not none %}
@@ -568,7 +569,8 @@ available_node_types:
               {% if k8s_fuse_device_required %}
               smarter-devices/fuse: "1"
               {% endif %}
-
+            {% endif %}
+            
 setup_commands:
   # Disable `unattended-upgrades` to prevent apt-get from hanging. It should be called at the beginning before the process started to avoid being blocked. (This is a temporary fix.)
   # Create ~/.ssh/config file in case the file does not exist in the image.


### PR DESCRIPTION
Currently if an accelerator is not specified and FUSE is not required by the pod, we set `limits` to null. This PR adds resource limits to the pod spec only if they exist.

Tested (run the relevant ones):
```
#~/.sky/config.yaml
kubernetes:
  pod_config:
    spec:
      containers:
        - resources:          # Custom resource requests and limits
            requests:
              rdma/rdma_shared_device_a: 1
            limits:
              rdma/rdma_shared_device_a: 1
```
`sky launch --cloud kubernetes -- echo hi`