### PR TITLE
[ux] managed jobs dashboard fixes

### DIFF
--- a/sky/jobs/dashboard/dashboard.py
+++ b/sky/jobs/dashboard/dashboard.py
@@ -6,6 +6,7 @@ https://github.com/ray-project/ray/tree/master/dashboard/client/src) and/or get
 rid of the SSH port-forwarding business (see cli.py's job_dashboard()
 comment).
 """
+import collections
 import datetime
 import pathlib
 
@@ -54,6 +55,12 @@ def home():
     rows = managed_jobs.format_job_table(all_managed_jobs,
                                          show_all=True,
                                          return_rows=True)
+
+    status_counts = collections.defaultdict(int)
+    for task in all_managed_jobs:
+        if not task['status'].is_terminal():
+            status_counts[task['status'].value] += 1
+
     # Add an empty column for the dropdown button. This will be added in the
     # jobs/templates/index.html file.
     rows = [[''] + row for row in rows]
@@ -63,7 +70,7 @@ def home():
     columns = [
         '', 'ID', 'Task', 'Name', 'Resources', 'Submitted', 'Total Duration',
         'Job Duration', 'Recoveries', 'Status', 'Started', 'Cluster', 'Region',
-        'Failure'
+        'Description'
     ]
     if rows and len(rows[0]) != len(columns):
         raise RuntimeError(
@@ -83,6 +90,7 @@ def home():
         rows=rows,
         last_updated_timestamp=timestamp,
         status_values=status_values,
+        status_counts=status_counts,
     )
     return rendered_html
 

--- a/sky/jobs/dashboard/templates/index.html
+++ b/sky/jobs/dashboard/templates/index.html
@@ -87,6 +87,32 @@
             </div>
         </header>
 
+        {% if status_counts %}
+        <p>In progress tasks: 
+            {% for status, count in status_counts|dictsort %}
+                {{ count }} 
+                {% if status.startswith('RUNNING') %}
+                <span class="badge bg-primary">{{ status }}</span>
+                {% elif status.startswith('PENDING') or status.startswith('SUBMITTED') %}
+                <span class="badge bg-light">{{ status }}</span>
+                {% elif status.startswith('RECOVERING') or status.startswith('CANCELLING') or status.startswith('STARTING') %}
+                <span class="badge bg-info">{{ status }}</span>
+                {% elif status.startswith('SUCCEEDED') %}
+                <span class="badge bg-success">{{ status }}</span>
+                {% elif status.startswith('CANCELLED') %}
+                <span class="badge bg-secondary">{{ status }}</span>
+                {% elif status.startswith('FAILED') %}
+                <span class="badge bg-warning">{{ status }}</span>
+                {% else %}
+                {{ status }}
+                {% endif %}
+                {% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+        {% else %}
+        <p>No in-progress managed jobs.</p>
+        {% endif %}
+
         <table class="table table-hover table-hover-selected fixed-header-table" id="jobs-table">
             <thead>
                 <tr>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. Rename "Failure" to "Description" as we've already done for the CLI `sky jobs queue`.
2. Add "In progress tasks" count at the top as in the CLI.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
