### PR TITLE
[API server] output all logs to stdout in helm deployment

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -52,7 +52,11 @@ spec:
           # Any local changes to the config.yaml file will be overwritten by the contents of the configmap.
           cp /tmp/config.yaml /root/.sky/config.yaml
           {{- end }}
-          sky api start --deploy && tail -f /root/.sky/api_server/server.log
+          if sky api start --deploy; then
+            tail -n+0 -f /root/.sky/api_server/server.log
+          else
+            cat /root/.sky/api_server/server.log
+          fi
         ports:
         - containerPort: 46580
         livenessProbe:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #4772 

follow up https://github.com/skypilot-org/skypilot/pull/4776#discussion_r1968820376

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] manually tested on kubernetes
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
