### PR TITLE
[ux] don't show optimization message if info is hidden

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3900,8 +3900,11 @@ def jobs_launch(
 
     common_utils.check_cluster_name_is_valid(name)
 
-    click.secho(f'Managed job {dag.name!r} will be launched on (estimated):',
-                fg='yellow')
+    # Optimize info is only show if _need_confirmation.
+    if not yes:
+        click.secho(
+            f'Managed job {dag.name!r} will be launched on (estimated):',
+            fg='yellow')
 
     request_id = managed_jobs.launch(dag, name, _need_confirmation=not yes)
     job_id_handle = _async_call_or_wait(request_id, async_call,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before this change, when using `-y`, we would see the "Managed job will be launched on (estimated):" but then nothing would follow.

This hides the message in this case.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
