### PR TITLE
[Nebius] Update Nebius storage prefix to 'nebius://'

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -4888,8 +4888,8 @@ class NebiusStore(AbstractStore):
                 raise exceptions.StorageBucketGetError(
                     'Attempted to use a non-existent bucket as a source: '
                     f'{self.source}. Consider using `aws s3 ls '
-                    f'{self.source} --endpoint={endpoint_url}`'
-                    f'--profile={nebius.NEBIUS_PROFILE_NAME} to debug.')
+                    f's3://{self.name} --endpoint={endpoint_url}'
+                    f'--profile={nebius.NEBIUS_PROFILE_NAME}` to debug.')
 
         # If bucket cannot be found in both private and public settings,
         # the bucket is to be created by Sky. However, creation is skipped if

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -203,7 +203,7 @@ class StoreType(enum.Enum):
             return 'oci://'
         # Nebius storages use 's3://' as a prefix for various aws cli commands
         elif self == StoreType.NEBIUS:
-            return 's3://'
+            return 'nebius://'
         else:
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(f'Unknown store type: {self}')


### PR DESCRIPTION
Fix bug found during https://github.com/skypilot-org/skypilot/pull/5010

Changed the prefix from 's3://' to 'nebius://' for Nebius storages to ensure consistency and accuracy in storage type representation. This update prevents confusion with AWS S3 prefixes and aligns with Nebius-specific requirements.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] `pytest tests/smoke_tests/test_mount_and_storage.py  --nebius`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
