### PR TITLE
[Test] Keep the test identifier for cancellation test

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -586,10 +586,9 @@ def test_managed_jobs_cancellation_aws(aws_config_region):
 @pytest.mark.managed_jobs
 def test_managed_jobs_cancellation_gcp():
     name = smoke_tests_utils.get_cluster_name()
-    # Use [:-5], [-2:] to avoid cluster name to be truncated twice for managed
-    # jobs. We keep the last 2 characters for the identifier across multiple
-    # tests.
-    name_3 = f'{name[:-5]}{name[-2:]}-3'
+    # Reduce the name length further to avoid cluster name to be truncated twice
+    # after adding the suffix '-3'.
+    name_3 = name.replace('-jobs', '-j') + '-3'
     name_3_on_cloud = common_utils.make_cluster_name_on_cloud(
         name_3, jobs.JOBS_CLUSTER_NAME_PREFIX_LENGTH, add_user_hash=False)
     zone = 'us-west3-b'

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -586,8 +586,10 @@ def test_managed_jobs_cancellation_aws(aws_config_region):
 @pytest.mark.managed_jobs
 def test_managed_jobs_cancellation_gcp():
     name = smoke_tests_utils.get_cluster_name()
-    # Use :-2 to avoid cluster name to be truncated twice for managed jobs.
-    name_3 = f'{name[:-2]}-3'
+    # Use [:-5], [-2:] to avoid cluster name to be truncated twice for managed
+    # jobs. We keep the last 2 characters for the identifier across multiple
+    # tests.
+    name_3 = f'{name[:-5]}{name[-2:]}-3'
     name_3_on_cloud = common_utils.make_cluster_name_on_cloud(
         name_3, jobs.JOBS_CLUSTER_NAME_PREFIX_LENGTH, add_user_hash=False)
     zone = 'us-west3-b'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This fixes an issue from #4680, where we removed the test identifier causes the smoke test to fail since there can be jobs with the same name from previous tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [x] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
  - [x] `pytest tests/test_smoke.py::test_managed_jobs_cancellation_gcp --gcp`
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
