### PR TITLE
Support build number in nightly pypi build

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       build_number:
-        description: 'Additional build number for same-day releases, counts from 1 (0 is reserved for the first release of the day, which omits the build number in the version string).'
+        description: 'Additional build number for same-day releases, from 1 to 99 (0 is reserved for the first release of the day).'
         required: false
         type: number
         default: 0
@@ -46,10 +46,12 @@ jobs:
           --user
       - name: Set release version
         run: |
-          RELEASE_VERSION=$(date +%Y%m%d)
-          if [ "${{ inputs.build_number }}" -gt 0 ]; then
-            RELEASE_VERSION="${RELEASE_VERSION}0${{ inputs.build_number }}"
+          if [ "${{ inputs.build_number }}" -lt 0 ] || [ "${{ inputs.build_number }}" -gt 99 ]; then
+            echo "Error: build_number must be a number between 0 and 99"
+            exit 1
           fi
+          # Format the version as YYYYMMDD00, YYYYMMDD01...
+          RELEASE_VERSION="$(date +%Y%m%d)$(printf "%02d" "${{ inputs.build_number }}")"
           sed -i "s/{{SKYPILOT_COMMIT_SHA}}/${{ github.sha }}/g" sky/__init__.py
           sed -i "s/__version__ = '.*'/__version__ = '1.0.0.dev${RELEASE_VERSION}'/g" sky/__init__.py
           sed -i "s/name='skypilot',/name='skypilot-nightly',/g" sky/setup_files/setup.py

--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '35 10 * * *' # 10:35am UTC, 2:35am PST, 5:35am EST
   workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'Additional build number for same-day releases, counts from 1 (0 is reserved for the first release of the day, which omits the build number in the version string).'
+        required: false
+        type: number
+        default: 0
 
 jobs:
   # nightly release check from https://stackoverflow.com/a/67527144
@@ -41,6 +47,9 @@ jobs:
       - name: Set release version
         run: |
           RELEASE_VERSION=$(date +%Y%m%d)
+          if [ "${{ inputs.build_number }}" -gt 0 ]; then
+            RELEASE_VERSION="${RELEASE_VERSION}0${{ inputs.build_number }}"
+          fi
           sed -i "s/{{SKYPILOT_COMMIT_SHA}}/${{ github.sha }}/g" sky/__init__.py
           sed -i "s/__version__ = '.*'/__version__ = '1.0.0.dev${RELEASE_VERSION}'/g" sky/__init__.py
           sed -i "s/name='skypilot',/name='skypilot-nightly',/g" sky/setup_files/setup.py


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

For our nightly release, fixes (e.g. https://github.com/skypilot-org/skypilot/pull/4852) must wait for at least the next nightly build to ship to users. To speed up the circle, this PR introduces a build number input so that the nightly build pipeline can be triggered manually to produce a new build like `skypilot-nightly 1.0.0.dev2025022801`.

The correctness of build number depends on the developer triggers the pipeline, which is okay since such triggering should be rare, just keep it simple.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
