### PR TITLE
[Tests] fix smoke test race condition on first run

### DIFF
--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -150,8 +150,8 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                     f'{role_name}{colorama.Style.RESET_ALL} from AWS.')
                 raise exc
 
-    def _create_instance_profile_if_not_exists(instance_profile_name: str
-                                               ) -> None:
+    def _create_instance_profile_if_not_exists(
+            instance_profile_name: str) -> None:
         try:
             iam.meta.client.create_instance_profile(
                 InstanceProfileName=instance_profile_name)
@@ -167,8 +167,8 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                 )
                 raise exc
 
-    def _create_role_if_not_exists(role_name: str, policy_doc: Dict[str, Any]
-                                   ) -> None:
+    def _create_role_if_not_exists(role_name: str,
+                                   policy_doc: Dict[str, Any]) -> None:
         try:
             iam.create_role(RoleName=role_name,
                             AssumeRolePolicyDocument=json.dumps(policy_doc))

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -150,7 +150,8 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                     f'{role_name}{colorama.Style.RESET_ALL} from AWS.')
                 raise exc
 
-    def _create_instance_profile_if_not_exists(instance_profile_name: str) -> None:
+    def _create_instance_profile_if_not_exists(instance_profile_name: str
+                                               ) -> None:
         try:
             iam.meta.client.create_instance_profile(
                 InstanceProfileName=instance_profile_name)
@@ -166,7 +167,8 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                 )
                 raise exc
 
-    def _create_role_if_not_exists(role_name: str, policy_doc: Dict[str, Any]):
+    def _create_role_if_not_exists(role_name: str, policy_doc: Dict[str, Any]
+                                   ) -> None:
         try:
             iam.create_role(RoleName=role_name,
                             AssumeRolePolicyDocument=json.dumps(policy_doc))
@@ -180,7 +182,7 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                     f'{role_name}{colorama.Style.RESET_ALL} in AWS.')
                 raise exc
 
-    def _check_instance_profile_role(profile: Any, role_name: str):
+    def _check_instance_profile_role(profile: Any, role_name: str) -> None:
         if profile.roles and profile.roles[0].name != role_name:
             logger.fatal(f'The instance profile {profile.name} already has '
                          f'an associated role {profile.roles[0].name}, but the '

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -182,11 +182,9 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
 
     def _check_instance_profile_role(profile: Any, role_name: str):
         if profile.roles and profile.roles[0].name != role_name:
-            # If the associated role is not the role we expect, error out
-            # to user instead of silently overriding the role.
             logger.fatal(f'The instance profile {profile.name} already has '
                          f'an associated role {profile.roles[0].name}, but the '
-                         f'role {role.name} is not the same as the expected '
+                         f'role {role_name} is not the same as the expected '
                          f'role. Please remove the existing role from the '
                          f'instance profile and try again.')
             raise SystemExit(1)

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -150,7 +150,7 @@ def _configure_iam_role(iam) -> Dict[str, Any]:
                     f'{role_name}{colorama.Style.RESET_ALL} from AWS.')
                 raise exc
 
-    def _create_instance_profile_if_not_exists(instance_profile_name: str):
+    def _create_instance_profile_if_not_exists(instance_profile_name: str) -> None:
         try:
             iam.meta.client.create_instance_profile(
                 InstanceProfileName=instance_profile_name)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix the following error when I ran `pytest tests/test_smoke.py` on my laptop, which cause test failure:

```
D 12-20 16:53:56 provisioner.py:153] Traceback (most recent call last):
D 12-20 16:53:56 provisioner.py:153]   File "/Users/aylei/repo/skypilot-org/skypilot/sky/provision/provisioner.py", line 142, in bulk_provision
D 12-20 16:53:56 provisioner.py:153]     return _bulk_provision(cloud, region, cluster_name,
D 12-20 16:53:56 provisioner.py:153]   File "/Users/aylei/repo/skypilot-org/skypilot/sky/provision/provisioner.py", line 60, in _bulk_provision
D 12-20 16:53:56 provisioner.py:153]     config = provision.bootstrap_instances(provider_name, region_name,
D 12-20 16:53:56 provisioner.py:153]   File "/Users/aylei/repo/skypilot-org/skypilot/sky/provision/__init__.py", line 52, in _wrapper
D 12-20 16:53:56 provisioner.py:153]     return impl(*args, **kwargs)
D 12-20 16:53:56 provisioner.py:153]   File "/Users/aylei/repo/skypilot-org/skypilot/sky/provision/aws/config.py", line 71, in bootstrap_instances
D 12-20 16:53:56 provisioner.py:153]     node_cfg['IamInstanceProfile'] = _configure_iam_role(iam)
D 12-20 16:53:56 provisioner.py:153]   File "/Users/aylei/repo/skypilot-org/skypilot/sky/provision/aws/config.py", line 161, in _configure_iam_role
D 12-20 16:53:56 provisioner.py:153]     iam.meta.client.create_instance_profile(
D 12-20 16:53:56 provisioner.py:153]   File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/site-packages/botocore/client.py", line 569, in _api_ca
ll
D 12-20 16:53:56 provisioner.py:153]     return self._make_api_call(operation_name, kwargs)
D 12-20 16:53:56 provisioner.py:153]   File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/site-packages/botocore/client.py", line 1023, in _make_
api_call
D 12-20 16:53:56 provisioner.py:153]     raise error_class(parsed_response, operation_name)
D 12-20 16:53:56 provisioner.py:153] botocore.errorfactory.EntityAlreadyExistsException: An error occurred (EntityAlreadyExists) when calling the Cr
eateInstanceProfile operation: Instance Profile skypilot-v1 already exists.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_aws_stale_job_manual_restart` 

```
$ profile_name=skypilot-v1
$ aws iam remove-role-from-instance-profile --instance-profile-name "$profile_name" --role-name "$profile_name"
$ aws iam delete-instance-profile --instance-profile-name "$profile_name"

$ pytest tests/test_smoke.py::test_aws_stale_job_manual_restart tests/test_smoke.py::test_minimal tests/test_smoke.py::test_launch_fast --aws
```

- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
