### PR TITLE
[GCP] Don't require TPU support for serve:gcp if TPU support is not required

### DIFF
--- a/sky/provision/gcp/instance.py
+++ b/sky/provision/gcp/instance.py
@@ -586,8 +586,11 @@ def open_ports(
     }
     handlers: List[Type[instance_utils.GCPInstance]] = [
         instance_utils.GCPComputeInstance,
-        instance_utils.GCPTPUVMInstance,
     ]
+    use_tpu_vms = provider_config.get('_has_tpus', False)
+    if use_tpu_vms:
+        handlers.append(instance_utils.GCPTPUVMInstance)
+
     handler_to_instances = _filter_instances(handlers, project_id, zone,
                                              label_filters, lambda _: None)
     operations = collections.defaultdict(list)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/4981

Manually tested (via print debugging) that `GCPTPUVMInstance.load_resource` is no longer called when launching sky serve controller instance.

The pattern here is already established at other places in this file:
https://github.com/skypilot-org/skypilot/blob/master/sky/provision/gcp/instance.py#L73-L75
https://github.com/skypilot-org/skypilot/blob/master/sky/provision/gcp/instance.py#L410-L412
https://github.com/skypilot-org/skypilot/blob/master/sky/provision/gcp/instance.py#L473-L475
https://github.com/skypilot-org/skypilot/blob/master/sky/provision/gcp/instance.py#L524-L547

so it's most likely that the pattern was simply left out in this one place.

Before
```
% sky serve up --cloud gcp service.yaml 
YAML to run: service.yaml
Service spec:
Readiness probe method:           GET /v1/models
Readiness initial delay seconds:  1200
Readiness probe timeout seconds:  15
Replica autoscaling policy:       Fixed 2 replicas
TLS Certificates:                 No TLS Enabled
Spot Policy:                      No spot fallback policy
Load Balancing Policy:            least_load

Each replica will use the following resources (estimated):
Considered resources (1 node):
--------------------------------------------------------------------------------------------
 CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
--------------------------------------------------------------------------------------------
 GCP     g2-standard-4   4       16        L4:1           us-east4-a    0.70          ✔     
--------------------------------------------------------------------------------------------
Launching a new service 'sky-service-b834'. Proceed? [Y/n]: Y
Launching controller for 'sky-service-b834'...
Choosing resources for serve controller...
Considered resources (1 node):
----------------------------------------------------------------------------------------------
 CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN   
----------------------------------------------------------------------------------------------
 GCP     n2-standard-4   4       16        -              us-central1-a   0.19          ✔     
----------------------------------------------------------------------------------------------
Warning: Credentials used for [GCP] may expire. Clusters may be leaked if the credentials expire while jobs are running. It is recommended to use credentials that never expire or a service account.
⚙︎ Launching serve controller on GCP us-central1 (us-central1-a).
└── Instance is up.
✓ Cluster launched: sky-serve-controller-2c3d9986.  View logs: sky api logs -l sky-2025-03-18-23-07-32-475179/provision.log
--------------------------------





loading TPU resource





--------------------------------
⚙︎ Syncing files.
  Syncing (to 1 node): /var/folders/4t/b03l11jx2lz6krkxv815mhmm0000gn/T/service-task-sky-service-b834-otlxermq -> ~/.sky/serve/sky_service_b834/task.yaml.tmp
  Syncing (to 1 node): /var/folders/4t/b03l11jx2lz6krkxv815mhmm0000gn/T/tmpq3rp2912 -> ~/.sky/serve/sky_service_b834/config.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-03-18-23-07-32-475179/file_mounts.log
⚙︎ Running setup on serve controller.
[4/5] Check & install cloud dependencies on controller: Kubernetes                    bash: https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl: No such file or directory
  Check & install cloud dependencies on controller: done.                                        
✓ Setup completed.  View logs: sky api logs -l sky-2025-03-18-23-07-32-475179/setup-*.log
⚙︎ Service registered.
```

After
```
% sky serve up --cloud gcp service.yaml 
YAML to run: service.yaml
Service spec:
Readiness probe method:           GET /v1/models
Readiness initial delay seconds:  1200
Readiness probe timeout seconds:  15
Replica autoscaling policy:       Fixed 2 replicas
TLS Certificates:                 No TLS Enabled
Spot Policy:                      No spot fallback policy
Load Balancing Policy:            least_load

Each replica will use the following resources (estimated):
Considered resources (1 node):
--------------------------------------------------------------------------------------------
 CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
--------------------------------------------------------------------------------------------
 GCP     g2-standard-4   4       16        L4:1           us-east4-a    0.70          ✔     
--------------------------------------------------------------------------------------------
Launching a new service 'sky-service-5f6d'. Proceed? [Y/n]: Y
Launching controller for 'sky-service-5f6d'...
Choosing resources for serve controller...
Considered resources (1 node):
----------------------------------------------------------------------------------------------
 CLOUD   INSTANCE        vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE     COST ($)   CHOSEN   
----------------------------------------------------------------------------------------------
 GCP     n2-standard-4   4       16        -              us-central1-a   0.19          ✔     
----------------------------------------------------------------------------------------------
Warning: Credentials used for [GCP] may expire. Clusters may be leaked if the credentials expire while jobs are running. It is recommended to use credentials that never expire or a service account.
⚙︎ Launching serve controller on GCP us-central1 (us-central1-a).
└── Instance is up.
✓ Cluster launched: sky-serve-controller-2c3d9986.  View logs: sky api logs -l sky-2025-03-18-23-16-06-173110/provision.log
⚙︎ Syncing files.
  Syncing (to 1 node): /var/folders/4t/b03l11jx2lz6krkxv815mhmm0000gn/T/service-task-sky-service-5f6d-11optx2f -> ~/.sky/serve/sky_service_5f6d/task.yaml.tmp
  Syncing (to 1 node): /var/folders/4t/b03l11jx2lz6krkxv815mhmm0000gn/T/tmpb8505lym -> ~/.sky/serve/sky_service_5f6d/config.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-03-18-23-16-06-173110/file_mounts.log
⚙︎ Running setup on serve controller.
[4/5] Check & install cloud dependencies on controller: Kubernetes                    bash: https://dl.k8s.io/release/v1.31.6/bin/linux/amd64/kubectl: No such file or directory
  Check & install cloud dependencies on controller: done.                                        
✓ Setup completed.  View logs: sky api logs -l sky-2025-03-18-23-16-06-173110/setup-*.log
⚙︎ Service registered.
```

note the conspicuous lack of "loading TPU resources" logline which I has inserted to https://github.com/skypilot-org/skypilot/blob/master/sky/provision/gcp/instance_utils.py#L1203

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see manual test above)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
