### PR TITLE
[Tests] Update initial_delay for serve tests to account for slow EKS load balancer provisioning

### DIFF
--- a/tests/skyserve/http/kubernetes.yaml
+++ b/tests/skyserve/http/kubernetes.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
   replicas: 2
 
 resources:

--- a/tests/skyserve/multi_ports.yaml
+++ b/tests/skyserve/multi_ports.yaml
@@ -1,7 +1,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
   replicas: 1
   ports: 8080
 

--- a/tests/skyserve/update/bump_version_after.yaml
+++ b/tests/skyserve/update/bump_version_after.yaml
@@ -12,7 +12,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
   replicas: 3
 
 resources:

--- a/tests/skyserve/update/bump_version_before.yaml
+++ b/tests/skyserve/update/bump_version_before.yaml
@@ -12,7 +12,7 @@
 service:
   readiness_probe:
     path: /health
-    initial_delay_seconds: 20
+    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
   replicas: 2
 
 resources:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
