### PR TITLE
[Catalog] Add TPU v6e missing zone southamerica-west1

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -648,10 +648,6 @@ def get_tpu_df(gce_skus: List[Dict[str, Any]],
         is_pod = ((num_cores > 8 or tpu_version == 'v4') and
                   not tpu_version.startswith('v5') and tpu_version != 'v6e')
 
-        with open('@temp/a.json', 'w') as f:
-            import json
-            json.dump(gce_skus + tpu_skus, f)
-
         for sku in gce_skus + tpu_skus:
             if tpu_region not in sku['serviceRegions']:
                 continue

--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -60,8 +60,8 @@ HIDDEN_TPU_DF = pd.read_csv(
  ,tpu-v3-2048,1,,,tpu-v3-2048,2048.0,614.4,us-east1,us-east1-d
  """)))
 
-# TPU V6e price for us-central2 is missing in the SKUs.
-TPU_V6E_MISSING_REGIONS = ['us-central2']
+# TPU V6e price for the following regions is missing in the SKUs.
+TPU_V6E_MISSING_REGIONS = ['us-central2', 'southamerica-west1']
 
 # TPU V5 is not visible in specific zones. We hardcode the missing zones here.
 # NOTE(dev): Keep the zones and the df in sync.
@@ -647,6 +647,10 @@ def get_tpu_df(gce_skus: List[Dict[str, Any]],
         # no 'Pod' keyword in the description.
         is_pod = ((num_cores > 8 or tpu_version == 'v4') and
                   not tpu_version.startswith('v5') and tpu_version != 'v6e')
+
+        with open('@temp/a.json', 'w') as f:
+            import json
+            json.dump(gce_skus + tpu_skus, f)
 
         for sku in gce_skus + tpu_skus:
             if tpu_region not in sku['serviceRegions']:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

TPU V6e's pricing is missing in a new zone. This PR add it to the blocked list.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
     - [x] python -u -m sky.clouds.service_catalog.data_fetchers.fetch_gcp --all-regions
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
