### PR TITLE
[k8s] Surface kubeconfig errors to users

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional, Set
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
 from sky.utils import annotations
+from sky.utils import common_utils
 from sky.utils import ux_utils
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Kubernetes. '
@@ -68,20 +69,20 @@ def _load_config(context: Optional[str] = None):
         try:
             kubernetes.config.load_kube_config(context=context)
         except kubernetes.config.config_exception.ConfigException as e:
-            suffix = f' Error: {str(e)}'
+            suffix = common_utils.format_exception(e, use_bracket=True)
             # Check if exception was due to no current-context
             if 'Expected key current-context' in str(e):
                 err_str = (
                     f'Failed to load Kubernetes configuration for {context!r}. '
                     'Kubeconfig does not contain any valid context(s).'
-                    f'{suffix}\n'
+                    f'\n{suffix}\n'
                     '    If you were running a local Kubernetes '
                     'cluster, run `sky local up` to start the cluster.')
             else:
                 err_str = (
                     f'Failed to load Kubernetes configuration for {context!r}. '
                     'Please check if your kubeconfig file exists at '
-                    f'~/.kube/config and is valid.{suffix}')
+                    f'~/.kube/config and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(err_str) from None

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -69,9 +69,7 @@ def _load_config(context: Optional[str] = None):
         try:
             kubernetes.config.load_kube_config(context=context)
         except kubernetes.config.config_exception.ConfigException as e:
-            suffix = ''
-            if env_options.Options.SHOW_DEBUG_INFO.get():
-                suffix += f' Error: {str(e)}'
+            suffix = f' Error: {str(e)}'
             # Check if exception was due to no current-context
             if 'Expected key current-context' in str(e):
                 err_str = (

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Optional, Set
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
 from sky.utils import annotations
-from sky.utils import env_options
 from sky.utils import ux_utils
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Kubernetes. '


### PR DESCRIPTION
We now surface underlying kubeconfig errors directly to the user, even if they don't have debug flag set. This is important to help users debug issues themselves.