### PR TITLE
[jobs] allow for null schedule_state

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -342,6 +342,8 @@ class ManagedJobScheduleState(enum.Enum):
     briefly observe inconsistent states, like a job that just finished but
     hasn't yet transitioned to DONE.
     """
+    # This job may have been created before the column was present.
+    INVALID = None
     # The job should be ignored by the scheduler.
     INACTIVE = 'INACTIVE'
     # The job is waiting to transition to LAUNCHING for the first time. The

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -313,6 +313,8 @@ _SPOT_STATUS_TO_COLOR = {
 class ManagedJobScheduleState(enum.Enum):
     """Captures the state of the job from the scheduler's perspective.
 
+    A job that predates the introduction of the scheduler will be INVALID.
+
     A newly created job will be INACTIVE.  The following transitions are valid:
     - INACTIVE -> WAITING: The job is "submitted" to the scheduler, and its job
       controller can be started.

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -342,7 +342,9 @@ class ManagedJobScheduleState(enum.Enum):
     briefly observe inconsistent states, like a job that just finished but
     hasn't yet transitioned to DONE.
     """
-    # This job may have been created before the column was present.
+    # This job may have been created before scheduler was introduced in #4458.
+    # This state is not used by scheduler but just for backward compatibility.
+    # TODO(cooperc): remove this in v0.11.0
     INVALID = None
     # The job should be ignored by the scheduler.
     INACTIVE = 'INACTIVE'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This fixes a bug where `sky jobs queue` will fail on a controller that already had jobs in the `job_info` table before #4485, because the `schedule_state` column will be null, which is not valid for the enum.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
