### PR TITLE
[Storage] Mount cached mode (cont'd from #4369)

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -61,6 +61,7 @@ from sky.utils import command_runner
 from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import controller_utils
+from sky.utils import env_options
 from sky.utils import log_utils
 from sky.utils import message_utils
 from sky.utils import registry
@@ -4809,7 +4810,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # Handle cases where `storage_mounts` is None. This occurs when users
         # initiate a 'sky start' command from a Skypilot version that predates
         # the introduction of the `storage_mounts_metadata` feature.
-        if not storage_mounts:
+        if storage_mounts is None:
             return
 
         # Process only mount mode objects here. COPY mode objects have been
@@ -4818,10 +4819,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         storage_mounts = {
             path: storage_mount
             for path, storage_mount in storage_mounts.items()
-            if storage_mount.mode == storage_lib.StorageMode.MOUNT
+            if (storage_mount.mode == storage_lib.StorageMode.MOUNT or
+                storage_mount.mode == storage_lib.StorageMode.MOUNT_CACHED)
         }
 
-        # Handle cases when there aren't any Storages with MOUNT mode.
+        # Handle cases when there aren't any Storages with either MOUNT or
+        # MOUNT_CACHED mode.
         if not storage_mounts:
             return
         start = time.time()
@@ -4851,7 +4854,13 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # Get the first store and use it to mount
             store = list(storage_obj.stores.values())[0]
             assert store is not None, storage_obj
-            mount_cmd = store.mount_command(dst)
+            if storage_obj.mode == storage_lib.StorageMode.MOUNT:
+                mount_cmd = store.mount_command(dst)
+                action_message = 'Mounting'
+            else:
+                assert storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED
+                mount_cmd = store.mount_cached_command(dst)
+                action_message = 'Mounting cached mode'
             src_print = (storage_obj.source
                          if storage_obj.source else storage_obj.name)
             if isinstance(src_print, list):
@@ -4863,7 +4872,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                     target=dst,
                     cmd=mount_cmd,
                     run_rsync=False,
-                    action_message='Mounting',
+                    action_message=action_message,
                     log_path=log_path,
                     # Need to source bashrc, as the cloud specific CLI or SDK
                     # may require PATH in bashrc.
@@ -4882,12 +4891,23 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                  f' to an empty or non-existent path.')
                     raise RuntimeError(error_msg) from None
                 else:
-                    # Strip the command (a big heredoc) from the exception
-                    raise exceptions.CommandError(
-                        e.returncode,
-                        command='to mount',
-                        error_msg=e.error_msg,
-                        detailed_reason=e.detailed_reason) from None
+                    # By default, raising an error caused from mounting_utils
+                    # shows a big heredoc as part of it. Here, we want to
+                    # conditionally show the heredoc only if SKYPILOT_DEBUG
+                    # is set
+                    if env_options.Options.SHOW_DEBUG_INFO.get():
+                        raise exceptions.CommandError(
+                            e.returncode,
+                            command='to mount',
+                            error_msg=e.error_msg,
+                            detailed_reason=e.detailed_reason)
+                    else:
+                        # Strip the command (a big heredoc) from the exception
+                        raise exceptions.CommandError(
+                            e.returncode,
+                            command='to mount',
+                            error_msg=e.error_msg,
+                            detailed_reason=e.detailed_reason) from None
 
         end = time.time()
         logger.debug(f'Storage mount sync took {end - start} seconds.')

--- a/sky/cloud_stores.py
+++ b/sky/cloud_stores.py
@@ -454,19 +454,18 @@ class IBMCosCloudStorage(CloudStorage):
     def _get_rclone_sync_command(self, source: str, destination: str):
         bucket_name, data_path, bucket_region = data_utils.split_cos_path(
             source)
-        bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-            bucket_name, Rclone.RcloneClouds.IBM)
-        data_path_in_bucket = bucket_name + data_path
-        rclone_config_data = Rclone.get_rclone_config(bucket_name,
-                                                      Rclone.RcloneClouds.IBM,
-                                                      bucket_region)
+        rclone_profile_name = (
+            Rclone.RcloneStores.IBM.get_profile_name(bucket_name))
+        data_path_in_bucket = f'{bucket_name}{data_path}'
+        rclone_config = Rclone.RcloneStores.IBM.get_config(
+            rclone_profile_name=rclone_profile_name, region=bucket_region)
         # configure_rclone stores bucket profile in remote cluster's rclone.conf
         configure_rclone = (
-            f' mkdir -p ~/.config/rclone/ &&'
-            f' echo "{rclone_config_data}">> {Rclone.RCLONE_CONFIG_PATH}')
+            f' mkdir -p {constants.RCLONE_CONFIG_DIR} &&'
+            f' echo "{rclone_config}">> {constants.RCLONE_CONFIG_PATH}')
         download_via_rclone = (
             'rclone copy '
-            f'{bucket_rclone_profile}:{data_path_in_bucket} {destination}')
+            f'{rclone_profile_name}:{data_path_in_bucket} {destination}')
 
         all_commands = list(self._GET_RCLONE)
         all_commands.append(configure_rclone)

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -1,7 +1,7 @@
 """Miscellaneous Utils for Sky Data
 """
 import concurrent.futures
-from enum import Enum
+import enum
 from multiprocessing import pool
 import os
 import re
@@ -13,6 +13,7 @@ import urllib.parse
 
 from filelock import FileLock
 
+from sky import clouds
 from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import aws
@@ -21,6 +22,7 @@ from sky.adaptors import cloudflare
 from sky.adaptors import gcp
 from sky.adaptors import ibm
 from sky.adaptors import nebius
+from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import ux_utils
@@ -589,72 +591,135 @@ def get_cos_regions() -> List[str]:
     ]
 
 
-class Rclone():
-    """Static class implementing common utilities of rclone without rclone sdk.
+class Rclone:
+    """Provides methods to manage and generate Rclone configuration profile."""
 
-    Storage providers supported by rclone are required to:
-    - list their rclone profile prefix in RcloneClouds
-    - implement configuration in get_rclone_config()
-    """
+    class RcloneStores(enum.Enum):
+        """Rclone supporting storage types and supporting methods."""
+        S3 = 'S3'
+        GCS = 'GCS'
+        IBM = 'IBM'
+        R2 = 'R2'
+        AZURE = 'AZURE'
 
-    RCLONE_CONFIG_PATH = '~/.config/rclone/rclone.conf'
-    _RCLONE_ABS_CONFIG_PATH = os.path.expanduser(RCLONE_CONFIG_PATH)
+        def get_profile_name(self, bucket_name: str) -> str:
+            """Gets the Rclone profile name for a given bucket.
+            Args:
+                bucket_name: The name of the bucket.
+            Returns:
+                A string containing the Rclone profile name, which combines
+                prefix based on the storage type and the bucket name.
+            """
+            profile_prefix = {
+                Rclone.RcloneStores.S3: 'sky-s3',
+                Rclone.RcloneStores.GCS: 'sky-gcs',
+                Rclone.RcloneStores.IBM: 'sky-ibm',
+                Rclone.RcloneStores.R2: 'sky-r2',
+                Rclone.RcloneStores.AZURE: 'sky-azure'
+            }
+            return f'{profile_prefix[self]}-{bucket_name}'
 
-    # Mapping of storage providers using rclone
-    # to their respective profile prefix
-    class RcloneClouds(Enum):
-        IBM = 'sky-ibm-'
+        def get_config(self,
+                       bucket_name: Optional[str] = None,
+                       rclone_profile_name: Optional[str] = None,
+                       region: Optional[str] = None,
+                       storage_account_name: Optional[str] = None,
+                       storage_account_key: Optional[str] = None) -> str:
+            """Generates an Rclone configuration for a specific storage type.
+            This method creates an Rclone configuration string based on the
+            storage type and the provided parameters.
+            Args:
+                bucket_name: The name of the bucket.
+                rclone_profile_name: The name of the Rclone profile. If not
+                    provided, it will be generated using the bucket_name.
+                region: Region of bucket.
+            Returns:
+                A string containing the Rclone configuration.
+            Raises:
+                NotImplementedError: If the storage type is not supported.
+            """
+            if rclone_profile_name is None:
+                assert bucket_name is not None
+                rclone_profile_name = self.get_profile_name(bucket_name)
+            if self is Rclone.RcloneStores.S3:
+                aws_credentials = (
+                    aws.session().get_credentials().get_frozen_credentials())
+                access_key_id = aws_credentials.access_key
+                secret_access_key = aws_credentials.secret_key
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = s3
+                    provider = AWS
+                    access_key_id = {access_key_id}
+                    secret_access_key = {secret_access_key}
+                    acl = private
+                    """)
+            elif self is Rclone.RcloneStores.GCS:
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = google cloud storage
+                    project_number = {clouds.GCP.get_project_id()}
+                    bucket_policy_only = true
+                    """)
+            elif self is Rclone.RcloneStores.IBM:
+                access_key_id, secret_access_key = ibm.get_hmac_keys()
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = s3
+                    provider = IBMCOS
+                    access_key_id = {access_key_id}
+                    secret_access_key = {secret_access_key}
+                    region = {region}
+                    endpoint = s3.{region}.cloud-object-storage.appdomain.cloud
+                    location_constraint = {region}-smart
+                    acl = private
+                    """)
+            elif self is Rclone.RcloneStores.R2:
+                cloudflare_session = cloudflare.session()
+                cloudflare_credentials = (
+                    cloudflare.get_r2_credentials(cloudflare_session))
+                endpoint = cloudflare.create_endpoint()
+                access_key_id = cloudflare_credentials.access_key
+                secret_access_key = cloudflare_credentials.secret_key
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = s3
+                    provider = Cloudflare
+                    access_key_id = {access_key_id}
+                    secret_access_key = {secret_access_key}
+                    endpoint = {endpoint}
+                    region = auto
+                    acl = private
+                    """)
+            elif self is Rclone.RcloneStores.AZURE:
+                assert storage_account_name and storage_account_key
+                config = textwrap.dedent(f"""\
+                    [{rclone_profile_name}]
+                    type = azureblob
+                    account = {storage_account_name}
+                    key = {storage_account_key}
+                    """)
+            else:
+                with ux_utils.print_exception_no_traceback():
+                    raise NotImplementedError(
+                        f'Unsupported store type for Rclone: {self}')
+            return config
 
     @staticmethod
-    def generate_rclone_bucket_profile_name(bucket_name: str,
-                                            cloud: RcloneClouds) -> str:
-        """Returns rclone profile name for specified bucket
-
-        Args:
-            bucket_name (str): name of bucket
-            cloud (RcloneClouds): enum object of storage provider
-                supported via rclone
-        """
-        try:
-            return cloud.value + bucket_name
-        except AttributeError as e:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Value: {cloud} isn\'t a member of '
-                                 'Rclone.RcloneClouds') from e
-
-    @staticmethod
-    def get_rclone_config(bucket_name: str, cloud: RcloneClouds,
-                          region: str) -> str:
-        bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-            bucket_name, cloud)
-        if cloud is Rclone.RcloneClouds.IBM:
-            access_key_id, secret_access_key = ibm.get_hmac_keys()
-            config_data = textwrap.dedent(f"""\
-                [{bucket_rclone_profile}]
-                type = s3
-                provider = IBMCOS
-                access_key_id = {access_key_id}
-                secret_access_key = {secret_access_key}
-                region = {region}
-                endpoint = s3.{region}.cloud-object-storage.appdomain.cloud
-                location_constraint = {region}-smart
-                acl = private
-                """)
-        else:
-            with ux_utils.print_exception_no_traceback():
-                raise NotImplementedError('No rclone configuration builder was '
-                                          f'implemented for cloud: {cloud}.')
-        return config_data
-
-    @staticmethod
-    def store_rclone_config(bucket_name: str, cloud: RcloneClouds,
+    def store_rclone_config(bucket_name: str, cloud: RcloneStores,
                             region: str) -> str:
-        """Creates a configuration files for rclone - used for
-        bucket syncing and mounting """
-
-        rclone_config_path = Rclone._RCLONE_ABS_CONFIG_PATH
-        config_data = Rclone.get_rclone_config(bucket_name, cloud, region)
-
+        """Creates rclone configuration files for bucket syncing and mounting.
+        Args:
+            bucket_name: Name of the bucket.
+            cloud: RcloneStores enum representing the cloud provider.
+            region: Region of the bucket.
+              Returns:
+            str: The configuration data written to the file.
+        Raises:
+            StorageError: If rclone is not installed.
+        """
+        rclone_config_path = os.path.expanduser(constants.RCLONE_CONFIG_PATH)
+        config_data = cloud.get_config(bucket_name=bucket_name, region=region)
         # Raise exception if rclone isn't installed
         try:
             subprocess.run('rclone version',
@@ -692,18 +757,22 @@ class Rclone():
         return config_data
 
     @staticmethod
-    def get_region_from_rclone(bucket_name: str, cloud: RcloneClouds) -> str:
-        """Returns region field of the specified bucket in rclone.conf
-         if bucket exists, else empty string"""
-        bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-            bucket_name, cloud)
-        with open(Rclone._RCLONE_ABS_CONFIG_PATH, 'r',
-                  encoding='utf-8') as file:
+    def get_region_from_rclone(bucket_name: str, cloud: RcloneStores) -> str:
+        """Returns the region field of the specified bucket in rclone.conf.
+        Args:
+            bucket_name: Name of the bucket.
+            cloud: RcloneStores enum representing the cloud provider.
+        Returns:
+            The region field if the bucket exists, otherwise an empty string.
+        """
+        rclone_profile = cloud.get_profile_name(bucket_name)
+        rclone_config_path = os.path.expanduser(constants.RCLONE_CONFIG_PATH)
+        with open(rclone_config_path, 'r', encoding='utf-8') as file:
             bucket_profile_found = False
             for line in file:
                 if line.lstrip().startswith('#'):  # skip user's comments.
                     continue
-                if line.strip() == f'[{bucket_rclone_profile}]':
+                if line.strip() == f'[{rclone_profile}]':
                     bucket_profile_found = True
                 elif bucket_profile_found and line.startswith('region'):
                     return line.split('=')[1].strip()
@@ -715,36 +784,42 @@ class Rclone():
         return ''
 
     @staticmethod
-    def delete_rclone_bucket_profile(bucket_name: str, cloud: RcloneClouds):
-        """Deletes specified bucket profile for rclone.conf"""
-        bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-            bucket_name, cloud)
-        rclone_config_path = Rclone._RCLONE_ABS_CONFIG_PATH
+    def delete_rclone_bucket_profile(bucket_name: str, cloud: RcloneStores):
+        """Deletes specified bucket profile from rclone.conf.
+        Args:
+            bucket_name: Name of the bucket.
+            cloud: RcloneStores enum representing the cloud provider.
+        """
+        rclone_profile = cloud.get_profile_name(bucket_name)
+        rclone_config_path = os.path.expanduser(constants.RCLONE_CONFIG_PATH)
 
         if not os.path.isfile(rclone_config_path):
-            logger.warning(
-                'Failed to locate "rclone.conf" while '
-                f'trying to delete rclone profile: {bucket_rclone_profile}')
+            logger.warning('Failed to locate "rclone.conf" while '
+                           f'trying to delete rclone profile: {rclone_profile}')
             return
 
         with FileLock(rclone_config_path + '.lock'):
             profiles_to_keep = Rclone._remove_bucket_profile_rclone(
                 bucket_name, cloud)
 
-            # write back file without profile: [bucket_rclone_profile]
+            # write back file without profile: [rclone_profile]
             with open(f'{rclone_config_path}', 'w', encoding='utf-8') as file:
                 file.writelines(profiles_to_keep)
 
     @staticmethod
     def _remove_bucket_profile_rclone(bucket_name: str,
-                                      cloud: RcloneClouds) -> List[str]:
-        """Returns rclone profiles without profiles matching
-          [profile_prefix+bucket_name]"""
-        bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-            bucket_name, cloud)
-        rclone_config_path = Rclone._RCLONE_ABS_CONFIG_PATH
+                                      cloud: RcloneStores) -> List[str]:
+        """Returns rclone profiles without ones matching [prefix+bucket_name].
+        Args:
+            bucket_name: Name of the bucket.
+            cloud: RcloneStores enum representing the cloud provider.
+        Returns:
+            Lines to keep in the rclone config file.
+        """
+        rclone_profile_name = cloud.get_profile_name(bucket_name)
+        rclone_config_path = os.path.expanduser(constants.RCLONE_CONFIG_PATH)
 
-        with open(f'{rclone_config_path}', 'r', encoding='utf-8') as file:
+        with open(rclone_config_path, 'r', encoding='utf-8') as file:
             lines = file.readlines()  # returns a list of the file's lines
             # delete existing bucket profile matching:
             # '[profile_prefix+bucket_name]'
@@ -757,7 +832,7 @@ class Rclone():
                 # keep user comments only if they aren't under
                 # a profile we are discarding
                 lines_to_keep.append(line)
-            elif f'[{bucket_rclone_profile}]' in line:
+            elif f'[{rclone_profile_name}]' in line:
                 skip_lines = True
             elif skip_lines:
                 if '[' in line:

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -266,6 +266,7 @@ class StoreType(enum.Enum):
 class StorageMode(enum.Enum):
     MOUNT = 'MOUNT'
     COPY = 'COPY'
+    MOUNT_CACHED = 'MOUNT_CACHED'
 
 
 class AbstractStore:
@@ -451,7 +452,19 @@ class AbstractStore:
     def mount_command(self, mount_path: str) -> str:
         """Returns the command to mount the Store to the specified mount_path.
 
-        Includes the setup commands to install mounting tools.
+        This command is used for MOUNT mode. Includes the setup commands to
+        install mounting tools.
+
+        Args:
+          mount_path: str; Mount path on remote server
+        """
+        raise NotImplementedError
+
+    def mount_cached_command(self, mount_path: str) -> str:
+        """Returns the command to mount the Store to the specified mount_path.
+
+        This command is used for MOUNT_CACHED mode. Includes the setup commands
+        to install mounting tools.
 
         Args:
           mount_path: str; Mount path on remote server

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -331,6 +331,9 @@ SKYPILOT_NODE_RANK = f'{SKYPILOT_ENV_VAR_PREFIX}NODE_RANK'
 # known after provisioning.
 SKY_SSH_USER_PLACEHOLDER = 'skypilot:ssh_user'
 
+RCLONE_CONFIG_DIR = '~/.config/rclone'
+RCLONE_CONFIG_PATH = f'{RCLONE_CONFIG_DIR}/rclone.conf'
+
 # The keys that can be overridden in the `~/.sky/config.yaml` file. The
 # overrides are specified in task YAMLs.
 OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [

--- a/sky/task.py
+++ b/sky/task.py
@@ -1128,7 +1128,7 @@ class Task:
                         assert storage.name is not None, storage
                         # extract region from rclone.conf
                         cos_region = data_utils.Rclone.get_region_from_rclone(
-                            storage.name, data_utils.Rclone.RcloneClouds.IBM)
+                            storage.name, data_utils.Rclone.RcloneStores.IBM)
                         blob_path = f'cos://{cos_region}/{storage.name}'
                     blob_path = storage.get_bucket_sub_path_prefix(blob_path)
                     self.update_file_mounts({mnt_path: blob_path})
@@ -1268,7 +1268,8 @@ class Task:
 
         # Storage mounting
         for _, storage_mount in self.storage_mounts.items():
-            if storage_mount.mode == storage_lib.StorageMode.MOUNT:
+            if (storage_mount.mode == storage_lib.StorageMode.MOUNT or
+                    storage_mount.mode == storage_lib.StorageMode.MOUNT_CACHED):
                 required_features.add(
                     clouds.CloudImplementationFeatures.STORAGE_MOUNTING)
                 break

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -1025,7 +1025,8 @@ def maybe_translate_local_file_mounts_and_sync_up(task: 'task_lib.Task',
     # it was handled in step 6.
     updated_mount_storages = {}
     for storage_path, storage_obj in task.storage_mounts.items():
-        if (storage_obj.mode == storage_lib.StorageMode.MOUNT and
+        if ((storage_obj.mode == storage_lib.StorageMode.MOUNT or
+             storage_obj.mode == storage_lib.StorageMode.MOUNT_CACHED) and
                 not storage_obj.source):
             # Construct source URL with first store type and storage name
             # E.g., s3://my-storage-name

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -148,7 +148,8 @@ def test_using_file_mounts_with_env_vars(generic_cloud: str):
 # ---------- storage ----------
 def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
                                        storage_name: str, ls_hello_command: str,
-                                       cloud: str, only_mount: bool):
+                                       cloud: str, only_mount: bool,
+                                       include_mount_cached: bool):
     template_str = pathlib.Path(
         'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
     template = jinja2.Template(template_str)
@@ -183,6 +184,18 @@ def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
         # the mounted directory
         f'sky exec {cluster_name} -- "set -ex; ls /mount_private_mount/hello.txt"',
     ]
+    rclone_stores = None
+    if cloud == 'aws':
+        rclone_stores = data_utils.Rclone.RcloneStores.S3
+    elif cloud == 'gcp':
+        rclone_stores = data_utils.Rclone.RcloneStores.GCS
+    elif cloud == 'azure':
+        rclone_stores = data_utils.Rclone.RcloneStores.AZURE
+    if rclone_stores is not None:
+        rclone_profile_name = rclone_stores.get_profile_name(storage_name)
+        test_commands.append(
+            f'sky exec {cluster_name} -- "set -ex; '
+            f'rclone ls {rclone_profile_name}:{storage_name}/hello.txt;"')
     clean_command = (
         f'sky down -y {cluster_name} && '
         f'{smoke_tests_utils.down_cluster_for_cloud_cmd(cluster_name)} && '
@@ -198,7 +211,7 @@ def test_aws_storage_mounts_with_stop():
     ls_hello_command = f'aws s3 ls {storage_name}/hello.txt'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, False)
+            f, name, storage_name, ls_hello_command, cloud, False, True)
         test = smoke_tests_utils.Test(
             'aws_storage_mounts',
             test_commands,
@@ -216,7 +229,7 @@ def test_aws_storage_mounts_with_stop_only_mount():
     ls_hello_command = f'aws s3 ls {storage_name}/hello.txt'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, True)
+            f, name, storage_name, ls_hello_command, cloud, True, False)
         test = smoke_tests_utils.Test(
             'aws_storage_mounts_only_mount',
             test_commands,
@@ -234,7 +247,7 @@ def test_gcp_storage_mounts_with_stop():
     ls_hello_command = f'{ACTIVATE_SERVICE_ACCOUNT_AND_GSUTIL} ls gs://{storage_name}/hello.txt'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, False)
+            f, name, storage_name, ls_hello_command, cloud, False, True)
         test = smoke_tests_utils.Test(
             'gcp_storage_mounts',
             test_commands,
@@ -261,7 +274,7 @@ def test_azure_storage_mounts_with_stop():
                         f'[ "$output" = "[]" ] && exit 1 || exit 0')
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, cloud, False)
+            f, name, storage_name, ls_hello_command, cloud, False, True)
         test = smoke_tests_utils.Test(
             'azure_storage_mounts',
             test_commands,
@@ -302,7 +315,7 @@ def test_kubernetes_storage_mounts():
     ls_hello_command = f'{cloud_cmd_cluster_setup_cmd} && {ls_hello_command}'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, 'kubernetes', False)
+            f, name, storage_name, ls_hello_command, 'kubernetes', False, False)
         test = smoke_tests_utils.Test(
             'kubernetes_storage_mounts',
             test_commands,
@@ -508,8 +521,8 @@ def test_nebius_storage_mounts(generic_cloud: str):
 def test_ibm_storage_mounts():
     name = smoke_tests_utils.get_cluster_name()
     storage_name = f'sky-test-{int(time.time())}'
-    bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-        storage_name, Rclone.RcloneClouds.IBM)
+    rclone_profile_name = data_utils.Rclone.RcloneStores.IBM.get_profile_name(
+        storage_name)
     template_str = pathlib.Path(
         'tests/test_yamls/test_ibm_cos_storage_mounting.yaml').read_text()
     template = jinja2.Template(template_str)
@@ -522,7 +535,7 @@ def test_ibm_storage_mounts():
             *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
             f'sky launch -y -c {name} --cloud ibm {file_path}',
             f'sky logs {name} 1 --status',  # Ensure job succeeded.
-            f'rclone ls {bucket_rclone_profile}:{storage_name}/hello.txt',
+            f'rclone ls {rclone_profile_name}:{storage_name}/hello.txt',
         ]
         test = smoke_tests_utils.Test(
             'ibm_storage_mounts',
@@ -746,9 +759,9 @@ class TestStorageWithCredentials:
             return f'aws s3 rb {url} --force --endpoint {endpoint_url} --profile={nebius.NEBIUS_PROFILE_NAME}'
 
         if store_type == storage_lib.StoreType.IBM:
-            bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-                bucket_name, Rclone.RcloneClouds.IBM)
-            return f'rclone purge {bucket_rclone_profile}:{bucket_name} && rclone config delete {bucket_rclone_profile}'
+            rclone_profile_name = (data_utils.Rclone.RcloneStores.IBM.
+                                   get_profile_name(bucket_name))
+            return f'rclone purge {rclone_profile_name}:{bucket_name} && rclone config delete {rclone_profile_name}'
 
     @classmethod
     def list_all_files(cls, store_type: storage_lib.StoreType,
@@ -843,9 +856,9 @@ class TestStorageWithCredentials:
 
         if store_type == storage_lib.StoreType.IBM:
             # rclone ls is recursive by default
-            bucket_rclone_profile = Rclone.generate_rclone_bucket_profile_name(
-                bucket_name, Rclone.RcloneClouds.IBM)
-            return f'rclone ls {bucket_rclone_profile}:{bucket_name}/{suffix}'
+            rclone_profile_name = data_utils.Rclone.RcloneStores.IBM.get_profile_name(
+                bucket_name)
+            return f'rclone ls {rclone_profile_name}:{bucket_name}/{suffix}'
 
     @staticmethod
     def cli_region_cmd(store_type, bucket_name=None, storage_account_name=None):

--- a/tests/test_yamls/test_storage_mounting.yaml.j2
+++ b/tests/test_yamls/test_storage_mounting.yaml.j2
@@ -40,6 +40,14 @@ file_mounts:
     mode: MOUNT
   {% endif %}
 
+  # Mounting private buckets in MOUNT_CACHED mode
+  {% if include_mount_cached | default(False) %}
+  /mount_private_mount_cached:
+    name: {{storage_name}}_mount_cached
+    source: ~/tmp-workdir
+    mode: MOUNT_CACHED
+  {% endif %}
+
 run: |
   set -ex
 
@@ -71,4 +79,19 @@ run: |
 
   # Write to private bucket in MOUNT mode should pass
   echo "hello" > /mount_private_mount/hello.txt
+  {% endif %}
+
+  # Write to private bucket in MOUNT_CACHED mode should pass
+  echo "hello" > /mount_private_mount_cached/hello.txt
+
+  {% if include_mount_cached | default(False) %}
+  # Check private bucket contents
+  ls -ltr /mount_private_mount_cached/foo
+  ls -ltr /mount_private_mount_cached/tmp\ file
+
+  # Symlinks are not copied to buckets
+  ! ls /mount_private_mount_cached/circle-link
+
+  # Write to private bucket in MOUNT_CACHED mode should pass
+  echo "hello" > /mount_private_mount_cached/hello.txt
   {% endif %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Continuation of PR #4369 

Tested (run the relevant ones):

- [x] Code formatting: `bash format.sh`
- [ ] Check if mountpoints remain mounted after restarting by running `sky stop` and `sky start`:
  - [ ] `pytest tests/test_smoke.py::test_aws_storage_mounts_with_stop --aws`
  - [ ] `pytest tests/test_smoke.py::test_gcp_storage_mounts_with_stop --gcp`
  - [ ] Manually running `sky stop` and `sky start` with `comp_test.yaml` to see if all the `MOUNT_CACHED` remains storage remains mounted.
- [ ] Set of comprehensive manual tests with `comp_test.yaml`:
  - [ ] `launch` tests:
    - [ ] sky launch comp_test.yaml --cloud aws -y
    - [ ] sky launch comp_test.yaml --cloud gcp -y
  - [ ] `sky launch` two instances mounting same backend storage. Create new file on mountpoint on instance 1, and check if it appears shortly in instance 2. 
  - [ ] managed `spot` jobs tests: 
    - [ ] sky jobs launch comp_test.yaml --use-spot --cloud aws -y
    - [ ] sky jobs launch comp_test.yaml --use-spot --cloud gcp -y
  - [ ] `launch `on docker containers: 
    - [ ] sky launch comp_test.yaml --cloud aws --image-id docker:continuumio/miniconda3:latest -y
    - [ ] sky launch comp_test.yaml --cloud gcp --image-id docker:continuumio/miniconda3:latest -y

`comp_test.yaml`:
```
file_mounts:
  #### S3 tests ####
  /s3-sky-managed-copy:
    name: s3-sky-managed-copy
    source: ~/sky_logs
    store: s3
    mode: COPY

  /s3-sky-managed-mount:
    name: s3-sky-managed-mount
    source: ~/sky_logs
    store: s3
    mode: MOUNT

  /s3-sky-managed-mount-cached:
    name: s3-sky-managed-mount-cached
    source: ~/sky_logs
    store: s3
    mode: MOUNT_CACHED

  /s3-external-private-by-user:
    source: s3://s3-external-private-by-user-dy
    mode: MOUNT_CACHED

  /s3-external-public-by-user:
    source: s3://s3-external-public-by-user-dy
    mode: MOUNT_CACHED

  /s3-external-public-not-by-user:
    source: s3://digitalcorpora
    mode: MOUNT_CACHED

  #### GCS tests ####
  /gcs-sky-managed-copy:
    name: gcs-sky-managed-copy
    source: ~/sky_logs
    store: gcs
    mode: COPY

  /gcs-sky-managed-mount:
    name: gcs-sky-managed-mount
    source: ~/sky_logs
    store: gcs
    mode: MOUNT

  /gcs-sky-managed-mount-cached:
    name: gcs-sky-managed-mount-cached
    source: ~/sky_logs
    store: gcs
    mode: MOUNT_CACHED

  /gcs-external-private-by-user:
    source: gs://gcs-external-private-by-user-dy
    mode: MOUNT_CACHED

  /gcs-external-public-by-user:
    source: gs://gcs-external-public-by-user-dy
    mode: MOUNT_CACHED

  /gcs-external-public-not-by-user:
    source: gs://gcp-public-data-sentinel-2
    mode: MOUNT_CACHED


workdir: ~/yaml

setup: |
  echo hi

run: |
  # Show workdir
  ls -l .

  # Show private/public storage copy/mount
  ls -l /s3-sky-managed-copy
  ls -l /s3-sky-managed-mount
  ls -l /s3-sky-managed-mount-cached
  ls -l /s3-external-private-by-user
  ls -l /s3-external-public-by-user
  ls -l /s3-external-public-not-by-user
  ls -l /gcs-sky-managed-copy
  ls -l /gcs-sky-managed-mount
  ls -l /gcs-sky-managed-mount-cached
  ls -l /gcs-external-private-by-user
  ls -l /gcs-external-public-by-user
  ls -l /gcs-external-public-not-by-user

  # Write files on a mounted storage with access
  date > /s3-sky-managed-mount/hellotest.txt
  date > /s3-sky-managed-mount-cached/hellotest.txt
  date > /s3-external-private-by-user/hellotest.txt
  date > /s3-external-public-by-user/hellotest.txt
  date > /gcs-sky-managed-mount/hellotest.txt
  date > /gcs-sky-managed-mount-cached/hellotest.txt
  date > /gcs-external-private-by-user/hellotest.txt
  date > /gcs-external-public-by-user/hellotest.txt

  # Confirm file was written
  cat /s3-sky-managed-mount/hellotest.txt
  cat /s3-sky-managed-mount-cached/hellotest.txt
  cat /s3-external-private-by-user/hellotest.txt
  cat /s3-external-public-by-user/hellotest.txt
  cat /gcs-sky-managed-mount/hellotest.txt
  cat /gcs-sky-managed-mount-cached/hellotest.txt
  cat /gcs-external-private-by-user/hellotest.txt
  cat /gcs-external-public-by-user/hellotest.txt
```



- [ ]  Specific tests on training with managed spot jobs:
  - [ ] Confirm if `MOUNT_CACHED` mode can recover from preemption to continue training using our vicuna training script.
  - [ ] [Confirm files written at mountpoint being uploaded to backed storage in order of creation.](https://github.com/skypilot-org/skypilot/issues/3353#issuecomment-2138774040)
  - [ ] [Confirm if `MOUNT_CACHED` mode performs as much as or better than our `MOUNT` mode when writting ](https://github.com/skypilot-org/skypilot/issues/3353#issuecomment-2138774040)checkpoints 