### PR TITLE
[robustness] cover some potential resource leakage cases

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1836,10 +1836,10 @@ def _update_cluster_status_no_lock(
 
     # All cases below are transitioning the cluster to non-UP states.
 
-    if not node_statuses:
-        time_since_launch = time.time() - record['launched_at']
-        if (record['status'] == status_lib.ClusterStatus.INIT and
-                time_since_launch < _LAUNCH_DOUBLE_CHECK_WINDOW):
+    if not node_statuses and record['status'] == status_lib.ClusterStatus.INIT:
+        cluster_duration = global_user_state.get_cluster_duration(
+            record['cluster_hash'])
+        if cluster_duration < _LAUNCH_DOUBLE_CHECK_WINDOW:
             # It's possible the instances for this cluster were just created,
             # and haven't appeared yet in the cloud API/console. Wait for a bit
             # and check again. This is a best-effort leak prevention check.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -123,7 +123,7 @@ _ENDPOINTS_RETRY_MESSAGE = ('If the cluster was recently started, '
 # request) and (the instances appearing on the cloud).
 # See https://github.com/skypilot-org/skypilot/issues/4431.
 _LAUNCH_DOUBLE_CHECK_WINDOW = 60
-_LAUNCH_DOUBLE_CHECK_DELAY = 2
+_LAUNCH_DOUBLE_CHECK_DELAY = 1
 
 # Include the fields that will be used for generating tags that distinguishes
 # the cluster in ray, to avoid the stopped cluster being discarded due to
@@ -1803,13 +1803,12 @@ def _update_cluster_status_no_lock(
             logger.debug(
                 f'Refreshing status ({cluster_name!r}) failed to get IPs.')
         except RuntimeError as e:
-            logger.debug(str(e))
+            logger.debug(common_utils.format_exception(e))
         except Exception as e:  # pylint: disable=broad-except
             # This can be raised by `external_ssh_ports()`, due to the
             # underlying call to kubernetes API.
-            logger.debug(
-                f'Refreshing status ({cluster_name!r}) failed: '
-                f'{common_utils.format_exception(e, use_bracket=True)}')
+            logger.debug(f'Refreshing status ({cluster_name!r}) failed: ',
+                         exc_info=e)
         return False
 
     # Determining if the cluster is healthy (UP):

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1836,10 +1836,14 @@ def _update_cluster_status_no_lock(
 
     # All cases below are transitioning the cluster to non-UP states.
 
-    if not node_statuses and record['status'] == status_lib.ClusterStatus.INIT:
-        cluster_duration = global_user_state.get_cluster_duration(
-            record['cluster_hash'])
-        if cluster_duration < _LAUNCH_DOUBLE_CHECK_WINDOW:
+    if not node_statuses:
+        # Note: launched_at is set during sky launch, even on an existing
+        # cluster. This could cause extra checks if the cluster was already up
+        # before sky launch, but it will catch the case where the cluster was
+        # terminated on the cloud and restarted by sky launch.
+        time_since_launch = time.time() - record['launched_at']
+        if (record['status'] == status_lib.ClusterStatus.INIT and
+                time_since_launch < _LAUNCH_DOUBLE_CHECK_WINDOW):
             # It's possible the instances for this cluster were just created,
             # and haven't appeared yet in the cloud API/console. Wait for a bit
             # and check again. This is a best-effort leak prevention check.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1836,7 +1836,7 @@ def _update_cluster_status_no_lock(
 
     # All cases below are transitioning the cluster to non-UP states.
 
-    if len(node_statuses) == 0:
+    if not node_statuses:
         time_since_launch = time.time() - record['launched_at']
         if (record['status'] == status_lib.ClusterStatus.INIT and
                 time_since_launch < _LAUNCH_DOUBLE_CHECK_WINDOW):
@@ -1881,7 +1881,7 @@ def _update_cluster_status_no_lock(
     # terminated and we can set the cluster status to TERMINATED. This handles
     # the edge case where the cluster is terminated by the user manually through
     # the UI.
-    to_terminate = len(node_statuses) == 0
+    to_terminate = not node_statuses
 
     # A cluster is considered "abnormal", if some (but not all) nodes are
     # TERMINATED, or not all nodes are STOPPED. We check that with the following

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1836,7 +1836,8 @@ def _update_cluster_status_no_lock(
 
     # All cases below are transitioning the cluster to non-UP states.
 
-    if not node_statuses:
+    if (not node_statuses and handle.launched_resources.cloud.STATUS_VERSION >=
+            clouds.StatusVersion.SKYPILOT):
         # Note: launched_at is set during sky launch, even on an existing
         # cluster. This could cause extra checks if the cluster was already up
         # before sky launch, but it will catch the case where the cluster was

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1839,9 +1839,8 @@ def _update_cluster_status_no_lock(
     if (not node_statuses and handle.launched_resources.cloud.STATUS_VERSION >=
             clouds.StatusVersion.SKYPILOT):
         # Note: launched_at is set during sky launch, even on an existing
-        # cluster. This could cause extra checks if the cluster was already up
-        # before sky launch, but it will catch the case where the cluster was
-        # terminated on the cloud and restarted by sky launch.
+        # cluster. This will catch the case where the cluster was terminated on
+        # the cloud and restarted by sky launch.
         time_since_launch = time.time() - record['launched_at']
         if (record['status'] == status_lib.ClusterStatus.INIT and
                 time_since_launch < _LAUNCH_DOUBLE_CHECK_WINDOW):

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2802,9 +2802,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     if e.no_failover:
                         error_message = str(e)
                     else:
-                        # Clean up the cluster's entry in `sky status`.
-                        global_user_state.remove_cluster(cluster_name,
-                                                         terminate=True)
                         usage_lib.messages.usage.update_final_cluster_status(
                             None)
                         error_message = (
@@ -3977,7 +3974,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 limit=1000).get_result()['items']
             vpc_id = None
             try:
-                # pylint: disable=line-too-long
                 vpc_id = vpcs_filtered_by_tags_and_region[0]['crn'].rsplit(
                     ':', 1)[-1]
                 vpc_found = True
@@ -3986,7 +3982,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 returncode = -1
 
             if vpc_found:
-                # pylint: disable=line-too-long E1136
                 # Delete VPC and it's associated resources
                 vpc_provider = IBMVPCProvider(
                     config_provider['resource_group_id'], region,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4133,7 +4133,14 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         backend_utils.SSHConfigHelper.remove_cluster(handle.cluster_name)
 
         # Confirm that instances have actually transitioned state before
-        # updating the state database.
+        # updating the state database. We do this immediately before removing
+        # the state from the database, so that we can guarantee that this is
+        # always called before the state is removed. We considered running this
+        # check as part of provisioner.teardown_cluster or
+        # provision.terminate_instances, but it would open the door code paths
+        # that successfully call this function but do not first call
+        # teardown_cluster or terminate_instances. See
+        # https://github.com/skypilot-org/skypilot/pull/4443#discussion_r1872798032
         attempts = 0
         while True:
             logger.debug(f'instance statuses attempt {attempts + 1}')

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -477,7 +477,7 @@ def _get_cluster_launch_time(cluster_hash: str) -> Optional[int]:
     return usage_intervals[0][0]
 
 
-def get_cluster_duration(cluster_hash: str) -> int:
+def _get_cluster_duration(cluster_hash: str) -> int:
     total_duration = 0
     usage_intervals = _get_cluster_usage_intervals(cluster_hash)
 
@@ -678,7 +678,7 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
         record = {
             'name': name,
             'launched_at': _get_cluster_launch_time(cluster_hash),
-            'duration': get_cluster_duration(cluster_hash),
+            'duration': _get_cluster_duration(cluster_hash),
             'num_nodes': num_nodes,
             'resources': pickle.loads(launched_resources),
             'cluster_hash': cluster_hash,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -477,7 +477,7 @@ def _get_cluster_launch_time(cluster_hash: str) -> Optional[int]:
     return usage_intervals[0][0]
 
 
-def _get_cluster_duration(cluster_hash: str) -> int:
+def get_cluster_duration(cluster_hash: str) -> int:
     total_duration = 0
     usage_intervals = _get_cluster_usage_intervals(cluster_hash)
 
@@ -678,7 +678,7 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
         record = {
             'name': name,
             'launched_at': _get_cluster_launch_time(cluster_hash),
-            'duration': _get_cluster_duration(cluster_hash),
+            'duration': get_cluster_duration(cluster_hash),
             'num_nodes': num_nodes,
             'resources': pickle.loads(launched_resources),
             'cluster_hash': cluster_hash,

--- a/sky/provision/azure/instance.py
+++ b/sky/provision/azure/instance.py
@@ -101,8 +101,8 @@ class AzureInstanceStatus(enum.Enum):
     ) -> Dict['AzureInstanceStatus', Optional[status_lib.ClusterStatus]]:
         return {
             cls.PENDING: status_lib.ClusterStatus.INIT,
-            cls.STOPPING: status_lib.ClusterStatus.INIT,
             cls.RUNNING: status_lib.ClusterStatus.UP,
+            cls.STOPPING: status_lib.ClusterStatus.STOPPED,
             cls.STOPPED: status_lib.ClusterStatus.STOPPED,
             cls.DELETING: None,
         }

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -52,6 +52,8 @@ def _filter_instances(
 # non_terminated_only=True?
 # Will there be callers who would want this to be False?
 # stop() and terminate() for example already implicitly assume non-terminated.
+# Currently, even with non_terminated_only=False, we may not have a dict entry
+# for terminated instances, if they have already been fully deleted.
 @common_utils.retry
 def query_instances(
     cluster_name_on_cloud: str,

--- a/sky/provision/lambda_cloud/instance.py
+++ b/sky/provision/lambda_cloud/instance.py
@@ -233,7 +233,7 @@ def query_instances(
         'booting': status_lib.ClusterStatus.INIT,
         'active': status_lib.ClusterStatus.UP,
         'unhealthy': status_lib.ClusterStatus.INIT,
-        'terminating': status_lib.ClusterStatus.INIT,
+        'terminating': None,
     }
     statuses: Dict[str, Optional[status_lib.ClusterStatus]] = {}
     for instance_id, instance in instances.items():

--- a/sky/provision/paperspace/instance.py
+++ b/sky/provision/paperspace/instance.py
@@ -286,12 +286,13 @@ def query_instances(
     assert provider_config is not None, (cluster_name_on_cloud, provider_config)
     instances = _filter_instances(cluster_name_on_cloud, None)
 
+    # https://docs.digitalocean.com/reference/paperspace/core/commands/machines/#show
     status_map = {
         'starting': status_lib.ClusterStatus.INIT,
         'restarting': status_lib.ClusterStatus.INIT,
         'upgrading': status_lib.ClusterStatus.INIT,
         'provisioning': status_lib.ClusterStatus.INIT,
-        'stopping': status_lib.ClusterStatus.INIT,
+        'stopping': status_lib.ClusterStatus.STOPPED,
         'serviceready': status_lib.ClusterStatus.INIT,
         'ready': status_lib.ClusterStatus.UP,
         'off': status_lib.ClusterStatus.STOPPED,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Includes the following changes: 

**[if a newly-created cluster is missing from the cloud, wait before deleting](https://github.com/skypilot-org/skypilot/pull/4443/commits/4daf50098c87d8a44c0864236cacae144bad5679)**
This protects against leaking instances that haven't appeared yet, because they were just created.
Addresses #4431, see that issue for more details.
- This is observed to affect AWS if the timing is exactly right - there's a <1s window where the instances have not yet appeared.
- Haven't been able to reproduce this on any other clouds.

**[confirm cluster actually terminates before deleting from the db](https://github.com/skypilot-org/skypilot/pull/4443/commits/b18b95980ffbaafe420a21c1a99d794f7b475dff)**
Previously, we optimistically assumed that a successful termination request will always delete cloud instances. This change validates that the instances are actually terminating or terminated before deleting them from our state database. This protects against silent failures in the termination, which are not expected, but are hypothesized to be possible.
- This potential leak has not been reproduced.
- This does not add any additional delay to AWS or GCP. Azure takes around 10s to transition the instances, so cluster teardown now takes that much longer.

**[avoid deleting cluster data outside the primary provision loop](https://github.com/skypilot-org/skypilot/pull/4443/commits/43e459eb297cd414852824f4f55f9b62265202f4)**
The main provision/failover/retry loop is quite complicated. There were some areas of code which could throw an exception and delete the cluster from our state database without terminating the instances. Attempt to clean up these paths.
The previous change (confirm cluster actually terminates before deleting from the db) also makes the provision loop safer. Since the instance termination and the state cleanup are in different places, this protects against the case where we don't successfully terminate the instances but still clean up our local state.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

part of #4410

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- Any manual or new tests for this PR (please specify below)
  - [x] Manually tried to reproduce leaks on AWS, Azure, and GCP. For successfully reproduced leaks (#4431), verified the fix.
  - [x] Normal launch and failover on these clouds.
  - [x] `sky launch --gpus H100:8` for longer failover checking
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_minimal` (on aws, azure, gcp)
