### PR TITLE
[k8s] Fix kubeconfig path in error if `KUBECONFIG` envvar is used

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -82,7 +82,7 @@ def _load_config(context: Optional[str] = None):
                 kubeconfig_path = os.environ.get('KUBECONFIG', '~/.kube/config')
                 err_str = (
                     f'Failed to load Kubernetes configuration for {context!r}. '
-                    f'Please check if your kubeconfig file exists at '
+                    'Please check if your kubeconfig file exists at '
                     f'{kubeconfig_path} and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
             with ux_utils.print_exception_no_traceback():

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -79,10 +79,11 @@ def _load_config(context: Optional[str] = None):
                     '    If you were running a local Kubernetes '
                     'cluster, run `sky local up` to start the cluster.')
             else:
+                kubeconfig_path = os.environ.get('KUBECONFIG', '~/.kube/config')
                 err_str = (
                     f'Failed to load Kubernetes configuration for {context!r}. '
-                    'Please check if your kubeconfig file exists at '
-                    f'~/.kube/config and is valid.\n{suffix}')
+                    f'Please check if your kubeconfig file exists at '
+                    f'{kubeconfig_path} and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(err_str) from None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
