### PR TITLE
[UX] GPU labeler UX improvement

### DIFF
--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -45,8 +45,8 @@ def cleanup() -> Tuple[bool, str]:
 
     success = False
     reason = ''
-    with rich_utils.safe_status('Cleaning up existing GPU labeling '
-                                'resources'):
+    with rich_utils.client_status('Cleaning up existing GPU labeling '
+                                  'resources'):
         try:
             subprocess.run(del_command.split(), check=True, capture_output=True)
             success = True
@@ -72,7 +72,7 @@ def label():
     manifest_dir = os.path.join(sky_dir, 'utils/kubernetes')
 
     # Apply the RBAC manifest using kubectl since it contains multiple resources
-    with rich_utils.safe_status('Setting up GPU labeling'):
+    with rich_utils.client_status('Setting up GPU labeling'):
         rbac_manifest_path = os.path.join(manifest_dir,
                                           'k8s_gpu_labeler_setup.yaml')
         try:
@@ -83,7 +83,7 @@ def label():
             print('Error setting up GPU labeling: ' + output)
             return
 
-    with rich_utils.safe_status('Creating GPU labeler jobs'):
+    with rich_utils.client_status('Creating GPU labeler jobs'):
         config.load_kube_config()
 
         v1 = client.CoreV1Api()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
```
% python -m sky.utils.kubernetes.gpu_labeler

<sky-payload>"<rich_init>Setting up GPU labeling</rich_init>"</sky-payload>
<sky-payload>"<rich_update>Setting up GPU labeling</rich_update>"</sky-payload>
<sky-payload>"<rich_start>Setting up GPU labeling</rich_start>"</sky-payload>
<sky-payload>"<rich_exit></rich_exit>"</sky-payload>
<sky-payload>"<rich_init>Creating GPU labeler jobs</rich_init>"</sky-payload>
<sky-payload>"<rich_update>Creating GPU labeler jobs</rich_update>"</sky-payload>
<sky-payload>"<rich_start>Creating GPU labeler jobs</rich_start>"</sky-payload>
Found 1 GPU nodes in the cluster
Using default RuntimeClass for GPU labeling.
Created GPU labeler job for node ip-192-168-0-11.ec2.internal
<sky-payload>"<rich_exit></rich_exit>"</sky-payload>
GPU labeling started - this may take 10 min or more to complete.
To check the status of GPU labeling jobs, run `kubectl get jobs -n kube-system -l job=sky-gpu-labeler`
You can check if nodes have been labeled by running `kubectl describe nodes` and looking for labels of the format `skypilot.co/accelerator: <gpu_name>`. 
```

After:
```
% python -m sky.utils.kubernetes.gpu_labeler          
⠋ Creating GPU labeler jobs
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] UX manual test

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
