### PR TITLE
[UX] "sky check" output improvements to reflect independent capability checks

### DIFF
--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -11,7 +11,6 @@ from sky.adaptors import common
 from sky.clouds import cloud
 from sky.utils import annotations
 from sky.utils import ux_utils
-from sky import exceptions
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Cloudflare.'
                          'Try pip install "skypilot[cloudflare]"')
@@ -26,7 +25,6 @@ R2_CREDENTIALS_PATH = '~/.cloudflare/r2.credentials'
 R2_PROFILE_NAME = 'r2'
 _INDENT_PREFIX = '    '
 NAME = 'Cloudflare'
-SKY_CHECK_NAME = 'Cloudflare (for R2 object store)'
 
 
 @contextlib.contextmanager

--- a/sky/adaptors/cloudflare.py
+++ b/sky/adaptors/cloudflare.py
@@ -11,6 +11,7 @@ from sky.adaptors import common
 from sky.clouds import cloud
 from sky.utils import annotations
 from sky.utils import ux_utils
+from sky import exceptions
 
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Cloudflare.'
                          'Try pip install "skypilot[cloudflare]"')

--- a/sky/check.py
+++ b/sky/check.py
@@ -178,7 +178,7 @@ def check_capabilities(
 
 
 def check_capability(
-    capability: CloudCapability,
+    capability: sky_cloud.CloudCapability,
     quiet: bool = False,
     verbose: bool = False,
     clouds: Optional[Iterable[str]] = None,
@@ -197,7 +197,8 @@ def check(
     clouds: Optional[Iterable[str]] = None,
 ) -> List[str]:
     return list(
-        check_capabilities(quiet, verbose, clouds, sky_cloud.ALL_CAPABILITIES).keys())
+        check_capabilities(quiet, verbose, clouds,
+                           sky_cloud.ALL_CAPABILITIES).keys())
 
 
 def get_cached_enabled_clouds_or_refresh(
@@ -271,14 +272,15 @@ def _print_checked_cloud(
     echo: Callable, verbose: bool, cloud_tuple: Tuple[str,
                                                       Union[sky_clouds.Cloud,
                                                             ModuleType]],
-    cloud_capabilities: List[Tuple[CloudCapability, bool,
-                                   Optional[str]]]) -> None:
+    cloud_capabilities: List[Tuple[sky_cloud.CloudCapability, bool,
+                                   Optional[str]]]
+) -> None:
     cloud_repr, cloud = cloud_tuple
     # Print the capabilities for the cloud.
     # consider cloud enabled if any capability is enabled.
-    enabled_capabilities: List[CloudCapability] = []
-    hints_to_capabilities: Dict[str, List[CloudCapability]] = {}
-    reasons_to_capabilities: Dict[str, List[CloudCapability]] = {}
+    enabled_capabilities: List[sky_cloud.CloudCapability] = []
+    hints_to_capabilities: Dict[str, List[sky_cloud.CloudCapability]] = {}
+    reasons_to_capabilities: Dict[str, List[sky_cloud.CloudCapability]] = {}
     for capability, ok, reason in cloud_capabilities:
         if ok:
             enabled_capabilities.append(capability)
@@ -310,7 +312,7 @@ def _print_checked_cloud(
 
 
 def _format_enabled_cloud(cloud_name: str,
-                          capabilities: List[CloudCapability]) -> str:
+                          capabilities: List[sky_cloud.CloudCapability]) -> str:
     cloud_and_capabilities = f'{cloud_name} ' + '[' + ', '.join(
         capabilities) + ']'
 

--- a/sky/check.py
+++ b/sky/check.py
@@ -184,8 +184,7 @@ def check_capability(
     capability: CloudCapability = CloudCapability.COMPUTE,
 ) -> List[str]:
     clouds_with_capability = []
-    enabled_clouds = check_capabilities(quiet, verbose, clouds,
-                                        ALL_CAPABILITIES)
+    enabled_clouds = check_capabilities(quiet, verbose, clouds, [capability])
     for cloud, capabilities in enabled_clouds.items():
         if capability in capabilities:
             clouds_with_capability.append(cloud)

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -50,7 +50,8 @@ class CloudImplementationFeatures(enum.Enum):
     AUTO_TERMINATE = 'auto_terminate'  # Pod/VM can stop or down itself
 
 
-class CloudCapability(enum.Enum):
+# Use str, enum.Enum to allow CloudCapability to be used as a string.
+class CloudCapability(str, enum.Enum):
     # Compute capability.
     COMPUTE = 'compute'
     # Storage capability.

--- a/sky/core.py
+++ b/sky/core.py
@@ -1136,9 +1136,10 @@ def local_down() -> None:
         # Run sky check
         with rich_utils.safe_status(
                 ux_utils.spinner_message('Running sky check...')):
-            sky_check.check(clouds=['kubernetes'],
-                            quiet=True,
-                            capability=sky_cloud.CloudCapability.COMPUTE)
+            sky_check.check_capability(
+                clouds=['kubernetes'],
+                quiet=True,
+                capability=sky_cloud.CloudCapability.COMPUTE)
         logger.info(
             ux_utils.finishing_message('Local cluster removed.',
                                        log_path=log_path,

--- a/sky/core.py
+++ b/sky/core.py
@@ -1136,10 +1136,9 @@ def local_down() -> None:
         # Run sky check
         with rich_utils.safe_status(
                 ux_utils.spinner_message('Running sky check...')):
-            sky_check.check_capability(
-                clouds=['kubernetes'],
-                quiet=True,
-                capability=sky_cloud.CloudCapability.COMPUTE)
+            sky_check.check_capability(sky_cloud.CloudCapability.COMPUTE,
+                                       clouds=['kubernetes'],
+                                       quiet=True)
         logger.info(
             ux_utils.finishing_message('Local cluster removed.',
                                        log_path=log_path,

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -107,8 +107,10 @@ def _is_storage_cloud_enabled(cloud_name: str,
         return True
     if try_fix_with_sky_check:
         # TODO(zhwu): Only check the specified cloud to speed up.
-        sky_check.check_capability(quiet=True,
-                                   capability=sky_cloud.CloudCapability.STORAGE)
+        sky_check.check_capability(
+            sky_cloud.CloudCapability.STORAGE,
+            quiet=True,
+        )
         return _is_storage_cloud_enabled(cloud_name,
                                          try_fix_with_sky_check=False)
     return False

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -107,8 +107,8 @@ def _is_storage_cloud_enabled(cloud_name: str,
         return True
     if try_fix_with_sky_check:
         # TODO(zhwu): Only check the specified cloud to speed up.
-        sky_check.check(quiet=True,
-                        capability=sky_cloud.CloudCapability.STORAGE)
+        sky_check.check_capability(quiet=True,
+                                   capability=sky_cloud.CloudCapability.STORAGE)
         return _is_storage_cloud_enabled(cloud_name,
                                          try_fix_with_sky_check=False)
     return False

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1226,10 +1226,10 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
             all_clouds_specified.add(cloud_str)
 
         # Explicitly check again to update the enabled cloud list.
-        sky_check.check_capability(quiet=True,
+        sky_check.check_capability(sky_cloud.CloudCapability.COMPUTE,
+                                   quiet=True,
                                    clouds=list(clouds_need_recheck -
-                                               global_disabled_clouds),
-                                   capability=sky_cloud.CloudCapability.COMPUTE)
+                                               global_disabled_clouds))
         enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
             capability=sky_cloud.CloudCapability.COMPUTE,
             raise_if_no_cloud_access=True)

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1226,10 +1226,10 @@ def _check_specified_clouds(dag: 'dag_lib.Dag') -> None:
             all_clouds_specified.add(cloud_str)
 
         # Explicitly check again to update the enabled cloud list.
-        sky_check.check(quiet=True,
-                        clouds=list(clouds_need_recheck -
-                                    global_disabled_clouds),
-                        capability=sky_cloud.CloudCapability.COMPUTE)
+        sky_check.check_capability(quiet=True,
+                                   clouds=list(clouds_need_recheck -
+                                               global_disabled_clouds),
+                                   capability=sky_cloud.CloudCapability.COMPUTE)
         enabled_clouds = sky_check.get_cached_enabled_clouds_or_refresh(
             capability=sky_cloud.CloudCapability.COMPUTE,
             raise_if_no_cloud_access=True)

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -173,7 +173,7 @@ async def check(request: fastapi.Request,
         request_id=request.state.request_id,
         request_name='check',
         request_body=check_body,
-        func=sky_check.check,
+        func=sky_check.check_all,
         schedule_type=requests_lib.ScheduleType.SHORT,
     )
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -173,7 +173,7 @@ async def check(request: fastapi.Request,
         request_id=request.state.request_id,
         request_name='check',
         request_body=check_body,
-        func=sky_check.check_all,
+        func=sky_check.check,
         schedule_type=requests_lib.ScheduleType.SHORT,
     )
 

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -168,9 +168,9 @@ def deploy_local_cluster(gpus: bool):
                                f'\nError: {stderr}')
     # Run sky check
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
-        sky_check.check_capability(clouds=['kubernetes'],
+        sky_check.check_capability(sky_check.CloudCapability.COMPUTE,
                                    quiet=True,
-                                   capability=sky_cloud.CloudCapability.COMPUTE)
+                                   clouds=['kubernetes'])
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -168,7 +168,7 @@ def deploy_local_cluster(gpus: bool):
                                f'\nError: {stderr}')
     # Run sky check
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
-        sky_check.check_capability(sky_check.CloudCapability.COMPUTE,
+        sky_check.check_capability(sky_cloud.CloudCapability.COMPUTE,
                                    quiet=True,
                                    clouds=['kubernetes'])
     if cluster_created:

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -168,9 +168,9 @@ def deploy_local_cluster(gpus: bool):
                                f'\nError: {stderr}')
     # Run sky check
     with rich_utils.safe_status('[bold cyan]Running sky check...'):
-        sky_check.check(clouds=['kubernetes'],
-                        quiet=True,
-                        capability=sky_cloud.CloudCapability.COMPUTE)
+        sky_check.check_capability(clouds=['kubernetes'],
+                                   quiet=True,
+                                   capability=sky_cloud.CloudCapability.COMPUTE)
     if cluster_created:
         # Prepare completion message which shows CPU and GPU count
         # Get number of CPUs

--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -141,7 +141,7 @@ def enable_all_clouds(monkeypatch, request, mock_client_requests):
     # Mock all the functions
     monkeypatch.setattr('sky.check.get_cached_enabled_clouds_or_refresh',
                         lambda *_, **__: enabled_clouds)
-    monkeypatch.setattr('sky.check.check', lambda *_, **__: None)
+    monkeypatch.setattr('sky.check.check_capability', lambda *_, **__: None)
     monkeypatch.setattr(
         'sky.clouds.service_catalog.aws_catalog._get_az_mappings',
         lambda *_, **__: pd.read_csv('tests/default_aws_az_mappings.csv'))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A few improvements to `sky check` output to better expose the capabilities enabled for each cloud:
- A cloud shows up as enabled for a capability even if its compute is disabled. See example screenshots: If GCP credentials is enough for storage but not compute, the new output correctly characterizes the credential.
- Each enabled cloud also shows the capabilities that are enabled for the cloud.
- Hints and reasons are associated with one or more cloud capabilities. 
- `clouds` in `To enable a cloud, follow the hints above and rerun: sky check <clouds>` is lowercased.
- Cloudflare no longer displays `(for R2 object store)`, as that part is now made obvious by capabilities enabled.


Before:
<img width="1124" alt="Screenshot 2025-03-19 at 6 58 01 PM" src="https://github.com/user-attachments/assets/8bb512e1-3a8b-491f-b455-6491504d7e69" />

After:
<img width="1122" alt="Screenshot 2025-03-19 at 6 58 08 PM" src="https://github.com/user-attachments/assets/46ea4211-451f-4763-850c-2afb4b305b2f" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test (see above)
- [x] Backwards compatibility using older CLI on newer API server
- [x] Backward compatibility: `/quicktest-core` (CI) 

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
