### PR TITLE
Split AUTO_TERMINATE to AUTO_DOWN and AUTO_STOP

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -47,8 +47,8 @@ class CloudImplementationFeatures(enum.Enum):
     OPEN_PORTS = 'open_ports'
     STORAGE_MOUNTING = 'storage_mounting'
     HOST_CONTROLLERS = 'host_controllers'  # Can run jobs/serve controllers
-    AUTO_TERMINATE = 'auto_terminate'  # Pod/VM can stop or down itself
-
+    AUTO_STOP = 'auto_stop'  # Pod/VM can stop itself
+    AUTO_DOWN = 'auto_down'  # Pod/VM can down itself
 
 class CloudCapability(enum.Enum):
     # Compute capability.

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -110,9 +110,12 @@ class Kubernetes(clouds.Cloud):
             # Controllers cannot spin up new pods with exec auth.
             unsupported_features[
                 clouds.CloudImplementationFeatures.HOST_CONTROLLERS] = message
-            # Pod does not have permissions to terminate itself with exec auth.
+            # Pod does not have permissions to down itself with exec auth.
             unsupported_features[
-                clouds.CloudImplementationFeatures.AUTO_TERMINATE] = message
+                clouds.CloudImplementationFeatures.AUTO_DOWN] = message
+            # Pod does not have permissions to stop itself with exec auth.
+            unsupported_features[
+                clouds.CloudImplementationFeatures.AUTO_STOP] = message
         # Allow spot instances if supported by the cluster
         try:
             spot_label_key, _ = kubernetes_utils.get_spot_label(context)

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -26,10 +26,8 @@ class Nebius(clouds.Cloud):
     """Nebius GPU Cloud"""
     _REPR = 'Nebius'
     _CLOUD_UNSUPPORTED_FEATURES = {
-        clouds.CloudImplementationFeatures.AUTO_TERMINATE:
-            ('Autodown and Autostop not supported. Can\'t delete disk.'),
-        # Autostop functionality can be implemented, but currently,
-        # there is only a single flag for both autostop and autodown.
+        clouds.CloudImplementationFeatures.AUTO_DOWN:
+            ('Autodown not supported. Can\'t delete disk.'),
         clouds.CloudImplementationFeatures.SPOT_INSTANCE:
             ('Spot is not supported, as Nebius API does not implement spot.'),
         clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER:

--- a/sky/core.py
+++ b/sky/core.py
@@ -648,7 +648,7 @@ def autostop(
         try:
             cloud.check_features_are_supported(
                 handle.launched_resources,
-                {clouds.CloudImplementationFeatures.AUTO_TERMINATE})
+                {clouds.CloudImplementationFeatures.AUTO_DOWN})
         except exceptions.NotSupportedError as e:
             raise exceptions.NotSupportedError(
                 f'{colorama.Fore.YELLOW}{operation} on cluster '

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -238,7 +238,7 @@ def _execute(
                 stages.remove(Stage.DOWN)
             if idle_minutes_to_autostop >= 0:
                 requested_features.add(
-                    clouds.CloudImplementationFeatures.AUTO_TERMINATE)
+                    clouds.CloudImplementationFeatures.AUTO_STOP)
                 if not down:
                     requested_features.add(
                         clouds.CloudImplementationFeatures.STOP)

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -812,11 +812,12 @@ def test_skyserve_update_autoscale(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
-@pytest.mark.no_fluidstack  # Spot instances are note supported by Fluidstack
+@pytest.mark.no_fluidstack  # Spot instances are not supported by Fluidstack
 @pytest.mark.serve
 @pytest.mark.no_kubernetes  # Spot instances are not supported in Kubernetes
 @pytest.mark.no_do  # Spot instances not on DO
 @pytest.mark.no_vast  # Vast doesn't support opening ports
+@pytest.mark.no_nebius # Spot instances are not supported by Nebius
 @pytest.mark.parametrize('mode', ['rolling', 'blue_green'])
 def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
     """Test skyserve with update that changes autoscaler"""

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -276,8 +276,7 @@ def test_skyserve_oci_http():
 
 @pytest.mark.no_fluidstack  # Fluidstack does not support T4 gpus for now
 @pytest.mark.no_vast  # Vast has low availability of T4 GPUs
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
-@pytest.mark.parametrize('accelerator', [{'do': 'H100'}])
+@pytest.mark.parametrize('accelerator', [{'do': 'H100', 'nebius': 'H100'}])
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_llm(generic_cloud: str, accelerator: Dict[str, str]):
@@ -347,7 +346,7 @@ def test_skyserve_spot_recovery():
 @pytest.mark.serve
 @pytest.mark.no_kubernetes
 @pytest.mark.no_do
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
+@pytest.mark.no_nebius  # Nebius does not support spot instances
 def test_skyserve_base_ondemand_fallback(generic_cloud: str):
     name = _get_service_name()
     test = smoke_tests_utils.Test(
@@ -418,7 +417,6 @@ def test_skyserve_dynamic_ondemand_fallback():
 # TODO: fluidstack does not support `--cpus 2`, but the check for services in this test is based on CPUs
 @pytest.mark.no_fluidstack
 @pytest.mark.no_do  # DO does not support `--cpus 2`
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.serve
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.resource_heavy
@@ -466,7 +464,6 @@ def test_skyserve_user_bug_restart(generic_cloud: str):
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
 @pytest.mark.no_kubernetes  # Replicas on k8s may be running on the same node and have the same public IP
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 def test_skyserve_load_balancer(generic_cloud: str):
     """Test skyserve load balancer round-robin policy"""
     name = _get_service_name()
@@ -492,7 +489,6 @@ def test_skyserve_load_balancer(generic_cloud: str):
 @pytest.mark.gcp
 @pytest.mark.serve
 @pytest.mark.no_kubernetes
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 def test_skyserve_auto_restart():
     """Test skyserve with auto restart"""
     name = _get_service_name()
@@ -540,7 +536,6 @@ def test_skyserve_auto_restart():
 
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.resource_heavy
 def test_skyserve_cancel(generic_cloud: str):
     """Test skyserve with cancel"""
@@ -569,7 +564,6 @@ def test_skyserve_cancel(generic_cloud: str):
 
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.resource_heavy
 def test_skyserve_streaming(generic_cloud: str):
     """Test skyserve with streaming"""
@@ -594,7 +588,6 @@ def test_skyserve_streaming(generic_cloud: str):
 
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 def test_skyserve_readiness_timeout_fail(generic_cloud: str):
     """Test skyserve with large readiness probe latency, expected to fail"""
     name = _get_service_name()
@@ -620,7 +613,6 @@ def test_skyserve_readiness_timeout_fail(generic_cloud: str):
 
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.resource_heavy
 def test_skyserve_large_readiness_timeout(generic_cloud: str):
     """Test skyserve with customized large readiness timeout"""
@@ -644,7 +636,6 @@ def test_skyserve_large_readiness_timeout(generic_cloud: str):
 @pytest.mark.no_fluidstack
 @pytest.mark.no_do  # DO does not support `--cpus 2`
 @pytest.mark.no_vast  # Vast doesn't support opening ports
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_update(generic_cloud: str):
@@ -681,7 +672,6 @@ def test_skyserve_update(generic_cloud: str):
 @pytest.mark.no_fluidstack
 @pytest.mark.no_do  # DO does not support `--cpus 2`
 @pytest.mark.no_vast  # Vast doesn't support opening ports
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_rolling_update(generic_cloud: str):
@@ -730,7 +720,6 @@ def test_skyserve_rolling_update(generic_cloud: str):
 
 @pytest.mark.no_fluidstack
 @pytest.mark.no_vast  # Vast doesn't support opening ports
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_fast_update(generic_cloud: str):
@@ -776,7 +765,6 @@ def test_skyserve_fast_update(generic_cloud: str):
 
 @pytest.mark.no_vast  # Vast doesn't support opening ports
 @pytest.mark.serve
-@pytest.mark.no_nebius  # Autodown and Autostop not supported.
 @pytest.mark.resource_heavy
 def test_skyserve_update_autoscale(generic_cloud: str):
     """Test skyserve update with autoscale"""
@@ -829,7 +817,6 @@ def test_skyserve_update_autoscale(generic_cloud: str):
 @pytest.mark.no_kubernetes  # Spot instances are not supported in Kubernetes
 @pytest.mark.no_do  # Spot instances not on DO
 @pytest.mark.no_vast  # Vast doesn't support opening ports
-@pytest.mark.no_nebius  # Autodown and Autostop not supported
 @pytest.mark.parametrize('mode', ['rolling', 'blue_green'])
 def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
     """Test skyserve with update that changes autoscaler"""
@@ -896,7 +883,6 @@ def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
 @pytest.mark.no_fluidstack
 @pytest.mark.no_do  # DO does not support `--cpus 2`
 @pytest.mark.no_vast  # Vast doesn't support opening ports
-@pytest.mark.no_nebius  # Autodown and Autostop not supported
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_failures(generic_cloud: str):
@@ -953,7 +939,6 @@ def test_skyserve_failures(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
-@pytest.mark.no_nebius  # Autodown and Autostop not supported
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_https(generic_cloud: str):
@@ -993,7 +978,6 @@ def test_skyserve_https(generic_cloud: str):
         smoke_tests_utils.run_one_test(test)
 
 
-@pytest.mark.no_nebius  # Autodown and Autostop not supported
 @pytest.mark.serve
 @pytest.mark.resource_heavy
 def test_skyserve_multi_ports(generic_cloud: str):


### PR DESCRIPTION
Refactor feature naming for clarity by splitting AUTO_TERMINATE into AUTO_DOWN and AUTO_STOP across the codebase. Adjusted feature checks, error messages, and test markers to align with this change. Improved consistency and readability in feature descriptions and related documentation.

<!-- Describe the changes in this PR -->

[x] pytest tests/smoke_tests/test_sky_serve.py --nebius

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `pytest tests/test_smoke.py`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
