### PR TITLE
[Tests] Fix SkyServe Smoke Test

### DIFF
--- a/tests/skyserve/auto_restart.yaml
+++ b/tests/skyserve/auto_restart.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replicas: 1
 
 

--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -28,6 +28,9 @@ setup: |
   fi
 
   # Install dependencies
+  # TODO(tian): transformers<4.48.0 is a temporary solution for breaking
+  # change in transformers 4.48.0. Update to latest version when the issue
+  # is fixed. Ref: https://github.com/huggingface/transformers/issues/35639
   pip install "fschat[model_worker,webui]==0.2.24" "transformers<4.48.0"
   pip install sentencepiece protobuf
 

--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -28,7 +28,7 @@ setup: |
   fi
 
   # Install dependencies
-  pip install "fschat[model_worker,webui]==0.2.24"
+  pip install "fschat[model_worker,webui]==0.2.24" "transformers<4.48.0"
   pip install sentencepiece protobuf
 
 run: |

--- a/tests/skyserve/restart/user_bug.yaml
+++ b/tests/skyserve/restart/user_bug.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replicas: 1
 
 

--- a/tests/skyserve/spot/base_ondemand_fallback.yaml
+++ b/tests/skyserve/spot/base_ondemand_fallback.yaml
@@ -14,7 +14,8 @@ resources:
   cpus: 2+
   use_spot: true
 
-workdir: examples/serve/http_server
+setup: |
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
 
 # Use 8080 to test jupyter service is terminated
 run: python3 server.py --port 8080

--- a/tests/skyserve/update/bump_version_after.yaml
+++ b/tests/skyserve/update/bump_version_after.yaml
@@ -16,7 +16,7 @@ service:
   replicas: 3
 
 resources:
-  ports: 8080
+  ports: 8081
   cpus: 2+
 
 setup: |

--- a/tests/skyserve/update/bump_version_before.yaml
+++ b/tests/skyserve/update/bump_version_before.yaml
@@ -16,7 +16,7 @@ service:
   replicas: 2
 
 resources:
-  ports: 8080
+  ports: 8081
   cpus: 2+
 
 setup: |

--- a/tests/skyserve/update/new_autoscaler_after.yaml
+++ b/tests/skyserve/update/new_autoscaler_after.yaml
@@ -12,7 +12,8 @@ resources:
   use_spot: true
   cpus: 2+
 
-workdir: examples/serve/http_server
+setup: |
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
 
 run: |
   if [ $SKYPILOT_SERVE_REPLICA_ID -eq 7 ]; then

--- a/tests/skyserve/update/new_autoscaler_before.yaml
+++ b/tests/skyserve/update/new_autoscaler_before.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replicas: 2
 
 resources:

--- a/tests/skyserve/update/new_autoscaler_before.yaml
+++ b/tests/skyserve/update/new_autoscaler_before.yaml
@@ -8,6 +8,7 @@ resources:
   ports: 8081
   cpus: 2+
 
-workdir: examples/serve/http_server
+setup: |
+  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py
 
 run: python3 server.py --port 8081

--- a/tests/skyserve/update/num_min_one.yaml
+++ b/tests/skyserve/update/num_min_one.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replica_policy:
     min_replicas: 1
 

--- a/tests/skyserve/update/num_min_two.yaml
+++ b/tests/skyserve/update/num_min_two.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replica_policy:
     min_replicas: 2
 

--- a/tests/skyserve/update/old.yaml
+++ b/tests/skyserve/update/old.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 60
   replicas: 2
   load_balancing_policy: round_robin
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -84,7 +84,7 @@ _TEARDOWN_SERVICE = (
 _SERVE_ENDPOINT_WAIT = (
     'export ORIGIN_SKYPILOT_DEBUG=$SKYPILOT_DEBUG; export SKYPILOT_DEBUG=0; '
     'endpoint=$(sky serve status --endpoint {name}); '
-    'until ! echo "$endpoint" | grep "Controller is initializing"; '
+    'until ! echo "$endpoint" | grep -qE "Controller is initializing|^-$"; '
     'do echo "Waiting for serve endpoint to be ready..."; '
     'sleep 5; endpoint=$(sky serve status --endpoint {name}); done; '
     'export SKYPILOT_DEBUG=$ORIGIN_SKYPILOT_DEBUG; echo "$endpoint"')

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -100,18 +100,18 @@ _SERVE_STATUS_WAIT = (
     'done; '
     # 2. Once controller is ready, check provisioning vs. vCPU=2
     'provisioning_count=$(echo "$s" | grep "PROVISIONING" | wc -l); '
-    'vcpu_count=$(echo "$s" | grep "vCPU=2" | wc -l); '
-    'until [ "$provisioning_count" -eq "$vcpu_count" ]; '
+    'vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
+    'until [ "$provisioning_count" -eq "$vcpu_in_provision" ]; '
     'do '
     '    echo "Waiting for provisioning resource repr ready..."; '
-    '    echo "PROVISIONING: $provisioning_count, vCPU=2: $vcpu_count"; '
+    '    echo "PROVISIONING: $provisioning_count, vCPU: $vcpu_in_provision"; '
     '    sleep 5; '
     '    s=$(sky serve status {name}); '
     '    provisioning_count=$(echo "$s" | grep "PROVISIONING" | wc -l); '
-    '    vcpu_count=$(echo "$s" | grep "vCPU=2" | wc -l); '
+    '    vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
     'done; '
     # 3. Provisioning is complete
-    'echo "Provisioning complete. PROVISIONING: $provisioning_count, vCPU=2: $vcpu_count"; '
+    'echo "Provisioning complete. PROVISIONING: $provisioning_count, vCPU=2: $vcpu_in_provision"; '
     'echo "$s"')
 
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -91,28 +91,43 @@ _SERVE_ENDPOINT_WAIT = (
 
 _SERVE_STATUS_WAIT = (
     's=$(sky serve status {name}); '
-    # 1. Wait for "Controller is initializing." to disappear
+    # Wait for "Controller is initializing." to disappear
     'until ! echo "$s" | grep "Controller is initializing."; '
     'do '
     '    echo "Waiting for serve status to be ready..."; '
     '    sleep 5; '
     '    s=$(sky serve status {name}); '
     'done; '
-    # 2. Once controller is ready, check provisioning vs. vCPU=2
-    'provisioning_count=$(echo "$s" | grep "PROVISIONING" | wc -l); '
-    'vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
-    'until [ "$provisioning_count" -eq "$vcpu_in_provision" ]; '
+    'echo "$s"')
+
+_WAIT_PROVISION_REPR = (
+    # Once controller is ready, check provisioning vs. vCPU=2. This is for
+    # the `_check_replica_in_status`, which will check number of `vCPU=2` in the
+    # `sky serve status` output and use that to suggest the number of replicas.
+    # However, replicas in provisioning state is possible to have a repr of `-`,
+    # since the desired `launched_resources` is not decided yet. This would
+    # cause an error when counting desired number of replicas. We wait for the
+    # representation of `vCPU=2` the same with number of provisioning replicas
+    # to avoid this error.
+    # NOTE(tian): This assumes the replica will not do failover, as the
+    # requested resources is only 2 vCPU and likely to be immediately available
+    # on every region, hence no failover. If the replica will go through
+    # failover
+    # Check #4565 for more information.
+    'num_provisioning=$(echo "$s" | grep "PROVISIONING" | wc -l); '
+    'num_vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
+    'until [ "$num_provisioning" -eq "$num_vcpu_in_provision" ]; '
     'do '
     '    echo "Waiting for provisioning resource repr ready..."; '
-    '    echo "PROVISIONING: $provisioning_count, vCPU: $vcpu_in_provision"; '
-    '    sleep 5; '
+    '    echo "PROVISIONING: $num_provisioning, vCPU: $num_vcpu_in_provision"; '
+    '    sleep 2; '
     '    s=$(sky serve status {name}); '
-    '    provisioning_count=$(echo "$s" | grep "PROVISIONING" | wc -l); '
-    '    vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
+    '    num_provisioning=$(echo "$s" | grep "PROVISIONING" | wc -l); '
+    '    num_vcpu_in_provision=$(echo "$s" | grep "PROVISIONING" | grep "vCPU=2" | wc -l); '
     'done; '
-    # 3. Provisioning is complete
-    'echo "Provisioning complete. PROVISIONING: $provisioning_count, vCPU=2: $vcpu_in_provision"; '
-    'echo "$s"')
+    # Provisioning is complete
+    'echo "Provisioning complete. PROVISIONING: $num_provisioning, vCPU=2: $num_vcpu_in_provision"'
+)
 
 
 def _get_replica_ip(name: str, replica_id: int) -> str:
@@ -161,7 +176,9 @@ def _check_replica_in_status(name: str, check_tuples: List[Tuple[int, bool,
             resource_str = f'({spot_str}vCPU=2)'
         check_cmd += (f' echo "$s" | grep "{resource_str}" | '
                       f'grep "{status}" | wc -l | grep {count} || exit 1;')
-    return (f'{_SERVE_STATUS_WAIT.format(name=name)}; echo "$s"; ' + check_cmd)
+    return (f'{_SERVE_STATUS_WAIT.format(name=name)}; '
+            f'{_WAIT_PROVISION_REPR.format(name=name)}; '
+            f'echo "$s"; {check_cmd}')
 
 
 def _check_service_version(service_name: str, version: str) -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes several broken SkyServe smoke tests:

1. LLM tests failed cuz this breaking change in transformers: huggingface/transformers#35639. Fix transformer version before this change.
2. `test_skyserve_fast_update`'s port has been accidentally changed by #3832. Revert it back.
3. Replacing several `workdir` with `wget` to avoid storage creation.
4. Fixes #4565 by waiting all provisioning resources has a `vCPU=2` representation.
5. When the controller is put in `INIT` status by other services, the `sky serve status --endpoint` is likely to return a `-` due to the following check. This PR do retry on getting a `-` when fetching the endpoint.

https://github.com/skypilot-org/skypilot/blob/0a810eeb0a1b649185925ddce782536f2f55ba61/sky/serve/serve_utils.py#L793-L798

An example:

```bash
+ export ORIGIN_SKYPILOT_DEBUG=$SKYPILOT_DEBUG; export SKYPILOT_DEBUG=0; endpoint=$(sky serve status --endpoint t-ss-new-autosca-6c-402b-64-rolling); until ! echo "$endpoint" | grep "Controller is initializing"; do echo "Waiting for serve endpoint to be ready..."; sleep 5; endpoint=$(sky serve status --endpoint t-ss-new-autosca-6c-402b-64-rolling); done; export SKYPILOT_DEBUG=$ORIGIN_SKYPILOT_DEBUG; echo "$endpoint"; s=$(curl http://$endpoint); echo "$s"; echo "$s" | grep "Hi, SkyPilot here"
-
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: -
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests:
     - [x] `pytest tests/test_smoke.py::test_skyserve_fast_update`
     - [x] `pytest tests/test_smoke.py::test_skyserve_base_ondemand_fallback`
     - [x] `pytest tests/test_smoke.py::test_skyserve_llm`
     - [x] `pytest tests/test_smoke.py::test_skyserve_new_autoscaler_update`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
