### PR TITLE
[Docs] Fix k8s volume mount config doc

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -274,17 +274,18 @@ Examples:
 
            experimental:
              config_overrides:
-               pod_config:
-                 spec:
-                   containers:
-                     - volumeMounts:
-                         - mountPath: /mnt/nfs
-                           name: my-host-nfs
-                   volumes:
-                     - name: my-host-nfs
-                       hostPath:
-                         path: /path/on/host/nfs
-                         type: Directory
+                kubernetes:
+                  pod_config:
+                    spec:
+                      containers:
+                        - volumeMounts:
+                            - mountPath: /mnt/nfs
+                              name: my-host-nfs
+                      volumes:
+                        - name: my-host-nfs
+                          hostPath:
+                            path: /path/on/host/nfs
+                            type: Directory
 
       **Global configuration:**
 
@@ -320,18 +321,19 @@ Examples:
 
            experimental:
              config_overrides:
-               pod_config:
-                 spec:
-                   containers:
-                     - volumeMounts:
-                         - mountPath: /mnt/nfs
-                           name: nfs-volume
-                   volumes:
-                     - name: nfs-volume
-                       nfs:
-                         server: nfs.example.com
-                         path: /shared
-                         readOnly: false
+                kubernetes:
+                  pod_config:
+                    spec:
+                      containers:
+                        - volumeMounts:
+                            - mountPath: /mnt/nfs
+                              name: nfs-volume
+                      volumes:
+                        - name: nfs-volume
+                          nfs:
+                            server: nfs.example.com
+                            path: /shared
+                            readOnly: false
 
       **Global configuration:**
 
@@ -361,24 +363,25 @@ Examples:
 
       .. code-block:: yaml
 
-           # task.yaml
-           run: |
-             echo "Hello, world!" > /mnt/nvme/hello.txt
-             ls -la /mnt/nvme
+          # task.yaml
+          run: |
+            echo "Hello, world!" > /mnt/nvme/hello.txt
+            ls -la /mnt/nvme
 
-           experimental:
-             config_overrides:
-               pod_config:
-                 spec:
-                   containers:
-                     - volumeMounts:
-                         - mountPath: /mnt/nvme
-                           name: nvme
-                   volumes:
-                     - name: nvme
-                       hostPath:
-                         path: /path/on/host/nvme
-                         type: Directory
+          experimental:
+            config_overrides:
+              kubernetes:
+                pod_config:
+                  spec:
+                    containers:
+                      - volumeMounts:
+                          - mountPath: /mnt/nvme
+                            name: nvme
+                    volumes:
+                      - name: nvme
+                        hostPath:
+                          path: /path/on/host/nvme
+                          type: Directory
 
       **Global configuration:**
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

the config override semantic seems outdated (w/o the `kubernetes` keyword). This PR fixed it.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
