### PR TITLE
[OCI]: Storage: support buckets from different region

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -290,7 +290,7 @@ Storage YAML reference
             - https://<azure_storage_account>.blob.core.windows.net/<container_name>
             - r2://<bucket_name>
             - cos://<region_name>/<bucket_name>
-            - oci://<bucket_name>
+            - oci://<bucket_name>@<region>
 
           If the source is local, data is uploaded to the cloud to an appropriate
           bucket (s3, gcs, azure, r2, oci, or ibm). If source is bucket URI,

--- a/examples/oci/dataset-mount.yaml
+++ b/examples/oci/dataset-mount.yaml
@@ -11,7 +11,7 @@ resources:
 file_mounts:
   # Mount an existing oci bucket
   /datasets-storage:
-    source: oci://skybucket
+    source: oci://skybucket@us-sanjose-1
     mode: MOUNT  # Either MOUNT or COPY. Optional.
 
 # Working directory (optional) containing the project codebase.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3985,15 +3985,22 @@ class OciStore(AbstractStore):
         #   /datasets-storage:
         #       source: oci://RAGData@us-sanjose-1
         # The name in above mount will be set to RAGData@us-sanjose-1
+        region_in_name = None
         if name is not None and '@' in name:
             self._validate_bucket_expr(name)
-            name, region = name.split('@')
+            name, region_in_name = name.split('@')
 
         # Region is from the specified source in oci://<bucket>@<region> format
+        region_in_source = None
         if isinstance(source,
                       str) and source.startswith('oci://') and '@' in source:
             self._validate_bucket_expr(source)
-            source, region = source.split('@')
+            source, region_in_source = source.split('@')
+
+        if region_in_name is not None:
+            region = region_in_name
+        elif region_in_source is not None:
+            region = region_in_source
 
         # Default region set to what specified in oci config.
         if region is None:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3998,7 +3998,8 @@ class OciStore(AbstractStore):
 
     def _validate_bucket_expr(self, bucket_expr: str):
         pattern = r'^(\w+://)?[A-Za-z0-9-._]+(@\w{2}-\w+-\d{1})$'
-        assert re.match(pattern, bucket_expr), (
+        if not re.match(pattern, bucket_expr):
+            raise ValueError(
             'The format for the bucket portion is <bucket>@<region> '
             'when specify a region with a bucket.')
 

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3997,6 +3997,13 @@ class OciStore(AbstractStore):
             self._validate_bucket_expr(source)
             source, region_in_source = source.split('@')
 
+        if region_in_name is not None and region_in_source is not None:
+            # This should never happen because name and source will never be
+            # the remote bucket at the same time.
+            assert region_in_name == region_in_source, (
+                f'Mismatch region specified. Region in name {region_in_name}, '
+                f'but region in source is {region_in_source}')
+
         if region_in_name is not None:
             region = region_in_name
         elif region_in_source is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This is an enhancement of OCI cloud storage support.

Before this change, the region the bucket belongs to is restricted to be same as the region in the OCI config file. This becomes the default setting if no region specified with this enhancement.

With this change, we can specify the region with the bucket name in the source or name attribute.
oci://<bucket_name>  -->  oci://<bucket_name>@<region>

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
sky launch -c teststore ./examples/oci/dataset-upload-and-mount.yaml
sky launch -c teststore ./examples/oci/dataset-mount.yaml

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
