### PR TITLE
[OCI] Set default image to ubuntu LTS 22.04

### DIFF
--- a/examples/oci/gpu-oraclelinux9.yaml
+++ b/examples/oci/gpu-oraclelinux9.yaml
@@ -1,0 +1,33 @@
+name: gpu-task
+
+resources:
+  # Optional; if left out, automatically pick the cheapest cloud.
+  cloud: oci
+
+  accelerators: A10:1
+
+  disk_size: 1024
+
+  disk_tier: high
+
+  image_id: skypilot:gpu-oraclelinux9
+
+
+# Working directory (optional) containing the project codebase.
+# Its contents are synced to ~/sky_workdir/ on the cluster.
+workdir: .
+
+num_nodes: 1
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "*** Running setup. ***"
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "*** Running the task on OCI ***"
+  echo "hello, world"
+  nvidia-smi
+  echo "The task is completed."

--- a/examples/oci/gpu-ubuntu-2204.yaml
+++ b/examples/oci/gpu-ubuntu-2204.yaml
@@ -1,0 +1,34 @@
+name: gpu-task
+
+resources:
+  # Optional; if left out, automatically pick the cheapest cloud.
+  cloud: oci
+
+  accelerators: A10:1
+
+  disk_size: 1024
+
+  disk_tier: high
+
+  #image_id: skypilot:gpu-oraclelinux8-cuda126
+  image_id: skypilot:gpu-ubuntu-2204
+
+
+# Working directory (optional) containing the project codebase.
+# Its contents are synced to ~/sky_workdir/ on the cluster.
+workdir: .
+
+num_nodes: 1
+
+# Typical use: pip install -r requirements.txt
+# Invoked under the workdir (i.e., can use its files).
+setup: |
+  echo "*** Running setup. ***"
+
+# Typical use: make use of resources, such as running training.
+# Invoked under the workdir (i.e., can use its files).
+run: |
+  echo "*** Running the task on OCI ***"
+  echo "hello, world"
+  nvidia-smi
+  echo "The task is completed."

--- a/examples/oci/gpu-ubuntu-2204.yaml
+++ b/examples/oci/gpu-ubuntu-2204.yaml
@@ -10,7 +10,6 @@ resources:
 
   disk_tier: high
 
-  #image_id: skypilot:gpu-oraclelinux8-cuda126
   image_id: skypilot:gpu-ubuntu-2204
 
 

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -6,8 +6,10 @@ History:
    configuration.
  - Hysun He (hysun.he@oracle.com) @ Nov.12, 2024: Add the constant
    SERVICE_PORT_RULE_TAG
- - Hysun He (hysun.he@oracle.com) @ Jan.01, 2025: Set the default gpu
-   image from skypilot:gpu-ubuntu-2004 to skypilot:gpu-ubuntu-2204
+ - Hysun He (hysun.he@oracle.com) @ Jan.01, 2025: Set the default image
+   from ubuntu 20.04 to ubuntu 22.04, including:
+   - GPU: skypilot:gpu-ubuntu-2004 -> skypilot:gpu-ubuntu-2204
+   - CPU: skypilot:cpu-ubuntu-2004 -> skypilot:cpu-ubuntu-2204
 """
 import os
 

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -6,6 +6,8 @@ History:
    configuration.
  - Hysun He (hysun.he@oracle.com) @ Nov.12, 2024: Add the constant
    SERVICE_PORT_RULE_TAG
+ - Hysun He (hysun.he@oracle.com) @ Jan.01, 2025: Set the default gpu
+   image from skypilot:gpu-ubuntu-2004 to skypilot:gpu-ubuntu-2204
 """
 import os
 
@@ -117,7 +119,7 @@ class OCIConfig:
         # the sky's user-config file (if not specified, use the hardcode one at
         # last)
         return skypilot_config.get_nested(('oci', 'default', 'image_tag_gpu'),
-                                          'skypilot:gpu-ubuntu-2004')
+                                          'skypilot:gpu-ubuntu-2204')
 
     @classmethod
     def get_default_image_tag(cls) -> str:

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -127,7 +127,7 @@ class OCIConfig:
         # set the default image tag in the sky's user-config file. (if not
         # specified, use the hardcode one at last)
         return skypilot_config.get_nested(
-            ('oci', 'default', 'image_tag_general'), 'skypilot:cpu-ubuntu-2004')
+            ('oci', 'default', 'image_tag_general'), 'skypilot:cpu-ubuntu-2204')
 
     @classmethod
     def get_sky_user_config_file(cls) -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Set the default image for both GPU and CPU to ubuntu 22.04. 

Please also help review the catalog PR https://github.com/skypilot-org/skypilot-catalog/pull/107 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

All images are validated with the following passed tests:
test1:  sky launch -c gpu-2204 examples/oci/gpu-ubuntu-2204.yaml (GPU ubuntu 22.04)
test2: sky launch -c gpu-ol9 examples/oci/gpu-oraclelinux9.yaml (GPU oraclelinux9)
test3: sky launch -c gpu-ol8 hysun_sky.yaml --image-id skypilot:gpu-oraclelinux8 (GPU oraclelinux8)
test4: sky launch -c gpu-2204 examples/oci/gpu-ubuntu-2204.yaml (comment out the image_id for testing the gpu default image)
test5: sky launch -c cputest --cloud oci --region us-sanjose-1 uptime (CPU default image: ubuntu 22.04)
test6: sky launch -c cputest --cloud oci --region us-sanjose-1 --image-id skypilot:cpu-oraclelinux8 "cat /etc/os-release" (CPU oraclelinux8)
test7: sky launch -c cputest --cloud oci --region us-sanjose-1 --image-id skypilot:cpu-oraclelinux9 "cat /etc/os-release" (CPU oraclelinux9)

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
