### PR TITLE
[OCI] Support reuse existing VCN for SkyServe

### DIFF
--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -10,6 +10,8 @@ History:
    from ubuntu 20.04 to ubuntu 22.04, including:
    - GPU: skypilot:gpu-ubuntu-2004 -> skypilot:gpu-ubuntu-2204
    - CPU: skypilot:cpu-ubuntu-2004 -> skypilot:cpu-ubuntu-2204
+ - Hysun He (hysun.he@oracle.com) @ Jan.01, 2025: Support reuse existing
+   VCN for SkyServe.
 """
 import os
 
@@ -110,7 +112,14 @@ class OCIConfig:
         return compartment
 
     @classmethod
+    def get_vcn_ocid(cls, region):
+        # Will reuse the regional VCN if specified.
+        vcn = skypilot_config.get_nested(('oci', region, 'vcn_ocid'), None)
+        return vcn
+
+    @classmethod
     def get_vcn_subnet(cls, region):
+        # Will reuse the subnet if specified.
         vcn = skypilot_config.get_nested(('oci', region, 'vcn_subnet'), None)
         return vcn
 

--- a/sky/provision/oci/query_utils.py
+++ b/sky/provision/oci/query_utils.py
@@ -18,6 +18,7 @@ import time
 import traceback
 import typing
 from typing import List, Optional, Tuple
+
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.adaptors import oci as oci_adaptor

--- a/sky/provision/oci/query_utils.py
+++ b/sky/provision/oci/query_utils.py
@@ -498,7 +498,7 @@ class QueryHelper:
 
         compartment = cls.find_compartment(region)
 
-        vcn_id = oci_utils.oci_config.get_vcn_ocid()
+        vcn_id = oci_utils.oci_config.get_vcn_ocid(region)
         if vcn_id is None:
             list_vcns_resp = net_client.list_vcns(
                 compartment_id=compartment,

--- a/sky/provision/oci/query_utils.py
+++ b/sky/provision/oci/query_utils.py
@@ -18,8 +18,6 @@ import time
 import traceback
 import typing
 from typing import List, Optional, Tuple
-
-from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.adaptors import oci as oci_adaptor

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -886,6 +886,9 @@ def get_config_schema():
                     'image_tag_gpu': {
                         'type': 'string',
                     },
+                    'vcn_ocid': {
+                        'type': 'string',
+                    },
                     'vcn_subnet': {
                         'type': 'string',
                     },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
User may demand to reuse the existing VCN. We already support that for sky launch with "vcn_subnet" config. Now we add "vcn_ocid" for SkyServe (need vcn_ocid to create network security group (NSG)).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Example ./sky/config.yaml:
```
oci:
  default:
    compartment_ocid: ocid1.compartment.oc1..aaaaaaaam5akmizz6fzm7old5rqjlsrrckelfv6tyw24woxhtwzmpu4x6ioq

  us-sanjose-1:
    vcn_ocid: ocid1.vcn.oc1.ap-seoul-1.amaaaaaaak7gbriarkfs2ssus5mh347ktmi3xa72tadajep6asio3ubqgarq
    vcn_subnet: ocid1.subnet.oc1.ap-seoul-1.aaaaaaaa5c6wndifsij6yfyfehmi3tazn6mvhhiewqmajzcrlryurnl7nuja
```

Then run:
`sky serve up ./examples/oci/serve-http-cpu.yaml`

Related docs will be updated later.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
