### PR TITLE
[Test] Add limited dependencies test workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
   python-test:
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
         test-path:
           - tests/unit_tests
           - tests/test_api.py
@@ -48,6 +48,37 @@ jobs:
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"
+          uv pip install pytest pytest-xdist pytest-env>=0.6 memory-profiler==0.61.0
+      - name: Run tests with pytest
+        run: |
+          source ~/test-env/bin/activate
+          SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
+
+  limited-deps-test:
+    # Test with limited dependencies to ensure cloud module imports don't break
+    # basic functionality (e.g., importing IBM shouldn't break AWS support)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+        test-path:
+          - tests/test_cli.py
+          - tests/test_jobs_and_serve.py
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          python-version: ${{ matrix.python-version }}
+      - name: Install limited dependencies
+        run: |
+          uv venv --seed ~/test-env
+          source ~/test-env/bin/activate
+          uv pip install --prerelease=allow "azure-cli>=2.65.0"
+          # Install limited dependencies only
+          uv pip install -e ".[kubernetes,aws,gcp,azure]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 memory-profiler==0.61.0
       - name: Run tests with pytest
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
   python-test:
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8"]
         test-path:
           - tests/unit_tests
           - tests/test_api.py
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8"]
         test-path:
           - tests/test_cli.py
           - tests/test_jobs_and_serve.py

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -40,6 +40,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 import click
 import colorama
 import dotenv
+import nebius
 import requests as requests_lib
 from rich import progress as rich_progress
 import yaml
@@ -3286,6 +3287,7 @@ def show_gpus(
       in the Kubernetes cluster. This is fetched in real-time and may change
       when other users are using the cluster.
     """
+    logger.info(f'nebius: {nebius}')
     # validation for the --region flag
     if region is not None and cloud is None:
         raise click.UsageError(

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -40,7 +40,6 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 import click
 import colorama
 import dotenv
-import nebius
 import requests as requests_lib
 from rich import progress as rich_progress
 import yaml
@@ -3287,7 +3286,6 @@ def show_gpus(
       in the Kubernetes cluster. This is fetched in real-time and may change
       when other users are using the cluster.
     """
-    logger.info(f'nebius: {nebius}')
     # validation for the --region flag
     if region is not None and cloud is None:
         raise click.UsageError(

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -713,7 +713,7 @@ class Optimizer:
         if message_data:
             metric = 'COST ($)' if minimize_cost else 'TIME (s)'
             table = _create_table(['SOURCE', 'TARGET', 'SIZE (GB)', metric])
-            table.add_rows(reversed(message_data))
+            table.add_rows(list(reversed(message_data)))
             logger.info(f'Egress plan:\n{table}\n')
 
     @staticmethod


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduces a new test job `limited-deps-test` to the GitHub Actions workflow that:

* Tests core functionality with only essential cloud dependencies installed (Kubernetes, AWS, GCP, Azure)
* Verifies our code works when only a subset of cloud services are installed
* Runs on a subset of test files (`test_cli.py` and `test_jobs_and_serve.py`)

The change helps ensure basic functionality remains intact even when not all cloud providers are installed, improving the robustness of the package's dependency management.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] We will [fail](https://github.com/skypilot-org/skypilot/actions/runs/14101327377/job/39497987894?pr=5047) if we break the import dependency in our code
  
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
