### PR TITLE
[Core] Use the same python to run API server

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -8,6 +8,7 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
 import time
 import typing
 from typing import Any, Dict, Optional
@@ -42,7 +43,7 @@ AVAILABLE_LOCAL_API_SERVER_URLS = [
     f'http://{host}:46580' for host in AVAILBLE_LOCAL_API_SERVER_HOSTS
 ]
 
-API_SERVER_CMD = 'python -m sky.server.server'
+API_SERVER_CMD = '-m sky.server.server'
 # The client dir on the API server for storing user-specific data, such as file
 # mounts, logs, etc. This dir is empheral and will be cleaned up when the API
 # server is restarted.
@@ -172,7 +173,7 @@ def start_uvicorn_in_background(deploy: bool = False, host: str = '127.0.0.1'):
         api_server_cmd += ' --deploy'
     if host is not None:
         api_server_cmd += f' --host {host}'
-    cmd = f'{api_server_cmd} > {log_path} 2>&1'
+    cmd = f'{sys.executable} {api_server_cmd} > {log_path} 2>&1'
 
     # Start the uvicorn process in the background and don't wait for it.
     # If this is called from a CLI invocation, we need start_new_session=True so


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently, the python executable can be different from the one used by the current sky program, which can cause module not found issue reported by a user.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
