### PR TITLE
[Core] Elevate experimental.config_overrides to top-level config field

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -549,13 +549,14 @@ class Task:
 
         # Experimental configs.
         experimental_configs = config.pop('experimental', None)
-        
+
         # Handle the top-level config field
         config_override = config.pop('config', None)
-        
+
         # Handle backward compatibility with experimental.config_overrides
         if experimental_configs is not None:
-            exp_config_override = experimental_configs.pop('config_overrides', None)
+            exp_config_override = experimental_configs.pop(
+                'config_overrides', None)
             if exp_config_override is not None:
                 if config_override is not None:
                     logger.warning(
@@ -565,10 +566,10 @@ class Task:
                 else:
                     config_override = exp_config_override
             logger.debug('Overriding skypilot config with task-level config: '
-                        f'{config_override}')
+                         f'{config_override}')
             assert not experimental_configs, ('Invalid task args: '
-                                          f'{experimental_configs.keys()}')
-                                          
+                                              f'{experimental_configs.keys()}')
+
         # Store the final config override for use in resource setup
         cluster_config_override = config_override
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -548,15 +548,29 @@ class Task:
                              estimated_size_gigabytes=estimated_size_gigabytes)
 
         # Experimental configs.
-        experimnetal_configs = config.pop('experimental', None)
-        cluster_config_override = None
-        if experimnetal_configs is not None:
-            cluster_config_override = experimnetal_configs.pop(
-                'config_overrides', None)
+        experimental_configs = config.pop('experimental', None)
+        
+        # Handle the top-level config field
+        config_override = config.pop('config', None)
+        
+        # Handle backward compatibility with experimental.config_overrides
+        if experimental_configs is not None:
+            exp_config_override = experimental_configs.pop('config_overrides', None)
+            if exp_config_override is not None:
+                if config_override is not None:
+                    logger.warning(
+                        f'{colorama.Fore.YELLOW}Both top-level `config` and '
+                        f'`experimental.config_overrides` are specified. '
+                        f'Using top-level `config`.{colorama.Style.RESET_ALL}')
+                else:
+                    config_override = exp_config_override
             logger.debug('Overriding skypilot config with task-level config: '
-                         f'{cluster_config_override}')
-        assert not experimnetal_configs, ('Invalid task args: '
-                                          f'{experimnetal_configs.keys()}')
+                        f'{config_override}')
+            assert not experimental_configs, ('Invalid task args: '
+                                          f'{experimental_configs.keys()}')
+                                          
+        # Store the final config override for use in resource setup
+        cluster_config_override = config_override
 
         # Parse resources field.
         resources_config = config.pop('resources', {})

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -463,6 +463,8 @@ def _filter_schema(schema: dict, keys_to_keep: List[Tuple[str, ...]]) -> dict:
 
 
 def _experimental_task_schema() -> dict:
+    # TODO: experimental.config_overrides has been deprecated in favor of the 
+    # top-level `config` field. Remove in v0.10.0.
     config_override_schema = _filter_schema(
         get_config_schema(), constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK)
     return {
@@ -545,6 +547,9 @@ def get_task_schema():
             'file_mounts_mapping': {
                 'type': 'object',
             },
+            # The new top-level config field uses the same schema as experimental.config_overrides
+            'config': _filter_schema(
+                get_config_schema(), constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK),
             **_experimental_task_schema(),
         }
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -463,7 +463,7 @@ def _filter_schema(schema: dict, keys_to_keep: List[Tuple[str, ...]]) -> dict:
 
 
 def _experimental_task_schema() -> dict:
-    # TODO: experimental.config_overrides has been deprecated in favor of the 
+    # TODO: experimental.config_overrides has been deprecated in favor of the
     # top-level `config` field. Remove in v0.10.0.
     config_override_schema = _filter_schema(
         get_config_schema(), constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK)
@@ -547,9 +547,9 @@ def get_task_schema():
             'file_mounts_mapping': {
                 'type': 'object',
             },
-            # The new top-level config field uses the same schema as experimental.config_overrides
             'config': _filter_schema(
-                get_config_schema(), constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK),
+                get_config_schema(),
+                constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK),
             **_experimental_task_schema(),
         }
     }


### PR DESCRIPTION
This PR elevates the experimental.config_overrides field directly into a top-level config field in the task spec, simplifying the task yaml. 

Before:
```
experimental:
  config_overrides:
    kubernetes:
      pod_config:
        spec:
          containers:
            - volumeMounts:
                - mountPath: /mnt/nfs
                  name: my-host-nfs
```

After:
```
resources:
  cloud: kubernetes
  
config:
  kubernetes:
    pod_config:
      spec:
        containers:
          - volumeMounts:
              - mountPath: /mnt/nfs
                name: my-host-nfs
```

This is a small part of the broader changes we want to make to the SkyPilot configuration system.

TODO:
- [ ] Update all references in docs to use `config` instead of `experimental.config_overrides`