### PR TITLE
[Core] Only set credentials when it exists

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -136,7 +136,8 @@ def _get_cluster_records_and_set_ssh_config(
         # During the failover, even though a cluster does not exist, the handle
         # can still exist in the record, and we check for credentials to avoid
         # updating the SSH config for non-existent clusters.
-        if handle is not None and 'credentials' in record:
+        if (handle is not None and handle.cached_external_ips is not None and
+            'credentials' in record):
             credentials = record['credentials']
             if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
                 # Replace the proxy command to proxy through the SkyPilot API

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -172,9 +172,9 @@ def _get_cluster_records_and_set_ssh_config(
                 handle.ssh_user,
             )
         else:
-            # If the cluster is not UP or does not have IPs, we need to remove
-            # the cluster from the SSH config.
-            cluster_utils.SSHConfigHelper.remove_cluster(handle.cluster_name)
+            # If the cluster is not UP or does not have credentials available,
+            # we need to remove the cluster from the SSH config.
+            cluster_utils.SSHConfigHelper.remove_cluster(record['name'])
 
     # Clean up SSH configs for clusters that do not exist.
     #

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -133,7 +133,7 @@ def _get_cluster_records_and_set_ssh_config(
     # Update the SSH config for all clusters
     for record in cluster_records:
         handle = record['handle']
-        if handle is not None and handle.cached_external_ips is not None:
+        if (handle is not None and handle.cached_external_ips is not None and 'credentials' in record):
             credentials = record['credentials']
             if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
                 # Replace the proxy command to proxy through the SkyPilot API

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -133,7 +133,8 @@ def _get_cluster_records_and_set_ssh_config(
     # Update the SSH config for all clusters
     for record in cluster_records:
         handle = record['handle']
-        if (handle is not None and handle.cached_external_ips is not None and 'credentials' in record):
+        if (handle is not None and handle.cached_external_ips is not None and
+                'credentials' in record):
             credentials = record['credentials']
             if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
                 # Replace the proxy command to proxy through the SkyPilot API

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -133,8 +133,10 @@ def _get_cluster_records_and_set_ssh_config(
     # Update the SSH config for all clusters
     for record in cluster_records:
         handle = record['handle']
-        if (handle is not None and handle.cached_external_ips is not None and
-                'credentials' in record):
+        # During the failover, even though a cluster does not exist, the handle
+        # can still exist in the record, and we check for credentials to avoid
+        # updating the SSH config for non-existent clusters.
+        if handle is not None and 'credentials' in record:
             credentials = record['credentials']
             if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
                 # Replace the proxy command to proxy through the SkyPilot API

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -137,7 +137,7 @@ def _get_cluster_records_and_set_ssh_config(
         # can still exist in the record, and we check for credentials to avoid
         # updating the SSH config for non-existent clusters.
         if (handle is not None and handle.cached_external_ips is not None and
-            'credentials' in record):
+                'credentials' in record):
             credentials = record['credentials']
             if isinstance(handle.launched_resources.cloud, clouds.Kubernetes):
                 # Replace the proxy command to proxy through the SkyPilot API


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user experience the following issue when running `sky status`:

```
  File "sky/cli.py", line 137, in _get_cluster_records_and_set_ssh_config
    credentials = record['credentials']
                  ~~~~~~^^^^^^^^^^^^^^^
KeyError: 'credentials'
```
 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
