### PR TITLE
[Catalog] Workaround for wrong accelerator name of `p5en.48xlarge` returned by AWS api

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_aws.py
@@ -306,6 +306,12 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
                 assert find_num_in_name is not None, row['InstanceType']
                 num_in_name = find_num_in_name.group(1)
                 acc_count = int(num_in_name) // 2
+            if row['InstanceType'] == 'p5en.48xlarge':
+                # TODO(andyl): Check if this workaround still needed after
+                # v0.10.0 released. Currently, the acc_name returned by the
+                # AWS API is 'NVIDIA', which is incorrect. See #4652.
+                acc_name = 'H200'
+                acc_count = 8
             return pd.Series({
                 'AcceleratorName': acc_name,
                 'AcceleratorCount': acc_count,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4652.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

I manually run `python -m sky.clouds.service_catalog.data_fetchers.fetch_aws --no-az-mappings --check-all-regions-enabled-for-account`, and got different `Accelerator Name` on `p5en.48xlarge`:
```
1,6c1,6
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",106.0,28.050400,ap-northeast-1,apne1-az4
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,21.160300,us-east-2,use2-az1
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,14.830500,us-east-2,use2-az2
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,16.288100,us-east-2,use2-az3
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,24.751300,us-west-2,usw2-az2
< p5en.48xlarge,NVIDIA,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,23.081600,us-west-2,usw2-az4
---
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",106.0,28.050400,ap-northeast-1,apne1-az4
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,21.160300,us-east-2,use2-az1
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,14.830500,us-east-2,use2-az2
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,16.288100,us-east-2,use2-az3
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,24.751300,us-west-2,usw2-az2
> p5en.48xlarge,H200,8.0,192.0,2048.0,"{'Gpus': [{'Name': 'NVIDIA', 'Manufacturer': 'NVIDIA', 'Count': 8, 'MemoryInfo': {'SizeInMiB': 144384}}], 'TotalGpuMemoryInMiB': 1155072}",84.8,23.081600,us-west-2,usw2-az4
```

Also, after use this newly generated `vms.csv` file to replace `~/.sky/catalogs/v6/aws/vms.csv`, I validate the effectiveness of this fix:
```
andyl@andylizf-dev-server ~/skypilot (fix-h200-acc-name) > sky show-gpus NVIDIA
Kubernetes GPUs
Resources 'NVIDIA' not found in Kubernetes cluster. If your cluster contains GPUs or TPUs, make sure nvidia.com/gpu or google.com/tpu resource is available on the nodes and the node labels for identifying GPUs/TPUs (e.g., skypilot.co/accelerator) are setup correctly. To show available accelerators on kubernetes, run: sky show-gpus --cloud kubernetes 

Cloud GPUs
Resources 'NVIDIA' not found in cloud catalogs. To show available accelerators, run: sky show-gpus --all

andyl@andylizf-dev-server ~/skypilot (fix-h200-acc-name) > sky show-gpus H200
Kubernetes GPUs
Resources 'H200' not found in Kubernetes cluster. If your cluster contains GPUs or TPUs, make sure nvidia.com/gpu or google.com/tpu resource is available on the nodes and the node labels for identifying GPUs/TPUs (e.g., skypilot.co/accelerator) are setup correctly. To show available accelerators on kubernetes, run: sky show-gpus --cloud kubernetes 

Cloud GPUs
GPU   QTY  CLOUD  INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION      
H200  8    AWS    p5en.48xlarge  141GB       192    2048GB    $ 84.800      $ 14.831           us-east-2   
H200  8    AWS    p5e.48xlarge   141GB       192    2048GB    -             -                  eu-north-1  

GPU    QTY  CLOUD   INSTANCE_TYPE  DEVICE_MEM  vCPUs  HOST_MEM  HOURLY_PRICE  HOURLY_SPOT_PRICE  REGION            
GH200  1    Lambda  gpu_1x_gh200   96GB        64     432GB     $ 1.490       -                  europe-central-1  
```