### PR TITLE
[API server] run API server in foreground in k8s Pod

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -37,6 +37,11 @@ spec:
         {{- end }}
         # Use tini as the init process
         command: ["tini", "--"]
+        # Start API server in foreground (if supported) to:
+        # 1. Bypass the healthz check of `sky api start`, let kubernetes probes manage the lifecycle directly.
+        # 2. Capture all logs in container to stdout/stderr, bypass in-container log file overhead.
+        # 3. Exec ensures the process is a direct child of tini, enables correct signal handling.
+        # Note: this comment is moved here to avoid appearing in the final start script.
         args:
         - /bin/sh
         - -c
@@ -57,6 +62,7 @@ spec:
             exec sky api start --deploy --foreground
           else
             # For backward compatibility, run in background if --foreground is not supported.
+            # TODO(aylei): this will bedropped in 0.11.0.
             if sky api start --deploy; then
               tail -n+0 -f /root/.sky/api_server/server.log
             else

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -52,10 +52,16 @@ spec:
           # Any local changes to the config.yaml file will be overwritten by the contents of the configmap.
           cp /tmp/config.yaml /root/.sky/config.yaml
           {{- end }}
-          if sky api start --deploy; then
-            tail -n+0 -f /root/.sky/api_server/server.log
+
+          if sky api start -h | grep -q -- "--foreground"; then
+            exec sky api start --deploy --foreground
           else
-            cat /root/.sky/api_server/server.log
+            # For backward compatibility, run in background if --foreground is not supported.
+            if sky api start --deploy; then
+              tail -n+0 -f /root/.sky/api_server/server.log
+            else
+              cat /root/.sky/api_server/server.log
+            fi
           fi
         ports:
         - containerPort: 46580

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5504,10 +5504,15 @@ def api():
               required=False,
               help=('The host to deploy the SkyPilot API server. To allow '
                     'remote access, set this to 0.0.0.0'))
+@click.option('--foreground',
+              is_flag=True,
+              default=False,
+              required=False,
+              help='Run the SkyPilot API server in the foreground.')
 @usage_lib.entrypoint
-def api_start(deploy: bool, host: Optional[str]):
+def api_start(deploy: bool, host: Optional[str], foreground: bool):
     """Starts the SkyPilot API server locally."""
-    sdk.api_start(deploy=deploy, host=host)
+    sdk.api_start(deploy=deploy, host=host, foreground=foreground)
 
 
 @api.command('stop', cls=_DocumentedCodeCommand)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5508,7 +5508,11 @@ def api():
               is_flag=True,
               default=False,
               required=False,
-              help='Run the SkyPilot API server in the foreground.')
+              help='Run the SkyPilot API server in the foreground and output '
+              'its logs to stdout/stderr. Allowing external systems '
+              'to manage the process lifecycle and collect logs directly. '
+              'This is useful when the API server is managed by systems '
+              'like systemd and Kubernetes.')
 @usage_lib.entrypoint
 def api_start(deploy: bool, host: Optional[str], foreground: bool):
     """Starts the SkyPilot API server locally."""

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1645,6 +1645,7 @@ def api_start(
                              'variable.')
     server_common.check_server_healthy_or_start_fn(deploy, host, foreground)
     if foreground:
+        # Explain why current process exited
         logger.info('API server is already running:')
     logger.info(f'{ux_utils.INDENT_SYMBOL}SkyPilot API server: '
                 f'{server_common.get_server_url(host)}\n'

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1611,6 +1611,7 @@ def api_start(
     *,
     deploy: bool = False,
     host: str = '127.0.0.1',
+    foreground: bool = False,
 ) -> None:
     """Starts the API server.
 
@@ -1622,7 +1623,8 @@ def api_start(
             resources of the machine.
         host: The host to deploy the API server. It will be set to 0.0.0.0
             if deploy is True, to allow remote access.
-
+        foreground: Whether to run the API server in the foreground (run in
+            the current process).
     Returns:
         None
     """
@@ -1641,7 +1643,9 @@ def api_start(
                              'from the config file and/or unset the '
                              'SKYPILOT_API_SERVER_ENDPOINT environment '
                              'variable.')
-    server_common.check_server_healthy_or_start_fn(deploy, host)
+    server_common.check_server_healthy_or_start_fn(deploy, host, foreground)
+    if foreground:
+        logger.info('API server is already running:')
     logger.info(f'{ux_utils.INDENT_SYMBOL}SkyPilot API server: '
                 f'{server_common.get_server_url(host)}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1085,9 +1085,9 @@ if __name__ == '__main__':
     if cmd_args.deploy:
         num_workers = os.cpu_count()
 
-    workers = []
+    sub_procs = []
     try:
-        workers = executor.start(cmd_args.deploy)
+        sub_procs = executor.start(cmd_args.deploy)
         logger.info('Starting SkyPilot API server')
         # We don't support reload for now, since it may cause leakage of request
         # workers or interrupt running requests.
@@ -1101,5 +1101,6 @@ if __name__ == '__main__':
         raise
     finally:
         logger.info('Shutting down SkyPilot API server...')
-        for worker in workers:
-            worker.terminate()
+        for sub_proc in sub_procs:
+            sub_proc.terminate()
+            sub_proc.join()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

In #4843 , API server can not start in 12 seconds on a 176 core machine since API server starts as many unvicorn processes as the cores.

Follow up https://github.com/skypilot-org/skypilot/pull/4776#discussion_r1968820376 , add a new arg `--foreground` to `sky api start` command that runs the API server in current process instead of background, so that:

1. The startup check is bypassed, enables the configurable k8s liveness/readiness probe to take effect;
2. The server can be the pid 1 process (or a direct child of pid 1 init process) in the container, enables correct signal handling in container;
3. The redundant log file in container and tail process can be eliminated;

close #4776 
close #4771 

It is a bit complicated to run smoke test for `--foreground` since we need an isolated sandbox to avoid intervening other cases. For this PR, the tests are done manually. tracked in:  https://github.com/skypilot-org/skypilot/issues/4853

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

Local test:

- [x] start and shutdown foreground API server
- [x] `sky status`, `sky launch`, `sky exec` on foreground API server
- [x] `sky api start --deploy --foreground` exit and output hints when there is a running server

```bash
$ sky api start --foreground
API server is already running:
├── SkyPilot API server: http://0.0.0.0:46580
└── View API server logs at: ~/.sky/api_server/server.log
```

On Kubernetes:

- [x] Tested new image with new chart (run in foreground)
- [x] Tested old image with new chart (run in background)

Other tests:
- [x] Code formatting: `bash format.sh`
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
