### PR TITLE
[Utils] Quickfix serve status message

### DIFF
--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -124,7 +124,7 @@ class Controllers(enum.Enum):
         cluster_name=common.SKY_SERVE_CONTROLLER_NAME,
         in_progress_hint=(
             f'* To see detailed service status: {colorama.Style.BRIGHT}'
-            f'sky serve status -a{colorama.Style.RESET_ALL}'),
+            f'sky serve status -v{colorama.Style.RESET_ALL}'),
         decline_cancel_hint=(
             'Cancelling the sky serve controller\'s jobs is not allowed.'),
         _decline_down_when_failed_to_fetch_status_hint=(


### PR DESCRIPTION
This change is a quick fix of the message given by the command `sky status`
When you run it the output is similar to 
```
Clusters                                                                                                          
No existing clusters.                                                                                             
                                                                                                                  
Managed jobs                                             
No in-progress managed jobs. (See: sky jobs -h)                                                                   
                                                                                                                  
Services                                                                                                          
NAME              VERSION  UPTIME       STATUS  REPLICAS  ENDPOINT                    
sky-service-xxxx  1        19h 11m 18s  READY   1/1       http://X.X.X.X:30001  
                                                                                                                  
Service Replicas                                                                                                  
SERVICE_NAME      ID  VERSION  ENDPOINT                LAUNCHED    RESOURCES                STATUS  REGION      
sky-service-xxxx  1   1        http://Y.Y.Y.Y:8000     19 hrs ago  1x AWS([Spot]{'T4': 1})  READY   eu-north-1  
                                                                                                                  
* To see detailed service status: sky serve status -a
```
When I run `sky serve status -a` to get more details as indicated in the message I get
```
Usage: sky serve status [OPTIONS] [SERVICE_NAMES]...                                                              
Try 'sky serve status -h' for help.                                                                               
                                                                                                                  
Error: No such option: -a
```
When asking for help it says
```
...
  Examples:                                              

    # Show status for all services
    sky serve status                                     
                                                         
    # Show detailed status for all services
    sky serve status -v                                  
                                                         
    # Only show status of my-service
    sky serve status my-service

Options:                                                 
  -v, --verbose  Show all information in full.
  --endpoint     Show service endpoint.
  -h, --help     Show this message and exit.
```
And by executing `sky serve status -v` we obtain the desired detail
```
Services
NAME              VERSION  UPTIME       STATUS  REPLICAS  ENDPOINT                    AUTOSCALING_POLICY                                            LOAD_BALANCING_POLICY  REQUESTED_RESOURCES             
sky-service-xxxx  1        19h 12m 25s  READY   1/1       http://X.X.X.X:30001      Autoscaling from 1 to 4 replicas (target QPS per replica: 2)  least_load             1x[T4:1, L4:1, P100:1, A10G:1]  

Service Replicas
SERVICE_NAME      ID  VERSION  ENDPOINT                LAUNCHED    RESOURCES                                                                           STATUS  REGION      ZONE         
sky-service-xxxx  1   1        http://Y.Y.Y.Y:8000      19 hrs ago  1x AWS(g4dn.2xlarge[Spot], {'T4': 1}, disk_tier=low, disk_size=50, ports=['8000'])  READY   eu-north-1  eu-north-1b
```
So, simply, quick fix for the message emitted by `sky status`.

I hope to contribute something more substantial in the future.

skypilot is amazing

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Only the format.sh is needed but only one letter has been replaced by another one.

Tested (run the relevant ones):

- [X] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
