### PR TITLE
[k8s] Fix `--purge` not cleaning up cluster in stale k8s context

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4195,8 +4195,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # that successfully call this function but do not first call
         # teardown_cluster or terminate_instances. See
         # https://github.com/skypilot-org/skypilot/pull/4443#discussion_r1872798032
-        # If purge is set, we do not care about instance status and can skip
-        # the check.
+        # If purge is set, we do not care about instance status and should skip
+        # the check because it may fail if the cluster is not reachable.
         attempts = 0
         if not purge:
             while True:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4211,8 +4211,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         f'set. Details: '
                         f'{common_utils.format_exception(e, use_bracket=True)}')
                     break
-                else:
-                    raise
+                raise
 
             unexpected_node_state: Optional[Tuple[str, str]] = None
             for node_id, node_status in node_status_dict.items():
@@ -4236,9 +4235,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                    f'state {node_status}. Skipping since purge '
                                    'is set.')
                     break
-                else:
-                    raise RuntimeError(f'Instance {node_id} in unexpected '
-                                       f'state {node_status}.')
+                raise RuntimeError(f'Instance {node_id} in unexpected '
+                                   f'state {node_status}.')
 
         global_user_state.remove_cluster(handle.cluster_name,
                                          terminate=terminate)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4206,7 +4206,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     cluster_name_on_cloud,
                     config['provider'],
                     non_terminated_only=False)
-            except Exception as e:
+            except Exception as e:  # pylint: disable=broad-except
                 if purge:
                     logger.warning(
                         f'Failed to query instances. Skipping since purge is '
@@ -4223,9 +4223,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 # between "stopping/stopped" and "terminating/terminated",
                 # so we allow for either status instead of casing
                 # on `terminate`.
-                if node_status not in [
-                        None, status_lib.ClusterStatus.STOPPED
-                ]:
+                if node_status not in [None, status_lib.ClusterStatus.STOPPED]:
                     unexpected_node_state = (node_id, node_status)
 
             if unexpected_node_state is None:
@@ -4238,12 +4236,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 (node_id, node_status) = unexpected_node_state
                 if purge:
                     logger.warning(f'Instance {node_id} in unexpected '
-                                    'state {node_status}. Skipping since purge '
-                                    'is set.')
+                                   'state {node_status}. Skipping since purge '
+                                   'is set.')
                     break
                 else:
                     raise RuntimeError(f'Instance {node_id} in unexpected '
-                                        'state {node_status}.')
+                                       'state {node_status}.')
 
         global_user_state.remove_cluster(handle.cluster_name,
                                          terminate=terminate)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4195,8 +4195,6 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # that successfully call this function but do not first call
         # teardown_cluster or terminate_instances. See
         # https://github.com/skypilot-org/skypilot/pull/4443#discussion_r1872798032
-        # If purge is set, we do not care about instance status and should skip
-        # the check because it may fail if the cluster is not reachable.
         attempts = 0
         while True:
             logger.debug(f'instance statuses attempt {attempts + 1}')
@@ -4220,9 +4218,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             for node_id, node_status in node_status_dict.items():
                 logger.debug(f'{node_id} status: {node_status}')
                 # FIXME(cooperc): Some clouds (e.g. GCP) do not distinguish
-                # between "stopping/stopped" and "terminating/terminated",
-                # so we allow for either status instead of casing
-                # on `terminate`.
+                # between "stopping/stopped" and "terminating/terminated", so we
+                # allow for either status instead of casing on `terminate`.
                 if node_status not in [None, status_lib.ClusterStatus.STOPPED]:
                     unexpected_node_state = (node_id, node_status)
 
@@ -4236,12 +4233,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 (node_id, node_status) = unexpected_node_state
                 if purge:
                     logger.warning(f'Instance {node_id} in unexpected '
-                                   'state {node_status}. Skipping since purge '
+                                   f'state {node_status}. Skipping since purge '
                                    'is set.')
                     break
                 else:
                     raise RuntimeError(f'Instance {node_id} in unexpected '
-                                       'state {node_status}.')
+                                       f'state {node_status}.')
 
         global_user_state.remove_cluster(handle.cluster_name,
                                          terminate=terminate)


### PR DESCRIPTION
Fixes issue reported here: https://github.com/skypilot-org/skypilot/issues/2807#issuecomment-2564567890

`sky down --purge` now works again even with stale or invalid context.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested with `sky local up; sky launch -c test --cloud kubernetes -- echo hi; mv ~/.kube/config ~/.kube/config.bak; sky down --purge test`