### PR TITLE
[SKY-1304] AWS throws `InvalidGroup.Duplicate` when user submits a lot of parallel launch

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -471,7 +471,6 @@ class AWS(clouds.Cloud):
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
                     'in `~/.sky/config.yaml`.')
-
         return {
             'instance_type': r.instance_type,
             'custom_resources': custom_resources,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Root cause:
- [Get_security_groups_from_vpc_ids](get_security_groups_from_vpc_ids) can't query security groups when security groups is under creating.
Solution:
- When `InvalidGroup.Duplicate` exception occurs during security groups creating, query security again and return the created else raise created but not found exception.

Test:
```bash
D 01-17 17:49:33 config.py:88] Creating or updating security groups...
W 01-17 17:49:34 config.py:593] sky-sg-hong-4292 already exists when creating.
I 01-17 17:49:37 config.py:598] Found existing security group sky-sg-hong-4292 [id=sg-0f255f9fecda37b1f]
I 01-17 17:49:37 config.py:103] Security groups created or updated in 3.44550 seconds.
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
