### PR TITLE
[UX] Remove do exception in `sky check`

### DIFF
--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -260,6 +260,8 @@ class DO(clouds.Cloud):
         try:
             # attempt to make a CURL request for listing instances
             do_utils.client().droplets.list()
+        except ImportError as err:
+            return False, str(err)
         except do.exceptions().HttpResponseError as err:
             return False, str(err)
         except do_utils.DigitalOceanError as err:

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -257,11 +257,15 @@ class DO(clouds.Cloud):
     @classmethod
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Verify that the user has valid credentials for DO."""
+
+        try:
+            do.exceptions()
+        except ImportError as err:
+            return False, str(err)
+
         try:
             # attempt to make a CURL request for listing instances
             do_utils.client().droplets.list()
-        except ImportError as err:
-            return False, str(err)
         except do.exceptions().HttpResponseError as err:
             return False, str(err)
         except do_utils.DigitalOceanError as err:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously
```
  DO: disabled                              
    Reason: sky.provision.do.utils.DigitalOceanError: no credentials file found from the following paths ['/home/vscode/Library/Application Support/doctl/config.yaml', '/home/vscode/.config/doctl/config.yaml']

During handling of the above exception, another exception occurred:

ModuleNotFoundError: No module named 'pydo'

The above exception was the direct cause of the following exception:

ImportError: Failed to import dependencies for DO. Try pip install "skypilot[do]"
```

Now
```
  DO: disabled                              
    Reason: Failed to import dependencies for DO. Try pip install "skypilot[do]"
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
