### PR TITLE
[k8s] better support for GKE scale-to-zero autoscaling node pools

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -631,7 +631,6 @@ class Kubernetes(clouds.Cloud):
             chosen_instance_type = (
                 kubernetes_utils.KubernetesInstanceType.from_resources(
                     gpu_task_cpus, gpu_task_memory, acc_count, acc_type).name)
-
         # Check the availability of the specified instance type in all contexts.
         available_regions = self.regions_with_offering(
             chosen_instance_type,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -246,9 +246,9 @@ class Kubernetes(clouds.Cloud):
                 regions_to_return.append(r)
             else:
                 if autoscaler_type is not None:
-                    autoscale_detector = kubernetes_utils. \
-                        get_autoscaler_detector(autoscaler_type)
-                    if autoscale_detector.can_create_new_instance_of_type(
+                    autoscaler = kubernetes_utils. \
+                        get_autoscaler(autoscaler_type)
+                    if autoscaler.can_create_new_instance_of_type(
                             context, instance_type):
                         regions_to_return.append(r)
                     else:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -249,100 +249,19 @@ class Kubernetes(clouds.Cloud):
                 if fits:
                     regions_to_return.append(r)
                 else:
-                    if autoscaler_type is not None and cls.check_can_autoscale(context, instance_type, autoscaler_type):
-                        regions_to_return.append(r)
-                    else:
-                        logger.debug(
-                            f'Instance type {instance_type} does '
-                            'not fit in the Kubernetes cluster with context: '
-                            f'{context}. Reason: {reason}')
+                    if autoscaler_type is not None:
+                        autoscale_detector = kubernetes_utils.AUTOSCALER_TO_AUTOSCALE_DETECTOR[autoscaler_type]
+                        if autoscale_detector.may_autoscale(context, instance_type):
+                            regions_to_return.append(r)
+                        else:
+                            logger.debug(
+                                f'Instance type {instance_type} does '
+                                'not fit in the Kubernetes cluster with context: '
+                                f'{context}. Reason: {reason}')
         else:
             regions_to_return = regions
 
         return regions_to_return
-    
-    @classmethod
-    def check_can_autoscale(cls, context: str, instance_type: str, autoscaler_type: kubernetes_enums.KubernetesAutoscalerType) -> bool:
-        if autoscaler_type == kubernetes_enums.KubernetesAutoscalerType.GKE:
-            return cls.check_can_autoscale_gke(context, instance_type)
-        return False
-
-    @classmethod
-    def check_can_autoscale_gke(cls, context: str, instance_type: str) -> bool:
-        # assume context naming convention of gke_PROJECT-ID_ZONE_CLUSTER-NAME
-        print(f"Checking if {context} can autoscale")
-        context_components = context.split("_")
-        if len(context_components) != 4:
-            return False
-        project_id = context_components[1]
-        location = context_components[2]
-        cluster_name = context_components[3]
-        # pylint: disable=import-outside-toplevel
-        import google.auth
-        credentials, _ = google.auth.default()
-        container_service = gcp.build('container',
-                                    'v1',
-                                    credentials=credentials)
-        cluster = container_service.projects().locations().clusters() \
-            .get(name=f"projects/{project_id}/locations/{location}/clusters/{cluster_name}").execute()
-
-        # get node pools
-        for node_pool in cluster['nodePools']:
-            if node_pool['autoscaling'] is not None \
-                and 'enabled' in node_pool['autoscaling'] \
-                and node_pool['autoscaling']['enabled']:
-                
-                if cls.check_instance_fits_gke_autoscaler_node_pool(context, instance_type, node_pool):
-                    return True
-
-        return False
-    
-    @classmethod
-    def check_instance_fits_gke_autoscaler_node_pool(cls, context: str, instance_type: str, node_pool: dict) -> bool:
-        print(f"Node pool", node_pool['name'])   
-
-        # check if there are any spare capacity in the autoscaler.   
-        node_count = 0
-        if 'initialNodeCount' in node_pool.keys():
-            node_count = node_pool['initialNodeCount']
-        max_node_count = node_pool['autoscaling']['maxNodeCount']
-        free_node_count = max_node_count - node_count
-        print(f"free node count: {free_node_count}")
-        if free_node_count == 0:
-            return False
-
-
-        k8s_instance_type = kubernetes_utils.KubernetesInstanceType.\
-            from_instance_type(instance_type)
-        
-        # Accelerator check
-        acc_type = k8s_instance_type.accelerator_type
-        acc_count = k8s_instance_type.accelerator_count
-        if acc_type is not None:   
-            if 'accelerators' in node_pool['config'].keys():
-                accelerator_type = kubernetes_utils.GKELabelFormatter.get_accelerator_from_label_value(
-                    node_pool['config']['accelerators'][0]['acceleratorType'])
-                accelerator_count = node_pool['config']['accelerators'][0]['acceleratorCount']
-
-                if accelerator_type is not None:
-                    print(f"accelerator: {accelerator_type}:{accelerator_count}")
-                else:
-                    print(f"no accelerator")
-
-                if accelerator_type != acc_type or int(accelerator_count) < acc_count:
-                    return False
-            else:
-                return False
-            
-        # VCPU and memory check
-        machine_type = node_pool['config']['machineType']
-        vcpus, mem = clouds.GCP.get_vcpus_mem_from_instance_type(machine_type)
-        if vcpus < k8s_instance_type.cpus or mem < k8s_instance_type.memory:
-            return False
-        
-        # disk_size = node_pool['config']['diskSizeGb']
-        # print(f"vcpus: {vcpus}, mem: {mem}, diskSizeGb: {disk_size}, maxNodeCount: {max_node_count}") 
-        return True
 
     def instance_type_to_hourly_cost(self,
                                      instance_type: str,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -232,7 +232,8 @@ class Kubernetes(clouds.Cloud):
         # kubernetes cluster/context).
         regions_to_return = []
         autoscaler_type = kubernetes_utils.get_autoscaler_type()
-        if autoscaler_type in [kubernetes_enums.KubernetesAutoscalerType.GKE, None] and instance_type is not None:
+        if (autoscaler_type in kubernetes_utils.AUTOSCALER_TO_AUTOSCALE_DETECTOR.keys() or
+        autoscaler_type is None) and instance_type is not None:
             # If autoscaler is not set, check if the instance type fits in the
             # cluster. Else, rely on the autoscaler to provision the right
             # instance type without running checks. Worst case, if autoscaling
@@ -250,7 +251,9 @@ class Kubernetes(clouds.Cloud):
                     regions_to_return.append(r)
                 else:
                     if autoscaler_type is not None:
-                        autoscale_detector = kubernetes_utils.AUTOSCALER_TO_AUTOSCALE_DETECTOR[autoscaler_type]
+                        autoscale_detector = kubernetes_utils.AUTOSCALER_TO_AUTOSCALE_DETECTOR.get(autoscaler_type)
+                        # autoscaler_type was verified to have a detector above if autoscaler_type is not None.
+                        assert autoscale_detector is not None, f'Unsupported autoscaler type: {autoscaler_type}'
                         if autoscale_detector.may_autoscale(context, instance_type):
                             regions_to_return.append(r)
                         else:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -234,10 +234,11 @@ class Kubernetes(clouds.Cloud):
         autoscaler_type = kubernetes_utils.get_autoscaler_type()
         if (autoscaler_type in kubernetes_utils.AUTOSCALER_TO_AUTOSCALE_DETECTOR.keys() or
         autoscaler_type is None) and instance_type is not None:
-            # If autoscaler is not set, check if the instance type fits in the
-            # cluster. Else, rely on the autoscaler to provision the right
-            # instance type without running checks. Worst case, if autoscaling
-            # fails, the pod will be stuck in pending state until
+            # If autoscaler is not set, or we have a way to interface with the autoscaler
+            # to determine if the instance type fits in the cluster, check if the 
+            # instance type fits in the cluster. Else, rely on the autoscaler to 
+            # provision the right instance type without running checks. Worst case, 
+            # if autoscaling fails, the pod will be stuck in pending state until
             # provision_timeout, after which failover will be triggered.
             for r in regions:
                 context = r.name

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -233,8 +233,8 @@ class Kubernetes(clouds.Cloud):
             return regions
 
         autoscaler_type = kubernetes_utils.get_autoscaler_type()
-        if (autoscaler_type is not None and autoscaler_type
-                not in kubernetes_utils.AUTOSCALER_TYPE_TO_AUTOSCALER):
+        if (autoscaler_type is not None and not kubernetes_utils.get_autoscaler(
+                autoscaler_type).supports_intelligent_scheduling):
             # Unsupported autoscaler type. Rely on the autoscaler to
             # provision the right instance type without running checks.
             # Worst case, if autoscaling fails, the pod will be stuck in

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -218,7 +218,6 @@ class Kubernetes(clouds.Cloud):
                               use_spot: bool, region: Optional[str],
                               zone: Optional[str]) -> List[clouds.Region]:
         del accelerators, zone, use_spot  # unused
-        print("calling regions_with_offering")
         existing_contexts = cls.existing_allowed_contexts()
 
         regions = []
@@ -250,9 +249,6 @@ class Kubernetes(clouds.Cloud):
                 if fits:
                     regions_to_return.append(r)
                 else:
-                    # for testing
-                    autoscaler_type = kubernetes_enums.KubernetesAutoscalerType.GKE
-                    print("calling check_can_autoscale")
                     if autoscaler_type is not None and cls.check_can_autoscale(context, instance_type, autoscaler_type):
                         regions_to_return.append(r)
                     else:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -558,9 +558,9 @@ def detect_gpu_label_formatter(
     return label_formatter, node_labels
 
 
-class AutoscaleDetector:
-    """Base class to define a autoscale detector for a Kubernetes cluster.
-    An autoscale detector is a class that defines how to detect if a Kubernetes
+class Autoscaler:
+    """Base class to define a autoscaler for a Kubernetes cluster.
+    An autoscaler is a class that defines how to detect if a Kubernetes
     context can autoscale to meet the resource requirements of a task.
     """
 
@@ -589,8 +589,8 @@ class AutoscaleDetector:
         return True
 
 
-class GKEAutoscaleDetector(AutoscaleDetector):
-    """GKE autoscale detector
+class GKEAutoscaler(Autoscaler):
+    """GKE autoscaler
     """
 
     @classmethod
@@ -680,16 +680,14 @@ class GKEAutoscaleDetector(AutoscaleDetector):
         return True
 
 
-# Mapping of autoscaler type to autoscaler detector
-AUTOSCALER_TO_AUTOSCALE_DETECTOR = {
-    kubernetes_enums.KubernetesAutoscalerType.GKE: GKEAutoscaleDetector,
+# Mapping of autoscaler type to autoscaler
+AUTOSCALER_TYPE_TO_AUTOSCALER = {
+    kubernetes_enums.KubernetesAutoscalerType.GKE: GKEAutoscaler,
 }
 
 
-def get_autoscaler_detector(
-        autoscaler_type: kubernetes_enums.KubernetesAutoscalerType):
-    return AUTOSCALER_TO_AUTOSCALE_DETECTOR.get(autoscaler_type,
-                                                AutoscaleDetector)
+def get_autoscaler(autoscaler_type: kubernetes_enums.KubernetesAutoscalerType):
+    return AUTOSCALER_TYPE_TO_AUTOSCALER.get(autoscaler_type, Autoscaler)
 
 
 @annotations.lru_cache(scope='request', maxsize=10)

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -623,9 +623,9 @@ class GKEAutoscaler(Autoscaler):
             f'/clusters/{cluster_name}').execute()
         # get node pools
         for node_pool in cluster['nodePools']:
-            if node_pool['autoscaling'] is not None \
-                and 'enabled' in node_pool['autoscaling'] \
-                and node_pool['autoscaling']['enabled']:
+            if (node_pool['autoscaling'] is not None and
+                    'enabled' in node_pool['autoscaling'] and
+                    node_pool['autoscaling']['enabled']):
 
                 if cls._check_instance_fits_gke_autoscaler_node_pool(
                         instance_type, node_pool):

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -597,6 +597,8 @@ class GKEAutoscaler(Autoscaler):
     label_formatter: Any = GKELabelFormatter
     can_query_backend: bool = True
 
+    # This variable is stored in memory in the server.
+    # The variable will reset if the server restarts.
     _pip_install_gcp_hint_last_sent = 0.0
 
     @classmethod
@@ -750,7 +752,7 @@ class GKEAutoscaler(Autoscaler):
                          f'on node pool {node_pool_name}')
             return False
         if mem is not None and mem >= k8s_instance_type.memory:
-            logger.debug(f'vcpu check failed for {machine_type} '
+            logger.debug(f'memory check failed for {machine_type} '
                          f'on node pool {node_pool_name}')
             return False
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -710,7 +710,7 @@ def check_instance_fits(context: Optional[str],
             node for node in nodes if gpu_label_key in node.metadata.labels and
             node.metadata.labels[gpu_label_key] == gpu_label_val
         ]
-        assert gpu_nodes, 'GPU nodes not found'
+        # assert gpu_nodes, 'GPU nodes not found'
         if is_tpu_on_gke(acc_type):
             # If requested accelerator is a TPU type, check if the cluster
             # has sufficient TPU resource to meet the requirement.


### PR DESCRIPTION
Addresses https://github.com/skypilot-org/skypilot/issues/4875 

<!-- Describe the changes in this PR -->
Currently, if a node autoscaler is configured in a k8s cluster, the only thing skypilot knows about the autoscaler is the [configuration](https://docs.skypilot.co/en/latest/reference/config.html#kubernetes-autoscaler) provided by the user. Specifically, skypilot has no idea if there is a node pool with the node type that may be able to handle a job that has simply been autoscaled to zero. Currently, skypilot gets around this by simply submitting a pod to each context with autoscaler enabled and seeing if the pod is scheduled before timeout.

While this approach is functional, it is inefficient because:
- A context (=cluster) may have an autoscaling node pool, but the node pool may not provide the VM needed to satisfy the request. For example, there may be an autoscaler on a node pool with A100 GPU VMs - skypilot doesn’t know this, only that there is an autoscaler group, and will try to launch H100 resources on it.
- The autoscaling node pool may have the correct accelerator but different number of accelerators, CPU / memory constraints. For example, a node pool that spins up VMs with 1 A100 cannot handle launch requests with A100:8, but again skypilot doesn’t know that.
- If there are multiple allowed contexts, and only some of them have autoscalers on them, there is no way for skypilot to know that. So skypilot may try to schedule a pod on a context w/o an autoscaler that cannot schedule the said pod.
^ note on above: the k8s autoscaler configuration is global, not per-context. A per-context autoscaler config could also solve this specific bullet point.

This PR attempts to solve these challenges for GKE autoscaler specifically. This is done by querying each context for its node pools, detecting if any node pool has autoscaling configured, and checking if any node can be spun up that can satisfy the job request.

Assumptions in code:
- Context name follows convention of `gke_PROJECT-ID_ZONE_CLUSTER-NAME`. If not, skypilot will fallback to legacy codepath.
- Customer has GCP auth set up for skypilot to query for GKE cluster details. If not, skypilot will fallback to legacy codepath.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

**Testing**

- Known failure case: `skypilot[gcp]` is not installed
```
% sky launch --gpus tpu-v5-lite-device:1 --cpus 32 --cloud kubernetes
Could not fetch autoscaler information from GKE. Run pip install "skypilot[gcp]" for more intelligent pod scheduling with GKE autoscaler.
Considered resources (1 node):
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                             vCPUs   Mem(GB)   ACCELERATORS           REGION/ZONE                                           COST ($)   CHOSEN   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   32CPU--128GB--tpu-v5-lite-device:1   32      128       tpu-v5-lite-device:1   gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔     
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-56a0-seungjinyang'. Proceed? [Y/n]:
...
% sky launch --gpus a100:1 --cloud kubernetes                                                               
Could not fetch autoscaler information from GKE. Run pip install "skypilot[gcp]" for more intelligent pod scheduling with GKE autoscaler.
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-e17b-seungjinyang'. Proceed? [Y/n]: 
```
As seen, GPUs that are not on the autoscaled node pool still attempts to be scheduled; this is consistent with legacy code behavior.

- Known failure case: context name does not follow gke standard context format.
Tested on a GKE cluster with a node pool of `ct5l-hightpu-1t` (exposing 1x`tpu-v5-lite-device` per node).
```
% kubectx test=.
Context "gke_<project>_us-central1-a_skypilot-test-cluster" renamed to "test".
% sky launch --gpus tpu-v5-lite-device:1 --cpus 32 --cloud kubernetes
Considered resources (1 node):
------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                             vCPUs   Mem(GB)   ACCELERATORS           REGION/ZONE   COST ($)   CHOSEN   
------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   32CPU--128GB--tpu-v5-lite-device:1   32      128       tpu-v5-lite-device:1   test          0.00          ✔     
------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-becc-seungjinyang'. Proceed? [Y/n]: 
...
% sky launch --gpus a100:1 --cloud kubernetes              
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
-----------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         test          0.00          ✔     
-----------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-0301-seungjinyang'. Proceed? [Y/n]: 
```
As seen, GPUs that are not on the autoscaled node pool still attempts to be scheduled; this is consistent with legacy code behavior.

- Test newly introduced functionality
Tested on a GKE cluster with a node pool of `ct5l-hightpu-1t` (exposing 1x`tpu-v5-lite-device` per node).
```
sky launch --gpus tpu-v5-lite-device:4 --cloud kubernetes    
No resource satisfying Kubernetes({'tpu-v5-lite-device': 4}, accelerator_args={}) on Kubernetes.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request: 1x Kubernetes({'tpu-v5-lite-device': 4}, accelerator_args={}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
% sky launch --gpus a100:1 --cloud kubernetes
No resource satisfying Kubernetes({'A100': 1}) on Kubernetes.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request: 1x Kubernetes({'A100': 1}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
% sky launch --gpus tpu-v5-lite-device:1 --cloud kubernetes
Considered resources (1 node):
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                          vCPUs   Mem(GB)   ACCELERATORS           REGION/ZONE                                           COST ($)   CHOSEN   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--tpu-v5-lite-device:1   2       8         tpu-v5-lite-device:1   <project>_us-central1-a_skypilot-test-cluster   0.00          ✔     
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-169e-seungjinyang'. Proceed? [Y/n]:
```
As seen, skypilot only proceeds to schedule a pod on the cluster if the correct accelerator is present.


**caveat**
context: the A100 node deployed on the cluster has 12 vcpus and 85 gig of mem.
```
% sky launch --gpus a100:1 --cpus 12 --memory 85  --cloud kubernetes
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE              vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN
-----------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   12CPU--85GB--A100:1   12      85        A100:1         gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔ 
-----------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-6d90-seungjinyang'. Proceed? [Y/n]:
Aborted!
% sky launch --gpus a100:1 --cpus 13 --memory 85 --cloud kubernetes
No resource satisfying Kubernetes(cpus=13, mem=85, {'A100': 1}) on Kubernetes.
Try specifying a different CPU count, or add "+" to the end of the CPU count to allow for larger instances.
Try specifying a different memory size, or add "+" to the end of the memory size to allow for larger instances.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request: 1x Kubernetes(cpus=13, mem=85, {'A100': 1}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
% sky launch --gpus a100:1 --cpus 12 --memory 86 --cloud kubernetes
No resource satisfying Kubernetes(cpus=12, mem=86, {'A100': 1}) on Kubernetes.
Try specifying a different CPU count, or add "+" to the end of the CPU count to allow for larger instances.
Try specifying a different memory size, or add "+" to the end of the memory size to allow for larger instances.
sky.exceptions.ResourcesUnavailableError: Kubernetes cluster does not contain any instances satisfying the request: 1x Kubernetes(cpus=12, mem=86, {'A100': 1}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
```
As seen here, skypilot will block requests on autoscaling node pool with GPUs that exceeds the node cpu and memory.

However, this is not true for requests on autoscaling node pool with TPUs.
context: the vt TPU node deployed on the cluster has 24 vcpus and 48 gig of mem.
```
% sky launch --gpus tpu-v5-lite-device:1 --cpus 24 --memory 48 --cloud kubernetes
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                            vCPUs   Mem(GB)   ACCELERATORS           REGION/ZONE                                           COST ($)   CHOSEN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   24CPU--48GB--tpu-v5-lite-device:1   24      48        tpu-v5-lite-device:1   gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-b28a-seungjinyang'. Proceed? [Y/n]: n
Aborted!
% sky launch --gpus tpu-v5-lite-device:1 --cpus 999 --memory 999 --cloud kubernetes
Considered resources (1 node):
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE                              vCPUs   Mem(GB)   ACCELERATORS           REGION/ZONE                                           COST ($)   CHOSEN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   999CPU--999GB--tpu-v5-lite-device:1   999     999       tpu-v5-lite-device:1   gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-5732-seungjinyang'. Proceed? [Y/n]: n
```
Requests that specify more cpus/mem than the TPU pod allows still goes through.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [x] Relevant individual tests: `/smoke-test --kubernetes` 
- [x] Backward compatibility: `/quicktest-core`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
