### PR TITLE
more permissive match for k8s accelerators

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -846,7 +846,7 @@ def get_accelerator_label_key_value(
                 for label, value in label_list:
                     if (label_formatter.match_label_key(label) and
                             label_formatter.get_accelerator_from_label_value(
-                                value) == acc_type):
+                                value).lower() == acc_type.lower()):
                         if is_tpu_on_gke(acc_type):
                             assert isinstance(label_formatter,
                                               GKELabelFormatter)

--- a/sky/utils/accelerator_registry.py
+++ b/sky/utils/accelerator_registry.py
@@ -77,7 +77,7 @@ def canonicalize_accelerator_name(accelerator: str,
     # Look for Kubernetes accelerators online if the accelerator is not found
     # in the public cloud catalog. This is to make sure custom accelerators
     # on Kubernetes can be correctly canonicalized.
-    if not names and cloud_str in ['kubernetes', None]:
+    if not names and cloud_str in ['Kubernetes', None]:
         with rich_utils.safe_status(
                 ux_utils.spinner_message('Listing accelerators on Kubernetes')):
             searched = service_catalog.list_accelerators(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Allows for more permissive (case insensitive, prefix) match for kubernetes when launching accelerators on kubernetes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
Tested against locally running k8s cluster with mocked accelerators.

Before:
```
% sky launch --gpus gh200 --cpus 1 --memory 1 --cloud kubernetes 
No resource satisfying Kubernetes(cpus=1, mem=1, {'gh200': 1}) on Kubernetes.
...
% sky launch --gpus gh200-480gb --cpus 1 --memory 1 --cloud kubernetes 
No resource satisfying Kubernetes(cpus=1, mem=1, {'gh200-480gb': 1}) on Kubernetes.
...
```
After:
```
% sky launch --gpus gh200-480 --cpus 1 --memory 1 --cloud kubernetes 
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                   vCPUs   Mem(GB)   ACCELERATORS    REGION/ZONE     COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------
 Kubernetes   1CPU--1GB--GH200-480GB:1   1       1         GH200-480GB:1   kind-skypilot   0.00          ✔     
---------------------------------------------------------------------------------------------------------------
Launching a new cluster <cluster>. Proceed?
...
% sky launch --gpus gh200 --cpus 1 --memory 1 --cloud kubernetes 
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                   vCPUs   Mem(GB)   ACCELERATORS    REGION/ZONE     COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------
 Kubernetes   1CPU--1GB--GH200-480GB:1   1       1         GH200-480GB:1   kind-skypilot   0.00          ✔     
---------------------------------------------------------------------------------------------------------------
Launching a new cluster  <cluster>. Proceed?
...
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
