### PR TITLE
[Usage] Fix usage for remote API server

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4585,6 +4585,7 @@ def serve_status(verbose: bool, endpoint: bool, service_names: List[str]):
               type=int,
               help='Tear down a given replica')
 @_add_click_options(_COMMON_OPTIONS)
+@usage_lib.entrypoint
 # pylint: disable=redefined-builtin
 def serve_down(
     service_names: List[str],

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -115,7 +115,8 @@ async def dashboard(request: fastapi.Request,
     # Find the port for the dashboard of the user
     os.environ[constants.USER_ID_ENV_VAR] = user_hash
     server_common.reload_for_new_request(client_entrypoint=None,
-                                         client_command=None)
+                                         client_command=None,
+                                         using_remote_api_server=False)
     logger.info(f'Starting dashboard for user hash: {user_hash}')
 
     with dashboard_utils.get_dashboard_lock_for_user(user_hash):

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -400,12 +400,14 @@ def request_body_to_params(body: pydantic.BaseModel) -> Dict[str, Any]:
 
 
 def reload_for_new_request(client_entrypoint: Optional[str],
-                           client_command: Optional[str]):
+                           client_command: Optional[str],
+                           using_remote_api_server: bool):
     """Reload modules, global variables, and usage message for a new request."""
     # Reset the client entrypoint and command for the usage message.
-    common_utils.set_client_entrypoint_and_command(
+    common_utils.set_client_status(
         client_entrypoint=client_entrypoint,
         client_command=client_command,
+        using_remote_api_server=using_remote_api_server,
     )
     # We need to reset usage message, so that the message is up-to-date with the
     # latest information in the context, e.g. client entrypoint and run id.

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -409,12 +409,16 @@ def reload_for_new_request(client_entrypoint: Optional[str],
         client_command=client_command,
         using_remote_api_server=using_remote_api_server,
     )
+
+    # Clear cache should be called before reload_logger and usage reset,
+    # otherwise, the latest env var will not be used.
+    for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
+        func.cache_clear()
+
     # We need to reset usage message, so that the message is up-to-date with the
     # latest information in the context, e.g. client entrypoint and run id.
     usage_lib.messages.reset(usage_lib.MessageType.USAGE)
 
-    for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
-        func.cache_clear()
 
     # Make sure the logger takes the new environment variables. This is
     # necessary because the logger is initialized before the environment

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -419,7 +419,6 @@ def reload_for_new_request(client_entrypoint: Optional[str],
     # latest information in the context, e.g. client entrypoint and run id.
     usage_lib.messages.reset(usage_lib.MessageType.USAGE)
 
-
     # Make sure the logger takes the new environment variables. This is
     # necessary because the logger is initialized before the environment
     # variables are set, such as SKYPILOT_DEBUG.

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -178,7 +178,8 @@ def override_request_env_and_config(
     os.environ['CLICOLOR_FORCE'] = '1'
     server_common.reload_for_new_request(
         client_entrypoint=request_body.entrypoint,
-        client_command=request_body.entrypoint_command)
+        client_command=request_body.entrypoint_command,
+        using_remote_api_server=request_body.using_remote_api_server)
     try:
         with skypilot_config.override_skypilot_config(
                 request_body.override_skypilot_config):

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -256,6 +256,7 @@ def _request_execution_wrapper(request_id: str,
         try:
             with override_request_env_and_config(request_body):
                 return_value = func(**request_body.to_kwargs())
+                f.flush()
         except KeyboardInterrupt:
             logger.info(f'Request {request_id} cancelled by user')
             _restore_output(original_stdout, original_stderr)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -37,7 +37,7 @@ def request_body_env_vars() -> dict:
     env_vars[constants.USER_ENV_VAR] = os.getenv(constants.USER_ENV_VAR,
                                                  getpass.getuser())
     env_vars[
-        usage_constants.USAGE_RUN_ID_ENV_VAR] = common_utils.get_usage_run_id()
+        usage_constants.USAGE_RUN_ID_ENV_VAR] = usage_lib.messages.usage.run_id
     # Remove the path to config file, as the config content is included in the
     # request body and will be merged with the config on the server side.
     env_vars.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -70,6 +70,7 @@ class RequestBody(pydantic.BaseModel):
     env_vars: Dict[str, str] = {}
     entrypoint: str = ''
     entrypoint_command: str = ''
+    using_remote_api_server: bool = False
     override_skypilot_config: Optional[Dict[str, Any]] = {}
 
     def __init__(self, **data):
@@ -80,6 +81,8 @@ class RequestBody(pydantic.BaseModel):
         data['entrypoint'] = data.get('entrypoint', usage_lib_entrypoint)
         data['entrypoint_command'] = data.get(
             'entrypoint_command', common_utils.get_pretty_entrypoint_cmd())
+        data['using_remote_api_server'] = data.get(
+            'using_remote_api_server', not common.is_api_server_local())
         data['override_skypilot_config'] = data.get(
             'override_skypilot_config',
             get_override_skypilot_config_from_client())
@@ -95,6 +98,7 @@ class RequestBody(pydantic.BaseModel):
         kwargs.pop('env_vars')
         kwargs.pop('entrypoint')
         kwargs.pop('entrypoint_command')
+        kwargs.pop('using_remote_api_server')
         kwargs.pop('override_skypilot_config')
         return kwargs
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -41,6 +41,7 @@ from sky.server.requests import executor
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
+from sky.usage import usage_lib
 from sky.utils import common as common_lib
 from sky.utils import common_utils
 from sky.utils import dag_utils
@@ -1076,6 +1077,10 @@ if __name__ == '__main__':
     parser.add_argument('--port', default=46580, type=int)
     parser.add_argument('--deploy', action='store_true')
     cmd_args = parser.parse_args()
+    # Show the privacy policy if it is not already shown. We place it here so
+    # that it is shown only when the API server is started.
+    usage_lib.maybe_show_privacy_policy()
+
     num_workers = None
     if cmd_args.deploy:
         num_workers = os.cpu_count()

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -165,10 +165,9 @@ class UsageMessageToReport(MessageToReport):
         self.exception: Optional[str] = None  # entrypoint_context
         self.stacktrace: Optional[str] = None  # entrypoint_context
 
-        # Whether API server is deployed remotely. It is only set on the client
-        # side, and the dashboard should consider a user to be using a remote
-        # API server if using_remote_api_server is True.
-        self.using_remote_api_server: bool = False
+        # Whether API server is deployed remotely.
+        self.using_remote_api_server: bool = (
+            common_utils.get_using_remote_api_server())
 
     def update_entrypoint(self, msg: str):
         if self.client_entrypoint is None:
@@ -269,16 +268,6 @@ class UsageMessageToReport(MessageToReport):
     def update_final_cluster_status(
             self, status: Optional['status_lib.ClusterStatus']):
         self.final_cluster_status = status.value if status is not None else None
-
-    def update_using_remote_api_server(self,
-                                       using_remote_api_server: bool) -> None:
-        """Set to True if it is on client and the API server is remote.
-
-        We keep the using_remote_api_server to be None if it is on server
-        side, because the server side does not have the information to make the
-        determination.
-        """
-        self.using_remote_api_server = using_remote_api_server
 
     def set_new_cluster(self):
         self.is_new_cluster = True

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -15,7 +15,9 @@ import click
 import sky
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
+from sky.server import common as server_common
 from sky.usage import constants
+from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import env_options
 from sky.utils import ux_utils
@@ -167,6 +169,11 @@ class UsageMessageToReport(MessageToReport):
         self.exception: Optional[str] = None  # entrypoint_context
         self.stacktrace: Optional[str] = None  # entrypoint_context
 
+        # Whether API server is deployed remotely. It is only set on the client
+        # side, and the dashboard should consider a user to be using a remote
+        # API server if using_remote_api_server is True.
+        self.using_remote_api_server: Optional[bool] = None
+
     def update_entrypoint(self, msg: str):
         if self.client_entrypoint is None:
             self.client_entrypoint = common_utils.get_current_client_entrypoint(
@@ -266,6 +273,17 @@ class UsageMessageToReport(MessageToReport):
     def update_final_cluster_status(
             self, status: Optional['status_lib.ClusterStatus']):
         self.final_cluster_status = status.value if status is not None else None
+
+    def update_using_remote_api_server(self):
+        """Set to True if it is on client and the API server is remote.
+
+        We keep the using_remote_api_server to be None if it is on server
+        side, because the server side does not have the information to make the
+        determination.
+        """
+        if not annotations.is_on_api_server:
+            self.using_remote_api_server = (
+                not server_common.is_api_server_local())
 
     def set_new_cluster(self):
         self.is_new_cluster = True

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -378,6 +378,7 @@ def _send_to_loki(message_type: MessageType):
     if message_type == MessageType.USAGE:
         prom_labels['new_cluster'] = (message.original_cluster_status != 'UP'
                                       and message.final_cluster_status == 'UP')
+        message.update_using_remote_api_server()
 
     headers = {'Content-type': 'application/json'}
     payload = {

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -215,9 +215,11 @@ class UsageMessageToReport(MessageToReport):
     def update_ray_yaml(self, yaml_config_or_path: Union[Dict, str]):
         if self.ray_yamls is None:
             self.ray_yamls = []
-        self.ray_yamls.extend(
-            prepare_json_from_yaml_config(yaml_config_or_path))
-        self.num_tried_regions = len(self.ray_yamls)
+        if self.num_tried_regions is None:
+            self.num_tried_regions = 0
+        # Only keep the latest ray yaml to reduce the size of the message.
+        self.ray_yamls = prepare_json_from_yaml_config(yaml_config_or_path)
+        self.num_tried_regions += 1
 
     def update_cluster_name(self, cluster_name: Union[List[str], str]):
         if isinstance(cluster_name, str):

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -289,6 +289,11 @@ def get_current_client_entrypoint(server_entrypoint: str) -> str:
     return server_entrypoint
 
 
+def get_using_remote_api_server() -> bool:
+    """Returns whether the API server is remote."""
+    return _using_remote_api_server
+
+
 def get_pretty_entrypoint_cmd() -> str:
     """Returns the prettified entry point of this process (sys.argv).
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -247,18 +247,23 @@ class Backoff:
 
 _current_command: Optional[str] = None
 _current_client_entrypoint: Optional[str] = None
+_using_remote_api_server: bool = False
 
 
-def set_client_entrypoint_and_command(client_entrypoint: Optional[str],
-                                      client_command: Optional[str]):
+def set_client_status(client_entrypoint: Optional[str],
+                      client_command: Optional[str],
+                      using_remote_api_server: bool):
     """Override the current client entrypoint and command.
 
     This is useful when we are on the SkyPilot API server side and we have a
     client entrypoint and command from the client.
     """
-    global _current_command, _current_client_entrypoint
+    global _current_command
+    global _current_client_entrypoint
+    global _using_remote_api_server
     _current_command = client_command
     _current_client_entrypoint = client_entrypoint
+    _using_remote_api_server = using_remote_api_server
 
 
 def get_current_command() -> str:

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -247,7 +247,7 @@ class Backoff:
 
 _current_command: Optional[str] = None
 _current_client_entrypoint: Optional[str] = None
-_using_remote_api_server: bool = False
+_using_remote_api_server: Optional[bool] = None
 
 
 def set_client_status(client_entrypoint: Optional[str],
@@ -291,7 +291,13 @@ def get_current_client_entrypoint(server_entrypoint: str) -> str:
 
 def get_using_remote_api_server() -> bool:
     """Returns whether the API server is remote."""
-    return _using_remote_api_server
+    if _using_remote_api_server is not None:
+        return _using_remote_api_server
+    # This gets the right status for the local client.
+    # TODO(zhwu): This is to prevent circular import. We should refactor this.
+    # pylint: disable=import-outside-toplevel
+    from sky.server import common as server_common
+    return not server_common.is_api_server_local()
 
 
 def get_pretty_entrypoint_cmd() -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes included:
- [x] Reduce message size
- [x] Add remote API server annotation
- [x] Avoid showing usage hint on client side
- [x] Fix the issue where the requests from a same CLI call not sharing the run id.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Local API server, checked local indicator and run id match for the same CLI call
  - [x] Remote API server, checked local indicator and run id match for the same CLI call
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
