### PR TITLE
Weekly smoke tests trigger on Github action

### DIFF
--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -5,8 +5,8 @@ on:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
   workflow_dispatch:
   # uncomment this for PR triggers testing
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -1,8 +1,10 @@
 name: Weekly Smoke Tests Trigger
 
 on:
-  schedule:
-    - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+    schedule:
+      - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+    pull_request:  # Add this section for PR triggers
+      types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,15 +3,16 @@ name: Smoke Tests Trigger (Scheduled and PR)
 on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # uncomment this for PR triggers testing
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cloud: [aws]
+        cloud: [aws, azure, gcp, kubernetes]
     steps:
       - name: Trigger Smoke Tests (${{ matrix.cloud }})
         env:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -24,6 +24,7 @@ jobs:
               "commit": "HEAD",
               "branch": "master",
               "message": "Weekly Smoke Tests on (${{ matrix.cloud }})",
+              "ignore_pipeline_branch_filters": true,
               "env": {
                 "ARGS": "--${{ matrix.cloud }}"
               }

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -2,11 +2,11 @@ name: Smoke Tests Trigger
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+    - cron: '0 0 1,15 * *'  # Runs at 00:00 on the 1st and 15th of each month (UTC)
   workflow_dispatch: {}
   # uncomment this for PR triggers testing
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:
@@ -22,7 +22,7 @@ jobs:
             -d '{
               "commit": "HEAD",
               "branch": "master",
-              "message": "Weekly Smoke Tests",
+              "message": "Biweekly Smoke Tests",
               "ignore_pipeline_branch_filters": true
             }')
 

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -20,8 +20,8 @@ jobs:
             -X POST "$BUILDKITE_API_URL" \
             -d '{
               "commit": "HEAD",
-              "branch": "main",
-              "message": "Weekly Smoke Tests (${{ matrix.cloud }})",
+              "branch": "master",
+              "message": "Weekly Smoke Tests on (${{ matrix.cloud }})",
               "env": {
                 "ARGS": "--${{ matrix.cloud }}"
               }

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -1,0 +1,28 @@
+name: Weekly Smoke Tests Trigger
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+
+jobs:
+  smoke-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cloud: [aws, azure, gcp, kubernetes]
+    steps:
+      - name: Trigger Smoke Tests (${{ matrix.cloud }})
+        env:
+          BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+          BUILDKITE_API_URL: "https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/smoke-tests/builds"
+        run: |
+          curl -H "Authorization: Bearer $BUILDKITE_TOKEN" \
+            -X POST "$BUILDKITE_API_URL" \
+            -d '{
+              "commit": "HEAD",
+              "branch": "main",
+              "message": "Weekly Smoke Tests (${{ matrix.cloud }})",
+              "env": {
+                "ARGS": "--${{ matrix.cloud }}"
+              }
+            }'

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,6 +3,12 @@ name: Smoke Tests Trigger (Scheduled and PR)
 on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+  workflow_dispatch:
+    inputs:
+      clouds:
+        description: 'Comma-separated clouds to test (aws,azure,gcp,kubernetes)'
+        required: true
+        default: 'aws,azure,gcp,kubernetes'
   # uncomment this for PR triggers testing
   # pull_request:
   #   types: [opened, synchronize, reopened]

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,10 +3,10 @@ name: Smoke Tests Trigger
 on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
-  workflow_dispatch:
+  workflow_dispatch: {}
   # uncomment this for PR triggers testing
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,12 +3,7 @@ name: Smoke Tests Trigger (Scheduled and PR)
 on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
-  workflow_dispatch:
-    inputs:
-      clouds:
-        description: 'Comma-separated clouds to test (aws,azure,gcp,kubernetes)'
-        required: true
-        default: 'aws,azure,gcp,kubernetes'
+  workflow_dispatch: {}  # Explicit empty configuration
   # uncomment this for PR triggers testing
   # pull_request:
   #   types: [opened, synchronize, reopened]
@@ -16,25 +11,19 @@ on:
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cloud: [aws, azure, gcp, kubernetes]
     steps:
-      - name: Trigger Smoke Tests (${{ matrix.cloud }})
+      - name: Trigger Smoke Tests
         env:
           BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
-          BUILDKITE_API_URL: "https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/smoke-tests/builds"
+          BUILDKITE_API_URL: "https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/full-smoke-tests-run/builds"
         run: |
           response=$(curl -w "%{http_code}" -H "Authorization: Bearer $BUILDKITE_TOKEN" \
             -X POST "$BUILDKITE_API_URL" \
             -d '{
               "commit": "HEAD",
               "branch": "master",
-              "message": "Weekly Smoke Tests on (${{ matrix.cloud }})",
-              "ignore_pipeline_branch_filters": true,
-              "env": {
-                "ARGS": "--${{ matrix.cloud }}"
-              }
+              "message": "Weekly Smoke Tests",
+              "ignore_pipeline_branch_filters": true
             }')
 
           http_code=$(echo "$response" | tail -n 1)

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -5,8 +5,8 @@ on:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
   workflow_dispatch: {}  # Explicit empty configuration
   # uncomment this for PR triggers testing
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -1,24 +1,24 @@
-name: Weekly Smoke Tests Trigger
+name: Smoke Tests Trigger (Scheduled and PR)
 
 on:
-    schedule:
-      - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
-    pull_request:  # Add this section for PR triggers
-      types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cloud: [aws, azure, gcp, kubernetes]
+        cloud: [aws]
     steps:
       - name: Trigger Smoke Tests (${{ matrix.cloud }})
         env:
           BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
           BUILDKITE_API_URL: "https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/smoke-tests/builds"
         run: |
-          curl -H "Authorization: Bearer $BUILDKITE_TOKEN" \
+          response=$(curl -w "%{http_code}" -H "Authorization: Bearer $BUILDKITE_TOKEN" \
             -X POST "$BUILDKITE_API_URL" \
             -d '{
               "commit": "HEAD",
@@ -27,4 +27,16 @@ jobs:
               "env": {
                 "ARGS": "--${{ matrix.cloud }}"
               }
-            }'
+            }')
+
+          http_code=$(echo "$response" | tail -n 1)
+          response_body=$(echo "$response" | head -n -1)
+
+          if [ "$http_code" != "201" ]; then
+            echo "Error: Buildkite API returned HTTP status code $http_code"
+            echo "Response body:"
+            echo "$response_body"
+            exit 1
+          fi
+
+          echo "Build triggered successfully (HTTP status code: $http_code)"

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -5,8 +5,8 @@ on:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
   workflow_dispatch: {}  # Explicit empty configuration
   # uncomment this for PR triggers testing
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -5,8 +5,8 @@ on:
     - cron: '0 0 1,15 * *'  # Runs at 00:00 on the 1st and 15th of each month (UTC)
   workflow_dispatch: {}
   # uncomment this for PR triggers testing
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   smoke-tests:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -1,4 +1,4 @@
-name: Smoke Tests Trigger (Scheduled and PR)
+name: Smoke Tests Trigger
 
 on:
   schedule:

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,7 +3,7 @@ name: Smoke Tests Trigger
 on:
   schedule:
     - cron: '0 0 * * 0'  # Runs at 00:00 on Sunday (UTC)
-  workflow_dispatch: {}  # Explicit empty configuration
+  workflow_dispatch:
   # uncomment this for PR triggers testing
   # pull_request:
   #   types: [opened, synchronize, reopened]

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@
     <img alt="Downloads" src="https://img.shields.io/pypi/dm/skypilot">
   </a>
 
-  <a href="https://buildkite.com/skypilot-1/full-smoke-tests-run">
-    <img alt="Smoke Tests" src="https://badge.buildkite.com/d3aa9d2370e4a9ac4fb5e210381f955082a63a9a46673b197a.svg?theme=github&branch=master">
-  </a>
-
 </p>
 
 <h3 align="center">

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
   <a href="https://github.com/skypilot-org/skypilot/releases">
     <img alt="Downloads" src="https://img.shields.io/pypi/dm/skypilot">
   </a>
-  <br>
-  <a href="https://buildkite.com/skypilot-1/smoke-tests">
-    <img alt="Smoke Tests" src="https://badge.buildkite.com/1a20bd4a902acd70cd8c5ed4446634b151a62b9c06609744bb.svg?theme=github&branch=master">
+
+  <a href="https://buildkite.com/skypilot-1/full-smoke-tests-run">
+    <img alt="Smoke Tests" src="https://badge.buildkite.com/d3aa9d2370e4a9ac4fb5e210381f955082a63a9a46673b197a.svg?theme=github&branch=master">
   </a>
 
 </p>

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
   <a href="https://github.com/skypilot-org/skypilot/releases">
     <img alt="Downloads" src="https://img.shields.io/pypi/dm/skypilot">
   </a>
+  <br>
+  <a href="https://buildkite.com/skypilot-1/smoke-tests">
+    <img alt="Smoke Tests" src="https://badge.buildkite.com/1a20bd4a902acd70cd8c5ed4446634b151a62b9c06609744bb.svg?theme=github&branch=master">
+  </a>
 
 </p>
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Trigger smoke tests pipeline weekly, Add a new pipeline that will trigger the following commands in one single build:
    * `/smoke-test --aws`
    * `/smoke-test --gcp`
    * `/smoke-test --azure`
    * `/smoke-test --kubernetes`
  

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

* Tested on my personal [repo](https://github.com/zpoint/skypilot/pull/14), successfully triggered this [build](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/1)
* A `workflow_dispatch` trigger
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/25f321bd-64fe-4285-9d5e-4d16188ace1e" />
* Add badge on readme file
<img width="961" alt="image" src="https://github.com/user-attachments/assets/7ae4e6e0-5a39-4161-adb6-e5a25684254e" />

* Replacement of #4755 since external PR can not read secret from repo.
