### PR TITLE
[Test] Github action trigger support param

### DIFF
--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -28,7 +28,7 @@ jobs:
             data='{
               "commit": "HEAD",
               "branch": "master",
-              "message": "Manual Smoke Tests",
+              "message": "Manual Smoke Tests: ${{ github.event.inputs.param }}",
               "ignore_pipeline_branch_filters": true,
               "env": {
                 "ARGS": "${{ github.event.inputs.param }}"

--- a/.github/workflows/weekly-smoke-tests-trigger.yaml
+++ b/.github/workflows/weekly-smoke-tests-trigger.yaml
@@ -3,7 +3,12 @@ name: Smoke Tests Trigger
 on:
   schedule:
     - cron: '0 0 1,15 * *'  # Runs at 00:00 on the 1st and 15th of each month (UTC)
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      param:
+        description: 'Parameter to pass to the smoke tests, example: --aws'
+        required: true
+        type: string
   # uncomment this for PR triggers testing
   # pull_request:
   #   types: [opened, synchronize, reopened]
@@ -15,16 +20,32 @@ jobs:
       - name: Trigger Smoke Tests
         env:
           BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
-          BUILDKITE_API_URL: "https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/full-smoke-tests-run/builds"
+          BUILDKITE_API_URL: ${{ github.event_name == 'workflow_dispatch'
+            && 'https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/smoke-tests/builds'
+            || 'https://api.buildkite.com/v2/organizations/skypilot-1/pipelines/full-smoke-tests-run/builds' }}
         run: |
-          response=$(curl -w "%{http_code}" -H "Authorization: Bearer $BUILDKITE_TOKEN" \
-            -X POST "$BUILDKITE_API_URL" \
-            -d '{
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            data='{
+              "commit": "HEAD",
+              "branch": "master",
+              "message": "Manual Smoke Tests",
+              "ignore_pipeline_branch_filters": true,
+              "env": {
+                "ARGS": "${{ github.event.inputs.param }}"
+              }
+            }'
+          else
+            data='{
               "commit": "HEAD",
               "branch": "master",
               "message": "Biweekly Smoke Tests",
               "ignore_pipeline_branch_filters": true
-            }')
+            }'
+          fi
+
+          response=$(curl -w "%{http_code}" -H "Authorization: Bearer $BUILDKITE_TOKEN" \
+            -X POST "$BUILDKITE_API_URL" \
+            -d "$data")
 
           http_code=$(echo "$response" | tail -n 1)
           response_body=$(echo "$response" | head -n -1)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Tested under my personal repo:

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/63d92f02-fcb9-4c35-86c1-9d21f448fdcd" />

<img width="1914" alt="image" src="https://github.com/user-attachments/assets/20c32a72-fc16-4c6f-95ad-e1d4890d4fa6" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
