### PR TITLE
[k8s] sky check detects unlabeled nodes

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -693,7 +693,11 @@ class Kubernetes(clouds.Cloud):
                 context)
             if len(unlabeled_nodes) > 0:
                 hints.append(f'Context {context} has {len(unlabeled_nodes)} '
-                             f'unlabeled nodes with accelerators.')
+                             f'unlabeled nodes with accelerators. '
+                             f'To label these nodes, run '
+                             f'`python -m sky.utils.kubernetes.gpu_labeler '
+                             f'--context {context}` from the project root '
+                             f'directory.')
         if success:
             return (True, cls._format_credential_check_results(hints, reasons))
         return (False, 'Failed to find available context with working '

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -689,6 +689,11 @@ class Kubernetes(clouds.Cloud):
             except Exception as e:  # pylint: disable=broad-except
                 return (False, f'Credential check failed for {context}: '
                         f'{common_utils.format_exception(e)}')
+            unlabeled_nodes = kubernetes_utils.get_unlabeled_accelerator_nodes(
+                context)
+            if len(unlabeled_nodes) > 0:
+                hints.append(f'Context {context} has {len(unlabeled_nodes)} '
+                             f'unlabeled nodes with accelerators.')
         if success:
             return (True, cls._format_credential_check_results(hints, reasons))
         return (False, 'Failed to find available context with working '

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2458,10 +2458,16 @@ def dict_to_k8s_object(object_dict: Dict[str, Any], object_type: 'str') -> Any:
 
 
 def get_unlabeled_accelerator_nodes(context: str) -> List[Any]:
-    """Detects unlabeled GPU nodes in the cluster.
+    """Gets a list of unlabeled GPU nodes in the cluster.
+
+    This function returns a list of nodes that have GPU resources but no label
+    that indicates the accelerator type.
 
     Args:
         context: The context to check.
+
+    Returns:
+        List[Any]: List of unlabeled nodes with accelerators.
     """
     nodes = get_kubernetes_nodes(context=context)
     nodes_with_accelerator = []

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2475,11 +2475,11 @@ def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
         if get_gpu_resource_key() in node.status.capacity:
             nodes_with_accelerator.append(node)
 
-    lf, _ = detect_gpu_label_formatter(context)
-    if not lf:
+    label_formatter, _ = detect_gpu_label_formatter(context)
+    if not label_formatter:
         return nodes_with_accelerator
     else:
-        label_keys = lf.get_label_keys()
+        label_keys = label_formatter.get_label_keys()
 
     unlabeled_nodes = []
     for node in nodes_with_accelerator:

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2483,9 +2483,13 @@ def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
 
     unlabeled_nodes = []
     for node in nodes_with_accelerator:
+        labeled = False
         for label_key in label_keys:
-            if label_key not in node.metadata.labels:
-                unlabeled_nodes.append(node)
+            if label_key in node.metadata.labels:
+                labeled = True
+                break
+        if not labeled:
+            unlabeled_nodes.append(node)
 
     return unlabeled_nodes
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2457,7 +2457,7 @@ def dict_to_k8s_object(object_dict: Dict[str, Any], object_type: 'str') -> Any:
     return kubernetes.api_client().deserialize(fake_kube_response, object_type)
 
 
-def get_unlabeled_accelerator_nodes(context: str) -> List[Any]:
+def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
     """Gets a list of unlabeled GPU nodes in the cluster.
 
     This function returns a list of nodes that have GPU resources but no label

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -124,12 +124,15 @@ def label(context: Optional[str] = None):
             batch_v1.create_namespaced_job(namespace, job_manifest)
             print(f'Created GPU labeler job for node {node_name}')
 
-        print('GPU labeling started - this may take 10 min or more to complete.'
-              '\nTo check the status of GPU labeling jobs, run '
-              '`kubectl get jobs -n kube-system -l job=sky-gpu-labeler`'
-              '\nYou can check if nodes have been labeled by running '
-              '`kubectl describe nodes` and looking for labels of the format '
-              '`skypilot.co/accelerator: <gpu_name>`. ')
+    context_str = f' --context {context}' if context else ''
+    print(f'GPU labeling started - this may take 10 min or more to complete.'
+          '\nTo check the status of GPU labeling jobs, run '
+          f'`kubectl get jobs -n kube-system '
+          f'-l job=sky-gpu-labeler{context_str}`'
+          '\nYou can check if nodes have been labeled by running '
+          f'`kubectl describe nodes{context_str}` '
+          'and looking for labels of the format '
+          '`skypilot.co/accelerator: <gpu_name>`. ')
 
 
 def main():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Adds a hint to kubernetes `sky check` for any nodes with accelerators that are not properly labeled for use with SkyPilot.

 
<img width="915" alt="Screenshot 2025-04-02 at 1 02 21 PM" src="https://github.com/user-attachments/assets/b32b1306-814c-42da-9ba4-a2eadfcc794e" />

The logic to detect contexts without proper labels can later be used to automatically label GPUs on those contexts.

Related issue: https://github.com/skypilot-org/skypilot/issues/4958
Fixes https://github.com/skypilot-org/skypilot/issues/5023

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually run `sky check kubernetes` on a cluster w/o labeling it beforehand
- [x] Manually run gpu label formatter script to check that jobs are only launched on unlabeled nodes.
```
$ python -m sky.utils.kubernetes.gpu_labeler   
Found 2 unlabeled GPU nodes in the cluster
Using default RuntimeClass for GPU labeling.
Created GPU labeler job for node ip-192-168-14-191.ec2.internal
Created GPU labeler job for node ip-192-168-24-7.ec2.internal
GPU labeling started - this may take 10 min or more to complete.
To check the status of GPU labeling jobs, run `kubectl get jobs -n kube-system -l job=sky-gpu-labeler`
You can check if nodes have been labeled by running `kubectl describe nodes` and looking for labels of the format `skypilot.co/accelerator: <gpu_name>`. 
$ ... # after some time
$ kubectl describe nodes | grep "skypilot.co"
                    skypilot.co/accelerator=v100
                    skypilot.co/accelerator=t4
$ python -m sky.utils.kubernetes.gpu_labeler 
No unlabeled GPU nodes found in the cluster. If you have unlabeled GPU nodes, please ensure that they have the resource `nvidia.com/gpu: <number of GPUs>` in their capacity.
```

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
