### PR TITLE
[UX] Auto-exclude unavailable kubernetes contexts

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -401,14 +401,14 @@ class Cloud:
         try:
             self.check_features_are_supported(resources,
                                               resources_required_features)
-        except exceptions.NotSupportedError:
-            # TODO(zhwu): The resources are now silently filtered out. We
-            # should have some logging telling the user why the resources
-            # are not considered.
-            return resources_utils.FeasibleResources(resources_list=[],
-                                                     fuzzy_candidate_list=[],
-                                                     hint=None)
-        return self._get_feasible_launchable_resources(resources)
+            return self._get_feasible_launchable_resources(resources)
+        except exceptions.NotSupportedError as e:
+            hint = f'Excluded due to feature requirements: {e}'
+        except exceptions.ResourcesUnavailableError as e:
+            hint = f'Excluded due to resource unavailability: {e}'
+        return resources_utils.FeasibleResources(resources_list=[],
+                                                 fuzzy_candidate_list=[],
+                                                 hint=hint)
 
     def _get_feasible_launchable_resources(
         self, resources: 'resources_lib.Resources'

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -89,6 +89,7 @@ class Kubernetes(clouds.Cloud):
     def _unsupported_features_for_resources(
         cls, resources: 'resources_lib.Resources'
     ) -> Dict[clouds.CloudImplementationFeatures, str]:
+        # TODO(aylei): features need to be regional (per context)
         unsupported_features = cls._CLOUD_UNSUPPORTED_FEATURES.copy()
         context = resources.region
         if context is None:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -80,7 +80,7 @@ class Kubernetes(clouds.Cloud):
 
     _INDENT_PREFIX = ' ' * 4
 
-    # Set of contexts that are marked as unavailable in runtime
+    # Set of contexts that are marked as unavailable at runtime
     unavailable_contexts: Set[str] = set()
 
     @property

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1313,9 +1313,7 @@ def _fill_in_launchable_resources(
             else:
                 all_fuzzy_candidates.update(
                     feasible_resources.fuzzy_candidate_list)
-        if not quiet:
-            for cloud, hint in hints.items():
-                logger.info(f'{repr(cloud)}: {hint}')
+
         if not launchable[resources]:
             clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                 clouds_list[0])
@@ -1340,6 +1338,8 @@ def _fill_in_launchable_resources(
                         logger.info('Try specifying a different memory size, '
                                     'or add "+" to the end of the memory size '
                                     'to allow for larger instances.')
+                for cloud, hint in hints.items():
+                    logger.info(f'{repr(cloud)}: {hint}')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_resources)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1313,6 +1313,9 @@ def _fill_in_launchable_resources(
             else:
                 all_fuzzy_candidates.update(
                     feasible_resources.fuzzy_candidate_list)
+        if not quiet:
+            for cloud, hint in hints.items():
+                logger.info(f'{repr(cloud)}: {hint}')
         if not launchable[resources]:
             clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                 clouds_list[0])
@@ -1328,17 +1331,15 @@ def _fill_in_launchable_resources(
                                 f'{colorama.Fore.CYAN}'
                                 f'{sorted(all_fuzzy_candidates)}'
                                 f'{colorama.Style.RESET_ALL}')
-                for cloud, hint in hints.items():
-                    logger.info(f'{repr(cloud)}: {hint}')
-            else:
-                if resources.cpus is not None:
-                    logger.info('Try specifying a different CPU count, '
-                                'or add "+" to the end of the CPU count '
-                                'to allow for larger instances.')
-                if resources.memory is not None:
-                    logger.info('Try specifying a different memory size, '
-                                'or add "+" to the end of the memory size '
-                                'to allow for larger instances.')
+                else:
+                    if resources.cpus is not None:
+                        logger.info('Try specifying a different CPU count, '
+                                    'or add "+" to the end of the CPU count '
+                                    'to allow for larger instances.')
+                    if resources.memory is not None:
+                        logger.info('Try specifying a different memory size, '
+                                    'or add "+" to the end of the memory size '
+                                    'to allow for larger instances.')
 
         launchable[resources] = _filter_out_blocked_launchable_resources(
             launchable[resources], blocked_resources)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1313,7 +1313,6 @@ def _fill_in_launchable_resources(
             else:
                 all_fuzzy_candidates.update(
                     feasible_resources.fuzzy_candidate_list)
-
         if not launchable[resources]:
             clouds_str = str(clouds_list) if len(clouds_list) > 1 else str(
                 clouds_list[0])

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -694,10 +694,7 @@ def check_instance_fits(context: Optional[str],
                        f'{tpu_list_in_cluster_str}. Note that multi-host TPU '
                        'podslices are currently not unsupported.')
 
-    try:
-        nodes = get_kubernetes_nodes(context)
-    except exceptions.ResourcesUnavailableError as e:
-        return False, f'Failed to get kubernetes nodes: {e}'
+    nodes = get_kubernetes_nodes(context)
     k8s_instance_type = KubernetesInstanceType.\
         from_instance_type(instance)
     acc_type = k8s_instance_type.accelerator_type

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -169,10 +169,12 @@ def _retry_on_error(max_retries=DEFAULT_MAX_RETRIES,
             # Format error message based on the type of exception
             resource_msg = f' when trying to get {resource_type} info' \
                 if resource_type else ''
-            debug_cmd = f' To debug, run: kubectl get {resource_type}s' \
+            debug_cmd = f' To debug, run: `kubectl get {resource_type}s' \
                 if resource_type else ''
             if context:
-                debug_cmd += f' --context {context}'
+                debug_cmd += f' --context {context}`'
+            else:
+                debug_cmd += '`'
 
             if isinstance(last_exception, kubernetes.max_retry_error()):
                 error_msg = f'Timed out{resource_msg} from Kubernetes cluster.'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/2807

- Excludes unavailable kubernetes contexts at runtime;
- Refine `sky check` message for multi-kubernetes setup to show hint/reason of each context and guide user exclude stale kubernetes cluster from `allowed_contexts` config;

UX:

- The default context is unavailable:

```bash
Excluding Kubernetes context kind-kind: Timed out when trying to get node info from Kubernetes cluster. Please check if the cluster is healthy and retry. To debug, run: `kubectl get nodes --context kind-kind`
No Kubernetes context available. Retry if it is a transient error or run `sky check` to refresh kubernetes availability if permanent.
Considered resources (1 node):
------------------------------------------------------------------------------------------
 CLOUD   INSTANCE      vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
------------------------------------------------------------------------------------------
 AWS     m6i.2xlarge   8       32        -              us-east-1     0.38          ✔
------------------------------------------------------------------------------------------
```

> The following test results were produced with config:
> ```
> allowed_clouds:
>    - aws
>    - kubernetes
> kubernetes:
>   allowed_contexts:
>   - kind-kind
>   - kind-test
> ```

- Some of `allowed_contexts` are unavailable:

```bash
$ sky launch
Excluding Kubernetes context kind-kind: Timed out when trying to get node info from Kubernetes cluster. Please check if the cluster is healthy and retry. To debug, run: `kubectl get nodes --context kind-kind`
Considered resources (1 node):
-----------------------------------------------------------------------------------------------
 CLOUD        INSTANCE      vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
-----------------------------------------------------------------------------------------------
 Kubernetes   2CPU--2GB     2       2         -              kind-test     0.00          ✔
 AWS          m6i.2xlarge   8       32        -              us-east-1     0.38
-----------------------------------------------------------------------------------------------
```

- All `allowed_contexts` are unavailable:

```bash
$ sky launch
Excluding Kubernetes context kind-test: Timed out when trying to get node info from Kubernetes cluster. Please check if the cluster is healthy and retry. To debug, run: `kubectl get nodes --context kind-test`
Excluding Kubernetes context kind-kind: Timed out when trying to get node info from Kubernetes cluster. Please check if the cluster is healthy and retry. To debug, run: `kubectl get nodes --context kind-kind`
No Kubernetes context available. Retry if it is a transient error or run `sky check` to refresh kubernetes availability if permanent.
Considered resources (1 node):
------------------------------------------------------------------------------------------
 CLOUD   INSTANCE      vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
------------------------------------------------------------------------------------------
 AWS     m6i.2xlarge   8       32        -              us-east-1     0.38          ✔
------------------------------------------------------------------------------------------
```

- `sky check`:

<img width="1479" alt="image" src="https://github.com/user-attachments/assets/61ada0d2-9c97-49ea-8492-9d08fdb9c6e4" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
