### PR TITLE
[Core] Refactor cloud compute / storage credential checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         files: "^sky/skylet/providers/ibm/.*"  # Only match IBM-specific directory
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991  # Match the version from requirements
+    rev: v1.4.0  # Match the version from requirements
     hooks:
     -   id: mypy
         args:
@@ -58,7 +58,7 @@ repos:
         name: yapf
         exclude: (sky/skylet/providers/ibm/.*)  # Matches exclusions from the script
         args: ['--recursive', '--parallel', '--in-place']  # Only necessary flags
-        additional_dependencies: [toml==0.10.2]
+        additional_dependencies: [toml==0.10.2] # Match the version from requirements
 
 -   repo: https://github.com/pylint-dev/pylint
     rev: v2.14.5  # Match the version from requirements

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ toml==0.10.2
 isort==5.12.0
 
 # type checking
-mypy==0.991
+mypy==1.4.0
 types-PyYAML
 # 2.31 requires urlib3>2, which is incompatible with SkyPilot, IBM and
 # kubernetes packages, which require urllib3<2.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,21 @@
 # formatting
+# match the version with .pre-commit-config.yaml
 yapf==0.32.0
+# match the version with .pre-commit-config.yaml
 pylint==2.14.5
 # formatting the node_providers code from upstream ray-project/ray project
+# match the version with .pre-commit-config.yaml
 black==22.10.0
 # https://github.com/edaniszewski/pylint-quotes
+# match the version with .pre-commit-config.yaml
 pylint-quotes==0.2.3
+# match the version with .pre-commit-config.yaml
 toml==0.10.2
+# match the version with .pre-commit-config.yaml
 isort==5.12.0
 
 # type checking
+# match the version with .pre-commit-config.yaml
 mypy==1.4.0
 types-PyYAML
 # 2.31 requires urlib3>2, which is incompatible with SkyPilot, IBM and

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional, Tuple
 
 from sky import exceptions
 from sky.adaptors import common
-from sky.clouds import CloudCapability
+from sky.clouds import cloud
 from sky.utils import annotations
 from sky.utils import ux_utils
 
@@ -151,13 +151,13 @@ def create_endpoint():
 
 
 def check_credentials(
-        cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-    if cloud_capability == CloudCapability.COMPUTE:
+        cloud_capability: cloud.CloudCapability) -> Tuple[bool, Optional[str]]:
+    if cloud_capability == cloud.CloudCapability.COMPUTE:
         # for backward compatibility,
         # we check storage credentials for compute.
         # TODO(seungjin): properly return not supported error for compute.
         return check_storage_credentials()
-    elif cloud_capability == CloudCapability.STORAGE:
+    elif cloud_capability == cloud.CloudCapability.STORAGE:
         return check_storage_credentials()
     else:
         raise exceptions.NotSupportedError(

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -6,7 +6,9 @@ import os
 import threading
 from typing import Dict, Optional, Tuple
 
+from sky import exceptions
 from sky.adaptors import common
+from sky.clouds import CloudCapability
 from sky.utils import annotations
 from sky.utils import ux_utils
 
@@ -130,8 +132,8 @@ def client(service_name: str, region):
 @common.load_lazy_modules(_LAZY_MODULES)
 def botocore_exceptions():
     """AWS botocore exception."""
-    from botocore import exceptions
-    return exceptions
+    from botocore import exceptions as boto_exceptions
+    return boto_exceptions
 
 
 def create_endpoint():
@@ -148,8 +150,18 @@ def create_endpoint():
     return endpoint
 
 
-def check_credentials() -> Tuple[bool, Optional[str]]:
-    return check_storage_credentials()
+def check_credentials(
+        cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+    if cloud_capability == CloudCapability.COMPUTE:
+        # for backward compatibility,
+        # we check storage credentials for compute.
+        # TODO(seungjin): properly return not supported error for compute.
+        return check_storage_credentials()
+    elif cloud_capability == CloudCapability.STORAGE:
+        return check_storage_credentials()
+    else:
+        raise exceptions.NotSupportedError(
+            f'{NAME} does not support {cloud_capability}.')
 
 
 def check_storage_credentials() -> Tuple[bool, Optional[str]]:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1981,7 +1981,8 @@ class RetryingVmProvisioner(object):
         # is running. Here we check the enabled clouds and expiring credentials
         # and raise a warning to the user.
         if task.is_controller_task():
-            enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh()
+            enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+                clouds.CloudCapability.COMPUTE)
             expirable_clouds = backend_utils.get_expirable_clouds(
                 enabled_clouds)
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -38,6 +38,7 @@ from sky import sky_logging
 from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.backends import wheel_utils
+from sky.clouds import cloud as sky_cloud
 from sky.clouds import service_catalog
 from sky.clouds.utils import gcp_utils
 from sky.data import data_utils
@@ -1982,7 +1983,7 @@ class RetryingVmProvisioner(object):
         # and raise a warning to the user.
         if task.is_controller_task():
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                clouds.CloudCapability.COMPUTE)
+                sky_cloud.CloudCapability.COMPUTE)
             expirable_clouds = backend_utils.get_expirable_clouds(
                 enabled_clouds)
 

--- a/sky/benchmark/benchmark_utils.py
+++ b/sky/benchmark/benchmark_utils.py
@@ -172,8 +172,9 @@ def _create_benchmark_bucket() -> Tuple[str, str]:
     bucket_name = f'sky-bench-{uuid.uuid4().hex[:4]}-{getpass.getuser()}'
 
     # Select the bucket type.
-    enabled_clouds = storage_lib.get_cached_enabled_storage_clouds_or_refresh(
-        raise_if_no_cloud_access=True)
+    enabled_clouds = (
+        storage_lib.get_cached_enabled_storage_cloud_names_or_refresh(
+            raise_if_no_cloud_access=True))
     # Sky Benchmark only supports S3 (see _download_remote_dir and
     # _delete_remote_dir).
     enabled_clouds = [

--- a/sky/check.py
+++ b/sky/check.py
@@ -12,6 +12,7 @@ from sky import exceptions
 from sky import global_user_state
 from sky import skypilot_config
 from sky.adaptors import cloudflare
+from sky.clouds import cloud as sky_cloud
 from sky.utils import registry
 from sky.utils import rich_utils
 from sky.utils import ux_utils
@@ -24,17 +25,17 @@ def check_capabilities(
     quiet: bool = False,
     verbose: bool = False,
     clouds: Optional[Iterable[str]] = None,
-    capabilities: Optional[List[sky_clouds.CloudCapability]] = None,
-) -> Dict[str, List[sky_clouds.CloudCapability]]:
+    capabilities: Optional[List[sky_cloud.CloudCapability]] = None,
+) -> Dict[str, List[sky_cloud.CloudCapability]]:
     echo = (lambda *_args, **_kwargs: None
            ) if quiet else lambda *args, **kwargs: click.echo(
                *args, **kwargs, color=True)
     echo('Checking credentials to enable clouds for SkyPilot.')
     if capabilities is None:
-        capabilities = sky_clouds.ALL_CAPABILITIES
+        capabilities = sky_cloud.ALL_CAPABILITIES
     assert capabilities is not None
-    enabled_clouds: Dict[str, List[sky_clouds.CloudCapability]] = {}
-    disabled_clouds: Dict[str, List[sky_clouds.CloudCapability]] = {}
+    enabled_clouds: Dict[str, List[sky_cloud.CloudCapability]] = {}
+    disabled_clouds: Dict[str, List[sky_cloud.CloudCapability]] = {}
 
     def check_one_cloud(
             cloud_tuple: Tuple[str, Union[sky_clouds.Cloud,
@@ -189,7 +190,7 @@ def check(
     quiet: bool = False,
     verbose: bool = False,
     clouds: Optional[Iterable[str]] = None,
-    capability: sky_clouds.CloudCapability = sky_clouds.CloudCapability.COMPUTE,
+    capability: sky_cloud.CloudCapability = sky_cloud.CloudCapability.COMPUTE,
 ) -> List[str]:
     clouds_with_capability = []
     enabled_clouds = check_capabilities(quiet, verbose, clouds, [capability])
@@ -200,7 +201,7 @@ def check(
 
 
 def get_cached_enabled_clouds_or_refresh(
-        capability: sky_clouds.CloudCapability,
+        capability: sky_cloud.CloudCapability,
         raise_if_no_cloud_access: bool = False) -> List[sky_clouds.Cloud]:
     """Returns cached enabled clouds and if no cloud is enabled, refresh.
 

--- a/sky/check.py
+++ b/sky/check.py
@@ -200,6 +200,7 @@ def check(
 
 
 def get_cached_enabled_clouds_or_refresh(
+        capability: sky_clouds.CloudCapability,
         raise_if_no_cloud_access: bool = False) -> List[sky_clouds.Cloud]:
     """Returns cached enabled clouds and if no cloud is enabled, refresh.
 
@@ -214,60 +215,23 @@ def get_cached_enabled_clouds_or_refresh(
             raise_if_no_cloud_access is set to True.
     """
     cached_enabled_clouds = global_user_state.get_cached_enabled_clouds(
-        sky_clouds.CloudCapability.COMPUTE)
+        capability)
     if not cached_enabled_clouds:
         try:
-            check(quiet=True, capability=sky_clouds.CloudCapability.COMPUTE)
+            check(quiet=True, capability=capability)
         except SystemExit:
             # If no cloud is enabled, check() will raise SystemExit.
             # Here we catch it and raise the exception later only if
             # raise_if_no_cloud_access is set to True.
             pass
         cached_enabled_clouds = global_user_state.get_cached_enabled_clouds(
-            sky_clouds.CloudCapability.COMPUTE)
+            capability)
     if raise_if_no_cloud_access and not cached_enabled_clouds:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.NoCloudAccessError(
                 'Cloud access is not set up. Run: '
                 f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')
     return cached_enabled_clouds
-
-
-def get_cached_enabled_storage_clouds_or_refresh(
-        raise_if_no_cloud_access: bool = False) -> List[sky_clouds.Cloud]:
-    """Returns cached enabled storage clouds and if no cloud is enabled,
-    refresh.
-
-    This function will perform a refresh if no public cloud is enabled.
-
-    Args:
-        raise_if_no_cloud_access: if True, raise an exception if no public
-            cloud is enabled.
-
-    Raises:
-        exceptions.NoCloudAccessError: if no public cloud is enabled and
-            raise_if_no_cloud_access is set to True.
-    """
-    cached_enabled_storage_clouds = (
-        global_user_state.get_cached_enabled_clouds(
-            sky_clouds.CloudCapability.STORAGE))
-    if not cached_enabled_storage_clouds:
-        try:
-            check(quiet=True, capability=sky_clouds.CloudCapability.STORAGE)
-        except SystemExit:
-            # If no cloud is enabled, check() will raise SystemExit.
-            # Here we catch it and raise the exception later only if
-            # raise_if_no_cloud_access is set to True.
-            pass
-        cached_enabled_storage_clouds = (
-            global_user_state.get_cached_enabled_clouds(
-                sky_clouds.CloudCapability.STORAGE))
-    if raise_if_no_cloud_access and not cached_enabled_storage_clouds:
-        with ux_utils.print_exception_no_traceback():
-            raise exceptions.NoCloudAccessError(
-                'Cloud access is not set up. Run: '
-                f'{colorama.Style.BRIGHT}sky check{colorama.Style.RESET_ALL}')
-    return cached_enabled_storage_clouds
 
 
 def get_cloud_credential_file_mounts(

--- a/sky/check.py
+++ b/sky/check.py
@@ -36,17 +36,6 @@ def check_capabilities(
     enabled_clouds: Dict[str, List[sky_clouds.CloudCapability]] = {}
     disabled_clouds: Dict[str, List[sky_clouds.CloudCapability]] = {}
 
-    def check_credentials(
-            cloud: Union[sky_clouds.Cloud,
-                         ModuleType], capability: sky_clouds.CloudCapability
-    ) -> Tuple[bool, Optional[str]]:
-        if capability == sky_clouds.CloudCapability.COMPUTE:
-            return cloud.check_credentials()
-        elif capability == sky_clouds.CloudCapability.STORAGE:
-            return cloud.check_storage_credentials()
-        else:
-            raise ValueError(f'Invalid capability: {capability}')
-
     def check_one_cloud(
             cloud_tuple: Tuple[str, Union[sky_clouds.Cloud,
                                           ModuleType]]) -> None:
@@ -55,7 +44,7 @@ def check_capabilities(
         for capability in capabilities:
             with rich_utils.safe_status(f'Checking {cloud_repr}...'):
                 try:
-                    ok, reason = check_credentials(cloud, capability)
+                    ok, reason = cloud.check_credentials(capability)
                 except exceptions.NotSupportedError:
                     continue
                 except Exception:  # pylint: disable=broad-except

--- a/sky/clouds/__init__.py
+++ b/sky/clouds/__init__.py
@@ -1,9 +1,7 @@
 """Clouds in Sky."""
 
-from sky.clouds.cloud import ALL_CAPABILITIES
 from sky.clouds.cloud import Cloud
 from sky.clouds.cloud import cloud_in_iterable
-from sky.clouds.cloud import CloudCapability
 from sky.clouds.cloud import CloudImplementationFeatures
 from sky.clouds.cloud import OpenPortsVersion
 from sky.clouds.cloud import ProvisionerVersion
@@ -55,6 +53,4 @@ __all__ = [
     'Nebius',
     # Utility functions
     'cloud_in_iterable',
-    'ALL_CAPABILITIES',
-    'CloudCapability',
 ]

--- a/sky/clouds/__init__.py
+++ b/sky/clouds/__init__.py
@@ -55,4 +55,6 @@ __all__ = [
     'Nebius',
     # Utility functions
     'cloud_in_iterable',
+    'ALL_CAPABILITIES',
+    'CloudCapability',
 ]

--- a/sky/clouds/__init__.py
+++ b/sky/clouds/__init__.py
@@ -1,7 +1,9 @@
 """Clouds in Sky."""
 
+from sky.clouds.cloud import ALL_CAPABILITIES
 from sky.clouds.cloud import Cloud
 from sky.clouds.cloud import cloud_in_iterable
+from sky.clouds.cloud import CloudCapability
 from sky.clouds.cloud import CloudImplementationFeatures
 from sky.clouds.cloud import OpenPortsVersion
 from sky.clouds.cloud import ProvisionerVersion

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -16,7 +16,6 @@ from sky import provision as provision_lib
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import aws
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.service_catalog import common as catalog_common
 from sky.clouds.utils import aws_utils
@@ -560,25 +559,22 @@ class AWS(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        """Checks if the user has access credentials to this cloud."""
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        elif cloud_capability == CloudCapability.STORAGE:
-            # TODO(seungjin): Implement separate check for
-            # if the user has access to S3.
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this AWS's compute service."""
+        return cls._check_credentials()
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this AWS's storage service."""
+        # TODO(seungjin): Implement separate check for
+        # if the user has access to S3.
+        return cls._check_credentials()
 
     @classmethod
     @annotations.lru_cache(scope='global',
                            maxsize=1)  # Cache since getting identity is slow.
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """Checks if the user has access credentials to this cloud."""
+        """Checks if the user has access credentials to AWS."""
 
         dependency_installation_hints = (
             'AWS dependencies are not installed. '

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -14,7 +14,6 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import azure
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import azure_utils
 from sky.utils import annotations
@@ -513,18 +512,16 @@ class Azure(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        elif cloud_capability == CloudCapability.STORAGE:
-            # TODO(seungjin): Implement separate check for
-            # if the user has access to Azure Blob Storage.
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this cloud's compute service."""
+        return cls._check_credentials()
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this cloud's storage service."""
+        # TODO(seungjin): Implement separate check for
+        # if the user has access to Azure Blob Storage.
+        return cls._check_credentials()
 
     @classmethod
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -14,6 +14,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import azure
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import azure_utils
 from sky.utils import annotations
@@ -512,7 +513,21 @@ class Azure(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        elif cloud_capability == CloudCapability.STORAGE:
+            # TODO(seungjin): Implement separate check for
+            # if the user has access to Azure Blob Storage.
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud."""
         help_str = (
             ' Run the following commands:'
@@ -573,11 +588,6 @@ class Azure(clouds.Cloud):
     def instance_type_exists(self, instance_type):
         return service_catalog.instance_type_exists(instance_type,
                                                     clouds='azure')
-
-    @classmethod
-    def check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
-        # TODO(seungjin): Check if the user has access to Azure Blob Storage.
-        return cls.check_credentials()
 
     @classmethod
     @annotations.lru_cache(scope='global',

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -13,8 +13,6 @@ import math
 import typing
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
-from typing_extensions import assert_never
-
 from sky import exceptions
 from sky import skypilot_config
 from sky.clouds import service_catalog
@@ -462,7 +460,9 @@ class Cloud:
             return cls._check_compute_credentials()
         elif cloud_capability == CloudCapability.STORAGE:
             return cls._check_storage_credentials()
-        assert_never(cloud_capability)
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
 
     @classmethod
     def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -453,7 +453,27 @@ class Cloud:
         Returns a boolean of whether the user can access this cloud, and a
         string describing the reason if the user cannot access.
         """
-        raise NotImplementedError
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_compute_credentials()
+        elif cloud_capability == CloudCapability.STORAGE:
+            return cls._check_storage_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        this cloud's compute service."""
+        raise exceptions.NotSupportedError(
+            f'{cls._REPR} does not support {CloudCapability.COMPUTE.value}.')
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        this cloud's storage service."""
+        raise exceptions.NotSupportedError(
+            f'{cls._REPR} does not support {CloudCapability.STORAGE.value}.')
 
     # TODO(zhwu): Make the return type immutable.
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -462,9 +462,6 @@ class Cloud:
             return cls._check_compute_credentials()
         elif cloud_capability == CloudCapability.STORAGE:
             return cls._check_storage_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
         assert_never(cloud_capability)
 
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -48,6 +48,16 @@ class CloudImplementationFeatures(enum.Enum):
     AUTO_TERMINATE = 'auto_terminate'  # Pod/VM can stop or down itself
 
 
+class CloudCapability(enum.Enum):
+    # Compute capability.
+    COMPUTE = 'compute'
+    # Storage capability.
+    STORAGE = 'storage'
+
+
+ALL_CAPABILITIES = [CloudCapability.COMPUTE, CloudCapability.STORAGE]
+
+
 class Region(collections.namedtuple('Region', ['name'])):
     """A region."""
     name: str

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -445,25 +445,15 @@ class Cloud:
         return {reservation: 0 for reservation in specific_reservations}
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud.
 
         Returns a boolean of whether the user can access this cloud, and a
         string describing the reason if the user cannot access.
         """
         raise NotImplementedError
-
-    @classmethod
-    def check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """Checks if the user has access credentials to this cloud's storage.
-
-        Returns a boolean of whether the user can access this cloud's storage,
-        and a string describing the reason if the user cannot access.
-        """
-        # A given cloud does not support storage
-        # unless it overrides this method.
-        raise exceptions.NotSupportedError(
-            f'{cls._REPR} does not support storage.')
 
     # TODO(zhwu): Make the return type immutable.
     @classmethod

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -13,6 +13,8 @@ import math
 import typing
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
+from typing_extensions import assert_never
+
 from sky import exceptions
 from sky import skypilot_config
 from sky.clouds import service_catalog
@@ -452,6 +454,9 @@ class Cloud:
 
         Returns a boolean of whether the user can access this cloud, and a
         string describing the reason if the user cannot access.
+
+        Raises NotSupportedError if the capability is
+        not supported by this cloud.
         """
         if cloud_capability == CloudCapability.COMPUTE:
             return cls._check_compute_credentials()
@@ -460,6 +465,7 @@ class Cloud:
         else:
             raise exceptions.NotSupportedError(
                 f'{cls._REPR} does not support {cloud_capability}.')
+        assert_never(cloud_capability)
 
     @classmethod
     def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -13,6 +13,8 @@ import math
 import typing
 from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 
+from typing_extensions import assert_never
+
 from sky import exceptions
 from sky import skypilot_config
 from sky.clouds import service_catalog
@@ -460,9 +462,7 @@ class Cloud:
             return cls._check_compute_credentials()
         elif cloud_capability == CloudCapability.STORAGE:
             return cls._check_storage_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+        assert_never(cloud_capability)
 
     @classmethod
     def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -4,6 +4,8 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import common_utils
 from sky.utils import registry
@@ -267,7 +269,17 @@ class Cudo(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
 
         try:
             # pylint: disable=import-outside-toplevel,unused-import

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -4,8 +4,6 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import common_utils
 from sky.utils import registry
@@ -269,18 +267,9 @@ class Cudo(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        Cudo's compute service."""
         try:
             # pylint: disable=import-outside-toplevel,unused-import
             from cudo_compute import cudo_api

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -5,9 +5,7 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
-from sky import exceptions
 from sky.adaptors import do
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.do import utils as do_utils
 from sky.utils import registry
@@ -261,18 +259,9 @@ class DO(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """Verify that the user has valid credentials for DO."""
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Verify that the user has valid credentials for
+        DO's compute service."""
 
         try:
             do.exceptions()

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -5,7 +5,9 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
+from sky import exceptions
 from sky.adaptors import do
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.do import utils as do_utils
 from sky.utils import registry
@@ -259,7 +261,17 @@ class DO(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Verify that the user has valid credentials for DO."""
 
         try:

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -6,6 +6,8 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.fluidstack import fluidstack_utils
 from sky.utils import registry
@@ -255,7 +257,17 @@ class Fluidstack(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
 
         try:
             assert os.path.exists(

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -6,8 +6,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.fluidstack import fluidstack_utils
 from sky.utils import registry
@@ -257,18 +255,9 @@ class Fluidstack(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        FluidStack's compute service."""
         try:
             assert os.path.exists(
                 os.path.expanduser(fluidstack_utils.FLUIDSTACK_API_KEY_PATH))

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -15,7 +15,6 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import gcp
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import gcp_utils
 from sky.utils import annotations
@@ -720,26 +719,23 @@ class GCP(clouds.Cloud):
         return DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials(  # Check APIs.
-                [
-                    ('compute', 'Compute Engine'),
-                    ('cloudresourcemanager', 'Cloud Resource Manager'),
-                    ('iam', 'Identity and Access Management (IAM)'),
-                    ('tpu', 'Cloud TPU'),  # Keep as final element.
-                ],
-                gcp_utils.get_minimal_compute_permissions())
-        elif cloud_capability == CloudCapability.STORAGE:
-            return cls._check_credentials(  # Check APIs.
-                [
-                    ('storage', 'Cloud Storage'),
-                ], gcp_utils.get_minimal_storage_permissions())
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this cloud's compute service."""
+        return cls._check_credentials(
+            [
+                ('compute', 'Compute Engine'),
+                ('cloudresourcemanager', 'Cloud Resource Manager'),
+                ('iam', 'Identity and Access Management (IAM)'),
+                ('tpu', 'Cloud TPU'),  # Keep as final element.
+            ],
+            gcp_utils.get_minimal_compute_permissions())
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to this cloud's storage service."""
+        return cls._check_credentials(
+            [('storage', 'Cloud Storage')],
+            gcp_utils.get_minimal_storage_permissions())
 
     @classmethod
     def _check_credentials(

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -6,11 +6,9 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 import colorama
 
 from sky import clouds
-from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import ibm
 from sky.adaptors.ibm import CREDENTIAL_FILE
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -397,18 +395,18 @@ class IBM(clouds.Cloud):
         return image_size
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        elif cloud_capability == CloudCapability.STORAGE:
-            # TODO(seungjin): Implement separate check for
-            # if the user has access to IBM COS.
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        IBM's compute service."""
+        return cls._check_credentials()
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        IBM's storage service."""
+        # TODO(seungjin): Implement separate check for
+        # if the user has access to IBM COS.
+        return cls._check_credentials()
 
     @classmethod
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -9,7 +9,6 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision import instance_setup
 from sky.provision.kubernetes import network_utils
@@ -656,17 +655,9 @@ class Kubernetes(clouds.Cloud):
                                                  [], None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        Kubernetes."""
         # Test using python API
         try:
             existing_allowed_contexts = cls.existing_allowed_contexts()

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -9,6 +9,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import kubernetes
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision import instance_setup
 from sky.provision.kubernetes import network_utils
@@ -655,7 +656,17 @@ class Kubernetes(clouds.Cloud):
                                                  [], None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         # Test using python API
         try:
             existing_allowed_contexts = cls.existing_allowed_contexts()

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -5,8 +5,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.lambda_cloud import lambda_utils
 from sky.utils import registry
@@ -243,17 +241,9 @@ class Lambda(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        Lambda's compute service."""
         try:
             lambda_utils.LambdaCloudClient().list_instances()
         except (AssertionError, KeyError, lambda_utils.LambdaCloudError):

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -5,6 +5,8 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.lambda_cloud import lambda_utils
 from sky.utils import registry
@@ -241,7 +243,17 @@ class Lambda(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         try:
             lambda_utils.LambdaCloudClient().list_instances()
         except (AssertionError, KeyError, lambda_utils.LambdaCloudError):

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -4,7 +4,9 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
+from sky import exceptions
 from sky.adaptors import nebius
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -250,7 +252,17 @@ class Nebius(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """ Verify that the user has valid credentials for Nebius. """
         logging.debug('Nebius cloud check credentials')
         token_cred_msg = ('    Credentials can be set up by running: \n'\

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -4,9 +4,7 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
-from sky import exceptions
 from sky.adaptors import nebius
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -252,18 +250,9 @@ class Nebius(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """ Verify that the user has valid credentials for Nebius. """
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        Nebius's compute service."""
         logging.debug('Nebius cloud check credentials')
         token_cred_msg = ('    Credentials can be set up by running: \n'\
                     f'        $ nebius iam get-access-token > {nebius.NEBIUS_IAM_TOKEN_PATH} \n'\

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -28,7 +28,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from sky import clouds
 from sky import exceptions
 from sky.adaptors import oci as oci_adaptor
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import oci_utils
 from sky.provision.oci.query_utils import query_helper
@@ -397,18 +396,18 @@ class OCI(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        elif cloud_capability == CloudCapability.STORAGE:
-            # TODO(seungjin): Implement separate check for
-            # if the user has access to OCI Object Storage.
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        OCI's compute service."""
+        return cls._check_credentials()
+
+    @classmethod
+    def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        OCI's storage service."""
+        # TODO(seungjin): Implement separate check for
+        # if the user has access to OCI Object Storage.
+        return cls._check_credentials()
 
     @classmethod
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -28,6 +28,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from sky import clouds
 from sky import exceptions
 from sky.adaptors import oci as oci_adaptor
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import oci_utils
 from sky.provision.oci.query_utils import query_helper
@@ -396,7 +397,21 @@ class OCI(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        elif cloud_capability == CloudCapability.STORAGE:
+            # TODO(seungjin): Implement separate check for
+            # if the user has access to OCI Object Storage.
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud."""
 
         short_credential_help_str = (
@@ -455,11 +470,6 @@ class OCI(clouds.Cloud):
                 f'{cls._INDENT_PREFIX}{credential_help_str}\n'
                 f'{cls._INDENT_PREFIX}Error details: '
                 f'{common_utils.format_exception(e, use_bracket=True)}')
-
-    @classmethod
-    def check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
-        # TODO(seungjin): Check if the user has access to OCI Object Storage.
-        return cls.check_credentials()
 
     @classmethod
     def check_disk_tier(

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -6,6 +6,8 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.paperspace import utils
 from sky.utils import registry
@@ -249,7 +251,17 @@ class Paperspace(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Verify that the user has valid credentials for Paperspace."""
         try:
             # attempt to make a CURL request for listing instances

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -6,8 +6,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.paperspace import utils
 from sky.utils import registry
@@ -251,18 +249,9 @@ class Paperspace(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """Verify that the user has valid credentials for Paperspace."""
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        Paperspace's compute service."""
         try:
             # attempt to make a CURL request for listing instances
             utils.PaperspaceCloudClient().list_instances()

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -4,6 +4,8 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -248,7 +250,17 @@ class RunPod(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """ Verify that the user has valid credentials for RunPod. """
         try:
             import runpod  # pylint: disable=import-outside-toplevel

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -4,8 +4,6 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -250,14 +248,10 @@ class RunPod(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        RunPod's compute service."""
+        return cls._check_credentials()
 
     @classmethod
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -10,7 +10,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import scp_utils
 from sky.utils import registry
@@ -313,17 +312,9 @@ class SCP(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        SCP's compute service."""
         try:
             scp_utils.SCPClient().list_instances()
         except (AssertionError, KeyError, scp_utils.SCPClientError,

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -10,6 +10,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.clouds.utils import scp_utils
 from sky.utils import registry
@@ -312,7 +313,17 @@ class SCP(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         try:
             scp_utils.SCPClient().list_instances()
         except (AssertionError, KeyError, scp_utils.SCPClientError,

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -12,6 +12,7 @@ from sky import clouds as sky_clouds
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.adaptors import kubernetes
+from sky.clouds import cloud
 from sky.clouds.service_catalog import CloudFilter
 from sky.clouds.service_catalog import common
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -133,7 +134,7 @@ def _list_accelerators(
     # First check if Kubernetes is enabled. This ensures k8s python client is
     # installed. Do not put any k8s-specific logic before this check.
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-        sky_clouds.CloudCapability.COMPUTE)
+        cloud.CloudCapability.COMPUTE)
     if not sky_clouds.cloud_in_iterable(sky_clouds.Kubernetes(),
                                         enabled_clouds):
         return {}, {}, {}

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -132,7 +132,8 @@ def _list_accelerators(
 
     # First check if Kubernetes is enabled. This ensures k8s python client is
     # installed. Do not put any k8s-specific logic before this check.
-    enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh()
+    enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+        sky_clouds.CloudCapability.COMPUTE)
     if not sky_clouds.cloud_in_iterable(sky_clouds.Kubernetes(),
                                         enabled_clouds):
         return {}, {}, {}

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -4,8 +4,6 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -236,18 +234,9 @@ class Vast(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """ Verify that the user has valid credentials for Vast. """
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has valid credentials for
+        Vast's compute service. """
         try:
             import vastai_sdk as _vast  # pylint: disable=import-outside-toplevel
             vast = _vast.VastAI()

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -4,6 +4,8 @@ import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -234,7 +236,17 @@ class Vast(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """ Verify that the user has valid credentials for Vast. """
         try:
             import vastai_sdk as _vast  # pylint: disable=import-outside-toplevel

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -6,6 +6,8 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
+from sky import exceptions
+from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.vsphere import vsphere_utils
 from sky.provision.vsphere.vsphere_utils import get_vsphere_credentials
@@ -254,7 +256,17 @@ class Vsphere(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(cls) -> Tuple[bool, Optional[str]]:
+    def check_credentials(
+            cls,
+            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
+        if cloud_capability == CloudCapability.COMPUTE:
+            return cls._check_credentials()
+        else:
+            raise exceptions.NotSupportedError(
+                f'{cls._REPR} does not support {cloud_capability}.')
+
+    @classmethod
+    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to this cloud."""
 
         try:

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -6,8 +6,6 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 import requests
 
 from sky import clouds
-from sky import exceptions
-from sky.clouds import CloudCapability
 from sky.clouds import service_catalog
 from sky.provision.vsphere import vsphere_utils
 from sky.provision.vsphere.vsphere_utils import get_vsphere_credentials
@@ -256,18 +254,9 @@ class Vsphere(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
-    def check_credentials(
-            cls,
-            cloud_capability: CloudCapability) -> Tuple[bool, Optional[str]]:
-        if cloud_capability == CloudCapability.COMPUTE:
-            return cls._check_credentials()
-        else:
-            raise exceptions.NotSupportedError(
-                f'{cls._REPR} does not support {cloud_capability}.')
-
-    @classmethod
-    def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
-        """Checks if the user has access credentials to this cloud."""
+    def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to
+        vSphere's compute service."""
 
         try:
             # pylint: disable=import-outside-toplevel,unused-import

--- a/sky/core.py
+++ b/sky/core.py
@@ -19,6 +19,7 @@ from sky import optimizer
 from sky import sky_logging
 from sky import task as task_lib
 from sky.backends import backend_utils
+from sky.clouds import cloud as sky_cloud
 from sky.clouds import service_catalog
 from sky.jobs.server import core as managed_jobs_core
 from sky.provision.kubernetes import constants as kubernetes_constants
@@ -1002,7 +1003,7 @@ def storage_delete(name: str) -> None:
 @usage_lib.entrypoint
 def enabled_clouds() -> List[clouds.Cloud]:
     return global_user_state.get_cached_enabled_clouds(
-        clouds.CloudCapability.COMPUTE)
+        sky_cloud.CloudCapability.COMPUTE)
 
 
 @usage_lib.entrypoint
@@ -1137,7 +1138,7 @@ def local_down() -> None:
                 ux_utils.spinner_message('Running sky check...')):
             sky_check.check(clouds=['kubernetes'],
                             quiet=True,
-                            capability=clouds.CloudCapability.COMPUTE)
+                            capability=sky_cloud.CloudCapability.COMPUTE)
         logger.info(
             ux_utils.finishing_message('Local cluster removed.',
                                        log_path=log_path,

--- a/sky/core.py
+++ b/sky/core.py
@@ -1001,7 +1001,8 @@ def storage_delete(name: str) -> None:
 # ===================
 @usage_lib.entrypoint
 def enabled_clouds() -> List[clouds.Cloud]:
-    return global_user_state.get_cached_enabled_clouds()
+    return global_user_state.get_cached_enabled_clouds(
+        clouds.CloudCapability.COMPUTE)
 
 
 @usage_lib.entrypoint
@@ -1136,7 +1137,7 @@ def local_down() -> None:
                 ux_utils.spinner_message('Running sky check...')):
             sky_check.check(clouds=['kubernetes'],
                             quiet=True,
-                            capability=sky_check.CloudCapability.COMPUTE)
+                            capability=clouds.CloudCapability.COMPUTE)
         logger.info(
             ux_utils.finishing_message('Local cluster removed.',
                                        log_path=log_path,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -78,7 +78,7 @@ _BUCKET_EXTERNALLY_DELETED_DEBUG_MESSAGE = (
 _STORAGE_LOG_FILE_NAME = 'storage_sync.log'
 
 
-def get_cached_enabled_storage_clouds_or_refresh(
+def get_cached_enabled_storage_cloud_names_or_refresh(
         raise_if_no_cloud_access: bool = False) -> List[str]:
     # This is a temporary solution until https://github.com/skypilot-org/skypilot/issues/1943 # pylint: disable=line-too-long
     # is resolved by implementing separate 'enabled_storage_clouds'
@@ -98,8 +98,9 @@ def get_cached_enabled_storage_clouds_or_refresh(
 
 def _is_storage_cloud_enabled(cloud_name: str,
                               try_fix_with_sky_check: bool = True) -> bool:
-    enabled_storage_clouds = get_cached_enabled_storage_clouds_or_refresh()
-    if cloud_name in enabled_storage_clouds:
+    enabled_storage_cloud_names = (
+        get_cached_enabled_storage_cloud_names_or_refresh())
+    if cloud_name in enabled_storage_cloud_names:
         return True
     if try_fix_with_sky_check:
         # TODO(zhwu): Only check the specified cloud to speed up.

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -24,6 +24,7 @@ from sky.adaptors import cloudflare
 from sky.adaptors import gcp
 from sky.adaptors import ibm
 from sky.adaptors import oci
+from sky.clouds import cloud as sky_cloud
 from sky.data import data_transfer
 from sky.data import data_utils
 from sky.data import mounting_utils
@@ -83,7 +84,7 @@ def get_cached_enabled_storage_cloud_names_or_refresh(
     # This is a temporary solution until https://github.com/skypilot-org/skypilot/issues/1943 # pylint: disable=line-too-long
     # is resolved by implementing separate 'enabled_storage_clouds'
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-        clouds.CloudCapability.STORAGE)
+        sky_cloud.CloudCapability.STORAGE)
     enabled_clouds = [str(cloud) for cloud in enabled_clouds]
 
     r2_is_enabled, _ = cloudflare.check_storage_credentials()
@@ -104,7 +105,8 @@ def _is_storage_cloud_enabled(cloud_name: str,
         return True
     if try_fix_with_sky_check:
         # TODO(zhwu): Only check the specified cloud to speed up.
-        sky_check.check(quiet=True, capability=clouds.CloudCapability.STORAGE)
+        sky_check.check(quiet=True,
+                        capability=sky_cloud.CloudCapability.STORAGE)
         return _is_storage_cloud_enabled(cloud_name,
                                          try_fix_with_sky_check=False)
     return False

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -102,8 +102,7 @@ def _is_storage_cloud_enabled(cloud_name: str,
         return True
     if try_fix_with_sky_check:
         # TODO(zhwu): Only check the specified cloud to speed up.
-        sky_check.check(quiet=True,
-                        capability=sky_check.CloudCapability.STORAGE)
+        sky_check.check(quiet=True, capability=clouds.CloudCapability.STORAGE)
         return _is_storage_cloud_enabled(cloud_name,
                                          try_fix_with_sky_check=False)
     return False

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -82,7 +82,8 @@ def get_cached_enabled_storage_clouds_or_refresh(
         raise_if_no_cloud_access: bool = False) -> List[str]:
     # This is a temporary solution until https://github.com/skypilot-org/skypilot/issues/1943 # pylint: disable=line-too-long
     # is resolved by implementing separate 'enabled_storage_clouds'
-    enabled_clouds = sky_check.get_cached_enabled_storage_clouds_or_refresh()
+    enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+        clouds.CloudCapability.STORAGE)
     enabled_clouds = [str(cloud) for cloud in enabled_clouds]
 
     r2_is_enabled, _ = cloudflare.check_storage_credentials()

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -26,6 +26,7 @@ from sky.utils import status_lib
 if typing.TYPE_CHECKING:
     from sky import backends
     from sky import clouds
+    from sky.clouds import cloud
     from sky.data import Storage
 
 logger = sky_logging.init_logger(__name__)
@@ -796,7 +797,7 @@ def get_cluster_names_start_with(starts_with: str) -> List[str]:
 
 
 def get_cached_enabled_clouds(
-        cloud_capability: 'clouds.CloudCapability') -> List['clouds.Cloud']:
+        cloud_capability: 'cloud.CloudCapability') -> List['clouds.Cloud']:
 
     rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
                               (_get_capability_key(cloud_capability),))
@@ -820,14 +821,14 @@ def get_cached_enabled_clouds(
 
 
 def set_enabled_clouds(enabled_clouds: List[str],
-                       cloud_capability: 'clouds.CloudCapability') -> None:
+                       cloud_capability: 'cloud.CloudCapability') -> None:
     _DB.cursor.execute(
         'INSERT OR REPLACE INTO config VALUES (?, ?)',
         (_get_capability_key(cloud_capability), json.dumps(enabled_clouds)))
     _DB.conn.commit()
 
 
-def _get_capability_key(cloud_capability: 'clouds.CloudCapability') -> str:
+def _get_capability_key(cloud_capability: 'cloud.CloudCapability') -> str:
     return _ENABLED_CLOUDS_KEY_PREFIX + cloud_capability.value
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -18,6 +18,7 @@ import uuid
 
 from sky import models
 from sky import sky_logging
+from sky.clouds import CloudCapability
 from sky.utils import common_utils
 from sky.utils import db_utils
 from sky.utils import registry
@@ -30,8 +31,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_ENABLED_CLOUDS_KEY = 'enabled_clouds'
-_ENABLED_STORAGE_CLOUDS_KEY = 'enabled_storage_clouds'
+_ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds'
 
 _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
@@ -796,9 +796,11 @@ def get_cluster_names_start_with(starts_with: str) -> List[str]:
     return [row[0] for row in rows]
 
 
-def get_cached_enabled_clouds() -> List['clouds.Cloud']:
+def get_cached_enabled_clouds(
+        cloud_capability: CloudCapability) -> List['clouds.Cloud']:
+
     rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
-                              (_ENABLED_CLOUDS_KEY,))
+                              (_get_capability_key(cloud_capability),))
     ret = []
     for (value,) in rows:
         ret = json.loads(value)
@@ -818,39 +820,16 @@ def get_cached_enabled_clouds() -> List['clouds.Cloud']:
     return enabled_clouds
 
 
-def get_cached_enabled_storage_clouds() -> List['clouds.Cloud']:
-    rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
-                              (_ENABLED_STORAGE_CLOUDS_KEY,))
-    ret = []
-    for (value,) in rows:
-        ret = json.loads(value)
-        break
-    enabled_clouds: List['clouds.Cloud'] = []
-    for c in ret:
-        try:
-            cloud = registry.CLOUD_REGISTRY.from_str(c)
-        except ValueError:
-            # Handle the case for the clouds whose support has been removed from
-            # SkyPilot, e.g., 'local' was a cloud in the past and may be stored
-            # in the database for users before #3037. We should ignore removed
-            # clouds and continue.
-            continue
-        if cloud is not None:
-            enabled_clouds.append(cloud)
-    return enabled_clouds
-
-
-def set_enabled_clouds(enabled_clouds: List[str]) -> None:
-    _DB.cursor.execute('INSERT OR REPLACE INTO config VALUES (?, ?)',
-                       (_ENABLED_CLOUDS_KEY, json.dumps(enabled_clouds)))
-    _DB.conn.commit()
-
-
-def set_enabled_storage_clouds(enabled_storage_clouds: List[str]) -> None:
+def set_enabled_clouds(enabled_clouds: List[str],
+                       cloud_capability: CloudCapability) -> None:
     _DB.cursor.execute(
         'INSERT OR REPLACE INTO config VALUES (?, ?)',
-        (_ENABLED_STORAGE_CLOUDS_KEY, json.dumps(enabled_storage_clouds)))
+        (_get_capability_key(cloud_capability), json.dumps(enabled_clouds)))
     _DB.conn.commit()
+
+
+def _get_capability_key(cloud_capability: CloudCapability) -> str:
+    return _ENABLED_CLOUDS_KEY_PREFIX + cloud_capability.value
 
 
 def add_or_update_storage(storage_name: str,

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -18,7 +18,6 @@ import uuid
 
 from sky import models
 from sky import sky_logging
-from sky.clouds import CloudCapability
 from sky.utils import common_utils
 from sky.utils import db_utils
 from sky.utils import registry
@@ -31,7 +30,7 @@ if typing.TYPE_CHECKING:
 
 logger = sky_logging.init_logger(__name__)
 
-_ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds'
+_ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds_'
 
 _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
@@ -797,7 +796,7 @@ def get_cluster_names_start_with(starts_with: str) -> List[str]:
 
 
 def get_cached_enabled_clouds(
-        cloud_capability: CloudCapability) -> List['clouds.Cloud']:
+        cloud_capability: 'clouds.CloudCapability') -> List['clouds.Cloud']:
 
     rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
                               (_get_capability_key(cloud_capability),))
@@ -821,14 +820,14 @@ def get_cached_enabled_clouds(
 
 
 def set_enabled_clouds(enabled_clouds: List[str],
-                       cloud_capability: CloudCapability) -> None:
+                       cloud_capability: 'clouds.CloudCapability') -> None:
     _DB.cursor.execute(
         'INSERT OR REPLACE INTO config VALUES (?, ?)',
         (_get_capability_key(cloud_capability), json.dumps(enabled_clouds)))
     _DB.conn.commit()
 
 
-def _get_capability_key(cloud_capability: CloudCapability) -> str:
+def _get_capability_key(cloud_capability: 'clouds.CloudCapability') -> str:
     return _ENABLED_CLOUDS_KEY_PREFIX + cloud_capability.value
 
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -105,7 +105,7 @@ def launch(
 
         local_to_controller_file_mounts = {}
 
-        if storage_lib.get_cached_enabled_storage_clouds_or_refresh():
+        if storage_lib.get_cached_enabled_storage_cloud_names_or_refresh():
             for task_ in dag.tasks:
                 controller_utils.maybe_translate_local_file_mounts_and_sync_up(
                     task_, task_type='jobs')

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -368,7 +368,8 @@ class Optimizer:
                 # mention "kubernetes cluster" and/instead of "catalog"
                 # in the error message.
                 enabled_clouds = (
-                    sky_check.get_cached_enabled_clouds_or_refresh())
+                    sky_check.get_cached_enabled_clouds_or_refresh(
+                        clouds.CloudCapability.COMPUTE))
                 if clouds.cloud_in_iterable(clouds.Kubernetes(),
                                             enabled_clouds):
                     if any(orig_resources.cloud is None
@@ -1206,6 +1207,7 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
         dag: The DAG specified by a user.
     """
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+        capability=clouds.CloudCapability.COMPUTE,
         raise_if_no_cloud_access=True)
 
     global_disabled_clouds: Set[str] = set()
@@ -1228,6 +1230,7 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
                                     global_disabled_clouds),
                         capability=clouds.CloudCapability.COMPUTE)
         enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+            capability=clouds.CloudCapability.COMPUTE,
             raise_if_no_cloud_access=True)
         disabled_clouds = (clouds_need_recheck -
                            {str(c) for c in enabled_clouds})
@@ -1269,6 +1272,7 @@ def _fill_in_launchable_resources(
         a cloud that is not enabled.
     """
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+        capability=clouds.CloudCapability.COMPUTE,
         raise_if_no_cloud_access=True)
 
     launchable: Dict[resources_lib.Resources, List[resources_lib.Resources]] = (

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1226,7 +1226,7 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
         sky_check.check(quiet=True,
                         clouds=list(clouds_need_recheck -
                                     global_disabled_clouds),
-                        capability=sky_check.CloudCapability.COMPUTE)
+                        capability=clouds.CloudCapability.COMPUTE)
         enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
             raise_if_no_cloud_access=True)
         disabled_clouds = (clouds_need_recheck -

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -16,6 +16,7 @@ from sky import resources as resources_lib
 from sky import sky_logging
 from sky import task as task_lib
 from sky.adaptors import common as adaptors_common
+from sky.clouds import cloud as sky_cloud
 from sky.usage import usage_lib
 from sky.utils import common
 from sky.utils import env_options
@@ -369,7 +370,7 @@ class Optimizer:
                 # in the error message.
                 enabled_clouds = (
                     sky_check.get_cached_enabled_clouds_or_refresh(
-                        clouds.CloudCapability.COMPUTE))
+                        sky_cloud.CloudCapability.COMPUTE))
                 if clouds.cloud_in_iterable(clouds.Kubernetes(),
                                             enabled_clouds):
                     if any(orig_resources.cloud is None
@@ -1207,7 +1208,7 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
         dag: The DAG specified by a user.
     """
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-        capability=clouds.CloudCapability.COMPUTE,
+        capability=sky_cloud.CloudCapability.COMPUTE,
         raise_if_no_cloud_access=True)
 
     global_disabled_clouds: Set[str] = set()
@@ -1228,9 +1229,9 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
         sky_check.check(quiet=True,
                         clouds=list(clouds_need_recheck -
                                     global_disabled_clouds),
-                        capability=clouds.CloudCapability.COMPUTE)
+                        capability=sky_cloud.CloudCapability.COMPUTE)
         enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-            capability=clouds.CloudCapability.COMPUTE,
+            capability=sky_cloud.CloudCapability.COMPUTE,
             raise_if_no_cloud_access=True)
         disabled_clouds = (clouds_need_recheck -
                            {str(c) for c in enabled_clouds})
@@ -1272,7 +1273,7 @@ def _fill_in_launchable_resources(
         a cloud that is not enabled.
     """
     enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-        capability=clouds.CloudCapability.COMPUTE,
+        capability=sky_cloud.CloudCapability.COMPUTE,
         raise_if_no_cloud_access=True)
 
     launchable: Dict[resources_lib.Resources, List[resources_lib.Resources]] = (

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -677,7 +677,7 @@ class Resources:
             # cloud corresponds to region/zone, errors out.
             valid_clouds = []
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                raise_if_no_cloud_access=True)
+                clouds.CloudCapability.COMPUTE, raise_if_no_cloud_access=True)
             cloud_to_errors = {}
             for cloud in enabled_clouds:
                 try:
@@ -796,7 +796,7 @@ class Resources:
             # If cloud not specified
             valid_clouds = []
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                raise_if_no_cloud_access=True)
+                clouds.CloudCapability.COMPUTE, raise_if_no_cloud_access=True)
             for cloud in enabled_clouds:
                 if cloud.instance_type_exists(self._instance_type):
                     valid_clouds.append(cloud)
@@ -991,6 +991,7 @@ class Resources:
         else:
             at_least_one_cloud_supports_ports = False
             for cloud in sky_check.get_cached_enabled_clouds_or_refresh(
+                    clouds.CloudCapability.COMPUTE,
                     raise_if_no_cloud_access=True):
                 try:
                     cloud.check_features_are_supported(
@@ -1020,7 +1021,8 @@ class Resources:
         else:
             # If no specific cloud is set, validate label against ALL clouds.
             # The label will be dropped if invalid for any one of the cloud
-            validated_clouds = sky_check.get_cached_enabled_clouds_or_refresh()
+            validated_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
+                clouds.CloudCapability.COMPUTE)
         invalid_table = log_utils.create_table(['Label', 'Reason'])
         for key, value in self._labels.items():
             for cloud in validated_clouds:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import colorama
 
 from sky import check as sky_check
-from sky.clouds import cloud as sky_cloud
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
+from sky.clouds import cloud as sky_cloud
 from sky.clouds import service_catalog
 from sky.provision import docker_utils
 from sky.provision.kubernetes import utils as kubernetes_utils

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union
 import colorama
 
 from sky import check as sky_check
+from sky.clouds import cloud as sky_cloud
 from sky import clouds
 from sky import exceptions
 from sky import sky_logging
@@ -677,7 +678,8 @@ class Resources:
             # cloud corresponds to region/zone, errors out.
             valid_clouds = []
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                clouds.CloudCapability.COMPUTE, raise_if_no_cloud_access=True)
+                sky_cloud.CloudCapability.COMPUTE,
+                raise_if_no_cloud_access=True)
             cloud_to_errors = {}
             for cloud in enabled_clouds:
                 try:
@@ -796,7 +798,8 @@ class Resources:
             # If cloud not specified
             valid_clouds = []
             enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                clouds.CloudCapability.COMPUTE, raise_if_no_cloud_access=True)
+                sky_cloud.CloudCapability.COMPUTE,
+                raise_if_no_cloud_access=True)
             for cloud in enabled_clouds:
                 if cloud.instance_type_exists(self._instance_type):
                     valid_clouds.append(cloud)
@@ -991,7 +994,7 @@ class Resources:
         else:
             at_least_one_cloud_supports_ports = False
             for cloud in sky_check.get_cached_enabled_clouds_or_refresh(
-                    clouds.CloudCapability.COMPUTE,
+                    sky_cloud.CloudCapability.COMPUTE,
                     raise_if_no_cloud_access=True):
                 try:
                     cloud.check_features_are_supported(
@@ -1022,7 +1025,7 @@ class Resources:
             # If no specific cloud is set, validate label against ALL clouds.
             # The label will be dropped if invalid for any one of the cloud
             validated_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
-                clouds.CloudCapability.COMPUTE)
+                sky_cloud.CloudCapability.COMPUTE)
         invalid_table = log_utils.create_table(['Label', 'Reason'])
         for key, value in self._labels.items():
             for cloud in validated_clouds:

--- a/sky/task.py
+++ b/sky/task.py
@@ -974,8 +974,8 @@ class Task:
         # assert len(self.resources) == 1, self.resources
         storage_cloud = None
 
-        enabled_storage_clouds = (
-            storage_lib.get_cached_enabled_storage_clouds_or_refresh(
+        enabled_storage_cloud_names = (
+            storage_lib.get_cached_enabled_storage_cloud_names_or_refresh(
                 raise_if_no_cloud_access=True))
 
         if self.best_resources is not None:
@@ -987,13 +987,13 @@ class Task:
             storage_region = resources.region
 
         if storage_cloud is not None:
-            if str(storage_cloud) not in enabled_storage_clouds:
+            if str(storage_cloud) not in enabled_storage_cloud_names:
                 storage_cloud = None
 
         storage_cloud_str = None
         if storage_cloud is None:
-            storage_cloud_str = enabled_storage_clouds[0]
-            assert storage_cloud_str is not None, enabled_storage_clouds[0]
+            storage_cloud_str = enabled_storage_cloud_names[0]
+            assert storage_cloud_str is not None, enabled_storage_cloud_names[0]
             storage_region = None  # Use default region in the Store class
         else:
             storage_cloud_str = str(storage_cloud)

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -216,9 +216,11 @@ def _get_cloud_dependencies_installation_commands(
                     f'{constants.SKY_UV_INSTALL_CMD} >/dev/null 2>&1')
 
     enabled_compute_clouds = set(
-        sky_check.get_cached_enabled_clouds_or_refresh())
+        sky_check.get_cached_enabled_clouds_or_refresh(
+            clouds.CloudCapability.COMPUTE))
     enabled_storage_clouds = set(
-        sky_check.get_cached_enabled_storage_clouds_or_refresh())
+        sky_check.get_cached_enabled_clouds_or_refresh(
+            clouds.CloudCapability.STORAGE))
     enabled_clouds = enabled_compute_clouds.union(enabled_storage_clouds)
 
     for cloud in enabled_clouds:

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -283,7 +283,7 @@ def _get_cloud_dependencies_installation_commands(
         python_packages.update(cloud_python_dependencies)
 
     if (cloudflare.NAME
-            in storage_lib.get_cached_enabled_storage_clouds_or_refresh()):
+            in storage_lib.get_cached_enabled_storage_cloud_names_or_refresh()):
         python_packages.update(dependencies.extras_require['cloudflare'])
 
     packages_string = ' '.join([f'"{package}"' for package in python_packages])
@@ -814,8 +814,8 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
         (store_type, bucket_name, sub_path, storage_account_name, region) = (
             storage_lib.StoreType.get_fields_from_store_url(bucket_wth_prefix))
         cloud_str = store_type.to_cloud()
-        if (cloud_str not in
-                storage_lib.get_cached_enabled_storage_clouds_or_refresh()):
+        if (cloud_str not in storage_lib.
+                get_cached_enabled_storage_cloud_names_or_refresh()):
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(
                     f'`{task_type}.bucket` is specified in SkyPilot config '

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -19,6 +19,7 @@ from sky import resources
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import cloudflare
+from sky.clouds import cloud as sky_cloud
 from sky.clouds import gcp
 from sky.data import data_utils
 from sky.data import storage as storage_lib
@@ -217,10 +218,10 @@ def _get_cloud_dependencies_installation_commands(
 
     enabled_compute_clouds = set(
         sky_check.get_cached_enabled_clouds_or_refresh(
-            clouds.CloudCapability.COMPUTE))
+            sky_cloud.CloudCapability.COMPUTE))
     enabled_storage_clouds = set(
         sky_check.get_cached_enabled_clouds_or_refresh(
-            clouds.CloudCapability.STORAGE))
+            sky_cloud.CloudCapability.STORAGE))
     enabled_clouds = enabled_compute_clouds.union(enabled_storage_clouds)
 
     for cloud in enabled_clouds:

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -6,9 +6,9 @@ import tempfile
 from typing import List, Optional
 
 from sky import check as sky_check
-from sky import clouds as sky_clouds
 from sky import sky_logging
 from sky.backends import backend_utils
+from sky.clouds import cloud as sky_cloud
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
 from sky.skylet import log_lib
@@ -170,7 +170,7 @@ def deploy_local_cluster(gpus: bool):
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
         sky_check.check(clouds=['kubernetes'],
                         quiet=True,
-                        capability=sky_clouds.CloudCapability.COMPUTE)
+                        capability=sky_cloud.CloudCapability.COMPUTE)
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import List, Optional
 
 from sky import check as sky_check
+from sky import clouds as sky_clouds
 from sky import sky_logging
 from sky.backends import backend_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
@@ -169,7 +170,7 @@ def deploy_local_cluster(gpus: bool):
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
         sky_check.check(clouds=['kubernetes'],
                         quiet=True,
-                        capability=sky_check.CloudCapability.COMPUTE)
+                        capability=sky_clouds.CloudCapability.COMPUTE)
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -9,4 +9,4 @@ import sky
 def test_enabled_clouds_empty():
     # In test environment, no cloud should be enabled.
     assert sky.global_user_state.get_cached_enabled_clouds(
-        sky.clouds.CloudCapability.COMPUTE) == []
+        sky.clouds.cloud.CloudCapability.COMPUTE) == []

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -8,4 +8,5 @@ import sky
 @pytest.mark.skipif(sys.platform != 'linux', reason='Only test in CI.')
 def test_enabled_clouds_empty():
     # In test environment, no cloud should be enabled.
-    assert sky.global_user_state.get_cached_enabled_clouds() == []
+    assert sky.global_user_state.get_cached_enabled_clouds(
+        sky.clouds.CloudCapability.COMPUTE) == []

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -6,9 +6,9 @@ from unittest import mock
 import pytest
 
 from sky import clouds
-from sky.clouds import cloud as sky_cloud
 from sky import global_user_state
 from sky import skypilot_config
+from sky.clouds import cloud as sky_cloud
 from sky.resources import Resources
 from sky.utils import resources_utils
 

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from sky import clouds
+from sky.clouds import cloud as sky_cloud
 from sky import global_user_state
 from sky import skypilot_config
 from sky.resources import Resources
@@ -98,7 +99,7 @@ def test_kubernetes_labels_resources():
 
 def test_no_cloud_labels_resources():
     global_user_state.set_enabled_clouds(['aws', 'gcp'],
-                                         clouds.CloudCapability.COMPUTE)
+                                         sky_cloud.CloudCapability.COMPUTE)
     allowed_labels = {
         **GLOBAL_VALID_LABELS,
     }
@@ -112,7 +113,7 @@ def test_no_cloud_labels_resources():
 
 def test_no_cloud_labels_resources_single_enabled_cloud():
     global_user_state.set_enabled_clouds(['aws'],
-                                         clouds.CloudCapability.COMPUTE)
+                                         sky_cloud.CloudCapability.COMPUTE)
     allowed_labels = {
         **GLOBAL_VALID_LABELS,
         'domain/key': 'value',  # Valid for AWS

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -97,7 +97,8 @@ def test_kubernetes_labels_resources():
 
 
 def test_no_cloud_labels_resources():
-    global_user_state.set_enabled_clouds(['aws', 'gcp'])
+    global_user_state.set_enabled_clouds(['aws', 'gcp'],
+                                         clouds.CloudCapability.COMPUTE)
     allowed_labels = {
         **GLOBAL_VALID_LABELS,
     }
@@ -110,7 +111,8 @@ def test_no_cloud_labels_resources():
 
 
 def test_no_cloud_labels_resources_single_enabled_cloud():
-    global_user_state.set_enabled_clouds(['aws'])
+    global_user_state.set_enabled_clouds(['aws'],
+                                         clouds.CloudCapability.COMPUTE)
     allowed_labels = {
         **GLOBAL_VALID_LABELS,
         'domain/key': 'value',  # Valid for AWS


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Instead of having separate compute and storage variants of 
- `get_cached_enabled_clouds`
- `set_enabled_clouds`
- `cloud.check_credentials`
we have these functions accept the specific capability being tested.

Ran `sky check` to check for no regressions

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
