### PR TITLE
[Examples] Fix ray distributed training example

### DIFF
--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -185,7 +185,7 @@ To execute a distributed Ray program on many nodes, you can download the `traini
       else
         sleep 5
         ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $HEAD_IP:6379 --disable-usage-stats
-        sleep infinity
+        sleep 5
       fi
 
 .. warning::

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -185,6 +185,7 @@ To execute a distributed Ray program on many nodes, you can download the `traini
       else
         sleep 5
         ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $HEAD_IP:6379 --disable-usage-stats
+        sleep infinity
       fi
 
 .. warning::

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -185,6 +185,7 @@ To execute a distributed Ray program on many nodes, you can download the `traini
       else
         sleep 5
         ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $HEAD_IP:6379 --disable-usage-stats
+        # Add sleep to after `ray start` to give ray enough time to daemonize
         sleep 5
       fi
 

--- a/examples/distributed_ray_train/ray_train.yaml
+++ b/examples/distributed_ray_train/ray_train.yaml
@@ -29,5 +29,5 @@ run: |
   else
     sleep 5
     ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $head_ip:6379 --disable-usage-stats
-    sleep infinity
+    sleep 5
   fi

--- a/examples/distributed_ray_train/ray_train.yaml
+++ b/examples/distributed_ray_train/ray_train.yaml
@@ -29,4 +29,5 @@ run: |
   else
     sleep 5
     ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $head_ip:6379 --disable-usage-stats
+    sleep infinity
   fi

--- a/examples/distributed_ray_train/ray_train.yaml
+++ b/examples/distributed_ray_train/ray_train.yaml
@@ -29,5 +29,6 @@ run: |
   else
     sleep 5
     ps aux | grep ray | grep 6379 &> /dev/null || ray start --address $head_ip:6379 --disable-usage-stats
+    # Add sleep to after `ray start` to give ray enough time to daemonize 
     sleep 5
   fi


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/4695. 

Seems like our subprocess handling kills the user started raylet processes after the SkyPilot job terminates. This PR fixes it by stalling the worker job with a sleep after `ray start`, presumably giving `ray start` enough time to daemonize.

Tested on AWS and Kubernetes.
