### PR TITLE
[k8s] Add validation for pod_config #4206

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -917,7 +917,8 @@ def write_cluster_config(
             cluster_config_overrides=to_provision.cluster_config_overrides)
         kubernetes_utils.combine_metadata_fields(tmp_yaml_path)
         yaml_obj = common_utils.read_yaml(tmp_yaml_path)
-        pod_config = yaml_obj['available_node_types']['ray_head_default']['node_config']
+        pod_config = yaml_obj['available_node_types']['ray_head_default'][
+            'node_config']
         valid, message = kubernetes_utils.check_pod_config(pod_config)
         if not valid:
             raise exceptions.InvalidCloudConfigs(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -916,6 +916,10 @@ def write_cluster_config(
             tmp_yaml_path,
             cluster_config_overrides=to_provision.cluster_config_overrides)
         kubernetes_utils.combine_metadata_fields(tmp_yaml_path)
+        valid, message = kubernetes_utils.check_pod_config(tmp_yaml_path)
+        if not valid:
+            raise exceptions.InvalidCloudConfigs(
+                f'There are invalid config in pod_config, deatil: {message}')
 
     if dryrun:
         # If dryrun, return the unfinished tmp yaml path.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -916,7 +916,8 @@ def write_cluster_config(
             tmp_yaml_path,
             cluster_config_overrides=to_provision.cluster_config_overrides)
         kubernetes_utils.combine_metadata_fields(tmp_yaml_path)
-        valid, message = kubernetes_utils.check_pod_config(tmp_yaml_path)
+        valid, message = kubernetes_utils.check_pod_config(
+            tmp_yaml_path, dryrun)
         if not valid:
             raise exceptions.InvalidCloudConfigs(
                 f'There are invalid config in pod_config, deatil: {message}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -916,8 +916,9 @@ def write_cluster_config(
             tmp_yaml_path,
             cluster_config_overrides=to_provision.cluster_config_overrides)
         kubernetes_utils.combine_metadata_fields(tmp_yaml_path)
-        valid, message = kubernetes_utils.check_pod_config(
-            tmp_yaml_path, dryrun)
+        yaml_obj = common_utils.read_yaml(tmp_yaml_path)
+        pod_config = yaml_obj['available_node_types']['ray_head_default']['node_config']
+        valid, message = kubernetes_utils.check_pod_config(pod_config)
         if not valid:
             raise exceptions.InvalidCloudConfigs(
                 f'There are invalid config in pod_config, deatil: {message}')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -922,7 +922,7 @@ def write_cluster_config(
         valid, message = kubernetes_utils.check_pod_config(pod_config)
         if not valid:
             raise exceptions.InvalidCloudConfigs(
-                f'Invalid pod_config. Deatils: {message}')
+                f'Invalid pod_config. Details: {message}')
 
     if dryrun:
         # If dryrun, return the unfinished tmp yaml path.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -922,7 +922,7 @@ def write_cluster_config(
         valid, message = kubernetes_utils.check_pod_config(pod_config)
         if not valid:
             raise exceptions.InvalidCloudConfigs(
-                f'There are invalid config in pod_config, deatil: {message}')
+                f'Invalid pod_config. Deatil: {message}')
 
     if dryrun:
         # If dryrun, return the unfinished tmp yaml path.

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -922,7 +922,7 @@ def write_cluster_config(
         valid, message = kubernetes_utils.check_pod_config(pod_config)
         if not valid:
             raise exceptions.InvalidCloudConfigs(
-                f'Invalid pod_config. Deatil: {message}')
+                f'Invalid pod_config. Deatils: {message}')
 
     if dryrun:
         # If dryrun, return the unfinished tmp yaml path.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -892,7 +892,8 @@ def check_credentials(context: Optional[str],
         return True, None
 
 
-def check_pod_config(cluster_yaml_path: str) -> Tuple[bool, Optional[str]]:
+def check_pod_config(cluster_yaml_path: str, dryrun: bool) \
+    -> Tuple[bool, Optional[str]]:
     """Check if the pod_config is a valid pod config
 
     Using create_namespaced_pod api with dry_run to check the pod_config
@@ -926,6 +927,11 @@ def check_pod_config(cluster_yaml_path: str) -> Tuple[bool, Optional[str]]:
             error_msg = str(e)
         return False, error_msg
     except ValueError as e:
+        if dryrun:
+            logger.debug('ignore ValueError as there is no kube config '
+                         'in the enviroment with dry_run. '
+                         'For now we don\'t support check pod_config offline.')
+            return True, None
         return False, common_utils.format_exception(e)
     except Exception as e:  # pylint: disable=broad-except
         return False, ('An error occurred: '

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -903,7 +903,9 @@ def check_pod_config(pod_config: dict) \
         str: Error message about why the pod_config is invalid, None otherwise.
     """
     errors = []
-    api_client = kubernetes.api_client()
+    # This api_client won't be used to send any requests, so there is no need to
+    # load kubeconfig
+    api_client = kubernetes.kubernetes.client.ApiClient()
 
     # Used for kubernetes api_client deserialize function, the function will use
     # data attr, the detail ref:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,12 +102,9 @@ def _create_task_yaml_file(task_file_path: pathlib.Path) -> None:
 
 def _create_invalid_config_yaml_file(task_file_path: pathlib.Path) -> None:
     task_file_path.write_text(
-        textwrap.dedent(f"""\
+        textwrap.dedent("""\
         experimental:
             config_overrides:
-                docker:
-                    run_options:
-                        - -v /tmp:/tmp
                 kubernetes:
                     pod_config:
                         metadata:
@@ -120,14 +117,6 @@ def _create_invalid_config_yaml_file(task_file_path: pathlib.Path) -> None:
                                 - name:
                             imagePullSecrets:
                                 - name: my-secret-2
-                    provision_timeout: 100
-                gcp:
-                    managed_instance_group:
-                        run_duration: {RUN_DURATION_OVERRIDE}
-                nvidia_gpus:
-                    disable_ecc: true
-        resources:
-            image_id: docker:ubuntu:latest
 
         setup: echo 'Setting up...'
         run: echo 'Running...'
@@ -387,7 +376,9 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     exception_occurred = False
     try:
         sky.launch(task, cluster_name=cluster_name, dryrun=True)
-    except sky.exceptions.ResourcesUnavailableError:
+    except sky.exceptions.ResourcesUnavailableError as e:
+        assert 'Invalid pod_config. Deatils: Invalid spec: \
+        Invalid value for `name`, must not be `None`' in str(e)
         exception_occurred = True
     assert exception_occurred
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -377,8 +377,10 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     try:
         sky.launch(task, cluster_name=cluster_name, dryrun=True)
     except sky.exceptions.ResourcesUnavailableError as e:
-        assert 'Invalid pod_config. Deatils: Invalid spec: \
-        Invalid value for `name`, must not be `None`' in str(e)
+        expect_error_message = (
+            'Invalid pod_config. Deatils: '
+            'Invalid spec: Invalid value for `name`, must not be `None`')
+        assert expect_error_message in str(e)
         exception_occurred = True
     assert exception_occurred
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,7 @@ def _create_task_yaml_file(task_file_path: pathlib.Path) -> None:
         run: echo 'Running...'
         """))
 
+
 def _create_invalid_config_yaml_file(task_file_path: pathlib.Path) -> None:
     task_file_path.write_text(
         textwrap.dedent(f"""\
@@ -368,6 +369,7 @@ def test_k8s_config_with_override(monkeypatch, tmp_path,
                    'imagePullSecrets'][0]['name'] == 'my-secret-2'
     assert cluster_pod_config['spec']['runtimeClassName'] == 'nvidia'
 
+
 def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
                                         enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
@@ -380,7 +382,7 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     task = sky.Task.from_yaml(task_path)
 
     # Test Kubernetes pod_config invalid
-    cluster_name = 'test-kubernetes-config-with-override'
+    cluster_name = 'test_k8s_config_with_invalid_config'
     task.set_resources_override({'cloud': sky.Kubernetes()})
     exception = None
     try:
@@ -388,6 +390,7 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     except sky.exceptions.ResourcesUnavailableError as e:
         exception = e
     assert not exception
+
 
 def test_gcp_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -376,11 +376,7 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     exception_occurred = False
     try:
         sky.launch(task, cluster_name=cluster_name, dryrun=True)
-    except sky.exceptions.ResourcesUnavailableError as e:
-        expect_error_message = (
-            'Invalid pod_config. Deatils: '
-            'Invalid spec: Invalid value for `name`, must not be `None`')
-        assert expect_error_message in str(e)
+    except sky.exceptions.ResourcesUnavailableError:
         exception_occurred = True
     assert exception_occurred
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -384,12 +384,12 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
     # Test Kubernetes pod_config invalid
     cluster_name = 'test_k8s_config_with_invalid_config'
     task.set_resources_override({'cloud': sky.Kubernetes()})
-    exception = None
+    exception_occurred = False
     try:
         sky.launch(task, cluster_name=cluster_name, dryrun=True)
-    except sky.exceptions.ResourcesUnavailableError as e:
-        exception = e
-    assert not exception
+    except sky.exceptions.ResourcesUnavailableError:
+        exception_occurred = True
+    assert exception_occurred
 
 
 def test_gcp_config_with_override(monkeypatch, tmp_path,


### PR DESCRIPTION
Check pod_config when run 'sky check k8s' by using k8s  #4206 

<!-- Describe the changes in this PR -->
This commit extends the functionality of `sky check k8s` by adding a check for `pod_config` in this step. The method used to check pod_config is by calling the K8s API. This approach has some advantages and disadvantages:

- Advantages:
1. Minimal code changes and 100% reliable check results.
2. Future K8s extensions to the pod format will not require any adjustments to skypilot's code.

- Disadvantages:
1. Requires interaction with the K8s cluster and cannot be validated locally offline.

Of course, any other suggestions are welcome for discussion.

<!-- Describe the tests ran -->
The test config.yaml
```yaml
kubernetes:
  pod_config:
    metadata:
      name: local-test
      labels:
        my-label: my-value    # Custom labels to SkyPilot pods
    spec:
      #runtimeClassName: nvidia    # Custom runtimeClassName for GPU pods.
      imagePullSecrets:
        - name: my-secret     # Pull images from a private registry using a secret
      containers:
        - name: local_test
          image: test
          env:                # Custom environment variables for the pod, e.g., for proxy
          - name: HTTP_PROXY
            value: http://proxy-host:3128
          volumeMounts:       # Custom volume mounts for the pod
            - mountPath: /foo
              name: example-volume
              readOnly: true
      volumes:
        - name: example-volume
          hostPath:
            path: /tmp
            type: Directory
        - name: dshm          # Use this to modify the /dev/shm volume mounted by SkyPilot
          emptyDir:
            medium: Memory
            sizeLimit: 3Gi    # Set a size limit for the /dev/shm volume
```

And the Check Result: 
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/091bc087-4862-4596-a267-951114bc9d5f" />

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`




