### PR TITLE
[Test] fixed managed job return code with --no-follow for compatibility test

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -736,9 +736,9 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> Tuple[str, int]:
         assert managed_job_status is not None, job_id
 
     if not follow and not managed_job_status.is_terminal():
-        # The job is not in terminal state and the log is not following,
-        # simply return with succeeded exit code.
-        return '', 0
+        # The job is not in terminal state and we are not following,
+        # just return.
+        return '', exceptions.JobExitCode.SUCCEEDED
     logger.info(
         ux_utils.finishing_message(f'Managed job finished: {job_id} '
                                    f'(status: {managed_job_status.value}).'))

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -735,9 +735,13 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> Tuple[str, int]:
         managed_job_status = managed_job_state.get_status(job_id)
         assert managed_job_status is not None, job_id
 
+    if not follow and not managed_job_status.is_terminal():
+        # The job is not in terminal state and the log is not following,
+        # simply return with succeeded exit code.
+        return '', 0
     logger.info(
-        ux_utils.finishing_message(f'Managed job finished: {job_id} '
-                                   f'(status: {managed_job_status.value}).'))
+            ux_utils.finishing_message(f'Managed job finished: {job_id} '
+                                       f'(status: {managed_job_status.value}).'))
     return '', exceptions.JobExitCode.from_managed_job_status(
         managed_job_status)
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -740,8 +740,8 @@ def stream_logs_by_id(job_id: int, follow: bool = True) -> Tuple[str, int]:
         # simply return with succeeded exit code.
         return '', 0
     logger.info(
-            ux_utils.finishing_message(f'Managed job finished: {job_id} '
-                                       f'(status: {managed_job_status.value}).'))
+        ux_utils.finishing_message(f'Managed job finished: {job_id} '
+                                   f'(status: {managed_job_status.value}).'))
     return '', exceptions.JobExitCode.from_managed_job_status(
         managed_job_status)
 

--- a/tests/backward_compatibility_tests.sh
+++ b/tests/backward_compatibility_tests.sh
@@ -39,8 +39,8 @@ ABSOLUTE_BASE_VERSION_DIR=$(cd "$(dirname "$BASE_VERSION_DIR")" 2>/dev/null && p
 rm -rf $ABSOLUTE_BASE_VERSION_DIR
 
 need_launch=${1:-0}
-start_from=7
-base_branch="fix-backward-compability-test"
+start_from=${2:-0}
+base_branch=${3:-master}
 
 CLUSTER_NAME="test-back-compat-$(whoami)"
 # Test managed jobs to make sure existing jobs and new job can run correctly,

--- a/tests/backward_compatibility_tests.sh
+++ b/tests/backward_compatibility_tests.sh
@@ -39,8 +39,8 @@ ABSOLUTE_BASE_VERSION_DIR=$(cd "$(dirname "$BASE_VERSION_DIR")" 2>/dev/null && p
 rm -rf $ABSOLUTE_BASE_VERSION_DIR
 
 need_launch=${1:-0}
-start_from=${2:-0}
-base_branch=${3:-master}
+start_from=7
+base_branch="fix-backward-compability-test"
 
 CLUSTER_NAME="test-back-compat-$(whoami)"
 # Test managed jobs to make sure existing jobs and new job can run correctly,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/4886

Covered by Backward compatibility tests, so no new case is added

Note that backward compatibility test of **THIS PR** will still fail since the skylet is deployed using the code on master branch. I verified this PR by changing the base branch of compatibility test to current branch. Checkout the test result here: https://buildkite.com/skypilot-1/quicktest-core/builds/172#019566fe-818b-4571-9a5c-279fada58ef2

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [x] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
