### PR TITLE
[Jobs] Restart dashboard when refreshing the controller

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import traceback
 import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
 import webbrowser
@@ -72,6 +73,7 @@ from sky.utils import admin_policy_utils
 from sky.utils import common_utils
 from sky.utils import controller_utils
 from sky.utils import dag_utils
+from sky.utils import env_options
 from sky.utils import log_utils
 from sky.utils import resources_utils
 from sky.utils import rich_utils
@@ -1398,8 +1400,12 @@ def _get_managed_jobs(
                 f'Details: {common_utils.format_exception(e, use_bracket=True)}'
             )
     except Exception as e:  # pylint: disable=broad-except
-        msg = ('Failed to query managed jobs: '
-               f'{common_utils.format_exception(e, use_bracket=True)}')
+        msg = ''
+        if env_options.Options.SHOW_DEBUG_INFO.get():
+            msg += traceback.format_exc()
+            msg += '\n'
+        msg += ('Failed to query managed jobs: '
+                f'{common_utils.format_exception(e, use_bracket=True)}')
     else:
         max_jobs_to_show = (_NUM_MANAGED_JOBS_TO_SHOW_IN_STATUS
                             if limit_num_jobs_to_show else None)

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -1,4 +1,7 @@
 """Constants used for Managed Jobs."""
+from typing import Dict, Union
+
+from sky.skylet import constants as skylet_constants
 
 JOBS_CONTROLLER_TEMPLATE = 'jobs-controller.yaml.j2'
 JOBS_CONTROLLER_YAML_PREFIX = '~/.sky/jobs_controller'
@@ -13,7 +16,11 @@ JOBS_TASK_YAML_PREFIX = '~/.sky/managed_jobs'
 # OOM (each vCPU can have 4 jobs controller processes as we set the CPU
 # requirement to 0.25, and 3 GB is barely enough for 4 job processes).
 # We use 50 GB disk size to reduce the cost.
-CONTROLLER_RESOURCES = {'cpus': '8+', 'memory': '3x', 'disk_size': 50}
+CONTROLLER_RESOURCES: Dict[str, Union[str, int]] = {
+    'cpus': '8+',
+    'memory': '3x',
+    'disk_size': 50
+}
 
 # Max length of the cluster name for GCP is 35, the user hash to be attached is
 # 4+1 chars, and we assume the maximum length of the job id is 4+1, so the max
@@ -25,3 +32,13 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # change for the jobs/utils, we need to bump this version and update
 # job.utils.ManagedJobCodeGen to handle the version update.
 MANAGED_JOBS_VERSION = 1
+
+DASHBOARD_SETUP_CMD = (
+    'ps aux | grep -v nohup | grep -v grep | grep -- "-m sky.spot.dashboard" | '
+    'awk \'{print $2}\' | xargs kill > /dev/null 2>&1 || true; '
+    'pip list | grep flask  > /dev/null 2>&1 || '
+    'pip install flask 2>&1 > /dev/null; '
+    '((ps aux | grep -v nohup | grep -v grep | '
+    'grep -q -- "-m sky.jobs.dashboard.dashboard") || '
+    f'(nohup {skylet_constants.SKY_PYTHON_CMD} -m sky.jobs.dashboard.dashboard '
+    '>> ~/.sky/job-dashboard.log 2>&1 &));')

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -27,9 +27,7 @@ setup: |
   {% endif %}
 
   # Dashboard.
-  ps aux | grep -v nohup | grep -v grep | grep -- "-m sky.spot.dashboard" | awk '{print $2}' | xargs kill > /dev/null 2>&1 || true
-  pip list | grep flask  > /dev/null 2>&1 || pip install flask 2>&1 > /dev/null
-  ((ps aux | grep -v nohup | grep -v grep | grep -q -- "-m sky.jobs.dashboard.dashboard") || (nohup {{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard >> ~/.sky/job-dashboard.log 2>&1 &));
+  {{ dashboard_setup_cmd }}
 
 run: |
   {{ sky_activate_python_env }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, the dashboard is not restarted when `sky jobs queue/logs --refresh` is used. This can be quite confusing when running `sky jobs dashboard` but seeing nothing for the dashboard

Future TODO:
- `sky start sky-jobs-controller-...` should restart the dashboard as well.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
