### PR TITLE
[Server] Add cgroup awareness to resource reflection

### DIFF
--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -758,13 +758,10 @@ def is_port_available(port: int, reuse_addr: bool = True) -> bool:
             return False
 
 
-# TODO(aylei): should be aware of cgroups
 def get_cpu_count() -> int:
-    """Get the number of CPUs.
-
-    If the API server is deployed as a pod in k8s cluster, we assume the
-    number of CPUs is provided by the downward API.
-    """
+    """Get the number of CPUs, with cgroup awareness."""
+    # This env-var is kept since it is still useful for limiting the resource
+    # of SkyPilot in non-containerized environments.
     cpu_count = os.getenv('SKYPILOT_POD_CPU_CORE_LIMIT')
     if cpu_count is not None:
         try:
@@ -774,16 +771,16 @@ def get_cpu_count() -> int:
                 raise ValueError(
                     f'Failed to parse the number of CPUs from {cpu_count}'
                 ) from e
-    return psutil.cpu_count()
+    # host cpu cores
+    cpu = psutil.cpu_count()
+    cgroup_cpu = _get_cgroup_cpu_limit()
+    if cgroup_cpu is not None:
+        cpu = min(cpu, int(cgroup_cpu))
+    return cpu
 
 
-# TODO(aylei): should be aware of cgroups
 def get_mem_size_gb() -> float:
-    """Get the memory size in GB.
-
-    If the API server is deployed as a pod in k8s cluster, we assume the
-    memory size is provided by the downward API.
-    """
+    """Get the memory size in GB, with cgroup awareness."""
     mem_size = os.getenv('SKYPILOT_POD_MEMORY_GB_LIMIT')
     if mem_size is not None:
         try:
@@ -792,4 +789,69 @@ def get_mem_size_gb() -> float:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'Failed to parse the memory size from {mem_size}') from e
-    return psutil.virtual_memory().total / (1024**3)
+    # host memory limit
+    mem = psutil.virtual_memory().total
+    cgroup_mem = _get_cgroup_memory_limit()
+    if cgroup_mem is not None:
+        mem = min(mem, cgroup_mem)
+    return mem / (1024**3)
+
+
+# Refer to:
+# - https://docs.kernel.org/admin-guide/cgroup-v1/index.html
+# - https://docs.kernel.org/admin-guide/cgroup-v2.html
+# for the standards of handler files in cgroupv1 and v2.
+# Since all those paths are well-known standards that are unlikely to change,
+# we use string literals instead of defining extra constants.
+def _get_cgroup_cpu_limit() -> Optional[float]:
+    """Return cpu limit from cgroups in cores.
+
+    Returns:
+        The cpu limit in cores as a float (can be fractional), or None if not
+        found, unspecified, or invalid.
+    """
+    try:
+        if _is_cgroup_v2():
+            with open('/sys/fs/cgroup/cpu.max', 'r', encoding='utf-8') as f:
+                quota_str, period_str = f.read().strip().split()
+                if quota_str == 'max':
+                    return None
+                quota = float(quota_str)
+                period = float(period_str)
+                return quota / period if quota > 0 else None
+        else:
+            # cgroup v1
+            quota_path = '/sys/fs/cgroup/cpu/cpu.cfs_quota_us'
+            period_path = '/sys/fs/cgroup/cpu/cpu.cfs_period_us'
+
+            with open(quota_path, 'r', encoding='utf-8') as f:
+                quota = float(f.read().strip())
+            with open(period_path, 'r', encoding='utf-8') as f:
+                period = float(f.read().strip())
+            return quota / period if quota > 0 else None
+    except (IOError, ValueError):
+        return None
+
+
+def _get_cgroup_memory_limit() -> Optional[int]:
+    """Return memory limit from cgroups in bytes.
+
+    Returns:
+        The memory limit in bytes, or None if not found or unspecified.
+    """
+    try:
+        path = ('/sys/fs/cgroup/memory.max' if _is_cgroup_v2() else
+                '/sys/fs/cgroup/memory/memory.limit_in_bytes')
+        with open(path, 'r', encoding='utf-8') as f:
+            value = f.read().strip()
+            if value == 'max' or not value:
+                return None
+            limit = int(value)
+            return limit if limit > 0 else None
+    except (IOError, ValueError):
+        return None
+
+
+def _is_cgroup_v2() -> bool:
+    """Return True if the environment is running cgroup v2."""
+    return os.path.exists('/sys/fs/cgroup/cgroup.controllers')

--- a/tests/unit_tests/test_common_utils.py
+++ b/tests/unit_tests/test_common_utils.py
@@ -52,3 +52,157 @@ class TestMakeClusterNameOnCloud:
             "Cuda_11.8")
         assert "cuda-11-8-ab12cd34" == common_utils.make_cluster_name_on_cloud(
             "Cuda_11.8", max_length=20)
+
+
+class TestCgroupFunctions:
+    """Test cgroup-related functions."""
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('sky.utils.common_utils._is_cgroup_v2')
+    def test_get_cgroup_cpu_limit_v2(self, mock_is_v2, mock_open):
+        # Test cgroup v2 CPU limit
+        mock_is_v2.return_value = True
+        mock_open.return_value.__enter__().read.return_value = '100000 100000'
+        assert common_utils._get_cgroup_cpu_limit() == 1.0
+
+        # Test no limit ("max")
+        mock_open.return_value.__enter__().read.return_value = 'max 100000'
+        assert common_utils._get_cgroup_cpu_limit() is None
+
+        # Test partial cores
+        mock_open.return_value.__enter__().read.return_value = '50000 100000'
+        assert common_utils._get_cgroup_cpu_limit() == 0.5
+
+        # Test file read error
+        mock_open.side_effect = IOError
+        assert common_utils._get_cgroup_cpu_limit() is None
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('sky.utils.common_utils._is_cgroup_v2')
+    def test_get_cgroup_cpu_limit_v1(self, mock_is_v2, mock_open):
+        # Test cgroup v1 CPU limit
+        mock_is_v2.return_value = False
+
+        # Mock both quota and period files
+        mock_files = {
+            '/sys/fs/cgroup/cpu/cpu.cfs_quota_us':
+                mock.mock_open(read_data='100000').return_value,
+            '/sys/fs/cgroup/cpu/cpu.cfs_period_us':
+                mock.mock_open(read_data='100000').return_value,
+        }
+        mock_open.side_effect = lambda path, *args, **kwargs: mock_files[path]
+
+        assert common_utils._get_cgroup_cpu_limit() == 1.0
+
+        # Test partial cores
+        mock_files = {
+            '/sys/fs/cgroup/cpu/cpu.cfs_quota_us':
+                mock.mock_open(read_data='50000').return_value,
+            '/sys/fs/cgroup/cpu/cpu.cfs_period_us':
+                mock.mock_open(read_data='100000').return_value,
+        }
+        mock_open.side_effect = lambda path, *args, **kwargs: mock_files[path]
+
+        assert common_utils._get_cgroup_cpu_limit() == 0.5
+
+        # Test no limit (-1)
+        mock_files = {
+            '/sys/fs/cgroup/cpu/cpu.cfs_quota_us': mock.mock_open(read_data='-1'
+                                                                 ).return_value,
+            '/sys/fs/cgroup/cpu/cpu.cfs_period_us':
+                mock.mock_open(read_data='100000').return_value,
+        }
+        mock_open.side_effect = lambda path, *args, **kwargs: mock_files[path]
+
+        assert common_utils._get_cgroup_cpu_limit() is None
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('sky.utils.common_utils._is_cgroup_v2')
+    def test_get_cgroup_memory_limit_v2(self, mock_is_v2, mock_open):
+        # Test cgroup v2 memory limit
+        mock_is_v2.return_value = True
+
+        # Test normal limit (8GB)
+        mock_open.return_value.__enter__().read.return_value = str(8 * 1024**3)
+        assert common_utils._get_cgroup_memory_limit() == 8 * 1024**3
+
+        # Test no limit ("max")
+        mock_open.return_value.__enter__().read.return_value = 'max'
+        assert common_utils._get_cgroup_memory_limit() is None
+
+        # Test empty value
+        mock_open.return_value.__enter__().read.return_value = ''
+        assert common_utils._get_cgroup_memory_limit() is None
+
+        # Test file read error
+        mock_open.side_effect = IOError
+        assert common_utils._get_cgroup_memory_limit() is None
+
+    @mock.patch('builtins.open', new_callable=mock.mock_open)
+    @mock.patch('sky.utils.common_utils._is_cgroup_v2')
+    def test_get_cgroup_memory_limit_v1(self, mock_is_v2, mock_open):
+        # Test cgroup v1 memory limit
+        mock_is_v2.return_value = False
+
+        # Test normal limit (1GB)
+        mock_open.return_value.__enter__().read.return_value = str(1024**3)
+        assert common_utils._get_cgroup_memory_limit() == 1024**3
+
+        # Test empty value
+        mock_open.return_value.__enter__().read.return_value = ''
+        assert common_utils._get_cgroup_memory_limit() is None
+
+        # Test file read error
+        mock_open.side_effect = IOError
+        assert common_utils._get_cgroup_memory_limit() is None
+
+    @mock.patch('os.path.exists')
+    def test_is_cgroup_v2(self, mock_exists):
+        # Test cgroup v2 detection
+        mock_exists.return_value = True
+        assert common_utils._is_cgroup_v2() is True
+
+        mock_exists.return_value = False
+        assert common_utils._is_cgroup_v2() is False
+
+    @mock.patch('psutil.cpu_count')
+    @mock.patch('sky.utils.common_utils._get_cgroup_cpu_limit')
+    def test_get_cpu_count(self, mock_cgroup_cpu, mock_cpu_count):
+        # Test when no cgroup limit
+        mock_cpu_count.return_value = 8
+        mock_cgroup_cpu.return_value = None
+        assert common_utils.get_cpu_count() == 8
+
+        # Test when cgroup limit is lower
+        mock_cgroup_cpu.return_value = 4.0
+        assert common_utils.get_cpu_count() == 4
+
+        # Test when cgroup limit is higher
+        mock_cgroup_cpu.return_value = 16.0
+        assert common_utils.get_cpu_count() == 8
+
+        # Test with env var
+        with mock.patch.dict('os.environ',
+                             {'SKYPILOT_POD_CPU_CORE_LIMIT': '2'}):
+            assert common_utils.get_cpu_count() == 2
+
+    @mock.patch('psutil.virtual_memory')
+    @mock.patch('sky.utils.common_utils._get_cgroup_memory_limit')
+    def test_get_mem_size_gb(self, mock_cgroup_mem, mock_virtual_memory):
+        # Test when no cgroup limit
+        mock_virtual_memory.return_value.total = 8 * 1024**3  # 8GB
+        mock_cgroup_mem.return_value = None
+        assert common_utils.get_mem_size_gb() == 8.0
+
+        # Test when cgroup limit is lower
+        mock_cgroup_mem.return_value = 4 * 1024**3  # 4GB
+        assert common_utils.get_mem_size_gb() == 4.0
+
+        # Test when cgroup limit is higher
+        mock_cgroup_mem.return_value = 16 * 1024**3  # 16GB
+        assert common_utils.get_mem_size_gb() == 8.0
+
+        # Test with env var
+        with mock.patch.dict('os.environ',
+                             {'SKYPILOT_POD_MEMORY_GB_LIMIT': '2'}):
+            assert common_utils.get_mem_size_gb() == 2.0


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

followup:
- https://github.com/skypilot-org/skypilot/pull/4731#discussion_r1962889953
- https://github.com/skypilot-org/skypilot/pull/4737/files/b973f2b99b18ac0b749afec7a7a73cfc8190cfc4#r1959068720

Since #4731 has been merged, now API Server can run in limited resources more reliably. This PR adds cgroup awareness so in most cases users don't have to set the env vars and the server will detect the right resource it can use automatically.

This PR also corrects the worker number choice of uvicorn, which does not respect the `SKYPILOT_POD_CPU_CORE_LIMIT` env previously.

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
