### PR TITLE
fix annotation "kubernetes.io/ingress.class" is deprecated

### DIFF
--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Namespace }}
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
@@ -28,6 +27,7 @@ metadata:
 
 
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -1,10 +1,17 @@
 {{- if .Values.ingress.enabled }}
+{{- $kubeVersion := .Capabilities.KubeVersion.Major -}}
+{{- $kubeMinorVersion := .Capabilities.KubeVersion.Minor | trimSuffix "+" | int -}}
+{{- $useNewIngressClass := or (gt ($kubeVersion | int) 1) (and (eq ($kubeVersion | int) 1) (ge $kubeMinorVersion 18)) -}}
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress
   namespace: {{ .Release.Namespace }}
   annotations:
+    {{- if not $useNewIngressClass }}
+    kubernetes.io/ingress.class: nginx
+    {{- end }}
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
@@ -27,7 +34,9 @@ metadata:
 
 
 spec:
+  {{- if $useNewIngressClass }}
   ingressClassName: nginx
+  {{- end }}
   rules:
   - http:
       paths:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixed Helm warning: annotation "kubernetes.io/ingress.class" is deprecated #4922 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
