### PR TITLE
[Core] Force UV to not use system python

### DIFF
--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -55,7 +55,7 @@ SKY_REMOTE_PYTHON_ENV = f'~/{SKY_REMOTE_PYTHON_ENV_NAME}'
 ACTIVATE_SKY_REMOTE_PYTHON_ENV = f'source {SKY_REMOTE_PYTHON_ENV}/bin/activate'
 # uv is used for venv and pip, much faster than python implementations.
 SKY_UV_INSTALL_DIR = '"$HOME/.local/bin"'
-SKY_UV_CMD = f'{SKY_UV_INSTALL_DIR}/uv'
+SKY_UV_CMD = f'UV_SYSTEM_PYTHON=false {SKY_UV_INSTALL_DIR}/uv'
 # This won't reinstall uv if it's already installed, so it's safe to re-run.
 SKY_UV_INSTALL_CMD = (f'{SKY_UV_CMD} -V >/dev/null 2>&1 || '
                       'curl -LsSf https://astral.sh/uv/install.sh '


### PR DESCRIPTION
Users may have `UV_SYSTEM_PYTHON=true` in their environments, esp. in their Dockerfiles. This breaks our `uv pip` commands since they end up installing to system python, instead of `skypilot-runtime`.

This PR sets SkyPilot UV commands to use `UV_SYSTEM_PYTHON=false` to force uv to use the specified `VIRTUAL_ENV`. 