### PR TITLE
[Storage] Azure bucket sub directory is ignored if the bucket previously exists

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -1463,6 +1463,8 @@ class S3Store(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        sub_path = (f'/{self._bucket_sub_path}'
+                    if self._bucket_sub_path else '')
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join([
@@ -1470,8 +1472,6 @@ class S3Store(AbstractStore):
                 for file_name in file_names
             ])
             base_dir_path = shlex.quote(base_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = ('aws s3 sync --no-follow-symlinks --exclude="*" '
                             f'{includes} {base_dir_path} '
                             f's3://{self.name}{sub_path}')
@@ -1486,8 +1486,6 @@ class S3Store(AbstractStore):
                 for file_name in excluded_list
             ])
             src_dir_path = shlex.quote(src_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = (f'aws s3 sync --no-follow-symlinks {excludes} '
                             f'{src_dir_path} '
                             f's3://{self.name}{sub_path}/{dest_dir_name}')
@@ -1501,7 +1499,7 @@ class S3Store(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> s3://{self.name}/'
+        sync_path = f'{source_message} -> s3://{self.name}{sub_path}/'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -1960,11 +1958,13 @@ class GcsStore(AbstractStore):
         copy_list = '\n'.join(
             os.path.abspath(os.path.expanduser(p)) for p in source_path_list)
         gsutil_alias, alias_gen = data_utils.get_gsutil_command()
+        sub_path = (f'/{self._bucket_sub_path}'
+                    if self._bucket_sub_path else '')
         sync_command = (f'{alias_gen}; echo "{copy_list}" | {gsutil_alias} '
-                        f'cp -e -n -r -I gs://{self.name}')
+                        f'cp -e -n -r -I gs://{self.name}{sub_path}')
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> gs://{self.name}/'
+        sync_path = f'{source_message} -> gs://{self.name}{sub_path}/'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -1996,13 +1996,13 @@ class GcsStore(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        sub_path = (f'/{self._bucket_sub_path}'
+                    if self._bucket_sub_path else '')
 
         def get_file_sync_command(base_dir_path, file_names):
             sync_format = '|'.join(file_names)
             gsutil_alias, alias_gen = data_utils.get_gsutil_command()
             base_dir_path = shlex.quote(base_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = (f'{alias_gen}; {gsutil_alias} '
                             f'rsync -e -x \'^(?!{sync_format}$).*\' '
                             f'{base_dir_path} gs://{self.name}{sub_path}')
@@ -2015,8 +2015,6 @@ class GcsStore(AbstractStore):
             excludes = '|'.join(excluded_list)
             gsutil_alias, alias_gen = data_utils.get_gsutil_command()
             src_dir_path = shlex.quote(src_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = (f'{alias_gen}; {gsutil_alias} '
                             f'rsync -e -r -x \'({excludes})\' {src_dir_path} '
                             f'gs://{self.name}{sub_path}/{dest_dir_name}')
@@ -2030,7 +2028,7 @@ class GcsStore(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> gs://{self.name}/'
+        sync_path = f'{source_message} -> gs://{self.name}{sub_path}/'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -2804,6 +2802,8 @@ class AzureBlobStore(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        container_path = (f'{self.container_name}/{self._bucket_sub_path}'
+                            if self._bucket_sub_path else self.container_name)
 
         def get_file_sync_command(base_dir_path, file_names) -> str:
             # shlex.quote is not used for file_names as 'az storage blob sync'
@@ -2812,8 +2812,6 @@ class AzureBlobStore(AbstractStore):
             includes_list = ';'.join(file_names)
             includes = f'--include-pattern "{includes_list}"'
             base_dir_path = shlex.quote(base_dir_path)
-            container_path = (f'{self.container_name}/{self._bucket_sub_path}'
-                              if self._bucket_sub_path else self.container_name)
             sync_command = (f'az storage blob sync '
                             f'--account-name {self.storage_account_name} '
                             f'--account-key {self.storage_account_key} '
@@ -2831,9 +2829,6 @@ class AzureBlobStore(AbstractStore):
                 [file_name.rstrip('*') for file_name in excluded_list])
             excludes = f'--exclude-path "{excludes_list}"'
             src_dir_path = shlex.quote(src_dir_path)
-            container_path = (f'{self.container_name}/{self._bucket_sub_path}'
-                              if self._bucket_sub_path else
-                              f'{self.container_name}')
             if dest_dir_name:
                 container_path = f'{container_path}/{dest_dir_name}'
             sync_command = (f'az storage blob sync '
@@ -2853,7 +2848,7 @@ class AzureBlobStore(AbstractStore):
             source_message = source_path_list[0]
         container_endpoint = data_utils.AZURE_CONTAINER_URL.format(
             storage_account_name=self.storage_account_name,
-            container_name=self.name)
+            container_name=container_path)
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
         sync_path = f'{source_message} -> {container_endpoint}/'
@@ -3247,6 +3242,8 @@ class R2Store(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        sub_path = (f'/{self._bucket_sub_path}'
+                    if self._bucket_sub_path else '')
 
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join([
@@ -3255,8 +3252,6 @@ class R2Store(AbstractStore):
             ])
             endpoint_url = cloudflare.create_endpoint()
             base_dir_path = shlex.quote(base_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
                             f'{cloudflare.R2_CREDENTIALS_PATH} '
                             'aws s3 sync --no-follow-symlinks --exclude="*" '
@@ -3276,8 +3271,6 @@ class R2Store(AbstractStore):
             ])
             endpoint_url = cloudflare.create_endpoint()
             src_dir_path = shlex.quote(src_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
                             f'{cloudflare.R2_CREDENTIALS_PATH} '
                             f'aws s3 sync --no-follow-symlinks {excludes} '
@@ -3295,7 +3288,7 @@ class R2Store(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> r2://{self.name}/'
+        sync_path = f'{source_message} -> r2://{self.name}{sub_path}/'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -3719,6 +3712,8 @@ class IBMCosStore(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        sub_path = (f'/{self._bucket_sub_path}'
+                    if self._bucket_sub_path else '')
 
         def get_dir_sync_command(src_dir_path, dest_dir_name) -> str:
             """returns an rclone command that copies a complete folder
@@ -3740,8 +3735,6 @@ class IBMCosStore(AbstractStore):
             # .git directory is excluded from the sync
             # wrapping src_dir_path with "" to support path with spaces
             src_dir_path = shlex.quote(src_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = (
                 'rclone copy --exclude ".git/*" '
                 f'{src_dir_path} '
@@ -3772,8 +3765,6 @@ class IBMCosStore(AbstractStore):
                 for file_name in file_names
             ])
             base_dir_path = shlex.quote(base_dir_path)
-            sub_path = (f'/{self._bucket_sub_path}'
-                        if self._bucket_sub_path else '')
             sync_command = (
                 'rclone copy '
                 f'{includes} {base_dir_path} '
@@ -3788,7 +3779,7 @@ class IBMCosStore(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> cos://{self.region}/{self.name}/'
+        sync_path = f'{source_message} -> cos://{self.region}/{self.name}{sub_path}/'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -4187,6 +4178,8 @@ class OciStore(AbstractStore):
                 set to True, the directory is created in the bucket root and
                 contents are uploaded to it.
         """
+        sub_path = (f'{self._bucket_sub_path}/'
+                    if self._bucket_sub_path else '')
 
         @oci.with_oci_env
         def get_file_sync_command(base_dir_path, file_names):
@@ -4196,6 +4189,7 @@ class OciStore(AbstractStore):
                 'oci os object bulk-upload --no-follow-symlinks --overwrite '
                 f'--bucket-name {self.name} --namespace-name {self.namespace} '
                 f'--region {self.region} --src-dir "{base_dir_path}" '
+                f'--object-prefix "{sub_path}" '
                 f'{includes}')
 
             return sync_command
@@ -4216,7 +4210,7 @@ class OciStore(AbstractStore):
             sync_command = (
                 'oci os object bulk-upload --no-follow-symlinks --overwrite '
                 f'--bucket-name {self.name} --namespace-name {self.namespace} '
-                f'--region {self.region} --object-prefix "{dest_dir_name}" '
+                f'--region {self.region} --object-prefix "{sub_path}{dest_dir_name}" '
                 f'--src-dir "{src_dir_path}" {excludes}')
 
             return sync_command
@@ -4229,7 +4223,7 @@ class OciStore(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> oci://{self.name}/'
+        sync_path = f'{source_message} -> oci://{self.name}/{sub_path}'
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -354,7 +354,8 @@ class AbstractStore:
                                              metadata.is_sky_managed),
             sync_on_reconstruction=override_args.get('sync_on_reconstruction',
                                                      True),
-            # backward compatibility
+            # Backward compatibility
+            # TODO: remove the hasattr check after v0.11.0
             _bucket_sub_path=override_args.get(
                 '_bucket_sub_path',
                 metadata._bucket_sub_path  # pylint: disable=protected-access
@@ -2307,6 +2308,8 @@ class AzureBlobStore(AbstractStore):
             An instance of AzureBlobStore.
         """
         assert isinstance(metadata, AzureBlobStore.AzureBlobStoreMetadata)
+                # TODO: this needs to be kept in sync with the abstract
+        # AbstractStore.from_metadata.
         return cls(name=override_args.get('name', metadata.name),
                    storage_account_name=override_args.get(
                        'storage_account', metadata.storage_account_name),
@@ -2315,7 +2318,13 @@ class AzureBlobStore(AbstractStore):
                    is_sky_managed=override_args.get('is_sky_managed',
                                                     metadata.is_sky_managed),
                    sync_on_reconstruction=override_args.get(
-                       'sync_on_reconstruction', True))
+                       'sync_on_reconstruction', True),
+                    # Backward compatibility
+                    # TODO: remove the hasattr check after v0.11.0
+                    _bucket_sub_path=override_args.get(
+                        '_bucket_sub_path',
+                        metadata._bucket_sub_path  # pylint: disable=protected-access
+                    ) if hasattr(metadata, '_bucket_sub_path') else None)
 
     def get_metadata(self) -> AzureBlobStoreMetadata:
         return self.AzureBlobStoreMetadata(

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2306,23 +2306,24 @@ class AzureBlobStore(AbstractStore):
             An instance of AzureBlobStore.
         """
         assert isinstance(metadata, AzureBlobStore.AzureBlobStoreMetadata)
-                # TODO: this needs to be kept in sync with the abstract
+        # TODO: this needs to be kept in sync with the abstract
         # AbstractStore.from_metadata.
-        return cls(name=override_args.get('name', metadata.name),
-                   storage_account_name=override_args.get(
-                       'storage_account', metadata.storage_account_name),
-                   source=override_args.get('source', metadata.source),
-                   region=override_args.get('region', metadata.region),
-                   is_sky_managed=override_args.get('is_sky_managed',
-                                                    metadata.is_sky_managed),
-                   sync_on_reconstruction=override_args.get(
-                       'sync_on_reconstruction', True),
-                    # Backward compatibility
-                    # TODO: remove the hasattr check after v0.11.0
-                    _bucket_sub_path=override_args.get(
-                        '_bucket_sub_path',
-                        metadata._bucket_sub_path  # pylint: disable=protected-access
-                    ) if hasattr(metadata, '_bucket_sub_path') else None)
+        return cls(
+            name=override_args.get('name', metadata.name),
+            storage_account_name=override_args.get(
+                'storage_account', metadata.storage_account_name),
+            source=override_args.get('source', metadata.source),
+            region=override_args.get('region', metadata.region),
+            is_sky_managed=override_args.get('is_sky_managed',
+                                             metadata.is_sky_managed),
+            sync_on_reconstruction=override_args.get('sync_on_reconstruction',
+                                                     True),
+            # Backward compatibility
+            # TODO: remove the hasattr check after v0.11.0
+            _bucket_sub_path=override_args.get(
+                '_bucket_sub_path',
+                metadata._bucket_sub_path  # pylint: disable=protected-access
+            ) if hasattr(metadata, '_bucket_sub_path') else None)
 
     def get_metadata(self) -> AzureBlobStoreMetadata:
         return self.AzureBlobStoreMetadata(
@@ -2803,7 +2804,7 @@ class AzureBlobStore(AbstractStore):
                 contents are uploaded to it.
         """
         container_path = (f'{self.container_name}/{self._bucket_sub_path}'
-                            if self._bucket_sub_path else self.container_name)
+                          if self._bucket_sub_path else self.container_name)
 
         def get_file_sync_command(base_dir_path, file_names) -> str:
             # shlex.quote is not used for file_names as 'az storage blob sync'
@@ -3781,7 +3782,8 @@ class IBMCosStore(AbstractStore):
 
         log_path = sky_logging.generate_tmp_logging_file_path(
             _STORAGE_LOG_FILE_NAME)
-        sync_path = f'{source_message} -> cos://{self.region}/{self.name}{sub_path}/'
+        sync_path = (
+            f'{source_message} -> cos://{self.region}/{self.name}{sub_path}/')
         with rich_utils.safe_status(
                 ux_utils.spinner_message(f'Syncing {sync_path}',
                                          log_path=log_path)):
@@ -4187,11 +4189,14 @@ class OciStore(AbstractStore):
         def get_file_sync_command(base_dir_path, file_names):
             includes = ' '.join(
                 [f'--include "{file_name}"' for file_name in file_names])
+            prefix_arg = ''
+            if sub_path:
+                prefix_arg = f'--object-prefix "{sub_path.strip("/")}"'
             sync_command = (
                 'oci os object bulk-upload --no-follow-symlinks --overwrite '
                 f'--bucket-name {self.name} --namespace-name {self.namespace} '
                 f'--region {self.region} --src-dir "{base_dir_path}" '
-                f'--object-prefix "{sub_path}" '
+                f'{prefix_arg} '
                 f'{includes}')
 
             return sync_command
@@ -4212,7 +4217,8 @@ class OciStore(AbstractStore):
             sync_command = (
                 'oci os object bulk-upload --no-follow-symlinks --overwrite '
                 f'--bucket-name {self.name} --namespace-name {self.namespace} '
-                f'--region {self.region} --object-prefix "{sub_path}{dest_dir_name}" '
+                f'--region {self.region} '
+                f'--object-prefix "{sub_path}{dest_dir_name}" '
                 f'--src-dir "{src_dir_path}" {excludes}')
 
             return sync_command

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -2830,14 +2830,16 @@ class AzureBlobStore(AbstractStore):
             excludes = f'--exclude-path "{excludes_list}"'
             src_dir_path = shlex.quote(src_dir_path)
             if dest_dir_name:
-                container_path = f'{container_path}/{dest_dir_name}'
+                dest_dir_name = f'/{dest_dir_name}'
+            else:
+                dest_dir_name = ''
             sync_command = (f'az storage blob sync '
                             f'--account-name {self.storage_account_name} '
                             f'--account-key {self.storage_account_key} '
                             f'{excludes} '
                             '--delete-destination false '
                             f'--source {src_dir_path} '
-                            f'--container {container_path}')
+                            f'--container {container_path}{dest_dir_name}')
             return sync_command
 
         # Generate message for upload

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -854,16 +854,18 @@ class TestStorageWithCredentials:
                                           persistent=persistent,
                                           mode=mode,
                                           _bucket_sub_path=_bucket_sub_path)
-        yield storage_obj
-        handle = global_user_state.get_handle_from_storage_name(
-            storage_obj.name)
-        if handle:
-            # If handle exists, delete manually
-            # TODO(romilb): This is potentially risky - if the delete method has
-            #   bugs, this can cause resource leaks. Ideally we should manually
-            #   eject storage from global_user_state and delete the bucket using
-            #   boto3 directly.
-            storage_obj.delete()
+        try:
+            yield storage_obj
+        finally:
+            handle = global_user_state.get_handle_from_storage_name(
+                storage_obj.name)
+            if handle:
+                # If handle exists, delete manually
+                # TODO(romilb): This is potentially risky - if the delete method has
+                #   bugs, this can cause resource leaks. Ideally we should manually
+                #   eject storage from global_user_state and delete the bucket using
+                #   boto3 directly.
+                storage_obj.delete()
 
     @pytest.fixture
     def tmp_scratch_storage_obj(self, tmp_bucket_name):
@@ -881,17 +883,19 @@ class TestStorageWithCredentials:
             timestamp = str(time.time()).replace('.', '')
             store_obj = storage_lib.Storage(name=f'sky-test-{timestamp}')
             storage_mult_obj.append(store_obj)
-        yield storage_mult_obj
-        for storage_obj in storage_mult_obj:
-            handle = global_user_state.get_handle_from_storage_name(
-                storage_obj.name)
-            if handle:
-                # If handle exists, delete manually
-                # TODO(romilb): This is potentially risky - if the delete method has
-                # bugs, this can cause resource leaks. Ideally we should manually
-                # eject storage from global_user_state and delete the bucket using
-                # boto3 directly.
-                storage_obj.delete()
+        try:
+            yield storage_mult_obj
+        finally:
+            for storage_obj in storage_mult_obj:
+                handle = global_user_state.get_handle_from_storage_name(
+                    storage_obj.name)
+                if handle:
+                    # If handle exists, delete manually
+                    # TODO(romilb): This is potentially risky - if the delete method has
+                    # bugs, this can cause resource leaks. Ideally we should manually
+                    # eject storage from global_user_state and delete the bucket using
+                    # boto3 directly.
+                    storage_obj.delete()
 
     @pytest.fixture
     def tmp_multiple_custom_source_storage_obj(self):
@@ -907,12 +911,14 @@ class TestStorageWithCredentials:
             store_obj = storage_lib.Storage(name=f'sky-test-{timestamp}',
                                             source=src_path)
             storage_mult_obj.append(store_obj)
-        yield storage_mult_obj
-        for storage_obj in storage_mult_obj:
-            handle = global_user_state.get_handle_from_storage_name(
-                storage_obj.name)
-            if handle:
-                storage_obj.delete()
+        try:
+            yield storage_mult_obj
+        finally:
+            for storage_obj in storage_mult_obj:
+                handle = global_user_state.get_handle_from_storage_name(
+                    storage_obj.name)
+                if handle:
+                    storage_obj.delete()
 
     @pytest.fixture
     def tmp_local_storage_obj(self, tmp_bucket_name, tmp_source):

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1099,7 +1099,14 @@ class TestStorageWithCredentials:
                              store_type):
         # Creates a new bucket with a local source, uploads files to it
         # and deletes it.
-        tmp_local_storage_obj_with_sub_path.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_local_storage_obj_with_sub_path.add_store(store_type,
+                                                      **region_kwargs)
 
         # Check files under bucket and filter by prefix
         files = self.list_all_files(store_type,
@@ -1412,7 +1419,13 @@ class TestStorageWithCredentials:
         # sky) and verifies that files are written.
         bucket_name, _ = request.getfixturevalue(ext_bucket_fixture)
         storage_obj = storage_lib.Storage(name=bucket_name, source=tmp_source)
-        storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        storage_obj.add_store(store_type, **region_kwargs)
 
         # Check if tmp_source/tmp-file exists in the bucket using aws cli
         out = subprocess.check_output(self.cli_ls_cmd(store_type, bucket_name),
@@ -1458,7 +1471,13 @@ class TestStorageWithCredentials:
     def test_list_source(self, tmp_local_list_storage_obj, store_type):
         # Uses a list in the source field to specify a file and a directory to
         # be uploaded to the storage object.
-        tmp_local_list_storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_local_list_storage_obj.add_store(store_type, **region_kwargs)
 
         # Check if tmp-file exists in the bucket root using cli
         out = subprocess.check_output(self.cli_ls_cmd(
@@ -1513,7 +1532,13 @@ class TestStorageWithCredentials:
                                                      tmp_gitignore_storage_obj):
         # tests if files included in .gitignore and .git/info/exclude are
         # excluded from being transferred to Storage
-        tmp_gitignore_storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_gitignore_storage_obj.add_store(store_type, **region_kwargs)
         upload_file_name = 'included'
         # Count the number of files with the given file name
         up_cmd = self.cli_count_name_in_bucket(store_type, \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR resolves two issues:

**Issue 1:** When there is an existing Azure bucket in SkyPilot storage database, the sub path will be ignored. This affects the smoke test `pytest tests/test_smoke.py::test_managed_jobs_storage --azure`.

To reproduce:
1. set `jobs.bucket: https://xxx.blob.core.windows.net/yyy` that is previously created by SkyPilot in `~/.sky/config.yaml`
2. `sky jobs launch -n test-azure-upload test.yaml`
```yaml
# A managed spot example with storages.
#
# Runs a task that uses cloud buckets for uploading and accessing files.
#
# Usage:
#   sky jobs launch -c spot-storage examples/managed_job_with_storage.yaml
#   sky down spot-storage

file_mounts:
  # File mounts for folder
  /tmp/workdir: ~/tmp-workdir


  # File mounts for file
  ~/tmpfile: ~/tmpfile
  ~/a/b/c/tmpfile: ~/tmpfile

run: |
  set -ex
  cat ~/tmpfile
  cat ~/a/b/c/tmpfile
  
  # Write to a file in the mounted bucket
  echo "hello world!" > /output_path/output.txt
```

The bucket will be polluted with in the root directory, and the job above fails with:
<details>
<summary>Detailed Error</summary>

```
E 02-13 01:43:29 subprocess_utils.py:149] Cannot perform sync due to error: trying to sync between different resource types (either file <-> directory or directory <-> file) which is not allowed.sync must happen between source and destination of the same type, e.g. either file <-> file or directory <-> directory.To make sure target is handled as a directory, add a trailing '/' to the target.
E 02-13 01:43:29 subprocess_utils.py:149] 

I 02-13 01:43:29 recovery_strategy.py:339] Failed to launch a cluster with error: sky.exceptions.CommandError: Command mkdir -p ~/tmpfile && azcopy --version > /dev/null 2>&1 || (mkdir -p /usr/local/bin; curl -L https:/... failed with return code 1.
I 02-13 01:43:29 recovery_strategy.py:339] Failed to run command before rsync https://sky635611d9a69285a3.blob.core.windows.net/skypilot-filemounts-vscode-11d9a692-ahpbb7v3/job-7xgk48n3/tmp-files/file-0 -> ~/tmpfile. Ensure that the network is stable, then retry. mkdir -p ~/tmpfile && azcopy --version > /dev/null 2>&1 || (mkdir -p /usr/local/bin; curl -L https://aka.ms/downloadazcopy-v10-linux -o azcopy.tar.gz; sudo tar -xvzf azcopy.tar.gz --strip-components=1 -C /usr/local/bin --exclude=*.txt; sudo chmod +x /usr/local/bin/azcopy; rm azcopy.tar.gz) && azcopy sync 'https://sky635611d9a69285a3.blob.core.windows.net/skypilot-filemounts-vscode-11d9a692-ahpbb7v3/job-7xgk48n3/tmp-files/file-0?se=2025-02-13T02%3A43%3A27Z&sp=rcwl&sv=2025-01-05&sr=c&sig=mr59%2B5SlTa72/5c%2BkM0BY6eiIqCx/uQOs3dUB%2BFnV1g%3D' ~/tmpfile/ --recursive --delete-destination=false See logs in ~/sky_logs/sky-2025-02-13-01-39-47-646407/file_mounts.log)
I 02-13 01:43:29 recovery_strategy.py:342]   Traceback: Traceback (most recent call last):
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/recovery_strategy.py", line 286, in _launch
I 02-13 01:43:29 recovery_strategy.py:342]     sky.launch(
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 385, in _record
I 02-13 01:43:29 recovery_strategy.py:342]     return f(*args, **kwargs)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 385, in _record
I 02-13 01:43:29 recovery_strategy.py:342]     return f(*args, **kwargs)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/execution.py", line 529, in launch
I 02-13 01:43:29 recovery_strategy.py:342]     return _execute(
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/execution.py", line 329, in _execute
I 02-13 01:43:29 recovery_strategy.py:342]     backend.sync_file_mounts(handle, task.file_mounts,
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 385, in _record
I 02-13 01:43:29 recovery_strategy.py:342]     return f(*args, **kwargs)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 365, in _record
I 02-13 01:43:29 recovery_strategy.py:342]     return f(*args, **kwargs)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/backend.py", line 101, in sync_file_mounts
I 02-13 01:43:29 recovery_strategy.py:342]     return self._sync_file_mounts(handle, all_file_mounts, storage_mounts)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 3207, in _sync_file_mounts
I 02-13 01:43:29 recovery_strategy.py:342]     self._execute_file_mounts(handle, all_file_mounts)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 4790, in _execute_file_mounts
I 02-13 01:43:29 recovery_strategy.py:342]     backend_utils.parallel_data_transfer_to_nodes(
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/backend_utils.py", line 1477, in parallel_data_transfer_to_nodes
I 02-13 01:43:29 recovery_strategy.py:342]     subprocess_utils.run_in_parallel(_sync_node, runners, num_threads)
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/subprocess_utils.py", line 122, in run_in_parallel
I 02-13 01:43:29 recovery_strategy.py:342]     return [func(args[0])]
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/backend_utils.py", line 1455, in _sync_node
I 02-13 01:43:29 recovery_strategy.py:342]     subprocess_utils.handle_returncode(rc,
I 02-13 01:43:29 recovery_strategy.py:342]   File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/subprocess_utils.py", line 156, in handle_returncode
I 02-13 01:43:29 recovery_strategy.py:342]     raise exceptions.CommandError(returncode, command, format_err_msg,
I 02-13 01:43:29 recovery_strategy.py:342] sky.exceptions.CommandError: Command mkdir -p ~/tmpfile && azcopy --version > /dev/null 2>&1 || (mkdir -p /usr/local/bin; curl -L https:/... failed with return code 1.
I 02-13 01:43:29 recovery_strategy.py:342] Failed to run command before rsync https://sky635611d9a69285a3.blob.core.windows.net/skypilot-filemounts-vscode-11d9a692-ahpbb7v3/job-7xgk48n3/tmp-files/file-0 -> ~/tmpfile. Ensure that the network is stable, then retry. mkdir -p ~/tmpfile && azcopy --version > /dev/null 2>&1 || (mkdir -p /usr/local/bin; curl -L https://aka.ms/downloadazcopy-v10-linux -o azcopy.tar.gz; sudo tar -xvzf azcopy.tar.gz --strip-components=1 -C /usr/local/bin --exclude=*.txt; sudo chmod +x /usr/local/bin/azcopy; rm azcopy.tar.gz) && azcopy sync 'https://sky635611d9a69285a3.blob.core.windows.net/skypilot-filemounts-vscode-11d9a692-ahpbb7v3/job-7xgk48n3/tmp-files/file-0?se=2025-02-13T02%3A43%3A27Z&sp=rcwl&sv=2025-01-05&sr=c&sig=mr59%2B5SlTa72/5c%2BkM0BY6eiIqCx/uQOs3dUB%2BFnV1g%3D' ~/tmpfile/ --recursive --delete-destination=false See logs in ~/sky_logs/sky-2025-02-13-01-39-47-646407/file_mounts.log
```

</details>

**Issue 2:** During the file mounts, the storage upload does not include the sub directory, which can be a bit confusing:
previously
```
  Excluded files to sync to cluster based on .gitignore.
✓ Storage synced: ./examples -> https://xxxx.blob.core.windows.net/skypilot-filemounts-vscode-yyyy/  View logs at: ~/sky_logs/sky-2025-02-13-01-38-17-371662/storage_sync.log
  Excluded files to sync to cluster based on .gitignore.
✓ Storage synced: ~/tmp-workdir -> https://xxxx.blob.core.windows.net/skypilot-filemounts-vscode-yyyy/  View logs at: ~/sky_logs/sky-2025-02-13-01-38-30-519142/storage_sync.log
```

Now
```
  Workdir: './examples' -> storage: 'skypilot-filemounts-vscode-11d9a692-ahpbb7v3'.
Verifying bucket and uploading from source for storage skypilot-filemounts-vscode-11d9a692-ahpbb7v3
  Excluded files to sync to cluster based on .gitignore.
✓ Storage synced: ~/tmp-workdir -> https://xxxx.blob.core.windows.net/skypilot-filemounts-vscode-yyyy/job-ct66lqv4/local-file-mounts/0/  View logs at: ~/sky_logs/sky-2025-02-13-01-35-59-046482/storage_sync.log
  Folder : '~/tmp-workdir' -> storage: 'skypilot-filemounts-vscode-11d9a692-ahpbb7v3'.
Verifying bucket and uploading from source for storage skypilot-filemounts-vscode-11d9a692-ahpbb7v3
  Excluded files to sync to cluster based on .gitignore.
✓ Storage synced: /tmp/skypilot-filemounts-files-ct66lqv4 -> https://xxxx.blob.core.windows.net/skypilot-filemounts-vscode-yyyy/job-ct66lqv4/tmp-files/  View logs at: ~/sky_logs/sky-2025-02-13-01-36-12-515049/storage_sync.log
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
