### PR TITLE
Exclude `.pyc` and `__pycache__` files from config hash calculation to fix `test_launch_fast --kubernetes` failures

### DIFF
--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -167,7 +167,7 @@ def build_sky_wheel() -> Tuple[pathlib.Path, str]:
                     mtime = os.path.getmtime(entry_path)
                     if mtime > max_time:
                         max_time = mtime
-                except OSError:
+                except FileNotFoundError:
                     # Handle cases where file might have been deleted after
                     # listing
                     continue

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -183,8 +183,8 @@ def build_sky_wheel() -> Tuple[pathlib.Path, str]:
         last_modification_time = _get_latest_modification_time(SKY_PACKAGE_PATH)
         last_wheel_modification_time = _get_latest_modification_time(WHEEL_DIR)
 
-        # Only build wheels if the wheel is outdated or wheel does not exist
-        # for the requested version.
+        # Only build wheels if the wheel is outdated, wheel does not exist
+        # for the requested version, or files were deleted during checking.
         if ((last_modification_time is None or
              last_wheel_modification_time is None) or
             (last_wheel_modification_time < last_modification_time) or

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -167,10 +167,10 @@ def build_sky_wheel() -> Tuple[pathlib.Path, str]:
                     mtime = os.path.getmtime(entry_path)
                     if mtime > max_time:
                         max_time = mtime
-                except FileNotFoundError:
+                except OSError:
                     # Handle cases where file might have been deleted after
                     # listing
-                    continue
+                    return -1.
         return max_time
 
     # This lock prevents that the wheel is updated while being copied.
@@ -186,7 +186,8 @@ def build_sky_wheel() -> Tuple[pathlib.Path, str]:
         # Only build wheels if the wheel is outdated or wheel does not exist
         # for the requested version.
         if (last_wheel_modification_time < last_modification_time) or not any(
-                WHEEL_DIR.glob(f'**/{_WHEEL_PATTERN}')):
+                WHEEL_DIR.glob(
+                    f'**/{_WHEEL_PATTERN}')) or last_modification_time == -1.:
             if not WHEEL_DIR.exists():
                 WHEEL_DIR.mkdir(parents=True, exist_ok=True)
             latest_wheel = _build_sky_wheel()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

# Issue

The `test_launch_fast --kubernetes` test has been failing intermittently on buildkite and occasionally on local machines. Upon investigation, it was discovered that the `config_hash` was changing due to modifications in `.pyc` files, specifically `sky/clouds/service_catalog/__pycache__/kubernetes_catalog.cpython-310.pyc`. This caused the `--fast` flag to not work as expected, as the cached wheel was not being reused.

[Failure build with detail log](https://buildkite.com/skypilot-1/smoke-tests/builds/290#01956494-3ed6-4dc9-8c4e-37883f35df0b)

# Change

* `_get_latest_modification_time` excludes `.pyc` and `__pycache__` files. This ensures that `build_sky_wheel` reuses the cached wheel if no changes are detected in the source code files.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

# Test

- [x] `/smoke-test --kubernetes -k test_launch_fast` - [pass](https://buildkite.com/skypilot-1/smoke-tests/builds/291)
- [x] `/smoke-test --aws -k test_launch_fast` - [pass](https://buildkite.com/skypilot-1/smoke-tests/builds/292)
- [x] `/smoke-test --gcp -k test_launch_fast` - [pass](https://buildkite.com/skypilot-1/smoke-tests/builds/293)
- [x] `/smoke-test --azure -k test_launch_fast` - [pass](https://buildkite.com/skypilot-1/smoke-tests/builds/294)