### PR TITLE
[k8s] refactor gpu labeler script / gpu labeler optionally accepts a context

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -148,6 +148,13 @@ def apps_api(context: Optional[str] = None):
 
 @_api_logging_decorator('urllib3', logging.ERROR)
 @annotations.lru_cache(scope='request')
+def batch_api(context: Optional[str] = None):
+    _load_config(context)
+    return kubernetes.client.BatchV1Api()
+
+
+@_api_logging_decorator('urllib3', logging.ERROR)
+@annotations.lru_cache(scope='request')
 def api_client(context: Optional[str] = None):
     _load_config(context)
     return kubernetes.client.ApiClient()

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -46,7 +46,7 @@ def get_node_hash(node_name: str):
 
 
 def label(context: Optional[str] = None):
-    deletion_success, reason = cleanup()
+    deletion_success, reason = cleanup(context=context)
     if not deletion_success:
         print(reason)
         return
@@ -86,7 +86,7 @@ def label(context: Optional[str] = None):
             if kubernetes_utils.get_gpu_resource_key() in node.status.capacity:
                 gpu_nodes.append(node)
 
-        print(f'Found {len(gpu_nodes)} GPU nodes in the cluster')
+        print(f'Found {len(gpu_nodes)} GPU node(s) in the cluster')
 
         # Check if the 'nvidia' RuntimeClass exists
         try:
@@ -127,12 +127,16 @@ def label(context: Optional[str] = None):
               'please ensure that they have the label '
               f'`{kubernetes_utils.get_gpu_resource_key()}: <number of GPUs>`')
     else:
-        print('GPU labeling started - this may take 10 min or more to complete.'
-              '\nTo check the status of GPU labeling jobs, run '
-              '`kubectl get jobs -n kube-system -l job=sky-gpu-labeler`'
-              '\nYou can check if nodes have been labeled by running '
-              '`kubectl describe nodes` and looking for labels of the format '
-              '`skypilot.co/accelerator: <gpu_name>`. ')
+        context_str = f' --context {context}' if context else ''
+        print(
+            f'GPU labeling started - this may take 10 min or more to complete.'
+            '\nTo check the status of GPU labeling jobs, run '
+            f'`kubectl get jobs -n kube-system '
+            f'-l job=sky-gpu-labeler{context_str}`'
+            '\nYou can check if nodes have been labeled by running '
+            f'`kubectl describe nodes{context_str}` '
+            'and looking for labels of the format '
+            '`skypilot.co/accelerator: <gpu_name>`. ')
 
 
 def main():

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -148,6 +148,9 @@ def main():
                         action='store_true',
                         help='delete all GPU labeler resources in the '
                         'Kubernetes cluster.')
+    parser.add_argument('--context',
+                        type=str,
+                        help='the context to use for the Kubernetes cluster.')
     args = parser.parse_args()
     context = None
     if args.context:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. Use existing helper functions where applicable instead of re-doing a lot of custom logic within the script, which prepares this script to eventually be run on the server as a result of an API call.
2. Allow the script to be called on a specific context, not just the active context.

UX:
if `--context` is specified
```
$ python -m sky.utils.kubernetes.gpu_labeler --context syang@my-cluster-2.us-east-1.eksctl.io                      
Found 1 GPU node(s) in the cluster
Using default RuntimeClass for GPU labeling.
Created GPU labeler job for node ip-192-168-56-224.ec2.internal
GPU labeling started - this may take 10 min or more to complete.
To check the status of GPU labeling jobs, run `kubectl get jobs -n kube-system -l job=sky-gpu-labeler --context syang@my-cluster-2.us-east-1.eksctl.io`
You can check if nodes have been labeled by running `kubectl describe nodes --context syang@my-cluster-2.us-east-1.eksctl.io` and looking for labels of the format `skypilot.co/accelerator: <gpu_name>`. 
```

If `--context` is not specified
```
$ python -m sky.utils.kubernetes.gpu_labeler                                                
Found 1 GPU node(s) in the cluster
Using default RuntimeClass for GPU labeling.
Created GPU labeler job for node ip-192-168-56-224.ec2.internal
GPU labeling started - this may take 10 min or more to complete.
To check the status of GPU labeling jobs, run `kubectl get jobs -n kube-system -l job=sky-gpu-labeler`
You can check if nodes have been labeled by running `kubectl describe nodes` and looking for labels of the format `skypilot.co/accelerator: <gpu_name>`. 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: run gpu labeler script on non default context using the `--context` flag
- [x] Manual test (bw compatibility): run gpu labeler script on default context without using the `--context` flag
- [x] Manual test: run gpu labeler script using `--context` flag and make sure the initial cleanup is executed correctly

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
