### PR TITLE
add tini to docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     # Install system packages
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse socat netcat-openbsd curl rsync vim tini && \
+    git gcc rsync sudo patch openssh-server \
+    pciutils nano fuse socat netcat-openbsd curl rsync vim tini && \
     rm -rf /var/lib/apt/lists/* && \
     # Install kubectl based on architecture
     ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
-        "x86_64") echo "amd64" ;; \
-        "aarch64") echo "arm64" ;; \
-        *) echo "$(uname -m)" ;; \
+    "x86_64") echo "amd64" ;; \
+    "aarch64") echo "arm64" ;; \
+    *) echo "$(uname -m)" ;; \
     esac)} && \
     curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
@@ -31,3 +31,9 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     conda clean -afy && \
     ~/.local/bin/uv cache clean && \
     rm -rf ~/.cache/pip ~/.cache/uv
+
+# Set tini as entrypoint
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# CMD instruction
+CMD ["bash"]

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -46,9 +46,9 @@ RUN conda init && \
     $HOME/.local/bin/uv pip install 'skypilot-nightly[remote,kubernetes]' 'ray[default]==2.9.3' 'pycryptodome==3.12.0' && \
     $HOME/.local/bin/uv pip uninstall skypilot-nightly && \
     ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
-        "x86_64") echo "amd64" ;; \
-        "aarch64") echo "arm64" ;; \
-        *) echo "$(uname -m)" ;; \
+    "x86_64") echo "amd64" ;; \
+    "aarch64") echo "arm64" ;; \
+    *) echo "$(uname -m)" ;; \
     esac)} && \
     curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     chmod +x kubectl && \
@@ -58,3 +58,18 @@ RUN conda init && \
 
 # Set PYTHONUNBUFFERED=1 to have Python print to stdout/stderr immediately
 ENV PYTHONUNBUFFERED=1
+
+# Switch back to root to install tini
+USER root
+
+# Install tini 
+RUN apt-get update && apt-get install -y tini && apt-get clean
+
+# Switch back to sky user
+USER sky
+
+# Set tini as entrypoint 
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# CMD instruction
+CMD ["bash"]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add tini to docker files #4750 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
