### PR TITLE
[docs] add jobs controller resource tuning reference in config page

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -183,6 +183,8 @@ Supported bucket types:
 
 Configure resources for the managed jobs controller.
 
+For more details about tuning the jobs controller resources, see :ref:`jobs-controller-sizing`.
+
 Example:
 
 .. code-block:: yaml
@@ -190,10 +192,13 @@ Example:
   jobs:
     controller:
       resources:  # same spec as 'resources' in a task YAML
+        # optionally set specific cloud/region
         cloud: gcp
         region: us-central1
-        cpus: 4+  # number of vCPUs, max concurrent spot jobs = 2 * cpus
-        disk_size: 100
+        # default resources:
+        cpus: 4+
+        memory: 8x
+        disk_size: 50
 
 .. _config-yaml-allowed-clouds:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `pytest tests/test_smoke.py` 
- [ ] Relevant individual smoke tests: `pytest tests/test_smoke.py::test_fill_in_the_name` 
- [ ] Backward compatibility tests: `conda deactivate; bash -i tests/backward_compatibility_tests.sh`
