### PR TITLE
[jobs] catch NotSupportedError for `sky down --purge`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3004,7 +3004,7 @@ def _down_or_stop_clusters(
                     # with the termination.
                     hint_or_raise(controller_name, purge)
                 except (exceptions.ClusterOwnerIdentityMismatchError,
-                        RuntimeError) as e:
+                        exceptions.NotSupportedError, RuntimeError) as e:
                     if purge:
                         click.echo(common_utils.format_exception(e))
                     else:


### PR DESCRIPTION
Fixes #4626.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
