### PR TITLE
[DO] Remove unnecessary client call in get_credential_file_mounts

### DIFF
--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -280,7 +280,6 @@ class DO(clouds.Cloud):
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
         try:
-            do_utils.client()
             return {
                 f'~/.config/doctl/{_CREDENTIAL_FILE}': do_utils.CREDENTIALS_PATH
             }

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -1,6 +1,7 @@
 """ Digital Ocean Cloud. """
 
 import json
+import os
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
@@ -279,12 +280,11 @@ class DO(clouds.Cloud):
         return True, None
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
-        try:
-            return {
-                f'~/.config/doctl/{_CREDENTIAL_FILE}': do_utils.CREDENTIALS_PATH
-            }
-        except do_utils.DigitalOceanError:
+        if not os.path.exists(os.path.expanduser(do_utils.CREDENTIALS_PATH)):
             return {}
+        return {
+            f'~/.config/doctl/{_CREDENTIAL_FILE}': do_utils.CREDENTIALS_PATH
+        }
 
     @classmethod
     def get_current_user_identity(cls) -> Optional[List[str]]:


### PR DESCRIPTION
Fix bug found during https://github.com/skypilot-org/skypilot/pull/5010

The redundant call to do_utils.client() has been removed as it required sky-pilot[do].

Issue: If you have DO and another cloud and try to serve over the other cloud, you will receive an error message saying that the DO dependencies are not installed because get_credential_file_mounts requires all DO dependencies.

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
