### PR TITLE
smoke tests support storage mount only

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -37,7 +37,7 @@ import sys
 import tempfile
 import textwrap
 import time
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, TextIO, Tuple
 import urllib.parse
 import uuid
 
@@ -1333,34 +1333,68 @@ def test_using_file_mounts_with_env_vars(generic_cloud: str):
 
 
 # ---------- storage ----------
+
+
+def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
+                                       storage_name: str, ls_hello_command: str,
+                                       cloud: str, only_allow_mount: bool):
+    template_str = pathlib.Path(
+        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
+    template = jinja2.Template(template_str)
+    content = template.render(
+        storage_name=storage_name,
+        cloud=cloud,
+        only_allow_mount=only_allow_mount,
+    )
+    f.write(content)
+    f.flush()
+    file_path = f.name
+    test_commands = [
+        *STORAGE_SETUP_COMMANDS,
+        f'sky launch -y -c {cluster_name} --cloud {cloud} {file_path}',
+        f'sky logs {cluster_name} 1 --status',  # Ensure job succeeded.
+        ls_hello_command,
+        f'sky stop -y {cluster_name}',
+        f'sky start -y {cluster_name}',
+        # Check if hello.txt from mounting bucket exists after restart in
+        # the mounted directory
+        f'sky exec {cluster_name} -- "set -ex; ls /mount_private_mount/hello.txt"',
+    ]
+    clean_command = f'sky down -y {cluster_name}; sky storage delete -y {storage_name}'
+    return test_commands, clean_command
+
+
 @pytest.mark.aws
 def test_aws_storage_mounts_with_stop():
     name = _get_cluster_name()
     cloud = 'aws'
     storage_name = f'sky-test-{int(time.time())}'
-    template_str = pathlib.Path(
-        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
-    template = jinja2.Template(template_str)
-    content = template.render(storage_name=storage_name, cloud=cloud)
+    ls_hello_command = f'aws s3 ls {storage_name}/hello.txt'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        f.write(content)
-        f.flush()
-        file_path = f.name
-        test_commands = [
-            *STORAGE_SETUP_COMMANDS,
-            f'sky launch -y -c {name} --cloud {cloud} {file_path}',
-            f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'aws s3 ls {storage_name}/hello.txt',
-            f'sky stop -y {name}',
-            f'sky start -y {name}',
-            # Check if hello.txt from mounting bucket exists after restart in
-            # the mounted directory
-            f'sky exec {name} -- "set -ex; ls /mount_private_mount/hello.txt"'
-        ]
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, False)
         test = Test(
             'aws_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            clean_command,
+            timeout=20 * 60,  # 20 mins
+        )
+        run_one_test(test)
+
+
+@pytest.mark.aws
+def test_aws_storage_mounts_with_stop_only_allow_mount():
+    name = _get_cluster_name()
+    cloud = 'aws'
+    storage_name = f'sky-test-{int(time.time())}'
+    ls_hello_command = f'aws s3 ls {storage_name}/hello.txt'
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, True)
+        test = Test(
+            'aws_storage_mounts_only_allow_mount',
+            test_commands,
+            clean_command,
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -1371,29 +1405,32 @@ def test_gcp_storage_mounts_with_stop():
     name = _get_cluster_name()
     cloud = 'gcp'
     storage_name = f'sky-test-{int(time.time())}'
-    template_str = pathlib.Path(
-        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
-    template = jinja2.Template(template_str)
-    content = template.render(storage_name=storage_name, cloud=cloud)
+    ls_hello_command = f'gsutil ls gs://{storage_name}/hello.txt'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        f.write(content)
-        f.flush()
-        file_path = f.name
-        test_commands = [
-            *STORAGE_SETUP_COMMANDS,
-            f'sky launch -y -c {name} --cloud {cloud} {file_path}',
-            f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'gsutil ls gs://{storage_name}/hello.txt',
-            f'sky stop -y {name}',
-            f'sky start -y {name}',
-            # Check if hello.txt from mounting bucket exists after restart in
-            # the mounted directory
-            f'sky exec {name} -- "set -ex; ls /mount_private_mount/hello.txt"'
-        ]
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, False)
         test = Test(
             'gcp_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            clean_command,
+            timeout=20 * 60,  # 20 mins
+        )
+        run_one_test(test)
+
+
+@pytest.mark.gcp
+def test_gcp_storage_mounts_with_stop_only_allow_mount():
+    name = _get_cluster_name()
+    cloud = 'gcp'
+    storage_name = f'sky-test-{int(time.time())}'
+    ls_hello_command = f'gsutil ls gs://{storage_name}/hello.txt'
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, True)
+        test = Test(
+            'gcp_storage_mounts_only_allow_mount',
+            test_commands,
+            clean_command,
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -1409,31 +1446,45 @@ def test_azure_storage_mounts_with_stop():
                             get_default_storage_account_name(default_region))
     storage_account_key = data_utils.get_az_storage_account_key(
         storage_account_name)
-    template_str = pathlib.Path(
-        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
-    template = jinja2.Template(template_str)
-    content = template.render(storage_name=storage_name, cloud=cloud)
+    ls_hello_command = (f'output=$(az storage blob list -c {storage_name} '
+                        f'--account-name {storage_account_name} '
+                        f'--account-key {storage_account_key} '
+                        f'--prefix hello.txt) '
+                        f'[ "$output" = "[]" ] && exit 1')
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        f.write(content)
-        f.flush()
-        file_path = f.name
-        test_commands = [
-            *STORAGE_SETUP_COMMANDS,
-            f'sky launch -y -c {name} --cloud {cloud} {file_path}',
-            f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'output=$(az storage blob list -c {storage_name} --account-name {storage_account_name} --account-key {storage_account_key} --prefix hello.txt)'
-            # if the file does not exist, az storage blob list returns '[]'
-            f'[ "$output" = "[]" ] && exit 1;'
-            f'sky stop -y {name}',
-            f'sky start -y {name}',
-            # Check if hello.txt from mounting bucket exists after restart in
-            # the mounted directory
-            f'sky exec {name} -- "set -ex; ls /mount_private_mount/hello.txt"'
-        ]
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, False)
         test = Test(
             'azure_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            clean_command,
+            timeout=20 * 60,  # 20 mins
+        )
+        run_one_test(test)
+
+
+@pytest.mark.azure
+def test_azure_storage_mounts_with_stop_only_allow_mount():
+    name = _get_cluster_name()
+    cloud = 'azure'
+    storage_name = f'sky-test-{int(time.time())}'
+    default_region = 'eastus'
+    storage_account_name = (storage_lib.AzureBlobStore.
+                            get_default_storage_account_name(default_region))
+    storage_account_key = data_utils.get_az_storage_account_key(
+        storage_account_name)
+    ls_hello_command = (f'output=$(az storage blob list -c {storage_name} '
+                        f'--account-name {storage_account_name} '
+                        f'--account-key {storage_account_key} '
+                        f'--prefix hello.txt) '
+                        f'[ "$output" = "[]" ] && exit 1')
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, cloud, True)
+        test = Test(
+            'azure_storage_mounts_only_allow_mount',
+            test_commands,
+            clean_command,
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)
@@ -1446,25 +1497,15 @@ def test_kubernetes_storage_mounts():
     # built for x86_64 only.
     name = _get_cluster_name()
     storage_name = f'sky-test-{int(time.time())}'
-    template_str = pathlib.Path(
-        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
-    template = jinja2.Template(template_str)
-    content = template.render(storage_name=storage_name)
+    ls_hello_command = (f'aws s3 ls {storage_name}/hello.txt || '
+                        f'gsutil ls gs://{storage_name}/hello.txt')
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        f.write(content)
-        f.flush()
-        file_path = f.name
-        test_commands = [
-            *STORAGE_SETUP_COMMANDS,
-            f'sky launch -y -c {name} --cloud kubernetes {file_path}',
-            f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'aws s3 ls {storage_name}/hello.txt || '
-            f'gsutil ls gs://{storage_name}/hello.txt',
-        ]
+        test_commands, clean_command = _storage_mounts_commands_generator(
+            f, name, storage_name, ls_hello_command, 'kubernetes', False)
         test = Test(
             'kubernetes_storage_mounts',
             test_commands,
-            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            clean_command,
             timeout=20 * 60,  # 20 mins
         )
         run_one_test(test)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1446,11 +1446,12 @@ def test_azure_storage_mounts_with_stop():
                             get_default_storage_account_name(default_region))
     storage_account_key = data_utils.get_az_storage_account_key(
         storage_account_name)
+    # if the file does not exist, az storage blob list returns '[]'
     ls_hello_command = (f'output=$(az storage blob list -c {storage_name} '
                         f'--account-name {storage_account_name} '
                         f'--account-key {storage_account_key} '
                         f'--prefix hello.txt) '
-                        f'[ "$output" = "[]" ] && exit 1')
+                        f'[ "$output" = "[]" ] && exit 1 || exit 0')
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
             f, name, storage_name, ls_hello_command, cloud, False)
@@ -1477,7 +1478,7 @@ def test_azure_storage_mounts_with_stop_only_allow_mount():
                         f'--account-name {storage_account_name} '
                         f'--account-key {storage_account_key} '
                         f'--prefix hello.txt) '
-                        f'[ "$output" = "[]" ] && exit 1')
+                        f'[ "$output" = "[]" ] && exit 1 || exit 0')
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
             f, name, storage_name, ls_hello_command, cloud, True)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1337,14 +1337,14 @@ def test_using_file_mounts_with_env_vars(generic_cloud: str):
 
 def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
                                        storage_name: str, ls_hello_command: str,
-                                       cloud: str, only_allow_mount: bool):
+                                       cloud: str, only_mount: bool):
     template_str = pathlib.Path(
         'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
     template = jinja2.Template(template_str)
     content = template.render(
         storage_name=storage_name,
         cloud=cloud,
-        only_allow_mount=only_allow_mount,
+        only_mount=only_mount,
     )
     f.write(content)
     f.flush()
@@ -1383,7 +1383,7 @@ def test_aws_storage_mounts_with_stop():
 
 
 @pytest.mark.aws
-def test_aws_storage_mounts_with_stop_only_allow_mount():
+def test_aws_storage_mounts_with_stop_only_mount():
     name = _get_cluster_name()
     cloud = 'aws'
     storage_name = f'sky-test-{int(time.time())}'
@@ -1392,7 +1392,7 @@ def test_aws_storage_mounts_with_stop_only_allow_mount():
         test_commands, clean_command = _storage_mounts_commands_generator(
             f, name, storage_name, ls_hello_command, cloud, True)
         test = Test(
-            'aws_storage_mounts_only_allow_mount',
+            'aws_storage_mounts_only_mount',
             test_commands,
             clean_command,
             timeout=20 * 60,  # 20 mins
@@ -1411,24 +1411,6 @@ def test_gcp_storage_mounts_with_stop():
             f, name, storage_name, ls_hello_command, cloud, False)
         test = Test(
             'gcp_storage_mounts',
-            test_commands,
-            clean_command,
-            timeout=20 * 60,  # 20 mins
-        )
-        run_one_test(test)
-
-
-@pytest.mark.gcp
-def test_gcp_storage_mounts_with_stop_only_allow_mount():
-    name = _get_cluster_name()
-    cloud = 'gcp'
-    storage_name = f'sky-test-{int(time.time())}'
-    ls_hello_command = f'gsutil ls gs://{storage_name}/hello.txt'
-    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, True)
-        test = Test(
-            'gcp_storage_mounts_only_allow_mount',
             test_commands,
             clean_command,
             timeout=20 * 60,  # 20 mins
@@ -1457,33 +1439,6 @@ def test_azure_storage_mounts_with_stop():
             f, name, storage_name, ls_hello_command, cloud, False)
         test = Test(
             'azure_storage_mounts',
-            test_commands,
-            clean_command,
-            timeout=20 * 60,  # 20 mins
-        )
-        run_one_test(test)
-
-
-@pytest.mark.azure
-def test_azure_storage_mounts_with_stop_only_allow_mount():
-    name = _get_cluster_name()
-    cloud = 'azure'
-    storage_name = f'sky-test-{int(time.time())}'
-    default_region = 'eastus'
-    storage_account_name = (storage_lib.AzureBlobStore.
-                            get_default_storage_account_name(default_region))
-    storage_account_key = data_utils.get_az_storage_account_key(
-        storage_account_name)
-    ls_hello_command = (f'output=$(az storage blob list -c {storage_name} '
-                        f'--account-name {storage_account_name} '
-                        f'--account-key {storage_account_key} '
-                        f'--prefix hello.txt) '
-                        f'[ "$output" = "[]" ] && exit 1 || exit 0')
-    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
-        test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, True)
-        test = Test(
-            'azure_storage_mounts_only_allow_mount',
             test_commands,
             clean_command,
             timeout=20 * 60,  # 20 mins

--- a/tests/test_yamls/test_storage_mounting.yaml.j2
+++ b/tests/test_yamls/test_storage_mounting.yaml.j2
@@ -20,13 +20,13 @@ file_mounts:
   /mount_private_copy:
     name: {{storage_name}}
     source: ~/tmp-workdir
-    mode: COPY
+    mode: {% if only_allow_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
 
   # Mounting private buckets in COPY mode with a list of files as source
   /mount_private_copy_lof:
     name: {{storage_name}}
     source: ['~/tmp-workdir/tmp file', '~/tmp-workdir/tmp file2']
-    mode: COPY
+    mode: {% if only_allow_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
 
   {% if include_private_mount | default(True) %}
   # Mounting private buckets in MOUNT mode
@@ -38,7 +38,7 @@ file_mounts:
 
 run: |
   set -ex
-  
+
   # Check public bucket contents
   ls -ltr /mount_public_s3/corpora
   ls -ltr /mount_public_gcp/tiles
@@ -55,12 +55,12 @@ run: |
   ls -ltr /mount_private_mount/foo
   ls -ltr /mount_private_mount/tmp\ file
   {% endif %}
-  
+
   # Symlinks are not copied to buckets
   ! ls /mount_private_copy/circle-link
   {% if include_private_mount | default(True) %}
   ! ls /mount_private_mount/circle-link
-  
+
   # Write to private bucket in MOUNT mode should pass
   echo "hello" > /mount_private_mount/hello.txt
   {% endif %}

--- a/tests/test_yamls/test_storage_mounting.yaml.j2
+++ b/tests/test_yamls/test_storage_mounting.yaml.j2
@@ -20,13 +20,13 @@ file_mounts:
   /mount_private_copy:
     name: {{storage_name}}
     source: ~/tmp-workdir
-    mode: {% if only_allow_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
+    mode: {% if only_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
 
   # Mounting private buckets in COPY mode with a list of files as source
   /mount_private_copy_lof:
     name: {{storage_name}}
     source: ['~/tmp-workdir/tmp file', '~/tmp-workdir/tmp file2']
-    mode: {% if only_allow_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
+    mode: {% if only_mount | default(false) %}MOUNT{% else %}COPY{% endif %}
 
   {% if include_private_mount | default(True) %}
   # Mounting private buckets in MOUNT mode


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Feature for #4423 

## About #4317

* Add the smoke test:
    * `test_aws_storage_mounts_with_stop_only_mount`
* Implement a command generator function to improve code reusability.
* Modify the `test_storage_mounting.yaml.j2` template to support an additional parameter, `only_allow_mount`, which specifies if only `MOUNT` is allowed and disables `COPY`.

<!-- Describe the tests ran -->

Test:

* `pytest tests/test_smoke.py::test_aws_storage_mounts_with_stop --aws`
* `pytest tests/test_smoke.py::test_aws_storage_mounts_with_stop_only_allow_mount --aws`
* `pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop --gcp`

All pass

*  `pytest tests/test_smoke.py::test_azure_storage_mounts_with_stop --azure`

All fail on master, success on 0.7.1. These two test cases fail on the master branch but pass on [release/0.7.1](https://github.com/skypilot-org/skypilot/pull/4438). We can proceed with 0.7.1 but need to take a closer look at the master branch(The master branch fails with or without this PR; it is not affected.)

```bash
E 12-06 14:43:31 subprocess_utils.py:141] blobfuse2 already installed. Proceeding...
E 12-06 14:43:31 subprocess_utils.py:141] Mounting  to /mount_private_mount with blobfuse2...
E 12-06 14:43:31 subprocess_utils.py:141] *** blobfuse2: A new version [2.3.2] is available. Consider upgrading to latest version for bug-fixes & new features. ***
E 12-06 14:43:31 subprocess_utils.py:141] Visit https://aka.ms/blobfuse2warnings#220 to see the list of vulnerabilities associated with your current version [2.2.0]
E 12-06 14:43:31 subprocess_utils.py:141] Error: failed to initialize new pipeline [config error in file_cache [temp directory not empty]]
E 12-06 14:43:31 subprocess_utils.py:141] 
Traceback (most recent call last):
  File "/Users/zepingguo/miniconda3/envs/sky/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/Users/zepingguo/.local/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/zepingguo/.local/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/zepingguo/Desktop/skypilot/sky/utils/common_utils.py", line 366, in _record
    return f(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/cli.py", line 838, in invoke
    return super().invoke(ctx)
  File "/Users/zepingguo/.local/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/zepingguo/.local/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/zepingguo/.local/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/cli.py", line 2576, in start
    core.start(name,
  File "/Users/zepingguo/Desktop/skypilot/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/core.py", line 379, in start
    return _start(cluster_name,
  File "/Users/zepingguo/Desktop/skypilot/sky/core.py", line 314, in _start
    backend.sync_file_mounts(handle=handle,
  File "/Users/zepingguo/Desktop/skypilot/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/utils/common_utils.py", line 366, in _record
    return f(*args, **kwargs)
  File "/Users/zepingguo/Desktop/skypilot/sky/backends/backend.py", line 76, in sync_file_mounts
    return self._sync_file_mounts(handle, all_file_mounts, storage_mounts)
  File "/Users/zepingguo/Desktop/skypilot/sky/backends/cloud_vm_ray_backend.py", line 3117, in _sync_file_mounts
    self._execute_storage_mounts(handle, storage_mounts)
  File "/Users/zepingguo/Desktop/skypilot/sky/backends/cloud_vm_ray_backend.py", line 4653, in _execute_storage_mounts
    raise exceptions.CommandError(
sky.exceptions.CommandError: Command to mount failed with return code 1.
Failed to run command before rsync ~/tmp-workdir -> /mount_private_mount. Ensure that the network is stable, then retry. echo '
#!/usr/bin/env bash
set -e

{ [ "$(whoami)" == "root" ] && function sudo() { "$@"; } || true; }

MOUNT_PATH=/mount_private_mount
MOUNT_BINARY=blobfuse2

# Check if path is already mounted
if grep -q $MOUNT_PATH /proc/mounts ; then
    echo "Path already mounted - unmounting..."
    fusermount -uz "$MOUNT_PATH"
    echo "Successfully unmounted $MOUNT_PATH."
fi

# Install MOUNT_BINARY if not already installed
if [ -x "$(command -v blobfuse2)" ]; then
  echo "$MOUNT_BINARY already installed. Proceeding..."
else
  echo "Installing $MOUNT_BINARY..."
  sudo apt-get update; sudo apt-get install -y -o Dpkg::Options::="--force-confdef" fuse3 libfuse3-dev && wget -nc https://github.com/Azure/azure-storage-fuse/releases/download/blobfuse2-2.2.0/blobfuse2-2.2.0-Debian-11.0.x86_64.deb -O /tmp/blobfuse2.deb && sudo dpkg --install /tmp/blobfuse2.deb && mkdir -p ~/.sky/blobfuse2_cache;
fi

# Check if mount path exists
if [ ! -d "$MOUNT_PATH" ]; then
  echo "Mount path $MOUNT_PATH does not exist. Creating..."
  sudo mkdir -p $MOUNT_PATH
  sudo chmod 777 $MOUNT_PATH
else
  # Check if mount path contains files
  if [ "$(ls -A $MOUNT_PATH)" ]; then
    echo "Mount path $MOUNT_PATH is not empty. Please mount to another path or remove it first."
    exit 42
  fi
fi
echo "Mounting $SOURCE_BUCKET to $MOUNT_PATH with $MOUNT_BINARY..."
AZURE_STORAGE_ACCOUNT=xxx AZURE_STORAGE_ACCESS_KEY=xxx blobfuse2 /mount_private_mount --allow-other --no-symlinks -o umask=022 -o default_permissions --tmp-path ~/.sky/blobfuse2_cache/sky635694a6141885a3_sky-test-1733466958 --container-name sky-test-1733466958
echo "Mounting done."
' > ~/.sky/mount_97651.sh && chmod +x ~/.sky/mount_97651.sh && bash ~/.sky/mount_97651.sh && rm ~/.sky/mount_97651.sh See logs in ~/sky_logs/sky-2024-12-06-14-40-59-370163/storage_mounts.log
D 12-06 14:43:32 cloud_vm_ray_backend.py:3914] Provisioner version: ProvisionerVersion.SKYPILOT using new provisioner for teardown.
D 12-06 14:43:38 metadata_utils.py:115] Remove metadata of cluster t-azure-storage-mount-b8-ee-94a6.
D 12-06 14:43:38 metadata_utils.py:115] Remove metadata of cluster t-azure-storage-mount-b8-ee.


Mounting  to /mount_private_mount with blobfuse2...
*** blobfuse2: A new version [2.3.2] is available. Consider upgrading to latest version for bug-fixes & new features. ***
Visit https://aka.ms/blobfuse2warnings#220 to see the list of vulnerabilities associated with your current version [2.2.0]
Error: failed to initialize new pipeline [config error in file_cache [temp directory not empty]]
^C
```


Test the modified command work as expected
```bash

(sky) ➜  skypilot git:(dev/zeping/smoke_test_support_storage_mount_only) ✗ (output="[]"; [ "$output" = "[]" ] && exit 1 || exit 0)
(sky) ➜  skypilot git:(dev/zeping/smoke_test_support_storage_mount_only) ✗ echo $?                                                
1
(sky) ➜  skypilot git:(dev/zeping/smoke_test_support_storage_mount_only) ✗ (output="[ss]"; [ "$output" = "[]" ] && exit 1 || exit 0)
(sky) ➜  skypilot git:(dev/zeping/smoke_test_support_storage_mount_only) ✗ echo $?                                                  
0
```

## About #4411

It seems the smoke test can already test it, no need to add

`pytest tests/test_smoke.py::test_use_spot --azure`


<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
