### PR TITLE
[AWS] Adding custom process as an option for aws credentials

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -94,6 +94,8 @@ class AWSIdentityType(enum.Enum):
     IAM_ROLE = 'iam-role'
 
     CONTAINER_ROLE = 'container-role'
+    
+    CUSTOM_PROCESS = 'custom-process'
 
     #       Name                    Value             Type    Location
     #       ----                    -----             ----    --------
@@ -614,10 +616,16 @@ class AWS(clouds.Cloud):
             hints = f'AWS IAM role is set.{single_cloud_hint}'
         elif identity_type == AWSIdentityType.CONTAINER_ROLE:
             # Similar to the IAM ROLE, an ECS container may not store credentials
-            # in the~/.aws/credentials file. So we don't check for the existence of
+            # in the ~/.aws/credentials file. So we don't check for the existence of
             # the file. i.e. the container will be assigned the IAM role of the
             # task: skypilot-v1.
             hints = f'AWS container-role is set.{single_cloud_hint}'
+        elif identity_type == AWSIdentityType.CUSTOM_PROCESS:
+            # Similar to the IAM ROLE, a custom process may not store credentials
+            # in the ~/.aws/credentials file. So we don't check for the existence of
+            # the file. i.e. the custom process will be assigned the IAM role of the
+            # task: skypilot-v1.
+            hints = f'AWS custom-process is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on
             # other clouds to access private s3 buckets and resources like EC2.
@@ -677,6 +685,8 @@ class AWS(clouds.Cloud):
             return AWSIdentityType.CONTAINER_ROLE
         elif _is_access_key_of_type(AWSIdentityType.ENV.value):
             return AWSIdentityType.ENV
+        elif _is_access_key_of_type(AWSIdentityType.CUSTOM_PROCESS.value):
+            return AWSIdentityType.CUSTOM_PROCESS
         else:
             return AWSIdentityType.SHARED_CREDENTIALS_FILE
 

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -94,7 +94,7 @@ class AWSIdentityType(enum.Enum):
     IAM_ROLE = 'iam-role'
 
     CONTAINER_ROLE = 'container-role'
-    
+
     CUSTOM_PROCESS = 'custom-process'
 
     #       Name                    Value             Type    Location


### PR DESCRIPTION
Adding the option for AWS credentials provided by custom process. This auth method already worked, it just wasn't recognized properly when checked.


### Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
