### PR TITLE
Small fixes for a problem with newer versions of sqlite3

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -60,7 +60,7 @@ def create_table(cursor, conn):
         last_use TEXT,
         status TEXT,
         autostop INTEGER DEFAULT -1,
-        metadata TEXT DEFAULT "{}",
+        metadata TEXT DEFAULT '{}',
         to_down INTEGER DEFAULT 0,
         owner TEXT DEFAULT null,
         cluster_hash TEXT DEFAULT null,
@@ -118,7 +118,7 @@ def create_table(cursor, conn):
                                  'INTEGER DEFAULT -1')
 
     db_utils.add_column_to_table(cursor, conn, 'clusters', 'metadata',
-                                 'TEXT DEFAULT "{}"')
+                                 'TEXT DEFAULT \'{}\'')
 
     db_utils.add_column_to_table(cursor, conn, 'clusters', 'to_down',
                                  'INTEGER DEFAULT 0')
@@ -271,7 +271,7 @@ def add_or_update_cluster(cluster_name: str,
         # Keep the old metadata value if it exists, otherwise set it to
         # default {}.
         'COALESCE('
-        '(SELECT metadata FROM clusters WHERE name=?), "{}"),'
+        '(SELECT metadata FROM clusters WHERE name=?), \'{}\'),'
         # Keep the old owner value if it exists, otherwise set it to
         # default null.
         'COALESCE('


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes for a problem with newer versions of sqlite3 that might have SQLITE_DQS=0 setting enable, which disables the double-quoted string literal misfeature.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
