### PR TITLE
[k8s] Support autoscaling TPU node pools

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -340,7 +340,7 @@ FAQs
       # ~/.sky/config.yaml
       kubernetes:
         provision_timeout: 900  # Wait 15 minutes for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
-        autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs in scale-to-zero setting
+        autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs/TPUs in scale-to-zero setting
 
 * **Can SkyPilot provision a Kubernetes cluster for me? Will SkyPilot add more nodes to my Kubernetes clusters?**
 
@@ -353,6 +353,15 @@ FAQs
 * **How do I view the pods created by SkyPilot on my Kubernetes cluster?**
 
   You can use your existing observability tools to filter resources with the label :code:`parent=skypilot` (:code:`kubectl get pods -l 'parent=skypilot'`). As an example, follow the instructions :ref:`here <kubernetes-observability>` to deploy the Kubernetes Dashboard on your cluster.
+
+* **Does SkyPilot support TPUs on GKE?**
+
+  SkyPilot supports single-host TPU topologies on GKE (e.g., 1x1, 2x2, 2x4). To use TPUs, add it to the accelerator field in your task YAML:
+
+  .. code-block:: yaml
+
+    resources:
+      accelerators: tpu-v5-lite-podslice:1  # or tpu-v5-lite-device, tpu-v5p-slice, tpu-v4-podslice
 
 * **I am using a custom image. How can I speed up the pod startup time?**
 

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -361,7 +361,7 @@ FAQs
   .. code-block:: yaml
 
     resources:
-      accelerators: tpu-v5-lite-podslice:1  # or tpu-v5-lite-device, tpu-v5p-slice, tpu-v4-podslice
+      accelerators: tpu-v5-lite-podslice:1  # or tpu-v5-lite-device, tpu-v5p-slice
 
 * **I am using a custom image. How can I speed up the pod startup time?**
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -345,7 +345,7 @@ class GKELabelFormatter(GPULabelFormatter):
     # label to use in an autoscaling environment. For list of topologies, see:
     # tpu v5e: https://cloud.google.com/tpu/docs/tpus-in-gke
     # tpu v5p: https://cloud.google.com/tpu/docs/v5p
-    # TODO(romilb): Add support for TPU v4.
+    # TODO(romilb): Add support for TPU v4 and v6.
     GKE_TPU_TOPOLOGIES = {
         'tpu-v5-lite-podslice': {
             1: '1x1',

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -331,9 +331,19 @@ class GKELabelFormatter(GPULabelFormatter):
     # tpu v5p: https://cloud.google.com/tpu/docs/v5p
     # TODO(romilb): Add support for TPU v4.
     GKE_TPU_TOPOLOGIES = {
-        'tpu-v5-lite-podslice': {1: '1x1', 4: '2x2', 8: '2x4'},
-        'tpu-v5-lite-device': {1: '1x1', 4: '2x2', 8: '2x4'},
-        'tpu-v5p-slice': {4: '2x2x1'},
+        'tpu-v5-lite-podslice': {
+            1: '1x1',
+            4: '2x2',
+            8: '2x4'
+        },
+        'tpu-v5-lite-device': {
+            1: '1x1',
+            4: '2x2',
+            8: '2x4'
+        },
+        'tpu-v5p-slice': {
+            4: '2x2x1'
+        },
     }
 
     @classmethod
@@ -360,11 +370,16 @@ class GKELabelFormatter(GPULabelFormatter):
 
         e.g. tpu-v5-lite-podslice:8 -> '2x4'
         """
-        count_to_topology = cls.GKE_TPU_TOPOLOGIES.get(acc_type, {}).get(acc_count, None)
+        count_to_topology = cls.GKE_TPU_TOPOLOGIES.get(acc_type,
+                                                       {}).get(acc_count, None)
         if count_to_topology is None:
-            supported_tpus = {tpu: list(topologies.values()) 
-                            for tpu, topologies in cls.GKE_TPU_TOPOLOGIES.items()}
-            raise ValueError(f'No TPU topology found for {acc_type} with count {acc_count}. Supported TPU types and counts: {supported_tpus}')
+            supported_tpus = {
+                tpu: list(topologies.values())
+                for tpu, topologies in cls.GKE_TPU_TOPOLOGIES.items()
+            }
+            raise ValueError(
+                f'No TPU topology found for {acc_type} with count {acc_count}. Supported TPU types and counts: {supported_tpus}'
+            )
         return count_to_topology
 
     @classmethod

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -323,11 +323,7 @@ class GKELabelFormatter(GPULabelFormatter):
     # Mapping from TPU count to topology. Used when determining TPU topology
     # label to use in an autoscaling environment. For list of topologies, see:
     # https://cloud.google.com/tpu/docs/tpus-in-gke
-    GKE_TPU_COUNT_TO_TOPOLOGY = {
-        1: '1x1',
-        4: '2x2',
-        8: '2x4'
-    }
+    GKE_TPU_COUNT_TO_TOPOLOGY = {1: '1x1', 4: '2x2', 8: '2x4'}
 
     GPU_LABEL_KEY = 'cloud.google.com/gke-accelerator'
     TPU_LABEL_KEY = 'cloud.google.com/gke-tpu-accelerator'
@@ -742,6 +738,7 @@ def get_accelerator_label_key_value(
         tpu_topology_label_key = None
         tpu_topology_label_value = None
         if is_tpu_on_gke(acc_type):
+            assert isinstance(formatter, GKELabelFormatter)
             tpu_topology_label_key = formatter.get_tpu_topology_label_key()
             tpu_topology_label_value = formatter.get_tpu_topology_label_value(
                 acc_count)
@@ -809,10 +806,11 @@ def get_accelerator_label_key_value(
                             if node_metadata_labels.get(
                                     label_formatter.TPU_LABEL_KEY) == acc_type:
                                 topology_label_key = (
-                                    label_formatter.get_tpu_topology_label_key())
+                                    label_formatter.get_tpu_topology_label_key(
+                                    ))
                                 # Instead of using get_tpu_topology_label_value,
                                 # we use the node's label value to determine the
-                                # topology. This is to make sure the node's 
+                                # topology. This is to make sure the node's
                                 # available topology matches our request.
                                 topology_value = node_metadata_labels.get(
                                     topology_label_key)
@@ -2366,7 +2364,7 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
 
 
 def is_tpu_on_gke(accelerator: str) -> bool:
-    """Determins if the given accelerator is a TPU supported on GKE."""
+    """Determines if the given accelerator is a TPU supported on GKE."""
     return accelerator in GKE_TPU_ACCELERATOR_TO_GENERATION
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -671,6 +671,7 @@ def check_instance_fits(context: Optional[str],
         # If GPU/TPUs are requested, check if GPU/TPU type is available, and
         # if so, check if CPU and memory requirements on the specific node are
         # met.
+        assert acc_count is not None, (acc_type, acc_count)
         try:
             gpu_label_key, gpu_label_val, _, _ = (
                 get_accelerator_label_key_value(context, acc_type, acc_count))
@@ -715,7 +716,7 @@ def check_instance_fits(context: Optional[str],
 def get_accelerator_label_key_value(
     context: Optional[str],
     acc_type: str,
-    acc_count: Optional[int],
+    acc_count: int,
     check_mode=False
 ) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Returns the label key and value for the given GPU/TPU type.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -185,6 +185,22 @@ class GPULabelFormatter:
     """
 
     @classmethod
+    def get_tpu_topology_label_key(cls) -> str:
+        """Returns the label for TPU topology used by the Kubernetes cluster.
+
+        Only implemented by formatters that support TPUs.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def get_tpu_topology_label_value(cls, acc_type: str, acc_count: int) -> str:
+        """Returns the TPU topology value for the given TPU type and count.
+
+        Only implemented by formatters that support TPUs.
+        """
+        raise NotImplementedError
+
+    @classmethod
     def get_label_key(cls, accelerator: Optional[str] = None) -> str:
         """Returns the label key for GPU type used by the Kubernetes cluster"""
         raise NotImplementedError
@@ -378,8 +394,8 @@ class GKELabelFormatter(GPULabelFormatter):
                 for tpu, topologies in cls.GKE_TPU_TOPOLOGIES.items()
             }
             raise ValueError(
-                f'No TPU topology found for {acc_type} with count {acc_count}. Supported TPU types and counts: {supported_tpus}'
-            )
+                f'No TPU topology found for {acc_type} with count {acc_count}. '
+                f'Supported TPU types and counts: {supported_tpus}')
         return count_to_topology
 
     @classmethod


### PR DESCRIPTION
Adds support for autoscaling TPU node pools on GKE.

Currently single-host TPU v5 is supported.

Users must configure `autoscaler: gke` and a large `provision_timeout` to let the cluster autoscale.
```
# ~/.sky/config.yaml
kubernetes:
  autoscaler: gke
  provision_timeout: 900
```

Tested on scale-from-zero nodepool with`ct5lp-hightpu-1t` (tpu v5e, 1x1):

1. Script to create GKE cluster with an autoscaling TPU nodepool:
```
gcloud beta container --project "sky-dev-465" clusters create "tputest" --region "us-west1" --tier "standard" --no-enable-basic-auth --cluster-version "1.31.4-gke.1256000" --release-channel "regular" --machine-type "e2-standard-8" --image-type "COS_CONTAINERD" --disk-type "pd-balanced" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM,STORAGE,POD,DEPLOYMENT,STATEFULSET,DAEMONSET,HPA,CADVISOR,KUBELET --enable-ip-alias --network "projects/sky-dev-465/global/networks/default" --subnetwork "projects/sky-dev-465/regions/us-west1/subnetworks/default" --no-enable-intra-node-visibility --default-max-pods-per-node "110" --enable-ip-access --security-posture=standard --workload-vulnerability-scanning=disabled --no-enable-master-authorized-networks --no-enable-google-cloud-access --addons HorizontalPodAutoscaling,HttpLoadBalancing,GcePersistentDiskCsiDriver --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --binauthz-evaluation-mode=DISABLED --enable-managed-prometheus --enable-shielded-nodes && gcloud beta container --project "sky-dev-465" node-pools create "tpupool" --cluster "tputest" --region "us-west1" --machine-type "ct5lp-hightpu-1t" --image-type "COS_CONTAINERD" --disk-type "pd-balanced" --disk-size "100" --metadata disable-legacy-endpoints=true --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "0" --enable-autoscaling --total-min-nodes "0" --total-max-nodes "2" --location-policy "ANY" --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0
```

2. Run `sky launch -c tpu --cloud kubernetes --gpus tpu-v5-lite-podslice`