### PR TITLE
[API server] honor SKYPILOT_DEBUG env in server log

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -45,6 +45,7 @@ from sky.utils import admin_policy_utils
 from sky.utils import common as common_lib
 from sky.utils import common_utils
 from sky.utils import dag_utils
+from sky.utils import env_options
 from sky.utils import status_lib
 
 # pylint: disable=ungrouped-imports
@@ -65,6 +66,10 @@ def _add_timestamp_prefix_for_server_logs() -> None:
     # Add date prefix to the log message printed by loggers under
     # server.
     stream_handler = logging.StreamHandler(sys.stdout)
+    if env_options.Options.SHOW_DEBUG_INFO.get():
+        stream_handler.setLevel(logging.DEBUG)
+    else:
+        stream_handler.setLevel(logging.INFO)
     stream_handler.flush = sys.stdout.flush  # type: ignore
     stream_handler.setFormatter(sky_logging.FORMATTER)
     server_logger.addHandler(stream_handler)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #4882

Test:

```
$ export SKYPILOT_DEBUG=0
$ sky api stop && sky api start && tail -f ~/.sky/api_server/server.log
...
I 03-05 17:22:50 executor.py:349] [Worker(id=1, schedule_type=short)] Submitting request: skypilot-status-refresh-daemon
I 03-05 17:22:50 executor.py:366] [Worker(id=1, schedule_type=short)] Submitted request: skypilot-status-refresh-daemon
I 03-05 17:22:51 executor.py:241] Running request skypilot-status-refresh-daemon with pid 43591

$ export SKYPILOT_DEBUG=1
$ sky api stop && sky api start && tail -f ~/.sky/api_server/server.log
...
D 03-05 17:23:19 payloads.py:60] The following keys ({"allowed_clouds": ["kubernetes"]}) are specified in the client SkyPilot config at '/Users/aylei/.sky/config.yaml'. This will be ignored. If you want to specify it, please modify it on server side or contact your administrator.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR: see above
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
