### PR TITLE
Add tests for Azure spot instance

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1310,7 +1310,8 @@ def test_azure_spot_instance_verification():
     test = smoke_tests_utils.Test(
         'azure-spot-verification',
         [
-            f'TARGET_VM_NAME=\'{name}\'; '
+            f'sky launch -c {name} --cloud azure tests/test_yamls/minimal.yaml --use-spot -y',
+            f'sky logs {name} 1 --status', f'TARGET_VM_NAME=\'{name}\'; '
             'VM_INFO=$(az vm list --query \'[?contains(name, "$TARGET_VM_NAME")].{Name:name, ResourceGroup:resourceGroup}\' -o tsv); '
             '[[ -z "$VM_INFO" ]] && exit 1; '
             'FULL_VM_NAME=$(echo "$VM_INFO" | awk \'{print $1}\'); '

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1322,7 +1322,7 @@ def test_azure_spot_instance_verification():
             'echo "VM Details:"; echo "$VM_DETAILS"; '
             'echo "$VM_DETAILS" | grep -qw "Spot" && exit 0 || exit 1'
         ],
-        #f'sky down -y {name}',
+        f'sky down -y {name}',
     )
     smoke_tests_utils.run_one_test(test)
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1310,15 +1310,14 @@ def test_azure_spot_instance_verification():
     test = smoke_tests_utils.Test(
         'azure-spot-verification',
         [
-            f'sky launch -c {name} --cloud azure tests/test_yamls/minimal.yaml --use-spot -y',
-            f'sky logs {name} 1 --status', f"TARGET_VM_NAME='{name}'; "
-            "VM_INFO=$(az vm list --query \"[?contains(name, '$TARGET_VM_NAME')].{Name:name, ResourceGroup:resourceGroup}\" -o tsv); "
-            "[[ -z \"$VM_INFO\" ]] && exit 1; "
-            "FULL_VM_NAME=$(echo \"$VM_INFO\" | awk '{print $1}'); "
-            "RESOURCE_GROUP=$(echo \"$VM_INFO\" | awk '{print $2}'); "
-            "VM_DETAILS=$(az vm list --resource-group \"$RESOURCE_GROUP\" --query \"[?name=='$FULL_VM_NAME'].{Name:name, Location:location, Priority:priority}\" -o table); "
-            "[[ -z \"$VM_DETAILS\" ]] && exit 1; "
-            "echo \"$VM_DETAILS\" | grep -qw 'Spot' && exit 0 || exit 1"
+            f'TARGET_VM_NAME=\'{name}\'; '
+            'VM_INFO=$(az vm list --query \'[?contains(name, "$TARGET_VM_NAME")].{Name:name, ResourceGroup:resourceGroup}\' -o tsv); '
+            '[[ -z "$VM_INFO" ]] && exit 1; '
+            'FULL_VM_NAME=$(echo "$VM_INFO" | awk \'{print $1}\'); '
+            'RESOURCE_GROUP=$(echo "$VM_INFO" | awk \'{print $2}\'); '
+            'VM_DETAILS=$(az vm list --resource-group "$RESOURCE_GROUP" --query \'[?name=="$FULL_VM_NAME"].{Name:name, Location:location, Priority:priority}\' -o table); '
+            '[[ -z "$VM_DETAILS" ]] && exit 1; '
+            'echo "$VM_DETAILS" | grep -qw "Spot" && exit 0 || exit 1'
         ],
         f'sky down -y {name}',
     )

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1317,6 +1317,7 @@ def test_azure_spot_instance_verification():
             'RESOURCE_GROUP=$(echo "$VM_INFO" | awk \'{print $2}\'); '
             'VM_DETAILS=$(az vm list --resource-group "$RESOURCE_GROUP" --query \'[?name=="$FULL_VM_NAME"].{Name:name, Location:location, Priority:priority}\' -o table); '
             '[[ -z "$VM_DETAILS" ]] && exit 1; '
+            'echo "VM Details:"; echo "$VM_DETAILS"; '
             'echo "$VM_DETAILS" | grep -qw "Spot" && exit 0 || exit 1'
         ],
         f'sky down -y {name}',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1299,6 +1299,32 @@ def test_use_spot(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.azure
+def test_azure_spot_instance_verification():
+    """Test Azure spot instance provisioning with explicit verification.
+    This test verifies that when --use-spot is specified for Azure:
+    1. The cluster launches successfully
+    2. The instances are actually provisioned as spot instances
+    """
+    name = smoke_tests_utils.get_cluster_name()
+    test = smoke_tests_utils.Test(
+        'azure-spot-verification',
+        [
+            f'sky launch -c {name} --cloud azure tests/test_yamls/minimal.yaml --use-spot -y',
+            f'sky logs {name} 1 --status', f"TARGET_VM_NAME='{name}'; "
+            "VM_INFO=$(az vm list --query \"[?contains(name, '$TARGET_VM_NAME')].{Name:name, ResourceGroup:resourceGroup}\" -o tsv); "
+            "[[ -z \"$VM_INFO\" ]] && exit 1; "
+            "FULL_VM_NAME=$(echo \"$VM_INFO\" | awk '{print $1}'); "
+            "RESOURCE_GROUP=$(echo \"$VM_INFO\" | awk '{print $2}'); "
+            "VM_DETAILS=$(az vm list --resource-group \"$RESOURCE_GROUP\" --query \"[?name=='$FULL_VM_NAME'].{Name:name, Location:location, Priority:priority}\" -o table); "
+            "[[ -z \"$VM_DETAILS\" ]] && exit 1; "
+            "echo \"$VM_DETAILS\" | grep -qw 'Spot' && exit 0 || exit 1"
+        ],
+        f'sky down -y {name}',
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 @pytest.mark.gcp
 def test_stop_gcp_spot():
     """Test GCP spot can be stopped, autostopped, restarted."""

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1311,17 +1311,18 @@ def test_azure_spot_instance_verification():
         'azure-spot-verification',
         [
             f'sky launch -c {name} --cloud azure tests/test_yamls/minimal.yaml --use-spot -y',
-            f'sky logs {name} 1 --status', f'TARGET_VM_NAME=\'{name}\'; '
-            'VM_INFO=$(az vm list --query \'[?contains(name, "$TARGET_VM_NAME")].{Name:name, ResourceGroup:resourceGroup}\' -o tsv); '
+            f'sky logs {name} 1 --status', f'TARGET_VM_NAME="{name}"; '
+            'VM_INFO=$(az vm list --query "[?contains(name, \'$TARGET_VM_NAME\')].{Name:name, ResourceGroup:resourceGroup}" -o tsv); '
             '[[ -z "$VM_INFO" ]] && exit 1; '
             'FULL_VM_NAME=$(echo "$VM_INFO" | awk \'{print $1}\'); '
             'RESOURCE_GROUP=$(echo "$VM_INFO" | awk \'{print $2}\'); '
-            'VM_DETAILS=$(az vm list --resource-group "$RESOURCE_GROUP" --query \'[?name=="$FULL_VM_NAME"].{Name:name, Location:location, Priority:priority}\' -o table); '
+            'VM_DETAILS=$(az vm list --resource-group "$RESOURCE_GROUP" '
+            '--query "[?name==\'$FULL_VM_NAME\'].{Name:name, Location:location, Priority:priority}" -o table); '
             '[[ -z "$VM_DETAILS" ]] && exit 1; '
             'echo "VM Details:"; echo "$VM_DETAILS"; '
             'echo "$VM_DETAILS" | grep -qw "Spot" && exit 0 || exit 1'
         ],
-        f'sky down -y {name}',
+        #f'sky down -y {name}',
     )
     smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Test case for: #4423

Add test case: `test_azure_spot_instance_verification`

```
Test Azure spot instance provisioning with explicit verification.
    This test verifies that when --use-spot is specified for Azure:
    1. The cluster launches successfully
    2. The instances are actually provisioned as spot instances
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
