### PR TITLE
[API server] Be patient if process is alive

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -222,7 +222,7 @@ def _start_api_server(deploy: bool = False,
         # Server might be just starting slowly (e.g. in high contetion env)
         # if it did not exit, so we set a conservative wait timeout that
         # unlikely to reach and exit eagerly if server exit.
-        timeout_secs = 60
+        timeout_sec = 60
         start_time = time.time()
         while True:
             # Check if process has exited
@@ -239,7 +239,7 @@ def _start_api_server(deploy: bool = False,
                 f'Client version: {server_constants.API_VERSION}')
             if api_server_info.status == ApiServerStatus.HEALTHY:
                 break
-            elif time.time() - start_time >= timeout_secs:
+            elif time.time() - start_time >= timeout_sec:
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(
                         'Failed to start SkyPilot API server at '

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -465,7 +465,7 @@ def start(deploy: bool) -> List[multiprocessing.Process]:
             target=mp_queue.start_queue_manager, args=(queue_names, port))
         queue_server.start()
         sub_procs.append(queue_server)
-        mp_queue.wait_for_queues_to_be_ready(queue_names, port=port)
+        mp_queue.wait_for_queues_to_be_ready(queue_names, queue_server, port)
 
     logger.info('Request queues created')
 

--- a/sky/server/requests/queues/mp_queue.py
+++ b/sky/server/requests/queues/mp_queue.py
@@ -1,4 +1,5 @@
 """Shared queues for multiprocessing."""
+import multiprocessing
 from multiprocessing import managers
 import queue
 import time
@@ -57,10 +58,13 @@ def get_queue(queue_name: str,
 
 
 def wait_for_queues_to_be_ready(queue_names: List[str],
+                                queue_server: multiprocessing.Process,
                                 port: int = DEFAULT_QUEUE_MANAGER_PORT) -> None:
     """Wait for the queues to be ready after queue manager is just started."""
     initial_time = time.time()
-    max_wait_time = 5
+    # Wait for queue manager to be ready. Exit eagerly if the manager process
+    # exits, just wait for a long timeout that is unlikely to reach otherwise.
+    timeout = 60
     while queue_names:
         try:
             get_queue(queue_names[0], port)
@@ -70,7 +74,10 @@ def wait_for_queues_to_be_ready(queue_names: List[str],
             logger.info(f'Waiting for request queue, named {queue_names[0]!r}, '
                         f'to be ready...')
             time.sleep(0.2)
-            if time.time() - initial_time > max_wait_time:
+            if not queue_server.is_alive():
+                raise RuntimeError(
+                    'Queue manager process exited unexpectedly.') from e
+            if time.time() - initial_time > timeout:
                 raise RuntimeError(
                     f'Request queue, named {queue_names[0]!r}, '
-                    f'is not ready after {max_wait_time} seconds.') from e
+                    f'is not ready after {timeout} seconds.') from e

--- a/sky/server/requests/queues/mp_queue.py
+++ b/sky/server/requests/queues/mp_queue.py
@@ -64,7 +64,7 @@ def wait_for_queues_to_be_ready(queue_names: List[str],
     initial_time = time.time()
     # Wait for queue manager to be ready. Exit eagerly if the manager process
     # exits, just wait for a long timeout that is unlikely to reach otherwise.
-    timeout = 60
+    max_wait_time = 60
     while queue_names:
         try:
             get_queue(queue_names[0], port)
@@ -77,7 +77,7 @@ def wait_for_queues_to_be_ready(queue_names: List[str],
             if not queue_server.is_alive():
                 raise RuntimeError(
                     'Queue manager process exited unexpectedly.') from e
-            if time.time() - initial_time > timeout:
+            if time.time() - initial_time > max_wait_time:
                 raise RuntimeError(
                     f'Request queue, named {queue_names[0]!r}, '
-                    f'is not ready after {timeout} seconds.') from e
+                    f'is not ready after {max_wait_time} seconds.') from e

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1116,7 +1116,7 @@ if __name__ == '__main__':
 
     sub_procs = []
     try:
-        sub_procs = executor.start(cmd_args.deploy)
+        sub_procs = executor.start(deploy=cmd_args.deploy)
         logger.info(f'Starting SkyPilot API server, workers={num_workers}')
         # We don't support reload for now, since it may cause leakage of request
         # workers or interrupt running requests.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5057

Backward compat test is now flaky due to resource contention issue. Before we get API server more resource-efficient, we can just be patient on timeout if the waited process is alive.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
- [x] Abnormal cases (by patching the code locally)
- [x] server exit 
```
$ sky api start
Failed to connect to SkyPilot API server at http://127.0.0.1:46580. Starting a local server.
sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580. Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health

During handling of the above exception, another exception occurred:

RuntimeError: SkyPilot API server process exited unexpectedly.
View logs at: ~/.sky/api_server/server.log
```
- [x] queue manager exit
```
$ sky api start --foreground
.....
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/server.py", line 1119, in <module>
    sub_procs = executor.start(deploy=cmd_args.deploy)
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/requests/executor.py", line 468, in start
    mp_queue.wait_for_queues_to_be_ready(queue_names, queue_server, port)
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/requests/queues/mp_queue.py", line 81, in wait_for_queues_to_be_ready
    raise RuntimeError(
RuntimeError: Queue manager process exited unexpectedly.
```

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
