### PR TITLE
Refactor DigitalOcean credential path handling

### DIFF
--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -280,12 +280,14 @@ class DO(clouds.Cloud):
         return True, None
 
     def get_credential_file_mounts(self) -> Dict[str, str]:
-        if do_utils.CREDENTIALS_PATH is None:
+        if do_utils.get_credentials_path() is None:
             return {}
-        if not os.path.exists(os.path.expanduser(do_utils.CREDENTIALS_PATH)):
+        if not os.path.exists(
+                os.path.expanduser(do_utils.get_credentials_path())):
             return {}
         return {
-            f'~/.config/doctl/{_CREDENTIAL_FILE}': do_utils.CREDENTIALS_PATH
+            f'~/.config/doctl/{_CREDENTIAL_FILE}':
+                do_utils.get_credentials_path()
         }
 
     @classmethod

--- a/sky/provision/do/utils.py
+++ b/sky/provision/do/utils.py
@@ -31,40 +31,43 @@ MAX_BACKOFF_FACTOR = 10
 MAX_ATTEMPTS = 6
 SSH_KEY_NAME_ON_DO = f'sky-key-{common_utils.get_user_hash()}'
 
-CREDENTIALS_PATH = '~/.config/doctl/config.yaml'
 _client = None
 _ssh_key_id = None
+_credentials_path = None
 
 
 class DigitalOceanError(Exception):
     pass
 
 
-def _init_client():
-    global _client, CREDENTIALS_PATH
-    assert _client is None
-    CREDENTIALS_PATH = None
-    credentials_found = 0
-    for path in POSSIBLE_CREDENTIALS_PATHS:
-        if os.path.exists(path):
-            CREDENTIALS_PATH = path
-            credentials_found += 1
-            logger.debug(f'Digital Ocean credential path found at {path}')
-    if not credentials_found > 1:
-        logger.debug('more than 1 credential file found')
-    if CREDENTIALS_PATH is None:
-        raise DigitalOceanError(
-            'no credentials file found from '
-            f'the following paths {POSSIBLE_CREDENTIALS_PATHS}')
+def get_credentials_path():
+    global _credentials_path
+    if _credentials_path is None:
+        credentials_found = 0
+        for path in POSSIBLE_CREDENTIALS_PATHS:
+            if os.path.exists(path):
+                logger.debug(f'Digital Ocean credential path found at {path}')
+                _credentials_path = path
+                credentials_found += 1
+        if credentials_found > 1:
+            logger.debug('More than 1 credential file found')
+    return _credentials_path
 
+
+def _init_client():
+    global _client
+    assert _client is None
     # attempt default context
-    credentials = common_utils.read_yaml(CREDENTIALS_PATH)
+    if get_credentials_path() is None:
+        raise DigitalOceanError(
+            'No credentials found, please run `doctl auth init`')
+    credentials = common_utils.read_yaml(get_credentials_path())
     default_token = credentials.get('access-token', None)
     if default_token is not None:
         try:
             test_client = do.pydo.Client(token=default_token)
             test_client.droplets.list()
-            logger.debug('trying `default` context')
+            logger.debug('Trying `default` context')
             _client = test_client
             return _client
         except do.exceptions().HttpResponseError:
@@ -76,7 +79,7 @@ def _init_client():
             try:
                 test_client = do.pydo.Client(token=api_token)
                 test_client.droplets.list()
-                logger.debug(f'using {context} context')
+                logger.debug(f'Using "{context}" context')
                 _client = test_client
                 break
             except do.exceptions().HttpResponseError:


### PR DESCRIPTION
Introduced `get_credentials_path` to encapsulate credential path logic, improving code readability and maintainability. Replaced direct access to `CREDENTIALS_PATH` with the new method in relevant parts of the code, ensuring consistency in handling credentials.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
