### PR TITLE
[k8s] LRU cache for GKE can_create_new_instance_of_type

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -602,7 +602,7 @@ class GKEAutoscaler(Autoscaler):
     _pip_install_gcp_hint_last_sent = 0.0
 
     @classmethod
-    @annotations.lru_cache(scope='global', maxsize=10)
+    @annotations.lru_cache(scope='request', maxsize=10)
     def can_create_new_instance_of_type(cls, context: str,
                                         instance_type: str) -> bool:
         """Looks at each node pool in the cluster and checks if


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, when calling `sky launch` for kubernetes contexts with GKE based autoscaler, the function `can_create_new_instance_of_type` is called twice with exact same arguments, per context:
```
sky launch --gpus a100 --cloud kubernetes
can_create_new_instance_of_type called with: context: gke_<project>_us-central1-a_skypilot-test-cluster, instance_type: 2CPU--8GB--A100:1
can_create_new_instance_of_type called with: context: gke_<project>_us-central1-a_skypilot-test-cluster, instance_type: 2CPU--8GB--A100:1
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-6b36-seungjinyang'. Proceed? [Y/n]:
```
This is pretty wasteful, so @cg505 suggested adding an LRU cache in this comment in a different PR: https://github.com/skypilot-org/skypilot/pull/4935#discussion_r1999123467

Turns out adding an LRU cache is a simple python annotation. Testing the same call with LRU annotation shows:
```
% sky launch --gpus a100 --cloud kubernetes
can_create_new_instance_of_type called with: context: gke_<project>_us-central1-a_skypilot-test-cluster, instance_type: 2CPU--8GB--A100:1
Considered resources (1 node):
---------------------------------------------------------------------------------------------------------------------------------------------
 CLOUD        INSTANCE            vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE                                           COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------------------------------------------------------
 Kubernetes   2CPU--8GB--A100:1   2       8         A100:1         gke_<project>_us-central1-a_skypilot-test-cluster   0.00          ✔     
---------------------------------------------------------------------------------------------------------------------------------------------
Launching a new cluster 'sky-2452-seungjinyang'. Proceed? [Y/n]:
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see above)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
