### PR TITLE
Awscliv2 dependency install from source

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -78,15 +78,9 @@ aws_dependencies = [
     # We have to explicitly pin the version to optimize the time for
     # poetry install. See https://github.com/orgs/python-poetry/discussions/7937
     'urllib3<2',
-    # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
-    # should instead use CLI V2 which is not pip-installable. See
-    # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.
-    'awscli>=1.27.10',
+    'awscli @ git+https://github.com/aws/aws-cli.git@v2',
     'botocore>=1.29.10',
-    'boto3>=1.26.1',
-    # NOTE: required by awscli. To avoid ray automatically installing
-    # the latest version.
-    'colorama < 0.4.5',
+    'boto3>=1.26.1'
 ]
 
 # azure-cli cannot be installed normally by uv, so we need to work around it in


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

bug reproduce:

```
# activate conda
cd docs
pip install -r requirements-docs.txt
cd ..
pip install -e .[all]
cd docs
./build.sh
```

output:

```
    'meta': (nodes.meta, 'docutils.nodes.meta'),  # type: ignore[attr-defined]
AttributeError: module 'docutils.nodes' has no attribute 'meta'
make: *** [html] Error 1
```


Its because `awscli>=1.27.10`  requires `docutils<0.17,>=0.10`, while our doc build use `sphinx==7.1.2`  which requires `docutils<0.21,>=0.18.1`
`pip install -e .[all]`  gets `docutils==0.16` from `awscli>=1.27.10`
`pip install -r requirements-docs.txt` gets `docutils==0.19` from `sphinx==7.1.2`
The doc build only works with `docutils==0.19`


Profile:

```bash
pip install git+https://github.com/aws/aws-cli.git@v2  18.50s user 10.30s system 57% cpu 49.714 total
pip install 'awscli>=1.27.10'  1.36s user 0.56s system 77% cpu 2.468 total
```

30 seconds slower install from source

[They are not publishing this to pypi](https://github.com/aws/aws-cli/issues/4947), if we want to install it we should install from source

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
