### PR TITLE
[GCP] Pin PyOpenSSL version for gcloud service account bug

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -118,7 +118,9 @@ extras_require: Dict[str, List[str]] = {
     # We need google-api-python-client>=2.69.0 to enable 'discardLocalSsd'
     # parameter for stopping instances. Reference:
     # https://github.com/googleapis/google-api-python-client/commit/f6e9d3869ed605b06f7cbf2e8cf2db25108506e6
-    'gcp': ['google-api-python-client>=2.69.0', 'google-cloud-storage'],
+    # pyOpenSSL>=24.3.0 has issues with gsutil bucket uploads when using service account:
+    # https://github.com/googleapis/google-api-python-client/issues/2554
+    'gcp': ['google-api-python-client>=2.69.0', 'google-cloud-storage', 'pyOpenSSL<24.3.0'],
     'ibm': [
         'ibm-cloud-sdk-core',
         'ibm-vpc',


### PR DESCRIPTION
gsutil has issues when using a service account. https://github.com/googleapis/google-api-python-client/issues/2554

Repro [needs double checking]:

Deploy API server with GCP enabled and using service account auth:
```
NAMESPACE=skypilot
kubectl create secret generic gcp-credentials \
  -n $NAMESPACE \
  --from-file=gcp-cred.json=<SERVICE ACCOUNT JSON HERE>

NAMESPACE=skypilot
RELEASE_NAME=skypilot
WEB_USERNAME=skypilot
WEB_PASSWORD=skypilot
AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
  --namespace $NAMESPACE \
  --create-namespace \
  --set ingress.authCredentials=$AUTH_STRING \
  --set apiService.image=berkeleyskypilot/skypilot-nightly:1.0.0.dev20250326 \
  --set gcpCredentials.enabled=true \
  --set gcpCredentials.projectId=<INSERT PROJECT ID HERE> \
  --set-file apiService.config=config.yaml
```

Define task YAML:
```
resources:
  cloud: gcp

file_mounts:
  /data:
    name: romil-test
    source: /tmp/mydir

run: |
  ls -l /data
```

Try `sky launch task.yaml`. Fails during bucket upload with:
```
ERROR: module 'OpenSSL.crypto' has no attribute 'sign'
```

Looks like a known issue: https://github.com/googleapis/google-api-python-client/issues/2554

I fixed by downgrading to `pyOpenSSL==24.2.1` on my API server deployment.

**Need someone to take over this PR and**:
* Reproduce this reliably. I ran into this on an API server deployment setup from scratch on a GKE cluster but wasn't able to reproduce on my mac.
* Validate the fix.