### PR TITLE
[k8s] Update the instance type format to support number only accelerator type

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1333,7 +1333,7 @@ class KubernetesInstanceType:
             # valid logical instance type name.
             assert self.accelerator_type is not None, self.accelerator_count
             acc_name = self.accelerator_type.replace(' ', '_')
-            name += f'--{self.accelerator_count}{acc_name}'
+            name += f'--{self.accelerator_count}__{acc_name}'
         return name
 
     @staticmethod
@@ -1354,7 +1354,7 @@ class KubernetesInstanceType:
             accelerator_type | str: Type of accelerator
         """
         pattern = re.compile(
-            r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+)(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
+            r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+)__(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
         )
         match = pattern.match(name)
         if match:
@@ -1400,7 +1400,7 @@ class KubernetesInstanceType:
         # Round up accelerator_count if it is not an int.
         accelerator_count = math.ceil(accelerator_count)
         if accelerator_count > 0:
-            name += f'--{accelerator_count}{accelerator_type}'
+            name += f'--{accelerator_count}__{accelerator_type}'
         return cls(cpus=cpus,
                    memory=memory,
                    accelerator_count=accelerator_count,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1333,6 +1333,8 @@ class KubernetesInstanceType:
             # valid logical instance type name.
             assert self.accelerator_type is not None, self.accelerator_count
             acc_name = self.accelerator_type.replace(' ', '_')
+            # Use double underscores to separate accelerator count and type
+            # to avoid confusion for the number-only accelerator type.
             name += f'--{self.accelerator_count}__{acc_name}'
         return name
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1333,9 +1333,9 @@ class KubernetesInstanceType:
             # valid logical instance type name.
             assert self.accelerator_type is not None, self.accelerator_count
             acc_name = self.accelerator_type.replace(' ', '_')
-            # Use double underscores to separate accelerator count and type
+            # Use `:` to separate accelerator count and type
             # to avoid confusion for the number-only accelerator type.
-            name += f'--{self.accelerator_count}__{acc_name}'
+            name += f'--{self.accelerator_count}:{acc_name}'
         return name
 
     @staticmethod
@@ -1356,7 +1356,7 @@ class KubernetesInstanceType:
             accelerator_type | str: Type of accelerator
         """
         pattern = re.compile(
-            r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+)__(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
+            r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+):(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
         )
         match = pattern.match(name)
         if match:
@@ -1402,7 +1402,7 @@ class KubernetesInstanceType:
         # Round up accelerator_count if it is not an int.
         accelerator_count = math.ceil(accelerator_count)
         if accelerator_count > 0:
-            name += f'--{accelerator_count}__{accelerator_type}'
+            name += f'--{accelerator_count}:{accelerator_type}'
         return cls(cpus=cpus,
                    memory=memory,
                    accelerator_count=accelerator_count,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1339,7 +1339,8 @@ class KubernetesInstanceType:
     @staticmethod
     def is_valid_instance_type(name: str) -> bool:
         """Returns whether the given name is a valid instance type."""
-        pattern = re.compile(r'^(\d+(\.\d+)?CPU--\d+(\.\d+)?GB)(--[\w\d-]+:\d+)?$')
+        pattern = re.compile(
+            r'^(\d+(\.\d+)?CPU--\d+(\.\d+)?GB)(--[\w\d-]+:\d+)?$')
         return bool(pattern.match(name))
 
     @classmethod
@@ -1355,7 +1356,7 @@ class KubernetesInstanceType:
         """
         pattern = re.compile(
             r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_type>[\w\d-]+):(?P<accelerator_count>\d+))?$'  # pylint: disable=line-too-long
-)
+        )
         match = pattern.match(name)
         if match:
             cpus = float(match.group('cpus'))

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -1,0 +1,47 @@
+"""Tests for instance type in Kubernetes.
+
+Tests verify correct instance type parsing and formatting.
+"""
+import pytest
+
+from sky.provision.kubernetes.utils import KubernetesInstanceType
+
+
+# Unit test for KubernetesInstanceType
+def test_kubernetes_instance_type():
+    test_cases = [
+        (4, 16, None, None, "4CPU--16GB"),
+        (0.5, 1.5, None, None, "0.5CPU--1.5GB"),
+        (4, 16, 1, "V100", "4CPU--16GB--V100:1"),
+        (4, 16, 2, "Atx100", "4CPU--16GB--Atx100:2"),
+        (4, 16, 4, "4090", "4CPU--16GB--4090:4"),
+        (4, 16, 1, "H100-80GB", "4CPU--16GB--H100-80GB:1"),
+        (1, 6, 1, "K80", "1CPU--6GB--K80:1"),
+    ]
+
+    for cpus, memory, accelerator_count, accelerator_type, expected in test_cases:
+        instance_type = KubernetesInstanceType(cpus=cpus, memory=memory, accelerator_count=accelerator_count, accelerator_type=accelerator_type)
+
+        assert instance_type.name == expected, f'Failed name check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+
+        assert KubernetesInstanceType.is_valid_instance_type(instance_type.name), f'Failed valid instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+
+        cpus, memory, accelerator_count, accelerator_type = KubernetesInstanceType._parse_instance_type(instance_type.name)
+        assert cpus == cpus, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert memory == memory, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert accelerator_count == accelerator_count, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert accelerator_type == accelerator_type, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+
+        instance_type_from_name = KubernetesInstanceType.from_instance_type(instance_type.name)
+        assert instance_type_from_name.cpus == cpus, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert instance_type_from_name.memory == memory, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert instance_type_from_name.accelerator_count == accelerator_count, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert instance_type_from_name.accelerator_type == accelerator_type, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+
+        if accelerator_count is not None:
+            instance_type_from_resources = KubernetesInstanceType.from_resources(cpus, memory, accelerator_count, accelerator_type)
+            assert instance_type_from_resources.cpus == cpus, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+            assert instance_type_from_resources.memory == memory, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+            assert instance_type_from_resources.accelerator_count == accelerator_count, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+            assert instance_type_from_resources.accelerator_type == accelerator_type, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -20,28 +20,36 @@ def test_kubernetes_instance_type():
     ]
 
     for cpus, memory, accelerator_count, accelerator_type, expected in test_cases:
-        instance_type = KubernetesInstanceType(cpus=cpus, memory=memory, accelerator_count=accelerator_count, accelerator_type=accelerator_type)
+        instance_type = KubernetesInstanceType(
+            cpus=cpus,
+            memory=memory,
+            accelerator_count=accelerator_count,
+            accelerator_type=accelerator_type)
 
         assert instance_type.name == expected, f'Failed name check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
 
-        assert KubernetesInstanceType.is_valid_instance_type(instance_type.name), f'Failed valid instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+        assert KubernetesInstanceType.is_valid_instance_type(
+            instance_type.name
+        ), f'Failed valid instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
 
-        cpus, memory, accelerator_count, accelerator_type = KubernetesInstanceType._parse_instance_type(instance_type.name)
+        cpus, memory, accelerator_count, accelerator_type = KubernetesInstanceType._parse_instance_type(
+            instance_type.name)
         assert cpus == cpus, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert memory == memory, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert accelerator_count == accelerator_count, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert accelerator_type == accelerator_type, f'Failed parse check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
 
-        instance_type_from_name = KubernetesInstanceType.from_instance_type(instance_type.name)
+        instance_type_from_name = KubernetesInstanceType.from_instance_type(
+            instance_type.name)
         assert instance_type_from_name.cpus == cpus, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert instance_type_from_name.memory == memory, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert instance_type_from_name.accelerator_count == accelerator_count, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
         assert instance_type_from_name.accelerator_type == accelerator_type, f'Failed from instance type check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
 
         if accelerator_count is not None:
-            instance_type_from_resources = KubernetesInstanceType.from_resources(cpus, memory, accelerator_count, accelerator_type)
+            instance_type_from_resources = KubernetesInstanceType.from_resources(
+                cpus, memory, accelerator_count, accelerator_type)
             assert instance_type_from_resources.cpus == cpus, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
             assert instance_type_from_resources.memory == memory, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
             assert instance_type_from_resources.accelerator_count == accelerator_count, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
             assert instance_type_from_resources.accelerator_type == accelerator_type, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
-


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Update the instance type format for Kubernetes to support number-only accelerator type, which is reported in https://github.com/skypilot-org/skypilot/issues/4608.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below) 
  - [x] Number-only accelerator type test
```
✗ python -m sky.cli launch -y -c mygpucluster --cloud k8s --gpus 4090:1 --cpus 1 --memory 6 --dryrun -- "nvidia-smi"

Command to run: nvidia-smi
Running on cluster: mygpucluster
D 02-20 10:15:11 optimizer.py:301] #### Task<name=sky-cmd>(run='nvidia-smi')
D 02-20 10:15:11 optimizer.py:301]   resources: Kubernetes(cpus=1, mem=6, {'4090': 1}) ####
D 02-20 10:15:11 optimizer.py:316] Defaulting the task's estimated time to 1 hour.
D 02-20 10:15:11 optimizer.py:338] resources: Kubernetes(1CPU--6GB--4090:1, cpus=1, mem=6, {'4090': 1})
D 02-20 10:15:11 optimizer.py:357]   estimated_runtime: 3600 s (1.0 hr)
D 02-20 10:15:11 optimizer.py:361]   estimated_cost (not incl. egress): $0.0
I 02-20 10:15:11 optimizer.py:884] Considered resources (1 node):
I 02-20 10:15:11 optimizer.py:952] -------------------------------------------------------------------------------------------------------
I 02-20 10:15:11 optimizer.py:952]  CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN
I 02-20 10:15:11 optimizer.py:952] -------------------------------------------------------------------------------------------------------
I 02-20 10:15:11 optimizer.py:952]  Kubernetes   1CPU--6GB--4090:1   1       6         4090:1         kind-skypilot   0.00          ✔
I 02-20 10:15:11 optimizer.py:952] -------------------------------------------------------------------------------------------------------
D 02-20 10:15:11 cloud_vm_ray_backend.py:4596] cluster_ever_up: False
D 02-20 10:15:11 cloud_vm_ray_backend.py:4597] record: None
D 02-20 10:15:11 utils.py:54] more than 1 credential file found
D 02-20 10:15:11 backend_utils.py:667] Using ssh_proxy_command: None
I 02-20 10:15:11 execution.py:323] Dryrun finished.
```

  - [x] Letter prefixed accelerator type (for backward compatibility)

```
✗ python -m sky.cli launch -y -c mygpucluster --cloud k8s --gpus K80:1 --cpus 1 --memory 6 --dryrun -- "nvidia-smi"

Command to run: nvidia-smi
Running on cluster: mygpucluster
D 02-20 10:14:38 optimizer.py:301] #### Task<name=sky-cmd>(run='nvidia-smi')
D 02-20 10:14:38 optimizer.py:301]   resources: Kubernetes(cpus=1, mem=6, {'K80': 1}) ####
D 02-20 10:14:38 optimizer.py:316] Defaulting the task's estimated time to 1 hour.
D 02-20 10:14:38 optimizer.py:338] resources: Kubernetes(1CPU--6GB--K80:1, cpus=1, mem=6, {'K80': 1})
D 02-20 10:14:38 optimizer.py:357]   estimated_runtime: 3600 s (1.0 hr)
D 02-20 10:14:38 optimizer.py:361]   estimated_cost (not incl. egress): $0.0
I 02-20 10:14:38 optimizer.py:884] Considered resources (1 node):
I 02-20 10:14:38 optimizer.py:952] ------------------------------------------------------------------------------------------------------
I 02-20 10:14:38 optimizer.py:952]  CLOUD        INSTANCE           vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN
I 02-20 10:14:38 optimizer.py:952] ------------------------------------------------------------------------------------------------------
I 02-20 10:14:38 optimizer.py:952]  Kubernetes   1CPU--6GB--K80:1   1       6         K80:1          kind-skypilot   0.00          ✔
I 02-20 10:14:38 optimizer.py:952] ------------------------------------------------------------------------------------------------------
D 02-20 10:14:38 cloud_vm_ray_backend.py:4596] cluster_ever_up: False
D 02-20 10:14:38 cloud_vm_ray_backend.py:4597] record: None
D 02-20 10:14:38 utils.py:54] more than 1 credential file found
D 02-20 10:14:38 backend_utils.py:667] Using ssh_proxy_command: None
I 02-20 10:14:38 execution.py:323] Dryrun finished.
```
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
