### PR TITLE
[jobs] handle FAILED_DRIVER jobs explicitly

### DIFF
--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -330,7 +330,7 @@ class JobsController:
                         )
                         failure_reason = (
                             'The job driver on the remote cluster failed. This '
-                            'be caused by the job taking too much memory or '
+                            'can be caused by the job taking too much memory or '
                             'other resources. Try adding more memory, CPU, or '
                             f'disk in your job definition. {failure_reason}')
                     should_restart_on_failure = (

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -302,14 +302,11 @@ class JobsController:
                 elif (job_status
                       in job_lib.JobStatus.user_code_failure_states() or
                       job_status == job_lib.JobStatus.FAILED_DRIVER):
-                    end_time: Optional[float] = None
-                    if job_status in job_lib.JobStatus.user_code_failure_states(
-                    ):
-                        # The user code has probably crashed, fail immediately.
-                        end_time = managed_job_utils.try_to_get_job_end_time(
-                            self._backend, cluster_name)
+                    # The user code has probably crashed, fail immediately.
+                    end_time = managed_job_utils.try_to_get_job_end_time(
+                        self._backend, cluster_name)
                     logger.info(
-                        f'The user job failed {job_status}. Please check the '
+                        f'The user job failed ({job_status}). Please check the '
                         'logs below.\n'
                         f'== Logs of the user job (ID: {self._job_id}) ==\n')
 
@@ -332,9 +329,10 @@ class JobsController:
                             managed_job_state.ManagedJobStatus.FAILED_CONTROLLER
                         )
                         failure_reason = (
-                            'The job driver failed. The job may need more '
-                            'resources - try adding more CPU, memory, or disk '
-                            f'in your job definition. {failure_reason}')
+                            'The job driver on the remote cluster failed. This '
+                            'be caused by the job taking too much memory or '
+                            'other resources. Try adding more memory, CPU, or '
+                            f'disk in your job definition. {failure_reason}')
                     should_restart_on_failure = (
                         self._strategy_executor.should_restart_on_failure())
                     if should_restart_on_failure:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -330,9 +330,9 @@ class JobsController:
                         )
                         failure_reason = (
                             'The job driver on the remote cluster failed. This '
-                            'can be caused by the job taking too much memory or '
-                            'other resources. Try adding more memory, CPU, or '
-                            f'disk in your job definition. {failure_reason}')
+                            'can be caused by the job taking too much memory '
+                            'or other resources. Try adding more memory, CPU, '
+                            f'or disk in your job definition. {failure_reason}')
                     should_restart_on_failure = (
                         self._strategy_executor.should_restart_on_failure())
                     if should_restart_on_failure:

--- a/sky/jobs/controller.py
+++ b/sky/jobs/controller.py
@@ -227,13 +227,13 @@ class JobsController:
                 self._backend, cluster_name)
 
             if job_status == job_lib.JobStatus.SUCCEEDED:
-                end_time = managed_job_utils.try_to_get_job_end_time(
+                success_end_time = managed_job_utils.try_to_get_job_end_time(
                     self._backend, cluster_name)
                 # The job is done. Set the job to SUCCEEDED first before start
                 # downloading and streaming the logs to make it more responsive.
                 managed_job_state.set_succeeded(self._job_id,
                                                 task_id,
-                                                end_time=end_time,
+                                                end_time=success_end_time,
                                                 callback_func=callback_func)
                 logger.info(
                     f'Managed job {self._job_id} (task: {task_id}) SUCCEEDED. '
@@ -299,23 +299,42 @@ class JobsController:
                 if job_status is not None and not job_status.is_terminal():
                     # The multi-node job is still running, continue monitoring.
                     continue
-                elif job_status in job_lib.JobStatus.user_code_failure_states():
-                    # The user code has probably crashed, fail immediately.
-                    end_time = managed_job_utils.try_to_get_job_end_time(
-                        self._backend, cluster_name)
+                elif (job_status
+                      in job_lib.JobStatus.user_code_failure_states() or
+                      job_status == job_lib.JobStatus.FAILED_DRIVER):
+                    end_time: Optional[float] = None
+                    if job_status in job_lib.JobStatus.user_code_failure_states(
+                    ):
+                        # The user code has probably crashed, fail immediately.
+                        end_time = managed_job_utils.try_to_get_job_end_time(
+                            self._backend, cluster_name)
                     logger.info(
-                        'The user job failed. Please check the logs below.\n'
+                        f'The user job failed {job_status}. Please check the '
+                        'logs below.\n'
                         f'== Logs of the user job (ID: {self._job_id}) ==\n')
 
                     self._download_log_and_stream(task_id, handle)
+
+                    failure_reason = (
+                        'To see the details, run: '
+                        f'sky jobs logs --controller {self._job_id}')
+
                     managed_job_status = (
                         managed_job_state.ManagedJobStatus.FAILED)
                     if job_status == job_lib.JobStatus.FAILED_SETUP:
                         managed_job_status = (
                             managed_job_state.ManagedJobStatus.FAILED_SETUP)
-                    failure_reason = (
-                        'To see the details, run: '
-                        f'sky jobs logs --controller {self._job_id}')
+                    elif job_status == job_lib.JobStatus.FAILED_DRIVER:
+                        # FAILED_DRIVER is kind of an internal error, so we mark
+                        # this as FAILED_CONTROLLER, even though the failure is
+                        # not strictly within the controller.
+                        managed_job_status = (
+                            managed_job_state.ManagedJobStatus.FAILED_CONTROLLER
+                        )
+                        failure_reason = (
+                            'The job driver failed. The job may need more '
+                            'resources - try adding more CPU, memory, or disk '
+                            f'in your job definition. {failure_reason}')
                     should_restart_on_failure = (
                         self._strategy_executor.should_restart_on_failure())
                     if should_restart_on_failure:
@@ -337,6 +356,21 @@ class JobsController:
                             end_time=end_time,
                             callback_func=callback_func)
                         return False
+                elif job_status is not None:
+                    # Either the job is cancelled (should not happen) or in some
+                    # unknown new state that we do not handle.
+                    logger.error(f'Unknown job status: {job_status}')
+                    failure_reason = (
+                        f'Unknown job status {job_status}. To see the details, '
+                        f'run: sky jobs logs --controller {self._job_id}')
+                    managed_job_state.set_failed(
+                        self._job_id,
+                        task_id,
+                        failure_type=managed_job_state.ManagedJobStatus.
+                        FAILED_CONTROLLER,
+                        failure_reason=failure_reason,
+                        callback_func=callback_func)
+                    return False
                 else:
                     # Although the cluster is healthy, we fail to access the
                     # job status. Try to recover the job (will not restart the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
In #5031 we see that a managed job failing with FAILED_DRIVER causes an `AssertionError`.
Explicitly handle this case and provide a better error message.

This will also handle a CANCELLED job explicitly instead of similarly causing an `AssertionError`.

Both cases still result in `FAILED_CONTROLLER`, since these are internal failures rather than user code failures.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
