### PR TITLE
[jobs] catch jobs that are DONE but non-terminal

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -720,7 +720,8 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
 
     # Get jobs that are either:
     # 1. Have schedule state that is not DONE, or
-    # 2. Have schedule state DONE AND are in non-terminal status, or
+    # 2. Have schedule state DONE AND are in non-terminal status (unexpected
+    #    inconsistent state), or
     # 3. Have no schedule state (legacy) AND are in non-terminal status
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute(

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -720,7 +720,8 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
 
     # Get jobs that are either:
     # 1. Have schedule state that is not DONE, or
-    # 2. Have no schedule state (legacy) AND are in non-terminal status
+    # 2. Have schedule state DONE AND are in non-terminal status, or
+    # 3. Have no schedule state (legacy) AND are in non-terminal status
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute(
             f"""\
@@ -733,10 +734,11 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
                 (job_info.schedule_state IS NOT NULL AND
                  job_info.schedule_state IS NOT ?)
                 OR
-                -- legacy or DONE jobs that are in non-terminal status
+                -- legacy or that are in non-terminal status or
+                -- DONE jobs that are in non-terminal status
                 ((-- legacy jobs
                   job_info.schedule_state IS NULL OR
-                  -- DONE jobs
+                  -- non-legacy DONE jobs
                   job_info.schedule_state IS ?
                  ) AND
                  -- non-terminal

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -276,9 +276,7 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
                          f'{", ".join(task["status"].value for task in tasks)}')
             failure_reason = ('Inconsistent internal job state. This is a bug')
         elif pid is None:
-            # Note: we already know that this is a non-legacy job, since it has
-            # a schedule state. (Legacy jobs are handled above.) So we expect
-            # that the controller just hasn't been started yet.
+            # Non-legacy job and controller process has not yet started.
             if schedule_state in (
                     managed_job_state.ManagedJobScheduleState.INACTIVE,
                     managed_job_state.ManagedJobScheduleState.WAITING):

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -274,7 +274,7 @@ def update_managed_jobs_statuses(job_id: Optional[int] = None):
             logger.error(f'Job {job_id} has DONE schedule state, but some '
                          f'tasks are not terminal. Task statuses: '
                          f'{", ".join(task["status"].value for task in tasks)}')
-            failure_reason = ('Inconsistent internal job state. This is a bug')
+            failure_reason = ('Inconsistent internal job state. This is a bug.')
         elif pid is None:
             # Non-legacy job and controller process has not yet started.
             if schedule_state in (

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -86,7 +86,7 @@ TASK_ID_LIST_ENV_VAR = 'SKYPILOT_TASK_IDS'
 # cluster yaml is updated.
 #
 # TODO(zongheng,zhanghao): make the upgrading of skylet automatic?
-SKYLET_VERSION = '11'
+SKYLET_VERSION = '12'
 # The version of the lib files that skylet/jobs use. Whenever there is an API
 # change for the job_lib or log_lib, we need to bump this version, so that the
 # user can be notified to update their SkyPilot version on the remote cluster.


### PR DESCRIPTION
Usually, a job should always transition to a terminal status before it is set to DONE. However, if a bug makes that fail for some reason (e.g. the issues fixed in #4637), we should still catch this state.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manually tested by artificially screwing up my jobs controller
- [x] quicktest-core
- [x] managed jobs smoke tests