### PR TITLE
[Lambda] Fix missing private ip

### DIFF
--- a/sky/provision/lambda_cloud/instance.py
+++ b/sky/provision/lambda_cloud/instance.py
@@ -64,6 +64,13 @@ def _get_ssh_key_name(prefix: str = '') -> str:
     return name
 
 
+def _get_private_ip(cluster_name_on_cloud: str,
+                    instance_info: Dict[str, Any]) -> str:
+    if len(_filter_instances(cluster_name_on_cloud, None)) == 1:
+        return instance_info.get('private_ip', '127.0.0.1')
+    return instance_info['private_ip']
+
+
 def run_instances(region: str, cluster_name_on_cloud: str,
                   config: common.ProvisionConfig) -> common.ProvisionRecord:
     """Runs instances for the given cluster"""
@@ -203,7 +210,8 @@ def get_cluster_info(
         instances[instance_id] = [
             common.InstanceInfo(
                 instance_id=instance_id,
-                internal_ip=instance_info['private_ip'],
+                internal_ip=_get_private_ip(cluster_name_on_cloud,
+                                            instance_info),
                 external_ip=instance_info['ip'],
                 ssh_port=22,
                 tags={},

--- a/sky/provision/lambda_cloud/instance.py
+++ b/sky/provision/lambda_cloud/instance.py
@@ -64,11 +64,19 @@ def _get_ssh_key_name(prefix: str = '') -> str:
     return name
 
 
-def _get_private_ip(cluster_name_on_cloud: str,
-                    instance_info: Dict[str, Any]) -> str:
-    if len(_filter_instances(cluster_name_on_cloud, None)) == 1:
-        return instance_info.get('private_ip', '127.0.0.1')
-    return instance_info['private_ip']
+def _get_private_ip(instance_info: Dict[str, Any], single_node: bool) -> str:
+    private_ip = instance_info.get('private_ip')
+    if private_ip is None:
+        if single_node:
+            # The Lambda cloud API may return an instance info without
+            # private IP. It does not align with their docs, but we still
+            # allow single-node cluster to proceed with provisioning, by using
+            # 127.0.0.1, as private IP is not critical for single-node case.
+            return '127.0.0.1'
+        msg = f'Failed to retrieve private IP for instance {instance_info}.'
+        logger.error(msg)
+        raise RuntimeError(msg)
+    return private_ip
 
 
 def run_instances(region: str, cluster_name_on_cloud: str,
@@ -204,14 +212,14 @@ def get_cluster_info(
 ) -> common.ClusterInfo:
     del region  # unused
     running_instances = _filter_instances(cluster_name_on_cloud, ['active'])
+    single_node = len(running_instances) == 1
     instances: Dict[str, List[common.InstanceInfo]] = {}
     head_instance_id = None
     for instance_id, instance_info in running_instances.items():
         instances[instance_id] = [
             common.InstanceInfo(
                 instance_id=instance_id,
-                internal_ip=_get_private_ip(cluster_name_on_cloud,
-                                            instance_info),
+                internal_ip=_get_private_ip(instance_info, single_node),
                 external_ip=instance_info['ip'],
                 ssh_port=22,
                 tags={},

--- a/tests/unit_tests/test_lambda.py
+++ b/tests/unit_tests/test_lambda.py
@@ -1,0 +1,15 @@
+import pytest
+
+from sky.provision.lambda_cloud.instance import _get_private_ip
+
+
+def test_get_private_ip():
+    valid_info = {'private_ip': '10.19.83.125'}
+    invalid_info = {}
+    assert _get_private_ip(valid_info, single_node=True) == valid_info['private_ip']
+    assert _get_private_ip(valid_info, single_node=False) == valid_info['private_ip']
+    assert _get_private_ip(invalid_info, single_node=True) == '127.0.0.1'
+    with pytest.raises(RuntimeError):
+        _get_private_ip(invalid_info, single_node=False)
+
+

--- a/tests/unit_tests/test_lambda.py
+++ b/tests/unit_tests/test_lambda.py
@@ -6,10 +6,10 @@ from sky.provision.lambda_cloud.instance import _get_private_ip
 def test_get_private_ip():
     valid_info = {'private_ip': '10.19.83.125'}
     invalid_info = {}
-    assert _get_private_ip(valid_info, single_node=True) == valid_info['private_ip']
-    assert _get_private_ip(valid_info, single_node=False) == valid_info['private_ip']
+    assert _get_private_ip(valid_info,
+                           single_node=True) == valid_info['private_ip']
+    assert _get_private_ip(valid_info,
+                           single_node=False) == valid_info['private_ip']
     assert _get_private_ip(invalid_info, single_node=True) == '127.0.0.1'
     with pytest.raises(RuntimeError):
         _get_private_ip(invalid_info, single_node=False)
-
-


### PR DESCRIPTION
Handle the setup failure when single-node A6000 VMs on Lambda Cloud do not return a private IP: in this case, cluster info now returns `127.0.0.1`.

Tested: `sky launch -c private-ip-bug --cloud lambda --gpus A6000` is successful.

