### PR TITLE
Proposal: More efficient `sky logs`

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -784,7 +784,7 @@ def cancel(
 def tail_logs(cluster_name: str,
               job_id: Optional[int],
               follow: bool = True,
-              tail: int = 0) -> None:
+              tail: int = 0) -> log_lib.ProcFuture:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tails the logs of a job.
 
@@ -809,7 +809,8 @@ def tail_logs(cluster_name: str,
     backend = backend_utils.get_backend_from_handle(handle)
 
     usage_lib.record_cluster_name_for_current_operation(cluster_name)
-    backend.tail_logs(handle, job_id, follow=follow, tail=tail)
+    return backend.tail_logs(handle, job_id, follow=follow, tail=tail,
+                             async_call=True)
 
 
 @usage_lib.entrypoint

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -598,6 +598,7 @@ def update_job_status(job_ids: List[int],
                     # running, we will change status to PENDING below.
                     failed_driver_transition_message = (
                         f'INIT job {job_id} is stale, setting to FAILED_DRIVER')
+                    logger.info(failed_driver_transition_message)
                     status = JobStatus.FAILED_DRIVER
 
             # job_pid is 0 if the job is not submitted yet.
@@ -622,6 +623,7 @@ def update_job_status(job_ids: List[int],
                         f'Job {job_id} driver process is not running, but '
                         'the job state is not in terminal states, setting '
                         'it to FAILED_DRIVER')
+                    logger.info(failed_driver_transition_message)
                     status = JobStatus.FAILED_DRIVER
             elif job_pid < 0:
                 # TODO(zhwu): Backward compatibility, remove after 0.9.0.
@@ -639,6 +641,7 @@ def update_job_status(job_ids: List[int],
                         f'boot_time={psutil.boot_time()}')
                     # The job is stale as it is created before the instance
                     # is booted, e.g. the instance is rebooted.
+                    logger.info(failed_driver_transition_message)
                     status = JobStatus.FAILED_DRIVER
                 elif pending_job['submit'] <= 0:
                     # The job is not submitted (submit <= 0), we set it to
@@ -669,6 +672,8 @@ def update_job_status(job_ids: List[int],
                     # need to reset the job status to FAILED_DRIVER if its
                     # original status is in nonterminal_statuses.
                     echo(f'Job {job_id} is in a unknown state, setting it to '
+                         'FAILED_DRIVER')
+                    logger.info(f'Job {job_id} is in a unknown state, setting it to '
                          'FAILED_DRIVER')
                     status = JobStatus.FAILED_DRIVER
                     _set_status_no_lock(job_id, status)

--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -345,6 +345,7 @@ class CommandRunner:
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
+            async_call: bool = False,
             **kwargs) -> Union[int, Tuple[int, str, str]]:
         """Runs the command on the cluster.
 
@@ -587,7 +588,8 @@ class SSHCommandRunner(CommandRunner):
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
-            **kwargs) -> Union[int, Tuple[int, str, str]]:
+            async_call: bool = False,
+            **kwargs) -> Union[int, Tuple[int, str, str], log_lib.ProcFuture]:
         """Uses 'ssh' to run 'cmd' on a node with ip.
 
         Args:
@@ -656,6 +658,7 @@ class SSHCommandRunner(CommandRunner):
                                     process_stream=process_stream,
                                     shell=True,
                                     executable=executable,
+                                    async_call=async_call,
                                     **kwargs)
 
     @timeline.event
@@ -782,6 +785,7 @@ class KubernetesCommandRunner(CommandRunner):
             connect_timeout: Optional[int] = None,
             source_bashrc: bool = False,
             skip_num_lines: int = 0,
+            async_call: bool = False,
             **kwargs) -> Union[int, Tuple[int, str, str]]:
         """Uses 'kubectl exec' to run 'cmd' on a pod by its name and namespace.
 


### PR DESCRIPTION
for #4767 

<!-- Describe the changes in this PR -->
This PR proposes adding async call support for `CommandRunner` to prevent `tail_log()` from blocking the background executor processes (`executors` hereafter). To demonstrate this change, a very draft code patch is also submitted in this PR.

 ## Background

As discussed in https://github.com/skypilot-org/skypilot/pull/4731, the `executors` are memory-consuming so the number of `executors` is limited by system resources. However, the `sky logs` command is not time bounded, which can block all executors in worst case.

## Mitigation

`sky logs` request can be divided into 2 phases:

- phase 1: pre-checks, cloud auth, look-ups and finally generate an `ssh` or `kubectl` command to tail remote logs
- phase 2: run the command util done or interrupted

While an `executor` process can stably consume up to ~250MB, the `ssh` or `kubectl` command only consumes about ~3MB and ~40MB. So, phase 2 is orders of magnitude lighter on resources compared to phase 1. This leads to the primary modification: 

- The tail log call stack returns the command process to the uppermost executor instead of waiting the process;
- The executor then starts a thread to monitor the command and proceed to run next requests without blocking;

Though the memory footprint of command process is relatively low and I don't expect users suffering hang requests due to too many parallel `sky logs`, a safe belt of max parallel tail requests is still necessary to prevent the server from being overwhelmed by infinite tail requests. I expect we are able to set a default value that is unreachable in most normal scenarios, for example 1024.

There are still many details that have not yet been fully explored, e.g. the server cancels a request by sending SIGTERM to the executor process. After this change, the signal should be sent to the executor process in phase 1 and the command process in phase 2, which incurs careful handling of race conditions. But most of the uncertainties are engineering issues I think, which does affect the overall design.

This PR is also a workable MVP: I launched 100 concurrent `sky logs` processes on an API server that is limited to 2c4g (in this case, only 2 long executors and 4 short executors will be launched) and it seems just fine except an error caused by too many SSH connections I think:

```
7:ControlSocket /tmp/skypilot_ssh_57339c81/ac3b06fa0c/81d65dd183d50155f879e9c989af2b560c072c50 already exists, disabling multiplexing
```

This is also relevant to efficient `sky logs`, but I would like to move this problem to following up PRs to keep this one focused.

## Alternatives

Provision a dedicated `executor` for `sky logs` request, so that `sky logs` won't block the long running workers in the fixed pool:

- pros:
  - easy and straightforward
- cons
  - concurrent `sky logs` still block each other
  - the more executor groups we have, the more likely of wasting resources

This actually works. Consequently, a key consideration arises: is this a case of premature optimization? I think the judgment is very subjective and to me the added complexity looks payoff. I want to hear everyone's opinions, thanks!

## Appendix

The memory consumption of 100 log tail processes:

<img width="1495" alt="企业微信截图_7ddac9e4-252e-4011-b05d-69c1b2ebb648" src="https://github.com/user-attachments/assets/63bd2c81-c626-407a-a3a4-68db3529d711" />
