### PR TITLE
support filter flag for buildkite

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -244,8 +244,7 @@ import click
 @click.option(
     '--filter-flag',
     type=str,
-    help='Filter to include only a subset of pytest marks, e.g., managed_jobs',
-    default='all')
+    help='Filter to include only a subset of pytest marks, e.g., managed_jobs')
 def main(filter_flag):
     test_files = os.listdir('tests/smoke_tests')
     release_files = []
@@ -259,11 +258,12 @@ def main(filter_flag):
         else:
             release_files.append(test_file_path)
 
-    if filter_flag == 'all':
-        filter_flag = []
-    else:
+    filter_flag = filter_flag or os.getenv('FILTER_FLAG')
+    if filter_flag:
         filter_flag = filter_flag.split(',')
-    print(f'Filter flag: {filter_flag}')
+        print(f'Filter flag: {filter_flag}')
+    else:
+        filter_flag = []
 
     _convert_release(release_files, filter_flag)
     _convert_quick_tests_core(quick_tests_core_files, filter_flag)

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -244,7 +244,8 @@ import click
 @click.option(
     '--filter-flag',
     type=str,
-    help='Filter to include specific types of jobs, e.g., managed_jobs')
+    help='Filter to include only a subset of pytest marks, e.g., managed_jobs',
+    default='all')
 def main(filter_flag):
     test_files = os.listdir('tests/smoke_tests')
     release_files = []
@@ -258,11 +259,11 @@ def main(filter_flag):
         else:
             release_files.append(test_file_path)
 
-    if filter_flag:
-        filter_flag = filter_flag.split(',')
-        print(f'Filter flag: {filter_flag}')
-    else:
+    if filter_flag == 'all':
         filter_flag = []
+    else:
+        filter_flag = filter_flag.split(',')
+    print(f'Filter flag: {filter_flag}')
 
     _convert_release(release_files, filter_flag)
     _convert_quick_tests_core(quick_tests_core_files, filter_flag)

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -79,7 +79,8 @@ def _extract_marked_tests(file_path: str,
     """
     cmd = f'pytest {file_path} --collect-only'
     output = subprocess.run(cmd, shell=True, capture_output=True, text=True)
-    matches = re.findall('Collected (.+?) with marks: \[(.*?)\]', output.stdout)
+    matches = re.findall('Collected .+?\.py::(.+?) with marks: \[(.*?)\]',
+                         output.stdout)
     function_name_marks_map = {}
     for function_name, marks in matches:
         function_name = re.sub(r'\[.*?\]', '', function_name)

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -92,7 +92,7 @@ def _extract_marked_tests(file_path: str,
     function_cloud_map = {}
     filter_marks = set(filter_marks)
     for function_name, marks in function_name_marks_map.items():
-        if not filter_marks & marks:
+        if filter_marks and not filter_marks & marks:
             continue
         clouds_to_include = []
         clouds_to_exclude = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,3 +220,11 @@ def aws_config_region(monkeypatch: pytest.MonkeyPatch) -> str:
         if isinstance(ssh_proxy_command, dict) and ssh_proxy_command:
             region = list(ssh_proxy_command.keys())[0]
     return region
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.option.collectonly:
+        for item in items:
+            full_name = item.nodeid
+            marks = [mark.name for mark in item.iter_markers()]
+            print(f"Collected {full_name} with marks: {marks}")


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

support

```bash
PYTHONPATH=$(pwd)/tests:$PYTHONPATH python .buildkite/generate_pipeline.py --filter-marks managed_jobs
```

So that we can configure Buildkite to call this script with this flag, supporting arbitrary pytest flags.

Now we can comment on PR: 
* `/smoke-test` to trigger all smoke tests.
* Or use `/smoke-test managed_jobs` to trigger smoke tests marked by certain pytest mark.
* Format: `/smoke-test <mark1>,<mark2>`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
