### PR TITLE
[Serve] BugFix: `any_of` field order issue cause version bump to not work

### DIFF
--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1209,17 +1209,11 @@ class SkyPilotReplicaManager(ReplicaManager):
                 # Here, we manually convert the any_of field to a set to avoid
                 # only the difference in the random order of the any_of fields.
                 old_config_any_of = old_config.get('resources',
-                                                   {}).pop('any_of', None)
+                                                   {}).pop('any_of', [])
                 new_config_any_of = new_config.get('resources',
-                                                   {}).pop('any_of', None)
-                if old_config_any_of is not None and new_config_any_of is None:
+                                                   {}).pop('any_of', [])
+                if set(old_config_any_of) != set(new_config_any_of):
                     continue
-                if old_config_any_of is None and new_config_any_of is not None:
-                    continue
-                if (old_config_any_of is not None and
-                        new_config_any_of is not None):
-                    if set(old_config_any_of) != set(new_config_any_of):
-                        continue
                 # File mounts should both be empty, as update always
                 # create new buckets if they are not empty.
                 if (old_config == new_config and

--- a/sky/serve/replica_managers.py
+++ b/sky/serve/replica_managers.py
@@ -1205,7 +1205,22 @@ class SkyPilotReplicaManager(ReplicaManager):
                 for key in ['service']:
                     old_config.pop(key)
                 # Bump replica version if all fields except for service are
-                # the same. File mounts should both be empty, as update always
+                # the same.
+                # Here, we manually convert the any_of field to a set to avoid
+                # only the difference in the random order of the any_of fields.
+                old_config_any_of = old_config.get('resources',
+                                                   {}).pop('any_of', None)
+                new_config_any_of = new_config.get('resources',
+                                                   {}).pop('any_of', None)
+                if old_config_any_of is not None and new_config_any_of is None:
+                    continue
+                if old_config_any_of is None and new_config_any_of is not None:
+                    continue
+                if (old_config_any_of is not None and
+                        new_config_any_of is not None):
+                    if set(old_config_any_of) != set(new_config_any_of):
+                        continue
+                # File mounts should both be empty, as update always
                 # create new buckets if they are not empty.
                 if (old_config == new_config and
                         old_config.get('file_mounts', None) == {}):


### PR DESCRIPTION
Previously, when there is an `any_of` field in the yaml, it will be load as a set and store back as a list in the YAML, which sometimes cause the list order not correct and version bump to fail. This PR fixed it.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
