### PR TITLE
[core] optimizer/provisioner fails over for cloud with expired credentials

### DIFF
--- a/sky/adaptors/gcp.py
+++ b/sky/adaptors/gcp.py
@@ -69,6 +69,13 @@ def credential_error_exception():
 
 
 @common.load_lazy_modules(_LAZY_MODULES)
+def auth_error_exception():
+    """GoogleAuthError exception."""
+    from google.auth import exceptions
+    return exceptions.GoogleAuthError
+
+
+@common.load_lazy_modules(_LAZY_MODULES)
 def gcp_auth_refresh_error_exception():
     """GCP auth refresh error exception."""
     from google.auth import exceptions

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -216,8 +216,6 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         else:
             raise
     except gcp.auth_error_exception() as e:
-        logger.error(
-            f'Error getting GCP project: {common_utils.format_exception(e)}')
         raise exceptions.InvalidCloudCredentials(
             f'{common_utils.format_exception(e)}')
     except socket.timeout:

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -33,6 +33,7 @@ import colorama
 import filelock
 
 from sky import clouds
+from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
@@ -214,6 +215,11 @@ def setup_gcp_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
             sys.exit(1)
         else:
             raise
+    except gcp.auth_error_exception() as e:
+        logger.error(
+            f'Error getting GCP project: {common_utils.format_exception(e)}')
+        raise exceptions.InvalidCloudCredentials(
+            f'{common_utils.format_exception(e)}')
     except socket.timeout:
         logger.error('Socket timed out when trying to get the GCP project. '
                      'Please check your network connection.')

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -820,9 +820,6 @@ def write_cluster_config(
         _add_auth_to_cluster_config(cloud, tmp_yaml_path)
     except exceptions.InvalidCloudCredentials as e:
         raise e
-    except Exception as e:  # pylint: disable=broad-except
-        logger.warning(f'Failed to add auth to cluster config: {e}')
-        logger.debug('Full exception:', exc_info=e)
 
     # Restore the old yaml content for backward compatibility.
     if os.path.exists(yaml_path) and keep_launch_fields_in_existing_config:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -815,11 +815,7 @@ def write_cluster_config(
             logger.warning(f'Failed to calculate config_hash: {e}')
             logger.debug('Full exception:', exc_info=e)
         return config_dict
-
-    try:
-        _add_auth_to_cluster_config(cloud, tmp_yaml_path)
-    except exceptions.InvalidCloudCredentials as e:
-        raise e
+    _add_auth_to_cluster_config(cloud, tmp_yaml_path)
 
     # Restore the old yaml content for backward compatibility.
     if os.path.exists(yaml_path) and keep_launch_fields_in_existing_config:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -815,7 +815,14 @@ def write_cluster_config(
             logger.warning(f'Failed to calculate config_hash: {e}')
             logger.debug('Full exception:', exc_info=e)
         return config_dict
-    _add_auth_to_cluster_config(cloud, tmp_yaml_path)
+
+    try:
+        _add_auth_to_cluster_config(cloud, tmp_yaml_path)
+    except exceptions.InvalidCloudCredentials as e:
+        raise e
+    except Exception as e:  # pylint: disable=broad-except
+        logger.warning(f'Failed to add auth to cluster config: {e}')
+        logger.debug('Full exception:', exc_info=e)
 
     # Restore the old yaml content for backward compatibility.
     if os.path.exists(yaml_path) and keep_launch_fields_in_existing_config:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1098,7 +1098,7 @@ class FailoverCloudErrorHandlerV2:
         output = str(error)
         logger.info(f'AWS handler error: {output}')
         # Block AWS if the credential has expired.
-        if output.find('InvalidCloudCredentials') != -1:
+        if isinstance(error, exceptions.InvalidCloudCredentials):
             _add_to_blocked_resources(
                 blocked_resources, resources_lib.Resources(cloud=clouds.AWS()))
         else:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1090,6 +1090,22 @@ class FailoverCloudErrorHandlerV2:
                 blocked_resources, launchable_resources, region, zones, error)
 
     @staticmethod
+    def _aws_handler(blocked_resources: Set['resources_lib.Resources'],
+                     launchable_resources: 'resources_lib.Resources',
+                     region: 'clouds.Region',
+                     zones: Optional[List['clouds.Zone']],
+                     error: Exception) -> None:
+        output = str(error)
+        logger.info(f'AWS handler error: {output}')
+        # Block AWS if the credential has expired.
+        if output.find('CloudCredentialExpired') != -1:
+            _add_to_blocked_resources(
+                blocked_resources, resources_lib.Resources(cloud=clouds.AWS()))
+        else:
+            FailoverCloudErrorHandlerV2._default_handler(
+                blocked_resources, launchable_resources, region, zones, error)
+
+    @staticmethod
     def _default_handler(blocked_resources: Set['resources_lib.Resources'],
                          launchable_resources: 'resources_lib.Resources',
                          region: 'clouds.Region',

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1095,8 +1095,7 @@ class FailoverCloudErrorHandlerV2:
                      region: 'clouds.Region',
                      zones: Optional[List['clouds.Zone']],
                      error: Exception) -> None:
-        output = str(error)
-        logger.info(f'AWS handler error: {output}')
+        logger.info(f'AWS handler error: {error}')
         # Block AWS if the credential has expired.
         if isinstance(error, exceptions.InvalidCloudCredentials):
             _add_to_blocked_resources(

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -180,6 +180,11 @@ class InvalidCloudConfigs(Exception):
     pass
 
 
+class CloudCredentialExpired(Exception):
+    """Raised when the cloud credentials have expired."""
+    pass
+
+
 class ProvisionPrechecksError(Exception):
     """Raised when a managed job fails prechecks before provision.
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -180,8 +180,8 @@ class InvalidCloudConfigs(Exception):
     pass
 
 
-class CloudCredentialExpired(Exception):
-    """Raised when the cloud credentials have expired."""
+class InvalidCloudCredentials(Exception):
+    """Raised when the cloud credentials are invalid."""
     pass
 
 

--- a/sky/provision/aws/utils.py
+++ b/sky/provision/aws/utils.py
@@ -74,10 +74,10 @@ def handle_boto_error(exc: Exception, msg: str) -> None:
             f'{colorama.Style.RESET_ALL}\n'
             f'You can find a script that automates this at:'
             f'{aws_session_script_url}')
-        # Raise the CloudCredentialExpired exception so that
+        # Raise the InvalidCloudCredentials exception so that
         # the provisioner can failover to other clouds
-        raise exceptions.CloudCredentialExpired(
-            f'CloudCredentialExpired: {generic_message}') from exc
+        raise exceptions.InvalidCloudCredentials(
+            f'InvalidCloudCredentials: {generic_message}') from exc
 
     # todo: any other errors that we should catch separately?
 

--- a/sky/provision/aws/utils.py
+++ b/sky/provision/aws/utils.py
@@ -1,6 +1,7 @@
 """Utils for AWS provisioner."""
 import colorama
 
+from sky import exceptions
 from sky import sky_logging
 
 logger = sky_logging.init_logger(__name__)
@@ -73,9 +74,10 @@ def handle_boto_error(exc: Exception, msg: str) -> None:
             f'{colorama.Style.RESET_ALL}\n'
             f'You can find a script that automates this at:'
             f'{aws_session_script_url}')
-        # Do not re-raise the exception here because it looks awful
-        # and we already print all the info in verbose
-        raise SystemExit(1)
+        # Raise the CloudCredentialExpired exception so that
+        # the provisioner can failover to other clouds
+        raise exceptions.CloudCredentialExpired(
+            f'CloudCredentialExpired: {generic_message}') from exc
 
     # todo: any other errors that we should catch separately?
 

--- a/sky/provision/aws/utils.py
+++ b/sky/provision/aws/utils.py
@@ -25,18 +25,17 @@ def handle_boto_error(exc: Exception, msg: str) -> None:
     generic_message = (f'{msg}\nError code: {colorama.Style.BRIGHT}{error_code}'
                        f'{colorama.Style.RESET_ALL}')
 
-    # apparently
-    # ExpiredTokenException
-    # ExpiredToken
-    # RequestExpired
-    # are all the same pretty much
-    credentials_expiration_codes = [
+    # For invalid credentials, like expired tokens or
+    # invalid tokens, raise InvalidCloudCredentials exception
+    invalid_credentials_codes = [
         'ExpiredTokenException',
         'ExpiredToken',
         'RequestExpired',
+        'InvalidClientTokenId',
+        'InvalidClientToken',
     ]
 
-    if error_code in credentials_expiration_codes:
+    if error_code in invalid_credentials_codes:
         # 'An error occurred (ExpiredToken) when calling the
         # GetInstanceProfile operation: The security token
         # included in the request is expired'

--- a/sky/provision/azure/config.py
+++ b/sky/provision/azure/config.py
@@ -120,7 +120,7 @@ def bootstrap_instances(
             except azure.exceptions().ClientAuthenticationError as e:
                 message = (
                     'Failed to authenticate with Azure. Please check your '
-                    'Azure credentials. Error: '
+                    'Azure credentials. ClientAuthenticationError: '
                     f'{common_utils.format_exception(e)}').replace('\n', ' ')
                 logger.error(message)
                 raise exceptions.NoClusterLaunchedError(message) from e

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -159,7 +159,10 @@ def _retry_on_error(max_retries=DEFAULT_MAX_RETRIES,
                     # or 403 (Forbidden)
                     if (isinstance(e, kubernetes.api_exception()) and
                             e.status in (401, 403)):
-                        raise
+                        # Raise KubeAPIUnreachableError exception so that the
+                        # optimizer/provisioner can failover to other clouds.
+                        raise exceptions.KubeAPIUnreachableError(
+                            f'Kubernetes API error: {str(e)}') from e
                     if attempt < max_retries - 1:
                         sleep_time = backoff.current_backoff()
                         logger.debug(f'Kubernetes API call {func.__name__} '

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -145,6 +145,10 @@ def bulk_provision(
         except exceptions.NoClusterLaunchedError:
             # Skip the teardown if the cluster was never launched.
             raise
+        except exceptions.CloudCredentialExpired:
+            # Skip the teardown if the cloud config is expired and
+            # the provisioner should failover to other clouds.
+            raise
         except Exception:  # pylint: disable=broad-except
             zone_str = 'all zones'
             if zones:

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -145,7 +145,7 @@ def bulk_provision(
         except exceptions.NoClusterLaunchedError:
             # Skip the teardown if the cluster was never launched.
             raise
-        except exceptions.CloudCredentialExpired:
+        except exceptions.InvalidCloudCredentials:
             # Skip the teardown if the cloud config is expired and
             # the provisioner should failover to other clouds.
             raise

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -13,14 +13,9 @@ from sky.provision.kubernetes import utils
 
 # Test for exception on permanent errors like 401 (Unauthorized)
 def test_get_kubernetes_nodes():
-    with patch('sky.provision.kubernetes.utils.kubernetes.core_api') as mock_core_api:
-        mock_core_api.return_value.list_node.side_effect = kubernetes.client.rest.ApiException(status=401)
+    with patch('sky.provision.kubernetes.utils.kubernetes.core_api'
+              ) as mock_core_api:
+        mock_core_api.return_value.list_node.side_effect = kubernetes.client.rest.ApiException(
+            status=401)
         with pytest.raises(exceptions.KubeAPIUnreachableError):
             utils.get_kubernetes_nodes(context='test')
-
-
-
-
-
-
-

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -1,0 +1,26 @@
+"""Tests for Kubernetes utils.
+
+"""
+
+from unittest.mock import patch
+
+import kubernetes
+import pytest
+
+from sky import exceptions
+from sky.provision.kubernetes import utils
+
+
+# Test for exception on permanent errors like 401 (Unauthorized)
+def test_get_kubernetes_nodes():
+    with patch('sky.provision.kubernetes.utils.kubernetes.core_api') as mock_core_api:
+        mock_core_api.return_value.list_node.side_effect = kubernetes.client.rest.ApiException(status=401)
+        with pytest.raises(exceptions.KubeAPIUnreachableError):
+            utils.get_kubernetes_nodes(context='test')
+
+
+
+
+
+
+

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -1,0 +1,32 @@
+"""Tests the functions in authentication.py.
+
+"""
+
+from unittest.mock import patch
+
+from google.auth import exceptions as google_exceptions
+import pytest
+
+from sky import authentication as auth
+from sky import exceptions
+
+
+def test_setup_gcp_authentication():
+    # Create a mock config with required fields
+    mock_config = {
+        'provider': {
+            'project_id': 'test-project'
+        },
+        'gcp_credentials': {
+            'type': 'service_account',
+            'credentials': '{"type": "service_account", "project_id": "test-project"}'
+        }
+    }
+    
+    with patch('sky.adaptors.gcp.build') as mock_build:       
+        # Mock the compute API response to raise RefreshError
+        mock_build.return_value.projects.return_value.get.return_value.execute.side_effect = google_exceptions.RefreshError('test')
+        
+        with pytest.raises(exceptions.InvalidCloudCredentials):
+            auth.setup_gcp_authentication(mock_config)
+

--- a/tests/unit_tests/test_authentication.py
+++ b/tests/unit_tests/test_authentication.py
@@ -22,11 +22,11 @@ def test_setup_gcp_authentication():
             'credentials': '{"type": "service_account", "project_id": "test-project"}'
         }
     }
-    
-    with patch('sky.adaptors.gcp.build') as mock_build:       
+
+    with patch('sky.adaptors.gcp.build') as mock_build:
         # Mock the compute API response to raise RefreshError
-        mock_build.return_value.projects.return_value.get.return_value.execute.side_effect = google_exceptions.RefreshError('test')
-        
+        mock_build.return_value.projects.return_value.get.return_value.execute.side_effect = (
+            google_exceptions.RefreshError('test'))
+
         with pytest.raises(exceptions.InvalidCloudCredentials):
             auth.setup_gcp_authentication(mock_config)
-

--- a/tests/unit_tests/test_aws_utils.py
+++ b/tests/unit_tests/test_aws_utils.py
@@ -21,7 +21,9 @@ def test_handle_boto_error():
             'RequestId': '123456-7890',
             'HTTPStatusCode': 400
         }
-    }    
-    
+    }
+
     with pytest.raises(exceptions.InvalidCloudCredentials):
-        utils.handle_boto_error(aws.botocore_exceptions().ClientError(error_response, 'test'), 'test')
+        utils.handle_boto_error(
+            aws.botocore_exceptions().ClientError(error_response, 'test'),
+            'test')

--- a/tests/unit_tests/test_aws_utils.py
+++ b/tests/unit_tests/test_aws_utils.py
@@ -1,0 +1,27 @@
+"""Tests for AWS utils.
+
+"""
+
+import pytest
+
+from sky import exceptions
+from sky.adaptors import aws
+from sky.provision.aws import utils
+
+
+def test_handle_boto_error():
+    # Create a mock error response
+    error_response = {
+        'Error': {
+            'Code': 'ExpiredToken',
+            'Message': 'Token expired',
+            'Type': 'Sender'
+        },
+        'ResponseMetadata': {
+            'RequestId': '123456-7890',
+            'HTTPStatusCode': 400
+        }
+    }    
+    
+    with pytest.raises(exceptions.InvalidCloudCredentials):
+        utils.handle_boto_error(aws.botocore_exceptions().ClientError(error_response, 'test'), 'test')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix #4373
- For Kubernetes with expired credentials, auto-exclude the contexts
- For invalid credentials of aws, azure, and gcp after enabled in cache, failover to the other clouds for provisioning 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Details are posted in separate comments 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
