### PR TITLE
[core] Lazy import modules to reduce importing time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,19 @@
 Thank you for your interest in contributing to SkyPilot! We welcome and value
 all contributions to the project, including but not limited to:
 
-* [Bug reports](https://github.com/skypilot-org/skypilot/issues) and [discussions](https://github.com/skypilot-org/skypilot/discussions)
-* [Pull requests](https://github.com/skypilot-org/skypilot/pulls) for bug fixes and new features
-* Test cases to make the codebase more robust
-* Examples
-* Documentation
-* Tutorials, blog posts and talks on SkyPilot
+- [Bug reports](https://github.com/skypilot-org/skypilot/issues) and [discussions](https://github.com/skypilot-org/skypilot/discussions)
+- [Pull requests](https://github.com/skypilot-org/skypilot/pulls) for bug fixes and new features
+- Test cases to make the codebase more robust
+- Examples
+- Documentation
+- Tutorials, blog posts and talks on SkyPilot
 
 ## Contributing code
 
 We use GitHub to track issues and features. For new contributors, we recommend looking at issues labeled ["good first issue"](https://github.com/sky-proj/sky/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+).
 
 ### Installing SkyPilot for development
+
 ```bash
 # SkyPilot requires python >= 3.7.
 # You can just install the dependencies for
@@ -24,7 +25,9 @@ pip install -r requirements-dev.txt
 ```
 
 ### Testing
+
 To run smoke tests (NOTE: Running all smoke tests launches ~20 clusters):
+
 ```
 # Run all tests on AWS and Azure (default smoke test clouds)
 pytest tests/test_smoke.py
@@ -49,6 +52,7 @@ pytest tests/test_smoke.py --generic-cloud azure
 ```
 
 For profiling code, use:
+
 ```
 pip install py-spy # py-spy is a sampling profiler for Python programs
 py-spy record -t -o sky.svg -- python -m sky.cli status # Or some other command
@@ -57,6 +61,7 @@ py-spy -h # For more options
 ```
 
 #### Testing in a container
+
 It is often useful to test your changes in a clean environment set up from scratch. Using a container is a good way to do this.
 We have a dev container image `berkeleyskypilot/skypilot-debug` which we use for debugging skypilot inside a container. Use this image by running:
 
@@ -67,14 +72,16 @@ docker run --platform linux/amd64 -it --rm --name skypilot-debug berkeleyskypilo
 ```
 
 It has some convenience features which you might find helpful (see [Dockerfile](https://github.com/skypilot-org/skypilot/blob/dev/dockerfile_debug/Dockerfile_debug)):
-* Common dependencies and some utilities (rsync, screen, vim, nano etc) are pre-installed
-* requirements-dev.txt is pre-installed
-* Environment variables for dev/debug are set correctly
-* Automatically clones the latest master to `/sky_repo/skypilot` when the container is launched.
-  * Note that you still have to manually run `pip install -e ".[all]"` to install skypilot, it is not pre-installed.
-  * If your branch is on the SkyPilot repo, you can run `git checkout <your_branch>` to switch to your branch.
+
+- Common dependencies and some utilities (rsync, screen, vim, nano etc) are pre-installed
+- requirements-dev.txt is pre-installed
+- Environment variables for dev/debug are set correctly
+- Automatically clones the latest master to `/sky_repo/skypilot` when the container is launched.
+  - Note that you still have to manually run `pip install -e ".[all]"` to install skypilot, it is not pre-installed.
+  - If your branch is on the SkyPilot repo, you can run `git checkout <your_branch>` to switch to your branch.
 
 ### Submitting pull requests
+
 - Fork the SkyPilot repository and create a new branch for your changes.
 - If relevant, add tests for your changes. For changes that touch the core system, run the [smoke tests](#testing) and ensure they pass.
 - Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html).
@@ -87,16 +94,27 @@ It has some convenience features which you might find helpful (see [Dockerfile](
 
 These are suggestions, not strict rules to follow. When in doubt, follow the [style guide](https://google.github.io/styleguide/pyguide.html).
 
-* Use `TODO(author_name)`/`FIXME(author_name)` instead of blank `TODO/FIXME`. This is critical for tracking down issues. You can write TODOs with your name and assign it to others (on github) if it is someone else's issue.
-* Delete your branch after merging it. This keeps the repo clean and faster to sync.
-* Use an exception if this is an error. Only use `assert` for debugging or proof-checking purposes. This is because exception messages usually contain more information.
-* Use modern python features and styles that increases code quality.
-  * Use f-string instead of `.format()` for short expressions to increase readability.
-  * Use `class MyClass:` instead of `class MyClass(object):`. The later one was a workaround for python2.x.
-  * Use `abc` module for abstract classes to ensure all abstract methods are implemented.
-  * Use python typing. But you should not import external objects just for typing. Instead, import typing-only external objects under `if typing.TYPE_CHECKING:`.
+- Use `TODO(author_name)`/`FIXME(author_name)` instead of blank `TODO/FIXME`. This is critical for tracking down issues. You can write TODOs with your name and assign it to others (on github) if it is someone else's issue.
+- Delete your branch after merging it. This keeps the repo clean and faster to sync.
+- Use an exception if this is an error. Only use `assert` for debugging or proof-checking purposes. This is because exception messages usually contain more information.
+- Use [`LazyImport`](https://github.com/skypilot-org/skypilot/blob/master/sky/adaptors/common.py) for third-party modules that meet these criteria:
+  - The module is imported during `import sky`
+  - The module has a significant import time (e.g. > 100ms)
+- To measure import time:
+  - Basic check: `python -X importtime -c "import sky"`
+  - Detailed visualization: use [`tuna`](https://github.com/nschloe/tuna) to analyze import time:
+    ```bash
+    python -X importtime -c "import sky" 2> import.log
+    tuna import.log
+    ```
+- Use modern python features and styles that increases code quality.
+  - Use f-string instead of `.format()` for short expressions to increase readability.
+  - Use `class MyClass:` instead of `class MyClass(object):`. The later one was a workaround for python2.x.
+  - Use `abc` module for abstract classes to ensure all abstract methods are implemented.
+  - Use python typing. But you should not import external objects just for typing. Instead, import typing-only external objects under `if typing.TYPE_CHECKING:`.
 
 ### Environment variables for developers
+
 - `export SKYPILOT_DISABLE_USAGE_COLLECTION=1` to disable usage logging.
 - `export SKYPILOT_DEBUG=1` to show debugging logs (use logging.DEBUG level).
 - `export SKYPILOT_MINIMIZE_LOGGING=1` to minimize logging. Useful when trying to avoid multiple lines of output, such as for demos.

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -6,18 +6,19 @@ from typing import Any, Callable, Optional, Tuple
 
 
 class LazyImport:
-    """Lazy importer for heavy 3rd party modules or cloud modules
-       only when enabled.
+    """Lazy importer for modules.
 
-    We use this for heavy 3rd party modules as they can be time-consuming to
-    import, for example, numpy(700+ms), pendulum(500+ms), cryptography(500+ms),
-    pandas(200+ms), and networkx(100+ms), etc. With this class, we can avoid the
-    unnecessary import time when the module is not used (e.g., `networkx` should
-    not be imported for `sky status` and `pandas` should not be imported for
-    `sky exec`).
+    This is mainly used in two cases:
+    1. Heavy 3rd party modules: They can be time-consuming to import
+    and not necessary for all `sky` imports, e.g., numpy(700+ms),
+    pendulum(500+ms), cryptography(500+ms), pandas(200+ms), and
+    networkx(100+ms), etc. With this class, we can avoid the
+    unnecessary import time when the module is not used (e.g.,
+    `networkx` should not be imported for `sky status` and `pandas`
+    should not be imported for `sky exec`).
 
-    We also use this for cloud adaptors, because we do not want to import the
-    cloud dependencies when it is not enabled.
+    2. Cloud modules in cloud adaptors: cloud dependencies are only required
+    when a cloud is enabled, so we only import them when actually needed.
     """
 
     def __init__(self,

--- a/sky/adaptors/common.py
+++ b/sky/adaptors/common.py
@@ -6,12 +6,15 @@ from typing import Any, Callable, Optional, Tuple
 
 
 class LazyImport:
-    """Lazy importer for heavy modules or cloud modules only when enabled.
+    """Lazy importer for heavy 3rd party modules or cloud modules
+       only when enabled.
 
-    We use this for pandas and networkx, as they can be time-consuming to import
-    (0.1-0.2 seconds). With this class, we can avoid the unnecessary import time
-    when the module is not used (e.g., `networkx` should not be imported for
-    `sky status and `pandas` should not be imported for `sky exec`).
+    We use this for heavy 3rd party modules as they can be time-consuming to
+    import, for example, numpy(700+ms), pendulum(500+ms), cryptography(500+ms),
+    pandas(200+ms), and networkx(100+ms), etc. With this class, we can avoid the
+    unnecessary import time when the module is not used (e.g., `networkx` should
+    not be imported for `sky status` and `pandas` should not be imported for
+    `sky exec`).
 
     We also use this for cloud adaptors, because we do not want to import the
     cloud dependencies when it is not enabled.

--- a/sky/adaptors/ibm.py
+++ b/sky/adaptors/ibm.py
@@ -6,9 +6,6 @@ import json
 import multiprocessing
 import os
 
-import requests
-import yaml
-
 from sky import sky_logging
 from sky.adaptors import common
 
@@ -27,6 +24,9 @@ ibm_boto3 = common.LazyImport('ibm_boto3',
                               import_error_message=_IMPORT_ERROR_MESSAGE)
 ibm_botocore = common.LazyImport('ibm_botocore',
                                  import_error_message=_IMPORT_ERROR_MESSAGE)
+requests = common.LazyImport('requests',
+                             import_error_message=_IMPORT_ERROR_MESSAGE)
+yaml = common.LazyImport('yaml', import_error_message=_IMPORT_ERROR_MESSAGE)
 
 
 def read_credential_file():

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -86,12 +86,10 @@ def get_ssh_key_and_lock_path() -> Tuple[str, str, str]:
 
 
 def _generate_rsa_key_pair() -> Tuple[str, str]:
-    from cryptography.hazmat.backends import (
-        default_backend)  # pylint: disable=import-outside-toplevel
-    from cryptography.hazmat.primitives import (
-        serialization)  # pylint: disable=import-outside-toplevel
-    from cryptography.hazmat.primitives.asymmetric import (
-        rsa)  # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
 
     key = rsa.generate_private_key(backend=default_backend(),
                                    public_exponent=65537,

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -85,6 +85,8 @@ def get_ssh_key_and_lock_path() -> Tuple[str, str, str]:
 
 
 def _generate_rsa_key_pair() -> Tuple[str, str]:
+    # Keep the import of the cryptography local to avoid expensive
+    # third-party imports when not needed.
     # pylint: disable=import-outside-toplevel
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import serialization

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, Tuple
 import uuid
 
 import colorama
+import filelock
 
 from sky import clouds
 from sky import sky_logging
@@ -65,10 +66,8 @@ MAX_TRIALS = 64
 _SSH_KEY_PATH_PREFIX = '~/.sky/clients/{user_hash}/ssh'
 
 if typing.TYPE_CHECKING:
-    import filelock
     import yaml
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     yaml = adaptors_common.LazyImport('yaml')
 
 

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -65,17 +65,9 @@ MAX_TRIALS = 64
 _SSH_KEY_PATH_PREFIX = '~/.sky/clients/{user_hash}/ssh'
 
 if typing.TYPE_CHECKING:
-    from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import rsa
     import filelock
     import yaml
 else:
-    # Lazy load cryptography modules
-    default_backend = adaptors_common.LazyImport('cryptography.hazmat.backends')
-    serialization = adaptors_common.LazyImport('cryptography.hazmat.primitives')
-    rsa = adaptors_common.LazyImport(
-        'cryptography.hazmat.primitives.asymmetric')
     filelock = adaptors_common.LazyImport('filelock')
     yaml = adaptors_common.LazyImport('yaml')
 
@@ -94,6 +86,13 @@ def get_ssh_key_and_lock_path() -> Tuple[str, str, str]:
 
 
 def _generate_rsa_key_pair() -> Tuple[str, str]:
+    from cryptography.hazmat.backends import (
+        default_backend)  # pylint: disable=import-outside-toplevel
+    from cryptography.hazmat.primitives import (
+        serialization)  # pylint: disable=import-outside-toplevel
+    from cryptography.hazmat.primitives.asymmetric import (
+        rsa)  # pylint: disable=import-outside-toplevel
+
     key = rsa.generate_private_key(backend=default_backend(),
                                    public_exponent=65537,
                                    key_size=2048)

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -25,19 +25,16 @@ import re
 import socket
 import subprocess
 import sys
+import typing
 from typing import Any, Dict, Tuple
 import uuid
 
 import colorama
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
-import filelock
-import yaml
 
 from sky import clouds
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import gcp
 from sky.adaptors import ibm
 from sky.adaptors import kubernetes
@@ -66,6 +63,21 @@ MAX_TRIALS = 64
 # because ssh key pair need to persist across API server restarts, while
 # the former dir is empheral.
 _SSH_KEY_PATH_PREFIX = '~/.sky/clients/{user_hash}/ssh'
+
+if typing.TYPE_CHECKING:
+    from cryptography.hazmat.backends import default_backend
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    import filelock
+    import yaml
+else:
+    # Lazy load cryptography modules
+    default_backend = adaptors_common.LazyImport('cryptography.hazmat.backends')
+    serialization = adaptors_common.LazyImport('cryptography.hazmat.primitives')
+    rsa = adaptors_common.LazyImport(
+        'cryptography.hazmat.primitives.asymmetric')
+    filelock = adaptors_common.LazyImport('filelock')
+    yaml = adaptors_common.LazyImport('yaml')
 
 
 def get_ssh_key_and_lock_path() -> Tuple[str, str, str]:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 import uuid
 
 import colorama
+import filelock
 from packaging import version
 from typing_extensions import Literal
 
@@ -51,7 +52,6 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    import filelock
     import requests
     from requests import adapters
     from requests.packages.urllib3.util import retry as retry_lib
@@ -64,7 +64,6 @@ if typing.TYPE_CHECKING:
     from sky.backends import local_docker_backend
 else:
     yaml = adaptors_common.LazyImport('yaml')
-    filelock = adaptors_common.LazyImport('filelock')
     requests = adaptors_common.LazyImport('requests')
     rich_progress = adaptors_common.LazyImport('rich.progress')
     adapters = adaptors_common.LazyImport('requests.adapters')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -17,14 +17,10 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 import uuid
 
 import colorama
-import filelock
 from packaging import version
-import requests
 from requests import adapters
 from requests.packages.urllib3.util import retry as retry_lib
-import rich.progress as rich_progress
 from typing_extensions import Literal
-import yaml
 
 import sky
 from sky import authentication as auth
@@ -36,6 +32,7 @@ from sky import global_user_state
 from sky import provision as provision_lib
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
@@ -56,10 +53,20 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import filelock
+    import requests
+    import rich.progress as rich_progress
+    import yaml
+
     from sky import resources as resources_lib
     from sky import task as task_lib
     from sky.backends import cloud_vm_ray_backend
     from sky.backends import local_docker_backend
+else:
+    yaml = adaptors_common.LazyImport('yaml')
+    filelock = adaptors_common.LazyImport('filelock')
+    requests = adaptors_common.LazyImport('requests')
+    rich_progress = adaptors_common.LazyImport('rich.progress')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -18,8 +18,6 @@ import uuid
 
 import colorama
 from packaging import version
-from requests import adapters
-from requests.packages.urllib3.util import retry as retry_lib
 from typing_extensions import Literal
 
 import sky
@@ -55,6 +53,8 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import filelock
     import requests
+    from requests import adapters
+    from requests.packages.urllib3.util import retry as retry_lib
     import rich.progress as rich_progress
     import yaml
 
@@ -67,6 +67,9 @@ else:
     filelock = adaptors_common.LazyImport('filelock')
     requests = adaptors_common.LazyImport('requests')
     rich_progress = adaptors_common.LazyImport('rich.progress')
+    adapters = adaptors_common.LazyImport('requests.adapters')
+    retry_lib = adaptors_common.LazyImport(
+        'requests.packages.urllib3.util.retry')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -14,10 +14,8 @@ from typing import Dict, Generator, Iterable
 import uuid
 import zipfile
 
-import httpx
-import requests
-
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.data import data_utils
 from sky.data import storage_utils
 from sky.server import common as server_common
@@ -29,8 +27,14 @@ from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import httpx
+    import requests
+
     import sky
     import sky.dag as dag_lib
+else:
+    httpx = adaptors_common.LazyImport('httpx')
+    requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -143,7 +147,7 @@ class FileChunkIterator:
 
 @dataclasses.dataclass
 class UploadChunkParams:
-    client: httpx.Client
+    client: 'httpx.Client'
     upload_id: str
     chunk_index: int
     total_chunks: int

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import colorama
+import filelock
 
 from sky import admin_policy
 from sky import backends
@@ -48,13 +49,11 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import io
 
-    import filelock
     import psutil
     import requests
 
     import sky
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     psutil = adaptors_common.LazyImport('psutil')
     requests = adaptors_common.LazyImport('requests')
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -21,15 +21,13 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import colorama
-import filelock
-import psutil
-import requests
 
 from sky import admin_policy
 from sky import backends
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
 from sky.server import common as server_common
 from sky.server.requests import payloads
@@ -50,14 +48,22 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import io
 
+    import filelock
+    import psutil
+    import requests
+
     import sky
+else:
+    filelock = adaptors_common.LazyImport('filelock')
+    psutil = adaptors_common.LazyImport('psutil')
+    requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
 logging.getLogger('httpx').setLevel(logging.CRITICAL)
 
 
 def stream_response(request_id: Optional[str],
-                    response: requests.Response,
+                    response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None) -> Any:
     """Streams the response to the console.
 

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -3,9 +3,8 @@ import os
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-import requests
-
 from sky import clouds
+from sky.adaptors import common as adaptors_common
 from sky.clouds import service_catalog
 from sky.provision.fluidstack import fluidstack_utils
 from sky.utils import registry
@@ -18,8 +17,12 @@ _CREDENTIAL_FILES = [
     fluidstack_utils.FLUIDSTACK_API_KEY_PATH
 ]
 if typing.TYPE_CHECKING:
+    import requests
+
     # Renaming to avoid shadowing variables.
     from sky import resources as resources_lib
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 
 @registry.CLOUD_REGISTRY.register

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -2,9 +2,8 @@
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-import requests
-
 from sky import clouds
+from sky.adaptors import common as adaptors_common
 from sky.clouds import service_catalog
 from sky.provision.lambda_cloud import lambda_utils
 from sky.utils import registry
@@ -12,8 +11,12 @@ from sky.utils import resources_utils
 from sky.utils import status_lib
 
 if typing.TYPE_CHECKING:
+    import requests
+
     # Renaming to avoid shadowing variables.
     from sky import resources as resources_lib
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 # Minimum set of files under ~/.lambda_cloud that grant Lambda Cloud access.
 _CREDENTIAL_FILES = [

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -3,16 +3,19 @@
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-import requests
-
 from sky import clouds
+from sky.adaptors import common as adaptors_common
 from sky.clouds import service_catalog
 from sky.provision.paperspace import utils
 from sky.utils import registry
 from sky.utils import resources_utils
 
 if typing.TYPE_CHECKING:
+    import requests
+
     from sky import resources as resources_lib
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 _CREDENTIAL_FILES = [
     # credential files for Paperspace,

--- a/sky/clouds/service_catalog/common.py
+++ b/sky/clouds/service_catalog/common.py
@@ -8,7 +8,6 @@ import typing
 from typing import Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import filelock
-import requests
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
@@ -21,8 +20,10 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import pandas as pd
+    import requests
 else:
     pd = adaptors_common.LazyImport('pandas')
+    requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/clouds/utils/scp_utils.py
+++ b/sky/clouds/utils/scp_utils.py
@@ -11,10 +11,16 @@ import json
 import logging
 import os
 import time
+import typing
 from typing import Any, Dict, List, Optional
 from urllib import parse
 
-import requests
+from sky.adaptors import common as adaptors_common
+
+if typing.TYPE_CHECKING:
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 CREDENTIALS_PATH = '~/.scp/scp_credential'
 API_ENDPOINT = 'https://openapi.samsungsdscloud.com'
@@ -98,7 +104,7 @@ class Metadata:
             return list(metadata.keys())
 
 
-def raise_scp_error(response: requests.Response) -> None:
+def raise_scp_error(response: 'requests.Response') -> None:
     """Raise SCPCloudError if appropriate. """
     status_code = response.status_code
     if status_code in (200, 202):

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -3,9 +3,8 @@ import subprocess
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
-import requests
-
 from sky import clouds
+from sky.adaptors import common as adaptors_common
 from sky.clouds import service_catalog
 from sky.provision.vsphere import vsphere_utils
 from sky.provision.vsphere.vsphere_utils import get_vsphere_credentials
@@ -15,8 +14,12 @@ from sky.utils import registry
 from sky.utils import resources_utils
 
 if typing.TYPE_CHECKING:
+    import requests
+
     # Renaming to avoid shadowing variables.
     from sky import resources as resources_lib
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 _CLOUD_VSPHERE = 'vsphere'
 _CREDENTIAL_FILES = [

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -5,9 +5,9 @@ from typing import Dict, List, Optional, Union
 import webbrowser
 
 import click
-import requests
 
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
 from sky.client import sdk
 from sky.server import common as server_common
@@ -20,7 +20,11 @@ from sky.utils import dag_utils
 if typing.TYPE_CHECKING:
     import io
 
+    import requests
+
     import sky
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -41,16 +41,22 @@ import contextlib
 from functools import lru_cache
 import os
 import time
-
-import filelock
-import psutil
+import typing
 
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import state
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import subprocess_utils
+
+if typing.TYPE_CHECKING:
+    import filelock
+    import psutil
+else:
+    filelock = adaptors_common.LazyImport('filelock')
+    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger('sky.jobs.controller')
 

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -43,6 +43,8 @@ import os
 import time
 import typing
 
+import filelock
+
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.jobs import constants as managed_job_constants
@@ -52,10 +54,8 @@ from sky.utils import common_utils
 from sky.utils import subprocess_utils
 
 if typing.TYPE_CHECKING:
-    import filelock
     import psutil
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger('sky.jobs.controller')

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -16,14 +16,13 @@ import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import colorama
-import filelock
-import psutil
 from typing_extensions import Literal
 
 from sky import backends
 from sky import exceptions
 from sky import global_user_state
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.backends import backend_utils
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import scheduler
@@ -40,8 +39,14 @@ from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import filelock
+    import psutil
+
     import sky
     from sky import dag as dag_lib
+else:
+    filelock = adaptors_common.LazyImport('filelock')
+    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -16,6 +16,7 @@ import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import colorama
+import filelock
 from typing_extensions import Literal
 
 from sky import backends
@@ -39,13 +40,11 @@ from sky.utils import subprocess_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    import filelock
     import psutil
 
     import sky
     from sky import dag as dag_lib
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -6,7 +6,6 @@ import typing
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import colorama
-import numpy as np
 import prettytable
 
 from sky import check as sky_check
@@ -28,10 +27,12 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import networkx as nx
+    import numpy as np
 
     from sky import dag as dag_lib
 else:
     nx = adaptors_common.LazyImport('networkx')
+    np = adaptors_common.LazyImport('numpy')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/fluidstack/fluidstack_utils.py
+++ b/sky/provision/fluidstack/fluidstack_utils.py
@@ -3,12 +3,17 @@
 import json
 import os
 import time
+import typing
 from typing import Any, Dict, List
 import uuid
 
-import requests
-
+from sky.adaptors import common as adaptors_common
 from sky.utils import annotations
+
+if typing.TYPE_CHECKING:
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 
 def get_key_suffix():

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -3,15 +3,20 @@ import copy
 import logging
 import math
 import os
+import typing
 from typing import Any, Dict, Optional, Union
 
-import yaml
-
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import kubernetes
 from sky.provision import common
 from sky.provision.kubernetes import network_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import kubernetes_enums
+
+if typing.TYPE_CHECKING:
+    import yaml
+else:
+    yaml = adaptors_common.LazyImport('yaml')
 
 logger = logging.getLogger(__name__)
 

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -1,19 +1,25 @@
 """Kubernetes network provisioning utils."""
 import os
 import time
+import typing
 from typing import Dict, List, Optional, Tuple, Union
-
-import jinja2
-import yaml
 
 import sky
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import kubernetes
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import kubernetes_enums
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import jinja2
+    import yaml
+else:
+    jinja2 = adaptors_common.LazyImport('jinja2')
+    yaml = adaptors_common.LazyImport('yaml')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -12,15 +12,13 @@ import typing
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
 
-import jinja2
-import yaml
-
 import sky
 from sky import clouds
 from sky import exceptions
 from sky import models
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import gcp
 from sky.adaptors import kubernetes
 from sky.provision import constants as provision_constants
@@ -38,8 +36,14 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import jinja2
+    import yaml
+
     from sky import backends
     from sky import resources as resources_lib
+else:
+    jinja2 = adaptors_common.LazyImport('jinja2')
+    yaml = adaptors_common.LazyImport('yaml')
 
 # TODO(romilb): Move constants to constants.py
 DEFAULT_NAMESPACE = 'default'

--- a/sky/provision/paperspace/utils.py
+++ b/sky/provision/paperspace/utils.py
@@ -3,13 +3,18 @@
 import json
 import os
 import time
+import typing
 from typing import Any, Dict, List, Optional, Union
 
-import requests
-
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 import sky.provision.paperspace.constants as constants
 from sky.utils import common_utils
+
+if typing.TYPE_CHECKING:
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 logger = sky_logging.init_logger(__name__)
 
@@ -25,7 +30,7 @@ class PaperspaceCloudError(Exception):
     pass
 
 
-def raise_paperspace_api_error(response: requests.Response) -> None:
+def raise_paperspace_api_error(response: 'requests.Response') -> None:
     """Raise PaperspaceCloudError if appropriate."""
     status_code = response.status_code
     if status_code == 200:

--- a/sky/provision/vsphere/common/ssl_helper.py
+++ b/sky/provision/vsphere/common/ssl_helper.py
@@ -1,16 +1,14 @@
 """SSL Helper
 """
+import ssl
 import typing
 
 from sky.adaptors import common as adaptors_common
 
 if typing.TYPE_CHECKING:
-    import ssl
-
     import requests
 else:
     requests = adaptors_common.LazyImport('requests')
-    ssl = adaptors_common.LazyImport('ssl')
 
 
 def get_unverified_context():

--- a/sky/provision/vsphere/common/ssl_helper.py
+++ b/sky/provision/vsphere/common/ssl_helper.py
@@ -1,9 +1,16 @@
 """SSL Helper
 """
+import typing
 
-import ssl
+from sky.adaptors import common as adaptors_common
 
-import requests
+if typing.TYPE_CHECKING:
+    import ssl
+
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
+    ssl = adaptors_common.LazyImport('ssl')
 
 
 def get_unverified_context():

--- a/sky/provision/vsphere/common/vapiconnect.py
+++ b/sky/provision/vsphere/common/vapiconnect.py
@@ -1,10 +1,17 @@
 """Vapi Connect
 """
 
-import requests
+import typing
+
 from urllib3.exceptions import InsecureRequestWarning
 
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import vsphere as vsphere_adaptor
+
+if typing.TYPE_CHECKING:
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 
 def get_jsonrpc_endpoint_url(host):

--- a/sky/provision/vsphere/vsphere_utils.py
+++ b/sky/provision/vsphere/vsphere_utils.py
@@ -3,12 +3,12 @@
 import http.cookies as http_cookies
 import os
 import ssl
+import typing
 from typing import Any, Dict, List, Optional
-
-import yaml
 
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.adaptors import vsphere as vsphere_adaptor
 from sky.clouds.service_catalog import vsphere_catalog
 from sky.clouds.service_catalog.common import get_catalog_path
@@ -32,6 +32,11 @@ from sky.provision.vsphere.common.vim_utils import create_spec_with_script
 from sky.provision.vsphere.common.vim_utils import poweron_vm
 from sky.provision.vsphere.common.vim_utils import wait_for_tasks
 from sky.provision.vsphere.common.vim_utils import wait_internal_ip_ready
+
+if typing.TYPE_CHECKING:
+    import yaml
+else:
+    yaml = adaptors_common.LazyImport('yaml')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -4,8 +4,8 @@ import typing
 from typing import List, Optional, Union
 
 import click
-import requests
 
+from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
 from sky.server import common as server_common
 from sky.server.requests import payloads
@@ -15,8 +15,12 @@ from sky.utils import dag_utils
 if typing.TYPE_CHECKING:
     import io
 
+    import requests
+
     import sky
     from sky.serve import serve_utils
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 
 @usage_lib.entrypoint

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -26,6 +26,7 @@ from sky.serve import constants
 from sky.serve import serve_state
 from sky.skylet import constants as skylet_constants
 from sky.skylet import job_lib
+from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import log_utils
 from sky.utils import message_utils
@@ -47,26 +48,11 @@ else:
     requests = adaptors_common.LazyImport('requests')
 
 
-def _get_system_memory_gb():
-    """Get system memory in GB."""
-    return psutil.virtual_memory().total // (1024**3)
-
-
-def _get_num_service_threshold():
-    """Get number of services threshold based on available memory."""
-    return _get_system_memory_gb() // constants.CONTROLLER_MEMORY_USAGE_GB
-
-
-# Only calculate these when actually needed
-_num_service_threshold = None
-
-
+@annotations.lru_cache(scope='request')
 def get_num_service_threshold():
     """Get number of services threshold, calculating it only when needed."""
-    global _num_service_threshold
-    if _num_service_threshold is None:
-        _num_service_threshold = _get_num_service_threshold()
-    return _num_service_threshold
+    system_memory_gb = psutil.virtual_memory().total // (1024**3)
+    return system_memory_gb // constants.CONTROLLER_MEMORY_USAGE_GB
 
 
 _CONTROLLER_URL = 'http://localhost:{CONTROLLER_PORT}'

--- a/sky/serve/serve_utils.py
+++ b/sky/serve/serve_utils.py
@@ -17,6 +17,7 @@ from typing import (Any, Callable, DefaultDict, Dict, Generic, Iterator, List,
 import uuid
 
 import colorama
+import filelock
 
 from sky import backends
 from sky import exceptions
@@ -36,14 +37,11 @@ from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
     import fastapi
-    import filelock
     import psutil
     import requests
 
     from sky.serve import replica_managers
 else:
-    fastapi = adaptors_common.LazyImport('fastapi')
-    filelock = adaptors_common.LazyImport('filelock')
     psutil = adaptors_common.LazyImport('psutil')
     requests = adaptors_common.LazyImport('requests')
 

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -147,7 +147,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     # Already checked before submit to controller.
     assert task.service is not None, task
     service_spec = task.service
-    if len(serve_state.get_services()) >= serve_utils.NUM_SERVICE_THRESHOLD:
+    if len(serve_state.get_services()) >= serve_utils.get_num_service_threshold(
+    ):
         cleanup_storage(tmp_task_yaml)
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError('Max number of services reached.')

--- a/sky/serve/service.py
+++ b/sky/serve/service.py
@@ -147,8 +147,8 @@ def _start(service_name: str, tmp_task_yaml: str, job_id: int):
     # Already checked before submit to controller.
     assert task.service is not None, task
     service_spec = task.service
-    if len(serve_state.get_services()) >= serve_utils.get_num_service_threshold(
-    ):
+    if (len(serve_state.get_services()) >=
+            serve_utils.get_num_service_threshold()):
         cleanup_storage(tmp_task_yaml)
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError('Max number of services reached.')

--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -2,17 +2,22 @@
 import json
 import os
 import textwrap
+import typing
 from typing import Any, Dict, List, Optional
 
-import yaml
-
 from sky import serve
+from sky.adaptors import common as adaptors_common
 from sky.serve import constants
 from sky.serve import load_balancing_policies as lb_policies
 from sky.serve import serve_utils
 from sky.utils import common_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import yaml
+else:
+    yaml = adaptors_common.LazyImport('yaml')
 
 
 class SkyServiceSpec:

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -14,13 +14,11 @@ from typing import Any, Dict, Optional
 import uuid
 
 import colorama
-import filelock
-import pydantic
-import requests
 
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.data import data_utils
 from sky.server import constants as server_constants
 from sky.skylet import constants
@@ -31,7 +29,15 @@ from sky.utils import rich_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import filelock
+    import pydantic
+    import requests
+
     from sky import dag as dag_lib
+else:
+    filelock = adaptors_common.LazyImport('filelock')
+    pydantic = adaptors_common.LazyImport('pydantic')
+    requests = adaptors_common.LazyImport('requests')
 
 DEFAULT_SERVER_URL = 'http://127.0.0.1:46580'
 AVAILBLE_LOCAL_API_SERVER_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1']
@@ -155,7 +161,7 @@ def handle_request_error(response: requests.Response) -> None:
                 f'{response.text}')
 
 
-def get_request_id(response: requests.Response) -> RequestId:
+def get_request_id(response: 'requests.Response') -> RequestId:
     handle_request_error(response)
     request_id = response.headers.get('X-Request-ID')
     if request_id is None:
@@ -398,7 +404,7 @@ def api_server_user_logs_dir_prefix(
     return API_SERVER_CLIENT_DIR / user_hash / 'sky_logs'
 
 
-def request_body_to_params(body: pydantic.BaseModel) -> Dict[str, Any]:
+def request_body_to_params(body: 'pydantic.BaseModel') -> Dict[str, Any]:
     return {
         k: v for k, v in body.model_dump(mode='json').items() if v is not None
     }

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -151,7 +151,7 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
     return ApiServerInfo(status=ApiServerStatus.UNHEALTHY, api_version=None)
 
 
-def handle_request_error(response: requests.Response) -> None:
+def handle_request_error(response: 'requests.Response') -> None:
     if response.status_code != 200:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 import uuid
 
 import colorama
+import filelock
 
 from sky import exceptions
 from sky import sky_logging
@@ -29,13 +30,11 @@ from sky.utils import rich_utils
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    import filelock
     import pydantic
     import requests
 
     from sky import dag as dag_lib
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     pydantic = adaptors_common.LazyImport('pydantic')
     requests = adaptors_common.LazyImport('requests')
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -8,14 +8,14 @@ payloads is that a user can find the default values in the Restful API docs.
 import getpass
 import json
 import os
+import typing
 from typing import Any, Dict, List, Optional, Tuple, Union
-
-import pydantic
 
 from sky import admin_policy
 from sky import serve
 from sky import sky_logging
 from sky import skypilot_config
+from sky.adaptors import common as adaptors_common
 from sky.server import common
 from sky.skylet import constants
 from sky.usage import constants as usage_constants
@@ -24,6 +24,11 @@ from sky.utils import annotations
 from sky.utils import common as common_lib
 from sky.utils import common_utils
 from sky.utils import registry
+
+if typing.TYPE_CHECKING:
+    import pydantic
+else:
+    pydantic = adaptors_common.LazyImport('pydantic')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -2,14 +2,19 @@
 import pickle
 import shlex
 import time
+import typing
 from typing import List, Optional
 
-import psutil
-
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import configs
 from sky.skylet import constants
 from sky.utils import message_utils
+
+if typing.TYPE_CHECKING:
+    import psutil
+else:
+    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -11,20 +11,27 @@ import shlex
 import signal
 import sqlite3
 import time
+import typing
 from typing import Any, Dict, List, Optional, Sequence
 
 import colorama
-import filelock
-import psutil
 
 from sky import global_user_state
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import db_utils
 from sky.utils import log_utils
 from sky.utils import message_utils
 from sky.utils import subprocess_utils
+
+if typing.TYPE_CHECKING:
+    import filelock
+    import psutil
+else:
+    filelock = adaptors_common.LazyImport('filelock')
+    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -15,6 +15,7 @@ import typing
 from typing import Any, Dict, List, Optional, Sequence
 
 import colorama
+import filelock
 
 from sky import global_user_state
 from sky import sky_logging
@@ -27,10 +28,8 @@ from sky.utils import message_utils
 from sky.utils import subprocess_utils
 
 if typing.TYPE_CHECKING:
-    import filelock
     import psutil
 else:
-    filelock = adaptors_common.LazyImport('filelock')
     psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -53,17 +53,22 @@ import copy
 import os
 import pprint
 import tempfile
+import typing
 from typing import Any, Dict, Iterator, Optional, Tuple
-
-import yaml
 
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import yaml
+else:
+    yaml = adaptors_common.LazyImport('yaml')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -9,12 +9,12 @@ from typing import (Any, Callable, Dict, Iterable, List, Optional, Set, Tuple,
                     Union)
 
 import colorama
-import yaml
 
 import sky
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 import sky.dag
 from sky.data import data_utils
 from sky.data import storage as storage_lib
@@ -26,7 +26,11 @@ from sky.utils import schemas
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    import yaml
+
     from sky import resources as resources_lib
+else:
+    yaml = adaptors_common.LazyImport('yaml')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -21,6 +21,7 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import inspect
 
+    import click
     import requests
 
     from sky import resources as resources_lib
@@ -31,6 +32,7 @@ else:
     # collection phase or skipped if user specifies no collection
     requests = adaptors_common.LazyImport('requests')
     inspect = adaptors_common.LazyImport('inspect')
+    click = adaptors_common.LazyImport('click')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -21,7 +21,6 @@ from sky.utils import ux_utils
 if typing.TYPE_CHECKING:
     import inspect
 
-    import click
     import requests
 
     from sky import resources as resources_lib
@@ -32,7 +31,6 @@ else:
     # collection phase or skipped if user specifies no collection
     requests = adaptors_common.LazyImport('requests')
     inspect = adaptors_common.LazyImport('inspect')
-    click = adaptors_common.LazyImport('click')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -13,21 +13,29 @@ import re
 import socket
 import sys
 import time
+import typing
 from typing import Any, Callable, Dict, List, Optional, Union
 import uuid
 
-import jinja2
-import jsonschema
-import psutil
-import yaml
-
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.usage import constants as usage_constants
 from sky.utils import annotations
 from sky.utils import ux_utils
 from sky.utils import validator
+
+if typing.TYPE_CHECKING:
+    import jinja2
+    import jsonschema
+    import psutil
+    import yaml
+else:
+    jinja2 = adaptors_common.LazyImport('jinja2')
+    jsonschema = adaptors_common.LazyImport('jsonschema')
+    psutil = adaptors_common.LazyImport('psutil')
+    yaml = adaptors_common.LazyImport('yaml')
 
 _USER_HASH_FILE = os.path.expanduser('~/.sky/user_hash')
 USER_HASH_LENGTH = 8
@@ -598,7 +606,7 @@ def validate_schema(obj, schema, err_msg_prefix='', skip_none=True):
         obj = {k: v for k, v in obj.items() if v is not None}
     err_msg = None
     try:
-        validator.SchemaValidator(schema).validate(obj)
+        validator.get_schema_validator()(schema).validate(obj)
     except jsonschema.ValidationError as e:
         if e.validator == 'additionalProperties':
             if tuple(e.schema_path) == ('properties', 'envs',

--- a/sky/utils/console_utils.py
+++ b/sky/utils/console_utils.py
@@ -1,0 +1,21 @@
+"""Utility functions for Console."""
+import typing
+
+from sky.adaptors import common as adaptors_common
+
+if typing.TYPE_CHECKING:
+    import rich.console as rich_console
+else:
+    rich_console = adaptors_common.LazyImport('rich.console')
+
+_console = None  # Lazy initialized console
+
+
+# Move global console to a function to avoid
+# importing rich console if not used
+def get_console():
+    """Get or create the rich console."""
+    global _console
+    if _console is None:
+        _console = rich_console.Console(soft_wrap=True)
+    return _console

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -6,6 +6,7 @@ import typing
 from typing import Callable, Iterator, List, Optional, TextIO, Type
 
 import colorama
+import prettytable
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
@@ -18,10 +19,8 @@ if typing.TYPE_CHECKING:
     # slow due to https://github.com/python-pendulum/pendulum/issues/808
     # FIXME(aylei): bump pendulum if it get fixed
     import pendulum
-    import prettytable
 else:
     pendulum = adaptors_common.LazyImport('pendulum')
-    prettytable = adaptors_common.LazyImport('prettytable')
 
 
 class LineProcessor(object):

--- a/sky/utils/log_utils.py
+++ b/sky/utils/log_utils.py
@@ -2,19 +2,26 @@
 import enum
 import time
 import types
+import typing
 from typing import Callable, Iterator, List, Optional, TextIO, Type
 
 import colorama
-# slow due to https://github.com/python-pendulum/pendulum/issues/808
-# FIXME(aylei): bump pendulum if it get fixed
-import pendulum
-import prettytable
 
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.utils import rich_utils
 from sky.utils import ux_utils
 
 logger = sky_logging.init_logger(__name__)
+
+if typing.TYPE_CHECKING:
+    # slow due to https://github.com/python-pendulum/pendulum/issues/808
+    # FIXME(aylei): bump pendulum if it get fixed
+    import pendulum
+    import prettytable
+else:
+    pendulum = adaptors_common.LazyImport('pendulum')
+    prettytable = adaptors_common.LazyImport('prettytable')
 
 
 class LineProcessor(object):

--- a/sky/utils/rich_console_utils.py
+++ b/sky/utils/rich_console_utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for Console."""
+"""Utility functions for RichConsole."""
 import typing
 
 from sky.adaptors import common as adaptors_common

--- a/sky/utils/rich_console_utils.py
+++ b/sky/utils/rich_console_utils.py
@@ -1,4 +1,4 @@
-"""Utility functions for RichConsole."""
+"""Utility functions for rich console."""
 import typing
 
 from sky.adaptors import common as adaptors_common

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -8,8 +8,8 @@ from typing import Dict, Iterator, Optional, Tuple, Union
 
 from sky.adaptors import common as adaptors_common
 from sky.utils import annotations
-from sky.utils import console_utils
 from sky.utils import message_utils
+from sky.utils import rich_console_utils
 
 if typing.TYPE_CHECKING:
     import requests
@@ -222,7 +222,7 @@ def client_status(msg: str) -> Union['rich_console.Status', _NoOpConsoleStatus]:
     if (threading.current_thread() is threading.main_thread() and
             not sky_logging.is_silent()):
         if _statuses['client'] is None:
-            _statuses['client'] = console_utils.get_console().status(msg)
+            _statuses['client'] = rich_console_utils.get_console().status(msg)
         return _RevertibleStatus(msg, 'client')
     return _NoOpConsoleStatus()
 

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -8,6 +8,7 @@ from typing import Dict, Iterator, Optional, Tuple, Union
 
 from sky.adaptors import common as adaptors_common
 from sky.utils import annotations
+from sky.utils import console_utils
 from sky.utils import message_utils
 
 if typing.TYPE_CHECKING:
@@ -16,19 +17,6 @@ if typing.TYPE_CHECKING:
 else:
     requests = adaptors_common.LazyImport('requests')
     rich_console = adaptors_common.LazyImport('rich.console')
-
-_console = None  # Lazy initialized console
-
-
-# Move global console to a function to avoid
-# importing rich console if not used
-def get_console():
-    """Get or create the rich console."""
-    global _console
-    if _console is None:
-        _console = rich_console.Console(soft_wrap=True)
-    return _console
-
 
 _statuses: Dict[str, Optional[Union['EncodedStatus',
                                     'rich_console.Status']]] = {
@@ -234,7 +222,7 @@ def client_status(msg: str) -> Union['rich_console.Status', _NoOpConsoleStatus]:
     if (threading.current_thread() is threading.main_thread() and
             not sky_logging.is_silent()):
         if _statuses['client'] is None:
-            _statuses['client'] = get_console().status(msg)
+            _statuses['client'] = console_utils.get_console().status(msg)
         return _RevertibleStatus(msg, 'client')
     return _NoOpConsoleStatus()
 

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -6,15 +6,29 @@ import threading
 import typing
 from typing import Dict, Iterator, Optional, Tuple, Union
 
-import rich.console as rich_console
-
+from sky.adaptors import common as adaptors_common
 from sky.utils import annotations
 from sky.utils import message_utils
 
 if typing.TYPE_CHECKING:
     import requests
+    import rich.console as rich_console
+else:
+    requests = adaptors_common.LazyImport('requests')
+    rich_console = adaptors_common.LazyImport('rich.console')
 
-console = rich_console.Console(soft_wrap=True)
+_console = None  # Lazy initialized console
+
+
+# Move global console to a function
+def get_console():
+    """Get or create the rich console."""
+    global _console
+    if _console is None:
+        _console = rich_console.Console(soft_wrap=True)
+    return _console
+
+
 _statuses: Dict[str, Optional[Union['EncodedStatus',
                                     'rich_console.Status']]] = {
                                         'server': None,
@@ -219,7 +233,7 @@ def client_status(msg: str) -> Union['rich_console.Status', _NoOpConsoleStatus]:
     if (threading.current_thread() is threading.main_thread() and
             not sky_logging.is_silent()):
         if _statuses['client'] is None:
-            _statuses['client'] = console.status(msg)
+            _statuses['client'] = get_console().status(msg)
         return _RevertibleStatus(msg, 'client')
     return _NoOpConsoleStatus()
 

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -20,7 +20,8 @@ else:
 _console = None  # Lazy initialized console
 
 
-# Move global console to a function
+# Move global console to a function to avoid
+# importing rich console if not used
 def get_console():
     """Get or create the rich console."""
     global _console

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -8,18 +8,24 @@ import shlex
 import subprocess
 import threading
 import time
+import typing
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Union
 
 import colorama
-import psutil
 
 from sky import exceptions
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import timeline
 from sky.utils import ux_utils
+
+if typing.TYPE_CHECKING:
+    import psutil
+else:
+    psutil = adaptors_common.LazyImport('psutil')
 
 logger = sky_logging.init_logger(__name__)
 

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -10,16 +10,11 @@ import os
 import threading
 import time
 import traceback
-import typing
 from typing import Callable, Optional, Union
 
-from sky.adaptors import common as adaptors_common
-from sky.utils import common_utils
+import filelock
 
-if typing.TYPE_CHECKING:
-    import filelock
-else:
-    filelock = adaptors_common.LazyImport('filelock')
+from sky.utils import common_utils
 
 _events = []
 

--- a/sky/utils/timeline.py
+++ b/sky/utils/timeline.py
@@ -10,11 +10,16 @@ import os
 import threading
 import time
 import traceback
+import typing
 from typing import Callable, Optional, Union
 
-import filelock
-
+from sky.adaptors import common as adaptors_common
 from sky.utils import common_utils
+
+if typing.TYPE_CHECKING:
+    import filelock
+else:
+    filelock = adaptors_common.LazyImport('filelock')
 
 _events = []
 

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -8,16 +8,30 @@ import typing
 from typing import Callable, Optional, Union
 
 import colorama
-import rich.console as rich_console
 
 from sky import sky_logging
+from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
 
 if typing.TYPE_CHECKING:
     import pathlib
 
-console = rich_console.Console()
+    import rich.console as rich_console
+else:
+    rich_console = adaptors_common.LazyImport('rich.console')
+
+_console = None  # Lazy initialized console
+
+
+# Move global console to a function
+def get_console():
+    """Get or create the rich console."""
+    global _console
+    if _console is None:
+        _console = rich_console.Console()
+    return _console
+
 
 INDENT_SYMBOL = f'{colorama.Style.DIM}├── {colorama.Style.RESET_ALL}'
 INDENT_LAST_SYMBOL = f'{colorama.Style.DIM}└── {colorama.Style.RESET_ALL}'
@@ -40,7 +54,7 @@ def console_newline():
 
     Useful when catching exceptions inside console.status()
     """
-    console.print()
+    get_console().print()
 
 
 @contextlib.contextmanager

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -10,29 +10,12 @@ from typing import Callable, Optional, Union
 import colorama
 
 from sky import sky_logging
-from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import console_utils
 
 if typing.TYPE_CHECKING:
     import pathlib
-
-    import rich.console as rich_console
-else:
-    rich_console = adaptors_common.LazyImport('rich.console')
-
-_console = None  # Lazy initialized console
-
-
-# Move global console to a function to avoid
-# importing rich console if not used
-def get_console():
-    """Get or create the rich console."""
-    global _console
-    if _console is None:
-        _console = rich_console.Console()
-    return _console
-
 
 INDENT_SYMBOL = f'{colorama.Style.DIM}├── {colorama.Style.RESET_ALL}'
 INDENT_LAST_SYMBOL = f'{colorama.Style.DIM}└── {colorama.Style.RESET_ALL}'
@@ -55,7 +38,7 @@ def console_newline():
 
     Useful when catching exceptions inside console.status()
     """
-    get_console().print()
+    console_utils.get_console().print()
 
 
 @contextlib.contextmanager

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -12,7 +12,7 @@ import colorama
 from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import common_utils
-from sky.utils import console_utils
+from sky.utils import rich_console_utils
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -38,7 +38,7 @@ def console_newline():
 
     Useful when catching exceptions inside console.status()
     """
-    console_utils.get_console().print()
+    rich_console_utils.get_console().print()
 
 
 @contextlib.contextmanager

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -24,7 +24,8 @@ else:
 _console = None  # Lazy initialized console
 
 
-# Move global console to a function
+# Move global console to a function to avoid
+# importing rich console if not used
 def get_console():
     """Get or create the rich console."""
     global _console

--- a/sky/utils/validator.py
+++ b/sky/utils/validator.py
@@ -4,7 +4,14 @@ The main motivation behind extending the existing JSON Schema validator is to
 allow for case-insensitive enum matching since this is currently not supported
 by the JSON Schema specification.
 """
-import jsonschema
+import typing
+
+from sky.adaptors import common as adaptors_common
+
+if typing.TYPE_CHECKING:
+    import jsonschema
+else:
+    jsonschema = adaptors_common.LazyImport('jsonschema')
 
 
 def case_insensitive_enum(validator, enums, instance, schema):
@@ -14,6 +21,15 @@ def case_insensitive_enum(validator, enums, instance, schema):
             f'{instance!r} is not one of {enums!r}')
 
 
-SchemaValidator = jsonschema.validators.extend(
-    jsonschema.Draft7Validator,
-    validators={'case_insensitive_enum': case_insensitive_enum})
+# Move this to a function to delay initialization
+def get_schema_validator():
+    """Get the schema validator class, initializing it only when needed."""
+    return jsonschema.validators.extend(
+        jsonschema.Draft7Validator,
+        validators={'case_insensitive_enum': case_insensitive_enum})
+
+
+# Remove the global initialization
+# SchemaValidator = jsonschema.validators.extend(
+#     jsonschema.Draft7Validator,
+#     validators={'case_insensitive_enum': case_insensitive_enum})

--- a/sky/utils/validator.py
+++ b/sky/utils/validator.py
@@ -27,9 +27,3 @@ def get_schema_validator():
     return jsonschema.validators.extend(
         jsonschema.Draft7Validator,
         validators={'case_insensitive_enum': case_insensitive_enum})
-
-
-# Remove the global initialization
-# SchemaValidator = jsonschema.validators.extend(
-#     jsonschema.Draft7Validator,
-#     validators={'case_insensitive_enum': case_insensitive_enum})

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -21,7 +21,7 @@ def lazy_import_modules():
     ]
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_delete_modules(request, monkeypatch):
     """Fixture to mock delete modules."""
     # Get the lazy_import_modules fixture
@@ -43,7 +43,7 @@ def mock_delete_modules(request, monkeypatch):
     # monkeypatch automatically restores sys.modules after the test
 
 
-def test_sky_import(lazy_import_modules):
+def test_sky_import(lazy_import_modules, mock_delete_modules):
     # Import sky
     try:
         import sky

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -1,0 +1,93 @@
+"""Ensure the lazy import of modules is not reverted.
+
+This test ensures that the lazy import of modules is not reverted.
+"""
+import sys
+
+import pytest
+
+
+def test_sky_import():
+    # Clean modules that are lazy imported by sky
+    modules_to_clean = [
+        module for module in list(sys.modules.keys()) if any(
+            module.startswith(prefix) for prefix in [
+                'numpy',
+                'pendulum',
+                'cryptography',
+                'requests',
+                'jsonschema',
+                'psutil',
+                'jinja2',
+                'yaml',
+                'rich.console',
+                'rich.progress',
+                'networkx',
+                'httpx',
+                'pydantic',
+            ])
+    ]
+
+    for module in modules_to_clean:
+        del sys.modules[module]
+
+    # Import sky
+    try:
+        import sky
+    except Exception as e:
+        print(f"Failed to import sky: {e}")
+        raise
+
+    # Check that the lazy imported modules are not imported
+    assert 'requests.packages.urllib3.util.retry' not in sys.modules
+    assert 'requests.adapters' not in sys.modules
+    assert 'requests' not in sys.modules
+    assert 'yaml' not in sys.modules
+    assert 'cryptography.hazmat.backends' not in sys.modules
+    assert 'cryptography.hazmat.primitives' not in sys.modules
+    assert 'cryptography.hazmat.primitives.asymmetric' not in sys.modules
+    assert 'rich.progress' not in sys.modules
+    assert 'rich.console' not in sys.modules
+    assert 'httpx' not in sys.modules
+    assert 'psutil' not in sys.modules
+    assert 'networkx' not in sys.modules
+    assert 'numpy' not in sys.modules
+    assert 'jinja2' not in sys.modules
+    assert 'pydantic' not in sys.modules
+    assert 'jsonschema' not in sys.modules
+    assert 'pendulum' not in sys.modules
+
+    # Check that the lazy imported modules are imported after used
+    from sky.utils import console_utils
+    console_utils.get_console()
+    assert 'rich.console' in sys.modules
+
+    from sky.backends import backend_utils
+    backend_utils.check_network_connection()
+    assert 'requests.packages.urllib3.util.retry' in sys.modules
+    assert 'requests.adapters' in sys.modules
+    assert 'requests' in sys.modules
+
+    from sky.authentication import _generate_rsa_key_pair
+    _generate_rsa_key_pair()
+    assert 'cryptography.hazmat.backends' in sys.modules
+    assert 'cryptography.hazmat.primitives' in sys.modules
+    assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
+
+    from sky.optimizer import _is_dag_resources_ordered
+    _is_dag_resources_ordered(sky.Dag())
+    assert 'networkx' in sys.modules
+
+    from sky.provision.kubernetes import network_utils
+    network_utils.fill_loadbalancer_template('test', 'test', [80], 'test',
+                                             'test')
+    assert 'jinja2' in sys.modules
+    assert 'yaml' in sys.modules
+
+    from sky.utils import common_utils
+    common_utils.validate_schema({}, {})
+    assert 'jsonschema' in sys.modules
+
+    from sky.utils import log_utils
+    log_utils.readable_time_duration(1, 1)
+    assert 'pendulum' in sys.modules

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -8,7 +8,7 @@ import sys
 
 import pytest
 
-from sky.adaptors.common import LazyImport
+from sky.adaptors import common as adaptors_common
 
 
 @pytest.fixture
@@ -17,7 +17,8 @@ def lazy_import_modules():
     return [
         obj._module_name
         for obj in gc.get_objects()
-        if isinstance(obj, LazyImport) and hasattr(obj, '_module_name')
+        if isinstance(obj, adaptors_common.LazyImport) and
+        hasattr(obj, '_module_name')
     ]
 
 

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -2,35 +2,30 @@
 
 This test ensures that the lazy import of modules is not reverted.
 """
+import gc
 import sys
 
 import pytest
 
+lazy_import_modules = [
+    'requests.packages.urllib3.util.retry',
+    'requests.adapters',
+    'numpy',
+    'pendulum',
+    'requests',
+    'jsonschema',
+    'psutil',
+    'jinja2',
+    'yaml',
+    'rich.console',
+    'rich.progress',
+    'networkx',
+    'httpx',
+    'pydantic',
+]
+
 
 def test_sky_import():
-    # Clean modules that are lazy imported by sky
-    modules_to_clean = [
-        module for module in list(sys.modules.keys()) if any(
-            module.startswith(prefix) for prefix in [
-                'numpy',
-                'pendulum',
-                'cryptography',
-                'requests',
-                'jsonschema',
-                'psutil',
-                'jinja2',
-                'yaml',
-                'rich.console',
-                'rich.progress',
-                'networkx',
-                'httpx',
-                'pydantic',
-            ])
-    ]
-
-    for module in modules_to_clean:
-        del sys.modules[module]
-
     # Import sky
     try:
         import sky
@@ -38,69 +33,13 @@ def test_sky_import():
         print(f"Failed to import sky: {e}")
         raise
 
-    # Check that the lazy imported modules are not imported
-    assert 'requests.packages.urllib3.util.retry' not in sys.modules
-    assert 'requests.adapters' not in sys.modules
-    assert 'requests' not in sys.modules
-    assert 'yaml' not in sys.modules
-    assert 'cryptography.hazmat.backends' not in sys.modules
-    assert 'cryptography.hazmat.primitives' not in sys.modules
-    assert 'cryptography.hazmat.primitives.asymmetric' not in sys.modules
-    assert 'rich.progress' not in sys.modules
-    assert 'rich.console' not in sys.modules
-    assert 'httpx' not in sys.modules
-    assert 'psutil' not in sys.modules
-    assert 'networkx' not in sys.modules
-    assert 'numpy' not in sys.modules
-    assert 'jinja2' not in sys.modules
-    assert 'pydantic' not in sys.modules
-    assert 'jsonschema' not in sys.modules
-    assert 'pendulum' not in sys.modules
+    # Get the lazy imported modules
+    lazy_module_names = [
+        obj._module_name if hasattr(obj, '_module_name') else None
+        for obj in gc.get_objects()
+        if isinstance(obj, sky.adaptors.common.LazyImport)
+    ]
 
-    # Check that the lazy imported modules are imported after used
-    from sky.utils import console_utils
-    try:
-        console_utils.get_console()
-    except Exception as e:
-        print(f"Failed to get console: {e}")
-    assert 'rich.console' in sys.modules
-
-    from sky.backends import backend_utils
-    try:
-        backend_utils.check_network_connection()
-    except Exception as e:
-        print(f"Failed to check network connection: {e}")
-    assert 'requests.packages.urllib3.util.retry' in sys.modules
-    assert 'requests.adapters' in sys.modules
-    assert 'requests' in sys.modules
-
-    import sky.authentication as auth
-    try:
-        auth._generate_rsa_key_pair()
-    except Exception as e:
-        print(f"Failed to generate RSA key pair: {e}")
-    assert 'cryptography.hazmat.backends' in sys.modules
-    assert 'cryptography.hazmat.primitives' in sys.modules
-
-    from sky.optimizer import _is_dag_resources_ordered
-    try:
-        _is_dag_resources_ordered(sky.Dag())
-    except Exception as e:
-        print(f"Failed to check DAG resources ordered: {e}")
-    assert 'networkx' in sys.modules
-
-    from sky.provision.kubernetes import network_utils
-    try:
-        network_utils.fill_loadbalancer_template('test', 'test', [80], 'test',
-                                                 'test')
-    except Exception as e:
-        print(f"Failed to fill loadbalancer template: {e}")
-    assert 'jinja2' in sys.modules
-    assert 'yaml' in sys.modules
-
-    from sky.utils import log_utils
-    try:
-        log_utils.readable_time_duration(1, 1)
-    except Exception as e:
-        print(f"Failed to readable time duration: {e}")
-    assert 'pendulum' in sys.modules
+    # Check that the lazy imported modules are in the list
+    for module in lazy_import_modules:
+        assert module in lazy_module_names, f"Module {module} is not lazy imported"

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -74,14 +74,13 @@ def test_sky_import():
     assert 'requests.adapters' in sys.modules
     assert 'requests' in sys.modules
 
-    from sky.authentication import _generate_rsa_key_pair
+    import sky.authentication as auth
     try:
-        _generate_rsa_key_pair()
+        auth._generate_rsa_key_pair()
     except Exception as e:
         print(f"Failed to generate RSA key pair: {e}")
     assert 'cryptography.hazmat.backends' in sys.modules
     assert 'cryptography.hazmat.primitives' in sys.modules
-    assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
 
     from sky.optimizer import _is_dag_resources_ordered
     try:
@@ -98,13 +97,6 @@ def test_sky_import():
         print(f"Failed to fill loadbalancer template: {e}")
     assert 'jinja2' in sys.modules
     assert 'yaml' in sys.modules
-
-    from sky.utils import common_utils
-    try:
-        common_utils.validate_schema({}, {})
-    except Exception as e:
-        print(f"Failed to validate schema: {e}")
-    assert 'jsonschema' in sys.modules
 
     from sky.utils import log_utils
     try:

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -68,11 +68,15 @@ def test_sky_import():
     assert 'requests.adapters' in sys.modules
     assert 'requests' in sys.modules
 
-    from sky.authentication import _generate_rsa_key_pair
-    _generate_rsa_key_pair()
-    assert 'cryptography.hazmat.backends' in sys.modules
-    assert 'cryptography.hazmat.primitives' in sys.modules
-    assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
+    # Skip cryptography tests with Python < 3.9 for the error:
+    # ImportError: PyO3 modules compiled for CPython 3.8 or older
+    # may only be initialized once per interpreter process
+    if sys.version_info >= (3, 9):
+        from sky.authentication import _generate_rsa_key_pair
+        _generate_rsa_key_pair()
+        assert 'cryptography.hazmat.backends' in sys.modules
+        assert 'cryptography.hazmat.primitives' in sys.modules
+        assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
 
     from sky.optimizer import _is_dag_resources_ordered
     _is_dag_resources_ordered(sky.Dag())

--- a/tests/unit_tests/test_sky_import.py
+++ b/tests/unit_tests/test_sky_import.py
@@ -59,39 +59,56 @@ def test_sky_import():
 
     # Check that the lazy imported modules are imported after used
     from sky.utils import console_utils
-    console_utils.get_console()
+    try:
+        console_utils.get_console()
+    except Exception as e:
+        print(f"Failed to get console: {e}")
     assert 'rich.console' in sys.modules
 
     from sky.backends import backend_utils
-    backend_utils.check_network_connection()
+    try:
+        backend_utils.check_network_connection()
+    except Exception as e:
+        print(f"Failed to check network connection: {e}")
     assert 'requests.packages.urllib3.util.retry' in sys.modules
     assert 'requests.adapters' in sys.modules
     assert 'requests' in sys.modules
 
-    # Skip cryptography tests with Python < 3.9 for the error:
-    # ImportError: PyO3 modules compiled for CPython 3.8 or older
-    # may only be initialized once per interpreter process
-    if sys.version_info >= (3, 9):
-        from sky.authentication import _generate_rsa_key_pair
+    from sky.authentication import _generate_rsa_key_pair
+    try:
         _generate_rsa_key_pair()
-        assert 'cryptography.hazmat.backends' in sys.modules
-        assert 'cryptography.hazmat.primitives' in sys.modules
-        assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
+    except Exception as e:
+        print(f"Failed to generate RSA key pair: {e}")
+    assert 'cryptography.hazmat.backends' in sys.modules
+    assert 'cryptography.hazmat.primitives' in sys.modules
+    assert 'cryptography.hazmat.primitives.asymmetric' in sys.modules
 
     from sky.optimizer import _is_dag_resources_ordered
-    _is_dag_resources_ordered(sky.Dag())
+    try:
+        _is_dag_resources_ordered(sky.Dag())
+    except Exception as e:
+        print(f"Failed to check DAG resources ordered: {e}")
     assert 'networkx' in sys.modules
 
     from sky.provision.kubernetes import network_utils
-    network_utils.fill_loadbalancer_template('test', 'test', [80], 'test',
-                                             'test')
+    try:
+        network_utils.fill_loadbalancer_template('test', 'test', [80], 'test',
+                                                 'test')
+    except Exception as e:
+        print(f"Failed to fill loadbalancer template: {e}")
     assert 'jinja2' in sys.modules
     assert 'yaml' in sys.modules
 
     from sky.utils import common_utils
-    common_utils.validate_schema({}, {})
+    try:
+        common_utils.validate_schema({}, {})
+    except Exception as e:
+        print(f"Failed to validate schema: {e}")
     assert 'jsonschema' in sys.modules
 
     from sky.utils import log_utils
-    log_utils.readable_time_duration(1, 1)
+    try:
+        log_utils.readable_time_duration(1, 1)
+    except Exception as e:
+        print(f"Failed to readable time duration: {e}")
     assert 'pendulum' in sys.modules


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Part of #4678 

Improvements for the core operations:
- sky exec, mean time for 5 runs from 3.45s to 2.747s, about 20% faster
- sky launch on existing cluster, mean time for 5 runs from 14.901s to 13.08s, about 12% faster
- sky status, mean time for 5 runs from 2.426s to 2.157s, about 11% faster
- sky queue, mean time for 5 runs from 3.155s to 2.734s, about 13% faster

This PR only covers the third-party modules to import lazily, however, from the test result below, it still takes a long time to import the whole sky module.
So this needs to be improved further, e.g.:
- Lazy import of other unnecessary modules
- Split some core modules further to make the import more fine-grained


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (please check the separate comments below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
