### PR TITLE
[Serve] Add endpoint caching for status `--endpoint`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1800,7 +1800,7 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
     if show_services:
         # Run the sky serve service query in parallel to speed up the
         # status query.
-        service_status_request_id = serve_lib.status(service_names=None, 
+        service_status_request_id = serve_lib.status(service_names=None,
                                                      use_endpoint_cache=False)
 
     if ip or show_endpoints:
@@ -2899,7 +2899,7 @@ def _hint_or_raise_for_down_sky_serve_controller(controller_name: str,
     assert controller is not None, controller_name
     with rich_utils.client_status('[bold cyan]Checking for live services[/]'):
         try:
-            request_id = serve_lib.status(service_names=None, 
+            request_id = serve_lib.status(service_names=None,
                                           use_endpoint_cache=False)
             services = sdk.stream_and_get(request_id)
         except exceptions.ClusterNotUpError as e:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1472,7 +1472,6 @@ def _handle_services_request(
         service_names: Optional[List[str]],
         show_all: bool,
         show_endpoint: bool,
-        use_endpoint_cache: bool,
         is_called_by_user: bool = False) -> Tuple[Optional[int], str]:
     """Get service statuses.
 
@@ -1480,8 +1479,6 @@ def _handle_services_request(
         service_names: If not None, only show the statuses of these services.
         show_all: Show all information of each service.
         show_endpoint: If True, only show the endpoint of the service.
-        use_endpoint_cache: If True, return the endpoint of the service stored
-            in the cache. Only used when show_endpoint is True.
         is_called_by_user: If this function is called by user directly, or an
             internal call.
 
@@ -1922,7 +1919,6 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
                         service_names=None,
                         show_all=False,
                         show_endpoint=False,
-                        use_endpoint_cache=False,
                         is_called_by_user=False)
                 except KeyboardInterrupt:
                     sdk.api_cancel(service_status_request_id, silent=True)
@@ -4538,7 +4534,8 @@ def serve_status(verbose: bool, endpoint: bool, force_refresh: bool,
     provided, show all services' status. If --endpoint is specified, output
     the endpoint of the service only. When the command is invoked with
     --endpoint, the returned endpoint will be cached for future invocations.
-    The cache can be refreshed by using the --force-refresh flag.
+    The cache can be refreshed by using the --force-refresh flag (only
+    applicable when --endpoint flag is used).
 
     Each service can have one of the following statuses:
 
@@ -4637,12 +4634,10 @@ def serve_status(verbose: bool, endpoint: bool, force_refresh: bool,
     # This won't pollute the output of --endpoint.
     with rich_utils.client_status('[cyan]Checking services[/]'):
         service_status_request_id = serve_lib.status(service_names_to_query)
-        use_cache = not force_refresh
         _, msg = _handle_services_request(service_status_request_id,
                                           service_names=service_names_to_query,
                                           show_all=verbose,
                                           show_endpoint=endpoint,
-                                          use_endpoint_cache=use_cache,
                                           is_called_by_user=True)
 
     if not endpoint:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4633,7 +4633,9 @@ def serve_status(verbose: bool, endpoint: bool, force_refresh: bool,
         service_names_to_query = None
     # This won't pollute the output of --endpoint.
     with rich_utils.client_status('[cyan]Checking services[/]'):
-        service_status_request_id = serve_lib.status(service_names_to_query)
+        use_endpoint_cache = endpoint and not force_refresh
+        service_status_request_id = serve_lib.status(service_names_to_query,
+                                                     use_endpoint_cache)
         _, msg = _handle_services_request(service_status_request_id,
                                           service_names=service_names_to_query,
                                           show_all=verbose,

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1800,7 +1800,8 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
     if show_services:
         # Run the sky serve service query in parallel to speed up the
         # status query.
-        service_status_request_id = serve_lib.status(service_names=None)
+        service_status_request_id = serve_lib.status(service_names=None, 
+                                                     use_endpoint_cache=False)
 
     if ip or show_endpoints:
         if refresh:
@@ -2898,7 +2899,8 @@ def _hint_or_raise_for_down_sky_serve_controller(controller_name: str,
     assert controller is not None, controller_name
     with rich_utils.client_status('[bold cyan]Checking for live services[/]'):
         try:
-            request_id = serve_lib.status(service_names=None)
+            request_id = serve_lib.status(service_names=None, 
+                                          use_endpoint_cache=False)
             services = sdk.stream_and_get(request_id)
         except exceptions.ClusterNotUpError as e:
             if controller.value.connection_error_hint in str(e):

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -213,10 +213,8 @@ def terminate_replica(service_name: str, replica_id: int,
 
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
-def status(
-        service_names: Optional[Union[str,
-                                      List[str]]],
-        use_endpoint_cache: bool) -> server_common.RequestId:
+def status(service_names: Optional[Union[str, List[str]]],
+           use_endpoint_cache: bool) -> server_common.RequestId:
     """Gets service statuses.
 
     If service_names is given, return those services. Otherwise, return all

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -215,7 +215,8 @@ def terminate_replica(service_name: str, replica_id: int,
 @server_common.check_server_healthy_or_start
 def status(
         service_names: Optional[Union[str,
-                                      List[str]]]) -> server_common.RequestId:
+                                      List[str]]],
+        use_endpoint_cache: bool) -> server_common.RequestId:
     """Gets service statuses.
 
     If service_names is given, return those services. Otherwise, return all
@@ -261,6 +262,9 @@ def status(
     Args:
         service_names: a single or a list of service names to query. If None,
             query all services.
+        use_endpoint_cache: flag whether to use endpoint caching. It is
+            important to note that other values in the cache apart from the
+            endpoint may be (more) stale.
 
     Returns:
         The request ID of the status request.
@@ -274,7 +278,8 @@ def status(
         RuntimeError: if failed to get the service status.
         exceptions.ClusterNotUpError: if the sky serve controller is not up.
     """
-    body = payloads.ServeStatusBody(service_names=service_names,)
+    body = payloads.ServeStatusBody(service_names=service_names,
+                                    use_endpoint_cache=use_endpoint_cache)
     response = requests.post(
         f'{server_common.get_server_url()}/serve/status',
         json=json.loads(body.model_dump_json()),

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -593,3 +593,11 @@ def set_endpoint_cache(service_name: str, endpoint: str) -> None:
             INSERT or REPLACE INTO endpoint_cache
             (service_name, endpoint)
             VALUES (?, ?)""", (service_name, endpoint))
+
+def delete_endpoint_cache(service_name: str) -> None:
+    """Removes endpoint cache (ignores missing case)."""
+    with db_utils.safe_cursor(_DB_PATH) as cursor:
+        cursor.execute(
+            """\
+            DELETE FROM endpoint_cache
+            WHERE service_name=(?)""", (service_name,))

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -566,12 +566,14 @@ def get_endpoint_cache(
     service_names: Optional[Union[str,
                                   List[str]]] = None) -> List[Dict[str, str]]:
     """Gets endpoint cache values for services."""
-    if service_names is not None:
-        if isinstance(service_names, str):
-            service_names = [service_names]
+    if service_names is None:
+        service_names = []
+    elif isinstance(service_names, str):
+        service_names = [service_names]
+
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = None
-        if service_names is None or len(service_names) == 0:
+        if not service_names:
             rows = cursor.execute("""SELECT * FROM endpoint_cache""")
         else:
             placeholder = ', '.join(['?'] * len(service_names))

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -574,18 +574,15 @@ def get_endpoint_cache(
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = None
         if not service_names:
-            rows = cursor.execute("""SELECT * FROM endpoint_cache""")
+            rows = cursor.execute("""SELECT * FROM endpoint_cache""").fetchall()
         else:
             placeholder = ', '.join(['?'] * len(service_names))
             rows = cursor.execute(
                 f"""\
                 SELECT * FROM endpoint_cache
-                WHERE service_name IN ({placeholder})""", tuple(service_names))
-    endpoints = []
-    for row in rows:
-        (name, endpoint) = row[:2]
-        endpoints.append({name: endpoint})
-    return endpoints
+                WHERE service_name IN ({placeholder})""",
+                tuple(service_names)).fetchall()
+    return [{'name': row[0], 'endpoint': row[1]} for row in rows]
 
 
 def set_endpoint_cache(service_name: str, endpoint: str) -> None:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -560,9 +560,11 @@ def delete_all_versions(service_name: str) -> None:
             DELETE FROM version_specs
             WHERE service_name=(?)""", (service_name,))
 
+
 # == Endpoint Cache functions ==
 def get_endpoint_cache(
-        service_names: Optional[Union[str, List[str]]] = None) -> Dict[str, str]:
+    service_names: Optional[Union[str,
+                                  List[str]]] = None) -> List[Dict[str, str]]:
     """Gets endpoint cache values for services."""
     if service_names is not None:
         if isinstance(service_names, str):
@@ -570,20 +572,19 @@ def get_endpoint_cache(
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = None
         if service_names is None or len(service_names) == 0:
-            rows = cursor.execute(
-                """SELECT * FROM endpoint_cache""")
+            rows = cursor.execute("""SELECT * FROM endpoint_cache""")
         else:
-            placeholder = ", ".join(["?"] * len(service_names))
+            placeholder = ', '.join(['?'] * len(service_names))
             rows = cursor.execute(
                 f"""\
                 SELECT * FROM endpoint_cache
-                WHERE service_name IN ({placeholder})""",
-                tuple(service_names))
+                WHERE service_name IN ({placeholder})""", tuple(service_names))
     endpoints = []
     for row in rows:
         (name, endpoint) = row[:2]
-        endpoints.append({ name: endpoint })
+        endpoints.append({name: endpoint})
     return endpoints
+
 
 def set_endpoint_cache(service_name: str, endpoint: str) -> None:
     """Sets endpoint cache value for a specific service."""
@@ -593,6 +594,7 @@ def set_endpoint_cache(service_name: str, endpoint: str) -> None:
             INSERT or REPLACE INTO endpoint_cache
             (service_name, endpoint)
             VALUES (?, ?)""", (service_name, endpoint))
+
 
 def delete_endpoint_cache(
         service_names: Optional[Union[str, List[str]]] = None) -> None:
@@ -604,9 +606,9 @@ def delete_endpoint_cache(
 
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         if not service_names:
-            cursor.execute("DELETE FROM endpoint_cache")
+            cursor.execute("""DELETE FROM endpoint_cache""")
         else:
-            placeholder = ", ".join(["?"] * len(service_names))
+            placeholder = ', '.join(['?'] * len(service_names))
             cursor.execute(
                 f"""\
                 DELETE FROM endpoint_cache

--- a/sky/serve/server/core.py
+++ b/sky/serve/server/core.py
@@ -639,7 +639,8 @@ def terminate_replica(service_name: str, replica_id: int, purge: bool) -> None:
 @usage_lib.entrypoint
 def status(
     service_names: Optional[Union[str,
-                                  List[str]]] = None) -> List[Dict[str, Any]]:
+                                  List[str]]] = None,
+    use_endpoint_cache: bool = False) -> List[Dict[str, Any]]:
     """Gets service statuses.
 
     If service_names is given, return those services. Otherwise, return all
@@ -686,10 +687,14 @@ def status(
     Args:
         service_names: a single or a list of service names to query. If None,
             query all services.
+        use_endpoint_cache: whether endpoint caching is used (for --endpoint).
 
     Returns:
         A list of dicts, with each dict containing the information of a service.
         If a service is not found, it will be omitted from the returned list.
+        When use_endpoint_cache is True, the endpoint for the service will be
+        retrieved from the cache (if exists). Returned dictionary will leave
+        some fields blank (ie: uptime, active_versions, etc).
 
     Raises:
         RuntimeError: if failed to get the service status.
@@ -698,6 +703,8 @@ def status(
     if service_names is not None:
         if isinstance(service_names, str):
             service_names = [service_names]
+
+    # TODO(kyuds): implement caching logic here. 
 
     try:
         backend_utils.check_network_connection()

--- a/sky/serve/server/core.py
+++ b/sky/serve/server/core.py
@@ -562,10 +562,10 @@ def down(
         argument_str += ' all' if all else ''
         raise ValueError('Can only specify one of service_names or all. '
                          f'Provided {argument_str!r}.')
-    
+
     # Clear cache if we have a valid set of inputs. We can always recache.
     serve_state.delete_endpoint_cache(None if all else service_names)
-    
+
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
     service_names = None if all else service_names
@@ -640,10 +640,8 @@ def terminate_replica(service_name: str, replica_id: int, purge: bool) -> None:
 
 
 @usage_lib.entrypoint
-def status(
-    service_names: Optional[Union[str,
-                                  List[str]]] = None,
-    use_endpoint_cache: bool = False) -> List[Dict[str, Any]]:
+def status(service_names: Optional[Union[str, List[str]]] = None,
+           use_endpoint_cache: bool = False) -> List[Dict[str, Any]]:
     """Gets service statuses.
 
     If service_names is given, return those services. Otherwise, return all
@@ -709,10 +707,12 @@ def status(
 
     if use_endpoint_cache:
         cached_records = serve_state.get_endpoint_cache(service_names)
-        if (service_names is None or len(service_names) == 0) and not cached_records:
+        if (service_names is None or
+                len(service_names) == 0) and not cached_records:
             logger.debug('Unspecified status check returned 0 cached '
                          'entries. Querying controller.')
-        elif service_names is not None and len(service_names) > 0 and len(service_names) != len(cached_records):
+        elif service_names is not None and len(service_names) > 0 and len(
+                service_names) != len(cached_records):
             logger.debug('Number of services queried did not match number of '
                          'cached records. Querying controller.')
         else:
@@ -766,7 +766,9 @@ def status(
                 protocol = ('https'
                             if service_record['tls_encrypted'] else 'http')
                 service_record['endpoint'] = f'{protocol}://{endpoint}'
-                serve_state.set_endpoint_cache(service_name=service_record['name'], endpoint=service_record['endpoint'])
+                serve_state.set_endpoint_cache(
+                    service_name=service_record['name'],
+                    endpoint=service_record['endpoint'])
 
     return service_records
 

--- a/sky/serve/server/core.py
+++ b/sky/serve/server/core.py
@@ -750,7 +750,7 @@ def status(service_names: Optional[Union[str, List[str]]] = None,
                                            stream_logs=True)
     except exceptions.CommandError as e:
         raise RuntimeError(e.error_msg) from e
-    
+
     # now that we've got some data back, we are going to clear cache for
     # the services we queried. We do this because external causes might
     # bring serve down (ie: user just terminates everything on AWS console)
@@ -774,7 +774,7 @@ def status(service_names: Optional[Union[str, List[str]]] = None,
                 service_record['endpoint'] = f'{protocol}://{endpoint}'
                 # we only cache is service is Ready. This is mostly to prevent
                 # status calls called after "down" to cache terminating
-                # endpoints. 
+                # endpoints.
                 if service_record['status'] == serve_state.ServiceStatus.READY:
                     serve_state.set_endpoint_cache(
                         service_name=service_record['name'],

--- a/sky/serve/server/core.py
+++ b/sky/serve/server/core.py
@@ -562,7 +562,10 @@ def down(
         argument_str += ' all' if all else ''
         raise ValueError('Can only specify one of service_names or all. '
                          f'Provided {argument_str!r}.')
-
+    
+    # Clear cache if we have a valid set of inputs. We can always recache.
+    serve_state.delete_endpoint_cache(None if all else service_names)
+    
     backend = backend_utils.get_backend_from_handle(handle)
     assert isinstance(backend, backends.CloudVmRayBackend)
     service_names = None if all else service_names
@@ -704,7 +707,16 @@ def status(
         if isinstance(service_names, str):
             service_names = [service_names]
 
-    # TODO(kyuds): implement caching logic here. 
+    if use_endpoint_cache:
+        cached_records = serve_state.get_endpoint_cache(service_names)
+        if (service_names is None or len(service_names) == 0) and not cached_records:
+            logger.debug('Unspecified status check returned 0 cached '
+                         'entries. Querying controller.')
+        elif service_names is not None and len(service_names) > 0 and len(service_names) != len(cached_records):
+            logger.debug('Number of services queried did not match number of '
+                         'cached records. Querying controller.')
+        else:
+            return cached_records
 
     try:
         backend_utils.check_network_connection()
@@ -754,6 +766,7 @@ def status(
                 protocol = ('https'
                             if service_record['tls_encrypted'] else 'http')
                 service_record['endpoint'] = f'{protocol}://{endpoint}'
+                serve_state.set_endpoint_cache(service_name=service_record['name'], endpoint=service_record['endpoint'])
 
     return service_records
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -421,6 +421,8 @@ class ServeLogsBody(RequestBody):
 class ServeStatusBody(RequestBody):
     """The request body for the serve status endpoint."""
     service_names: Optional[Union[str, List[str]]]
+    # only True when --endpoint and not --force-refresh
+    use_endpoint_cache: bool = False
 
 
 class RealtimeGpuAvailabilityRequestBody(RequestBody):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Addresses #2915 

This is a caching feature to cache the output for `sky serve status --endpoint`. When `sky serve up` is invoked or `sky serve status` is invoked, then the returned serve endpoint will be cached to the db table `endpoint_cache` under `~/.sky/serve/service.db`.

This endpoint is cached on two conditions:
1. Caching the return value of `sky serve up`.
2. Caching the return of `sky serve status` IFF the `ServiceStatus` enum is `Ready`.

This endpoint is removed from the cache on two conditions:
1. The return `ServiceStatus` of `sky serve status` is not `Ready`.
2. `sky serve down` is invoked.

Also there is a new flag called `--force-refresh` that only takes into effect when `--endpoint` is also used, which effectively is used to bypass the cache and query the serve controller.

One thing I wanted to ask though is I had to make a helper function called `_make_dummy` in line 649 of `serve/server/core.py`, which creates dummy data to simulate the return schema of a status request. Without this the code seems to go into an infinitely spinning loop. I couldn't really find where the schema is enforced, and couldn't really determine whether it is appropriate at all to remove the schema enforcement anyways. If the dummy data present in `_make_dummy` doesn't seem right, I will be more than happy to modify it!

<`_make_dummy` function in question>
```
def _make_dummy(cached_record: Dict[str, str]) -> Dict[str, Any]:
    """Dummy data for service status.

    sky serve status --endpoint deadlocks if we do not return
    the complete schema.
    """
    service_name = cached_record['name']
    endpoint = cached_record['endpoint']
    return {
        'name': service_name,
        'active_versions': [],
        'controller_job_id': -1,
        'uptime': -1,
        'status': serve_state.ServiceStatus.READY,
        'controller_port': None,
        'load_balancer_port': None,
        'endpoint': endpoint,
        'policy': None,
        'requested_resources_str': '',
        'load_balancing_policy': '',
        'tls_encrypted': False,
        'replica_info': []
    }
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
```
sky serve status --endpoint
sky serve status --endpoint --force-refresh
sky serve status <service_name> --endpoint
sky serve status <service_name> --endpoint --force-refresh
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->