### PR TITLE
[Docs] fix typo in gemma3 example

### DIFF
--- a/llm/gemma3/README.md
+++ b/llm/gemma3/README.md
@@ -45,7 +45,7 @@ Now it's time to run deepseek with SkyPilot. The instruction can be dependent on
 ```
 sky launch gemma3.yaml \
   -c gemma-3 \
-  --env MODEL_NAME= google/gemma-3-4b-it \
+  --env MODEL_NAME=google/gemma-3-4b-it \
   --gpus L4:1
   --env HF_TOKEN=xxxx
 ```


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

One of our user hits https://github.com/skypilot-org/skypilot/issues/4969 when following the gemma3 doc, looks like there is a typo.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
