### PR TITLE
[Test]test client server compatibility

### DIFF
--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -11,7 +11,6 @@ import pytest
 import requests
 
 import sky
-from sky import cli
 from sky import global_user_state
 from sky import sky_logging
 from sky.backends.cloud_vm_ray_backend import CloudVmRayBackend

--- a/tests/smoke_tests/test_backward_compat.py
+++ b/tests/smoke_tests/test_backward_compat.py
@@ -36,7 +36,7 @@ class TestBackwardCompatibility:
     # Fix the flakyness of the test, server may not ready when we run the command after restart.
     WAIT_FOR_API = (
         'for i in $(seq 1 30); do '
-        'if curl -s {ENDPOINT} > /dev/null; then '
+        f'if curl -s {ENDPOINT} > /dev/null; then '
         'echo "API is up and running"; break; fi; '
         'echo "Waiting for API to be ready... ($i/30)"; '
         '[ $i -eq 30 ] && echo "Timed out waiting for API to be ready" && exit 1; '

--- a/tests/smoke_tests/test_backward_compat.py
+++ b/tests/smoke_tests/test_backward_compat.py
@@ -33,7 +33,7 @@ class TestBackwardCompatibility:
     ACTIVATE_BASE = f'rm -r {SKY_WHEEL_DIR} || true && source {BASE_ENV_DIR}/bin/activate && cd {BASE_SKY_DIR}'
     ACTIVATE_CURRENT = f'rm -r {SKY_WHEEL_DIR} || true && source {CURRENT_ENV_DIR}/bin/activate && cd {CURRENT_SKY_DIR}'
 
-    # Single-line version that can be safely concatenated with other bash commands
+    # Fix the flakyness of the test, server may not ready when we run the command after restart.
     WAIT_FOR_API = (
         'for i in $(seq 1 30); do '
         'if curl -s {ENDPOINT} > /dev/null; then '

--- a/tests/smoke_tests/test_backward_compat.py
+++ b/tests/smoke_tests/test_backward_compat.py
@@ -358,9 +358,9 @@ class TestBackwardCompatibility:
             f'{self.ACTIVATE_CURRENT} && result="$(sky queue {cluster_name})"; echo "$result"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 1 --status)"; echo "$result"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 1)"; echo "$result"; echo "$result" | grep "hello world"',
-            f'{self.ACTIVATE_BASE} && {self.SKY_API_RESTART} && sky exec {cluster_name} "echo from base"',
-            # No restart on switch to current, cli in current, server in base
+            f'{self.ACTIVATE_BASE} && sky exec {cluster_name} "echo from base"',
             f'{self.ACTIVATE_CURRENT} && result="$(sky logs {cluster_name} 2)"; echo "$result"; echo "$result" | grep "from base"',
+            f'{self.ACTIVATE_BASE} && sky autostop -i 1 -y {cluster_name}',
             # serve test
             f'{self.ACTIVATE_BASE} && {self.SKY_API_RESTART} && '
             f'sky serve up --cloud {generic_cloud} -y -n {cluster_name}-0 examples/serve/http_server/task.yaml',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Add one more test case: `test_client_server_compatibility` in `tests/smoke_tests/test_backward_compat.py`

First, launch managed jobs and start the cluster in the `BASE` branch. Then switch to the `CURRENT` branch without restarting the `API server`. Run the CLI commands and verify they succeed.  

Cover the following tests:

| API Version | CLI Version | Result                  | Notes                                  |
|-------------|-------------|-------------------------|----------------------------------------|
| 1           | 2           | ❌ Fails immediately    | Version mismatch error                |
| 2           | 1           | ❌ Fails immediately    | Version mismatch error                |
| 2           | 2           | ✅ Works normally       | Make sure `sky jobs`, `sky launch` `sky serve` etc work without API restart |

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Backward compatibility: `/quicktest-core -k test_client_server_compatibility` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
