### PR TITLE
[k8s] Fix list merging in `merge_k8s_configs`

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -200,7 +200,7 @@ def merge_k8s_configs(
                             base_config[key].append(new_volume)
             else:
                 # For other list values, merge lists and maintain uniqueness.
-                # Preserve order by keeping original items and appending any 
+                # Preserve order by keeping original items and appending any
                 # new item not already present.
                 result = list(base_config[key])
                 for item in value:

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -199,7 +199,15 @@ def merge_k8s_configs(
                         else:
                             base_config[key].append(new_volume)
             else:
-                # For other list values, merge lists and maintain uniqueness
-                base_config[key] = list(set(base_config[key] + value))
+                # For other list values, merge lists and maintain uniqueness.
+                # Preserve the order - first list is the base_config list, and
+                # the second list is the override list. This is required for
+                # order sensitive lists like allowed_contexts.
+                seen = set(base_config[key])
+                # Append new items from override in-place while preserving order
+                for item in value:
+                    if item not in seen:
+                        seen.add(item)
+                        base_config[key].append(item)
         else:
             base_config[key] = value

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -199,6 +199,7 @@ def merge_k8s_configs(
                         else:
                             base_config[key].append(new_volume)
             else:
-                base_config[key].extend(value)
+                # For other list values, merge lists and maintain uniqueness
+                base_config[key] = list(set(base_config[key] + value))
         else:
             base_config[key] = value

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -200,14 +200,12 @@ def merge_k8s_configs(
                             base_config[key].append(new_volume)
             else:
                 # For other list values, merge lists and maintain uniqueness.
-                # Preserve the order - first list is the base_config list, and
-                # the second list is the override list. This is required for
-                # order sensitive lists like allowed_contexts.
-                seen = set(base_config[key])
-                # Append new items from override in-place while preserving order
+                # Preserve order by keeping original items and appending any 
+                # new item not already present.
+                result = list(base_config[key])
                 for item in value:
-                    if item not in seen:
-                        seen.add(item)
-                        base_config[key].append(item)
+                    if item not in result:
+                        result.append(item)
+                base_config[key] = result
         else:
             base_config[key] = value

--- a/tests/unit_tests/sky/utils/test_config_utils.py
+++ b/tests/unit_tests/sky/utils/test_config_utils.py
@@ -390,3 +390,51 @@ def test_merge_k8s_configs_list_deduplication():
     assert base_config['allowed_contexts'] == [
         'context1', 'context2', 'context3', 'context4', 'context5'
     ]
+
+    # Test deduplication when list items are dictionaries
+    base_config = {
+        'volumes': [{
+            'name': 'vol1',
+            'persistentVolumeClaim': {
+                'claimName': 'pvc1'
+            }
+        }, {
+            'name': 'vol2', 
+            'persistentVolumeClaim': {
+                'claimName': 'pvc2'
+            }
+        }]
+    }
+    override_config = {
+        'volumes': [{
+            'name': 'vol2',
+            'persistentVolumeClaim': {
+                'claimName': 'pvc2-new'
+            }
+        }, {
+            'name': 'vol3',
+            'persistentVolumeClaim': {
+                'claimName': 'pvc3'
+            }
+        }]
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+    
+    # Should merge vol2 and append vol3
+    assert base_config['volumes'] == [{
+        'name': 'vol1',
+        'persistentVolumeClaim': {
+            'claimName': 'pvc1'
+        }
+    }, {
+        'name': 'vol2',
+        'persistentVolumeClaim': {
+            'claimName': 'pvc2-new'
+        }
+    }, {
+        'name': 'vol3',
+        'persistentVolumeClaim': {
+            'claimName': 'pvc3'
+        }
+    }]

--- a/tests/unit_tests/sky/utils/test_config_utils.py
+++ b/tests/unit_tests/sky/utils/test_config_utils.py
@@ -445,26 +445,40 @@ def test_merge_k8s_configs_list_deduplication():
     base_config = {
         'containers': [{
             'name': 'container-1',
-            'env': [
-                {'name': 'ENV1', 'value': 'v1'},
-                {'name': 'ENV2', 'value': 'v2'}
-            ]
+            'env': [{
+                'name': 'ENV1',
+                'value': 'v1'
+            }, {
+                'name': 'ENV2',
+                'value': 'v2'
+            }]
         }]
     }
     override_config = {
         'containers': [{
             'env': [
-                {'name': 'ENV2', 'value': 'v2'},     # duplicate exactly
-                {'name': 'ENV3', 'value': 'v3'}      # new env variable
+                {
+                    'name': 'ENV2',
+                    'value': 'v2'
+                },  # duplicate exactly
+                {
+                    'name': 'ENV3',
+                    'value': 'v3'
+                }  # new env variable
             ]
         }]
     }
     # Expected: base env is preserved and only new env var ENV3 is appended.
-    expected_env = [
-        {'name': 'ENV1', 'value': 'v1'},
-        {'name': 'ENV2', 'value': 'v2'},
-        {'name': 'ENV3', 'value': 'v3'}
-    ]
+    expected_env = [{
+        'name': 'ENV1',
+        'value': 'v1'
+    }, {
+        'name': 'ENV2',
+        'value': 'v2'
+    }, {
+        'name': 'ENV3',
+        'value': 'v3'
+    }]
     config_utils.merge_k8s_configs(base_config, override_config)
     merged_env = base_config['containers'][0]['env']
     assert merged_env == expected_env

--- a/tests/unit_tests/sky/utils/test_config_utils.py
+++ b/tests/unit_tests/sky/utils/test_config_utils.py
@@ -370,3 +370,23 @@ def test_nested_config_override_with_nonexistent_key():
                                     default_value=None,
                                     override_configs=override_config)
     assert result == override_config['kubernetes']['pod_config']
+
+
+def test_merge_k8s_configs_list_deduplication():
+    """Test that merge_k8s_configs correctly deduplicates list values."""
+    base_config = {'allowed_contexts': ['context1', 'context2']}
+    override_config = {'allowed_contexts': ['context2', 'context3']}
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+
+    # Test order preservation with multiple duplicates
+    base_config = {'allowed_contexts': ['context1', 'context2', 'context3']}
+    override_config = {
+        'allowed_contexts': ['context2', 'context4', 'context1', 'context5']
+    }
+
+    config_utils.merge_k8s_configs(base_config, override_config)
+    # Should keep original order of base_config items and append new items in order
+    assert base_config['allowed_contexts'] == [
+        'context1', 'context2', 'context3', 'context4', 'context5'
+    ]


### PR DESCRIPTION
Repro: a config.yaml with a single allowed_context would be read as multiple contexts: 
```
# ~/.sky/config.yaml
kubernetes:
  allowed_contexts:
    - myctx
```

```
$ sky check
...
D 02-19 15:23:45 config_utils.py:146] User config: kubernetes.allowed_contexts -> ['myctx', 'myctx']
...
🎉 Enabled clouds 🎉
  GCP
  Kubernetes
  Allowed contexts:
    ├── myctx
    └── myctx
```

Our k8s dict merge logic would extend lists instead of adding only unique elements. This PR fixes it. 