### PR TITLE
[Core] Exit with non-zero code on launch/exec/jobs launch

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1225,6 +1225,14 @@ def launch(
         # provided)
         if not detach_run and job_id is not None:
             sdk.tail_logs(handle.get_cluster_name(), job_id, follow=True)
+            
+            # Check job status and exit with non-zero code if job failed
+            job_statuses = sdk.stream_and_get(
+                sdk.job_status(handle.get_cluster_name(), [job_id]))
+            job_status = job_statuses.get(job_id)
+            if job_status is not None and job_status != job_lib.JobStatus.SUCCEEDED:
+                sys.exit(1)
+                
         click.secho(
             ux_utils.command_hint_messages(ux_utils.CommandHintType.CLUSTER_JOB,
                                            job_id, handle.get_cluster_name()))
@@ -3882,6 +3890,8 @@ def jobs_launch(
                                job_id=job_id,
                                follow=True,
                                controller=False)
+                               
+        # Check job status and exit with non-zero code if job failed
 
 
 @jobs.command('queue', cls=_DocumentedCodeCommand)


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/4599.

Blocked on https://github.com/skypilot-org/skypilot/issues/4817. 
Also we should maybe do a better fix by parsing tail_logs to get job status since queue in `jobs launch` may be quite large and adding an extra API call adds latency.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
