### PR TITLE
[Nebius] Fix check storage credentials for Nebius

### DIFF
--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -316,17 +316,16 @@ class Nebius(clouds.Cloud):
         hints = None
         if not nebius_profile_in_aws_cred():
             hints = (f'[{nebius.NEBIUS_PROFILE_NAME}] profile '
-            'is not set in ~/.aws/credentials.')
+                     'is not set in ~/.aws/credentials.')
         if hints:
             hints += ' Run the following commands:'
             if not nebius_profile_in_aws_cred():
                 hints += (
                     f'\n{_INDENT_PREFIX}  $ pip install boto3'
-                    f'\n{_INDENT_PREFIX}  $ aws configure --profile nebius'
-                )
+                    f'\n{_INDENT_PREFIX}  $ aws configure --profile nebius')
             hints += (
                 f'\n{_INDENT_PREFIX}For more info: '
-                'https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius' # pylint: disable=line-too-long
+                'https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius'  # pylint: disable=line-too-long
             )
         return (False, hints) if hints else (True, hints)
 

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -26,23 +26,17 @@ _INDENT_PREFIX = '    '
 
 
 def nebius_profile_in_aws_cred() -> bool:
-    """Checks if Nebius Object Storage profile is set in aws credentials
-     and has endpoint_url."""
+    """Checks if Nebius Object Storage profile is set in aws credentials."""
 
     profile_path = os.path.expanduser('~/.aws/credentials')
-    nebius_endpoint_re = re.compile(r'/^endpoint_url *= *https:\/\/storage\.[a-zA-Z1-9\-]*\.nebius\.cloud:443$/gm')  # pylint: disable=line-too-long
     nebius_profile_exists = False
-    nebius_endpoint_exists = False
     if os.path.isfile(profile_path):
         with open(profile_path, 'r', encoding='utf-8') as file:
             for line in file:
                 if f'[{nebius.NEBIUS_PROFILE_NAME}]' in line:
                     nebius_profile_exists = True
-                if nebius_endpoint_re.match(line):
-                    nebius_endpoint_exists = True
-                    break
 
-    return nebius_profile_exists and nebius_endpoint_exists
+    return nebius_profile_exists
 
 
 @registry.CLOUD_REGISTRY.register

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,5 +1,6 @@
 """ Nebius Cloud. """
 import logging
+import os
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
@@ -19,6 +20,22 @@ _CREDENTIAL_FILES = [
     nebius.NEBIUS_PROJECT_ID_FILENAME,
     nebius.NEBIUS_CREDENTIALS_FILENAME
 ]
+
+_INDENT_PREFIX = '    '
+
+
+def nebius_profile_in_aws_cred() -> bool:
+    """Checks if Nebius Object Storage profile is set in aws credentials"""
+
+    profile_path = os.path.expanduser('~/.aws/credentials')
+    nebius_profile_exists = False
+    if os.path.isfile(profile_path):
+        with open(profile_path, 'r', encoding='utf-8') as file:
+            for line in file:
+                if f'[{nebius.NEBIUS_PROFILE_NAME}]' in line:
+                    nebius_profile_exists = True
+                    break
+    return nebius_profile_exists
 
 
 @registry.CLOUD_REGISTRY.register
@@ -253,14 +270,15 @@ class Nebius(clouds.Cloud):
     def check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """ Verify that the user has valid credentials for Nebius. """
         logging.debug('Nebius cloud check credentials')
-        token_cred_msg = ('    Credentials can be set up by running: \n'\
-                    f'        $ nebius iam get-access-token > {nebius.NEBIUS_IAM_TOKEN_PATH} \n'\
-                          '    or generate  ~/.nebius/credentials.json')  # pylint: disable=line-too-long
+        token_cred_msg = (
+            f'{_INDENT_PREFIX}Credentials can be set up by running: \n'
+            f'{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.NEBIUS_IAM_TOKEN_PATH} \n'  # pylint: disable=line-too-long
+            f'{_INDENT_PREFIX} or generate  ~/.nebius/credentials.json')
 
-        tenant_msg = ('   Copy your tenat ID from the web console and save it to file \n'  # pylint: disable=line-too-long
-                      f'        $ echo $NEBIUS_TENANT_ID_PATH > {nebius.NEBIUS_TENANT_ID_PATH} \n'  # pylint: disable=line-too-long
-                      '   Or if you have 1 tenant you can run:\n'  # pylint: disable=line-too-long
-                      f'        $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.NEBIUS_TENANT_ID_PATH} \n')  # pylint: disable=line-too-long
+        tenant_msg = (f'{_INDENT_PREFIX}Copy your tenat ID from the web console and save it to file \n'  # pylint: disable=line-too-long
+                      f'{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.NEBIUS_TENANT_ID_PATH} \n'  # pylint: disable=line-too-long
+                      f'{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n'  # pylint: disable=line-too-long
+                      f'{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.NEBIUS_TENANT_ID_PATH} \n')  # pylint: disable=line-too-long
         if not nebius.is_token_or_cred_file_exist():
             return False, f'{token_cred_msg}'
         sdk = nebius.sdk()
@@ -277,6 +295,28 @@ class Nebius(clouds.Cloud):
                 f'{token_cred_msg}'
                 f'{tenant_msg}')
         return True, None
+
+    @classmethod
+    def check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
+        """Checks if the user has access credentials to Nebius Object Storage.
+
+        Returns:
+            A tuple of a boolean value and a hint message where the bool
+            is True when both credentials needed for Nebius is set. It is False
+            when either of those are not set, which would hint with a
+            string on unset credential.
+        """
+        hints = None
+        if not nebius_profile_in_aws_cred():
+            hints = f'[{nebius.NEBIUS_PROFILE_NAME}] profile is not set in ~/.aws/credentials.'  # pylint: disable=line-too-long
+        if hints:
+            hints += ' Run the following commands:'
+            if not nebius_profile_in_aws_cred():
+                hints += f'\n{_INDENT_PREFIX}  $ pip install boto3'
+                hints += f'\n{_INDENT_PREFIX}  $ aws configure --profile nebius'
+            hints += f'\n{_INDENT_PREFIX}For more info: '
+            hints += 'https://docs.skypilot.co/en/latest/getting-started/installation.html#nebius'  # pylint: disable=line-too-long
+        return (False, hints) if hints else (True, hints)
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
         credential_file_mounts = {

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,7 +1,6 @@
 """ Nebius Cloud. """
 import logging
 import os
-import re
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 


### PR DESCRIPTION
Fixes after https://github.com/skypilot-org/skypilot/pull/4977, https://github.com/skypilot-org/skypilot/pull/4993

<!-- Describe the changes in this PR -->

Introduce `check_storage_credentials` method to verify if the Nebius Object Storage profile is configured in AWS credentials. Also, refactor credential setup messages for better readability and add utility `_INDENT_PREFIX` for consistent formatting.


<!-- Describe the tests ran -->

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: pytest tests/smoke_tests/test_mount_and_storage.py::test_nebius_storage_mounts  --nebius (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
