### PR TITLE
[Test]Separate different param into different steps on buildkite and fix flacky of test_job_queue_with_docker

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -112,7 +112,7 @@ def test_job_queue_with_docker(generic_cloud: str, image_id: str,
         'job_queue_with_docker',
         [
             f'sky launch -y -c {name} --cloud {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} --gpus {accelerator} --image-id {image_id} examples/job_queue/cluster_docker.yaml',
-            f'sky exec {name} -n {name}-1 -d --gpus {accelerator}:0.5 --image-id {image_id} --env TIME_TO_SLEEP={time_to_sleep} examples/job_queue/job_docker.yaml',
+            f'sky exec {name} -n {name}-1 -d --gpus {accelerator}:0.5 --image-id {image_id} --env TIME_TO_SLEEP={time_to_sleep*2} examples/job_queue/job_docker.yaml',
             f'sky exec {name} -n {name}-2 -d --gpus {accelerator}:0.5 --image-id {image_id} --env TIME_TO_SLEEP={time_to_sleep} examples/job_queue/job_docker.yaml',
             f'sky exec {name} -n {name}-3 -d --gpus {accelerator}:0.5 --image-id {image_id} --env TIME_TO_SLEEP={time_to_sleep} examples/job_queue/job_docker.yaml',
             f's=$(sky queue {name}); echo "$s"; echo; echo; echo "$s" | grep {name}-1 | grep RUNNING',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Separate different parameters into different steps for better visualization of logs on buildkite, and also increase timeout to fix #4943.

See [comment](https://github.com/skypilot-org/skypilot/issues/4943#issuecomment-2724104230)

Previously:


```yaml
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws
  label: test_job_queue_with_docker on aws
  retry:
    automatic: true
```


Now:

```yaml
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws -k docker:nvidia/cuda:11.8.0-devel-ubuntu18.04-accelerator0
  label: test_job_queue_with_docker on aws with param docker:nvidia/cuda:11.8.0-devel-ubuntu18.04-accelerator0
  retry:
    automatic: true
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws -k docker:ubuntu:18.04-accelerator0
  label: test_job_queue_with_docker on aws with param docker:ubuntu:18.04-accelerator0
  retry:
    automatic: true
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws -k docker:continuumio/miniconda3:24.1.2-0-accelerator0
  label: test_job_queue_with_docker on aws with param docker:continuumio/miniconda3:24.1.2-0-accelerator0
  retry:
    automatic: true
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws -k docker:continuumio/miniconda3:latest-accelerator0
  label: test_job_queue_with_docker on aws with param docker:continuumio/miniconda3:latest-accelerator0
  retry:
    automatic: true
- agents:
    queue: generic_cloud
  command: pytest tests/smoke_tests/test_cluster_job.py::test_job_queue_with_docker
    --aws -k docker:winglian/axolotl:main-latest-accelerator0
  label: test_job_queue_with_docker on aws with param docker:winglian/axolotl:main-latest-accelerator0
  retry:
    automatic: true
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
