### PR TITLE
[k8s] filter out nodes with less accelerators than requested

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -716,8 +716,8 @@ def check_instance_fits(context: Optional[str],
             node for node in gpu_nodes
             if get_node_accelerator_count(node.status.allocatable) >= acc_count
         ]
-        if len(gpu_nodes) == 0:
-            return False, 'No GPU nodes found with the enough GPUs'
+        if not gpu_nodes:
+            return False, f'No GPU nodes found with {acc_count} or more GPUs'
         if is_tpu_on_gke(acc_type):
             # If requested accelerator is a TPU type, check if the cluster
             # has sufficient TPU resource to meet the requirement.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -711,6 +711,13 @@ def check_instance_fits(context: Optional[str],
             node.metadata.labels[gpu_label_key] == gpu_label_val
         ]
         assert gpu_nodes, 'GPU nodes not found'
+        # filter out nodes that do not have enough GPUs
+        gpu_nodes = [
+            node for node in gpu_nodes
+            if get_node_accelerator_count(node.status.allocatable) >= acc_count
+        ]
+        if len(gpu_nodes) == 0:
+            return False, 'No GPU nodes found with the enough GPUs'
         if is_tpu_on_gke(acc_type):
             # If requested accelerator is a TPU type, check if the cluster
             # has sufficient TPU resource to meet the requirement.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When evaluating k8s nodes to serve jobs, only consider nodes that have enough GPU capacity to serve the job.

Note: Here we use the total node GPU, not free node GPU, to determine node eligibility. The idea is a node that has enough total GPUs which are not free at the moment can serve the (queued) job once the current job is done, but if a node's total GPU count is less than what the job requires then the node can _never_ serve the job.

The check is performed via calling `get_node_accelerator_count` on `node.status.allocatable`, which is used on `sky/clouds/service_catalog/kubernetes_catalog.py:L209-L211`
```
                accelerator_count = (
                    kubernetes_utils.get_node_accelerator_count(
                        node.status.allocatable))
```
to generate the total free GPUs for the node when using `sky show-gpus`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
Tested against GKE cluster with 1 A100 accelerator node.

Before:

```
% sky show-gpus
Kubernetes GPUs 
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS  
A100  1                         1           1      
...
 % sky launch --gpus a100:1 --cloud kubernetes
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         <project>_<location>_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-ee7c-seungjinyang'. Proceed? [Y/n]: 
...
(sky) seungjinyang@Seungjins-MacBook-Air skypilot % sky launch --gpus a100:2 --cloud kubernetes
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:2   2       8         A100:2         <project>_<location>_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-cfd8-seungjinyang'. Proceed? [Y/n]: 
...
```
After:

```
% sky show-gpus
Kubernetes GPUs 
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS  
A100  1                         1           1                
...
% sky launch --gpus a100:1 --cloud kubernetes  
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         <project>_<location>_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-8fbf-seungjinyang'. Proceed? [Y/n]:
...
% sky launch --gpus a100:2 --cloud kubernetes 
No resource satisfying Kubernetes({'A100': 2}) on Kubernetes.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request: 1x Kubernetes({'A100': 2}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] Relevant individual tests: `/smoke-test --kubernetes`
- [x] Backward compatibility: `/quicktest-core`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
