### PR TITLE
[API server] accelerate start by slowly start workers

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1128,3 +1128,4 @@ if __name__ == '__main__':
             if sub_proc.is_alive():
                 sub_proc.terminate()
                 sub_proc.join()
+            sub_proc.close()

--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -1,0 +1,73 @@
+"""Uvicorn wrapper for Sky server."""
+import os
+import threading
+import time
+
+import uvicorn
+from uvicorn.supervisors import multiprocess
+
+
+def run(config: uvicorn.Config):
+    """Run unvicorn server."""
+    if config.reload:
+        # Reload and multi-workers are mutually exclusive
+        # in uvicorn. Since we do not use reload now, simply
+        # guard by an exception.
+        raise ValueError('Reload is not supported yet.')
+    server = uvicorn.Server(config=config)
+    try:
+        if config.workers is not None and config.workers > 1:
+            sock = config.bind_socket()
+            SlowStartMultiprocess(config, target=server.run,
+                                  sockets=[sock]).run()
+        else:
+            server.run()
+    finally:
+        # Copied from unvicorn.run()
+        if config.uds and os.path.exists(config.uds):
+            os.remove(config.uds)
+
+
+class SlowStartMultiprocess(multiprocess.Multiprocess):
+    """Uvicorn Multiprocess wrapper with slow start."""
+
+    def __init__(self,
+                 config: uvicorn.Config,
+                 slow_start_delay: float = 2.0,
+                 **kwargs):
+        """Initialize the multiprocess wrapper.
+
+        Args:
+            config: The uvicorn config.
+            slow_start_delay: The delay between starting each worker process,
+                default to 2.0 seconds based on profile.
+        """
+        super().__init__(config, **kwargs)
+        self.slow_start_delay = slow_start_delay
+
+    def init_processes(self) -> None:
+        # Slow start worker processes asynchronously to avoid blocking signal
+        # handling of uvicorn.
+        threading.Thread(target=self.slow_start_processes, daemon=True).start()
+
+    def slow_start_processes(self) -> None:
+        """Initialize remaining processes with slow start."""
+        batch_size = 1
+        processes_left = self.processes_num
+
+        # Though the processes are started asynchronously, we still have to be
+        # slow to avoid overwhelming the CPU on startup.
+        while processes_left > 0:
+            current_batch = min(batch_size, processes_left)
+            for _ in range(current_batch):
+                process = multiprocess.Process(self.config, self.target,
+                                               self.sockets)
+                # Must start the process before appending to self.processes
+                # since uvicorn periodically restarts unresponsive workers.
+                process.start()
+                self.processes.append(process)
+                processes_left -= 1
+            if processes_left <= 0:
+                break
+            time.sleep(self.slow_start_delay)
+            batch_size *= 2

--- a/tests/unit_tests/sky/utils/test_subprocess_utils.py
+++ b/tests/unit_tests/sky/utils/test_subprocess_utils.py
@@ -1,0 +1,160 @@
+"""Unit tests for subprocess_utils.py."""
+import logging
+import time
+from unittest import mock
+
+import pytest
+
+from sky.utils import subprocess_utils
+
+logger = logging.getLogger(__name__)
+
+# Fixtures to replace setUp and tearDown
+
+
+@pytest.fixture
+def mock_startable():
+    """Create a mock class that implements the Startable protocol."""
+
+    def create_mock():
+        return mock.MagicMock(spec=subprocess_utils.Startable)
+
+    mock_factory = mock.MagicMock()
+    mock_factory.side_effect = create_mock
+    return mock_factory
+
+
+@pytest.fixture
+def mock_sleep():
+    """Patch time.sleep to avoid actual delays during tests."""
+    with mock.patch('time.sleep') as mock_sleep:
+        yield mock_sleep
+
+
+@pytest.fixture
+def mock_cpu_count():
+    """Patch common_utils.get_cpu_count to return a predictable value."""
+    with mock.patch('sky.utils.common_utils.get_cpu_count',
+                    return_value=16) as mock_count:
+        yield mock_count
+
+
+# Test functions to replace test methods
+
+
+def test_empty_process_list(mock_sleep):
+    """Test with an empty process list."""
+    processes = []
+    subprocess_utils.slow_start_processes(processes)
+    # No processes to start, so sleep should not be called
+    mock_sleep.assert_not_called()
+
+
+def test_single_process(mock_startable, mock_sleep):
+    """Test with a single process."""
+    process = mock_startable()
+    processes = [process]
+
+    subprocess_utils.slow_start_processes(processes)
+
+    # Process should be started
+    process.start.assert_called_once()
+    # No sleep should be called with only one process
+    mock_sleep.assert_not_called()
+
+
+def test_multiple_processes(mock_startable, mock_sleep):
+    """Test with multiple processes."""
+    processes = [mock_startable() for _ in range(5)]
+
+    subprocess_utils.slow_start_processes(processes)
+
+    # All processes should be started
+    for process in processes:
+        process.start.assert_called_once()
+
+    # Sleep should be called the correct number of times
+    # With 5 processes and batch sizes of 1, 2, 2 (based on the logs)
+    # We expect 2 sleep calls
+    assert mock_sleep.call_count == 2
+
+
+def test_custom_delay(mock_startable, mock_sleep):
+    """Test with a custom delay value."""
+    processes = [mock_startable() for _ in range(3)]
+    custom_delay = 5.0
+
+    subprocess_utils.slow_start_processes(processes, delay=custom_delay)
+
+    # Sleep should be called with the custom delay
+    mock_sleep.assert_called_with(custom_delay)
+
+
+def test_on_start_callback(mock_startable):
+    """Test the on_start callback functionality."""
+    processes = [mock_startable() for _ in range(3)]
+    on_start_mock = mock.Mock()
+
+    subprocess_utils.slow_start_processes(processes, on_start=on_start_mock)
+
+    # All processes should be started
+    for process in processes:
+        process.start.assert_called_once()
+
+    # Verify callback was called with each process
+    calls = [mock.call(process) for process in processes]
+    on_start_mock.assert_has_calls(calls)
+
+
+def test_batch_size_growth(mock_startable, mock_sleep):
+    """Test that batch size grows exponentially but is limited by max_batch_size."""
+    # Create enough processes to test batch size growth
+    processes = [mock_startable() for _ in range(32)]
+
+    # Mock the implementation to capture batch sizes
+    batch_sizes = []
+
+    def mock_sleep_side_effect(delay):
+        # Calculate the current batch size based on the number of started processes
+        started_count = sum(p.start.called for p in processes)
+        batch_sizes.append(started_count)
+        # Don't actually sleep or call original_sleep to avoid recursion
+
+    mock_sleep.side_effect = mock_sleep_side_effect
+
+    # Mock get_cpu_count to return an integer to avoid float issues
+    with mock.patch('sky.utils.subprocess_utils.common_utils.get_cpu_count',
+                    return_value=16):
+        subprocess_utils.slow_start_processes(processes)
+
+    # With CPU count of 16, max_batch_size = 8
+    # So we expect batch sizes to grow: 1, 2, 4, 8, 8, 8, ...
+    # Verify the expected pattern of batch size growth
+    expected_started_counts = [1, 3, 7, 15, 23, 31]
+    assert batch_sizes == expected_started_counts
+
+
+def test_with_low_cpu_count(mock_startable, mock_sleep, mock_cpu_count):
+    """Test with a low CPU count to verify max_batch_size behavior."""
+    # Temporarily change the CPU count to a lower value
+    mock_cpu_count.return_value = 2
+
+    # Create processes
+    processes = [mock_startable() for _ in range(5)]
+
+    # Mock the implementation to capture batch sizes
+    batch_sizes = []
+
+    def mock_sleep_side_effect(delay):
+        # Calculate the current batch size based on the number of started processes
+        started_count = sum(p.start.called for p in processes)
+        batch_sizes.append(started_count)
+        return None  # Don't actually sleep
+
+    mock_sleep.side_effect = mock_sleep_side_effect
+
+    subprocess_utils.slow_start_processes(processes)
+
+    # Start 1 at a time
+    expected_started_counts = [1, 2, 3, 4]
+    assert batch_sizes == expected_started_counts


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

For https://github.com/skypilot-org/skypilot/issues/4843, the number of uvicorn workers and skypilot's background long workers are proportional to available CPU cores, which cause issues if the machine is not dedicated to our API server. e.g. the machine has 128 cores but the API server can only get 10 due to contention. The CPU pressure of launching 128 + 256 worker processes simultaneously would severely slow the startup.

This PR introduces TCP-like start for unvicorn workers and long workers. The launch delay is set to fix value based on profiling (2 seconds now) for simplicity.

Test on simulated high resource contention env on my 12 core laptop:

```bash
# Cheat API server that the env has 64c256g resources
$ export SKYPILOT_POD_CPU_CORE_LIMIT=64
$ export SKYPILOT_POD_MEMORY_GB_LIMIT=256

# master, timeout
/usr/bin/time sky api start --deploy
sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580. Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health

During handling of the above exception, another exception occurred:
....

# PR branch, start in 4.2s
/usr/bin/time sky api start --deploy
Failed to connect to SkyPilot API server at http://0.0.0.0:46580. Starting a local server.
✓ SkyPilot API server started.
├── SkyPilot API server: http://0.0.0.0:46580
└── View API server logs at: ~/.sky/api_server/server.log
        4,20 real         1,06 user         0,59 sys
```

For environment without any resource contention, this PR also accelerates the start time. The start time was accelerated from ~7s->~3.5s on my laptop, achieving a 100% acceleration in daily usage:

```bash
# master
$ /usr/bin/time sky api start --deploy
...
        6,96 real         0,54 user         0,56 sys

# PR branch
$ /usr/bin/time sky api start --deploy
...
        3,28 real         0,63 user         0,56 sys
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`

## Appendix

Profiling, launching 1 uvicorn server process takes about ~1s (sky api start):

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/e0a141f1-bcf7-459a-b29c-6fb0aeb9bc70" />


Launching 12 uvicorn server processes, each takes about 2~3s (sky api start --deploy)

<img width="1496" alt="image" src="https://github.com/user-attachments/assets/46f41c72-a027-4d9d-b618-19f45d2fa067" />
