### PR TITLE
[Core] Handle mid-sequence chunking in log streaming

### DIFF
--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -252,8 +252,8 @@ def decode_rich_status(
                 if e.start > 0:
                     # Decode the valid part
                     encoded_msg = current_bytes[:e.start].decode('utf-8')
-                    
-                    # Check if the remaining bytes are likely a partial character
+
+                    # Check if the remaining bytes are likely a partial char
                     # or actually invalid UTF-8
                     remaining_bytes = current_bytes[e.start:]
                     if len(remaining_bytes) < 4:  # Max UTF-8 char is 4 bytes
@@ -261,11 +261,13 @@ def decode_rich_status(
                         undecoded_buffer = remaining_bytes
                     else:
                         # Likely invalid - replace with replacement character
-                        encoded_msg += remaining_bytes.decode('utf-8', errors='replace')
+                        encoded_msg += remaining_bytes.decode('utf-8',
+                                                              errors='replace')
                         undecoded_buffer = b''
                 else:
-                    # Error at the very beginning of the buffer - this is invalid UTF-8
-                    encoded_msg = current_bytes.decode('utf-8', errors='replace')
+                    # Error at the very beginning of the buffer - invalid UTF-8
+                    encoded_msg = current_bytes.decode('utf-8',
+                                                       errors='replace')
                     undecoded_buffer = b''
 
             lines = encoded_msg.splitlines(keepends=True)

--- a/sky/utils/rich_utils.py
+++ b/sky/utils/rich_utils.py
@@ -232,18 +232,18 @@ def decode_rich_status(
         last_line = ''
         # Buffer to store incomplete UTF-8 bytes between chunks
         undecoded_buffer = b''
-        
+
         # Iterate over the response content in chunks. We do not use iter_lines
         # because it will strip the trailing newline characters, causing the
         # progress bar ending with `\r` becomes a pyramid.
         for chunk in response.iter_content(chunk_size=None):
             if chunk is None:
                 return
-            
+
             # Append the new chunk to any leftover bytes from previous iteration
             current_bytes = undecoded_buffer + chunk
             undecoded_buffer = b''
-            
+
             # Try to decode the combined bytes
             try:
                 encoded_msg = current_bytes.decode('utf-8')
@@ -253,13 +253,13 @@ def decode_rich_status(
                 valid_byte_count = e.start
                 encoded_msg = current_bytes[:valid_byte_count].decode('utf-8')
                 undecoded_buffer = current_bytes[valid_byte_count:]
-                
+
             lines = encoded_msg.splitlines(keepends=True)
-            
+
             # Skip processing if lines is empty to avoid IndexError
             if not lines:
                 continue
-                
+
             # Append any leftover text from previous chunk to first line
             lines[0] = last_line + lines[0]
             last_line = lines[-1]

--- a/tests/unit_tests/sky/utils/test_rich_utils.py
+++ b/tests/unit_tests/sky/utils/test_rich_utils.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest import mock
+
+import requests
+
+from sky.utils import rich_utils
+
+
+class RichUtilsTest(unittest.TestCase):
+
+    def test_decode_rich_status_with_split_utf8(self):
+        """Test that decode_rich_status handles UTF-8 characters split across chunks."""
+        # This is a progress bar with UTF-8 box drawing characters
+        # The character █ is a multibyte UTF-8 character (0xE2 0x96 0x88)
+        progress_bar = "20%|████        | 115/581 [00:12<00:41, 11.20it/s]\n"
+        
+        # Create a response object with a custom content iterator
+        mock_response = mock.MagicMock(spec=requests.Response)
+        
+        # Convert to bytes and deliberately split in the middle of a multibyte character
+        # The character █ is encoded as three bytes: \xe2\x96\x88
+        progress_bytes = progress_bar.encode('utf-8')
+        
+        # Find position of the first █ character and split between its bytes
+        pos = progress_bytes.find(b'\xe2\x96\x88')
+        
+        # Split the bytes so that \xe2 is in one chunk and \x96\x88 is in the next
+        chunk1 = progress_bytes[:pos+1]  # Include the first byte of █ (\xe2)
+        chunk2 = progress_bytes[pos+1:]  # Rest of the bytes including \x96\x88
+        
+        # Configure the mock to return these chunks when iterated
+        mock_response.iter_content.return_value = [chunk1, chunk2]
+        
+        # The function should handle the split character correctly
+        result = list(rich_utils.decode_rich_status(mock_response))
+        
+        # Verify the output contains the correctly decoded progress bar
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], progress_bar)
+        
+    def test_decode_rich_status_with_multiple_split_characters(self):
+        """Test handling multiple UTF-8 characters split across several chunks."""
+        # Progress bar with multiple multibyte characters
+        progress_bar = "50%|█████████████████████████████░░░░░░░░░░░░░| 250/500 [01:15<01:15, 3.33it/s]\n"
+        progress_bytes = progress_bar.encode('utf-8')
+        
+        # Create chunks that split at several different points
+        # Find positions of several █ characters and split between their bytes
+        multibyte_char = '█'.encode('utf-8')  # \xe2\x96\x88
+        positions = []
+        start = 0
+        while True:
+            pos = progress_bytes.find(multibyte_char, start)
+            if pos == -1 or len(positions) >= 3:
+                break
+            positions.append(pos)
+            start = pos + len(multibyte_char)
+        
+        # Create chunks that split at different multibyte character boundaries
+        chunks = []
+        last_pos = 0
+        for i, pos in enumerate(positions):
+            if i % 2 == 0:  # For even indices, split after first byte of multibyte char
+                chunks.append(progress_bytes[last_pos:pos+1])
+                last_pos = pos+1
+            else:  # For odd indices, split normally
+                chunks.append(progress_bytes[last_pos:pos])
+                last_pos = pos
+        
+        # Add the final chunk
+        chunks.append(progress_bytes[last_pos:])
+        
+        # Configure mock response
+        mock_response = mock.MagicMock(spec=requests.Response)
+        mock_response.iter_content.return_value = chunks
+        
+        # Should handle multiple split characters correctly
+        result = list(rich_utils.decode_rich_status(mock_response))
+        
+        # Verify the output
+        joined_result = ''.join(r for r in result if r is not None)
+        self.assertEqual(joined_result, progress_bar)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests/sky/utils/test_rich_utils.py
+++ b/tests/unit_tests/sky/utils/test_rich_utils.py
@@ -13,37 +13,38 @@ class RichUtilsTest(unittest.TestCase):
         # This is a progress bar with UTF-8 box drawing characters
         # The character █ is a multibyte UTF-8 character (0xE2 0x96 0x88)
         progress_bar = "20%|████        | 115/581 [00:12<00:41, 11.20it/s]\n"
-        
+
         # Create a response object with a custom content iterator
         mock_response = mock.MagicMock(spec=requests.Response)
-        
+
         # Convert to bytes and deliberately split in the middle of a multibyte character
         # The character █ is encoded as three bytes: \xe2\x96\x88
         progress_bytes = progress_bar.encode('utf-8')
-        
+
         # Find position of the first █ character and split between its bytes
         pos = progress_bytes.find(b'\xe2\x96\x88')
-        
+
         # Split the bytes so that \xe2 is in one chunk and \x96\x88 is in the next
-        chunk1 = progress_bytes[:pos+1]  # Include the first byte of █ (\xe2)
-        chunk2 = progress_bytes[pos+1:]  # Rest of the bytes including \x96\x88
-        
+        chunk1 = progress_bytes[:pos + 1]  # Include the first byte of █ (\xe2)
+        chunk2 = progress_bytes[pos +
+                                1:]  # Rest of the bytes including \x96\x88
+
         # Configure the mock to return these chunks when iterated
         mock_response.iter_content.return_value = [chunk1, chunk2]
-        
+
         # The function should handle the split character correctly
         result = list(rich_utils.decode_rich_status(mock_response))
-        
+
         # Verify the output contains the correctly decoded progress bar
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], progress_bar)
-        
+
     def test_decode_rich_status_with_multiple_split_characters(self):
         """Test handling multiple UTF-8 characters split across several chunks."""
         # Progress bar with multiple multibyte characters
         progress_bar = "50%|█████████████████████████████░░░░░░░░░░░░░| 250/500 [01:15<01:15, 3.33it/s]\n"
         progress_bytes = progress_bar.encode('utf-8')
-        
+
         # Create chunks that split at several different points
         # Find positions of several █ characters and split between their bytes
         multibyte_char = '█'.encode('utf-8')  # \xe2\x96\x88
@@ -55,31 +56,28 @@ class RichUtilsTest(unittest.TestCase):
                 break
             positions.append(pos)
             start = pos + len(multibyte_char)
-        
+
         # Create chunks that split at different multibyte character boundaries
         chunks = []
         last_pos = 0
         for i, pos in enumerate(positions):
             if i % 2 == 0:  # For even indices, split after first byte of multibyte char
-                chunks.append(progress_bytes[last_pos:pos+1])
-                last_pos = pos+1
+                chunks.append(progress_bytes[last_pos:pos + 1])
+                last_pos = pos + 1
             else:  # For odd indices, split normally
                 chunks.append(progress_bytes[last_pos:pos])
                 last_pos = pos
-        
+
         # Add the final chunk
         chunks.append(progress_bytes[last_pos:])
-        
+
         # Configure mock response
         mock_response = mock.MagicMock(spec=requests.Response)
         mock_response.iter_content.return_value = chunks
-        
+
         # Should handle multiple split characters correctly
         result = list(rich_utils.decode_rich_status(mock_response))
-        
+
         # Verify the output
         joined_result = ''.join(r for r in result if r is not None)
         self.assertEqual(joined_result, progress_bar)
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Closes #4905.

Our chunking may chunk in the middle of a UTF-8 sequence, which would cause decoding to break. We now store the undecoded bytes in a buffer and wait to receive the next chunk before trying to decode again.