### PR TITLE
commit after adding columns to skyserve db

### DIFF
--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -55,33 +55,35 @@ def create_table(cursor: 'sqlite3.Cursor', conn: 'sqlite3.Connection') -> None:
         PRIMARY KEY (service_name, replica_id))""")
     cursor.execute("""\
         CREATE TABLE IF NOT EXISTS version_specs (
-        version INTEGER, 
+        version INTEGER,
         service_name TEXT,
         spec BLOB,
         PRIMARY KEY (service_name, version))""")
     conn.commit()
 
+    # Backward compatibility.
+    db_utils.add_column_to_table(cursor, conn, 'services',
+                                 'requested_resources_str', 'TEXT')
+    # Deprecated: switched to `active_versions` below for the version
+    # considered active by the load balancer. The
+    # authscaler/replica_manager version can be found in the
+    # version_specs table.
+    db_utils.add_column_to_table(
+        cursor, conn, 'services', 'current_version',
+        f'INTEGER DEFAULT {constants.INITIAL_VERSION}')
+    # The versions that is activated for the service. This is a list
+    # of integers in json format.
+    db_utils.add_column_to_table(cursor, conn, 'services', 'active_versions',
+                                 f'TEXT DEFAULT {json.dumps([])!r}')
+    db_utils.add_column_to_table(cursor, conn, 'services',
+                                 'load_balancing_policy', 'TEXT DEFAULT NULL')
+    # Whether the service's load balancer is encrypted with TLS.
+    db_utils.add_column_to_table(cursor, conn, 'services', 'tls_encrypted',
+                                 'INTEGER DEFAULT 0')
+    conn.commit()
 
-_DB = db_utils.SQLiteConn(_DB_PATH, create_table)
-# Backward compatibility.
-db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services',
-                             'requested_resources_str', 'TEXT')
-# Deprecated: switched to `active_versions` below for the version considered
-# active by the load balancer. The authscaler/replica_manager version can be
-# found in the version_specs table.
-db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services',
-                             'current_version',
-                             f'INTEGER DEFAULT {constants.INITIAL_VERSION}')
-# The versions that is activated for the service. This is a list of integers in
-# json format.
-db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services',
-                             'active_versions',
-                             f'TEXT DEFAULT {json.dumps([])!r}')
-db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services',
-                             'load_balancing_policy', 'TEXT DEFAULT NULL')
-# Whether the service's load balancer is encrypted with TLS.
-db_utils.add_column_to_table(_DB.cursor, _DB.conn, 'services', 'tls_encrypted',
-                             'INTEGER DEFAULT 0')
+
+db_utils.SQLiteConn(_DB_PATH, create_table)
 _UNIQUE_CONSTRAINT_FAILED_ERROR_MSG = 'UNIQUE constraint failed: services.name'
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
A long-running command that applies a migration (e.g. adding a column) could indefinitely lock the database. Example case:
1. User upgrades skypilot
2. User runs sky launch that takes a long time.
  a. This sky process adds a new column, obtaining a write lock on sqlite. But it doesn't commit, so it holds the write lock open, blocking other users of the database.
3. User tries to use sky in another process. (e.g. sky status)
  a. Because the transaction from 2a hasn't been committed, this one also tries to add the new column.
  b. But because the process from 2. is still alive, it can't get the write lock.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manually test sky serve on the commit before the new column, then on this commit
- [x] /quicktest-core
