### PR TITLE
[Test] Add support for missing bashrc file in zsh shells

### DIFF
--- a/tests/backward_compatibility_tests.sh
+++ b/tests/backward_compatibility_tests.sh
@@ -120,13 +120,13 @@ git clone -b ${base_branch} https://github.com/skypilot-org/skypilot.git $ABSOLU
 UV=~/.local/bin/uv
 
 # Create environment for compatibility tests
-if [ -n "$ZSH_VERSION" ]; then
-  CONFIG_FILE="~/.zshrc"
-else
-  CONFIG_FILE="~/.bashrc"
+RC_FILE="$HOME/.bashrc"
+if [ ! -f "$RC_FILE" ]; then
+  touch $RC_FILE
+  echo "created $RC_FILE as it didn't exist"
 fi
 
-source "$CONFIG_FILE"
+source "$RC_FILE"
 $UV venv --seed --python=3.9 ~/sky-back-compat-base
 $UV venv --seed --python=3.9 ~/sky-back-compat-current
 
@@ -137,7 +137,7 @@ if ! gcloud --version; then
   rm -rf ~/google-cloud-sdk
   mv google-cloud-sdk ~/
   ~/google-cloud-sdk/install.sh -q
-  echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> "$CONFIG_FILE"
+  echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> "$RC_FILE"
   source ~/google-cloud-sdk/path.bash.inc
 fi
 

--- a/tests/backward_compatibility_tests.sh
+++ b/tests/backward_compatibility_tests.sh
@@ -120,7 +120,13 @@ git clone -b ${base_branch} https://github.com/skypilot-org/skypilot.git $ABSOLU
 UV=~/.local/bin/uv
 
 # Create environment for compatibility tests
-source ~/.bashrc
+if [ -n "$ZSH_VERSION" ]; then
+  CONFIG_FILE="~/.zshrc"
+else
+  CONFIG_FILE="~/.bashrc"
+fi
+
+source "$CONFIG_FILE"
 $UV venv --seed --python=3.9 ~/sky-back-compat-base
 $UV venv --seed --python=3.9 ~/sky-back-compat-current
 
@@ -131,7 +137,7 @@ if ! gcloud --version; then
   rm -rf ~/google-cloud-sdk
   mv google-cloud-sdk ~/
   ~/google-cloud-sdk/install.sh -q
-  echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> ~/.bashrc
+  echo "source ~/google-cloud-sdk/path.bash.inc > /dev/null 2>&1" >> "$CONFIG_FILE"
   source ~/google-cloud-sdk/path.bash.inc
 fi
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, the `backward_compatibility_tests.sh` file runs on bash, but some mac computers (like mine) has ZSH. These macs have bash too and specifying `#!/bin/bash` works fine to run the code, but when it tries to access non-existent `.bashrc` files, then it errors out. 

Obviously, the simple fix to this is to just create a bashrc file. This fix automatically adds that feature so that manual intervention is not necessary.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [X] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
