### PR TITLE
[Existing clusters] Add `--context-name` arg, multi-cluster docs

### DIFF
--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -156,20 +156,15 @@ This will stop all Kubernetes services on the remote machines.
 Setting up Multiple Clusters
 ----------------------------
 
-You can set up multiple Kubernetes clusters with SkyPilot by using different ``context-name`` values for each cluster and merging the kubeconfigs:
+You can set up multiple Kubernetes clusters with SkyPilot by using different ``context-name`` values for each cluster:
 
 .. code-block:: bash
 
     # Set up first cluster and save the kubeconfig
     sky local up --ips cluster1-ips.txt --ssh-user user1 --ssh-key-path key1.pem --context-name cluster1
-    cp ~/.kube/config ~/.kube/config.cluster1
-
     # Set up second cluster
     sky local up --ips cluster2-ips.txt --ssh-user user2 --ssh-key-path key2.pem --context-name cluster2
-    cp ~/.kube/config ~/.kube/config.cluster2
 
-    # Combine the kubeconfigs into ~/.kube/config
-    KUBECONFIG=~/.kube/config.cluster1:~/.kube/config.cluster2 kubectl config view --flatten > ~/.kube/config
 
 You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/config.yaml`` file:
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -75,7 +75,8 @@ Deploying SkyPilot
       IP_FILE=ips.txt
       SSH_USER=username
       SSH_KEY=path/to/ssh/key
-      sky local up --ips $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY
+      CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
+      sky local up --ips $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME
 
    SkyPilot will deploy a Kubernetes cluster on the remote machines, set up GPU support, configure Kubernetes credentials on your local machine, and set up SkyPilot to operate with the new cluster.
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -157,7 +157,7 @@ This will stop all Kubernetes services on the remote machines.
 Setting up Multiple Clusters
 ----------------------------
 
-You can set up multiple Kubernetes clusters with SkyPilot by using different ``context-name`` values for each cluster:
+You can set up multiple Kubernetes clusters with SkyPilot by using different ``context-name`` values for each cluster and merging the kubeconfigs:
 
 .. code-block:: bash
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -76,7 +76,7 @@ Deploying SkyPilot
       SSH_USER=username
       SSH_KEY=path/to/ssh/key
       CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
-      sky local up --ips $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME
+      sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME
 
    SkyPilot will deploy a Kubernetes cluster on the remote machines, set up GPU support, configure Kubernetes credentials on your local machine, and set up SkyPilot to operate with the new cluster.
 
@@ -84,8 +84,7 @@ Deploying SkyPilot
 
    .. code-block:: console
 
-      $ sky local up --ips ips.txt --ssh-user gcpuser --ssh-key-path ~/.ssh/id_rsa
-      Found existing kube config. It will be backed up to ~/.kube/config.bak.
+      $ sky local up --ips ips.txt --ssh-user gcpuser --ssh-key-path ~/.ssh/id_rsa --context-name mycluster
       To view detailed progress: tail -n100 -f ~/sky_logs/sky-2024-09-23-18-53-14-165534/local_up.log
       ✔ K3s successfully deployed on head node.
       ✔ K3s successfully deployed on worker node.

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -152,3 +152,53 @@ To clean up all state created by SkyPilot on your machines, use the ``--cleanup`
     sky local up --ip $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --cleanup
 
 This will stop all Kubernetes services on the remote machines.
+
+
+Setting up Multiple Clusters
+----------------------------
+
+You can set up multiple Kubernetes clusters with SkyPilot by using different ``context-name`` values for each cluster:
+
+.. code-block:: bash
+
+    # Set up first cluster and save the kubeconfig
+    sky local up --ips cluster1-ips.txt --ssh-user user1 --ssh-key-path key1.pem --context-name cluster1
+    cp ~/.kube/config ~/.kube/config.cluster1
+
+    # Set up second cluster
+    sky local up --ips cluster2-ips.txt --ssh-user user2 --ssh-key-path key2.pem --context-name cluster2
+    cp ~/.kube/config ~/.kube/config.cluster2
+
+    # Combine the kubeconfigs into ~/.kube/config
+    KUBECONFIG=~/.kube/config.cluster1:~/.kube/config.cluster2 kubectl config view --flatten > ~/.kube/config
+
+You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/config.yaml`` file:
+
+.. code-block:: yaml
+
+   # ~/.sky/config.yaml
+    allowed_contexts:
+      - cluster1
+      - cluster2
+
+
+.. code-block:: bash
+
+    # Run on cluster1
+    sky launch --cloud k8s --region cluster1 -- echo "Running on cluster 1"
+
+    # Run on cluster2
+    sky launch --cloud k8s --region cluster2 -- echo "Running on cluster 2"
+
+    # Let SkyPilot automatically select the cluster with available resources
+    sky launch --cloud k8s -- echo "Running on SkyPilot selected cluster"
+
+You can view the available clusters and GPUs using:
+
+.. code-block:: bash
+
+    # List GPUs on cluster1
+    sky show-gpus --cloud k8s --region cluster1
+
+    # List GPUs on cluster2
+    sky show-gpus --cloud k8s --region cluster2

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5380,10 +5380,11 @@ def local():
 @click.option('--cleanup',
               is_flag=True,
               help='Clean up the remote cluster instead of deploying it.')
-@click.option('--context-name',
-              type=str,
-              required=False,
-              help='Name to use for the kubeconfig context. Defaults to "default".')
+@click.option(
+    '--context-name',
+    type=str,
+    required=False,
+    help='Name to use for the kubeconfig context. Defaults to "default".')
 @local.command('up', cls=_DocumentedCodeCommand)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint
@@ -5433,7 +5434,8 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
             raise click.BadParameter(
                 f'Failed to read SSH key file {ssh_key_path}: {str(e)}')
 
-    request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup, context_name)
+    request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup,
+                              context_name)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5380,11 +5380,15 @@ def local():
 @click.option('--cleanup',
               is_flag=True,
               help='Clean up the remote cluster instead of deploying it.')
+@click.option('--context-name',
+              type=str,
+              required=False,
+              help='Name to use for the kubeconfig context. Defaults to "default".')
 @local.command('up', cls=_DocumentedCodeCommand)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
-             cleanup: bool, async_call: bool):
+             cleanup: bool, context_name: Optional[str], async_call: bool):
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key_path, cleanup):
@@ -5429,7 +5433,7 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
             raise click.BadParameter(
                 f'Failed to read SSH key file {ssh_key_path}: {str(e)}')
 
-    request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup)
+    request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup, context_name)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1266,7 +1266,7 @@ def storage_delete(name: str) -> server_common.RequestId:
 @server_common.check_server_healthy_or_start
 @annotations.client_api
 def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
-             ssh_key: Optional[str], cleanup: bool) -> server_common.RequestId:
+             ssh_key: Optional[str], cleanup: bool, context_name: Optional[str] = None) -> server_common.RequestId:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:
@@ -1284,7 +1284,8 @@ def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
                                 ips=ips,
                                 ssh_user=ssh_user,
                                 ssh_key=ssh_key,
-                                cleanup=cleanup)
+                                cleanup=cleanup,
+                                context_name=context_name)
     response = requests.post(f'{server_common.get_server_url()}/local_up',
                              json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1265,8 +1265,12 @@ def storage_delete(name: str) -> server_common.RequestId:
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
-             ssh_key: Optional[str], cleanup: bool, context_name: Optional[str] = None) -> server_common.RequestId:
+def local_up(gpus: bool,
+             ips: Optional[List[str]],
+             ssh_user: Optional[str],
+             ssh_key: Optional[str],
+             cleanup: bool,
+             context_name: Optional[str] = None) -> server_common.RequestId:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:

--- a/sky/core.py
+++ b/sky/core.py
@@ -1009,7 +1009,7 @@ def realtime_kubernetes_gpu_availability(
 # =================
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
-             ssh_key: Optional[str], cleanup: bool) -> None:
+             ssh_key: Optional[str], cleanup: bool, context_name: Optional[str] = None) -> None:
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key, cleanup):
@@ -1035,7 +1035,7 @@ def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
     if ips:
         assert ssh_user is not None and ssh_key is not None
         kubernetes_deploy_utils.deploy_remote_cluster(ips, ssh_user, ssh_key,
-                                                      cleanup)
+                                                      cleanup, context_name)
     else:
         # Run local deployment (kind) if no remote args are specified
         kubernetes_deploy_utils.deploy_local_cluster(gpus)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1008,8 +1008,12 @@ def realtime_kubernetes_gpu_availability(
 # = Local Cluster =
 # =================
 @usage_lib.entrypoint
-def local_up(gpus: bool, ips: Optional[List[str]], ssh_user: Optional[str],
-             ssh_key: Optional[str], cleanup: bool, context_name: Optional[str] = None) -> None:
+def local_up(gpus: bool,
+             ips: Optional[List[str]],
+             ssh_user: Optional[str],
+             ssh_key: Optional[str],
+             cleanup: bool,
+             context_name: Optional[str] = None) -> None:
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key, cleanup):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -444,6 +444,7 @@ class LocalUpBody(RequestBody):
     ssh_user: Optional[str] = None
     ssh_key: Optional[str] = None
     cleanup: bool = False
+    context_name: Optional[str] = None
 
 
 class ServeTerminateReplicaBody(RequestBody):

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -56,7 +56,7 @@ def deploy_remote_cluster(ip_list: List[str],
         run_timestamp = sky_logging.get_run_timestamp()
         log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
                                 'local_up.log')
-        
+
         if cleanup:
             msg_str = 'Cleaning up remote cluster...'
         else:

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -56,11 +56,7 @@ def deploy_remote_cluster(ip_list: List[str],
         run_timestamp = sky_logging.get_run_timestamp()
         log_path = os.path.join(constants.SKY_LOGS_DIRECTORY, run_timestamp,
                                 'local_up.log')
-
-        # Check if ~/.kube/config exists:
-        if os.path.exists(os.path.expanduser('~/.kube/config')):
-            logger.info('Found existing kube config. '
-                        'It will be backed up to ~/.kube/config.bak.')
+        
         if cleanup:
             msg_str = 'Cleaning up remote cluster...'
         else:

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -19,8 +19,11 @@ from sky.utils import ux_utils
 logger = sky_logging.init_logger(__name__)
 
 
-def deploy_remote_cluster(ip_list: List[str], ssh_user: str, ssh_key: str,
-                          cleanup: bool, context_name: Optional[str] = None):
+def deploy_remote_cluster(ip_list: List[str],
+                          ssh_user: str,
+                          ssh_key: str,
+                          cleanup: bool,
+                          context_name: Optional[str] = None):
     success = False
     path_to_package = os.path.dirname(__file__)
     up_script_path = os.path.join(path_to_package, 'deploy_remote_cluster.sh')

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import subprocess
 import tempfile
-from typing import List
+from typing import List, Optional
 
 from sky import check as sky_check
 from sky import sky_logging
@@ -20,7 +20,7 @@ logger = sky_logging.init_logger(__name__)
 
 
 def deploy_remote_cluster(ip_list: List[str], ssh_user: str, ssh_key: str,
-                          cleanup: bool):
+                          cleanup: bool, context_name: Optional[str] = None):
     success = False
     path_to_package = os.path.dirname(__file__)
     up_script_path = os.path.join(path_to_package, 'deploy_remote_cluster.sh')
@@ -41,6 +41,8 @@ def deploy_remote_cluster(ip_list: List[str], ssh_user: str, ssh_key: str,
 
         deploy_command = (f'{up_script_path} {ip_file.name} '
                           f'{ssh_user} {key_file.name}')
+        if context_name is not None:
+            deploy_command += f' {context_name}'
         if cleanup:
             deploy_command += ' --cleanup'
 


### PR DESCRIPTION
This PR adds support for specifying a custom Kubernetes context name when using sky local up to deploy a remote cluster. This provides better control over kubeconfig context naming, especially useful when merging multiple kube contexts. 

Also adds multi-cluster docs.