### PR TITLE
[AWS] Adding aws assume role option, and env var detection

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -630,14 +630,14 @@ class AWS(clouds.Cloud):
             hints = f'AWS custom-process is set.{single_cloud_hint}'
         elif identity_type == AWSIdentityType.ASSUME_ROLE:
             # When using ASSUME ROLE, the credentials are coming from a different
-            # source profile. So we don't check for the existence of the file.
-            # the file. i.e. the assumed role will be assigned the IAM role of the
+            # source profile. So we don't check for the existence of ~/.aws/credentials.
+            # i.e. the assumed role will be assigned the IAM role of the
             # task: skypilot-v1.
             hints = f'AWS assume-role is set.{single_cloud_hint}'
         elif identity_type == AWSIdentityType.ENV:
             # When using ENV vars, the credentials are coming from the environment
-            # variables. So we don't check for the existence of the file.
-            # the file. i.e. the identity is not determined by the file.
+            # variables. So we don't check for the existence of ~/.aws/credentials.
+            # i.e. the identity is not determined by the file.
             hints = f'AWS env is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -97,6 +97,8 @@ class AWSIdentityType(enum.Enum):
 
     CUSTOM_PROCESS = 'custom-process'
 
+    ASSUME_ROLE = 'assume-role'
+
     #       Name                    Value             Type    Location
     #       ----                    -----             ----    --------
     #    profile                <not set>             None    None
@@ -626,6 +628,17 @@ class AWS(clouds.Cloud):
             # the file. i.e. the custom process will be assigned the IAM role of the
             # task: skypilot-v1.
             hints = f'AWS custom-process is set.{single_cloud_hint}'
+        elif identity_type == AWSIdentityType.ASSUME_ROLE:
+            # When using ASSUME ROLE, the credentials are coming from a different
+            # source profile. So we don't check for the existence of the file.
+            # the file. i.e. the assumed role will be assigned the IAM role of the
+            # task: skypilot-v1.
+            hints = f'AWS assume-role is set.{single_cloud_hint}'
+        elif identity_type == AWSIdentityType.ENV:
+            # When using ENV vars, the credentials are coming from the environment
+            # variables. So we don't check for the existence of the file.
+            # the file. i.e. the identity is not determined by the file.
+            hints = f'AWS env is set.{single_cloud_hint}'
         else:
             # This file is required because it is required by the VMs launched on
             # other clouds to access private s3 buckets and resources like EC2.
@@ -677,18 +690,10 @@ class AWS(clouds.Cloud):
                     f'Unexpected `aws configure list` output:\n{output}')
             return len(results) == 1
 
-        if _is_access_key_of_type(AWSIdentityType.SSO.value):
-            return AWSIdentityType.SSO
-        elif _is_access_key_of_type(AWSIdentityType.IAM_ROLE.value):
-            return AWSIdentityType.IAM_ROLE
-        elif _is_access_key_of_type(AWSIdentityType.CONTAINER_ROLE.value):
-            return AWSIdentityType.CONTAINER_ROLE
-        elif _is_access_key_of_type(AWSIdentityType.ENV.value):
-            return AWSIdentityType.ENV
-        elif _is_access_key_of_type(AWSIdentityType.CUSTOM_PROCESS.value):
-            return AWSIdentityType.CUSTOM_PROCESS
-        else:
-            return AWSIdentityType.SHARED_CREDENTIALS_FILE
+        for identity_type in AWSIdentityType:
+            if _is_access_key_of_type(identity_type.value):
+                return identity_type
+        return AWSIdentityType.SHARED_CREDENTIALS_FILE
 
     @classmethod
     @functools.lru_cache(maxsize=1)


### PR DESCRIPTION
Adding an option for an AWS identity that is an assumed role, set by using the `source_profile` and `role_arn` options in your `~/.aws/config`. Also refactored the identity option check to a for loop as it was getting repetitive. Also made it so the env var identity is recognized by `sky check`


### Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Testing with env vars: 
```
sky check aws     
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled                              
    Hint: AWS env is set. It will work if you use AWS only, but will cause problems if you want to use multiple clouds. To set up static credentials, try: aws configure
```
  - [x] Testing with assumed role:
```
sky check aws
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled                              
    Hint: AWS assume-role is set. It will work if you use AWS only, but will cause problems if you want to use multiple clouds. To set up static credentials, try: aws configure
```
  - [x] Testing with custom credential process:
```
sky check aws                                                                            
Checking credentials to enable clouds for SkyPilot.
  AWS: enabled                              
    Hint: AWS custom-process is set. It will work if you use AWS only, but will cause problems if you want to use multiple clouds. To set up static credentials, try: aws configure
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
