### PR TITLE
[k8s] Support exec based auth on controller when with `allowed_contexts`

### DIFF
--- a/sky/utils/kubernetes/exec_kubeconfig_converter.py
+++ b/sky/utils/kubernetes/exec_kubeconfig_converter.py
@@ -18,7 +18,7 @@ import os
 import yaml
 
 
-def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
+def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str) -> bool:
     """Strip path information from exec plugin commands in a kubeconfig file.
 
     Args:
@@ -40,13 +40,10 @@ def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
                 exec_info['command'] = executable
                 updated = True
 
-    if updated:
-        with open(output_path, 'w', encoding='utf-8') as file:
-            yaml.safe_dump(config, file)
-        print('Kubeconfig updated with path-less exec auth. '
-              f'Saved to {output_path}')
-    else:
-        print('No updates made. No exec-based auth commands paths found.')
+    with open(output_path, 'w', encoding='utf-8') as file:
+        yaml.safe_dump(config, file)
+    
+    return updated
 
 
 def main():
@@ -66,7 +63,11 @@ def main():
         help='Output kubeconfig file path (default: %(default)s)')
 
     args = parser.parse_args()
-    strip_auth_plugin_paths(args.input, args.output)
+    updated = strip_auth_plugin_paths(args.input, args.output)
+    if updated:
+        print(f'Kubeconfig updated with path-less exec auth. Saved to {args.output}')
+    else:
+        print('No updates made. No exec-based auth commands paths found.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/4379.

This PR uses our kubeconfig convertor (used in helm deployment) to sanitize kubeconfigs to be uploaded to the controller. We also now install the GKE auth plugin if both gcp and k8s are enabled. With this, we controllers are able to target multiple kubernetes clusters (listed in `allowed_contexts`). 

TODO:
- Fix `/Users/romilb/tools/anaconda3/lib/python3.9/runpy.py:127: RuntimeWarning: 'sky.utils.kubernetes.exec_kubeconfig_converter' found in sys.modules after import of package 'sky.utils.kubernetes', but prior to execution of 'sky.utils.kubernetes.exec_kubeconfig_converter'; this may result in unpredictable behaviour` when running `python -m sky.utils.kubernetes.exec_kubeconfig_converter` by refactoring. 
- Test with:
```
# Launch controller on 1st context
sky jobs launch --cloud k8s --region gke_sky-dev-465_us-central1-c_skypilot-test-cluster-mega -- echo hi
# Submit and run job on 2nd context
sky jobs launch --cloud k8s --region gke_sky-dev-465_us-central1-c_skypilot-test-cluster-mega2 -- echo hi
```
