### PR TITLE
[Jobs] Fix kill cluster request issue during tearing down for managed jobs

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3631,6 +3631,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # release the lock from other requests.
             exclude_request_to_kill = 'sky.down' if terminate else 'sky.stop'
             try:
+                # TODO(zhwu): we should get rid of this when it is being called
+                # internally without involving an API server, e.g., when a
+                # controller is trying to terminate a cluster.
                 requests_lib.kill_cluster_requests(handle.cluster_name,
                                                    exclude_request_to_kill)
             except Exception as e:  # pylint: disable=broad-except
@@ -4037,6 +4040,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # confusing to see the cluster restarted immediately after it is
         # terminated/stopped, when there is a pending launch request.
         try:
+            # TODO(zhwu): we should get rid of this when it is being called
+            # internally without involving an API server, e.g., when a
+            # controller is trying to terminate a cluster.
             requests_lib.kill_cluster_requests(handle.cluster_name,
                                                exclude_request_to_kill)
         except Exception as e:  # pylint: disable=broad-except

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -396,7 +396,6 @@ pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 
 
 def create_table(cursor, conn):
-    del conn
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
     # https://github.com/microsoft/WSL/issues/2395

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -428,6 +428,9 @@ def create_table(cursor, conn):
         {COL_USER_ID} TEXT,
         {COL_STATUS_MSG} TEXT)""")
 
+    db_utils.add_column_to_table(cursor, conn, REQUEST_TABLE, COL_STATUS_MSG,
+                                 'TEXT')
+
 
 _DB = None
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The recent PR #4867 adds a new column in request db, but does not have a backward compatibility handling for existing request DB. It is ok for API server, which will remove the request DB during restart, but it fails the managed jobs with the following reproduce:

1. `sky jobs launch` with a verion before #4867, so that the controller gets a request DB without the `status_msg` column
2. Switch to the master branch, restart the API server
3. `sky jobs launch` again and `sky jobs cancel`. The job shows `FAILED_CONTROLLER` due to the missing `status_msg` during terminating the cluster.

```
Traceback (most recent call last):
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/utils.py", line 101, in terminate_cluster
    core.down(cluster_name)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 457, in _record
    return f(*args, **kwargs)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/core.py", line 495, in down
    backend.teardown(handle, terminate=True, purge=purge)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 457, in _record
    return f(*args, **kwargs)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/utils/common_utils.py", line 437, in _record
    return f(*args, **kwargs)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/backend.py", line 146, in teardown
    self._teardown(handle, terminate, purge)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/backends/cloud_vm_ray_backend.py", line 3633, in _teardown
    requests_lib.kill_cluster_requests(handle.cluster_name,
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/server/requests/requests.py", line 298, in kill_cluster_requests
    request_task.request_id for request_task in get_request_tasks(
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/server/requests/requests.py", line 443, in wrapper
    return func(*args, **kwargs)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/server/requests/requests.py", line 572, in get_request_tasks
    cursor.execute(
sqlite3.OperationalError: no such column: status_msg

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 612, in <module>
    start(args.job_id, args.dag_yaml)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 570, in start
    _cleanup(job_id, dag_yaml=dag_yaml)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/controller.py", line 492, in _cleanup
    managed_job_utils.terminate_cluster(cluster_name)
  File "/home/sky/skypilot-runtime/lib/python3.10/site-packages/sky/jobs/utils.py", line 110, in terminate_cluster
    raise RuntimeError(
RuntimeError: Failed to terminate the cluster compute-text-vectors-100.
```

Our backward compatibility test should capture this. @aylei Could you help double check if there is something missing in our backward compatibility test for managed jobs?

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
