### PR TITLE
[UX] Fix `sky jobs logs` for finished jobs

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -329,7 +329,7 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> str:
                            f'{managed_job_state.get_failure_reason(job_id)}')
             log_file = managed_job_state.get_local_log_file(job_id, None)
             if log_file is not None:
-                with open(log_file, 'r', encoding='utf-8') as f:
+                with open(os.path.expanduser(log_file), 'r', encoding='utf-8') as f:
                     # Stream the logs to the console without reading the whole
                     # file into memory.
                     start_streaming = False

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -312,7 +312,7 @@ def download_and_stream_latest_job_log(
 
     This function is only used by jobs controller and sky serve controller.
     """
-    os.makedirs(local_dir, exist_ok=True)
+    os.makedirs(os.path.expanduser(local_dir), exist_ok=True)
     log_file = None
     try:
         log_dirs = backend.sync_down_logs(
@@ -338,7 +338,7 @@ def download_and_stream_latest_job_log(
             # TODO(zhwu): refactor this into log_utils, along with the
             # refactoring for the log_lib.tail_logs.
             try:
-                with open(log_file, 'r', encoding='utf-8') as f:
+                with open(os.path.expanduser(log_file), 'r', encoding='utf-8') as f:
                     # Stream the logs to the console without reading the whole
                     # file into memory.
                     start_streaming = False


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`sky jobs logs` has an issue with finished jobs as we did not expand the log files with username. In this PR we fixed it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
