### PR TITLE
[api server] avoid deleting requests.db but not -wal/-shm

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -32,7 +32,6 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.client import common as client_common
 from sky.server import common as server_common
-from sky.server import constants as server_constants
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
@@ -1707,14 +1706,8 @@ def api_stop() -> None:
                                                      force=True)
             found = True
 
-    # Remove the database for requests including any files starting with
-    # api.constants.API_SERVER_REQUEST_DB_PATH
-    db_path = os.path.expanduser(server_constants.API_SERVER_REQUEST_DB_PATH)
-    for extension in ['', '-shm', '-wal']:
-        try:
-            os.remove(f'{db_path}{extension}')
-        except FileNotFoundError:
-            logger.debug(f'Database file {db_path}{extension} not found.')
+    # Remove the database for requests.
+    server_common.clear_local_api_server_database()
 
     if found:
         logger.info(f'{colorama.Fore.GREEN}SkyPilot API server stopped.'

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -428,3 +428,19 @@ def reload_for_new_request(client_entrypoint: Optional[str],
     # necessary because the logger is initialized before the environment
     # variables are set, such as SKYPILOT_DEBUG.
     sky_logging.reload_logger()
+
+
+def clear_local_api_server_database() -> None:
+    """Removes the local API server database.
+
+    The CLI can call this during cleanup of a local API server, or the API
+    server can call it during startup.
+    """
+    # Remove the database for requests including any files starting with
+    # api.constants.API_SERVER_REQUEST_DB_PATH
+    db_path = os.path.expanduser(server_constants.API_SERVER_REQUEST_DB_PATH)
+    for extension in ['', '-shm', '-wal']:
+        try:
+            os.remove(f'{db_path}{extension}')
+        except FileNotFoundError:
+            logger.debug(f'Database file {db_path}{extension} not found.')

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -447,7 +447,7 @@ def init_db(func):
 
 def reset_db_and_logs():
     """Create the database."""
-    common_utils.remove_file_if_exists(_DB_PATH)
+    server_common.clear_local_api_server_database()
     shutil.rmtree(pathlib.Path(REQUEST_LOG_PATH_PREFIX).expanduser(),
                   ignore_errors=True)
     shutil.rmtree(server_common.API_SERVER_CLIENT_DIR.expanduser(),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before, on API server startup, we would delete ~/.sky/api_server/requests.db, but not requests.db-wal or requests.db-shm. This could lead to inconsistent SQLite state on startup, which would surface as `sqlite3.OperationalError: disk I/O error`, if the previous API server exited abnormally (e.g. kill -9).

To fix, make sure to remove all three files.

This may also mitigate the impact of #4894.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - `sky api start`
  - `ps -ef | grep -- '-m sky.server'` and `lsof -i :50011` to find PIDs
  - `kill -9` the two PIDs from before
  - `sky api start` again. It will fail with `sqlite3.OperationalError: disk I/O error` before this PR, but works after this PR.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
