### PR TITLE
fix: Include disk size during instance creation

### DIFF
--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -114,7 +114,8 @@ def launch(name: str, instance_type: str, region: str, disk_size: int,
             f'echo "{vast.vast().api_key_access}" > ~/.vast_api_key',
         ]),
         'label': name,
-        'image': image_name
+        'image': image_name,
+	'disk': disk_size
     }
 
     if preemptible:

--- a/sky/provision/vast/utils.py
+++ b/sky/provision/vast/utils.py
@@ -115,7 +115,7 @@ def launch(name: str, instance_type: str, region: str, disk_size: int,
         ]),
         'label': name,
         'image': image_name,
-	'disk': disk_size
+        'disk': disk_size
     }
 
     if preemptible:


### PR DESCRIPTION
Fixed Vast instance creation to include the disk size argument. If a disk size is not passed it defaults to just 10 GiB.
