### PR TITLE
[Core] Support setting sudo password when deploying remote clusters

### DIFF
--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -48,7 +48,7 @@ Prerequisites
 
 * Debian-based OS (tested on Debian 11)
 * SSH access from local machine to all remote machines with key-based authentication
-* It's recommended to use passwordless sudo for all remote machines. If passwordless sudo cannot be used, all machines must use the same password for the SSH username.
+* It's recommended to use passwordless sudo for all remote machines. If passwordless sudo cannot be used, all machines must use the same password for the SSH username to use sudo.
 * All machines must use the same SSH key and username
 * All machines must have network access to each other
 * Port 6443 must be accessible on at least one node from your local machine
@@ -70,6 +70,7 @@ Deploying SkyPilot
    In this example, the first node (``192.168.1.1``) has port 6443 open and will be used as the head node.
 
 2. Run ``sky local up`` and pass the ``ips.txt`` file, SSH username, and SSH key as arguments:
+
    If passwordless sudo is available:
 
    .. code-block:: bash

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -71,8 +71,6 @@ Deploying SkyPilot
 
 2. Run ``sky local up`` and pass the ``ips.txt`` file, SSH username, and SSH key as arguments:
 
-   If passwordless sudo is available:
-
    .. code-block:: bash
 
       IP_FILE=ips.txt
@@ -81,16 +79,13 @@ Deploying SkyPilot
       CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
       sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME
 
-   If passwordless sudo is not available:
+   .. tip::
+      If your cluster does not have passwordless sudo, specify the sudo password with the ``--password`` option:
 
-   .. code-block:: bash
+      .. code-block:: bash
 
-      IP_FILE=ips.txt
-      SSH_USER=username
-      SSH_KEY=path/to/ssh/key
-      PASSWORD=password
-      CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
-      sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME --password $PASSWORD
+         PASSWORD=password
+         sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME --password $PASSWORD
 
    SkyPilot will deploy a Kubernetes cluster on the remote machines, set up GPU support, configure Kubernetes credentials on your local machine, and set up SkyPilot to operate with the new cluster.
 
@@ -157,24 +152,20 @@ Cleanup
 
 To clean up all state created by SkyPilot on your machines, use the ``--cleanup`` flag:
 
-If passwordless sudo is available:
-
 .. code-block:: bash
 
     IP_FILE=ips.txt
     SSH_USER=username
     SSH_KEY=path/to/ssh/key
-    sky local up --ip $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --cleanup
+    sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --cleanup
 
-If passwordless sudo is not available:
+.. tip::
+   If your cluster does not have passwordless sudo, specify the sudo password with the ``--password`` option:
 
-.. code-block:: bash
+   .. code-block:: bash
 
-    IP_FILE=ips.txt
-    SSH_USER=username
-    SSH_KEY=path/to/ssh/key
-    PASSWORD=password
-    sky local up --ip $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --password $PASSWORD --cleanup
+      PASSWORD=password
+      sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --password $PASSWORD --cleanup
 
 This will stop all Kubernetes services on the remote machines.
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -47,7 +47,8 @@ Prerequisites
 **Remote machines (your cluster, optionally with GPUs):**
 
 * Debian-based OS (tested on Debian 11)
-* SSH access from local machine to all remote machines with key-based authentication and passwordless sudo
+* SSH access from local machine to all remote machines with key-based authentication
+* It's recommended to use passwordless sudo for all remote machines. If passwordless sudo cannot be used, all machines must use the same password for the SSH username.
 * All machines must use the same SSH key and username
 * All machines must have network access to each other
 * Port 6443 must be accessible on at least one node from your local machine
@@ -69,6 +70,7 @@ Deploying SkyPilot
    In this example, the first node (``192.168.1.1``) has port 6443 open and will be used as the head node.
 
 2. Run ``sky local up`` and pass the ``ips.txt`` file, SSH username, and SSH key as arguments:
+   If passwordless sudo is available:
 
    .. code-block:: bash
 
@@ -77,6 +79,17 @@ Deploying SkyPilot
       SSH_KEY=path/to/ssh/key
       CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
       sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME
+
+   If passwordless sudo is not available:
+
+   .. code-block:: bash
+
+      IP_FILE=ips.txt
+      SSH_USER=username
+      SSH_KEY=path/to/ssh/key
+      PASSWORD=password
+      CONTEXT_NAME=mycluster  # Optional, sets the context name in the kubeconfig. Defaults to "default".
+      sky local up --ips $IP_FILE --ssh-user $SSH_USER --ssh-key-path $SSH_KEY --context-name $CONTEXT_NAME --password $PASSWORD
 
    SkyPilot will deploy a Kubernetes cluster on the remote machines, set up GPU support, configure Kubernetes credentials on your local machine, and set up SkyPilot to operate with the new cluster.
 
@@ -143,12 +156,24 @@ Cleanup
 
 To clean up all state created by SkyPilot on your machines, use the ``--cleanup`` flag:
 
+If passwordless sudo is available:
+
 .. code-block:: bash
 
     IP_FILE=ips.txt
     SSH_USER=username
     SSH_KEY=path/to/ssh/key
     sky local up --ip $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --cleanup
+
+If passwordless sudo is not available:
+
+.. code-block:: bash
+
+    IP_FILE=ips.txt
+    SSH_USER=username
+    SSH_KEY=path/to/ssh/key
+    PASSWORD=password
+    sky local up --ip $IP_FILE --ssh-user SSH_USER --ssh-key-path $SSH_KEY --password $PASSWORD --cleanup
 
 This will stop all Kubernetes services on the remote machines.
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5455,11 +5455,16 @@ def local():
     type=str,
     required=False,
     help='Name to use for the kubeconfig context. Defaults to "default".')
+@click.option('--password',
+              type=str,
+              required=False,
+              help='Password for the ssh-user to execute sudo commands.')
 @local.command('up', cls=_DocumentedCodeCommand)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
-             cleanup: bool, context_name: Optional[str], async_call: bool):
+             cleanup: bool, context_name: Optional[str],
+             password: Optional[str], async_call: bool):
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key_path, cleanup):
@@ -5505,7 +5510,7 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
                 f'Failed to read SSH key file {ssh_key_path}: {str(e)}')
 
     request_id = sdk.local_up(gpus, ip_list, ssh_user, ssh_key, cleanup,
-                              context_name)
+                              context_name, password)
     _async_call_or_wait(request_id, async_call, request_name='local up')
 
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5458,7 +5458,8 @@ def local():
 @click.option('--password',
               type=str,
               required=False,
-              help='Password for the ssh-user to execute sudo commands.')
+              help='Password for the ssh-user to execute sudo commands. '
+              'Required only if passwordless sudo is not setup.')
 @local.command('up', cls=_DocumentedCodeCommand)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1295,7 +1295,8 @@ def local_up(gpus: bool,
              ssh_user: Optional[str],
              ssh_key: Optional[str],
              cleanup: bool,
-             context_name: Optional[str] = None) -> server_common.RequestId:
+             context_name: Optional[str] = None,
+             password: Optional[str] = None) -> server_common.RequestId:
     """Launches a Kubernetes cluster on local machines.
 
     Returns:
@@ -1314,7 +1315,8 @@ def local_up(gpus: bool,
                                 ssh_user=ssh_user,
                                 ssh_key=ssh_key,
                                 cleanup=cleanup,
-                                context_name=context_name)
+                                context_name=context_name,
+                                password=password)
     response = requests.post(f'{server_common.get_server_url()}/local_up',
                              json=json.loads(body.model_dump_json()))
     return server_common.get_request_id(response)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1062,9 +1062,9 @@ def local_up(gpus: bool,
              ips: Optional[List[str]],
              ssh_user: Optional[str],
              ssh_key: Optional[str],
-             password: Optional[str],
              cleanup: bool,
-             context_name: Optional[str] = None) -> None:
+             context_name: Optional[str] = None,
+             password: Optional[str] = None) -> None:
     """Creates a local or remote cluster."""
 
     def _validate_args(ips, ssh_user, ssh_key, cleanup):
@@ -1090,8 +1090,8 @@ def local_up(gpus: bool,
     if ips:
         assert ssh_user is not None and ssh_key is not None
         kubernetes_deploy_utils.deploy_remote_cluster(ips, ssh_user, ssh_key,
-                                                      password, cleanup,
-                                                      context_name)
+                                                      cleanup, context_name,
+                                                      password)
     else:
         # Run local deployment (kind) if no remote args are specified
         kubernetes_deploy_utils.deploy_local_cluster(gpus)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1062,6 +1062,7 @@ def local_up(gpus: bool,
              ips: Optional[List[str]],
              ssh_user: Optional[str],
              ssh_key: Optional[str],
+             password: Optional[str],
              cleanup: bool,
              context_name: Optional[str] = None) -> None:
     """Creates a local or remote cluster."""
@@ -1089,7 +1090,8 @@ def local_up(gpus: bool,
     if ips:
         assert ssh_user is not None and ssh_key is not None
         kubernetes_deploy_utils.deploy_remote_cluster(ips, ssh_user, ssh_key,
-                                                      cleanup, context_name)
+                                                      password, cleanup,
+                                                      context_name)
     else:
         # Run local deployment (kind) if no remote args are specified
         kubernetes_deploy_utils.deploy_local_cluster(gpus)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -464,6 +464,7 @@ class LocalUpBody(RequestBody):
     ssh_key: Optional[str] = None
     cleanup: bool = False
     context_name: Optional[str] = None
+    password: Optional[str] = None
 
 
 class ServeTerminateReplicaBody(RequestBody):

--- a/sky/utils/kubernetes/deploy_remote_cluster.sh
+++ b/sky/utils/kubernetes/deploy_remote_cluster.sh
@@ -12,12 +12,18 @@ NC='\033[0m' # No color
 CLEANUP=false
 INSTALL_GPU=false
 POSITIONAL_ARGS=()
+PASSWORD=""
 
 # Process all arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --cleanup)
             CLEANUP=true
+            shift
+            ;;
+        --password)
+            PASSWORD=$2
+            shift
             shift
             ;;
         *)
@@ -40,7 +46,7 @@ K3S_TOKEN=mytoken  # Any string can be used as the token
 # Basic argument checks
 if [ -z "$IPS_FILE" ] || [ -z "$USER" ] || [ -z "$SSH_KEY" ]; then
     >&2 echo -e "${RED}Error: Missing required arguments.${NC}"
-    >&2 echo "Usage: ./deploy_remote_cluster.sh ips.txt username path/to/ssh/key [context-name] [--cleanup]"
+    >&2 echo "Usage: ./deploy_remote_cluster.sh ips.txt username path/to/ssh/key [context-name] [--cleanup] [--password password]"
     exit 1
 fi
 
@@ -89,9 +95,19 @@ cleanup_server_node() {
     local NODE_IP=$1
     echo -e "${YELLOW}Cleaning up head node $NODE_IP...${NC}"
     run_remote "$NODE_IP" "
+        # Create temporary askpass script
+        ASKPASS_SCRIPT=\$(mktemp)
+        trap 'rm -f \$ASKPASS_SCRIPT' EXIT INT TERM ERR QUIT
+cat > \$ASKPASS_SCRIPT << EOF
+#!/bin/bash
+echo "$PASSWORD"
+EOF
+        chmod 700 \$ASKPASS_SCRIPT
+        # Use askpass
+        export SUDO_ASKPASS=\$ASKPASS_SCRIPT
         echo 'Uninstalling k3s...' &&
-        /usr/local/bin/k3s-uninstall.sh || true &&
-        sudo rm -rf /etc/rancher /var/lib/rancher /var/lib/kubelet /etc/kubernetes ~/.kube
+        sudo -A /usr/local/bin/k3s-uninstall.sh || true &&
+        sudo -A rm -rf /etc/rancher /var/lib/rancher /var/lib/kubelet /etc/kubernetes ~/.kube
     "
     echo -e "${GREEN}Node $NODE_IP cleaned up successfully.${NC}"
 }
@@ -101,9 +117,19 @@ cleanup_agent_node() {
     local NODE_IP=$1
     echo -e "${YELLOW}Cleaning up node $NODE_IP...${NC}"
     run_remote "$NODE_IP" "
+        # Create temporary askpass script
+        ASKPASS_SCRIPT=\$(mktemp)
+        trap 'rm -f \$ASKPASS_SCRIPT' EXIT INT TERM ERR QUIT
+cat > \$ASKPASS_SCRIPT << EOF
+#!/bin/bash
+echo "$PASSWORD"
+EOF
+        chmod 700 \$ASKPASS_SCRIPT
+        # Use askpass
+        export SUDO_ASKPASS=\$ASKPASS_SCRIPT
         echo 'Uninstalling k3s...' &&
-        /usr/local/bin/k3s-agent-uninstall.sh || true &&
-        sudo rm -rf /etc/rancher /var/lib/rancher /var/lib/kubelet /etc/kubernetes ~/.kube
+        sudo -A /usr/local/bin/k3s-agent-uninstall.sh || true &&
+        sudo -A rm -rf /etc/rancher /var/lib/rancher /var/lib/kubelet /etc/kubernetes ~/.kube
     "
     echo -e "${GREEN}Node $NODE_IP cleaned up successfully.${NC}"
 }
@@ -151,10 +177,20 @@ fi
 # Step 1: Install k3s on the head node
 progress_message "Deploying Kubernetes on head node ($HEAD_NODE)..."
 run_remote "$HEAD_NODE" "
-    curl -sfL https://get.k3s.io | K3S_TOKEN=$K3S_TOKEN sh - &&
+    # Create temporary askpass script
+    ASKPASS_SCRIPT=\$(mktemp)
+    trap 'rm -f \$ASKPASS_SCRIPT' EXIT INT TERM ERR QUIT
+cat > \$ASKPASS_SCRIPT << EOF
+#!/bin/bash
+echo "$PASSWORD"
+EOF
+    chmod 700 \$ASKPASS_SCRIPT
+    # Use askpass
+    export SUDO_ASKPASS=\$ASKPASS_SCRIPT
+    curl -sfL https://get.k3s.io | K3S_TOKEN=$K3S_TOKEN sudo -E -A sh - &&
     mkdir -p ~/.kube &&
-    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config &&
-    sudo chown \$(id -u):\$(id -g) ~/.kube/config &&
+    sudo -A cp /etc/rancher/k3s/k3s.yaml ~/.kube/config &&
+    sudo -A chown \$(id -u):\$(id -g) ~/.kube/config &&
     for i in {1..3}; do
         if kubectl wait --for=condition=ready node --all --timeout=2m --kubeconfig ~/.kube/config; then
             break
@@ -163,7 +199,7 @@ run_remote "$HEAD_NODE" "
             sleep 5
         fi
     done
-    if [ $i -eq 3 ]; then
+    if [ \$i -eq 3 ]; then
         echo 'Failed to wait for nodes to be ready after 3 attempts'
         exit 1
     fi"
@@ -184,7 +220,17 @@ echo -e "${GREEN}Master node internal IP: $MASTER_ADDR${NC}"
 for NODE in $WORKER_NODES; do
     progress_message "Deploying Kubernetes on worker node ($NODE)..."
     run_remote "$NODE" "
-        curl -sfL https://get.k3s.io | K3S_URL=https://$MASTER_ADDR:6443 K3S_TOKEN=$K3S_TOKEN sh -"
+        # Create temporary askpass script
+        ASKPASS_SCRIPT=\$(mktemp)
+        trap 'rm -f \$ASKPASS_SCRIPT' EXIT INT TERM ERR QUIT
+cat > \$ASKPASS_SCRIPT << EOF
+#!/bin/bash
+echo "$PASSWORD"
+EOF
+        chmod 700 \$ASKPASS_SCRIPT
+        # Use askpass
+        export SUDO_ASKPASS=\$ASKPASS_SCRIPT
+        curl -sfL https://get.k3s.io | K3S_URL=https://$MASTER_ADDR:6443 K3S_TOKEN=$K3S_TOKEN sudo -E -A sh -"
     success_message "Kubernetes deployed on worker node ($NODE)."
 
     # Check if worker node has a GPU
@@ -247,12 +293,22 @@ echo "Cluster deployment completed. You can now run 'kubectl get nodes' to verif
 if [ "$INSTALL_GPU" == "true" ]; then
     echo -e "${YELLOW}GPU detected in the cluster. Installing Nvidia GPU Operator...${NC}"
     run_remote "$HEAD_NODE" "
+        # Create temporary askpass script
+        ASKPASS_SCRIPT=\$(mktemp)
+        trap 'rm -f \$ASKPASS_SCRIPT' EXIT INT TERM ERR QUIT
+cat > \$ASKPASS_SCRIPT << EOF
+#!/bin/bash
+echo "$PASSWORD"
+EOF
+        chmod 700 \$ASKPASS_SCRIPT
+        # Use askpass
+        export SUDO_ASKPASS=\$ASKPASS_SCRIPT
         curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 &&
         chmod 700 get_helm.sh &&
         ./get_helm.sh &&
         helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update &&
         kubectl create namespace gpu-operator --kubeconfig ~/.kube/config || true &&
-        sudo ln -s /sbin/ldconfig /sbin/ldconfig.real || true &&
+        sudo -A ln -s /sbin/ldconfig /sbin/ldconfig.real || true &&
         helm install gpu-operator -n gpu-operator --create-namespace nvidia/gpu-operator \
         --set 'toolkit.env[0].name=CONTAINERD_CONFIG' \
         --set 'toolkit.env[0].value=/var/lib/rancher/k3s/agent/etc/containerd/config.toml' \

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -23,9 +23,9 @@ logger = sky_logging.init_logger(__name__)
 def deploy_remote_cluster(ip_list: List[str],
                           ssh_user: str,
                           ssh_key: str,
-                          password: Optional[str],
                           cleanup: bool,
-                          context_name: Optional[str] = None):
+                          context_name: Optional[str] = None,
+                          password: Optional[str] = None):
     success = False
     path_to_package = os.path.dirname(__file__)
     up_script_path = os.path.join(path_to_package, 'deploy_remote_cluster.sh')

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -23,6 +23,7 @@ logger = sky_logging.init_logger(__name__)
 def deploy_remote_cluster(ip_list: List[str],
                           ssh_user: str,
                           ssh_key: str,
+                          password: Optional[str],
                           cleanup: bool,
                           context_name: Optional[str] = None):
     success = False
@@ -47,6 +48,8 @@ def deploy_remote_cluster(ip_list: List[str],
                           f'{ssh_user} {key_file.name}')
         if context_name is not None:
             deploy_command += f' {context_name}'
+        if password is not None:
+            deploy_command += f' --password {password}'
         if cleanup:
             deploy_command += ' --cleanup'
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix #4795 

- Update doc to recommend using passwordless sudo when deploying remote clusters with `sky local up`
- If passwordless sudo is not available, support setting sudo password when deploying remote clusters with `sky local up`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see detailed cases below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
