### PR TITLE
[k8s] Allow kubernetes python client versions != 32.0.0

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -122,7 +122,7 @@ extras_require: Dict[str, List[str]] = {
     'scp': local_ray,
     'oci': ['oci'] + local_ray,
     # Kubernetes 32.0.0 has an authentication bug: https://github.com/kubernetes-client/python/issues/2333 # pylint: disable=line-too-long
-    'kubernetes': ['kubernetes>=20.0.0,<32.0.0'],
+    'kubernetes': ['kubernetes>=20.0.0,!=32.0.0'],
     'remote': remote,
     # For the container registry auth api. Reference:
     # https://github.com/runpod/runpod-python/releases/tag/1.6.1


### PR DESCRIPTION
Follow up to #4604.

K8s seems to have fixed the bug in https://github.com/kubernetes-client/python/pull/2338, future releases should be ok to use.