### PR TITLE
[Core] honor allowed_cloud config in catalog lookup

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -31,11 +31,9 @@ Available fields and semantics:
         cpus: 4+  # number of vCPUs, max concurrent spot jobs = 2 * cpus
         disk_size: 100
 
-  # Allow list for clouds to be used in `sky check`
+  # Allow list for clouds to be used
   #
-  # This field is used to restrict the clouds that SkyPilot will check and use
-  # when running `sky check`. Any cloud already enabled but not specified here
-  # will be disabled on the next `sky check` run.
+  # This field is used to restrict the clouds that SkyPilot will check and use.
   # If this field is not set, SkyPilot will check and use all supported clouds.
   #
   # Default: null (use all supported clouds).

--- a/sky/clouds/service_catalog/__init__.py
+++ b/sky/clouds/service_catalog/__init__.py
@@ -4,6 +4,7 @@ import importlib
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+from sky import skypilot_config
 from sky.clouds.service_catalog.config import fallback_to_default_catalog
 from sky.clouds.service_catalog.constants import ALL_CLOUDS
 from sky.clouds.service_catalog.constants import CATALOG_DIR
@@ -20,7 +21,12 @@ CloudFilter = Optional[Union[List[str], str]]
 
 def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
-        clouds = list(ALL_CLOUDS)
+        # Honor the allowed_clouds config when clouds is not specified.
+        # Note: no op if disabled clouds are specified, since Optimizer will
+        # error out to user in the end.
+        clouds = typing.cast(
+            List[str],
+            skypilot_config.get_nested(('allowed_clouds',), list(ALL_CLOUDS)))
 
         # TODO(hemil): Remove this once the common service catalog
         # functions are refactored from clouds/kubernetes.py to


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

follow up https://github.com/skypilot-org/skypilot/pull/4483#issuecomment-2552672752

This PR will speed up `sky launch` when the number of allowed clouds is small and a non-canonical GPU name is requested. As a test, with only `runpod` allowed in both case, this PR speed up `sky launch` by 4x:

```bash
# PR branch
$ /usr/bin/time sky launch --gpus L40:1
Considered resources (1 node):
---------------------------------------------------------------------------------------------
 CLOUD    INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
---------------------------------------------------------------------------------------------
 RunPod   1x_L40_SECURE   16      48        L40:1          CA            1.14          ✔
---------------------------------------------------------------------------------------------
        0,76 real         0,89 user         2,72 sys

# master branch
$ /usr/bin/time sky launch --gpus L40:1
Considered resources (1 node):
---------------------------------------------------------------------------------------------
 CLOUD    INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
---------------------------------------------------------------------------------------------
 RunPod   1x_L40_SECURE   16      48        L40:1          CA            1.14          ✔
---------------------------------------------------------------------------------------------
        2,94 real         1,62 user         2,61 sys
```

@Michaelvll PTAL, thanks!

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (see test above)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
