### PR TITLE
[deps] pin ibm-platform-services to >=0.48.0 to work around issue

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -120,7 +120,10 @@ extras_require: Dict[str, List[str]] = {
     # https://github.com/googleapis/google-api-python-client/commit/f6e9d3869ed605b06f7cbf2e8cf2db25108506e6
     'gcp': ['google-api-python-client>=2.69.0', 'google-cloud-storage'],
     'ibm': [
-        'ibm-cloud-sdk-core', 'ibm-vpc', 'ibm-platform-services', 'ibm-cos-sdk'
+        'ibm-cloud-sdk-core',
+        'ibm-vpc',
+        'ibm-platform-services>=0.48.0',
+        'ibm-cos-sdk',
     ] + local_ray,
     'docker': ['docker'] + local_ray,
     'lambda': [],  # No dependencies needed for lambda


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This seems to resolve the crashes we've been seeing in CI ([example](https://github.com/skypilot-org/skypilot/actions/runs/13818935203/job/38662591200?pr=4930)). Seems something changed in downstream deps, but this at least works around whatever happened.

Broken: `uv pip install --prerelease=allow 'azure-cli>=2.65.0' && uv pip install skypilot[aws,azure,ibm]`

After this PR, it works.

Note that this also affects uv installation of stable. We could release 0.8.1 to work around.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
