### PR TITLE
[API server] use console entrypoint to start server

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1702,9 +1702,14 @@ def api_stop() -> None:
     found = False
     for process in psutil.process_iter(attrs=['pid', 'cmdline']):
         cmdline = process.info['cmdline']
-        if cmdline and server_common.API_SERVER_CMD in ' '.join(cmdline):
-            subprocess_utils.kill_children_processes(parent_pids=[process.pid],
-                                                     force=True)
+        if cmdline:
+            cmd_str = ' '.join(cmdline)
+            if (server_common.API_SERVER_CMD in cmd_str or
+                    # Backward compatible with the legacy command
+                    # TODO(aylei): remove in 0.11.0
+                    server_common.LEGACY_API_SERVER_CMD in cmd_str):
+                subprocess_utils.kill_children_processes(
+                    parent_pids=[process.pid], force=True)
             found = True
 
     # Remove the database for requests including any files starting with

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -6,8 +6,8 @@ import functools
 import json
 import os
 import pathlib
+import shutil
 import subprocess
-import sys
 import time
 import typing
 from typing import Any, Dict, Optional
@@ -39,7 +39,9 @@ AVAILABLE_LOCAL_API_SERVER_URLS = [
     f'http://{host}:46580' for host in AVAILBLE_LOCAL_API_SERVER_HOSTS
 ]
 
-API_SERVER_CMD = '-m sky.server.server'
+# TODO(aylei): remove in 0.11.0
+LEGACY_API_SERVER_CMD = '-m sky.server.server'
+API_SERVER_CMD = 'skyserver'
 # The client dir on the API server for storing user-specific data, such as file
 # mounts, logs, etc. This dir is empheral and will be cleaned up when the API
 # server is restarted.
@@ -193,7 +195,16 @@ def _start_api_server(deploy: bool = False,
                 'recommended to support higher load with better performance.'
                 f'{colorama.Style.RESET_ALL}')
 
-        args = [sys.executable, *API_SERVER_CMD.split()]
+        # If user is on master branch and does not run `pip install -e .`
+        # after update the code, skyserver will not be available in PATH.
+        if shutil.which(API_SERVER_CMD) is None:
+            raise RuntimeError(
+                f'{colorama.Fore.YELLOW}SkyPilot API server command '
+                f'{API_SERVER_CMD} is not available in PATH. '
+                f'Rerun `pip install -e .` to install the command.'
+                f'{colorama.Style.RESET_ALL}')
+        args = [API_SERVER_CMD]
+
         if deploy:
             args += ['--deploy']
         if host is not None:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1081,8 +1081,10 @@ async def complete_storage_name(incomplete: str,) -> List[str]:
     return global_user_state.get_storage_names_start_with(incomplete)
 
 
-if __name__ == '__main__':
+def main():
+    # pylint: disable=import-outside-toplevel
     import uvicorn
+
     requests_lib.reset_db_and_logs()
 
     parser = argparse.ArgumentParser()
@@ -1117,3 +1119,7 @@ if __name__ == '__main__':
         for sub_proc in sub_procs:
             sub_proc.terminate()
             sub_proc.join()
+
+
+if __name__ == '__main__':
+    main()

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -168,7 +168,11 @@ setuptools.setup(
     install_requires=dependencies['install_requires'],
     extras_require=dependencies['extras_require'],
     entry_points={
-        'console_scripts': ['sky = sky.cli:cli'],
+        'console_scripts': [
+            # Install skyserver to venv to pin the module used, refer to #4801
+            'sky = sky.cli:cli',
+            'skyserver = sky.server.server:main'
+        ],
     },
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #4801

Tested manually, checked whether the module in current working dir is used:

```bash
# Avoid -e to install once 
$ pip install ".[all]"
$ sed -i "s/API_VERSION = '3'/API_VERSION = '9'/" sky/server/constants.py
$ sky api stop && sky api start
```

This branch, the installed module is used instead of current dir, which is expected:

```bash
{"status":"healthy","api_version":"3","commit":"296a22e868b9bdf1faccbe3effbfb858a5a05905-dirty","version":"1.0.0-dev0"}%
```

Master branch, start raise an error, indicates the local dir is used:

```
sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580. Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health

During handling of the above exception, another exception occurred:

AssertionError: API server version mismatch when starting the server. Server version: 9 Client version: 3
```

Also tested the case that `skyserver` is not installed:

```
sky api start
Failed to connect to SkyPilot API server at http://127.0.0.1:46580. Starting a local server.
sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580. Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health

During handling of the above exception, another exception occurred:

RuntimeError: SkyPilot API server command skyserver is not available in PATH. Rerun `pip install -e .` to install the command.
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
