### PR TITLE
correct security contexts

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -205,15 +205,12 @@ gcpCredentials:
   # TODO(romilb): This can be made optional by using the project in the key json by default.
   projectId: null
 
+
 # Set securityContext for the api pod
-securityContext:
-  capabilities:
-    drop:
-    - ALL  
-  allowPrivilegeEscalation: false
+podSecurityContext: {}
 
 # Set securityContext for the api container inside the api pod
-podSecurityContext: 
+securityContext:
   capabilities:
     drop:
     - ALL  


### PR DESCRIPTION
Remove the pod security context values, they were just a dupe of the container ones, which is incorrect and causes errors.

[Pod securityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) does not have `allowPrivilegeEscalation` nor `capabilities`

[Container securityContext](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) does have `allowPrivilegeEscalation` and `capabilities`


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Manual test:
I had to set the value to `null` when I was deploying the helm chart, otherwise it didn't work.

Not sure other tests for the helm chart now