### PR TITLE
[Docs] Fix A100 Support for DeepSeek-R1 671B: Clarify FP8 Issue & YAML Inconsistencies

### DIFF
--- a/llm/deepseek-r1-distilled/README.md
+++ b/llm/deepseek-r1-distilled/README.md
@@ -48,7 +48,6 @@ Now it's time to run deepseek with SkyPilot. The instruction can be dependent on
 ```
 sky launch deepseek-r1-vllm.yaml \
   -c deepseek \
-  --env HF_TOKEN=YOUR_HUGGING_FACE_API_TOKEN \
   --env MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-8B \
   --gpus L4:1
 ```
@@ -57,12 +56,11 @@ sky launch deepseek-r1-vllm.yaml \
 ```
 sky launch deepseek-r1-vllm.yaml \
   -c deepseek \
-  --env HF_TOKEN=YOUR_HUGGING_FACE_API_TOKEN \
   --env MODEL_NAME=deepseek-ai/DeepSeek-R1-Distill-Llama-70B \
   --gpus A100-80GB:2
 ```
 
-replace the command with your own huggingface token and the GPU that you wish to use. You may run `sky show-gpus` to know what GPU that you have access to. As a reference, here is the model-GPU compatibility matrix:
+replace the command with the model and the GPU that you wish to use. You may run `sky show-gpus` to know what GPU that you have access to. As a reference, here is the model-GPU compatibility matrix:
 
 | **GPU**         	| **DeepSeek-R1-Distill-Qwen-7B**  | **DeepSeek-R1-Distill-Llama-70B** 	| **DeepSeek-R1**  	| 
 |-----------------	|------------------------------	|------------------------	|------------------------------	|

--- a/llm/deepseek-r1-distilled/deepseek-r1-vllm.yaml
+++ b/llm/deepseek-r1-distilled/deepseek-r1-vllm.yaml
@@ -1,7 +1,6 @@
 envs:
   MODEL_NAME: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
   MAX_MODEL_LEN: 4096
-  HF_TOKEN: # TODO: Fill with your own huggingface token, or use --env to pass.
 
 resources:
   accelerators: {L4:1, A10G:1, A10:1, A100:1, A100-80GB:1}
@@ -13,7 +12,6 @@ setup: |
   uv pip install transformers==4.48.1
   uv pip install vllm==0.6.6.post1
 
-  python -c "import huggingface_hub; huggingface_hub.login('${HF_TOKEN}')"
 
 run: |
   echo 'Starting vllm openai api server...'

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -80,7 +80,7 @@ It may take a while (30-40 minutes) for SGLang to download the model weights, co
 
 After the initialization, you can access the model with the endpoint:
 ```
-ENDPOINT=$(sky status --endpoint 30000 deepseek)
+ENDPOINT=$(sky status --endpoint 30000 r1)
 
 curl http://$ENDPOINT/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -102,7 +102,7 @@ curl http://$ENDPOINT/v1/chat/completions \
 You will get the following answer, which interestingly does not trigger any chain of thoughts.
 
 <details>
-    <summary>How many Rs are in strawberry: So, the answer is **3**. 🍓</summary>
+    <summary>How many Rs are in strawberry: So, the answer is <b>3</b>. 🍓</summary>
 
 Okay, let's figure out how many times the letter \"r\" appears in the word \"strawberry.\" First, I need to make sure I'm spelling \"strawberry\" correctly. Sometimes people might miss letters or add extra ones. Let me write it out: S-T-R-A-W-B-E-R-R-Y. Wait, is that right? Let's double-check. Strawberry is spelled S-T-R-A-W-B-E-R-R-Y. Yes, that's correct. Now, I need to go through each letter one by one and count the number of \"r\"s.\n\nStarting with the first letter: S (no), T (no), R (yes, that's one). Then A (no), W (no), B (no), E (no), R (that's two), R (that's three), Y (no). Wait, wait, hold on. Let me write out the letters with their positions to be precise.\n\nBreaking down \"strawberry\" letter by letter:\n1. S\n2. T\n3. R\n4. A\n5. W\n6. B\n7. E\n8. R\n9. R\n10. Y\n\nSo, looking at positions 3, 8, and 9: that's three \"r\"s. But wait, does that match the actual spelling? Let me confirm again. The word is strawberry. Sometimes people might think it's \"strawberry\" with two \"r\"s, but actually, according to correct spelling, it's S-T-R-A-W-B-E-R-R-Y. So after the B and E, there are two R's, right? Let me check a dictionary or maybe think of the pronunciation. Straw-ber-ry. The \"ber\" part is one R, but the correct spelling includes two R's after the E. So yes, that makes three R's in total. Hmm, but let me make sure I'm not miscounting. So positions 3, 8, 9: R, then two R's at the end before Y. That's three R's. Wait, actually, in the breakdown above, position 3 is R, then positions 8 and 9 are the two R's. So total three. Yes, that's right. So the answer should be three. Let me see if I can find any source that confirms this. Alternatively, I can write the word again and count: S T R A W B E R R Y. So R appears once at the beginning (third letter) and then twice towards the end (8th and 9th letters). So total of three times. Therefore, the correct answer is three.\n</think>\n\nThe word \"strawberry\" contains **3** instances of the letter \"r\". Here's the breakdown:\n\n1. **S**  \n2. **T**  \n3. **R** (1st \"r\")  \n4. **A**  \n5. **W**  \n6. **B**  \n7. **E**  \n8. **R** (2nd \"r\")  \n9. **R** (3rd \"r\")  \n10. **Y**  \n\nSo, the answer is **3**. 🍓
 

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -73,7 +73,7 @@ Adjust the `accelerators` and `num_nodes` to fit your needs. Common configuratio
 
 .. note::
 
-  For A100 GPUs, use the [deepseek-r1-671B-A100.yaml](deepseek-r1-671B-A100.yaml) for FP8 to BF16 conversion, as FP8 is unsupported on A100 GPUs. Alternatively, use a pre-converted version from the Hugging Face community.
+  For A100 GPUs, use [deepseek-r1-671B-A100.yaml](deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
 
   For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
 

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -62,6 +62,21 @@ run: |
 
 ```
 
+Adjust the `accelerators` and `num_nodes` to fit your needs. Common configurations include:
+
+| **GPU**          | **Num Nodes** |
+|------------------|---------------|
+| H200:8           | 1             |
+| H100:8           | 2             |
+| A100-80GB:8      | 2             |
+| A100:8           | 4             |
+| L4:8             | 8             |
+
+.. note::
+
+  For A100 GPUs, use the [deepseek-r1-671B-A100.yaml](deepseek-r1-671B-A100.yaml) for FP8 to BF16 conversion, as FP8 is unsupported on A100 GPUs. Alternatively, use a pre-converted version from the Hugging Face community.
+
+  For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
 
 ```bash
 sky launch -c r1 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -65,7 +65,7 @@ run: |
 
 ```
 
-Adjust the `accelerators` and `num_nodes` to fit your needs. Common configurations include:
+You can also adjust the `accelerators` and `num_nodes` to fit your needs. Common configurations include:
 
 | **GPU**          | **Num Nodes** |
 |------------------|---------------|

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -17,7 +17,11 @@ We use [SGLang](https://github.com/sgl-project/sglang) to serve the model distri
 
 SkyPilot allows you to run the model distributedly with a single command using [SGLang](https://github.com/sgl-project/sglang).
 
-The SkyPilot YAML for DeepSeek-R1 671B ([view full file](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B.yaml)):
+```bash
+sky launch -c r1 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up
+```
+
+Below is the SkyPilot YAML configuration for DeepSeek-R1 671B, as provided in [`llm/deepseek-r1/deepseek-r1-671B.yaml`](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B.yaml):
 ```yaml
 name: deepseek-r1
 
@@ -70,17 +74,19 @@ Adjust the `accelerators` and `num_nodes` to fit your needs. Common configuratio
 | A100-80GB:8      | 4             |
 | A100:8           | 8             |
 
-.. note::
-
-  For A100 GPUs, use [deepseek-r1-671B-A100.yaml](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
-
-  Since BF16 models consume more memory, A100 deployments require twice the number of nodes compared to H100. That is, if an H100 setup requires 2 nodes, an A100-80GB setup requires 4 nodes, and an A100-40GB setup requires 8 nodes.
-
-  For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
+You can override `num_nodes` in the command line without modifying the YAML file. For example:
 
 ```bash
-sky launch -c r1 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up
+sky launch -c r1-A100 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up --num-nodes=4 --accelerators=A100-80GB:8
 ```
+
+> [!IMPORTANT]
+> For A100 GPUs, use [deepseek-r1-671B-A100.yaml](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
+>
+> Since BF16 models consume more memory, A100 deployments require twice the number of nodes compared to H100. That is, if an H100 setup requires 2 nodes, an A100-80GB setup requires 4 nodes, and an A100-40GB setup requires 8 nodes.
+>
+> For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
+
 
 ![Find any cheapest candidate resources](https://i.imgur.com/FpAV6Ok.png)
 

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -67,13 +67,14 @@ Adjust the `accelerators` and `num_nodes` to fit your needs. Common configuratio
 |------------------|---------------|
 | H200:8           | 1             |
 | H100:8           | 2             |
-| A100-80GB:8      | 2             |
-| A100:8           | 4             |
-| L4:8             | 8             |
+| A100-80GB:8      | 4             |
+| A100:8           | 8             |
 
 .. note::
 
   For A100 GPUs, use [deepseek-r1-671B-A100.yaml](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
+
+  Since BF16 models consume more memory, A100 deployments require twice the number of nodes compared to H100. That is, if an H100 setup requires 2 nodes, an A100-80GB setup requires 4 nodes, and an A100-40GB setup requires 8 nodes.
 
   For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
 

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -15,7 +15,7 @@ We use [SGLang](https://github.com/sgl-project/sglang) to serve the model distri
 
 ## Run 671B DeepSeek-R1 on Kubernetes or any Cloud
 
-SkyPilot allows you to run the model distributedly with a single command using [SGLang](https://github.com/sgl-project/sglang).
+SkyPilot allows you to run the model distributedly with a single command, leveraging the framework [SGLang](https://github.com/sgl-project/sglang).
 
 ```bash
 sky launch -c r1 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up
@@ -77,10 +77,10 @@ You can also adjust the `accelerators` and `num_nodes` to fit your needs. Common
 You can override `num_nodes` in the command line without modifying the YAML file. For example:
 
 ```bash
-sky launch -c r1-A100 llm/deepseek-r1/deepseek-r1-671B.yaml --retry-until-up --num-nodes=4 --accelerators=A100-80GB:8
+sky launch -c r1-A100 llm/deepseek-r1/deepseek-r1-671B-A100.yaml --retry-until-up --gpus A100-80GB:8 --num-nodes 4
 ```
 
-> [!IMPORTANT]
+> [!NOTE]
 > For A100 GPUs, use [deepseek-r1-671B-A100.yaml](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
 >
 > Since BF16 models consume more memory, A100 deployments require twice the number of nodes compared to H100. That is, if an H100 setup requires 2 nodes, an A100-80GB setup requires 4 nodes, and an A100-40GB setup requires 8 nodes.

--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -73,7 +73,7 @@ Adjust the `accelerators` and `num_nodes` to fit your needs. Common configuratio
 
 .. note::
 
-  For A100 GPUs, use [deepseek-r1-671B-A100.yaml](deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
+  For A100 GPUs, use [deepseek-r1-671B-A100.yaml](https://github.com/skypilot-org/skypilot/blob/master/llm/deepseek-r1/deepseek-r1-671B-A100.yaml), which includes a preprocessing step to convert the model from FP8 to BF16, as A100 does not support FP8. This conversion process takes an additional 30-40 minutes. Alternatively, you can use a pre-converted BF16 model from the Hugging Face community to skip the conversion step.
 
   For more configuration options, refer to the [DeepSeek SGLang Docs](https://github.com/sgl-project/sglang/blob/main/benchmark/deepseek_v3/README.md).
 

--- a/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
@@ -10,7 +10,7 @@ resources:
     - use_spot: true
     - use_spot: false
 
-num_nodes: 2 # Specify number of nodes to launch, the requirement might be different for different accelerators
+num_nodes: 4 # Specify number of nodes to launch, the requirement might be different for different accelerators
 
 setup: |
   # Install sglang with all dependencies using uv

--- a/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
@@ -1,0 +1,72 @@
+name: deepseek-r1-A100
+
+resources:
+  accelerators: { A100-80GB:8 }
+  disk_size: 3072 # More needed for the conversion
+  disk_tier: best
+  ports: 30000
+  any_of:
+    - use_spot: true
+    - use_spot: false
+
+num_nodes: 2 # Specify number of nodes to launch, the requirement might be different for different accelerators
+
+setup: |
+  # Install sglang with all dependencies using uv
+  uv pip install "sglang[all]>=0.4.2.post4" --find-links https://flashinfer.ai/whl/cu124/torch2.5/flashinfer
+
+  # Set up shared memory for better performance
+  sudo bash -c "echo 'vm.max_map_count=655300' >> /etc/sysctl.conf"
+  sudo sysctl -p
+
+  echo "FP8 is not supported on A100, we need to convert the model to BF16 format"
+
+  # Conversion script
+  git clone https://github.com/deepseek-ai/DeepSeek-V3.git deepseek_repo
+  # A workaround for running conversion script on A100. See https://github.com/deepseek-ai/DeepSeek-V3/issues/4
+  sed -i 's/new_state_dict\[weight_name\] = weight_dequant(weight, scale_inv)/new_state_dict[weight_name] = weight_dequant(weight.float(), scale_inv)/' ./deepseek_repo/inference/fp8_cast_bf16.py
+
+  uv venv venv_convert && source venv_convert/bin/activate
+  uv pip install huggingface_hub -r deepseek_repo/inference/requirements.txt
+
+  # Download the model weights and convert to BF16 format
+  echo "Downloading model weights..."
+  python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='deepseek-ai/DeepSeek-R1', local_dir='./DeepSeek-R1-FP8')"
+
+  # Convert the model to BF16 format
+  MODEL_DIR="DeepSeek-R1-BF16"
+  python deepseek_repo/inference/fp8_cast_bf16.py \
+    --input-fp8-hf-path DeepSeek-R1-FP8 \
+    --output-bf16-hf-path $MODEL_DIR
+
+  if [ $? -ne 0 ]; then
+    echo "BF16 conversion failed"
+    exit 1
+  fi
+
+  echo "BF16 conversion completed. Model saved to $MODEL_DIR"
+
+run: |
+  # Launch the server with appropriate configuration
+  MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  # TP should be number of GPUs per node times number of nodes
+  TP=$(($SKYPILOT_NUM_GPUS_PER_NODE * $SKYPILOT_NUM_NODES))
+
+  # For A100, we only export the head node for serving requests
+  if [ "$SKYPILOT_NODE_RANK" -eq 0 ]; then
+      EXTRA_ARGS="--host 0.0.0.0 --port 30000"
+  else
+      EXTRA_ARGS=""
+  fi
+
+  python -m sglang.launch_server \
+    --model-path DeepSeek-R1-BF16 \
+    --tp $TP \
+    --dist-init-addr ${MASTER_ADDR}:5000 \
+    --nnodes ${SKYPILOT_NUM_NODES} \
+    --node-rank ${SKYPILOT_NODE_RANK} \
+    --trust-remote-code \
+    --enable-dp-attention \
+    --enable-torch-compile \
+    --torch-compile-max-bs 8 \
+    $EXTRA_ARGS

--- a/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
@@ -1,8 +1,9 @@
+# Ajusted on deepseek-r1-671B.yaml for A100.
 name: deepseek-r1-A100
 
 resources:
   accelerators: { A100-80GB:8 }
-  disk_size: 3072 # More needed for the conversion
+  disk_size: 2048 # The model in BF16 format takes about 1.3TB
   disk_tier: best
   ports: 30000
   any_of:

--- a/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
@@ -25,19 +25,23 @@ setup: |
   # Conversion script
   git clone https://github.com/deepseek-ai/DeepSeek-V3.git deepseek_repo
   # A workaround for running conversion script on A100. See https://github.com/deepseek-ai/DeepSeek-V3/issues/4
-  sed -i 's/new_state_dict\[weight_name\] = weight_dequant(weight, scale_inv)/new_state_dict[weight_name] = weight_dequant(weight.float(), scale_inv)/' ./deepseek_repo/inference/fp8_cast_bf16.py
+  CONVERSION_SCRIPT="deepseek_repo/inference/fp8_cast_bf16.py"
+  sed -i 's/new_state_dict\[weight_name\] = weight_dequant(weight, scale_inv)/new_state_dict[weight_name] = weight_dequant(weight.float(), scale_inv)/' $CONVERSION_SCRIPT
 
   uv venv venv_convert && source venv_convert/bin/activate
-  uv pip install huggingface_hub -r deepseek_repo/inference/requirements.txt
+
+  # setuptools is needed by triton
+  uv pip install huggingface_hub setuptools -r deepseek_repo/inference/requirements.txt
 
   # Download the model weights and convert to BF16 format
   echo "Downloading model weights..."
-  python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='deepseek-ai/DeepSeek-R1', local_dir='./DeepSeek-R1-FP8')"
+  FP8_MODEL_DIR="DeepSeek-R1-FP8"
+  python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='deepseek-ai/DeepSeek-R1', local_dir='./$FP8_MODEL_DIR')"
 
   # Convert the model to BF16 format
   MODEL_DIR="DeepSeek-R1-BF16"
-  python deepseek_repo/inference/fp8_cast_bf16.py \
-    --input-fp8-hf-path DeepSeek-R1-FP8 \
+  python $CONVERSION_SCRIPT \
+    --input-fp8-hf-path $FP8_MODEL_DIR \
     --output-bf16-hf-path $MODEL_DIR
 
   if [ $? -ne 0 ]; then
@@ -45,7 +49,21 @@ setup: |
     exit 1
   fi
 
-  echo "BF16 conversion completed. Model saved to $MODEL_DIR"
+  MODEL_FILES=(
+  "config.json"
+  "generation_config.json"
+  "modeling_deepseek.py"
+  "configuration_deepseek.py"
+  "tokenizer.json"
+  "tokenizer_config.json"
+  # the bf16 directory has its own model.safetensors.index.json
+  )
+  cp "${MODEL_FILES[@]/#/$FP8_MODEL_DIR/}" $MODEL_DIR/
+  # See https://github.com/sgl-project/sglang/issues/3491
+  sed -i '/"quantization_config": {/,/}/d' $MODEL_DIR/config.json
+
+  echo "BF16 conversion completed. Model saved to $(realpath $MODEL_DIR)"
+  ls -lh "$MODEL_DIR"  # List files for verification
 
 run: |
   # Launch the server with appropriate configuration
@@ -55,9 +73,9 @@ run: |
 
   # For A100, we only export the head node for serving requests
   if [ "$SKYPILOT_NODE_RANK" -eq 0 ]; then
-      EXTRA_ARGS="--host 0.0.0.0 --port 30000"
+      HEAD_NODE_ARGS="--host 0.0.0.0 --port 30000"
   else
-      EXTRA_ARGS=""
+      HEAD_NODE_ARGS=""
   fi
 
   python -m sglang.launch_server \
@@ -70,4 +88,4 @@ run: |
     --enable-dp-attention \
     --enable-torch-compile \
     --torch-compile-max-bs 8 \
-    $EXTRA_ARGS
+    $HEAD_NODE_ARGS

--- a/llm/deepseek-r1/deepseek-r1-671B.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B.yaml
@@ -1,15 +1,5 @@
 name: deepseek-r1
 
-service:
-  # Specifying the path to the endpoint to check the readiness of the service.
-  readiness_probe: /health
-  # Allow 1 hour for code start.
-  initial_delay_seconds: 3600
-  # Autoscaling from 0 to 2 replicas
-  replica_policy:
-    min_replicas: 0
-    max_replicas: 2
-
 resources:
   accelerators: {H200:8, H100:8, A100-80GB:8}
   disk_size: 1024 # Large disk for model weights


### PR DESCRIPTION
Resolves #4723

A100 does not support FP8, but the current example incorrectly lists `A100` as a valid accelerator.

This PR removes A100 from the default accelerator list and introduces a dedicated job YAML for running DeepSeek-R1 on A100 with BF16 conversion. It also adds a documentation section explaining how to use A100 properly.

Additionally, this PR addresses several documentation inconsistencies and improves wording for clarity.
