### PR TITLE
[Core] Support ARM architecture

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -66,9 +66,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          # TODO: add support for linux/arm64 for M series Macs
-          # It currently fails due to the failure to install google-cloud-sdk
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: "${{ secrets.DOCKER_USERNAME }}/${{ inputs.package_name }}:latest,${{ secrets.DOCKER_USERNAME }}/${{ inputs.package_name }}:${{ steps.version.outputs.latest_version }}"
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
         pciutils nano fuse socat netcat-openbsd curl rsync vim tini && \
     rm -rf /var/lib/apt/lists/* && \
     # Install kubectl based on architecture
-    ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+    ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
         *) echo "$(uname -m)" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use the latest version with Python 3.10
 FROM continuumio/miniconda3:23.3.1-0
 
+# Detect architecture
+ARG TARGETPLATFORM="linux/amd64"
+ARG TARGETARCH
+
 # Install dependencies
 RUN conda install -c conda-forge google-cloud-sdk && \
     gcloud components install gke-gcloud-auth-plugin --quiet && \
@@ -11,8 +15,13 @@ RUN conda install -c conda-forge google-cloud-sdk && \
         git gcc rsync sudo patch openssh-server \
         pciutils nano fuse socat netcat-openbsd curl rsync vim tini && \
     rm -rf /var/lib/apt/lists/* && \
-    # Install kubectl
-    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl" && \
+    # Install kubectl based on architecture
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
+    else \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
+    fi && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl && \
     # Install uv and skypilot

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM continuumio/miniconda3:23.3.1-0
 
 # Detect architecture
-ARG TARGETPLATFORM="linux/amd64"
 ARG TARGETARCH
 
 # Install dependencies
@@ -16,12 +15,12 @@ RUN conda install -c conda-forge google-cloud-sdk && \
         pciutils nano fuse socat netcat-openbsd curl rsync vim tini && \
     rm -rf /var/lib/apt/lists/* && \
     # Install kubectl based on architecture
-    ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
-    else \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
-    fi && \
+    ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+        "x86_64") echo "amd64" ;; \
+        "aarch64") echo "arm64" ;; \
+        *) echo "$(uname -m)" ;; \
+    esac)} && \
+    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl && \
     # Install uv and skypilot

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -8,12 +8,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM="linux/amd64"
 ARG TARGETARCH
 
-# Initialize conda for root user and install packages in smaller batches to avoid QEMU segfaults on ARM
+# Initialize conda for root user, install ssh and other local dependencies
 RUN apt update -y && \
-    apt install -y git && \
-    apt install -y gcc rsync sudo patch && \
-    apt install -y openssh-server pciutils nano fuse && \
-    apt install -y socat netcat-openbsd curl unzip && \
+    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt remove -y python3 && \
     conda init

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -5,7 +5,6 @@ FROM continuumio/miniconda3:23.3.1-0
 
 ARG DEBIAN_FRONTEND=noninteractive
 # Detect architecture
-ARG TARGETPLATFORM="linux/amd64"
 ARG TARGETARCH
 
 # Initialize conda for root user, install ssh and other local dependencies
@@ -46,12 +45,12 @@ RUN conda init && \
     source ~/skypilot-runtime/bin/activate && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
-    else \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
-    fi && \
+    ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+        "x86_64") echo "amd64" ;; \
+        "aarch64") echo "arm64" ;; \
+        *) echo "$(uname -m)" ;; \
+    esac)} && \
+    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     chmod +x kubectl && \
     mkdir -p $HOME/.local/bin && \
     mv kubectl $HOME/.local/bin/ && \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -45,7 +45,7 @@ RUN conda init && \
     source ~/skypilot-runtime/bin/activate && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+    ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
         *) echo "$(uname -m)" ;; \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -8,9 +8,12 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM="linux/amd64"
 ARG TARGETARCH
 
-# Initialize conda for root user, install ssh and other local dependencies
+# Initialize conda for root user and install packages in smaller batches to avoid QEMU segfaults on ARM
 RUN apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl unzip -y && \
+    apt install -y git && \
+    apt install -y gcc rsync sudo patch && \
+    apt install -y openssh-server pciutils nano fuse && \
+    apt install -y socat netcat-openbsd curl unzip && \
     rm -rf /var/lib/apt/lists/* && \
     apt remove -y python3 && \
     conda init

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -31,7 +31,7 @@ RUN useradd -m -s /bin/bash sky && \
 USER sky
 
 # Set HOME environment variable for sky user
-ENV HOME /home/sky
+ENV HOME=/home/sky
 
 # Set current working directory
 WORKDIR /home/sky
@@ -45,7 +45,7 @@ RUN conda init && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $HOME/.local/bin/uv pip uninstall skypilot-nightly -y && \
+    $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -1,13 +1,16 @@
-FROM --platform=linux/amd64 continuumio/miniconda3:23.3.1-0
+FROM continuumio/miniconda3:23.3.1-0
 
 # TODO(romilb): Investigate if this image can be consolidated with the skypilot
 #  client image (`Dockerfile`)
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Detect architecture
+ARG TARGETPLATFORM="linux/amd64"
+ARG TARGETARCH
 
 # Initialize conda for root user, install ssh and other local dependencies
 RUN apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl -y && \
+    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl unzip -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt remove -y python3 && \
     conda init
@@ -33,14 +36,25 @@ ENV HOME /home/sky
 # Set current working directory
 WORKDIR /home/sky
 
+SHELL ["/bin/bash", "-c"]
+
 # Install skypilot dependencies
-RUN conda init && export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-    python3 -m venv ~/skypilot-runtime && \
-    PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
-    $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
-    curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl" && \
-    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+RUN conda init && \
+    export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
+    source ~/skypilot-runtime/bin/activate && \
+    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+    $HOME/.local/bin/uv pip uninstall skypilot-nightly -y && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
+    else \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
+    fi && \
+    chmod +x kubectl && \
+    mkdir -p $HOME/.local/bin && \
+    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -52,14 +52,15 @@ RUN ARCH=$(uname -m) && \
     conda init && \
     conda config --set auto_activate_base true && \
     export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
-    python3 -m venv ~/skypilot-runtime && \
-    PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
-    $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
+    source ~/skypilot-runtime/bin/activate && \
+    $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
+    $HOME/.local/bin/uv pip uninstall skypilot-nightly -y && \
     if [ "$ARCH" = "x86_64" ]; then \
-        curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl"; \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
     else \
-        curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/arm64/kubectl"; \
+        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
     fi && \
     sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -39,7 +39,7 @@ SHELL ["/bin/bash", "-c"]
 # Install conda and other dependencies based on architecture
 # Keep the conda and Ray versions below in sync with the ones in skylet.constants
 # Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
-RUN ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "x86_64") echo "amd64" ;; \
         "aarch64") echo "arm64" ;; \
         *) echo "$(uname -m)" ;; \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -1,6 +1,9 @@
 # We use the cuda runtime image instead of devel image to reduce size (1.3GB vs 3.6GB)
 FROM nvidia/cuda:12.1.1-runtime-ubuntu20.04
 
+# Detect architecture using ARG and ARG with default value, then extract architecture from platform
+ARG TARGETPLATFORM="linux/amd64"
+ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install ssh and other local dependencies
@@ -27,27 +30,37 @@ RUN sudo useradd -m -s /bin/bash sky && \
 USER sky
 
 # Set HOME environment variable for sky user
-ENV HOME /home/sky
+ENV HOME=/home/sky
 
 # Set current working directory
 WORKDIR /home/sky
 
 SHELL ["/bin/bash", "-c"]
 
-# Install conda and other dependencies
+# Install conda and other dependencies based on architecture
 # Keep the conda and Ray versions below in sync with the ones in skylet.constants
 # Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
-RUN curl https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o Miniconda3-Linux-x86_64.sh && \
-    bash Miniconda3-Linux-x86_64.sh -b && \
-    eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && conda config --set auto_activate_base true && conda activate base && \
-    grep "# >>> conda initialize >>>" ~/.bashrc || { conda init && source ~/.bashrc; } && \
-    rm Miniconda3-Linux-x86_64.sh && \
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
+    else \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+    fi && \
+    bash miniconda.sh -b -p $HOME/miniconda3 && \
+    rm miniconda.sh && \
+    eval "$($HOME/miniconda3/bin/conda shell.bash hook)" && \
+    conda init && \
+    conda config --set auto_activate_base true && \
     export PIP_DISABLE_PIP_VERSION_CHECK=1 && \
     python3 -m venv ~/skypilot-runtime && \
     PYTHON_EXEC=$(echo ~/skypilot-runtime)/bin/python && \
     $PYTHON_EXEC -m pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $PYTHON_EXEC -m pip uninstall skypilot-nightly -y && \
-    curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl" && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/amd64/kubectl"; \
+    else \
+        curl -LO "https://dl.k8s.io/release/v1.28.11/bin/linux/arm64/kubectl"; \
+    fi && \
     sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -56,7 +56,7 @@ RUN ARCH=$(uname -m) && \
     $HOME/.local/bin/uv venv ~/skypilot-runtime --seed --python=3.10 && \
     source ~/skypilot-runtime/bin/activate && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
-    $HOME/.local/bin/uv pip uninstall skypilot-nightly -y && \
+    $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
     if [ "$ARCH" = "x86_64" ]; then \
         curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
     else \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -1,8 +1,7 @@
 # We use the cuda runtime image instead of devel image to reduce size (1.3GB vs 3.6GB)
 FROM nvidia/cuda:12.1.1-runtime-ubuntu20.04
 
-# Detect architecture using ARG and ARG with default value, then extract architecture from platform
-ARG TARGETPLATFORM="linux/amd64"
+# Detect architecture using ARG with default value
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,8 +39,12 @@ SHELL ["/bin/bash", "-c"]
 # Install conda and other dependencies based on architecture
 # Keep the conda and Ray versions below in sync with the ones in skylet.constants
 # Keep this section in sync with the custom image optimization recommendations in our docs (kubernetes-getting-started.rst)
-RUN ARCH=$(uname -m) && \
-    if [ "$ARCH" = "x86_64" ]; then \
+RUN ARCH=$(TARGETARCH:-$(case "$(uname -m)" in \
+        "x86_64") echo "amd64" ;; \
+        "aarch64") echo "arm64" ;; \
+        *) echo "$(uname -m)" ;; \
+    esac)} && \
+    if [ "$ARCH" = "amd64" ]; then \
         curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
     else \
         curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
@@ -57,11 +60,7 @@ RUN ARCH=$(uname -m) && \
     source ~/skypilot-runtime/bin/activate && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
-    if [ "$ARCH" = "x86_64" ]; then \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl"; \
-    else \
-        curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
-    fi && \
+    curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     # Install kubectl to user's local bin instead of system path to avoid
     # sudo-related issues during cross-architecture builds, especially on ARM
     chmod +x kubectl && \

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -62,7 +62,11 @@ RUN ARCH=$(uname -m) && \
     else \
         curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/arm64/kubectl"; \
     fi && \
-    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    # Install kubectl to user's local bin instead of system path to avoid
+    # sudo-related issues during cross-architecture builds, especially on ARM
+    chmod +x kubectl && \
+    mkdir -p $HOME/.local/bin && \
+    mv kubectl $HOME/.local/bin/ && \
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -44,10 +44,10 @@ RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
         "aarch64") echo "arm64" ;; \
         *) echo "$(uname -m)" ;; \
     esac)} && \
-    if [ "$ARCH" = "amd64" ]; then \
-        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
-    else \
+    if [ "$ARCH" = "arm64" ]; then \
         curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-aarch64.sh -o miniconda.sh; \
+    else \
+        curl -fsSL https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o miniconda.sh; \
     fi && \
     bash miniconda.sh -b -p $HOME/miniconda3 && \
     rm miniconda.sh && \

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -75,7 +75,7 @@ Deploying SkyPilot
       IP_FILE=ips.txt
       SSH_USER=username
       SSH_KEY=path/to/ssh/key
-      sky local up --ips $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY
+      sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY
 
    SkyPilot will deploy a Kubernetes cluster on the remote machines, set up GPU support, configure Kubernetes credentials on your local machine, and set up SkyPilot to operate with the new cluster.
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1280,12 +1280,17 @@ def parallel_data_transfer_to_nodes(
                                             stream_logs=stream_logs,
                                             require_outputs=True,
                                             source_bashrc=source_bashrc)
-            err_msg = ('Failed to run command before rsync '
+            err_msg = (f'{colorama.Style.RESET_ALL}{colorama.Style.DIM}'
+                       f'----- CMD -----\n'
+                       f'{cmd}\n'
+                       f'----- CMD END -----\n'
+                       f'{colorama.Style.RESET_ALL}'
+                       f'{colorama.Fore.RED}'
+                       f'Failed to run command before rsync '
                        f'{origin_source} -> {target}. '
-                       'Ensure that the network is stable, then retry. '
-                       f'{cmd}')
+                       f'{colorama.Style.RESET_ALL}')
             if log_path != os.devnull:
-                err_msg += f' See logs in {log_path}'
+                err_msg += ux_utils.log_path_hint(log_path)
             subprocess_utils.handle_returncode(rc,
                                                cmd,
                                                err_msg,

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -54,8 +54,9 @@ class S3CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws --version >/dev/null 2>&1 '
-        f'|| {constants.SKY_UV_PIP_CMD} install awscli',
+        'awscli_path=$(which aws) || '
+        f'{{ {constants.SKY_UV_PIP_CMD} install awscli && '
+        f'awscli_path={constants.SKY_REMOTE_PYTHON_ENV}/bin/aws; }}',
     ]
 
     def is_directory(self, url: str) -> bool:
@@ -85,8 +86,7 @@ class S3CloudStorage(CloudStorage):
         # AWS Sync by default uses 10 threads to upload files to the bucket.
         # To increase parallelism, modify max_concurrent_requests in your
         # aws config file (Default path: ~/.aws/config).
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
-                               'sync --no-follow-symlinks '
+        download_via_awscli = (f'$awscli_path s3 sync --no-follow-symlinks '
                                f'{source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
@@ -95,8 +95,7 @@ class S3CloudStorage(CloudStorage):
 
     def make_sync_file_command(self, source: str, destination: str) -> str:
         """Downloads a file using AWS CLI."""
-        download_via_awscli = (f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws s3 '
-                               f'cp {source} {destination}')
+        download_via_awscli = (f'$awscli_path s3 cp {source} {destination}')
 
         all_commands = list(self._GET_AWSCLI)
         all_commands.append(download_via_awscli)

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -54,8 +54,8 @@ class S3CloudStorage(CloudStorage):
 
     # List of commands to install AWS CLI
     _GET_AWSCLI = [
-        'aws --version >/dev/null 2>&1 || '
-        f'{constants.SKY_UV_PIP_CMD} install awscli',
+        f'{constants.SKY_REMOTE_PYTHON_ENV}/bin/aws --version >/dev/null 2>&1 '
+        f'|| {constants.SKY_UV_PIP_CMD} install awscli',
     ]
 
     def is_directory(self, url: str) -> bool:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -67,8 +67,20 @@ _GCLOUD_VERSION = '424.0.0'
 GOOGLE_SDK_INSTALLATION_COMMAND: str = f'pushd /tmp &>/dev/null && \
     {{ gcloud --help > /dev/null 2>&1 || \
     {{ mkdir -p {os.path.dirname(_GCLOUD_INSTALLATION_LOG)} && \
-    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz > {_GCLOUD_INSTALLATION_LOG} && \
-    tar xzf google-cloud-sdk-{_GCLOUD_VERSION}-linux-x86_64.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        echo "Installing Google Cloud SDK for $ARCH" > {_GCLOUD_INSTALLATION_LOG} && \
+        ARCH_SUFFIX="x86_64"; \
+    elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \
+        echo "Installing Google Cloud SDK for $ARCH" > {_GCLOUD_INSTALLATION_LOG} && \
+        ARCH_SUFFIX="arm"; \
+    else \
+        echo "Architecture $ARCH not supported by Google Cloud SDK. Defaulting to x86_64." > {_GCLOUD_INSTALLATION_LOG} && \
+        ARCH_SUFFIX="x86_64"; \
+    fi && \
+    echo "Detected architecture: $ARCH, using package: $ARCH_SUFFIX" >> {_GCLOUD_INSTALLATION_LOG} && \
+    wget --quiet https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{_GCLOUD_VERSION}-linux-${{ARCH_SUFFIX}}.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
+    tar xzf google-cloud-sdk-{_GCLOUD_VERSION}-linux-${{ARCH_SUFFIX}}.tar.gz >> {_GCLOUD_INSTALLATION_LOG} && \
     rm -rf ~/google-cloud-sdk >> {_GCLOUD_INSTALLATION_LOG}  && \
     mv google-cloud-sdk ~/ && \
     ~/google-cloud-sdk/install.sh -q >> {_GCLOUD_INSTALLATION_LOG} 2>&1 && \

--- a/sky/clouds/service_catalog/images/provisioners/cuda.sh
+++ b/sky/clouds/service_catalog/images/provisioners/cuda.sh
@@ -6,7 +6,19 @@
 #   AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html
 export DEBIAN_FRONTEND=noninteractive
 
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+# Detect architecture
+ARCH=$(uname -m)
+
+if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+    echo "Detected ARM architecture: $ARCH"
+    ARCH_PATH="arm64"
+else
+    echo "Detected x86_64 architecture"
+    ARCH_PATH="x86_64"
+fi
+
+# Download architecture-specific CUDA keyring package
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${ARCH_PATH}/cuda-keyring_1.1-1_all.deb
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 sudo apt-get update
 

--- a/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
+++ b/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Builds the Dockerfile_k8s image as the SkyPilot image.
 # Uses buildx to build the image for both amd64 and arm64.
+#
+# Note: Running `docker run --rm --privileged multiarch/qemu-user-static --reset -p yes`
+# first may solve some segmentation faults issue with QEMU when building the
+# image across architectures.
+#
 # Usage: ./skypilot-k8s-image.sh [-p] [-g] [-l] [-r region]
 # -p: Push the image to the registry
 # -g: Builds the GPU image in Dockerfile_k8s_gpu. GPU image is built only for amd64

--- a/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
+++ b/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
@@ -56,8 +56,10 @@ fi
 # Add -gpu to the tag if the GPU image is being built
 if [[ $gpu == "true" ]]; then
   TAG=$TAG-gpu:${VERSION_TAG}
+  DOCKERFILE=Dockerfile_k8s_gpu
 else
   TAG=$TAG:${VERSION_TAG}
+  DOCKERFILE=Dockerfile_k8s
 fi
 
 echo "Building image: $TAG"
@@ -69,33 +71,35 @@ shift $((OPTIND-1))
 # Navigate to the root of the project (inferred from git)
 cd "$(git rev-parse --show-toplevel)"
 
+# Set up Docker buildx for multi-platform builds if it's not already set up
+if ! docker buildx inspect mybuilder >/dev/null 2>&1; then
+  echo "Setting up Docker buildx builder for multi-platform builds..."
+  docker buildx create --name mybuilder --driver docker-container --bootstrap
+  docker buildx use mybuilder
+fi
+
 # If push is used, build the image for both amd64 and arm64
 if [[ $push == "true" ]]; then
-  # If gpu is used, build the GPU image
-  if [[ $gpu == "true" ]]; then
-    echo "Building and pushing GPU image for amd64 and arm64: $TAG"
-    docker buildx build --push --platform linux/amd64,linux/arm64 -t $TAG -f Dockerfile_k8s_gpu ./sky
+  # Build for both architectures
+  echo "Building and pushing image for amd64 and arm64: $TAG"
+  docker buildx build --push --platform linux/amd64,linux/arm64 -t $TAG -f $DOCKERFILE ./sky
+else
+  # Load the right image depending on the architecture of the host machine (Apple Silicon or Intel)
+  if [[ $(uname -m) == "arm64" ]]; then
+    echo "Loading image for arm64 (Apple Silicon etc.): $TAG"
+    docker buildx build --load --platform linux/arm64 -t $TAG -f $DOCKERFILE ./sky
+  elif [[ $(uname -m) == "x86_64" ]]; then
+    echo "Building for amd64 (Intel CPUs): $TAG"
+    docker buildx build --load --platform linux/amd64 -t $TAG -f $DOCKERFILE ./sky
   else
-    echo "Building and pushing CPU image for amd64 and arm64: $TAG"
-    docker buildx build --push --platform linux/arm64,linux/amd64 -t $TAG -f Dockerfile_k8s ./sky
+    echo "Unsupported architecture: $(uname -m)"
+    exit 1
   fi
-fi
 
-# Load the right image depending on the architecture of the host machine (Apple Silicon or Intel)
-if [[ $(uname -m) == "arm64" ]]; then
-  echo "Loading image for arm64 (Apple Silicon etc.): $TAG"
-  docker buildx build --load --platform linux/arm64 -t $TAG -f Dockerfile_k8s ./sky
-elif [[ $(uname -m) == "x86_64" ]]; then
-  echo "Building for amd64 (Intel CPUs): $TAG"
-  docker buildx build --load --platform linux/amd64 -t $TAG -f Dockerfile_k8s ./sky
-else
-  echo "Unsupported architecture: $(uname -m)"
-  exit 1
-fi
-
-echo "Tagging image."
-if [[ $gpu ]]; then
-  docker tag $TAG skypilot-gpu:latest
-else
-  docker tag $TAG skypilot:latest
+  echo "Tagging image."
+  if [[ $gpu ]]; then
+    docker tag $TAG skypilot-gpu:latest
+  else
+    docker tag $TAG skypilot:latest
+  fi
 fi

--- a/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
+++ b/sky/clouds/service_catalog/images/skypilot-k8s-image.sh
@@ -73,8 +73,8 @@ cd "$(git rev-parse --show-toplevel)"
 if [[ $push == "true" ]]; then
   # If gpu is used, build the GPU image
   if [[ $gpu == "true" ]]; then
-    echo "Building and pushing GPU image for amd64: $TAG"
-    docker buildx build --push --platform linux/amd64 -t $TAG -f Dockerfile_k8s_gpu ./sky
+    echo "Building and pushing GPU image for amd64 and arm64: $TAG"
+    docker buildx build --push --platform linux/amd64,linux/arm64 -t $TAG -f Dockerfile_k8s_gpu ./sky
   else
     echo "Building and pushing CPU image for amd64 and arm64: $TAG"
     docker buildx build --push --platform linux/arm64,linux/amd64 -t $TAG -f Dockerfile_k8s ./sky

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -83,23 +83,24 @@ def get_gcs_mount_cmd(bucket_name: str,
 
 def get_az_mount_install_cmd() -> str:
     """Returns a command to install AZ Container mount utility blobfuse2."""
-    install_cmd = ('sudo apt-get update; '
-                   'sudo apt-get install -y '
-                   '-o Dpkg::Options::="--force-confdef" '
-                   'fuse3 libfuse3-dev && '
-                   'ARCH=$(uname -m) && '
-                   'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
-                   '  echo "blobfuse2 is not supported on $ARCH" && '
-                   '  exit 1; '
-                   'else '
-                   '  ARCH_SUFFIX="x86_64"; '
-                   'fi && '
-                   'wget -nc https://github.com/Azure/azure-storage-fuse'
-                   f'/releases/download/blobfuse2-{BLOBFUSE2_VERSION}'
-                   f'/blobfuse2-{BLOBFUSE2_VERSION}-Debian-11.0.${{ARCH_SUFFIX}}.deb '
-                   '-O /tmp/blobfuse2.deb && '
-                   'sudo dpkg --install /tmp/blobfuse2.deb && '
-                   f'mkdir -p {_BLOBFUSE_CACHE_ROOT_DIR};')
+    install_cmd = (
+        'sudo apt-get update; '
+        'sudo apt-get install -y '
+        '-o Dpkg::Options::="--force-confdef" '
+        'fuse3 libfuse3-dev && '
+        'ARCH=$(uname -m) && '
+        'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+        '  echo "blobfuse2 is not supported on $ARCH" && '
+        '  exit 1; '
+        'else '
+        '  ARCH_SUFFIX="x86_64"; '
+        'fi && '
+        'wget -nc https://github.com/Azure/azure-storage-fuse'
+        f'/releases/download/blobfuse2-{BLOBFUSE2_VERSION}'
+        f'/blobfuse2-{BLOBFUSE2_VERSION}-Debian-11.0.${{ARCH_SUFFIX}}.deb '
+        '-O /tmp/blobfuse2.deb && '
+        'sudo dpkg --install /tmp/blobfuse2.deb && '
+        f'mkdir -p {_BLOBFUSE_CACHE_ROOT_DIR};')
 
     return install_cmd
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -49,9 +49,15 @@ def get_s3_mount_cmd(bucket_name: str,
 
 def get_gcs_mount_install_cmd() -> str:
     """Returns a command to install GCS mount utility gcsfuse."""
-    install_cmd = ('wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
+    install_cmd = ('ARCH=$(uname -m) && '
+                   'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                   '  ARCH_SUFFIX="arm64"; '
+                   'else '
+                   '  ARCH_SUFFIX="amd64"; '
+                   'fi && '
+                   'wget -nc https://github.com/GoogleCloudPlatform/gcsfuse'
                    f'/releases/download/v{GCSFUSE_VERSION}/'
-                   f'gcsfuse_{GCSFUSE_VERSION}_amd64.deb '
+                   f'gcsfuse_{GCSFUSE_VERSION}_${{ARCH_SUFFIX}}.deb '
                    '-O /tmp/gcsfuse.deb && '
                    'sudo dpkg --install /tmp/gcsfuse.deb')
     return install_cmd
@@ -81,9 +87,16 @@ def get_az_mount_install_cmd() -> str:
                    'sudo apt-get install -y '
                    '-o Dpkg::Options::="--force-confdef" '
                    'fuse3 libfuse3-dev && '
+                   'ARCH=$(uname -m) && '
+                   'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                   '  echo "blobfuse2 is not supported on $ARCH" && '
+                   '  exit 1; '
+                   'else '
+                   '  ARCH_SUFFIX="x86_64"; '
+                   'fi && '
                    'wget -nc https://github.com/Azure/azure-storage-fuse'
                    f'/releases/download/blobfuse2-{BLOBFUSE2_VERSION}'
-                   f'/blobfuse2-{BLOBFUSE2_VERSION}-Debian-11.0.x86_64.deb '
+                   f'/blobfuse2-{BLOBFUSE2_VERSION}-Debian-11.0.${{ARCH_SUFFIX}}.deb '
                    '-O /tmp/blobfuse2.deb && '
                    'sudo dpkg --install /tmp/blobfuse2.deb && '
                    f'mkdir -p {_BLOBFUSE_CACHE_ROOT_DIR};')
@@ -207,14 +220,20 @@ def get_rclone_install_cmd() -> str:
     """
     # pylint: disable=line-too-long
     install_cmd = (
+        'ARCH=$(uname -m) && '
+        'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+        '  ARCH_SUFFIX="arm"; '
+        'else '
+        '  ARCH_SUFFIX="amd64"; '
+        'fi && '
         f'(which dpkg > /dev/null 2>&1 && (which rclone > /dev/null || (cd ~ > /dev/null'
-        f' && curl -O https://downloads.rclone.org/{RCLONE_VERSION}/rclone-{RCLONE_VERSION}-linux-amd64.deb'
-        f' && sudo dpkg -i rclone-{RCLONE_VERSION}-linux-amd64.deb'
-        f' && rm -f rclone-{RCLONE_VERSION}-linux-amd64.deb)))'
+        f' && curl -O https://downloads.rclone.org/{RCLONE_VERSION}/rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb'
+        f' && sudo dpkg -i rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb'
+        f' && rm -f rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb)))'
         f' || (which rclone > /dev/null || (cd ~ > /dev/null'
-        f' && curl -O https://downloads.rclone.org/{RCLONE_VERSION}/rclone-{RCLONE_VERSION}-linux-amd64.rpm'
-        f' && sudo yum --nogpgcheck install rclone-{RCLONE_VERSION}-linux-amd64.rpm -y'
-        f' && rm -f rclone-{RCLONE_VERSION}-linux-amd64.rpm))')
+        f' && curl -O https://downloads.rclone.org/{RCLONE_VERSION}/rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm'
+        f' && sudo yum --nogpgcheck install rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm -y'
+        f' && rm -f rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm))')
     return install_cmd
 
 

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -24,7 +24,14 @@ RCLONE_VERSION = 'v1.68.2'
 
 def get_s3_mount_install_cmd() -> str:
     """Returns a command to install S3 mount utility goofys."""
-    install_cmd = ('sudo wget -nc https://github.com/romilbhardwaj/goofys/'
+    install_cmd = ('ARCH=$(uname -m) && '
+                   'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                   '  echo "goofys is not supported on $ARCH" && '
+                   f'  exit {exceptions.ARCH_NOT_SUPPORTED_EXIT_CODE}; '
+                   'else '
+                   '  ARCH_SUFFIX="amd64"; '
+                   'fi && '
+                   'sudo wget -nc https://github.com/romilbhardwaj/goofys/'
                    'releases/download/0.24.0-romilb-upstream/goofys '
                    '-O /usr/local/bin/goofys && '
                    'sudo chmod 755 /usr/local/bin/goofys')
@@ -91,7 +98,7 @@ def get_az_mount_install_cmd() -> str:
         'ARCH=$(uname -m) && '
         'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
         '  echo "blobfuse2 is not supported on $ARCH" && '
-        '  exit 1; '
+        f'  exit {exceptions.ARCH_NOT_SUPPORTED_EXIT_CODE}; '
         'else '
         '  ARCH_SUFFIX="x86_64"; '
         'fi && '

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -22,6 +22,8 @@ MOUNT_PATH_NON_EMPTY_CODE = 42
 INSUFFICIENT_PRIVILEGES_CODE = 52
 # Return code when git command is ran in a dir that is not git repo
 GIT_FATAL_EXIT_CODE = 128
+# Architecture, such as arm64, not supported by the dependency
+ARCH_NOT_SUPPORTED_EXIT_CODE = 133
 
 
 def is_safe_exception(exc: Exception) -> bool:

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -123,7 +123,7 @@ extras_require: Dict[str, List[str]] = {
         'ibm-cloud-sdk-core', 'ibm-vpc', 'ibm-platform-services', 'ibm-cos-sdk'
     ] + local_ray,
     'docker': ['docker'] + local_ray,
-    'lambda': [], # No dependencies needed for lambda
+    'lambda': [],  # No dependencies needed for lambda
     'cloudflare': aws_dependencies,
     'scp': local_ray,
     'oci': ['oci'] + local_ray,

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -123,7 +123,7 @@ extras_require: Dict[str, List[str]] = {
         'ibm-cloud-sdk-core', 'ibm-vpc', 'ibm-platform-services', 'ibm-cos-sdk'
     ] + local_ray,
     'docker': ['docker'] + local_ray,
-    'lambda': local_ray,
+    'lambda': [], # No dependencies needed for lambda
     'cloudflare': aws_dependencies,
     'scp': local_ray,
     'oci': ['oci'] + local_ray,

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -144,12 +144,14 @@ DISABLE_GPU_ECC_COMMAND = (
 CONDA_INSTALLATION_COMMANDS = (
     'which conda > /dev/null 2>&1 || '
     '{ '
-    'curl https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-x86_64.sh -o Miniconda3-Linux-x86_64.sh && '  # pylint: disable=line-too-long
+    # Use uname -m to get the architecture of the machine and download the
+    # corresponding Miniconda3-Linux.sh script.
+    'curl https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Linux-$(uname -m).sh -o Miniconda3-Linux.sh && '  # pylint: disable=line-too-long
     # We do not use && for installation of conda and the following init commands
     # because for some images, conda is already installed, but not initialized.
     # In this case, we need to initialize conda and set auto_activate_base to
     # true.
-    '{ bash Miniconda3-Linux-x86_64.sh -b; '
+    '{ bash Miniconda3-Linux.sh -b; '
     'eval "$(~/miniconda3/bin/conda shell.bash hook)" && conda init && '
     # Caller should replace {conda_auto_activate} with either true or false.
     'conda config --set auto_activate_base {conda_auto_activate} && '

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -246,11 +246,15 @@ def _get_cloud_dependencies_installation_commands(
                 'apt install curl socat netcat -y &> /dev/null; '
                 'fi" && '
                 # Install kubectl
+                'ARCH=$(uname -m) && '
+                'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                '  ARCH="arm64"; '
+                'else '
+                '  ARCH="amd64"; '
+                'fi && '
                 '(command -v kubectl &>/dev/null || '
-                '(curl -s -LO "https://dl.k8s.io/release/'
-                '$(curl -L -s https://dl.k8s.io/release/stable.txt)'
-                '/bin/linux/amd64/kubectl" && '
-                'sudo install -o root -g root -m 0755 '
+                '("https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" '
+                '&& sudo install -o root -g root -m 0755 '
                 'kubectl /usr/local/bin/kubectl))')
         elif isinstance(cloud, clouds.Cudo):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1402,9 +1402,14 @@ def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
         'cancel-pytorch',
         [
             f'sky launch -c {name} --cloud {generic_cloud} --gpus {accelerator} examples/resnet_distributed_torch.yaml -y -d',
-            # Wait the GPU process to start. Azure takes longer to start due to
-            # the long Azure VM setup time.
-            'sleep 150' if generic_cloud == 'azure' else 'sleep 90',
+            # Wait until the setup finishes.
+            smoke_tests_utils.get_cmd_wait_until_job_status_contains_matching_job_id(
+                cluster_name=name,
+                job_id='1',
+                job_status=[sky.JobStatus.RUNNING],
+                timeout=150),
+            # Wait the GPU process to start.
+            'sleep 90',
             f'sky exec {name} --num-nodes 2 \'s=$(nvidia-smi); echo "$s"; echo "$s" | grep python || '
             # When run inside container/k8s, nvidia-smi cannot show process ids.
             # See https://github.com/NVIDIA/nvidia-docker/issues/179

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -424,8 +424,8 @@ def test_multi_echo(generic_cloud: str):
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
             'sleep 30',
             # Make sure that our job scheduler is fast enough to have at least
-            # 18 RUNNING jobs in parallel.
-            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "RUNNING" | wc -l | awk \'{{if ($1 < 18) exit 1}}\'',
+            # 15 RUNNING jobs in parallel.
+            f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "RUNNING" | wc -l | awk \'{{if ($1 < 15) exit 1}}\'',
             'sleep 30',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep "FAILED" && exit 1 || true',
             # This is to make sure we can finish job 32 before the test timeout.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1403,7 +1403,8 @@ def test_cancel_pytorch(generic_cloud: str, accelerator: Dict[str, str]):
         [
             f'sky launch -c {name} --cloud {generic_cloud} --gpus {accelerator} examples/resnet_distributed_torch.yaml -y -d',
             # Wait until the setup finishes.
-            smoke_tests_utils.get_cmd_wait_until_job_status_contains_matching_job_id(
+            smoke_tests_utils.
+            get_cmd_wait_until_job_status_contains_matching_job_id(
                 cluster_name=name,
                 job_id='1',
                 job_status=[sky.JobStatus.RUNNING],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Mitigates #4793

Fixes #4601 

This enables the SkyPilot clusters to run on arm architecture with the default image.

ARM support is becoming more important as the NV's GH200, GB200 (offered by Lambda clouds, GCP) come with ARM CPUs by default, but our docker image does not support ARM CPU well.

Original k8s gpu image does not support ARM architecture
```
sky launch --cloud lambda --gpus gh200 nvidia-smi --image-id docker:us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest -c test-lambda-arm-origin
```
Error:
```
latest: Pulling from sky-dev-465/skypilotk8s/skypilot-gpu
no matching manifest for linux/arm64/v8 in the manifest list entries

⨯ Failed to set up SkyPilot runtime on cluster.  View logs: sky api logs -l sky-2025-02-27-22-36-28-562705/provision.log
sky.exceptions.CommandError: Command docker pull us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest failed with return code 1.
Failed to run docker setup commands.
```

TODO (future PRs):
- [x] Make SkyPilot runtime dependency installation compatible with ARM
- [x] Make bucket dependency compatible with ARM
- [ ] Kubernetes GPU image does not have base env activate by default, while the CPU image does
- [x] Make sure the API server helm chart image is arm compatible
- [x] Make sure `sky local up --ips` works for remote ARM machines
- [ ] Create SkyPilot custom ARM image on different clouds, e.g. `sky launch -t c6g.large` works if we specify `--image-id` with a ARM based deep learning image, but does not work with our default image

TODO before merging:
- [x] make the new k8s image to be the `latest` tag.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [x] `cd sky/clouds/service_catalogs/images/; ./skypilot-k8s-image.sh -p -g`
  - [x] `cd sky/clouds/service_catalogs/images/; ./skypilot-k8s-image.sh -p`
  - [x] `sky launch --cloud kubernetes --cpus 1 --image-id docker:us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250227 echo hi`
  - [x] `sky autostop sky-b694-ubuntu --down -i 0`
  - [x] `sky launch --cloud kubernetes --cpus 1 --image-id docker:us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20250227 echo hi`
  - [x] `sky autostop sky-b694-ubuntu --down -i 0`
  - [x] `docker build .` on Mac and AMD64 linux
  - [x] `sky launch --cloud lambda --gpus Gh200 --image-id docker:us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:20250227 nvidia-smi -c test-lambda-arm`, ssh into the machine and `uname -m` shows aarch64, i.e. arm architecture
  - [x] Launch on ARM arch:
      - [x] `sky launch --gpus Gh200 --cloud lambda examples/using_file_mounts.yaml -c test-fm-arm --down`
      - [x] Deploy `local up` on the machine: `sky local up --ips`
      - [x] Deploy API server on the kubernetes cluster deployed above
      - [x] `sky launch --gpus gh200 --cloud kubernetes nvidia-smi`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
  - [x] `pytest tests/test_smoke.py --kubernetes` with the new images 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
