### PR TITLE
[jobs queue] move scheduler state to its own column

### DIFF
--- a/sky/jobs/dashboard/dashboard.py
+++ b/sky/jobs/dashboard/dashboard.py
@@ -91,6 +91,9 @@ JOB_TABLE_COLUMNS = [
     'Recoveries', 'Details', 'Actions'
 ]
 
+# This column is given by format_job_table but should be ignored.
+SCHED_STATE_COLUMN = 12
+
 
 def _extract_launch_history(log_content: str) -> str:
     """Extract launch history from log content.
@@ -151,8 +154,10 @@ def home():
             status_counts[task['status'].value] += 1
 
     # Add an empty column for the dropdown button and actions column
-    rows = [[''] + row + [''] + [''] for row in rows
-           ]  # Add empty cell for failover and actions column
+    # Exclude SCHED. STATE column
+    rows = [[''] + row[:SCHED_STATE_COLUMN] + row[SCHED_STATE_COLUMN + 1:] +
+            # Add empty cell for failover and actions column
+            [''] + [''] for row in rows]
 
     # Add log content as failover history for each job
     for row in rows:

--- a/sky/jobs/dashboard/dashboard.py
+++ b/sky/jobs/dashboard/dashboard.py
@@ -97,7 +97,7 @@ SCHED_STATE_COLUMN = 12
 
 def _extract_launch_history(log_content: str) -> str:
     """Extract launch history from log content.
-    
+
     Args:
         log_content: Content of the log file.
     Returns:
@@ -155,9 +155,11 @@ def home():
 
     # Add an empty column for the dropdown button and actions column
     # Exclude SCHED. STATE column
-    rows = [[''] + row[:SCHED_STATE_COLUMN] + row[SCHED_STATE_COLUMN + 1:] +
-            # Add empty cell for failover and actions column
-            [''] + [''] for row in rows]
+    rows = [
+        [''] + row[:SCHED_STATE_COLUMN] + row[SCHED_STATE_COLUMN + 1:] +
+        # Add empty cell for failover and actions column
+        [''] + [''] for row in rows
+    ]
 
     # Add log content as failover history for each job
     for row in rows:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -965,7 +965,7 @@ def format_job_table(
         'STATUS',
     ]
     if show_all:
-        columns += ['STARTED', 'CLUSTER', 'REGION', 'DESCRIPTION']
+        columns += ['STARTED', 'CLUSTER', 'REGION', 'SCHED. STATE', 'DETAILS']
     if tasks_have_user:
         columns.insert(0, 'USER')
     job_table = log_utils.create_table(columns)
@@ -984,20 +984,10 @@ def format_job_table(
         # by the task_id.
         jobs[get_hash(task)].append(task)
 
-    def generate_description(failure_reason: Optional[str],
-                             schedule_state: Optional[str]) -> str:
-        description = ''
-        if schedule_state is not None:
-            description += f'Scheduler: {schedule_state}'
-            if failure_reason is not None:
-                description += ', '
+    def generate_details(failure_reason: Optional[str]) -> str:
         if failure_reason is not None:
-            description += f'Failure: {failure_reason}'
-
-        if description == '':
-            return '-'
-
-        return description
+            return f'Failure: {failure_reason}'
+        return '-'
 
     for job_hash, job_tasks in jobs.items():
         if show_all:
@@ -1050,13 +1040,13 @@ def format_job_table(
                 status_str,
             ]
             if show_all:
-                schedule_state = job_tasks[0]['schedule_state']
                 failure_reason = job_tasks[current_task_id]['failure_reason']
                 job_values.extend([
                     '-',
                     '-',
                     '-',
-                    generate_description(failure_reason, schedule_state),
+                    job_tasks[0]['schedule_state'],
+                    generate_details(failure_reason),
                 ])
             if tasks_have_user:
                 job_values.insert(0, job_tasks[0].get('user', '-'))
@@ -1087,14 +1077,14 @@ def format_job_table(
                 # schedule_state is only set at the job level, so if we have
                 # more than one task, only display on the aggregated row.
                 schedule_state = (task['schedule_state']
-                                  if len(job_tasks) == 1 else None)
+                                  if len(job_tasks) == 1 else '-')
                 values.extend([
                     # STARTED
                     log_utils.readable_time_duration(task['start_at']),
                     task['cluster_resources'],
                     task['region'],
-                    generate_description(task['failure_reason'],
-                                         schedule_state),
+                    schedule_state,
+                    generate_details(task['failure_reason']),
                 ])
             if tasks_have_user:
                 values.insert(0, task.get('user', '-'))

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -965,6 +965,7 @@ def format_job_table(
         'STATUS',
     ]
     if show_all:
+        # TODO: move SCHED. STATE to a separate flag (e.g. --debug)
         columns += ['STARTED', 'CLUSTER', 'REGION', 'SCHED. STATE', 'DETAILS']
     if tasks_have_user:
         columns.insert(0, 'USER')


### PR DESCRIPTION
This allows it to be excluded from dashboard.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
