### PR TITLE
[OCI] 1. Support specify OS with custom image id. 2. Corner case fix

### DIFF
--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -238,7 +238,7 @@ class OCI(clouds.Cloud):
             # custom image's ocid provided in the --image-id parameter.
             #  - ocid1.image...aaa:oraclelinux (os type is oraclelinux)
             #  - ocid1.image...aaa (OS not provided)
-            image_id, os_type = image_id.split(':')
+            image_id, os_type = image_id.replace(' ', '').split(':')
 
         cpus = resources.cpus
         instance_type_arr = resources.instance_type.split(

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -305,7 +305,7 @@ class OCI(clouds.Cloud):
             cpus=None if cpus is None else float(cpus),
             disk_tier=resources.disk_tier)
 
-        if not os_type:
+        if os_type is None:
             # OS type is not determined yet. So try to get it from vms.csv
             image_str = self._get_image_str(
                 image_id=resources.image_id,

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -232,6 +232,14 @@ class OCI(clouds.Cloud):
             listing_id = None
             res_ver = None
 
+        os_type = None
+        if ':' in image_id:
+            # OS type provided in the --image-id. This is the case where
+            # custom image's ocid provided in the --image-id parameter.
+            #  - ocid1.image...aaa:oraclelinux (os type is oraclelinux)
+            #  - ocid1.image...aaa (OS not provided)
+            image_id, os_type = image_id.split(':')
+
         cpus = resources.cpus
         instance_type_arr = resources.instance_type.split(
             oci_utils.oci_config.INSTANCE_TYPE_RES_SPERATOR)
@@ -297,15 +305,18 @@ class OCI(clouds.Cloud):
             cpus=None if cpus is None else float(cpus),
             disk_tier=resources.disk_tier)
 
-        image_str = self._get_image_str(image_id=resources.image_id,
-                                        instance_type=resources.instance_type,
-                                        region=region.name)
+        if not os_type:
+            # OS type is not determined yet. So try to get it from vms.csv
+            image_str = self._get_image_str(
+                image_id=resources.image_id,
+                instance_type=resources.instance_type,
+                region=region.name)
 
-        # pylint: disable=import-outside-toplevel
-        from sky.clouds.service_catalog import oci_catalog
-        os_type = oci_catalog.get_image_os_from_tag(tag=image_str,
-                                                    region=region.name)
-        logger.debug(f'OS type for the image {image_str} is {os_type}')
+            # pylint: disable=import-outside-toplevel
+            from sky.clouds.service_catalog import oci_catalog
+            os_type = oci_catalog.get_image_os_from_tag(tag=image_str,
+                                                        region=region.name)
+        logger.debug(f'OS type for the image {image_id} is {os_type}')
 
         return {
             'instance_type': instance_type,

--- a/sky/provision/oci/query_utils.py
+++ b/sky/provision/oci/query_utils.py
@@ -506,8 +506,11 @@ class QueryHelper:
             raise exceptions.ResourcesUnavailableError(
                 'The VCN is not available')
 
-        # Get the primary vnic.
-        assert len(list_vcns_resp.data) > 0
+        # Get the primary vnic. The vnic might be none for the
+        # corner case when the cluster was exited during provision.
+        if not list_vcns_resp.data:
+            return None
+
         vcn = list_vcns_resp.data[0]
 
         list_nsg_resp = net_client.list_network_security_groups(

--- a/sky/provision/oci/query_utils.py
+++ b/sky/provision/oci/query_utils.py
@@ -506,7 +506,7 @@ class QueryHelper:
             raise exceptions.ResourcesUnavailableError(
                 'The VCN is not available')
 
-        # Get the primary vnic. The vnic might be none for the
+        # Get the primary vnic. The vnic might be an empty list for the
         # corner case when the cluster was exited during provision.
         if not list_vcns_resp.data:
             return None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. Support specify OS type when specify custom image with --image-id. (Currently ubuntu/oraclelinux)  
2. A corner case fix when ctrl+c during creating cluster, which might cause the cluster cannot be terminated if the vNIC is not attached to the provisioning instance.

I'll create a doc PR later to add image-id description for OCI in task yaml.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

sky launch -c img-ol8 --cloud oci --region ap-seoul-1 --cpus 2 --image-id ocid1.image.oc1.ap-seoul-1.aaaaaaaarhw7elbcsnsxmtetmicg5eh5yf5yodmjozhxzrg7h4glptqfiwua:oraclelinux "cat /etc/os-release"

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
