### PR TITLE
[jobs] prevent downing jobs controller with clusters

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1152,6 +1152,24 @@ class ManagedJobCodeGen:
         return cls._build(code)
 
     @classmethod
+    def get_clusters_on_controller(cls) -> str:
+        """Returns code for getting clusters on the controller.
+
+        Returns a list of tuples of (cluster_name, status) for each cluster.
+        """
+        code = textwrap.dedent("""\
+        from sky.backends import backend_utils
+        from sky.utils import common_utils
+
+        # Get all clusters launched by the controller
+        clusters = backend_utils.get_clusters(include_controller=True, refresh=False)
+        # Return tuples of (name, status) for each cluster
+        cluster_info = [(c['name'], c['status'].value) for c in clusters]
+        print(common_utils.encode_payload(cluster_info), flush=True)
+        """)
+        return cls._build(code)
+
+    @classmethod
     def cancel_jobs_by_id(cls, job_ids: Optional[List[int]]) -> str:
         code = textwrap.dedent(f"""\
         msg = utils.cancel_jobs_by_id({job_ids})

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -88,15 +88,17 @@ def stop_safe_status():
     stream logs from user program and do not want it to interfere with the
     spinner display.
     """
+    from sky import sky_logging  # pylint: disable=import-outside-toplevel
     if (threading.current_thread() is threading.main_thread() and
-            _status is not None):
+            not sky_logging.is_silent() and _status is not None):
         _status.stop()
 
 
 def force_update_status(msg: str):
     """Update the status message even if sky_logging.is_silent() is true."""
+    from sky import sky_logging  # pylint: disable=import-outside-toplevel
     if (threading.current_thread() is threading.main_thread() and
-            _status is not None):
+            not sky_logging.is_silent() and _status is not None):
         _status.update(msg)
 
 


### PR DESCRIPTION
If we leak a jobs cluster (e.g. due to FAILED_CONTROLLER), we should not let the user down the jobs controller until the leak is manually cleaned up.

![image](https://github.com/user-attachments/assets/3b7a7d4b-2760-4327-8c03-d3db78f8e65e)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
