### PR TITLE
[client-server] avoid killing the API server on SIGINT

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -175,7 +175,9 @@ def start_uvicorn_in_background(deploy: bool = False, host: str = '127.0.0.1'):
     cmd = f'{api_server_cmd} > {log_path} 2>&1'
 
     # Start the uvicorn process in the background and don't wait for it.
-    subprocess.Popen(cmd, shell=True)
+    # If this is called from a CLI invocation, we need start_new_session=True so
+    # that SIGINT on the CLI will not also kill the API server.
+    subprocess.Popen(cmd, shell=True, start_new_session=True)
 
     # Wait for the server to start until timeout.
     # Conservative upper time bound for starting the server based on profiling.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
My autostarted local API server was dying when I ctrl+c the CLI command that autostarted it.

This prevents the ctrl+c / SIGINT from being passed through to the API server.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
