### PR TITLE
[k8s] Pin kubernetes-python versions to avoid auth errors

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -121,7 +121,8 @@ extras_require: Dict[str, List[str]] = {
     'cloudflare': aws_dependencies,
     'scp': local_ray,
     'oci': ['oci'] + local_ray,
-    'kubernetes': ['kubernetes>=20.0.0'],
+    # Kubernetes 32.0.0 has an authentication bug: https://github.com/kubernetes-client/python/issues/2333 # pylint: disable=line-too-long
+    'kubernetes': ['kubernetes>=20.0.0,<32.0.0'],
     'remote': remote,
     # For the container registry auth api. Reference:
     # https://github.com/runpod/runpod-python/releases/tag/1.6.1


### PR DESCRIPTION
Kubernetes 32.0.0 has an auth bug which breaks sky: https://github.com/kubernetes-client/python/issues/2333