### PR TITLE
Fix .gitignore incorrect upload issue and broken tests

### DIFF
--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -202,7 +202,7 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
 
         for item in output_list:
 
-            if repo == '.' and item == './':
+            if repo == '' and item == './':
                 logger.warning(f'{src_dir_path} is within a git repo, but the '
                                'entire directory is ignored by git. We will '
                                'ignore all git exclusions. '

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -172,7 +172,7 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
     submodules = submodules_output.stdout.split('\0')[:-1]
 
     # The empty string is the relative reference to the src_dir_path.
-    all_git_repos = ['.'] + [
+    all_git_repos = [''] + [
         # We only care about submodules that are a subdirectory of src_dir_path.
         submodule for submodule in submodules if not submodule.startswith('../')
     ]

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -18,12 +18,6 @@ from sky.utils import log_utils
 
 logger = sky_logging.init_logger(__name__)
 
-_FILE_EXCLUSION_FROM_GITIGNORE_FAILURE_MSG = (
-    f'{colorama.Fore.YELLOW}Warning: Files/dirs '
-    'specified in .gitignore will be uploaded '
-    'to the cloud storage for {path!r}'
-    'due to the following error: {error_msg!r}')
-
 _USE_SKYIGNORE_HINT = (
     'To avoid using .gitignore, you can create a .skyignore file instead.')
 

--- a/sky/data/storage_utils.py
+++ b/sky/data/storage_utils.py
@@ -195,25 +195,19 @@ def get_excluded_files_from_gitignore(src_dir_path: str) -> List[str]:
                                 text=True)
         # Don't catch any errors. We would only expect to see errors during the
         # first git invocation - so if we see any here, crash.
+
         output_list = output.stdout.split('\0')
         # trim the empty string at the end
         output_list = output_list[:-1]
+
         for item in output_list:
-            if repo == '':
-                check_dir_cmd = (f'git -C {shlex.quote(repo_path)} '
-                                 'check-ignore -q .')
-                dir_ignored = subprocess.run(check_dir_cmd,
-                                             shell=True,
-                                             stderr=subprocess.PIPE,
-                                             check=False)
-                # Exit code 0 means the path is ignored
-                if dir_ignored.returncode == 0:
-                    logger.warning(
-                        f'{src_dir_path} is within a git repo, but the '
-                        'entire directory is ignored by git. We will '
-                        'ignore all git exclusions. '
-                        f'{_USE_SKYIGNORE_HINT}')
-                    return []
+
+            if repo == '.' and item == './':
+                logger.warning(f'{src_dir_path} is within a git repo, but the '
+                               'entire directory is ignored by git. We will '
+                               'ignore all git exclusions. '
+                               f'{_USE_SKYIGNORE_HINT}')
+                return []
 
             to_be_excluded = os.path.join(repo, item)
             if item.endswith('/'):

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1106,6 +1106,9 @@ class TestStorageWithCredentials:
         # with .gitignore and .git/info/exclude files to test exclude filter.
         # Stores must be added in the test.
         with tempfile.TemporaryDirectory() as tmpdir:
+            # Initialize git repository
+            subprocess.check_call(['git', 'init'], cwd=tmpdir)
+
             # Creates file structure to be uploaded in the Storage
             self.create_dir_structure(tmpdir, gitignore_structure)
 
@@ -1117,7 +1120,6 @@ class TestStorageWithCredentials:
 
             # Create .git/info/exclude and list files/dirs to be excluded in it
             temp_path = f'{tmpdir}/.git/info/'
-            os.makedirs(temp_path)
             temp_exclude_path = os.path.join(temp_path, 'exclude')
             file_path = os.path.join(skypilot_path,
                                      'tests/git_info_exclude_test')

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -1692,29 +1692,19 @@ class TestStorageWithCredentials:
 
     @pytest.mark.no_vast  # Requires AWS or S3
     @pytest.mark.no_fluidstack
-    @pytest.mark.parametrize('gitignore_structure, store_type, test_case', [
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.S3, 'normal'),
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.GCS,
-         'normal'),
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.AZURE,
-         'normal'),
-        pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
-                     storage_lib.StoreType.R2,
-                     'normal',
-                     marks=pytest.mark.cloudflare),
-        pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
-                     storage_lib.StoreType.NEBIUS,
-                     'normal',
-                     marks=pytest.mark.nebius),
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.S3,
-         'asterisk'),
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.GCS,
-         'asterisk'),
-        (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.AZURE,
-         'asterisk')
-    ])
+    @pytest.mark.parametrize(
+        'gitignore_structure, store_type',
+        [(GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.S3),
+         (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.GCS),
+         (GITIGNORE_SYNC_TEST_DIR_STRUCTURE, storage_lib.StoreType.AZURE),
+         pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
+                      storage_lib.StoreType.R2,
+                      marks=pytest.mark.cloudflare),
+         pytest.param(GITIGNORE_SYNC_TEST_DIR_STRUCTURE,
+                      storage_lib.StoreType.NEBIUS,
+                      marks=pytest.mark.nebius)])
     def test_excluded_file_cloud_storage_upload_copy(self, gitignore_structure,
-                                                     store_type, test_case,
+                                                     store_type,
                                                      tmp_gitignore_storage_obj):
         # tests if files included in .gitignore and .git/info/exclude are
         # excluded from being transferred to Storage
@@ -1723,13 +1713,6 @@ class TestStorageWithCredentials:
             # We have to specify the region for Azure storage, as the default
             # Azure storage account is in centralus region.
             region_kwargs['region'] = 'centralus'
-
-        # For the asterisk test case, modify the .gitignore file to just contain "*"
-        if test_case == 'asterisk':
-            gitignore_path = os.path.join(tmp_gitignore_storage_obj.source,
-                                          constants.GIT_IGNORE_FILE)
-            with open(gitignore_path, 'w', encoding='utf-8') as f:
-                f.write('*\n')
 
         tmp_gitignore_storage_obj.add_store(store_type, **region_kwargs)
         upload_file_name = 'included'
@@ -1745,22 +1728,14 @@ class TestStorageWithCredentials:
                                                      shell=True)
         cnt_output = subprocess.check_output(cnt_num_file_cmd, shell=True)
 
-        if test_case == 'normal':
-            assert '3' in up_output.decode('utf-8'), \
-                    'Files to be included are not completely uploaded.'
-            # 1 is read as .gitignore is uploaded
-            assert '1' in git_exclude_output.decode('utf-8'), \
-                   '.git directory should not be uploaded.'
-            # 4 files include .gitignore, included.log, included.txt, include_dir/included.log
-            assert '4' in cnt_output.decode('utf-8'), \
-                   'Some items listed in .gitignore and .git/info/exclude are not excluded.'
-        else:  # test_case == 'asterisk'
-            # Check that all files are uploaded (ignoring .git directory)
-            cnt_output_str = cnt_output.decode('utf-8').strip()
-            # All 29 files should be uploaded, ignoring .git directory
-            assert int(cnt_output_str) == 29, \
-                   f'Expected 29 files, but got {cnt_output_str}. ' \
-                   'The .gitignore with "*" should not exclude any files.'
+        assert '3' in up_output.decode('utf-8'), \
+                'Files to be included are not completely uploaded.'
+        # 1 is read as .gitignore is uploaded
+        assert '1' in git_exclude_output.decode('utf-8'), \
+               '.git directory should not be uploaded.'
+        # 4 files include .gitignore, included.log, included.txt, include_dir/included.log
+        assert '4' in cnt_output.decode('utf-8'), \
+               'Some items listed in .gitignore and .git/info/exclude are not excluded.'
 
     @pytest.mark.no_vast  # Requires AWS or S3
     @pytest.mark.parametrize('ext_bucket_fixture, store_type',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

After #4988, this [test](https://buildkite.com/skypilot-1/smoke-tests/builds/464#0195d568-bb6b-4d64-ac04-442f139e66f5) is broken.

This PR:
* Resolves #5045 by adding `git init` when creating test data so that we won't ignore the `.gitignore` file. On master it goes to this [code branch](https://github.com/skypilot-org/skypilot/blob/master/sky/data/storage_utils.py#L149) and uploads all files which is not expected.
* Replaces the `['.']` with `['']` so that our upload command changes to the correct one:
  * Before: 
    ```bash 
    sync_command: aws s3 sync --no-follow-symlinks --exclude './double_asterisk/*' --exclude ./double_asterisk/double_asterisk_excluded --exclude './double_asterisk/double_asterisk_excluded_dir/*' --exclude './double_asterisk_parent/*' --exclude './double_asterisk_parent/parent/*' --exclude ./double_asterisk_parent/parent/also_excluded.txt --exclude './double_asterisk_parent/parent/child/*' --exclude ./double_asterisk_parent/parent/child/double_asterisk_parent_child_excluded.txt --exclude ./double_asterisk_parent/parent/double_asterisk_parent_excluded.txt --exclude ./excluded.log --exclude './excluded_dir/*' --exclude './exp-1/*' --exclude './exp-2/*' --exclude ./front_slash_excluded --exclude ./include_dir/excluded.log --exclude './nested_double_asterisk/*' --exclude './nested_double_asterisk/one/*' --exclude ./nested_double_asterisk/one/also_exclude.txt --exclude './nested_double_asterisk/two/*' --exclude ./nested_double_asterisk/two/also_exclude.txt --exclude './nested_wildcard_dir/*' --exclude './nested_wildcard_dir/monday/*' --exclude ./nested_wildcard_dir/monday/also_exclude.txt --exclude './nested_wildcard_dir/tuesday/*' --exclude ./nested_wildcard_dir/tuesday/also_exclude.txt --exclude ./no_slash_excluded --exclude './no_slash_tests/*' --exclude './no_slash_tests/no_slash_excluded/*' --exclude './question_mark/*' --exclude ./question_mark/excluded1.txt --exclude ./question_mark/excluded@.txt --exclude './square_bracket/*' --exclude ./square_bracket/excluded1.txt --exclude './square_bracket_alpha/*' --exclude ./square_bracket_alpha/excludedz.txt --exclude './square_bracket_excla/*' --exclude ./square_bracket_excla/excluded2.txt --exclude ./square_bracket_excla/excluded@.txt --exclude './square_bracket_single/*' --exclude ./square_bracket_single/excluded0.txt --exclude '.git/*' /var/folders/83/zxqx914s57x310rfnhq8kk9r0000gn/T/tmp08gt37gk s3://sky-test-1743071160166492/
    ```
  * After:
    ```bash
    sync_command: aws s3 sync --no-follow-symlinks --exclude 'double_asterisk/*' --exclude double_asterisk/double_asterisk_excluded --exclude 'double_asterisk/double_asterisk_excluded_dir/*' --exclude 'double_asterisk_parent/*' --exclude 'double_asterisk_parent/parent/*' --exclude double_asterisk_parent/parent/also_excluded.txt --exclude 'double_asterisk_parent/parent/child/*' --exclude double_asterisk_parent/parent/child/double_asterisk_parent_child_excluded.txt --exclude double_asterisk_parent/parent/double_asterisk_parent_excluded.txt --exclude excluded.log --exclude 'excluded_dir/*' --exclude 'exp-1/*' --exclude 'exp-2/*' --exclude front_slash_excluded --exclude include_dir/excluded.log --exclude 'nested_double_asterisk/*' --exclude 'nested_double_asterisk/one/*' --exclude nested_double_asterisk/one/also_exclude.txt --exclude 'nested_double_asterisk/two/*' --exclude nested_double_asterisk/two/also_exclude.txt --exclude 'nested_wildcard_dir/*' --exclude 'nested_wildcard_dir/monday/*' --exclude nested_wildcard_dir/monday/also_exclude.txt --exclude 'nested_wildcard_dir/tuesday/*' --exclude nested_wildcard_dir/tuesday/also_exclude.txt --exclude no_slash_excluded --exclude 'no_slash_tests/*' --exclude 'no_slash_tests/no_slash_excluded/*' --exclude 'question_mark/*' --exclude question_mark/excluded1.txt --exclude question_mark/excluded@.txt --exclude 'square_bracket/*' --exclude square_bracket/excluded1.txt --exclude 'square_bracket_alpha/*' --exclude square_bracket_alpha/excludedz.txt --exclude 'square_bracket_excla/*' --exclude square_bracket_excla/excluded2.txt --exclude square_bracket_excla/excluded@.txt --exclude 'square_bracket_single/*' --exclude square_bracket_single/excluded0.txt --exclude '.git/*' /var/folders/83/zxqx914s57x310rfnhq8kk9r0000gn/T/tmpzi1fqepb s3://sky-test-1743072142109447/
    ```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_excluded_file_cloud_storage_upload_copy --aws`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
