### PR TITLE
[AWS] Adding filter for default aws vpc if not specified

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -223,7 +223,7 @@ IAM Role Creation
 
 Using a specific VPC
 -----------------------
-By default, SkyPilot uses the "default" VPC in each region.
+By default, SkyPilot uses the "default" VPC in each region. If a region does not have a `default VPC <https://docs.aws.amazon.com/vpc/latest/userguide/work-with-default-vpc.html#create-default-vpc>`_, SkyPilot will not be able to use the region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
 file ``~/.sky/config.yaml`` to specify the VPC name in the ``aws.vpc_name``

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -385,7 +385,7 @@ def _usable_subnets(
     if not subnets:
         vpc_msg = (f'Does a default VPC exist in region '
                    f'{ec2.meta.client.meta.region_name}? ') if (
-                vpc_id_of_sg is None) else ''
+                       vpc_id_of_sg is None) else ''
         _skypilot_log_error_and_exit_for_failover(
             f'No usable subnets found. {vpc_msg}'
             'Try manually creating an instance in your specified region to '

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -383,10 +383,13 @@ def _usable_subnets(
         raise exc
 
     if not subnets:
+        vpc_msg = (f'Does a default VPC exist in region '
+                   f'{ec2.meta.client.meta.region_name}? ') if (
+                vpc_id_of_sg is None) else ''
         _skypilot_log_error_and_exit_for_failover(
-            'No usable subnets found, try '
-            'manually creating an instance in your specified region to '
-            'populate the list of subnets and trying this again. '
+            f'No usable subnets found. {vpc_msg}'
+            'Try manually creating an instance in your specified region to '
+            'populate the list of subnets and try again. '
             'Note that the subnet must map public IPs '
             'on instance launch unless you set `use_internal_ips: true` in '
             'the `provider` config.')
@@ -496,6 +499,8 @@ def _get_subnet_and_vpc_id(ec2, security_group_ids: Optional[List[str]],
 
     all_subnets = list(ec2.subnets.all())
     # If no VPC is specified, use the default VPC.
+    # We filter only for default VPCs to avoid using subnets that users may
+    # not want SkyPilot to use.
     if vpc_id_of_sg is None:
         all_subnets = [s for s in all_subnets if s.vpc.is_default]
     subnets, vpc_id = _usable_subnets(

--- a/sky/provision/aws/config.py
+++ b/sky/provision/aws/config.py
@@ -495,6 +495,9 @@ def _get_subnet_and_vpc_id(ec2, security_group_ids: Optional[List[str]],
         vpc_id_of_sg = None
 
     all_subnets = list(ec2.subnets.all())
+    # If no VPC is specified, use the default VPC.
+    if vpc_id_of_sg is None:
+        all_subnets = [s for s in all_subnets if s.vpc.is_default]
     subnets, vpc_id = _usable_subnets(
         ec2,
         user_specified_subnets=None,


### PR DESCRIPTION
Adding a filter for the default AWS VPC when no VPC is specified. This is matching the [docs](https://docs.skypilot.co/en/latest/reference/config.html): 
```
aws:
  # ...
  # VPC to use in each region (optional).
  #
  # If this is set, SkyPilot will only provision in regions that contain a VPC
  # with this name (provisioner automatically looks for such regions).
  # Regions without a VPC with this name will not be used to launch nodes.
  #
  # Default: null (use the default VPC in each region).
  vpc_name: skypilot-vpc
```

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
