### PR TITLE
remove --fast flag from sky jobs launch

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3600,12 +3600,6 @@ def jobs():
               default=False,
               required=False,
               help='Skip confirmation prompt.')
-# TODO(cooperc): remove this flag before releasing 0.8.0
-@click.option('--fast',
-              default=False,
-              is_flag=True,
-              help=('[Deprecated] Does nothing. Previous flag behavior is now '
-                    'enabled by default.'))
 @timeline.event
 @usage_lib.entrypoint
 def jobs_launch(
@@ -3631,7 +3625,6 @@ def jobs_launch(
     ports: Tuple[str],
     detach_run: bool,
     yes: bool,
-    fast: bool,
 ):
     """Launch a managed job from a YAML or a command.
 
@@ -3673,16 +3666,6 @@ def jobs_launch(
         ports=ports,
         job_recovery=job_recovery,
     )
-
-    # Deprecation. The default behavior is fast, and the flag will be removed.
-    # The flag was not present in 0.7.x (only nightly), so we will remove before
-    # 0.8.0 so that it never enters a stable release.
-    if fast:
-        click.secho(
-            'Flag --fast is deprecated, as the behavior is now default. The '
-            'flag will be removed soon. Please do not use it, so that you '
-            'avoid "No such option" errors.',
-            fg='yellow')
 
     if not isinstance(task_or_dag, sky.Dag):
         assert isinstance(task_or_dag, sky.Task), task_or_dag

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -37,12 +37,10 @@ if typing.TYPE_CHECKING:
 @timeline.event
 @usage_lib.entrypoint
 def launch(
-        task: Union['sky.Task', 'sky.Dag'],
-        name: Optional[str] = None,
-        stream_logs: bool = True,
-        detach_run: bool = False,
-        # TODO(cooperc): remove fast arg before 0.8.0
-        fast: bool = True,  # pylint: disable=unused-argument for compatibility
+    task: Union['sky.Task', 'sky.Dag'],
+    name: Optional[str] = None,
+    stream_logs: bool = True,
+    detach_run: bool = False,
 ) -> None:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.
@@ -54,8 +52,6 @@ def launch(
           managed job.
         name: Name of the managed job.
         detach_run: Whether to detach the run.
-        fast: [Deprecated] Does nothing, and will be removed soon. We will
-          always use fast mode as it's fully safe now.
 
     Raises:
         ValueError: cluster does not exist. Or, the entrypoint is not a valid


### PR DESCRIPTION
The flag was already deprecated, this fully removes it before 0.8.0.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] /quicktest-core
- [x] /smoke-test --managed-jobs
