### PR TITLE
[API server] fix nodeport sevice selector

### DIFF
--- a/charts/skypilot/templates/ingress-nodeport.yaml
+++ b/charts/skypilot/templates/ingress-nodeport.yaml
@@ -21,6 +21,6 @@ spec:
       name: https
   selector:
     app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: skypilot
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/name: ingress-nginx
 {{- end}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/4815

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Manually test deployment in k8s
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
