### PR TITLE
[UX] Allow purging non-existent k8s cluster

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4362,9 +4362,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 if purge:
                     msg = common_utils.format_exception(e, use_bracket=True)
                     logger.warning(
-                        'Failed abnormal non-terminated nodes cleanup. Skipping and cleaning up as '
-                        f'purge is set. Cleaning up cluster configuration data. Details: {msg}'
-                        )
+                        'Failed abnormal non-terminated nodes cleanup. '
+                        'Skipping and cleaning up as purge is set. Cleaning '
+                        f'up cluster configuration data. Details: {msg}')
                     self.remove_cluster_config(handle)
                 else:
                     raise

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4365,7 +4365,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         'Failed abnormal non-terminated nodes cleanup. '
                         'Skipping and cleaning up as purge is set. '
                         f'Details: {msg}')
-                    logger.debug(f'Full exception details: {msg}',
+                    logger.debug(
+                        f'Full exception details: {msg}',
                         exc_info=True)
                 else:
                     raise

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4365,9 +4365,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         'Failed abnormal non-terminated nodes cleanup. '
                         'Skipping and cleaning up as purge is set. '
                         f'Details: {msg}')
-                    logger.debug(
-                        f'Full exception details: {msg}',
-                        exc_info=True)
+                    logger.debug(f'Full exception details: {msg}',
+                                 exc_info=True)
                 else:
                     raise
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4363,9 +4363,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     msg = common_utils.format_exception(e, use_bracket=True)
                     logger.warning(
                         'Failed abnormal non-terminated nodes cleanup. '
-                        'Skipping and cleaning up as purge is set. Cleaning '
-                        f'up cluster configuration data. Details: {msg}')
-                    self.remove_cluster_config(handle)
+                        'Skipping and cleaning up as purge is set. '
+                        f'Details: {msg}')
                 else:
                     raise
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4365,6 +4365,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                         'Failed abnormal non-terminated nodes cleanup. '
                         'Skipping and cleaning up as purge is set. '
                         f'Details: {msg}')
+                    logger.debug(f'Full exception details: {msg}',
+                        exc_info=True)
                 else:
                     raise
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #4769 . 

Skypilot was crashing as it was unable to find the kubernetes cluster in the `_detect_abnormal_non_terminated_nodes` helper method under `cloud_vm_ray_backend.py`. This happens because of an earlier no-cluster exception in the port cleanup section. The order of the function calls is such that during port clean up skypilot will also clean up the metadata in the state tables. However, the relevant method calls for port cleanups is processed BEFORE the metadata, this means that when an exception is raised on port clean up, metadata is not cleared, hence leading to a call of `_detect_abnormal_non_terminated_nodes`. As that function call is the last in the chain, we simply check if purge is set and clear any metadata. 

<!-- Describe the tests ran -->

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
