### PR TITLE
Not mutate azure dep list at runtime

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -211,8 +211,8 @@ def _get_cloud_dependencies_installation_commands(
                     f'{constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1')
 
     for cloud in sky_check.get_cached_enabled_clouds_or_refresh():
-        cloud_python_dependencies: List[str] = dependencies.extras_require[
-            cloud.canonical_name()]
+        cloud_python_dependencies: List[str] = copy.deepcopy(
+            dependencies.extras_require[cloud.canonical_name()])
 
         if isinstance(cloud, clouds.Azure):
             # azure-cli cannot be normally installed by uv.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Without deepcopy, `cloud_python_dependencies.remove(dependencies.AZURE_CLI)` will end up modifying the constant, affecting other runtimes that are referencing this module, and if other runtime tries to remove the same item again, ValueError will get thrown.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_managed_jobs_storage` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
