### PR TITLE
[Test]fix flaky smoke tests

### DIFF
--- a/tests/skyserve/streaming/send_streaming_request.py
+++ b/tests/skyserve/streaming/send_streaming_request.py
@@ -1,4 +1,5 @@
 import argparse
+import time
 
 import requests
 
@@ -15,36 +16,37 @@ index = 0
 max_retries = 3
 retry_count = 0
 
-while retry_count < max_retries:
+for attempt in range(1, max_retries + 1):
     try:
         with requests.get(url, stream=True) as response:
-            response.raise_for_status()
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    current = chunk.decode().strip()
-                    assert current == expected[index], (current,
-                                                        expected[index])
-                    index += 1
-            break  # Success, exit the loop
-    except requests.exceptions.HTTPError as e:
-        if e.response.status_code == 503:
-            # 503 Service Unavailable errors can occur when the load balancer has no available replicas.
-            # As seen in the logs: "No replica selected for request" and "Available Replica URLs: []"
-            # The availability of replicas can fluctuate during service startup and operation.
-            # Implementing retries helps handle these temporary unavailability periods.
-            retry_count += 1
-            if retry_count < max_retries:
+            if response.status_code == 503:
+                # 503 Service Unavailable errors can occur when the load balancer has no available replicas.
+                # As seen in the logs: "No replica selected for request" and "Available Replica URLs: []"
+                # The availability of replicas can fluctuate during service startup and operation.
+                # Implementing retries helps handle these temporary unavailability periods.
+                if attempt >= max_retries:
+                    raise Exception("Max retries reached")
                 print(
-                    f"Got 503 Server Error, retrying in 5 seconds... (attempt {retry_count}/{max_retries})"
+                    f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})"
                 )
-                import time
                 time.sleep(5)
+                continue
             else:
-                print(f"Max retries reached after {max_retries} attempts")
-                raise
-        else:
-            # For other HTTP errors, raise immediately
-            raise
+                response.raise_for_status()
+                for chunk in response.iter_content(chunk_size=8192):
+                    if chunk:
+                        current = chunk.decode().strip()
+                        assert current == expected[index], (current,
+                                                            expected[index])
+                        index += 1
+                break  # Success, exit the loop
+    except requests.exceptions.ConnectionError:
+        # EKS could have connection errors when the service is starting up.
+        if attempt >= max_retries:
+            raise Exception("Max retries reached")
+        print(f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})")
+        time.sleep(5)
+        continue
 
 assert index == len(expected)
 

--- a/tests/skyserve/streaming/send_streaming_request.py
+++ b/tests/skyserve/streaming/send_streaming_request.py
@@ -14,9 +14,8 @@ url = f'{args.endpoint}/'
 expected = WORD_TO_STREAM.split()
 index = 0
 max_retries = 3
-retry_count = 0
 
-for attempt in range(1, max_retries + 1):
+for attempt in range(max_retries):
     try:
         with requests.get(url, stream=True) as response:
             if response.status_code == 503:
@@ -24,8 +23,6 @@ for attempt in range(1, max_retries + 1):
                 # As seen in the logs: "No replica selected for request" and "Available Replica URLs: []"
                 # The availability of replicas can fluctuate during service startup and operation.
                 # Implementing retries helps handle these temporary unavailability periods.
-                if attempt >= max_retries:
-                    raise Exception("Max retries reached")
                 print(
                     f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})"
                 )
@@ -42,8 +39,6 @@ for attempt in range(1, max_retries + 1):
                 break  # Success, exit the loop
     except requests.exceptions.ConnectionError:
         # EKS could have connection errors when the service is starting up.
-        if attempt >= max_retries:
-            raise Exception("Max retries reached")
         print(f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})")
         time.sleep(5)
         continue

--- a/tests/skyserve/streaming/send_streaming_request.py
+++ b/tests/skyserve/streaming/send_streaming_request.py
@@ -13,9 +13,9 @@ url = f'{args.endpoint}/'
 
 expected = WORD_TO_STREAM.split()
 index = 0
-max_retries = 3
+max_attempts = 3
 
-for attempt in range(max_retries):
+for attempt in range(max_attempts):
     try:
         with requests.get(url, stream=True) as response:
             if response.status_code == 503:
@@ -24,7 +24,7 @@ for attempt in range(max_retries):
                 # The availability of replicas can fluctuate during service startup and operation.
                 # Implementing retries helps handle these temporary unavailability periods.
                 print(
-                    f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})"
+                    f"Retrying in 5 seconds... (attempt {attempt}/{max_attempts})"
                 )
                 time.sleep(5)
                 continue
@@ -39,7 +39,7 @@ for attempt in range(max_retries):
                 break  # Success, exit the loop
     except requests.exceptions.ConnectionError:
         # EKS could have connection errors when the service is starting up.
-        print(f"Retrying in 5 seconds... (attempt {attempt}/{max_retries})")
+        print(f"Retrying in 5 seconds... (attempt {attempt}/{max_attempts})")
         time.sleep(5)
         continue
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1275,8 +1275,9 @@ def test_autodown(generic_cloud: str):
     name = smoke_tests_utils.get_cluster_name()
     # Azure takes ~ 13m30s (810s) to autodown a VM, so here we use 900 to ensure
     # the VM is terminated.
-    autodown_timeout = 900 if generic_cloud == 'azure' else 240
-    total_timeout_minutes = 90 if generic_cloud == 'azure' else 20
+    autodown_timeout = 900 if generic_cloud in ('azure', 'kubernetes') else 240
+    total_timeout_minutes = 90 if generic_cloud in ('azure',
+                                                    'kubernetes') else 20
     check_autostop_set = f's=$(sky status) && echo "$s" && echo "==check autostop set==" && echo "$s" | grep {name} | grep "1m (down)"'
     test = smoke_tests_utils.Test(
         'autodown',

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -435,6 +435,9 @@ def test_image_no_conda():
 @pytest.mark.no_kubernetes  # Kubernetes does not support stopping instances
 @pytest.mark.no_nebius  # Nebius does not support autostop
 def test_custom_default_conda_env(generic_cloud: str):
+    timeout = 80
+    if generic_cloud == 'azure':
+        timeout *= 3
     name = smoke_tests_utils.get_cluster_name()
     test = smoke_tests_utils.Test('custom_default_conda_env', [
         f'sky launch -c {name} -y {smoke_tests_utils.LOW_RESOURCE_ARG} --cloud {generic_cloud} tests/test_yamls/test_custom_default_conda_env.yaml',
@@ -447,7 +450,7 @@ def test_custom_default_conda_env(generic_cloud: str):
         smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
             cluster_name=name,
             cluster_status=[sky.ClusterStatus.STOPPED],
-            timeout=80),
+            timeout=timeout),
         f'sky start -y {name}',
         f'sky logs {name} 2 --no-follow | grep -E "myenv\\s+\\*"',
         f'sky exec {name} tests/test_yamls/test_custom_default_conda_env.yaml',

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -66,7 +66,8 @@ def test_managed_jobs_basic(generic_cloud: str):
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=f'{name}-2',
                 job_status=[sky.ManagedJobStatus.RUNNING],
-                timeout=360 if generic_cloud == 'azure' else 120),
+                timeout=360
+                if generic_cloud in ['azure', 'kubernetes'] else 120),
             f'sky jobs cancel -y -n {name}-1',
             smoke_tests_utils.
             get_cmd_wait_until_managed_job_status_contains_matching_job_name(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We achieved a [100% pass rate](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/13#_) on the full smoke tests.

However, some tests still required retries to pass. By inspecting the logs, we found that modifying the test code could reduce flakiness in some tests.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: 
  - [x] `/smoke-test -k test_skyserve_rolling_update --kubernetes`
  - [x] `/smoke-test -k test_skyserve_streaming --kubernetes`
  - [x] `/smoke-test -k test_skyserve_rolling_update --aws`
  - [x] `/smoke-test -k test_skyserve_streaming --aws`
  - [x] `/smoke-test -k test_autodown --kubernets`
  - [x] `/smoke-test -k test_custom_default_conda_env --azure`
  - [x] `/smoke-test -k test_managed_jobs_basic --kubernetes`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
