### PR TITLE
[Azure] Revert Azure images to address NCCL issues 

### DIFF
--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -39,9 +39,11 @@ _DEFAULT_AZURE_UBUNTU_HPC_IMAGE_GB = 30
 _DEFAULT_AZURE_UBUNTU_2004_IMAGE_GB = 150
 _DEFAULT_SKYPILOT_IMAGE_GB = 30
 
-_DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-v2'
-_DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-v2'
-_DEFAULT_V1_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-v1'
+# TODO(romilb): Switch back to using our custom images after NCCL + Azure issues
+#  are resolved: https://github.com/skypilot-org/skypilot/issues/4448
+_DEFAULT_CPU_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
+_DEFAULT_GPU_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
+_DEFAULT_V1_IMAGE_ID = 'skypilot:v1-ubuntu-2004'
 _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-ubuntu-2004'
 _FALLBACK_IMAGE_ID = 'skypilot:gpu-ubuntu-2204'
 # This is used by Azure GPU VMs that use grid drivers (e.g. A10).


### PR DESCRIPTION
Intermediate fix for https://github.com/skypilot-org/skypilot/issues/4448 by reverting to Azure's default images. We should fix our custom image to support NCCL + Azure accelerated networking before starting to use them again. 

Tested:
- [x] `sky launch -c azure --cloud azure --gpus A100-80GB:1 -- nvidia-smi`