### PR TITLE
remove sky jobs launch --fast

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3601,15 +3601,12 @@ def jobs():
               default=False,
               required=False,
               help='Skip confirmation prompt.')
-# TODO(cooperc): remove this flag once --fast can robustly detect cluster
-# yaml config changes
+# TODO(cooperc): remove this flag before releasing 0.8.0
 @click.option('--fast',
               default=False,
               is_flag=True,
-              help='[Experimental] Launch the job faster by skipping '
-              'controller initialization steps. If you update SkyPilot or '
-              'your local cloud credentials, they will not be reflected until '
-              'you run `sky jobs launch` at least once without this flag.')
+              help=('[Deprecated] Does nothing. Previous flag behavior is now '
+                    'enabled by default.'))
 @timeline.event
 @usage_lib.entrypoint
 def jobs_launch(
@@ -3634,7 +3631,7 @@ def jobs_launch(
     disk_tier: Optional[str],
     ports: Tuple[str],
     detach_run: bool,
-    retry_until_up: bool,
+    retry_until_up: Optional[bool],
     yes: bool,
     fast: bool,
 ):
@@ -3692,6 +3689,16 @@ def jobs_launch(
     else:
         retry_until_up = True
 
+    # Deprecation. The default behavior is fast, and the flag will be removed.
+    # The flag was not present in 0.7.x (only nightly), so we will remove before
+    # 0.8.0 so that it never enters a stable release.
+    if fast:
+        click.secho(
+            'Flag --fast is deprecated, as the behavior is now default. The '
+            'flag will be removed soon. Please do not use it, so that you '
+            'avoid "No such option" errors.',
+            fg='yellow')
+
     if not isinstance(task_or_dag, sky.Dag):
         assert isinstance(task_or_dag, sky.Task), task_or_dag
         with sky.Dag() as dag:
@@ -3733,8 +3740,7 @@ def jobs_launch(
     managed_jobs.launch(dag,
                         name,
                         detach_run=detach_run,
-                        retry_until_up=retry_until_up,
-                        fast=fast)
+                        retry_until_up=retry_until_up)
 
 
 @jobs.command('queue', cls=_DocumentedCodeCommand)

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -37,13 +37,13 @@ if typing.TYPE_CHECKING:
 @timeline.event
 @usage_lib.entrypoint
 def launch(
-    task: Union['sky.Task', 'sky.Dag'],
-    name: Optional[str] = None,
-    stream_logs: bool = True,
-    detach_run: bool = False,
-    retry_until_up: bool = False,
-    # TODO(cooperc): remove fast arg before 0.8.0
-    fast: bool = True,
+        task: Union['sky.Task', 'sky.Dag'],
+        name: Optional[str] = None,
+        stream_logs: bool = True,
+        detach_run: bool = False,
+        retry_until_up: bool = False,
+        # TODO(cooperc): remove fast arg before 0.8.0
+        fast: bool = True,  # pylint: disable=unused-argument for compatibility
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -42,7 +42,8 @@ def launch(
     stream_logs: bool = True,
     detach_run: bool = False,
     retry_until_up: bool = False,
-    fast: bool = False,
+    # TODO(cooperc): remove fast arg before 0.8.0
+    fast: bool = True,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.
@@ -54,9 +55,8 @@ def launch(
           managed job.
         name: Name of the managed job.
         detach_run: Whether to detach the run.
-        fast: Whether to use sky.launch(fast=True) for the jobs controller. If
-          True, the SkyPilot wheel and the cloud credentials may not be updated
-          on the jobs controller.
+        fast: [Deprecated] Does nothing, and will be removed soon. We will
+          always use fast mode as it's fully safe now.
 
     Raises:
         ValueError: cluster does not exist. Or, the entrypoint is not a valid
@@ -149,7 +149,7 @@ def launch(
                    idle_minutes_to_autostop=skylet_constants.
                    CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
                    retry_until_up=True,
-                   fast=fast,
+                   fast=True,
                    _disable_controller_check=True)
 
 


### PR DESCRIPTION
The --fast behavior is now always enabled. This was unsafe before but since #4289 it should be safe.

We will remove the flag before 0.8.0 so that it never touches a stable version.

sky launch still has the --fast flag. This flag is unsafe because it could cause setup to be skipped even though it should be re-run. In the managed jobs case, this is not an issue because we fully control the setup and know it will not change.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
