### PR TITLE
Add IAD02 (us-east-3) to Lambda Cloud regions

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_lambda_cloud.py
@@ -28,6 +28,7 @@ REGIONS = [
     'asia-northeast-2',
     'us-east-1',
     'us-east-2',
+    'us-east-3',
     'us-west-2',
     'us-west-1',
     'us-south-1',


### PR DESCRIPTION
This pull request adds `IAD02` (`us-east-3`) to Lambda Cloud's regions.

Closes: #4702