### PR TITLE
[GCP] Activate service account for storage

### DIFF
--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -114,7 +114,10 @@ class GcsCloudStorage(CloudStorage):
     def _gsutil_command(self):
         gsutil_alias, alias_gen = data_utils.get_gsutil_command()
         return (f'{alias_gen}; GOOGLE_APPLICATION_CREDENTIALS='
-                f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH} {gsutil_alias}')
+                f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH}; '
+                'gcloud auth activate-service-account '
+                '--key-file=$GOOGLE_APPLICATION_CREDENTIALS || true; '
+                f'{gsutil_alias}')
 
     def is_directory(self, url: str) -> bool:
         """Returns whether 'url' is a directory.

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -526,7 +526,8 @@ def run_upload_cli(command: str, access_denied_message: str, bucket_name: str,
     returncode, stdout, stderr = log_lib.run_with_log(command,
                                                       log_path,
                                                       shell=True,
-                                                      require_outputs=True)
+                                                      require_outputs=True,
+                                                      executable='/bin/bash')
     if access_denied_message in stderr:
         with ux_utils.print_exception_no_traceback():
             raise PermissionError('Failed to upload files to '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4528

When a service account is used locally, although the service account key is uploaded, it cannot be used by the code for cloud storage. This is because `gcloud auth activate-service-account` is required for service account key, which is not needed for the normal user application key. We now activate the service account anyway, to make sure the service account works.

To reproduce:
1. Set a `~/.sky/config.yaml`
  ```yaml
  jobs:
    controller:
      resources:
        cpus: 2
        cloud: kubernetes
  ```
2. Have the service account activated for GCP locally: `gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIAL`
3. Run a managed job with `sky jobs launch test.yaml`
  ```yaml
  resources:
    cloud: kubernetes
    cpus: 2
  
  
  workdir: examples
  
  run: ls
  ```
4. The current master will fail to download the workdir from the bucket to the job cluster due to the `gsutil` fail to find the credential.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] The reproducibility above
  - [ ] With normal user account.
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
