### PR TITLE
[azure] support latest version for image id in azure cloud

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -198,6 +198,16 @@ class Azure(clouds.Cloud):
             # not the image location. Marketplace image is globally available.
             region = 'eastus'
         publisher, offer, sku, version = image_id.split(':')
+        # Since the Azure SDK requires explicitly specifying the image version number,
+        # when the version is "latest," we need to manually query the current latest version.
+        if version == 'latest':
+            versions = compute_client.virtual_machine_images.list(
+                location=region,
+                publisher_name=publisher,
+                offer=offer,
+                skus=sku)
+            latest_version = max(versions, key=lambda x: x.name)
+            version = latest_version.name
         try:
             image = compute_client.virtual_machine_images.get(
                 region, publisher, offer, sku, version)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
As titled.

close https://github.com/skypilot-org/skypilot/issues/4435 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

I manually tested with following task:

```yaml
resources:
  cloud: azure
  region: japaneast
  instance_type: Standard_D2s_v3
  image_id: Canonical:ubuntu-24_04-lts:server:latest

# Working directory (optional) containing the project codebase.
# Its contents are synced to ~/sky_workdir/ on the cluster.
workdir: .

# Typical use: pip install -r requirements.txt
# Invoked under the workdir (i.e., can use its files).
setup: |
  echo "Running setup."

# Typical use: make use of resources, such as running training.
# Invoked under the workdir (i.e., can use its files).
run: |
  echo "Hello, SkyPilot!"
  conda env list
```

The cluster was launched and the job work well. I checked the image in the azure console, and it was `ubuntu-24_04-lts` as expected


- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
