### PR TITLE
[K8s] Add netcat, socat check.

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -2,7 +2,6 @@
 import os
 import re
 import shutil
-import sys
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Removed socat manually,
```
» sky api stop; sky check k8s
SkyPilot API server stopped.
Failed to connect to SkyPilot API server at http://127.0.0.1:46580. Starting a local server.
✓ SkyPilot API server started.
Checking credentials to enable clouds for SkyPilot.
  Kubernetes: disabled
    Reason: The following dependencies are missing: socat.
    Please install them before proceeding. For example:
    • macOS:   brew install socat
    • Ubuntu:  sudo apt-get install socat
    • Other:   <use your OS package manager>

To enable a cloud, follow the hints above and rerun: sky check Kubernetes
If any problems remain, refer to detailed docs at: https://docs.skypilot.co/en/latest/getting-started/installation.html

🎉 Enabled clouds 🎉
  AWS
  Azure
  RunPod

Using SkyPilot API server: http://127.0.0.1:46580
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
