### PR TITLE
[GCP] skip MIG termination for only CPU instances

### DIFF
--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -155,6 +155,8 @@ VM_MINIMAL_PERMISSIONS = [
     'compute.instances.setServiceAccount',
     'compute.instances.start',
     'compute.instances.stop',
+    'compute.instanceGroupManagers.get',
+    'compute.instanceGroupManagers.update',
     'compute.networks.get',
     'compute.networks.list',
     'compute.networks.getEffectiveFirewalls',

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -528,7 +528,7 @@ def terminate_instances(
         instance_utils.delete_tpu_node(project_id, zone, tpu_node)
 
     use_mig = provider_config.get('use_managed_instance_group', False)
-    if use_mig and use_tpu_vms: # Skip for MIG if no TPU on the cluster
+    if use_mig and use_tpu_vms: # Skip for MIG if no TPU
         # Deleting the MIG will also delete the instances.
         instance_utils.GCPManagedInstanceGroup.delete_mig(
             project_id, zone, cluster_name_on_cloud)

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -528,7 +528,8 @@ def terminate_instances(
         instance_utils.delete_tpu_node(project_id, zone, tpu_node)
 
     use_mig = provider_config.get('use_managed_instance_group', False)
-    if use_mig and use_tpu_vms: # Skip for MIG if no TPU
+    # Deleting MIG if it uses MIG and uses TPUs on the cluster.
+    if use_mig and use_tpu_vms:
         # Deleting the MIG will also delete the instances.
         instance_utils.GCPManagedInstanceGroup.delete_mig(
             project_id, zone, cluster_name_on_cloud)

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -528,7 +528,7 @@ def terminate_instances(
         instance_utils.delete_tpu_node(project_id, zone, tpu_node)
 
     use_mig = provider_config.get('use_managed_instance_group', False)
-    if use_mig:
+    if use_mig and use_tpu_vms: # Skip for MIG if no TPU on the cluster
         # Deleting the MIG will also delete the instances.
         instance_utils.GCPManagedInstanceGroup.delete_mig(
             project_id, zone, cluster_name_on_cloud)

--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -528,7 +528,7 @@ def terminate_instances(
         instance_utils.delete_tpu_node(project_id, zone, tpu_node)
 
     use_mig = provider_config.get('use_managed_instance_group', False)
-    # Deleting MIG if it uses MIG and uses TPUs on the cluster.
+    # Deleting MIG only if it uses MIG and has TPUs on the cluster.
     if use_mig and use_tpu_vms:
         # Deleting the MIG will also delete the instances.
         instance_utils.GCPManagedInstanceGroup.delete_mig(


### PR DESCRIPTION
Resolve for https://github.com/skypilot-org/skypilot/issues/4594

check:

https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagerResizeRequests/get

https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagerResizeRequests/cancel

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
