### PR TITLE
[jobs] resolve jobs queue user on API server side

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -341,6 +341,8 @@ def queue(refresh: bool,
                 'status': (sky.jobs.ManagedJobStatus) of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
+                'user_name': (str) job creator's user name,
+                'user_hash': (str) job creator's user hash,
             }
         ]
     Raises:

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -341,7 +341,7 @@ def queue(refresh: bool,
                 'status': (sky.jobs.ManagedJobStatus) of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
-                'user_name': (str) job creator's user name,
+                'user_name': (Optional[str]) job creator's user name,
                 'user_hash': (str) job creator's user hash,
             }
         ]

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -918,6 +918,10 @@ def load_managed_job_queue(payload: str) -> List[Dict[str, Any]]:
     jobs = message_utils.decode_payload(payload)
     for job in jobs:
         job['status'] = managed_job_state.ManagedJobStatus(job['status'])
+        if 'user_hash' in job and job['user_hash'] is not None:
+            # Skip jobs that do not have user_hash info.
+            # TODO(cooperc): Remove check before 0.12.0.
+            job['user_name'] = global_user_state.get_user(job['user_hash']).name
     return jobs
 
 
@@ -1047,16 +1051,20 @@ def format_job_table(
     def get_user_column_values(task: Dict[str, Any]) -> List[str]:
         user_values: List[str] = []
         if show_user:
+            user_name = '-' # default value
 
-            user_name = '-'
-            user_hash = task.get('user_hash', None)
-            if user_hash:
-                user = global_user_state.get_user(user_hash)
-                user_name = user.name if user.name else '-'
+            task_user_name = task.get('user_name', None)
+            task_user_hash = task.get('user_hash', None)
+            if task_user_name is not None:
+                user_name = task_user_name
+            elif task_user_hash is not None:
+                # Fallback to the user hash if we are somehow missing the name.
+                user_name = task_user_hash
+
             user_values = [user_name]
 
             if show_all:
-                user_values.append(user_hash if user_hash is not None else '-')
+                user_values.append(task_user_hash if task_user_hash is not None else '-')
 
         return user_values
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -1051,7 +1051,7 @@ def format_job_table(
     def get_user_column_values(task: Dict[str, Any]) -> List[str]:
         user_values: List[str] = []
         if show_user:
-            user_name = '-' # default value
+            user_name = '-'  # default value
 
             task_user_name = task.get('user_name', None)
             task_user_hash = task.get('user_hash', None)
@@ -1064,7 +1064,8 @@ def format_job_table(
             user_values = [user_name]
 
             if show_all:
-                user_values.append(task_user_hash if task_user_hash is not None else '-')
+                user_values.append(
+                    task_user_hash if task_user_hash is not None else '-')
 
         return user_values
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Only the API server has full view of all the users. Neither the jobs controller or the client will necessarily have it. So we need to make sure that the resolution of user_id -> user name happens when the API server loads the managed jobs table.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
