### PR TITLE
[UX] minor optimizations for launch and introduce py-spy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,10 @@ pytest tests/test_smoke.py --generic-cloud azure
 
 For profiling code, use:
 ```
-pip install tuna # Tuna is used for visualization of profiling data.
-python3 -m cProfile -o sky.prof -m sky.cli status # Or some other command
-tuna sky.prof
+pip install py-spy # py-spy is a sampling profiler for Python programs
+py-spy record -t -o sky.svg -- python -m sky.cli status # Or some other command
+py-spy top -- python -m sky.cli status # Get a live top view
+py-spy -h # For more options
 ```
 
 #### Testing in a container

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -1,6 +1,7 @@
 """Lazy import for modules to avoid import error when not used."""
 import functools
 import importlib
+import threading
 from typing import Any, Callable, Optional, Tuple
 
 
@@ -24,8 +25,12 @@ class LazyImport:
         self._module = None
         self._import_error_message = import_error_message
         self._set_loggers = set_loggers
+        self._lock = threading.RLock()
 
     def load_module(self):
+        # Avoid extra imports when multiple threads try to import the same
+        # module. The overhead is minor since import can only run in serial
+        # due to GIL even in multi-threaded environments.
         if self._module is None:
             try:
                 self._module = importlib.import_module(self._module_name)

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -3,7 +3,6 @@
 import contextlib
 import datetime
 import enum
-import inspect
 import json
 import os
 import time
@@ -12,19 +11,28 @@ import typing
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import click
-import requests
 
 import sky
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.usage import constants
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import inspect
+
+    import requests
+
     from sky import resources as resources_lib
     from sky import status_lib
     from sky import task as task_lib
+else:
+    # requests and inspect cost ~100ms to load, which can be postponed to
+    # collection phase or skipped if user specifies no collection
+    requests = adaptors_common.LazyImport('requests')
+    inspect = adaptors_common.LazyImport('inspect')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -5,6 +5,8 @@ import types
 from typing import Callable, Iterator, List, Optional, TextIO, Type
 
 import colorama
+# slow due to https://github.com/python-pendulum/pendulum/issues/808
+# FIXME(aylei): bump pendulum if it get fixed
 import pendulum
 import prettytable
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I've investigated python profiling tools when developing #3159 since `python -m cProfile` only [sees profile on main thread](https://stackoverflow.com/questions/653419/how-can-i-profile-a-multithread-program-in-python) and profiling multi-thread applications using cProfile [is tedious](https://dev.to/oryaacov/how-to-profile-your-multi-threaded-running-python-code-programmatically-collect-periodically-and-analyze-the-results-5fh3). I evaluated [yappi](https://pypi.org/project/yappi/) and [py-spy](https://github.com/benfred/py-spy), it turns out the latter one has better UX and broader adoption. Therefore, I propose changing the profiling approach in dev guide to py-spy.

Also, I found some minor optimization chances and made some quicks in this PR. `sky launch` speed ​​up 100ms in average:

```bash
# PR branch, 26.16s
/usr/bin/time bash -c 'for i in {1..10}; do SKYPILOT_DISABLE_USAGE_COLLECTION=1 python -m sky.cli launch --gpus H100:8> /dev/null; done;'
       26,16 real        16,37 user        25,22 sys

# master branch, 27.26s
/usr/bin/time bash -c 'for i in {1..10}; do SKYPILOT_DISABLE_USAGE_COLLECTION=1 python -m sky.cli launch --gpus H100:8> /dev/null; done;'
       27,26 real        16,26 user        25,34 sys
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (see benchmark above)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

appendix:

- GIL flamegrpah captured by py-spy 

![gil](https://github.com/user-attachments/assets/2c579d28-2c6e-4b7f-9bc7-32bd680d8f3e)

- Speedscope flamegraph captured by py-sy, which is more user-friendly

<img width="1608" alt="Screenshot 2024-12-20 at 18 38 51" src="https://github.com/user-attachments/assets/ea507059-d2d6-4fd6-b5f6-11ac6d117ce2" />

