### PR TITLE
[Python API] Return job_id on `sky.jobs.launch`

### DIFF
--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -66,8 +66,8 @@ def launch(
       job_id: Optional[int]; the job ID of the submitted job. None if the
         backend is not CloudVmRayBackend, or no job is submitted to
         the cluster.
-      handle: Optional[backends.ResourceHandle]; the handle to the cluster. None
-        if dryrun.
+      handle: Optional[backends.ResourceHandle]; handle to the controller VM.
+        None if dryrun.
     """
     entrypoint = task
     dag_uuid = str(uuid.uuid4().hex[:4])

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -146,14 +146,14 @@ def launch(
             f'Launching managed job {dag.name!r} from jobs controller...'
             f'{colorama.Style.RESET_ALL}')
         job_id, _ = sky.launch(task=controller_task,
-                   stream_logs=stream_logs,
-                   cluster_name=controller_name,
-                   detach_run=detach_run,
-                   idle_minutes_to_autostop=skylet_constants.
-                   CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
-                   retry_until_up=True,
-                   fast=True,
-                   _disable_controller_check=True)
+                               stream_logs=stream_logs,
+                               cluster_name=controller_name,
+                               detach_run=detach_run,
+                               idle_minutes_to_autostop=skylet_constants.
+                               CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
+                               retry_until_up=True,
+                               fast=True,
+                               _disable_controller_check=True)
         return job_id
 
 

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -2,7 +2,7 @@
 import os
 import tempfile
 import typing
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import uuid
 
 import colorama
@@ -43,7 +43,7 @@ def launch(
         detach_run: bool = False,
         # TODO(cooperc): remove fast arg before 0.8.0
         fast: bool = True,  # pylint: disable=unused-argument for compatibility
-) -> Optional[int]:
+) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.
 
@@ -63,9 +63,11 @@ def launch(
         sky.exceptions.NotSupportedError: the feature is not supported.
 
     Returns:
-        job_id: Optional[int]; The job ID of the managed job. None if the
+      job_id: Optional[int]; the job ID of the submitted job. None if the
         backend is not CloudVmRayBackend, or no job is submitted to
         the cluster.
+      handle: Optional[backends.ResourceHandle]; the handle to the cluster. None
+        if dryrun.
     """
     entrypoint = task
     dag_uuid = str(uuid.uuid4().hex[:4])
@@ -145,7 +147,7 @@ def launch(
             f'{colorama.Fore.YELLOW}'
             f'Launching managed job {dag.name!r} from jobs controller...'
             f'{colorama.Style.RESET_ALL}')
-        job_id, _ = sky.launch(task=controller_task,
+        return sky.launch(task=controller_task,
                                stream_logs=stream_logs,
                                cluster_name=controller_name,
                                detach_run=detach_run,
@@ -154,7 +156,6 @@ def launch(
                                retry_until_up=True,
                                fast=True,
                                _disable_controller_check=True)
-        return job_id
 
 
 def queue_from_kubernetes_pod(

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -43,7 +43,7 @@ def launch(
         detach_run: bool = False,
         # TODO(cooperc): remove fast arg before 0.8.0
         fast: bool = True,  # pylint: disable=unused-argument for compatibility
-) -> None:
+) -> Optional[int]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.
 
@@ -61,6 +61,11 @@ def launch(
         ValueError: cluster does not exist. Or, the entrypoint is not a valid
             chain dag.
         sky.exceptions.NotSupportedError: the feature is not supported.
+
+    Returns:
+        job_id: Optional[int]; The job ID of the managed job. None if the
+        backend is not CloudVmRayBackend, or no job is submitted to
+        the cluster.
     """
     entrypoint = task
     dag_uuid = str(uuid.uuid4().hex[:4])
@@ -140,7 +145,7 @@ def launch(
             f'{colorama.Fore.YELLOW}'
             f'Launching managed job {dag.name!r} from jobs controller...'
             f'{colorama.Style.RESET_ALL}')
-        sky.launch(task=controller_task,
+        job_id, _ = sky.launch(task=controller_task,
                    stream_logs=stream_logs,
                    cluster_name=controller_name,
                    detach_run=detach_run,
@@ -149,6 +154,7 @@ def launch(
                    retry_until_up=True,
                    fast=True,
                    _disable_controller_check=True)
+        return job_id
 
 
 def queue_from_kubernetes_pod(

--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -37,12 +37,12 @@ if typing.TYPE_CHECKING:
 @timeline.event
 @usage_lib.entrypoint
 def launch(
-        task: Union['sky.Task', 'sky.Dag'],
-        name: Optional[str] = None,
-        stream_logs: bool = True,
-        detach_run: bool = False,
-        # TODO(cooperc): remove fast arg before 0.8.0
-        fast: bool = True,  # pylint: disable=unused-argument for compatibility
+    task: Union['sky.Task', 'sky.Dag'],
+    name: Optional[str] = None,
+    stream_logs: bool = True,
+    detach_run: bool = False,
+    # TODO(cooperc): remove fast arg before 0.8.0
+    fast: bool = True,  # pylint: disable=unused-argument for compatibility
 ) -> Tuple[Optional[int], Optional[backends.ResourceHandle]]:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Launch a managed job.
@@ -148,14 +148,14 @@ def launch(
             f'Launching managed job {dag.name!r} from jobs controller...'
             f'{colorama.Style.RESET_ALL}')
         return sky.launch(task=controller_task,
-                               stream_logs=stream_logs,
-                               cluster_name=controller_name,
-                               detach_run=detach_run,
-                               idle_minutes_to_autostop=skylet_constants.
-                               CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
-                               retry_until_up=True,
-                               fast=True,
-                               _disable_controller_check=True)
+                          stream_logs=stream_logs,
+                          cluster_name=controller_name,
+                          detach_run=detach_run,
+                          idle_minutes_to_autostop=skylet_constants.
+                          CONTROLLER_IDLE_MINUTES_TO_AUTOSTOP,
+                          retry_until_up=True,
+                          fast=True,
+                          _disable_controller_check=True)
 
 
 def queue_from_kubernetes_pod(


### PR DESCRIPTION
User report: it's hard to get job_id after submitting job with python API, requires correlating against jobs.queue and gets even harder is submitting concurrent jobs. 

This PR returns `job_id` and handle from `sky.jobs.launch()`.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manual python script
```
import sky

task = sky.Task(
    name='test',
    run='echo "Hello, World!"'
)

job_id = sky.jobs.launch(task=task)
print(job_id)

job_id = sky.jobs.launch(task=task)
print(job_id)
```