### PR TITLE
[k8s] Fix GPU detection when running with `sky local up --ips`

### DIFF
--- a/sky/utils/kubernetes/deploy_remote_cluster.sh
+++ b/sky/utils/kubernetes/deploy_remote_cluster.sh
@@ -93,11 +93,11 @@ cleanup_agent_node() {
 
 check_gpu() {
     local NODE_IP=$1
-    run_remote "$NODE_IP" "
-        if command -v nvidia-smi &> /dev/null; then
-            nvidia-smi --list-gpus | grep 'GPU 0'
-        fi
-    "
+    if run_remote "$NODE_IP" "command -v nvidia-smi &> /dev/null && nvidia-smi --query-gpu=gpu_name --format=csv,noheader &> /dev/null"; then
+        return 0  # GPU detected
+    else
+        return 1  # No GPU detected
+    fi
 }
 
 # Pre-flight checks


### PR DESCRIPTION
When `sky local up --ips` is run on a remote cluster with CPUs only, our script incorrectly detects GPUs and gets stuck at installing nvidia GPU operator. This is because the check_gpu function is silently failing but the output is still being interpreted as truthy. This PR fixes it by explicitly returning true/false values. 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] `sky local up --ips ips.txt --ssh-user ubuntu --ssh-key-path ~/.sky/generated/ssh-keys/aws.key` on a CPU only cluster. 