### PR TITLE
fix incorrect vcpu/mem checks for GKE autoscaler

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -747,11 +747,11 @@ class GKEAutoscaler(Autoscaler):
             return True
 
         vcpus, mem = clouds.GCP.get_vcpus_mem_from_instance_type(machine_type)
-        if vcpus is not None and vcpus >= k8s_instance_type.cpus:
+        if vcpus is not None and vcpus < k8s_instance_type.cpus:
             logger.debug(f'vcpu check failed for {machine_type} '
                          f'on node pool {node_pool_name}')
             return False
-        if mem is not None and mem >= k8s_instance_type.memory:
+        if mem is not None and mem < k8s_instance_type.memory:
             logger.debug(f'memory check failed for {machine_type} '
                          f'on node pool {node_pool_name}')
             return False


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The check for vcpu/memory here was backwards.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
