### PR TITLE
[k8s] Fix sky show-gpus not showing GPU name on GKE

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2178,52 +2178,53 @@ def get_kubernetes_node_info(
 
     lf, _ = detect_gpu_label_formatter(context)
     if not lf:
-        label_key = None
+        label_keys = []
     else:
         label_keys = lf.get_label_keys()
 
     node_info_dict: Dict[str, KubernetesNodeInfo] = {}
 
-    for label_key in label_keys:
-        for node in nodes:
-            allocated_qty = 0
+    for node in nodes:
+        accelerator_name = None
+        # Determine the accelerator name from the node labels
+        for label_key in label_keys:
             if lf is not None and label_key in node.metadata.labels:
                 accelerator_name = lf.get_accelerator_from_label_value(
                     node.metadata.labels.get(label_key))
-            else:
-                accelerator_name = None
+                break
 
-            accelerator_count = get_node_accelerator_count(
-                node.status.allocatable)
+        allocated_qty = 0
+        accelerator_count = get_node_accelerator_count(
+            node.status.allocatable)
 
-            if pods is None:
-                accelerators_available = -1
+        if pods is None:
+            accelerators_available = -1
 
-            else:
-                for pod in pods:
-                    # Get all the pods running on the node
-                    if (pod.spec.node_name == node.metadata.name and
-                            pod.status.phase in ['Running', 'Pending']):
-                        # Iterate over all the containers in the pod and sum the
-                        # GPU requests
-                        for container in pod.spec.containers:
-                            if container.resources.requests:
-                                allocated_qty += get_node_accelerator_count(
-                                    container.resources.requests)
+        else:
+            for pod in pods:
+                # Get all the pods running on the node
+                if (pod.spec.node_name == node.metadata.name and
+                        pod.status.phase in ['Running', 'Pending']):
+                    # Iterate over all the containers in the pod and sum the
+                    # GPU requests
+                    for container in pod.spec.containers:
+                        if container.resources.requests:
+                            allocated_qty += get_node_accelerator_count(
+                                container.resources.requests)
 
-                accelerators_available = accelerator_count - allocated_qty
+            accelerators_available = accelerator_count - allocated_qty
 
-            # Exclude multi-host TPUs from being processed.
-            # TODO(Doyoung): Remove the logic when adding support for
-            # multi-host TPUs.
-            if is_multi_host_tpu(node.metadata.labels):
-                continue
+        # Exclude multi-host TPUs from being processed.
+        # TODO(Doyoung): Remove the logic when adding support for
+        # multi-host TPUs.
+        if is_multi_host_tpu(node.metadata.labels):
+            continue
 
-            node_info_dict[node.metadata.name] = KubernetesNodeInfo(
-                name=node.metadata.name,
-                accelerator_type=accelerator_name,
-                total={'accelerator_count': int(accelerator_count)},
-                free={'accelerators_available': int(accelerators_available)})
+        node_info_dict[node.metadata.name] = KubernetesNodeInfo(
+            name=node.metadata.name,
+            accelerator_type=accelerator_name,
+            total={'accelerator_count': int(accelerator_count)},
+            free={'accelerators_available': int(accelerators_available)})
 
     return node_info_dict
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2196,8 +2196,7 @@ def get_kubernetes_node_info(
                 break
 
         allocated_qty = 0
-        accelerator_count = get_node_accelerator_count(
-            node.status.allocatable)
+        accelerator_count = get_node_accelerator_count(node.status.allocatable)
 
         if pods is None:
             accelerators_available = -1

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2186,7 +2186,9 @@ def get_kubernetes_node_info(
 
     for node in nodes:
         accelerator_name = None
-        # Determine the accelerator name from the node labels
+        # Determine the accelerator name from the node labels and pick the
+        # first one found. We assume that the node has only one accelerator type
+        # (e.g., either GPU or TPU).
         for label_key in label_keys:
             if lf is not None and label_key in node.metadata.labels:
                 accelerator_name = lf.get_accelerator_from_label_value(


### PR DESCRIPTION
Our TPU support broke `sky show-gpus` for GKE clusters containing GPUs. Since the labelformatter now returns multiple possible label types, our `show-gpus` logic would try to detect TPUs in the GKE cluster and mark GPU name as none when it was not found.

### Before
```
Kubernetes GPUs (context: gke_sky-dev-465_us-central1-c_testclusterromil)
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
L4    1                         2           2
T4    1                         2           2
V100  1                         2           2

Kubernetes per node accelerator availability
NODE_NAME                                        GPU_NAME  TOTAL_GPUS  FREE_GPUS
gke-testclusterromil-default-pool-41dc668e-10t7  None      1           1
gke-testclusterromil-default-pool-41dc668e-5x09  None      1           1
gke-testclusterromil-l4-b2f514af-0ggs            None      1           1
gke-testclusterromil-l4-b2f514af-93bq            None      1           1
gke-testclusterromil-largecpu-dc0c4f25-l0fd      None      0           0
gke-testclusterromil-largecpu-dc0c4f25-stxj      None      0           0
gke-testclusterromil-v100-ebe85506-8n4j          None      1           1
gke-testclusterromil-v100-ebe85506-pt6g          None      1           1
```


### After

```
Kubernetes GPUs (context: gke_sky-dev-465_us-central1-c_testclusterromil)
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
L4    1                         2           2
T4    1                         2           2
V100  1                         2           2

Kubernetes per node accelerator availability
NODE_NAME                                        GPU_NAME  TOTAL_GPUS  FREE_GPUS
gke-testclusterromil-default-pool-41dc668e-10t7  T4        1           1
gke-testclusterromil-default-pool-41dc668e-5x09  T4        1           1
gke-testclusterromil-l4-b2f514af-0ggs            L4        1           1
gke-testclusterromil-l4-b2f514af-93bq            L4        1           1
gke-testclusterromil-largecpu-dc0c4f25-l0fd      None      0           0
gke-testclusterromil-largecpu-dc0c4f25-stxj      None      0           0
gke-testclusterromil-v100-ebe85506-8n4j          V100      1           1
gke-testclusterromil-v100-ebe85506-pt6g          V100      1           1
```

Tested on GKE cluster with and without GPUs.