### PR TITLE
[jobs] fix AssertionError for preempted cluster

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -130,6 +130,7 @@ def get_job_status(backend: 'backends.CloudVmRayBackend',
         # refresh already noticed and cleaned it up.
         logger.info(f'Cluster {cluster_name} not found.')
         return None
+    assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
     status = None
     try:
         logger.info('=== Checking the job status... ===')

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -125,7 +125,11 @@ def get_job_status(backend: 'backends.CloudVmRayBackend',
     FAILED_SETUP or CANCELLED.
     """
     handle = global_user_state.get_handle_from_cluster_name(cluster_name)
-    assert isinstance(handle, backends.CloudVmRayResourceHandle), handle
+    if handle is None:
+        # This can happen if the cluster was preempted and background status
+        # refresh already noticed and cleaned it up.
+        logger.info(f'Cluster {cluster_name} not found.')
+        return None
     status = None
     try:
         logger.info('=== Checking the job status... ===')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If there is a local API server running on the jobs controller (could be triggered by the jobs dashboard), then preempted clusters may get automatically cleaned up during regular status refresh.

This could cause an AssertionError in the controller code, which assumed that clusters should only be cleaned up by itself.

To fix, explicitly handle the case where the cluster has already been cleaned up.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] manual tests
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
