### PR TITLE
Add options to set pod/container securityContext, runtimeClassName

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -18,10 +18,19 @@ spec:
     spec:
       automountServiceAccountToken: {{ .Values.kubernetesCredentials.useApiServerCluster }}
       serviceAccountName: {{ .Release.Name }}-api-sa
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}      
+      runtimeClassName: {{ .Values.runtimeClassName }}
       containers:
       - name: skypilot-api
         image: {{ .Values.apiService.image }}
         imagePullPolicy: Always
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}        
         resources:
           {{- toYaml .Values.apiService.resources | nindent 10 }}
         env:

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -125,3 +125,20 @@ gcpCredentials:
   enabled: false
   # TODO(romilb): This can be made optional by using the project in the key json by default.
   projectId: null
+
+# Set securityContext for the api pod
+securityContext:
+  capabilities:
+    drop:
+    - ALL  
+  allowPrivilegeEscalation: false
+
+# Set securityContext for the api container inside the api pod
+podSecurityContext: 
+  capabilities:
+    drop:
+    - ALL  
+  allowPrivilegeEscalation: false
+
+# Set the runtime class
+runtimeClassName: 


### PR DESCRIPTION
Signed-off-by: David Young <davidy@funkypenguin.co.nz>

Hi guys,

In our environment we use various policy controls to prevent insecure deployments, and in order to deploy skypilot-api, I needed basic securityContexts applied to both the pod and the container. 

I've updated the chart to set some working securityContext defaults (*can be tightened one day if we don't run as root*), 
as well as the option for a custom runtimeClassName (*we use kata containers, for example*)

The changes are tested and running happily in our Kubernetes 1.30 cluster. The `runtimeClassName` feature was released as stable in Kubernetes 1.20.

Cheers!
D