### PR TITLE
[Jobs] Error out for intermediate bucket on cloud not enabled

### DIFF
--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -69,6 +69,13 @@ def credential_error_exception():
 
 
 @common.load_lazy_modules(_LAZY_MODULES)
+def gcp_auth_refresh_error_exception():
+    """GCP auth refresh error exception."""
+    from google.auth import exceptions
+    return exceptions.RefreshError
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
 def get_credentials(cred_type: str, credentials_field: str):
     """Get GCP credentials."""
     from google.oauth2 import service_account

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -845,7 +845,7 @@ class GCP(clouds.Cloud):
                                                     body=permissions)
         try:
             ret_permissions = request.execute().get('permissions', [])
-        except Exception as e:
+        except gcp.gcp_auth_refresh_error_exception() as e:  #
             return False, common_utils.format_exception(e, use_bracket=True)
 
         diffs = set(gcp_minimal_permissions).difference(set(ret_permissions))

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -845,7 +845,7 @@ class GCP(clouds.Cloud):
                                                     body=permissions)
         try:
             ret_permissions = request.execute().get('permissions', [])
-        except gcp.gcp_auth_refresh_error_exception() as e:  #
+        except gcp.gcp_auth_refresh_error_exception() as e:
             return False, common_utils.format_exception(e, use_bracket=True)
 
         diffs = set(gcp_minimal_permissions).difference(set(ret_permissions))

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -843,7 +843,10 @@ class GCP(clouds.Cloud):
         permissions = {'permissions': gcp_minimal_permissions}
         request = crm.projects().testIamPermissions(resource=project,
                                                     body=permissions)
-        ret_permissions = request.execute().get('permissions', [])
+        try:
+            ret_permissions = request.execute().get('permissions', [])
+        except Exception as e:
+            return False, common_utils.format_exception(e, use_bracket=True)
 
         diffs = set(gcp_minimal_permissions).difference(set(ret_permissions))
         if diffs:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -143,6 +143,22 @@ class StoreType(enum.Enum):
 
         raise ValueError(f'Unsupported cloud for StoreType: {cloud}')
 
+    def to_cloud(self) -> str:
+        if self == StoreType.S3:
+            return str(clouds.AWS())
+        elif self == StoreType.GCS:
+            return str(clouds.GCP())
+        elif self == StoreType.AZURE:
+            return str(clouds.Azure())
+        elif self == StoreType.R2:
+            return cloudflare.NAME
+        elif self == StoreType.IBM:
+            return str(clouds.IBM())
+        elif self == StoreType.OCI:
+            return str(clouds.OCI())
+        else:
+            raise ValueError(f'Unknown store type: {self}')
+
     @classmethod
     def from_store(cls, store: 'AbstractStore') -> 'StoreType':
         if isinstance(store, S3Store):

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -805,6 +805,16 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
     else:
         (store_type, bucket_name, sub_path, storage_account_name, region) = (
             storage_lib.StoreType.get_fields_from_store_url(bucket_wth_prefix))
+        cloud_str = store_type.to_cloud()
+        if (cloud_str not in
+                storage_lib.get_cached_enabled_storage_clouds_or_refresh()):
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(
+                    f'`{task_type}.bucket` is specified in SkyPilot config '
+                    f'with {bucket_wth_prefix}, but {cloud_str} is not '
+                    'enabled. Please avoid specifying the bucket or enable the '
+                    f'cloud by: sky check {cloud_str}')
+
         if storage_account_name is not None:
             store_kwargs['storage_account_name'] = storage_account_name
         if region is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

If a cloud is not enabled, we should error out if it is used as an intermediate bucket for jobs.

This slightly mitigate the issue in #4946

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
