### PR TITLE
[Release] Release 0.8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm -rf /var/lib/apt/lists/*
 
 # Install sky
-RUN pip install --no-cache-dir "skypilot[all]==0.6.0"
+RUN pip install --no-cache-dir "skypilot[all]==0.8.0"

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -35,7 +35,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '1.0.0-dev0'
+__version__ = '0.8.0'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Freeze the version on the master branch on ~~2025-02-08~~ 2025-02-12.

The `releases/*` branches are protected, so use the `cut_version_date` branch for code review.

base branch: `cut_version_date` is the master branch on 2025-02-12.
current branch: base branch + following changes:

* And the [bump up version commit](https://github.com/zpoint/skypilot/commit/77c1286b880d20b3eed5b7cbaff3f7b5f0aaa628)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Release Test:

The release test was conducted in the branch [0.8.0_rc_20250212_test](https://github.com/zpoint/skypilot/tree/dev/zeping/0.8.0_rc_20250212_test), [diff here](https://github.com/zpoint/skypilot/compare/dev/zeping/0.8.0_rc_20250212_test...dev/zeping/0.8.0_rc)

 After the test:

* #4700  
* #4699  
* #4697  

were merged without additional testing, which should be fine.  
Therefore, we recut the master branch to include these three changes.

Pass:

- [x] [/smoke-test --aws](https://buildkite.com/skypilot-1/smoke-tests/builds/177) -- All pass
- [x] [/smoke-test --azure](https://buildkite.com/skypilot-1/smoke-tests/builds/181) -- All pass
- [x] [/smoke-test --gcp](https://buildkite.com/skypilot-1/smoke-tests/builds/182) -- All pass
- [x] [/smoke-test --kubernetes](https://buildkite.com/skypilot-1/smoke-tests/builds/178)
    * Ignore the failures since they pass on GKE
- [x] [/quicktest-core](https://buildkite.com/skypilot-1/quicktest-core/builds/116) -- All pass
- [x] [/release](https://buildkite.com/skypilot-1/release/builds/28)
    * Ignore the failure -- no resource

Fail:
- [ ] [0.8.0 backward_compatibility with 0.7.0
](https://buildkite.com/skypilot-1/quicktest-core-dev/builds/3#_)
