### PR TITLE
[Jobs] Refactor dashboard controller launching with systemd

### DIFF
--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -25,11 +25,28 @@ setup: |
   # Internal: disable logging for manually logging into the jobs controller for debugging.
   echo 'export SKYPILOT_DEV=1' >> ~/.bashrc
   {% endif %}
+  # Install Flask if not present
+  pip list | grep flask > /dev/null 2>&1 || pip install flask 2>&1 > /dev/null
 
-  # Dashboard.
-  ps aux | grep -v nohup | grep -v grep | grep -- "-m sky.spot.dashboard" | awk '{print $2}' | xargs kill > /dev/null 2>&1 || true
-  pip list | grep flask  > /dev/null 2>&1 || pip install flask 2>&1 > /dev/null
-  ((ps aux | grep -v nohup | grep -v grep | grep -q -- "-m sky.jobs.dashboard.dashboard") || (nohup {{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard >> ~/.sky/job-dashboard.log 2>&1 &));
+  # Create systemd service file
+  cat << EOF | sudo tee /etc/systemd/system/skypilot-dashboard.service
+  [Unit]
+  Description=SkyPilot Jobs Dashboard
+  After=network.target
+
+  [Service]
+  Environment="PATH={{ sky_python_env_path }}:\$PATH"
+  ExecStart={{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard
+  Restart=always
+
+  [Install]
+  WantedBy=multi-user.target
+  EOF
+
+  # Reload systemd, enable and start the service
+  sudo systemctl daemon-reload
+  sudo systemctl enable skypilot-dashboard
+  sudo systemctl start skypilot-dashboard
 
 run: |
   {{ sky_activate_python_env }}

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -29,24 +29,33 @@ setup: |
   pip list | grep flask > /dev/null 2>&1 || pip install flask 2>&1 > /dev/null
 
   # Create systemd service file
-  cat << EOF | sudo tee /etc/systemd/system/skypilot-dashboard.service
+  mkdir -p ~/.config/systemd/user/
+
+  # Create systemd user service file
+  cat << EOF > ~/.config/systemd/user/skypilot-dashboard.service
   [Unit]
   Description=SkyPilot Jobs Dashboard
   After=network.target
 
   [Service]
   Environment="PATH={{ sky_python_env_path }}:\$PATH"
-  ExecStart={{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard
+  Environment="SKYPILOT_USER_ID={{controller_envs.SKYPILOT_USER_ID}}"
+  Environment="SKYPILOT_USER={{controller_envs.SKYPILOT_USER}}"
   Restart=always
+  # Redirect logs to the home directory
+  StandardOutput=append:/home/$USER/.sky/job-dashboard.log
+  StandardError=append:/home/$USER/.sky/job-dashboard.log
+  # setup environment variable of controller name
+  ExecStart={{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard
 
   [Install]
   WantedBy=multi-user.target
   EOF
 
   # Reload systemd, enable and start the service
-  sudo systemctl daemon-reload
-  sudo systemctl enable skypilot-dashboard
-  sudo systemctl start skypilot-dashboard
+  systemctl --user daemon-reload
+  systemctl --user enable skypilot-dashboard
+  systemctl --user start skypilot-dashboard
 
 run: |
   {{ sky_activate_python_env }}

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -52,10 +52,19 @@ setup: |
   WantedBy=multi-user.target
   EOF
 
-  # Reload systemd, enable and start the service
-  systemctl --user daemon-reload
-  systemctl --user enable skypilot-dashboard
-  systemctl --user start skypilot-dashboard
+  if command -v systemctl &>/dev/null && systemctl --user show &>/dev/null; then
+    systemctl --user daemon-reload
+    systemctl --user enable skypilot-dashboard
+    systemctl --user start skypilot-dashboard
+  else
+    echo "Systemd user services not found. Setting up SkyPilot dashboard manually."
+    # Kill any old dashboard processes
+    ps aux | grep -v nohup | grep -v grep | grep -- '-m sky.jobs.dashboard.dashboard' \
+      | awk '{print $2}' | xargs kill > /dev/null 2>&1 || true
+    # Launch the dashboard in the background if not already running
+    (ps aux | grep -v nohup | grep -v grep | grep -q -- '-m sky.jobs.dashboard.dashboard') || \
+      (nohup {{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard >> ~/.sky/job-dashboard.log 2>&1 &)
+  fi
 
 run: |
   {{ sky_activate_python_env }}

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -25,8 +25,6 @@ setup: |
   # Internal: disable logging for manually logging into the jobs controller for debugging.
   echo 'export SKYPILOT_DEV=1' >> ~/.bashrc
   {% endif %}
-  # Install Flask if not present
-  pip list | grep flask > /dev/null 2>&1 || pip install flask 2>&1 > /dev/null
 
   # Create systemd service file
   mkdir -p ~/.config/systemd/user/
@@ -42,14 +40,12 @@ setup: |
   Environment="SKYPILOT_USER_ID={{controller_envs.SKYPILOT_USER_ID}}"
   Environment="SKYPILOT_USER={{controller_envs.SKYPILOT_USER}}"
   Restart=always
-  # Redirect logs to the home directory
   StandardOutput=append:/home/$USER/.sky/job-dashboard.log
   StandardError=append:/home/$USER/.sky/job-dashboard.log
-  # setup environment variable of controller name
   ExecStart={{ sky_python_cmd }} -m sky.jobs.dashboard.dashboard
 
   [Install]
-  WantedBy=multi-user.target
+  WantedBy=default.target
   EOF
 
   if command -v systemctl &>/dev/null && systemctl --user show &>/dev/null; then

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -54,8 +54,7 @@ setup: |
 
   if command -v systemctl &>/dev/null && systemctl --user show &>/dev/null; then
     systemctl --user daemon-reload
-    systemctl --user enable skypilot-dashboard
-    systemctl --user start skypilot-dashboard
+    systemctl --user enable --now skypilot-dashboard
   else
     echo "Systemd user services not found. Setting up SkyPilot dashboard manually."
     # Kill any old dashboard processes

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -206,6 +206,9 @@ def _get_cloud_dependencies_installation_commands(
     # installed, so we don't check that.
     python_packages: Set[str] = set()
 
+    # add flask to the controller dependencies for dashboard
+    python_packages.add('flask')
+
     step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
     commands.append(f'echo -en "\\r{step_prefix}uv{empty_str}" &&'
                     f'{constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1')


### PR DESCRIPTION
closes #4299 by systemd

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR 
```
sky start sky-jobs-controller-<hash>
sky jobs launch --fast echo hi
curl localhost:5000
```

