### PR TITLE
Fix type error -- Kubernetes sky down exception

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -976,7 +976,7 @@ def terminate_instances(
         _terminate_node(namespace, context, pod_name)
 
     # Run pod termination in parallel
-    subprocess_utils.run_in_parallel(_terminate_pod_thread, pods.items(),
+    subprocess_utils.run_in_parallel(_terminate_pod_thread, list(pods.items()),
                                      _NUM_THREADS)
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #4582

Test:

Before:

```
sky down sky-serve-controller-220e162b

  File "/home/buildkite-generic-4074b/miniconda3/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/buildkite-generic-4074b/miniconda3/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/cli.py", line 2656, in down
    _down_or_stop_clusters(clusters,
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/cli.py", line 2975, in _down_or_stop_clusters
    subprocess_utils.run_in_parallel(_down_or_stop, clusters)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/subprocess_utils.py", line 120, in run_in_parallel
    return [func(args[0])]
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/cli.py", line 2947, in _down_or_stop
    core.down(name, purge=purge)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/core.py", line 487, in down
    backend.teardown(handle, terminate=True, purge=purge)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/common_utils.py", line 386, in _record
    return f(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/common_utils.py", line 366, in _record
    return f(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/backends/backend.py", line 146, in teardown
    self._teardown(handle, terminate, purge)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/backends/cloud_vm_ray_backend.py", line 3669, in _teardown
    self.teardown_no_lock(
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/backends/cloud_vm_ray_backend.py", line 4120, in teardown_no_lock
    provisioner.teardown_cluster(repr(cloud),
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/provision/provisioner.py", line 208, in teardown_cluster
    provision.terminate_instances(cloud_name, cluster_name.name_on_cloud,
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/provision/__init__.py", line 52, in _wrapper
    return impl(*args, **kwargs)
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/provision/kubernetes/instance.py", line 979, in terminate_instances
    subprocess_utils.run_in_parallel(_terminate_pod_thread, pods.items(),
  File "/home/buildkite-generic-4074b/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release/sky/utils/subprocess_utils.py", line 120, in run_in_parallel
    return [func(args[0])]
TypeError: 'dict_items' object is not subscriptable
```

After:

```
(base) buildkite-generic-4074b@ip-10-0-35-236:~/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release$ sky down sky-serve-controller-220e162b
Terminate sky serve controller: sky-serve-controller-220e162b.
To proceed, please type 'delete': delete
Terminating cluster sky-serve-controller-220e162b...done.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
(base) buildkite-generic-4074b@ip-10-0-35-236:~/.buildkite-agent/builds/gke/ip-10-0-35-236-1/skypilot-1/release$ Connection to 3.84.151.235 closed by remote host.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
