### PR TITLE
[WIP] [API server] run in foreground in k8s pod

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -37,6 +37,12 @@ spec:
         {{- end }}
         # Use tini as the init process
         command: ["tini", "--"]
+        # Start API server directly to:
+        # 1. Bypass the healthz check of `sky api start`, probe will do the job better
+        # 2. Ensure all logs are properly captured in container stdout/stderr
+        # See: https://github.com/skypilot-org/skypilot/issues/4471
+        #      https://github.com/skypilot-org/skypilot/issues/4772
+        # PS: this comment is moved here to avoid appearing in the final start script.
         args:
         - /bin/sh
         - -c
@@ -52,19 +58,20 @@ spec:
           # Any local changes to the config.yaml file will be overwritten by the contents of the configmap.
           cp /tmp/config.yaml /root/.sky/config.yaml
           {{- end }}
-          sky api start --deploy && tail -f /root/.sky/api_server/server.log
+          exec python -m sky.server.server --deploy --host 0.0.0.0 --port 46580
         ports:
         - containerPort: 46580
         livenessProbe:
           httpGet:
             path: /api/health
             port: 46580
-          periodSeconds: 30
+          periodSeconds: 10
         readinessProbe:
           httpGet:
             path: /api/health
             port: 46580
-          periodSeconds: 30
+          # Accelerate startup and failover
+          periodSeconds: 10
         volumeMounts:
         {{- if .Values.storage.enabled }}
         - name: state-volume


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #4771 
close #4772 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Tested in kubernetes, no more initial restart observed
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
