### PR TITLE
[Test] Fix HTTPS Test self signed str

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -837,7 +837,7 @@ def test_skyserve_https(generic_cloud: str):
                 # Self signed certificate should fail without -k.
                 f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
                 'output=$(curl $endpoint 2>&1); echo $output; '
-                'echo $output | grep "self-signed certificate"',
+                'echo $output | grep -E "self[ -]signed certificate"',
                 # curl with wrong schema (http) should fail.
                 f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '
                 'http_endpoint="${endpoint/https:/http:}"; '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The return value for self signed certificates is sometimes with the dash and sometimes not. This PR fixes it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
