### PR TITLE
Fix flaky for test_cancel_launch_and_exec_async

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -768,7 +768,7 @@ def test_cancel_launch_and_exec_async(generic_cloud: str):
     """Test if async launch and exec commands work correctly when cluster is shutdown"""
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test('cancel_launch_and_exec_async', [
-        (f'sky launch -c {name} -y --async',
+        (f'sky launch -c {name} -y --cloud {generic_cloud} --async',
          f's=$(sky exec {name} echo --async) && '
          'echo "$s" && '
          'logs_cmd=$(echo "$s" | grep "Check logs with" | sed -E "s/.*with: (sky api logs .*).*/\\1/") && '

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -773,7 +773,7 @@ def test_cancel_launch_and_exec_async(generic_cloud: str):
          'echo "$s" && '
          'logs_cmd=$(echo "$s" | grep "Check logs with" | sed -E "s/.*with: (sky api logs .*).*/\\1/") && '
          'echo "Extracted logs command: $logs_cmd" && '
-         f'{smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(name, [sky.ClusterStatus.INIT], 30)} &&'
+         f'{smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(name, [sky.ClusterStatus.INIT, sky.ClusterStatus.UP], 30)} &&'
          f'sky down -y {name} && '
          'log_output=$(eval $logs_cmd || true) && '
          'echo "===logs===" && echo "$log_output" && '

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -768,7 +768,7 @@ def test_cancel_launch_and_exec_async(generic_cloud: str):
     """Test if async launch and exec commands work correctly when cluster is shutdown"""
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test('cancel_launch_and_exec_async', [
-        (f'sky launch -c {name} -y --async && '
+        (f'sky launch -c {name} -y --async',
          f's=$(sky exec {name} echo --async) && '
          'echo "$s" && '
          'logs_cmd=$(echo "$s" | grep "Check logs with" | sed -E "s/.*with: (sky api logs .*).*/\\1/") && '

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -768,12 +768,13 @@ def test_cancel_launch_and_exec_async(generic_cloud: str):
     """Test if async launch and exec commands work correctly when cluster is shutdown"""
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test('cancel_launch_and_exec_async', [
-        (f'sky launch -c {name} -y --cloud {generic_cloud} --async',
-         f's=$(sky exec {name} echo --async) && '
+        f'sky launch -c {name} -y --cloud {generic_cloud} --async',
+        (f's=$(sky exec {name} echo --async) && '
          'echo "$s" && '
-         'logs_cmd=$(echo "$s" | grep "Check logs with" | sed -E "s/.*with: (sky api logs .*).*/\\1/") && '
+         'logs_cmd=$(echo "$s" | grep "Check logs with" | '
+         'sed -E "s/.*with: (sky api logs .*).*/\\1/") && '
          'echo "Extracted logs command: $logs_cmd" && '
-         f'{smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(name, [sky.ClusterStatus.INIT, sky.ClusterStatus.UP], 30)} &&'
+         f'{smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(name, [sky.ClusterStatus.INIT, sky.ClusterStatus.UP], 30)} && '
          f'sky down -y {name} && '
          'log_output=$(eval $logs_cmd || true) && '
          'echo "===logs===" && echo "$log_output" && '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See this [build](https://buildkite.com/skypilot-1/smoke-tests/builds/400#01959882-6771-450a-a559-d7dae30683e0). The first 8 times, the cluster just shows `UP` when checking for sky status. Wait for either `INIT` or `UP` status to make the test less flaky. Save @SeungjinYang's manual click 😄.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_cancel_launch_and_exec_async --aws`
- [x] Relevant individual tests: `/smoke-test -k test_cancel_launch_and_exec_async --kubernetes`
- [x] Relevant individual tests: `/smoke-test -k test_cancel_launch_and_exec_async --azure`
- [x] Relevant individual tests: `/smoke-test -k test_cancel_launch_and_exec_async --gcp`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
