### PR TITLE
[Tests] Bug fixes for v0.8.0

### DIFF
--- a/examples/multi_echo.py
+++ b/examples/multi_echo.py
@@ -23,7 +23,7 @@ def run(cluster: Optional[str] = None, cloud: Optional[str] = None):
 
     # Create the cluster.
     with sky.Dag() as dag:
-        cluster_resources = sky.Resources(cloud, accelerators={'T4': 1})
+        cluster_resources = sky.Resources(cloud, cpus='4+', accelerators={'T4': 1})
         task = sky.Task(num_nodes=2).set_resources(cluster_resources)
     # `detach_run` will only detach the `run` command. The provision and
     # `setup` are still blocking.

--- a/examples/multi_echo.py
+++ b/examples/multi_echo.py
@@ -23,7 +23,9 @@ def run(cluster: Optional[str] = None, cloud: Optional[str] = None):
 
     # Create the cluster.
     with sky.Dag() as dag:
-        cluster_resources = sky.Resources(cloud, cpus='4+', accelerators={'T4': 1})
+        cluster_resources = sky.Resources(cloud,
+                                          cpus='4+',
+                                          accelerators={'T4': 1})
         task = sky.Task(num_nodes=2).set_resources(cluster_resources)
     # `detach_run` will only detach the `run` command. The provision and
     # `setup` are still blocking.

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -373,15 +373,16 @@ available_node_types:
                 done;
                 if [ ! -z "$INSTALL_FIRST" ]; then
                   echo "Installing core packages: $INSTALL_FIRST";
-                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y $INSTALL_FIRST;
+                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" $INSTALL_FIRST;
                 fi;
                 # SSH and other packages are not necessary, so we disable set -e
                 set +e
                 
                 if [ ! -z "$MISSING_PACKAGES" ]; then
                   echo "Installing missing packages: $MISSING_PACKAGES";
-                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y $MISSING_PACKAGES;
+                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" $MISSING_PACKAGES;
                 fi;
+              
                 $(prefix_cmd) mkdir -p /var/run/sshd;
                 $(prefix_cmd) sed -i "s/PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config;
                 $(prefix_cmd) sed "s@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g" -i /etc/pam.d/sshd;

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -345,6 +345,7 @@ def test_core_api_sky_launch_exec():
 
 # The sky launch CLI has some additional checks to make sure the cluster is up/
 # restarted. However, the core API doesn't have these; make sure it still works
+@pytest.mark.no_kubernetes
 def test_core_api_sky_launch_fast(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     cloud = sky.clouds.CLOUD_REGISTRY.from_str(generic_cloud)


### PR DESCRIPTION
Fixes a few bugs for v0.8.0:

* Fix FUSE not getting installed on Miniconda base image due to debconf conflicts
* Fix multi-echo test for k8s (2CPU default limits number of concurrent jobs)
* Disable fast launch test for k8s since it requires autostop.