### PR TITLE
[UX] warning before launching jobs/serve when using a reauth required credentials

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -809,6 +809,7 @@ def write_cluster_config(
                 excluded_clouds.add(cloud_obj)
 
     credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
+
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}
     region_name = resources_vars.get('region')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -773,7 +773,6 @@ def write_cluster_config(
         # Some clouds (e.g., AWS) support specifying multiple service accounts
         # chosen based on the cluster name. Do the matching here to pick the
         # correct one.
-        
         for profile in remote_identity_config:
             if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
                 remote_identity = list(profile.values())[0]
@@ -809,7 +808,6 @@ def write_cluster_config(
                     schemas.RemoteIdentityOptions.NO_UPLOAD.value):
                 excluded_clouds.add(cloud_obj)
     credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
-
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}
     region_name = resources_vars.get('region')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -807,6 +807,7 @@ def write_cluster_config(
             if (remote_identity_config ==
                     schemas.RemoteIdentityOptions.NO_UPLOAD.value):
                 excluded_clouds.add(cloud_obj)
+
     credentials = sky_check.get_cloud_credential_file_mounts(excluded_clouds)
     auth_config = {'ssh_private_key': auth.PRIVATE_SSH_KEY_PATH}
     region_name = resources_vars.get('region')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -764,7 +764,6 @@ def write_cluster_config(
     # running required checks.
     assert cluster_name is not None
     excluded_clouds = set()
-
     remote_identity_config = skypilot_config.get_nested(
         (str(cloud).lower(), 'remote_identity'), None)
     remote_identity = schemas.get_default_remote_identity(str(cloud).lower())
@@ -774,6 +773,7 @@ def write_cluster_config(
         # Some clouds (e.g., AWS) support specifying multiple service accounts
         # chosen based on the cluster name. Do the matching here to pick the
         # correct one.
+        
         for profile in remote_identity_config:
             if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
                 remote_identity = list(profile.values())[0]

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -650,6 +650,33 @@ def _replace_yaml_dicts(
     return common_utils.dump_yaml_str(new_config)
 
 
+@functools.lru_cache(maxsize=1)
+def get_remote_identity(cloud: Optional[clouds.Cloud],
+                        cluster_name: str) -> str:
+    """Retrieves the remote identity for a given cloud and cluster name.
+
+    Args:
+        cloud: The cloud object or None.
+        cluster_name: The name of the cluster.
+
+    Returns:
+        The remote identity as a string.
+    """
+    remote_identity_config = skypilot_config.get_nested(
+        (str(cloud).lower(), 'remote_identity'), None)
+    remote_identity = schemas.get_default_remote_identity(str(cloud).lower())
+    if isinstance(remote_identity_config, str):
+        remote_identity = remote_identity_config
+    if isinstance(remote_identity_config, list):
+        # Some clouds (e.g., AWS) support specifying multiple service accounts
+        # chosen based on the cluster name. Do the matching here to pick the
+        # correct one.
+        for profile in remote_identity_config:
+            if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
+                return list(profile.values())[0]
+    return remote_identity
+
+
 # TODO: too many things happening here - leaky abstraction. Refactor.
 @timeline.event
 def write_cluster_config(
@@ -728,19 +755,8 @@ def write_cluster_config(
     # running required checks.
     assert cluster_name is not None
     excluded_clouds = set()
-    remote_identity_config = skypilot_config.get_nested(
-        (str(cloud).lower(), 'remote_identity'), None)
-    remote_identity = schemas.get_default_remote_identity(str(cloud).lower())
-    if isinstance(remote_identity_config, str):
-        remote_identity = remote_identity_config
-    if isinstance(remote_identity_config, list):
-        # Some clouds (e.g., AWS) support specifying multiple service accounts
-        # chosen based on the cluster name. Do the matching here to pick the
-        # correct one.
-        for profile in remote_identity_config:
-            if fnmatch.fnmatchcase(cluster_name, list(profile.keys())[0]):
-                remote_identity = list(profile.values())[0]
-                break
+
+    remote_identity = get_remote_identity(cloud, cluster_name)
     if remote_identity != schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value:
         # If LOCAL_CREDENTIALS is not specified, we add the cloud to the
         # excluded_clouds set, but we must also check if the cloud supports

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -21,7 +21,6 @@ import typing
 from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Tuple,
                     Union)
 
-import click
 import colorama
 import filelock
 
@@ -2008,12 +2007,12 @@ class RetryingVmProvisioner(object):
                 enabled_clouds)
 
             if len(expirable_clouds) > 0:
-                warnings = (f'\nWarning: Expiring credentials detected for '
-                            f'{expirable_clouds}. Clusters may be leaked if '
-                            f'the credentials expire while jobs are running. '
-                            f'It is recommended to use credentials that never'
-                            f' expire or a service account.')
-                click.secho(warnings, fg='yellow')
+                warnings = (f'\n\033[93m Warning: Credentials used for '
+                            f'{expirable_clouds} may expire.Clusters may be '
+                            f'leaked if the credentials expire while jobs '
+                            f'are running.It is recommended to use credentials'
+                            f' that never expire or a service account.\033[0m')
+                logger.warning(warnings)
 
         # Retrying launchable resources.
         while True:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1997,9 +1997,9 @@ class RetryingVmProvisioner(object):
                                        skip_unnecessary_provisioning else None)
 
         failover_history: List[Exception] = list()
-        # If the user is using local credentials which may expire, the 
-        # controller may leak resources if the credentials expire while a job 
-        # is running. Here we check the enabled clouds and expiring credentials 
+        # If the user is using local credentials which may expire, the
+        # controller may leak resources if the credentials expire while a job
+        # is running. Here we check the enabled clouds and expiring credentials
         # and raise a warning to the user.
         if task.is_controller_task():
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1997,10 +1997,10 @@ class RetryingVmProvisioner(object):
                                        skip_unnecessary_provisioning else None)
 
         failover_history: List[Exception] = list()
-        # When jobs controller/server using the local credentials which are
-        # expiring it may cause the cluster to be leaked. So, checking the
-        # enabled clouds and expiring credentials and warning the user to use
-        # the credentials that never expire or a service account.
+        # If the user is using local credentials which may expire, the 
+        # controller may leak resources if the credentials expire while a job 
+        # is running. Here we check the enabled clouds and expiring credentials 
+        # and raise a warning to the user.
         if task.is_controller_task():
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh()
             expirable_clouds = backend_utils.get_expirable_clouds(

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -21,6 +21,7 @@ import typing
 from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Tuple,
                     Union)
 
+import click
 import colorama
 import filelock
 
@@ -61,6 +62,7 @@ from sky.utils import controller_utils
 from sky.utils import log_utils
 from sky.utils import resources_utils
 from sky.utils import rich_utils
+from sky.utils import schemas
 from sky.utils import subprocess_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
@@ -1996,6 +1998,21 @@ class RetryingVmProvisioner(object):
                                        skip_unnecessary_provisioning else None)
 
         failover_history: List[Exception] = list()
+
+        cloud = to_provision.cloud
+        if task.is_controller_task():
+            remote_identity = backend_utils.get_remote_identity(
+                cloud, cluster_name)
+            local_credentials_value = schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value  # pylint: disable=line-too-long
+            use_local_cred = remote_identity == local_credentials_value
+            expirable_cred = to_provision.cloud.can_credential_expire()
+            if use_local_cred and expirable_cred:
+                warnings = (
+                    f'\nWarning: Expiring credentials detected for {cloud}.'
+                    'Clusters may be leaked if the credentials expire while '
+                    'jobs are running. It is recommended to use credentials '
+                    'that never expire or a service account.')
+                click.secho(warnings, fg='yellow')
 
         # Retrying launchable resources.
         while True:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2007,7 +2007,7 @@ class RetryingVmProvisioner(object):
                 enabled_clouds)
 
             if len(expirable_clouds) > 0:
-                warnings = (f'\n\033[93m Warning: Credentials used for '
+                warnings = (f'\033[93mWarning: Credentials used for '
                             f'{expirable_clouds} may expire.Clusters may be '
                             f'leaked if the credentials expire while jobs '
                             f'are running.It is recommended to use credentials'

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3742,11 +3742,12 @@ def jobs_launch(
         resource.cloud is not None and resource.cloud.can_credential_expire()
     ]
     if len(reauth_needed_clouds) > 0:
-        prompt = (
-            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to '
-            'jobs being out of control. It is recommended to use credentials  '
-            'that never expire or a service account. Proceed?')
-        click.confirm(prompt, default=False, abort=True, show_default=True)
+        warnings = (
+            f'Expiring credentials detected for {reauth_needed_clouds}. Clusters may '
+            'be leaked if the credentials expire while jobs are running. It is '
+            'recommended to use credentials that never expire or a service account.'
+        )
+        click.secho(warnings, fg='yellow')
 
     managed_jobs.launch(dag,
                         name,
@@ -4239,11 +4240,12 @@ def serve_up(
         resource.cloud is not None and resource.cloud.can_credential_expire()
     ]
     if len(reauth_needed_clouds) > 0:
-        prompt = (
-            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to '
-            'jobs being out of control. It is recommended to use credentials '
-            'that never expire or a service account. Proceed?')
-        click.confirm(prompt, default=False, abort=True, show_default=True)
+        warnings = (
+            f'Expiring credentials detected for {reauth_needed_clouds}. Clusters may '
+            'be leaked if the credentials expire while jobs are running. It is '
+            'recommended to use credentials that never expire or a service account.'
+        )
+        click.secho(warnings, fg='yellow')
 
     serve_lib.up(task, service_name)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3743,10 +3743,10 @@ def jobs_launch(
     ]
     if len(reauth_needed_clouds) > 0:
         warnings = (
-            f'Expiring credentials detected for {reauth_needed_clouds}. Clusters may '
-            'be leaked if the credentials expire while jobs are running. It is '
-            'recommended to use credentials that never expire or a service account.'
-        )
+            f'Expiring credentials detected for {reauth_needed_clouds}.'
+            'Clusters may be leaked if the credentials expire while jobs are '
+            'running. It is recommended to use credentials that never expire '
+            'or a service account.')
         click.secho(warnings, fg='yellow')
 
     managed_jobs.launch(dag,
@@ -4241,10 +4241,10 @@ def serve_up(
     ]
     if len(reauth_needed_clouds) > 0:
         warnings = (
-            f'Expiring credentials detected for {reauth_needed_clouds}. Clusters may '
-            'be leaked if the credentials expire while jobs are running. It is '
-            'recommended to use credentials that never expire or a service account.'
-        )
+            f'Expiring credentials detected for {reauth_needed_clouds}.'
+            'Clusters may be leaked if the credentials expire while jobs are '
+            'running. It is recommended to use credentials that never expire '
+            'or a service account.')
         click.secho(warnings, fg='yellow')
 
     serve_lib.up(task, service_name)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3737,6 +3737,18 @@ def jobs_launch(
 
     common_utils.check_cluster_name_is_valid(name)
 
+    reauth_needed_clouds = [
+        resource.cloud for task in dag.tasks for resource in task.resources
+        if resource.cloud.can_credential_expire()
+    ]
+    if reauth_needed_clouds:
+        prompt = (
+            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to jobs '
+            'being out of control. It is recommended to use credentials that never '
+            'expire or a service account. Proceed?'
+        )
+        click.confirm(prompt, default=False, abort=True, show_default=True)
+
     managed_jobs.launch(dag,
                         name,
                         detach_run=detach_run,
@@ -4222,6 +4234,18 @@ def serve_up(
         prompt = f'Launching a new service {service_name!r}. Proceed?'
         if prompt is not None:
             click.confirm(prompt, default=True, abort=True, show_default=True)
+
+    reauth_needed_clouds = [
+        resource.cloud for task in dag.tasks for resource in task.resources
+        if resource.cloud.can_credential_expire()
+    ]
+    if reauth_needed_clouds:
+        prompt = (
+            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to jobs '
+            'being out of control. It is recommended to use credentials that never '
+            'expire or a service account. Proceed?'
+        )
+        click.confirm(prompt, default=False, abort=True, show_default=True)
 
     serve_lib.up(task, service_name)
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3738,15 +3738,14 @@ def jobs_launch(
     common_utils.check_cluster_name_is_valid(name)
 
     reauth_needed_clouds = [
-        resource.cloud for task in dag.tasks for resource in task.resources
-        if resource.cloud.can_credential_expire()
+        resource.cloud for task in dag.tasks for resource in task.resources if
+        resource.cloud is not None and resource.cloud.can_credential_expire()
     ]
-    if reauth_needed_clouds:
+    if len(reauth_needed_clouds) > 0:
         prompt = (
-            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to jobs '
-            'being out of control. It is recommended to use credentials that never '
-            'expire or a service account. Proceed?'
-        )
+            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to '
+            'jobs being out of control. It is recommended to use credentials  '
+            'that never expire or a service account. Proceed?')
         click.confirm(prompt, default=False, abort=True, show_default=True)
 
     managed_jobs.launch(dag,
@@ -4236,15 +4235,14 @@ def serve_up(
             click.confirm(prompt, default=True, abort=True, show_default=True)
 
     reauth_needed_clouds = [
-        resource.cloud for task in dag.tasks for resource in task.resources
-        if resource.cloud.can_credential_expire()
+        resource.cloud for task in dag.tasks for resource in task.resources if
+        resource.cloud is not None and resource.cloud.can_credential_expire()
     ]
-    if reauth_needed_clouds:
+    if len(reauth_needed_clouds) > 0:
         prompt = (
-            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to jobs '
-            'being out of control. It is recommended to use credentials that never '
-            'expire or a service account. Proceed?'
-        )
+            f'Launching jobs with cloud(s) {reauth_needed_clouds} may lead to '
+            'jobs being out of control. It is recommended to use credentials '
+            'that never expire or a service account. Proceed?')
         click.confirm(prompt, default=False, abort=True, show_default=True)
 
     serve_lib.up(task, service_name)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3737,18 +3737,6 @@ def jobs_launch(
 
     common_utils.check_cluster_name_is_valid(name)
 
-    reauth_needed_clouds = [
-        resource.cloud for task in dag.tasks for resource in task.resources if
-        resource.cloud is not None and resource.cloud.can_credential_expire()
-    ]
-    if len(reauth_needed_clouds) > 0:
-        warnings = (
-            f'Expiring credentials detected for {reauth_needed_clouds}.'
-            'Clusters may be leaked if the credentials expire while jobs are '
-            'running. It is recommended to use credentials that never expire '
-            'or a service account.')
-        click.secho(warnings, fg='yellow')
-
     managed_jobs.launch(dag,
                         name,
                         detach_run=detach_run,
@@ -4234,18 +4222,6 @@ def serve_up(
         prompt = f'Launching a new service {service_name!r}. Proceed?'
         if prompt is not None:
             click.confirm(prompt, default=True, abort=True, show_default=True)
-
-    reauth_needed_clouds = [
-        resource.cloud for task in dag.tasks for resource in task.resources if
-        resource.cloud is not None and resource.cloud.can_credential_expire()
-    ]
-    if len(reauth_needed_clouds) > 0:
-        warnings = (
-            f'Expiring credentials detected for {reauth_needed_clouds}.'
-            'Clusters may be leaked if the credentials expire while jobs are '
-            'running. It is recommended to use credentials that never expire '
-            'or a service account.')
-        click.secho(warnings, fg='yellow')
 
     serve_lib.up(task, service_name)
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -111,7 +111,6 @@ class AWSIdentityType(enum.Enum):
         """
         expirable_types = {
             AWSIdentityType.ENV, AWSIdentityType.IAM_ROLE,
-            AWSIdentityType.CONTAINER_ROLE,
             AWSIdentityType.SHARED_CREDENTIALS_FILE
         }
         return self in expirable_types

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -110,8 +110,9 @@ class AWSIdentityType(enum.Enum):
         used,they will expire and require re-authentication.
         """
         expirable_types = {
-            AWSIdentityType.SSO, AWSIdentityType.IAM_ROLE,
-            AWSIdentityType.CONTAINER_ROLE
+            AWSIdentityType.ENV, AWSIdentityType.IAM_ROLE,
+            AWSIdentityType.CONTAINER_ROLE,
+            AWSIdentityType.SHARED_CREDENTIALS_FILE
         }
         return self in expirable_types
 
@@ -827,6 +828,7 @@ class AWS(clouds.Cloud):
             if os.path.exists(os.path.expanduser(f'~/.aws/{filename}'))
         }
 
+    @functools.lru_cache(maxsize=1)
     def can_credential_expire(self) -> bool:
         identity_type = self._current_identity_type()
         return identity_type is not None and identity_type.can_credential_expire(

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -105,7 +105,8 @@ class AWSIdentityType(enum.Enum):
 
         SSO,IAM_ROLE and CONTAINER_ROLE are temporary credentials and refreshed
         automatically. ENV and SHARED_CREDENTIALS_FILE are short-lived
-        credentials without refresh. IAM ROLE:
+        credentials without refresh.
+        IAM ROLE:
         https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
         SSO/Container-role refresh token:
         https://docs.aws.amazon.com/solutions/latest/dea-api/auth-refreshtoken.html

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -103,15 +103,16 @@ class AWSIdentityType(enum.Enum):
     def can_credential_expire(self) -> bool:
         """Check if the AWS identity type can expire.
 
-        SSO,IAM Role,and Container Role use temporary credentials, which
-        expire and require re-authentication or re-acquisition of credentials.
-        ENV and Shared Credentials File store long-term credentials, which do
-        not expire unless manually changed, but if temporary credentials are
-        used,they will expire and require re-authentication.
+        SSO,IAM_ROLE and CONTAINER_ROLE are temporary credentials and refreshed
+        automatically. ENV and SHARED_CREDENTIALS_FILE are short-lived
+        credentials without refresh. IAM ROLE:
+        https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+        SSO/Container-role refresh token:
+        https://docs.aws.amazon.com/solutions/latest/dea-api/auth-refreshtoken.html
         """
+        # TODO(hong): Add a check for the expiration of the temporary
         expirable_types = {
-            AWSIdentityType.ENV, AWSIdentityType.IAM_ROLE,
-            AWSIdentityType.SHARED_CREDENTIALS_FILE
+            AWSIdentityType.ENV, AWSIdentityType.SHARED_CREDENTIALS_FILE
         }
         return self in expirable_types
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -103,8 +103,7 @@ class AWSIdentityType(enum.Enum):
     def can_credential_expire(self) -> bool:
         """Check if the AWS identity type can expire."""
         expirable_types = {
-            AWSIdentityType.SSO, AWSIdentityType.ENV, AWSIdentityType.IAM_ROLE,
-            AWSIdentityType.CONTAINER_ROLE
+            AWSIdentityType.SSO, AWSIdentityType.ENV, AWSIdentityType.CONTAINER_ROLE
         }
         return self in expirable_types
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -103,9 +103,7 @@ class AWSIdentityType(enum.Enum):
     def can_credential_expire(self) -> bool:
         """Check if the AWS identity type can expire."""
         expirable_types = {
-            AWSIdentityType.SSO,
-            AWSIdentityType.ENV,
-            AWSIdentityType.IAM_ROLE,
+            AWSIdentityType.SSO, AWSIdentityType.ENV, AWSIdentityType.IAM_ROLE,
             AWSIdentityType.CONTAINER_ROLE
         }
         return self in expirable_types
@@ -823,7 +821,9 @@ class AWS(clouds.Cloud):
         }
 
     def can_credential_expire(self) -> bool:
-        return self._current_identity_type().can_credential_expire()
+        identity_type = self._current_identity_type()
+        return identity_type is not None and identity_type.can_credential_expire(
+        )
 
     def instance_type_exists(self, instance_type):
         return service_catalog.instance_type_exists(instance_type, clouds='aws')

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -101,9 +101,17 @@ class AWSIdentityType(enum.Enum):
     SHARED_CREDENTIALS_FILE = 'shared-credentials-file'
 
     def can_credential_expire(self) -> bool:
-        """Check if the AWS identity type can expire."""
+        """Check if the AWS identity type can expire.
+
+        SSO,IAM Role,and Container Role use temporary credentials, which
+        expire and require re-authentication or re-acquisition of credentials.
+        ENV and Shared Credentials File store long-term credentials, which do
+        not expire unless manually changed, but if temporary credentials are
+        used,they will expire and require re-authentication.
+        """
         expirable_types = {
-            AWSIdentityType.SSO, AWSIdentityType.ENV, AWSIdentityType.CONTAINER_ROLE
+            AWSIdentityType.SSO, AWSIdentityType.IAM_ROLE,
+            AWSIdentityType.CONTAINER_ROLE
         }
         return self in expirable_types
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -100,6 +100,16 @@ class AWSIdentityType(enum.Enum):
     #     region                us-east-1      config-file    ~/.aws/config
     SHARED_CREDENTIALS_FILE = 'shared-credentials-file'
 
+    def can_credential_expire(self) -> bool:
+        """Check if the AWS identity type can expire."""
+        expirable_types = {
+            AWSIdentityType.SSO,
+            AWSIdentityType.ENV,
+            AWSIdentityType.IAM_ROLE,
+            AWSIdentityType.CONTAINER_ROLE
+        }
+        return self in expirable_types
+
 
 @clouds.CLOUD_REGISTRY.register
 class AWS(clouds.Cloud):
@@ -811,6 +821,9 @@ class AWS(clouds.Cloud):
             for filename in _CREDENTIAL_FILES
             if os.path.exists(os.path.expanduser(f'~/.aws/{filename}'))
         }
+
+    def can_credential_expire(self) -> bool:
+        return self._current_identity_type().can_credential_expire()
 
     def instance_type_exists(self, instance_type):
         return service_catalog.instance_type_exists(instance_type, clouds='aws')

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -536,6 +536,10 @@ class Cloud:
         """
         raise NotImplementedError
 
+    def can_credential_expire(self) -> bool:
+        """Returns whether the cloud credential can expire."""
+        return False
+
     @classmethod
     def get_image_size(cls, image_id: str, region: Optional[str]) -> float:
         """Check the image size from the cloud.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -867,7 +867,9 @@ class GCP(clouds.Cloud):
         return credentials
 
     def can_credential_expire(self) -> bool:
-        return self._get_identity_type().can_credential_expire()
+        identity_type = self._get_identity_type()
+        return identity_type is not None and identity_type.can_credential_expire(
+        )
 
     @classmethod
     def _get_identity_type(cls) -> Optional[GCPIdentityType]:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -866,6 +866,7 @@ class GCP(clouds.Cloud):
             pass
         return credentials
 
+    @functools.lru_cache(maxsize=1)
     def can_credential_expire(self) -> bool:
         identity_type = self._get_identity_type()
         return identity_type is not None and identity_type.can_credential_expire(

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -132,6 +132,9 @@ class GCPIdentityType(enum.Enum):
 
     SHARED_CREDENTIALS_FILE = ''
 
+    def can_credential_expire(self) -> bool:
+        return self == GCPIdentityType.SHARED_CREDENTIALS_FILE
+
 
 @clouds.CLOUD_REGISTRY.register
 class GCP(clouds.Cloud):
@@ -862,6 +865,9 @@ class GCP(clouds.Cloud):
             # Skip if the application key path is not found.
             pass
         return credentials
+
+    def can_credential_expire(self) -> bool:
+        return self._get_identity_type().can_credential_expire()
 
     @classmethod
     def _get_identity_type(cls) -> Optional[GCPIdentityType]:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
issue link: https://github.com/skypilot-org/skypilot/issues/4433
Solution:

context:
- Jobs controller or server need permission to launch/down nodes of multiple clouds.

detail:
- Get clouds whose remote identities are `LOCAL_CREDENTIALS` and credentials are expiring and warning to the user before provision.

Test case 1:
config in `~/.sky/config.yaml`
```
gcp:
    remote_identity: LOCAL_CREDENTIALS

aws:
    remote_identity: LOCAL_CREDENTIALS

jobs:
   controller:
       resources:
          cloud: gcp
```
Local `AWS` credential configured by `SSO`
Launch controller on `GCP` and task on `AWS`
Command to run:
```bash
python cli.py jobs launch ~/hello-sky/hello_sky.yaml -y
```
Logs:
```bash
~/skypilot/sky on dev/hong/controller wip *1 > python cli.py jobs launch ~/hello-sky/hello_sky.yaml -y                      took 49s py sky at 17:27:04
Task from YAML spec: /Users/hong/hello-sky/hello_sky.yaml
Resources for managed job 'sky-17a6-hong' will be computed on the managed jobs controller, since --yes is set.
⚙︎ Translating workdir to SkyPilot Storage...
  Workdir: '.' -> storage: 'skypilot-workdir-hong-a0c33aaf'.
  Created S3 bucket 'skypilot-workdir-hong-a0c33aaf' in us-east-1
  Excluded files to sync to cluster based on .gitignore.
✓ Uploaded local files/folders.
Launching managed job 'sky-17a6-hong' from jobs controller...
Choosing resources for managed jobs controller...
Considered resources (1 node):
----------------------------------------------------------------------------------------------
 CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN
----------------------------------------------------------------------------------------------
 GCP     n2-standard-8   8       32        -              us-central1-a   0.39          ✔
----------------------------------------------------------------------------------------------
⠹ Launching  View logs at: ~/sky_logs/sky-2025-01-02-17-28-17-672434/provision.log
Warning: Expiring credentials detected for [GCP]. Clusters may be leaked if the credentials expire while jobs are running. It is recommended to use credentials that never expire or a service account.
⠼ Launching  View logs at: ~/sky_logs/sky-2025-01-02-17-28-17-672434/provision.logINFO:oci.circuit_breaker:Default Auth client Circuit breaker strategy enabled
⚙︎ Launching managed jobs controller on GCP us-central1 (us-central1-a).
```
Warnings detail:
```bash
Warning: Expiring credentials detected for [GCP]. Clusters may be leaked if the credentials expire while jobs are running. It is recommended to use credentials that never expire or a service account.
```
worker provision failed since `AWS` not accessible from `GCP` cloud.

Test case 2:
Provision controller on `AWS` and worker on `GCP`
```bash
Launching managed job 'sky-40f6-hong' from jobs controller...
Choosing resources for managed jobs controller...
Considered resources (1 node):
------------------------------------------------------------------------------------------
 CLOUD   INSTANCE      vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
------------------------------------------------------------------------------------------
 AWS     m6i.2xlarge   8       32        -              us-east-1     0.38          ✔
------------------------------------------------------------------------------------------
⠴ Launching  View logs at: ~/sky_logs/sky-2025-01-02-18-04-56-343901/provision.log
Warning: Expiring credentials detected for [GCP]. Clusters may be leaked if the credentials expire while jobs are running. It is recommended to use credentials that never expire or a service account.
⠹ Launching  View logs at: ~/sky_logs/sky-2025-01-02-18-04-56-343901/provision.logINFO:oci.circuit_breaker:Default Auth client Circuit breaker strategy enabled
⚙︎ Launching managed jobs controller on AWS us-east-1 (us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f).
```
Still warning for expiring local credentials.

Job completed in this case
```bash
⚙︎ Running setup on managed jobs controller.
  Check & install cloud dependencies on controller: done.
✓ Setup completed.  View logs at: ~/sky_logs/sky-2025-01-02-18-04-56-343901/setup-*.log
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(setup pid=3601) Running setup.
(sky-40f6-hong, pid=3601) Hello, SkyPilot!
(sky-40f6-hong, pid=3601) # conda environments:
(sky-40f6-hong, pid=3601) #
(sky-40f6-hong, pid=3601) base                  *  /home/gcpuser/miniconda3
(sky-40f6-hong, pid=3601) skypilot-runtime         /home/gcpuser/miniconda3/envs/skypilot-runtime
(sky-40f6-hong, pid=3601)
(sky-40f6-hong, pid=3601) End task.
✓ Job finished (status: SUCCEEDED).
✓ Managed job finished: 1 (status: SUCCEEDED).
```

Test case 3:
same as test case 2 but using service account for `GCP`
```bash
Launching managed job 'sky-ae51-hong' from jobs controller...
Choosing resources for managed jobs controller...
Considered resources (1 node):
------------------------------------------------------------------------------------------
 CLOUD   INSTANCE      vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
------------------------------------------------------------------------------------------
 AWS     m6i.2xlarge   8       32        -              us-east-1     0.38          ✔
------------------------------------------------------------------------------------------
⠏ Launching  View logs at: ~/sky_logs/sky-2025-01-02-18-21-57-280832/provision.logINFO:oci.circuit_breaker:Default Auth client Circuit breaker strategy enabled
⚙︎ Launching managed jobs controller on AWS us-east-1 (us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f).
└── Instance is up.
Open file descriptor limit (256) is low. File sync to remote clusters may be slow. Consider increasing the limit using `ulimit -n <number>` or modifying system limits.
✓ Cluster launched: sky-jobs-controller-d8a421b3.  View logs at: ~/sky_logs/sky-2025-01-02-18-21-57-280832/provision.log
⚙︎ Mounting files.
  Syncing (to 1 node): /var/folders/d1/c810pqs51p58jyq4g4d8czbh0000gn/T/managed-dag-sky-ae51-hong-4exdx6sw -> ~/.sky/managed_jobs/sky-ae51-hong-757c.yaml
  Syncing (to 1 node): /var/folders/d1/c810pqs51p58jyq4g4d8czbh0000gn/T/tmprzouvn9a -> ~/.sky/managed_jobs/sky-ae51-hong-757c.config_yaml
✓ Files synced.  View logs at: ~/sky_logs/sky-2025-01-02-18-21-57-280832/file_mounts.log
⚙︎ Running setup on managed jobs controller.
[2/3] Check & install cloud dependencies on controller: GCP SDK
```
Provision instance without warning message.
Job on `GCP` finished.
```bash
✓ Files synced.  View logs at: ~/sky_logs/sky-2025-01-02-18-21-57-280832/file_mounts.log
⚙︎ Running setup on managed jobs controller.
  Check & install cloud dependencies on controller: done.
✓ Setup completed.  View logs at: ~/sky_logs/sky-2025-01-02-18-21-57-280832/setup-*.log
⚙︎ Job submitted, ID: 1
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(setup pid=3194) Running setup.
(sky-ae51-hong, pid=3194) Hello, SkyPilot!
(sky-ae51-hong, pid=3194) # conda environments:
(sky-ae51-hong, pid=3194) #
(sky-ae51-hong, pid=3194) base                  *  /home/gcpuser/miniconda3
(sky-ae51-hong, pid=3194) skypilot-runtime         /home/gcpuser/miniconda3/envs/skypilot-runtime
(sky-ae51-hong, pid=3194)
(sky-ae51-hong, pid=3194) End task.
✓ Managed job finished: 1 (status: SUCCEEDED).
``` 

@Michaelvll @romilbhardwaj  can you help review?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
