### PR TITLE
[k8s] Fix AssertionError in show-gpus when all GPUs were allocated

### DIFF
--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -118,12 +118,12 @@ def _list_accelerators(
 
     Returns:
         A tuple of three dictionaries:
-        - qtys_map: Dict mapping accelerator names to lists of InstanceTypeInfo 
+        - qtys_map: Dict mapping accelerator names to lists of InstanceTypeInfo
             objects with quantity information.
-        - total_accelerators_capacity: Dict mapping accelerator names to their 
+        - total_accelerators_capacity: Dict mapping accelerator names to their
             total capacity in the cluster.
-        - total_accelerators_available: Dict mapping accelerator names to their 
-            current availability. Returns -1 for each accelerator if 
+        - total_accelerators_available: Dict mapping accelerator names to their
+            current availability. Returns -1 for each accelerator if
             realtime=False or if insufficient permissions.
     """
     # TODO(romilb): This should be refactored to use get_kubernetes_node_info()

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -115,6 +115,16 @@ def _list_accelerators(
 
     If the user does not have sufficient permissions to list pods in all
     namespaces, the function will return free GPUs as -1.
+
+    Returns:
+        A tuple of three dictionaries:
+        - qtys_map: Dict mapping accelerator names to lists of InstanceTypeInfo 
+            objects with quantity information.
+        - total_accelerators_capacity: Dict mapping accelerator names to their 
+            total capacity in the cluster.
+        - total_accelerators_available: Dict mapping accelerator names to their 
+            current availability. Returns -1 for each accelerator if 
+            realtime=False or if insufficient permissions.
     """
     # TODO(romilb): This should be refactored to use get_kubernetes_node_info()
     #   function from kubernetes_utils.
@@ -242,6 +252,10 @@ def _list_accelerators(
                                         container.resources.requests))
 
                 accelerators_available = accelerator_count - allocated_qty
+
+                # Initialize the entry if it doesn't exist yet
+                if accelerator_name not in total_accelerators_available:
+                    total_accelerators_available[accelerator_name] = 0
 
                 if accelerators_available >= min_quantity_filter:
                     quantized_availability = min_quantity_filter * (


### PR DESCRIPTION
Fixes #4556.

Before this PR:
```
(base) ➜  ~ sky show-gpus --cloud kubernetes
Traceback (most recent call last):
  File "/Users/romilb/tools/anaconda3/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/common_utils.py", line 366, in _record
    return f(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 838, in invoke
    return super().invoke(ctx)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/romilb/tools/anaconda3/lib/python3.9/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/clouds/service_catalog/config.py", line 51, in wrapper
    return func(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 3468, in show_gpus
    for out in _output():
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 3222, in _output
    k8s_realtime_table = _get_kubernetes_realtime_gpu_table(
  File "/Users/romilb/Romil/Berkeley/Research/sky-experiments/sky/cli.py", line 3141, in _get_kubernetes_realtime_gpu_table
    assert (set(counts.keys()) == set(capacity.keys()) == set(
AssertionError: Keys of counts (['H100']), capacity (['H100']), and available ([]) must be same.
```

After this PR:
```
(base) ➜  ~ sky show-gpus --cloud kubernetes
Kubernetes GPUs (context: kind-skypilot)
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
H100  1, 2, 4, 8                8           0

Kubernetes per node accelerator availability
NODE_NAME               GPU_NAME  TOTAL_GPUS  FREE_GPUS
skypilot-control-plane  H100      8           0
```