### PR TITLE
[Jobs/Serve] Use unique id for intermediate bucket

### DIFF
--- a/sky/jobs/core.py
+++ b/sky/jobs/core.py
@@ -101,7 +101,7 @@ def launch(
             ux_utils.spinner_message('Initializing managed job')):
         for task_ in dag.tasks:
             controller_utils.maybe_translate_local_file_mounts_and_sync_up(
-                task_, path='jobs')
+                task_, task_type='jobs')
 
     with tempfile.NamedTemporaryFile(prefix=f'managed-dag-{dag.name}-',
                                      mode='w') as f:

--- a/sky/serve/core.py
+++ b/sky/serve/core.py
@@ -175,7 +175,7 @@ def up(
     with rich_utils.safe_status(
             ux_utils.spinner_message('Initializing service')):
         controller_utils.maybe_translate_local_file_mounts_and_sync_up(
-            task, path='serve')
+            task, task_type='serve')
 
     tls_template_vars = _rewrite_tls_credential_paths_and_get_tls_env_vars(
         service_name, task)
@@ -458,7 +458,7 @@ def update(
     with rich_utils.safe_status(
             ux_utils.spinner_message('Initializing service')):
         controller_utils.maybe_translate_local_file_mounts_and_sync_up(
-            task, path='serve')
+            task, task_type='serve')
 
     code = serve_utils.ServeCodeGen.add_version(service_name)
     returncode, version_string_payload, stderr = backend.run_on_head(

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -268,7 +268,7 @@ CLUSTER_NAME_VALID_REGEX = '[a-zA-Z]([-_.a-zA-Z0-9]*[a-zA-Z0-9])?'
 # Used for translate local file mounts to cloud storage. Please refer to
 # sky/execution.py::_maybe_translate_local_file_mounts_and_sync_up for
 # more details.
-FILE_MOUNTS_BUCKET_NAME = 'skypilot-filemounts-{username}-{id}'
+FILE_MOUNTS_BUCKET_NAME = 'skypilot-filemounts-{username}-{user_hash}-{id}'
 FILE_MOUNTS_LOCAL_TMP_DIR = 'skypilot-filemounts-files-{id}'
 FILE_MOUNTS_REMOTE_TMP_DIR = '/tmp/sky-{}-filemounts-files'
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -678,7 +678,7 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.StorageBucketCreateError(
                     f'{task_type.capitalize()} bucket {store.name!r} does not '
-                    'exist. Please check jobs.bucket configuration in '
+                    f'exist. Please check {task_type}.bucket configuration in '
                     'your SkyPilot config.')
 
     # We use uuid to generate a unique run id for the job, so that the bucket/

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -686,7 +686,8 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
     # We should not use common_utils.get_usage_run_id() here, because when
     # Python API is used, the run id will be the same across multiple
     # jobs.launch/serve.up calls after the sky is imported.
-    run_id = str(uuid.uuid4())[:8]
+    run_id = common_utils.base36_encode(uuid.uuid4().hex)[:8]
+    user_hash = common_utils.get_user_hash()
     original_file_mounts = task.file_mounts if task.file_mounts else {}
     original_storage_mounts = task.storage_mounts if task.storage_mounts else {}
 
@@ -720,7 +721,9 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
         store_type = store_cls = sub_path = None
         storage_account_name = region = None
         bucket_name = constants.FILE_MOUNTS_BUCKET_NAME.format(
-            username=common_utils.get_cleaned_username(), id=run_id)
+            username=common_utils.get_cleaned_username(),
+            user_hash=user_hash,
+            id=run_id)
     else:
         store_type, store_cls, bucket_name, sub_path, storage_account_name, \
             region = storage_lib.StoreType.get_fields_from_store_url(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When a user is using the python API to submit jobs the `usage_run_id` will not be updated across multiple jobs.launch as we save the `usage_run_id` as a global variable, this causes multiple jobs always to share the same bucket.

When one job finishes, it will delete the bucket and cause the other jobs to fail to find the bucket.
https://github.com/skypilot-org/skypilot/blob/db90a41f4dff842aaaacd105d77f9e9a4e29b4bc/sky/utils/controller_utils.py#L676

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py --aws --managed-jobs` (see buildkite)
  - [x] `pytest tests/test_smoke.py --azure --managed-jobs` (see buildkite)
  - [x] `pytest tests/test_smoke.py --gcp --managed-jobs` (see buildkite)
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
