### PR TITLE
[Client-server] fix address confliction check on MacOS

### DIFF
--- a/docs/source/examples/docker-containers.rst
+++ b/docs/source/examples/docker-containers.rst
@@ -10,7 +10,7 @@ SkyPilot can run a container either as a task, or as the runtime environment of 
 
 .. note::
 
-    Running docker containers is `not supported on RunPod <https://docs.runpod.io/references/faq#can-i-run-my-own-docker-daemon-on-runpod>`_. To use RunPod, either use your docker image (the username should be ``root`` for RunPod) :ref:`as a runtime environment <docker-containers-as-runtime-environments>` or use ``setup`` and ``run`` to configure your environment. See `GitHub issue <https://github.com/skypilot-org/skypilot/issues/3096#issuecomment-2150559797>`_ for more.
+    Running docker containers is `not supported on RunPod <https://docs.runpod.io/references/faq#can-i-run-my-own-docker-daemon-on-runpod>`_. To use RunPod, either use your docker image :ref:`as a runtime environment <docker-containers-as-runtime-environments>` or use ``setup`` and ``run`` to configure your environment. See `GitHub issue <https://github.com/skypilot-org/skypilot/issues/3096#issuecomment-2150559797>`_ for more.
 
 
 .. _docker-containers-as-tasks:
@@ -121,6 +121,19 @@ For example, to use the :code:`ubuntu:20.04` image from Docker Hub:
 
   run: |
     # Commands to run inside the container
+
+.. note::
+  For **non-root** docker images on RunPod, you must manually set the :code:`SKYPILOT_RUNPOD_DOCKER_USERNAME` environment variable to match the login user of the docker image (set by the last `USER` instruction in the Dockerfile).
+
+  You can set this environment variable in the :code:`envs` section of your task YAML file:
+
+  .. code-block:: yaml
+
+    envs:
+      SKYPILOT_RUNPOD_DOCKER_USERNAME: <ssh-user>
+
+  It's a workaround for RunPod's limitation that we can't get the login user for the created pods, and even `runpodctl` uses a hardcoded `root` for SSH access.
+  But for other clouds, the login users for the created docker containers are automatically fetched and used.
 
 As another example, here's how to use `NVIDIA's PyTorch NGC Container <https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch>`_:
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -285,6 +285,10 @@ Available fields:
     # Values set here can be overridden by a CLI flag:
     # `sky launch/exec --env ENV=val` (if ENV is present).
     #
+    # For costumized non-root docker image in RunPod, you need to set
+    # `SKYPILOT_RUNPOD_DOCKER_USERNAME` to specify the login username for the
+    # docker image. See :ref:`docker-containers-as-runtime-environments` for more.
+    #
     # If you want to use a docker image as runtime environment in a private
     # registry, you can specify your username, password, and registry server as
     # task environment variable.  For example:

--- a/examples/airflow/workflow_clientserver/README.md
+++ b/examples/airflow/workflow_clientserver/README.md
@@ -4,9 +4,12 @@ In this guide, we show how a training workflow involving data preprocessing, tra
 
 This example uses a remote SkyPilot API Server to manage shared state across invocations, and includes a failure callback to tear down the SkyPilot cluster on task failure.
 
+<!-- Source: https://docs.google.com/drawings/d/1Di_KIOlxQEUib_RhMKysXBc6u-5WW9FnbougVWRiGF0/edit?usp=sharing -->
+
 <p align="center">
-  <img src="https://i.imgur.com/TXn5eKI.png" width="800">
+  <img src="https://i.imgur.com/IiPYQTW.png" width="400">
 </p>
+
 
 **💡 Tip:**  SkyPilot also supports defining and running pipelines without Airflow. Check out [Jobs Pipelines](https://skypilot.readthedocs.io/en/latest/examples/managed-jobs.html#job-pipelines) for more information. 
 
@@ -34,8 +37,25 @@ Here's how you can use SkyPilot to take your dev workflows to production in Airf
 
 * Airflow installed [locally](https://airflow.apache.org/docs/apache-airflow/stable/start.html) (`SequentialExecutor`)
 * SkyPilot API server endpoint to send requests to.
-  * If you do not have one, deploy with TODO: Add instructions.
+  * If you do not have one, refer to the [API server docs](https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html) to deploy one.
   * This API server should have AWS/GCS access to create buckets to store intermediate task outputs.
+
+## Configuring the API server endpoint
+
+Once your API server is deployed, you will need to configure your Airflow worker to use it. Set the `SKYPILOT_API_SERVER_ENDPOINT` environment variable in your Airflow worker environment to the endpoint of the SkyPilot API server:
+
+```bash
+# In your bashrc/zshrc
+export SKYPILOT_API_SERVER_ENDPOINT=<api-server-endpoint>
+```
+
+Alternatively, you can also set the endpoint in the `~/.sky/config.yaml` file on your Airflow workers:
+
+```yaml
+# In ~/.sky/config.yaml on your Airflow worker
+api_server:
+  endpoint: http://<api-server-endpoint>
+```
 
 ## Defining the tasks
 
@@ -122,7 +142,7 @@ All clusters are set to auto-down after the task is done, so no dangling cluster
 
 1. Copy the DAG file to the Airflow DAGs directory.
    ```bash
-   cp sky_k8s_train_pipeline.py /path/to/airflow/dags                                              
+   cp sky_k8s_train_pipeline.py /path/to/airflow/dags                                               
    # If your Airflow is running on Kubernetes, you may use kubectl cp to copy the file to the pod
    # kubectl cp sky_k8s_example.py <airflow-pod-name>:/opt/airflow/dags 
    ```
@@ -131,8 +151,9 @@ All clusters are set to auto-down after the task is done, so no dangling cluster
 4. Trigger the DAG from the Airflow UI using the `Trigger DAG` button.
 5. Navigate to the run in the Airflow UI to see the DAG progress and logs of each task.
 
+
 <p align="center">
-  <img src="https://i.imgur.com/Z1iEikn.png" width="800">
+  <img src="https://i.imgur.com/TXn5eKI.png" width="800">
 </p>
 <p align="center">
   <img src="https://i.imgur.com/D89N5xt.png" width="800">

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -465,7 +465,9 @@ class Kubernetes(clouds.Cloud):
         # CPU resources on the node instead within the pod.
         custom_ray_options = {
             'object-store-memory': 500000000,
-            'num-cpus': str(int(cpus)),
+            # 'num-cpus' must be an integer, but we should not set it to 0 if
+            # cpus is <1.
+            'num-cpus': str(max(int(cpus), 1)),
         }
         deploy_vars = {
             'instance_type': resources.instance_type,

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -178,6 +178,11 @@ class RunPod(clouds.Cloud):
         hourly_cost = self.instance_type_to_hourly_cost(
             instance_type=instance_type, use_spot=use_spot)
 
+        # default to root
+        docker_username_for_runpod = (resources.docker_username_for_runpod
+                                      if resources.docker_username_for_runpod
+                                      is not None else 'root')
+
         return {
             'instance_type': instance_type,
             'custom_resources': custom_resources,
@@ -185,6 +190,7 @@ class RunPod(clouds.Cloud):
             'image_id': image_id,
             'use_spot': use_spot,
             'bid_per_gpu': str(hourly_cost),
+            'docker_username_for_runpod': docker_username_for_runpod,
         }
 
     def _get_feasible_launchable_resources(

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -451,6 +451,13 @@ def _post_provision_setup(
         logger.info(f'{indent_str}{colorama.Style.DIM}{vm_str}{plural} {verb} '
                     f'up.{colorama.Style.RESET_ALL}')
 
+        # It's promised by the cluster config that docker_config does not
+        # exist for docker-native clouds, i.e. they provide docker containers
+        # instead of full VMs, like Kubernetes and RunPod, as it requires some
+        # special handlings to run docker inside their docker virtualization.
+        # For their Docker image settings, we do them when provisioning the
+        # cluster. See provision/{cloud}/instance.py:get_cluster_info for more
+        # details.
         if docker_config:
             status.update(
                 ux_utils.spinner_message(

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -186,7 +186,7 @@ def delete_pod_template(template_name: str) -> None:
         runpod.runpod.api.graphql.run_graphql_query(
             f'mutation {{deleteTemplate(templateName: "{template_name}")}}')
     except runpod.runpod.error.QueryError as e:
-        logger.warning(f'Failed to delete template {template_name}: {e}'
+        logger.warning(f'Failed to delete template {template_name}: {e} '
                        'Please delete it manually.')
 
 
@@ -195,8 +195,9 @@ def delete_register_auth(registry_auth_id: str) -> None:
     try:
         runpod.runpod.delete_container_registry_auth(registry_auth_id)
     except runpod.runpod.error.QueryError as e:
-        logger.warning(f'Failed to delete registry auth {registry_auth_id}: {e}'
-                       'Please delete it manually.')
+        logger.warning(
+            f'Failed to delete registry auth {registry_auth_id}: {e} '
+            'Please delete it manually.')
 
 
 def _create_template_for_docker_login(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -67,6 +67,7 @@ class Resources:
         # Internal use only.
         # pylint: disable=invalid-name
         _docker_login_config: Optional[docker_utils.DockerLoginConfig] = None,
+        _docker_username_for_runpod: Optional[str] = None,
         _is_image_managed: Optional[bool] = None,
         _requires_fuse: Optional[bool] = None,
         _cluster_config_overrides: Optional[Dict[str, Any]] = None,
@@ -148,6 +149,9 @@ class Resources:
           _docker_login_config: the docker configuration to use. This includes
             the docker username, password, and registry server. If None, skip
             docker login.
+          _docker_username_for_runpod: the login username for the docker
+            containers. This is used by RunPod to set the ssh user for the
+            docker containers.
           _requires_fuse: whether the task requires FUSE mounting support. This
             is used internally by certain cloud implementations to do additional
             setup for FUSE mounting. This flag also safeguards against using
@@ -230,6 +234,12 @@ class Resources:
         self._labels = labels
 
         self._docker_login_config = _docker_login_config
+
+        # TODO(andyl): This ctor param seems to be unused.
+        # We always use `Task.set_resources` and `Resources.copy` to set the
+        # `docker_username_for_runpod`. But to keep the consistency with
+        # `_docker_login_config`, we keep it here.
+        self._docker_username_for_runpod = _docker_username_for_runpod
 
         self._requires_fuse = _requires_fuse
 
@@ -481,6 +491,10 @@ class Resources:
     @requires_fuse.setter
     def requires_fuse(self, value: Optional[bool]) -> None:
         self._requires_fuse = value
+
+    @property
+    def docker_username_for_runpod(self) -> Optional[str]:
+        return self._docker_username_for_runpod
 
     def _set_cpus(
         self,
@@ -1073,6 +1087,10 @@ class Resources:
         cloud_specific_variables = self.cloud.make_deploy_resources_variables(
             self, cluster_name, region, zones, num_nodes, dryrun)
 
+        # TODO(andyl): Should we print some warnings if users' envs share
+        # same names with the cloud specific variables, but not enabled
+        # since it's not on the particular cloud?
+
         # Docker run options
         docker_run_options = skypilot_config.get_nested(
             ('docker', 'run_options'),
@@ -1285,6 +1303,9 @@ class Resources:
             labels=override.pop('labels', self.labels),
             _docker_login_config=override.pop('_docker_login_config',
                                               self._docker_login_config),
+            _docker_username_for_runpod=override.pop(
+                '_docker_username_for_runpod',
+                self._docker_username_for_runpod),
             _is_image_managed=override.pop('_is_image_managed',
                                            self._is_image_managed),
             _requires_fuse=override.pop('_requires_fuse', self._requires_fuse),
@@ -1446,6 +1467,8 @@ class Resources:
         resources_fields['labels'] = config.pop('labels', None)
         resources_fields['_docker_login_config'] = config.pop(
             '_docker_login_config', None)
+        resources_fields['_docker_username_for_runpod'] = config.pop(
+            '_docker_username_for_runpod', None)
         resources_fields['_is_image_managed'] = config.pop(
             '_is_image_managed', None)
         resources_fields['_requires_fuse'] = config.pop('_requires_fuse', None)
@@ -1494,6 +1517,9 @@ class Resources:
         if self._docker_login_config is not None:
             config['_docker_login_config'] = dataclasses.asdict(
                 self._docker_login_config)
+        if self._docker_username_for_runpod is not None:
+            config['_docker_username_for_runpod'] = (
+                self._docker_username_for_runpod)
         add_if_not_none('_cluster_config_overrides',
                         self._cluster_config_overrides)
         if self._is_image_managed is not None:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -414,7 +414,8 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
             target=mp_queue.start_queue_manager, args=(queue_names,))
         queue_server.start()
 
-        # Start a monitoring thread to watch queue_server process
+        # Monitor the queue server process and raise an error if it exits to
+        # avoid the main process hanging on the queue server.
         def monitor_queue_server():
             queue_server.join()
             raise RuntimeError('Queue server process exited unexpectedly')

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -412,7 +412,8 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
         # port automatically.
         port = mp_queue.DEFAULT_QUEUE_MANAGER_PORT
         if not common_utils.is_port_available(port):
-            raise RuntimeError(f'Queue manager port {port} is already in use.')
+            raise RuntimeError(f'SkyPilot API server fails to start as port {port!r} is already in use '
+                                              'by another process.')
         queue_server = multiprocessing.Process(
             target=mp_queue.start_queue_manager, args=(queue_names, port))
         queue_server.start()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -27,7 +27,6 @@ import os
 import queue as queue_lib
 import signal
 import sys
-import threading
 import time
 import traceback
 import typing
@@ -409,21 +408,16 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
         queue_names = [
             schedule_type.value for schedule_type in api_requests.ScheduleType
         ]
-        # TODO(aylei): queue manager port should be configurable.
+        # TODO(aylei): make queue manager port configurable or pick an available
+        # port automatically.
+        port = mp_queue.DEFAULT_QUEUE_MANAGER_PORT
+        if not common_utils.is_port_available(port):
+            raise RuntimeError(f'Queue manager port {port} is already in use.')
         queue_server = multiprocessing.Process(
-            target=mp_queue.start_queue_manager, args=(queue_names,))
+            target=mp_queue.start_queue_manager, args=(queue_names, port))
         queue_server.start()
 
-        # Monitor the queue server process and raise an error if it exits to
-        # avoid the main process hanging on the queue server.
-        def monitor_queue_server():
-            queue_server.join()
-            raise RuntimeError('Queue server process exited unexpectedly')
-
-        monitor_thread = threading.Thread(target=monitor_queue_server,
-                                          daemon=True)
-        monitor_thread.start()
-        mp_queue.wait_for_queues_to_be_ready(queue_names)
+        mp_queue.wait_for_queues_to_be_ready(queue_names, port=port)
 
     logger.info('Request queues created')
 

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -412,8 +412,9 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
         # port automatically.
         port = mp_queue.DEFAULT_QUEUE_MANAGER_PORT
         if not common_utils.is_port_available(port):
-            raise RuntimeError(f'SkyPilot API server fails to start as port {port!r} is already in use '
-                                              'by another process.')
+            raise RuntimeError(
+                f'SkyPilot API server fails to start as port {port!r} is '
+                'already in use by another process.')
         queue_server = multiprocessing.Process(
             target=mp_queue.start_queue_manager, args=(queue_names, port))
         queue_server.start()

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -408,6 +408,7 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
         queue_names = [
             schedule_type.value for schedule_type in api_requests.ScheduleType
         ]
+        # TODO(aylei): queue manager port should be configurable.
         queue_server = multiprocessing.Process(
             target=mp_queue.start_queue_manager, args=(queue_names,))
         queue_server.start()

--- a/sky/server/requests/queues/mp_queue.py
+++ b/sky/server/requests/queues/mp_queue.py
@@ -8,6 +8,8 @@ from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
+# The default port used by SkyPilot API server's request queue.
+# We avoid 50010, as it might be taken by HDFS.
 DEFAULT_QUEUE_MANAGER_PORT = 50011
 
 

--- a/sky/server/requests/queues/mp_queue.py
+++ b/sky/server/requests/queues/mp_queue.py
@@ -8,7 +8,7 @@ from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
 
-DEFAULT_QUEUE_MANAGER_PORT = 50010
+DEFAULT_QUEUE_MANAGER_PORT = 50011
 
 
 # Have to create custom manager to handle different processes connecting to the
@@ -32,7 +32,16 @@ def start_queue_manager(queue_names: List[str],
         QueueManager.register(name, callable=queue_getter(q_obj))
 
     # Start long-running manager server.
-    manager = QueueManager(address=('', port), authkey=b'skypilot')
+    # Manager will set socket.SO_REUSEADDR, but BSD and Linux have different
+    # behaviors on this option:
+    # - BSD(e.g. MacOS): * (0.0.0.0) does not conflict with other addresses on
+    #   the same port
+    # - Linux: in the contrary, * conflicts with any other addresses
+    # So on BSD systems, binding to * while the port is already bound to
+    # localhost (127.0.0.1) will succeed, but the Manager won't actually be able
+    # to accept connections on localhost.
+    # For portability, we use the loopback address instead of *.
+    manager = QueueManager(address=('localhost', port), authkey=b'skypilot')
     server = manager.get_server()
     server.serve_forever()
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1085,6 +1085,10 @@ if __name__ == '__main__':
                     host=cmd_args.host,
                     port=cmd_args.port,
                     workers=num_workers)
+    except Exception as e:
+        logger.error(f'Failed to start SkyPilot API server: {e}')
     finally:
+        logger.error('Shutting down SkyPilot API server...')
         for worker in workers:
             worker.terminate()
+        sys.exit(1)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1086,7 +1086,7 @@ if __name__ == '__main__':
                     port=cmd_args.port,
                     workers=num_workers)
     except Exception as outer_e:  # pylint: disable=broad-except
-        logger.error(f'Fakled to start SkyPilot API server: {outer_e}')
+        logger.error(f'Failed to start SkyPilot API server: {common_utils.format_exception(outer_e, use_bracket=True)}')
     finally:
         logger.error('Shutting down SkyPilot API server...')
         for worker in workers:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1085,8 +1085,8 @@ if __name__ == '__main__':
                     host=cmd_args.host,
                     port=cmd_args.port,
                     workers=num_workers)
-    except Exception as e:
-        logger.error(f'Failed to start SkyPilot API server: {e}')
+    except Exception as outer_e:  # pylint: disable=broad-except
+        logger.error(f'Fakled to start SkyPilot API server: {outer_e}')
     finally:
         logger.error('Shutting down SkyPilot API server...')
         for worker in workers:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1085,10 +1085,10 @@ if __name__ == '__main__':
                     host=cmd_args.host,
                     port=cmd_args.port,
                     workers=num_workers)
-    except Exception as outer_e:  # pylint: disable=broad-except
-        logger.error(f'Failed to start SkyPilot API server: {common_utils.format_exception(outer_e, use_bracket=True)}')
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error(f'Failed to start SkyPilot API server: '
+                     f'{common_utils.format_exception(exc, use_bracket=True)}')
     finally:
-        logger.error('Shutting down SkyPilot API server...')
+        logger.info('Shutting down SkyPilot API server...')
         for worker in workers:
             worker.terminate()
-        sys.exit(1)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1088,6 +1088,7 @@ if __name__ == '__main__':
     except Exception as exc:  # pylint: disable=broad-except
         logger.error(f'Failed to start SkyPilot API server: '
                      f'{common_utils.format_exception(exc, use_bracket=True)}')
+        raise
     finally:
         logger.info('Shutting down SkyPilot API server...')
         for worker in workers:

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -113,6 +113,8 @@ DOCKER_LOGIN_ENV_VARS = {
     DOCKER_SERVER_ENV_VAR,
 }
 
+RUNPOD_DOCKER_USERNAME_ENV_VAR = 'SKYPILOT_RUNPOD_DOCKER_USERNAME'
+
 # Commands for disable GPU ECC, which can improve the performance of the GPU
 # for some workloads by 30%. This will only be applied when a user specify
 # `nvidia_gpus.disable_ecc: true` in ~/.sky/config.yaml.

--- a/sky/task.py
+++ b/sky/task.py
@@ -121,6 +121,9 @@ def _check_docker_login_config(task_envs: Dict[str, str]) -> bool:
 
     If any of the docker login env vars is set, all of them must be set.
 
+    Returns:
+        True if there is a valid docker login config in task_envs.
+        False otherwise.
     Raises:
         ValueError: if any of the docker login env vars is set, but not all of
             them are set.
@@ -166,6 +169,23 @@ def _with_docker_login_config(
     for r in resources:
         new_resources.append(_add_docker_login_config(r))
     return type(resources)(new_resources)
+
+
+def _with_docker_username_for_runpod(
+    resources: Union[Set['resources_lib.Resources'],
+                     List['resources_lib.Resources']],
+    task_envs: Dict[str, str],
+) -> Union[Set['resources_lib.Resources'], List['resources_lib.Resources']]:
+    docker_username_for_runpod = task_envs.get(
+        constants.RUNPOD_DOCKER_USERNAME_ENV_VAR)
+
+    # We should not call r.copy() if docker_username_for_runpod is None,
+    # to prevent `DummyResources` instance becoming a `Resources` instance.
+    if docker_username_for_runpod is None:
+        return resources
+    return (type(resources)(
+        r.copy(_docker_username_for_runpod=docker_username_for_runpod)
+        for r in resources))
 
 
 class Task:
@@ -647,6 +667,8 @@ class Task:
         if _check_docker_login_config(self._envs):
             self.resources = _with_docker_login_config(self.resources,
                                                        self._envs)
+        self.resources = _with_docker_username_for_runpod(
+            self.resources, self._envs)
         return self
 
     @property
@@ -712,6 +734,9 @@ class Task:
             resources = {resources}
         # TODO(woosuk): Check if the resources are None.
         self.resources = _with_docker_login_config(resources, self.envs)
+        # Only have effect on RunPod.
+        self.resources = _with_docker_username_for_runpod(
+            self.resources, self.envs)
 
         # Evaluate if the task requires FUSE and set the requires_fuse flag
         for _, storage_obj in self.storage_mounts.items():

--- a/sky/templates/runpod-ray.yml.j2
+++ b/sky/templates/runpod-ray.yml.j2
@@ -25,7 +25,7 @@ provider:
   {%- endif %}
 
 auth:
-  ssh_user: root
+  ssh_user: {{docker_username_for_runpod}}
   ssh_private_key: {{ssh_private_key}}
 
 available_node_types:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -732,3 +732,13 @@ def hash_file(path: str, hash_alg: str) -> 'hashlib._Hash':
                 break
             file_hash.update(view[:size])
         return file_hash
+
+
+def is_port_available(port: int) -> bool:
+    """Check if the given port is available."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(('localhost', port))
+            return True
+        except socket.error:
+            return False

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -740,5 +740,5 @@ def is_port_available(port: int) -> bool:
         try:
             s.bind(('localhost', port))
             return True
-        except socket.error:
+        except OSError:
             return False

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -912,16 +912,18 @@ class TestStorageWithCredentials:
                                           mode=mode,
                                           _bucket_sub_path=_bucket_sub_path)
         storage_obj.construct()
-        yield storage_obj
-        handle = global_user_state.get_handle_from_storage_name(
-            storage_obj.name)
-        if handle:
-            # If handle exists, delete manually
-            # TODO(romilb): This is potentially risky - if the delete method has
-            #   bugs, this can cause resource leaks. Ideally we should manually
-            #   eject storage from global_user_state and delete the bucket using
-            #   boto3 directly.
-            storage_obj.delete()
+        try:
+            yield storage_obj
+        finally:
+            handle = global_user_state.get_handle_from_storage_name(
+                storage_obj.name)
+            if handle:
+                # If handle exists, delete manually
+                # TODO(romilb): This is potentially risky - if the delete method has
+                #   bugs, this can cause resource leaks. Ideally we should manually
+                #   eject storage from global_user_state and delete the bucket using
+                #   boto3 directly.
+                storage_obj.delete()
 
     @pytest.fixture
     def tmp_scratch_storage_obj(self, tmp_bucket_name):
@@ -940,17 +942,19 @@ class TestStorageWithCredentials:
             store_obj = storage_lib.Storage(name=f'sky-test-{timestamp}')
             store_obj.construct()
             storage_mult_obj.append(store_obj)
-        yield storage_mult_obj
-        for storage_obj in storage_mult_obj:
-            handle = global_user_state.get_handle_from_storage_name(
-                storage_obj.name)
-            if handle:
-                # If handle exists, delete manually
-                # TODO(romilb): This is potentially risky - if the delete method has
-                # bugs, this can cause resource leaks. Ideally we should manually
-                # eject storage from global_user_state and delete the bucket using
-                # boto3 directly.
-                storage_obj.delete()
+        try:
+            yield storage_mult_obj
+        finally:
+            for storage_obj in storage_mult_obj:
+                handle = global_user_state.get_handle_from_storage_name(
+                    storage_obj.name)
+                if handle:
+                    # If handle exists, delete manually
+                    # TODO(romilb): This is potentially risky - if the delete method has
+                    # bugs, this can cause resource leaks. Ideally we should manually
+                    # eject storage from global_user_state and delete the bucket using
+                    # boto3 directly.
+                    storage_obj.delete()
 
     @pytest.fixture
     def tmp_multiple_custom_source_storage_obj(self):
@@ -967,12 +971,14 @@ class TestStorageWithCredentials:
                                             source=src_path)
             store_obj.construct()
             storage_mult_obj.append(store_obj)
-        yield storage_mult_obj
-        for storage_obj in storage_mult_obj:
-            handle = global_user_state.get_handle_from_storage_name(
-                storage_obj.name)
-            if handle:
-                storage_obj.delete()
+        try:
+            yield storage_mult_obj
+        finally:
+            for storage_obj in storage_mult_obj:
+                handle = global_user_state.get_handle_from_storage_name(
+                    storage_obj.name)
+                if handle:
+                    storage_obj.delete()
 
     @pytest.fixture
     def tmp_local_storage_obj(self, tmp_bucket_name, tmp_source):

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1160,7 +1160,14 @@ class TestStorageWithCredentials:
                              store_type):
         # Creates a new bucket with a local source, uploads files to it
         # and deletes it.
-        tmp_local_storage_obj_with_sub_path.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_local_storage_obj_with_sub_path.add_store(store_type,
+                                                      **region_kwargs)
 
         # Check files under bucket and filter by prefix
         files = self.list_all_files(store_type,
@@ -1476,7 +1483,13 @@ class TestStorageWithCredentials:
         bucket_name, _ = request.getfixturevalue(ext_bucket_fixture)
         storage_obj = storage_lib.Storage(name=bucket_name, source=tmp_source)
         storage_obj.construct()
-        storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        storage_obj.add_store(store_type, **region_kwargs)
 
         # Check if tmp_source/tmp-file exists in the bucket using aws cli
         out = subprocess.check_output(self.cli_ls_cmd(store_type, bucket_name),
@@ -1522,7 +1535,13 @@ class TestStorageWithCredentials:
     def test_list_source(self, tmp_local_list_storage_obj, store_type):
         # Uses a list in the source field to specify a file and a directory to
         # be uploaded to the storage object.
-        tmp_local_list_storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_local_list_storage_obj.add_store(store_type, **region_kwargs)
 
         # Check if tmp-file exists in the bucket root using cli
         out = subprocess.check_output(self.cli_ls_cmd(
@@ -1578,7 +1597,13 @@ class TestStorageWithCredentials:
                                                      tmp_gitignore_storage_obj):
         # tests if files included in .gitignore and .git/info/exclude are
         # excluded from being transferred to Storage
-        tmp_gitignore_storage_obj.add_store(store_type)
+        region_kwargs = {}
+        if store_type == storage_lib.StoreType.AZURE:
+            # We have to specify the region for Azure storage, as the default
+            # Azure storage account is in centralus region.
+            region_kwargs['region'] = 'centralus'
+
+        tmp_gitignore_storage_obj.add_store(store_type, **region_kwargs)
         upload_file_name = 'included'
         # Count the number of files with the given file name
         up_cmd = self.cli_count_name_in_bucket(store_type, \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

1. change the default port of QueueManager to avoid conflict with WeCom (HDFS datanode also uses 50010 by default)
2. QueueManager will bind at `localhost` instead of `0.0.0.0`
3. Check port availability explicitly to fail fast

```
I 02-13 21:55:12 executor.py:400] SkyPilot API server will start 24 workers for blocking requests and will allow at max 53 non-blocking requests in parallel.
I 02-13 21:55:12 executor.py:407] Creating shared request queues
ERROR:__main__:Failed to start SkyPilot API server: [RuntimeError] Queue manager port 50010 is already in use.
INFO:__main__:Shutting down SkyPilot API server...
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/server.py", line 1080, in <module>
    workers = executor.start(cmd_args.deploy)
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/requests/executor.py", line 415, in start
    raise RuntimeError(f'Queue manager port {port} is already in use.')
RuntimeError: Queue manager port 50010 is already in use.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
