### PR TITLE
[GCP] relax storage minimal permissions

### DIFF
--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -182,13 +182,7 @@ VM_MINIMAL_PERMISSIONS = [
 
 STORAGE_MINIMAL_PERMISSIONS = [
     'storage.buckets.create',
-    'storage.buckets.get',
     'storage.buckets.delete',
-    'storage.objects.create',
-    'storage.objects.update',
-    'storage.objects.delete',
-    'storage.objects.get',
-    'storage.objects.list',
 ]
 
 # Permissions implied by GCP built-in roles. We hardcode these here, as we


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes a regression introduced in https://github.com/skypilot-org/skypilot/issues/5020

Pre-https://github.com/skypilot-org/skypilot/pull/4977, having `roles/owner` role was sufficient to use both compute and storage in GCP. However, the PR incorrectly classifies `roles/owner` role as not having enough permission to use GCP storage. See the following `sky check` failure:
```
  GCP: enabled [compute]
    Reason [storage]: The following permissions are not enabled for the current GCP identity (apiserverbeta@sky-dev-***.iam.gserviceaccount.com [project_id=sky-dev-***]):
    {'storage.objects.delete', 'storage.objects.create', 'storage.objects.get', 'storage.buckets.get', 'storage.objects.update', 'storage.objects.list'}
    For more details, visit: https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/gcp.html
```
The listed permissions {'storage.objects.delete', 'storage.objects.create', 'storage.objects.get', 'storage.buckets.get', 'storage.objects.update', 'storage.objects.list'} are usually granted at bucket level, which might be the reason that the permission check failed on the IAM role.

Indeed, while `roles/owner` does not have the iam permissions listed at project level, the principals with `roles/owner` (or `roles/editor`) roles usually have the necessary permissions to interact with buckets assigned at bucket level. See [link](https://cloud.google.com/storage/docs/access-control/iam-roles#basic-roles-modifiable) and screenshot:

<img width="906" alt="Image" src="https://github.com/user-attachments/assets/b2b96a01-feb0-46a1-95bd-92b0418be2d5" />

Long story short, checking storage iam permissions at project level is not a good indicator of whether a service principal is able to effectively leverage storage.

This is true especially if the user intends to only use specific buckets, and assign user permissions directly to buckets instead of to the project. Since `sky check` has no information about which buckets a user intends to use with SkyPilot, I am dropping the checks for permissions that could be assigned at bucket level. Runtime will decide if a user has enough permissions to interact with specific buckets used with SkyPilot.

Since we are checking for `STORAGE_MINIMAL_PERMISSIONS` during `sky check`, I think leaving more specific checks to runtime is acceptable. In fact, this is what has been done pre-https://github.com/skypilot-org/skypilot/pull/4977, so this is not a regression.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (ran `sky check` with owner role and checked it passes)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
