### PR TITLE
Adding cookie support for api server

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -51,6 +51,8 @@ FILE_UPLOAD_LOGS_DIR = os.path.join(constants.SKY_LOGS_DIRECTORY,
 # Connection timeout when sending requests to the API server.
 API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS = 5
 
+get_api_cookie_jar = server_common.get_api_cookie_jar
+
 
 def download_logs_from_api_server(
         paths_on_api_server: Iterable[str]) -> Dict[str, str]:
@@ -75,7 +77,8 @@ def download_logs_from_api_server(
     body = payloads.DownloadBody(folder_paths=list(paths_on_api_server),)
     response = requests.post(f'{server_common.get_server_url()}/download',
                              json=json.loads(body.model_dump_json()),
-                             stream=True)
+                             stream=True,
+                             cookies=get_api_cookie_jar())
     if response.status_code == 200:
         remote_home_path = response.headers.get('X-Home-Path')
         assert remote_home_path is not None, response.headers
@@ -176,7 +179,8 @@ def _upload_chunk_with_retry(params: UploadChunkParams) -> None:
                 },
                 content=FileChunkIterator(f, _UPLOAD_CHUNK_BYTES,
                                           params.chunk_index),
-                headers={'Content-Type': 'application/octet-stream'})
+                headers={'Content-Type': 'application/octet-stream'},
+                cookies=get_api_cookie_jar())
             if response.status_code == 200:
                 data = response.json()
                 status = data.get('status')

--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -51,8 +51,6 @@ FILE_UPLOAD_LOGS_DIR = os.path.join(constants.SKY_LOGS_DIRECTORY,
 # Connection timeout when sending requests to the API server.
 API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS = 5
 
-get_api_cookie_jar = server_common.get_api_cookie_jar
-
 
 def download_logs_from_api_server(
         paths_on_api_server: Iterable[str]) -> Dict[str, str]:
@@ -78,7 +76,7 @@ def download_logs_from_api_server(
     response = requests.post(f'{server_common.get_server_url()}/download',
                              json=json.loads(body.model_dump_json()),
                              stream=True,
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     if response.status_code == 200:
         remote_home_path = response.headers.get('X-Home-Path')
         assert remote_home_path is not None, response.headers
@@ -180,7 +178,7 @@ def _upload_chunk_with_retry(params: UploadChunkParams) -> None:
                 content=FileChunkIterator(f, _UPLOAD_CHUNK_BYTES,
                                           params.chunk_index),
                 headers={'Content-Type': 'application/octet-stream'},
-                cookies=get_api_cookie_jar())
+                cookies=server_common.get_api_cookie_jar())
             if response.status_code == 200:
                 data = response.json()
                 status = data.get('status')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -60,8 +60,6 @@ else:
 logger = sky_logging.init_logger(__name__)
 logging.getLogger('httpx').setLevel(logging.CRITICAL)
 
-get_api_cookie_jar = server_common.get_api_cookie_jar
-
 
 def stream_response(request_id: Optional[str],
                     response: 'requests.Response',
@@ -105,7 +103,7 @@ def check(clouds: Optional[Tuple[str]],
     body = payloads.CheckBody(clouds=clouds, verbose=verbose)
     response = requests.post(f'{server_common.get_server_url()}/check',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -122,7 +120,7 @@ def enabled_clouds() -> server_common.RequestId:
         A list of enabled clouds in string format.
     """
     response = requests.get(f'{server_common.get_server_url()}/enabled_clouds',
-                            cookies=get_api_cookie_jar())
+                            cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -173,7 +171,7 @@ def list_accelerators(gpus_only: bool = True,
     response = requests.post(
         f'{server_common.get_server_url()}/list_accelerators',
         json=json.loads(body.model_dump_json()),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -214,7 +212,7 @@ def list_accelerator_counts(
     response = requests.post(
         f'{server_common.get_server_url()}/list_accelerator_counts',
         json=json.loads(body.model_dump_json()),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -253,7 +251,7 @@ def optimize(
                                  request_options=admin_policy_request_options)
     response = requests.post(f'{server_common.get_server_url()}/optimize',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -289,7 +287,7 @@ def validate(
                                  request_options=admin_policy_request_options)
     response = requests.post(f'{server_common.get_server_url()}/validate',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     if response.status_code == 400:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.deserialize_exception(
@@ -497,10 +495,12 @@ def launch(
             _is_launched_by_sky_serve_controller),
         disable_controller_check=_disable_controller_check,
     )
-    response = requests.post(f'{server_common.get_server_url()}/launch',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/launch',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -579,10 +579,12 @@ def exec(  # pylint: disable=redefined-builtin
         backend=backend.NAME if backend else None,
     )
 
-    response = requests.post(f'{server_common.get_server_url()}/exec',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/exec',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -633,7 +635,7 @@ def tail_logs(cluster_name: str,
         stream=True,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     request_id = server_common.get_request_id(response)
     return stream_response(request_id, response, output_stream)
 
@@ -671,7 +673,7 @@ def download_logs(cluster_name: str,
     )
     response = requests.post(f'{server_common.get_server_url()}/download_logs',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     job_id_remote_path_dict = stream_and_get(
         server_common.get_request_id(response))
     remote2local_path_dict = client_common.download_logs_from_api_server(
@@ -749,10 +751,12 @@ def start(
         down=down,
         force=force,
     )
-    response = requests.post(f'{server_common.get_server_url()}/start',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/start',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -793,10 +797,12 @@ def down(cluster_name: str, purge: bool = False) -> server_common.RequestId:
         cluster_name=cluster_name,
         purge=purge,
     )
-    response = requests.post(f'{server_common.get_server_url()}/down',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/down',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -840,10 +846,12 @@ def stop(cluster_name: str, purge: bool = False) -> server_common.RequestId:
         cluster_name=cluster_name,
         purge=purge,
     )
-    response = requests.post(f'{server_common.get_server_url()}/stop',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/stop',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -908,10 +916,12 @@ def autostop(
         idle_minutes=idle_minutes,
         down=down,
     )
-    response = requests.post(f'{server_common.get_server_url()}/autostop',
-                             json=json.loads(body.model_dump_json()),
-                             timeout=5,
-                             cookies=get_api_cookie_jar())
+    response = requests.post(
+        f'{server_common.get_server_url()}/autostop',
+        json=json.loads(body.model_dump_json()),
+        timeout=5,
+        cookies=server_common.get_api_cookie_jar(),
+    )
     return server_common.get_request_id(response)
 
 
@@ -971,7 +981,7 @@ def queue(cluster_name: str,
     )
     response = requests.post(f'{server_common.get_server_url()}/queue',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1013,7 +1023,7 @@ def job_status(cluster_name: str,
     )
     response = requests.post(f'{server_common.get_server_url()}/job_status',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1067,7 +1077,7 @@ def cancel(
     )
     response = requests.post(f'{server_common.get_server_url()}/cancel',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1163,7 +1173,7 @@ def status(
     )
     response = requests.post(f'{server_common.get_server_url()}/status',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1198,7 +1208,7 @@ def endpoints(
     )
     response = requests.post(f'{server_common.get_server_url()}/endpoints',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1237,7 +1247,7 @@ def cost_report() -> server_common.RequestId:  # pylint: disable=redefined-built
             }
     """
     response = requests.get(f'{server_common.get_server_url()}/cost_report',
-                            cookies=get_api_cookie_jar())
+                            cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1267,7 +1277,7 @@ def storage_ls() -> server_common.RequestId:
         ]
     """
     response = requests.get(f'{server_common.get_server_url()}/storage/ls',
-                            cookies=get_api_cookie_jar())
+                            cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1292,7 +1302,7 @@ def storage_delete(name: str) -> server_common.RequestId:
     body = payloads.StorageBody(name=name)
     response = requests.post(f'{server_common.get_server_url()}/storage/delete',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1331,7 +1341,7 @@ def local_up(gpus: bool,
                                 password=password)
     response = requests.post(f'{server_common.get_server_url()}/local_up',
                              json=json.loads(body.model_dump_json()),
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1348,7 +1358,7 @@ def local_down() -> server_common.RequestId:
             raise ValueError('sky local down is only supported when running '
                              'SkyPilot locally.')
     response = requests.post(f'{server_common.get_server_url()}/local_down',
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1373,7 +1383,7 @@ def realtime_kubernetes_gpu_availability(
         f'{server_common.get_server_url()}/'
         'realtime_kubernetes_gpu_availability',
         json=json.loads(body.model_dump_json()),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1405,7 +1415,7 @@ def kubernetes_node_info(
     response = requests.post(
         f'{server_common.get_server_url()}/kubernetes_node_info',
         json=json.loads(body.model_dump_json()),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1435,7 +1445,7 @@ def status_kubernetes() -> server_common.RequestId:
     """
     response = requests.get(
         f'{server_common.get_server_url()}/status_kubernetes',
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1462,7 +1472,7 @@ def get(request_id: str) -> Any:
         f'{server_common.get_server_url()}/api/get?request_id={request_id}',
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     request_task = None
     if response.status_code == 200:
         request_task = requests_lib.Request.decode(
@@ -1542,7 +1552,7 @@ def stream_and_get(
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None),
         stream=True,
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     if response.status_code in [404, 400]:
         detail = response.json().get('detail')
         with ux_utils.print_exception_no_traceback():
@@ -1599,7 +1609,7 @@ def api_cancel(request_ids: Optional[Union[str, List[str]]] = None,
     response = requests.post(f'{server_common.get_server_url()}/api/cancel',
                              json=json.loads(body.model_dump_json()),
                              timeout=5,
-                             cookies=get_api_cookie_jar())
+                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1628,7 +1638,7 @@ def api_status(
         params=server_common.request_body_to_params(body),
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None),
-        cookies=get_api_cookie_jar())
+        cookies=server_common.get_api_cookie_jar())
     server_common.handle_request_error(response)
     return [
         requests_lib.RequestPayload(**request) for request in response.json()
@@ -1656,7 +1666,7 @@ def api_info() -> Dict[str, str]:
 
     """
     response = requests.get(f'{server_common.get_server_url()}/api/health',
-                            cookies=get_api_cookie_jar())
+                            cookies=server_common.get_api_cookie_jar())
     response.raise_for_status()
     return response.json()
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -60,6 +60,8 @@ else:
 logger = sky_logging.init_logger(__name__)
 logging.getLogger('httpx').setLevel(logging.CRITICAL)
 
+get_api_cookie_jar = server_common.get_api_cookie_jar
+
 
 def stream_response(request_id: Optional[str],
                     response: 'requests.Response',
@@ -102,7 +104,8 @@ def check(clouds: Optional[Tuple[str]],
     """
     body = payloads.CheckBody(clouds=clouds, verbose=verbose)
     response = requests.post(f'{server_common.get_server_url()}/check',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -118,7 +121,8 @@ def enabled_clouds() -> server_common.RequestId:
     Request Returns:
         A list of enabled clouds in string format.
     """
-    response = requests.get(f'{server_common.get_server_url()}/enabled_clouds')
+    response = requests.get(f'{server_common.get_server_url()}/enabled_clouds',
+                            cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -168,7 +172,8 @@ def list_accelerators(gpus_only: bool = True,
     )
     response = requests.post(
         f'{server_common.get_server_url()}/list_accelerators',
-        json=json.loads(body.model_dump_json()))
+        json=json.loads(body.model_dump_json()),
+        cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -208,7 +213,8 @@ def list_accelerator_counts(
     )
     response = requests.post(
         f'{server_common.get_server_url()}/list_accelerator_counts',
-        json=json.loads(body.model_dump_json()))
+        json=json.loads(body.model_dump_json()),
+        cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -246,7 +252,8 @@ def optimize(
                                  minimize=minimize,
                                  request_options=admin_policy_request_options)
     response = requests.post(f'{server_common.get_server_url()}/optimize',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -281,7 +288,8 @@ def validate(
     body = payloads.ValidateBody(dag=dag_str,
                                  request_options=admin_policy_request_options)
     response = requests.post(f'{server_common.get_server_url()}/validate',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     if response.status_code == 400:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.deserialize_exception(
@@ -489,11 +497,10 @@ def launch(
             _is_launched_by_sky_serve_controller),
         disable_controller_check=_disable_controller_check,
     )
-    response = requests.post(
-        f'{server_common.get_server_url()}/launch',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/launch',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -572,11 +579,10 @@ def exec(  # pylint: disable=redefined-builtin
         backend=backend.NAME if backend else None,
     )
 
-    response = requests.post(
-        f'{server_common.get_server_url()}/exec',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/exec',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -626,7 +632,8 @@ def tail_logs(cluster_name: str,
         json=json.loads(body.model_dump_json()),
         stream=True,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None))
+                 None),
+        cookies=get_api_cookie_jar())
     request_id = server_common.get_request_id(response)
     return stream_response(request_id, response, output_stream)
 
@@ -663,7 +670,8 @@ def download_logs(cluster_name: str,
         job_ids=job_ids,
     )
     response = requests.post(f'{server_common.get_server_url()}/download_logs',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     job_id_remote_path_dict = stream_and_get(
         server_common.get_request_id(response))
     remote2local_path_dict = client_common.download_logs_from_api_server(
@@ -741,11 +749,10 @@ def start(
         down=down,
         force=force,
     )
-    response = requests.post(
-        f'{server_common.get_server_url()}/start',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/start',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -786,11 +793,10 @@ def down(cluster_name: str, purge: bool = False) -> server_common.RequestId:
         cluster_name=cluster_name,
         purge=purge,
     )
-    response = requests.post(
-        f'{server_common.get_server_url()}/down',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/down',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -834,11 +840,10 @@ def stop(cluster_name: str, purge: bool = False) -> server_common.RequestId:
         cluster_name=cluster_name,
         purge=purge,
     )
-    response = requests.post(
-        f'{server_common.get_server_url()}/stop',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/stop',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -903,11 +908,10 @@ def autostop(
         idle_minutes=idle_minutes,
         down=down,
     )
-    response = requests.post(
-        f'{server_common.get_server_url()}/autostop',
-        json=json.loads(body.model_dump_json()),
-        timeout=5,
-    )
+    response = requests.post(f'{server_common.get_server_url()}/autostop',
+                             json=json.loads(body.model_dump_json()),
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -966,7 +970,8 @@ def queue(cluster_name: str,
         all_users=all_users,
     )
     response = requests.post(f'{server_common.get_server_url()}/queue',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1007,7 +1012,8 @@ def job_status(cluster_name: str,
         job_ids=job_ids,
     )
     response = requests.post(f'{server_common.get_server_url()}/job_status',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1060,7 +1066,8 @@ def cancel(
         try_cancel_if_cluster_is_init=_try_cancel_if_cluster_is_init,
     )
     response = requests.post(f'{server_common.get_server_url()}/cancel',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1155,7 +1162,8 @@ def status(
         all_users=all_users,
     )
     response = requests.post(f'{server_common.get_server_url()}/status',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1189,7 +1197,8 @@ def endpoints(
         port=port,
     )
     response = requests.post(f'{server_common.get_server_url()}/endpoints',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1227,7 +1236,8 @@ def cost_report() -> server_common.RequestId:  # pylint: disable=redefined-built
               'total_cost': (float) cost given resources and usage intervals,
             }
     """
-    response = requests.get(f'{server_common.get_server_url()}/cost_report')
+    response = requests.get(f'{server_common.get_server_url()}/cost_report',
+                            cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1256,7 +1266,8 @@ def storage_ls() -> server_common.RequestId:
                 }
         ]
     """
-    response = requests.get(f'{server_common.get_server_url()}/storage/ls')
+    response = requests.get(f'{server_common.get_server_url()}/storage/ls',
+                            cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1280,7 +1291,8 @@ def storage_delete(name: str) -> server_common.RequestId:
     """
     body = payloads.StorageBody(name=name)
     response = requests.post(f'{server_common.get_server_url()}/storage/delete',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1318,7 +1330,8 @@ def local_up(gpus: bool,
                                 context_name=context_name,
                                 password=password)
     response = requests.post(f'{server_common.get_server_url()}/local_up',
-                             json=json.loads(body.model_dump_json()))
+                             json=json.loads(body.model_dump_json()),
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1334,7 +1347,8 @@ def local_down() -> server_common.RequestId:
         with ux_utils.print_exception_no_traceback():
             raise ValueError('sky local down is only supported when running '
                              'SkyPilot locally.')
-    response = requests.post(f'{server_common.get_server_url()}/local_down')
+    response = requests.post(f'{server_common.get_server_url()}/local_down',
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1358,7 +1372,8 @@ def realtime_kubernetes_gpu_availability(
     response = requests.post(
         f'{server_common.get_server_url()}/'
         'realtime_kubernetes_gpu_availability',
-        json=json.loads(body.model_dump_json()))
+        json=json.loads(body.model_dump_json()),
+        cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1389,7 +1404,8 @@ def kubernetes_node_info(
     body = payloads.KubernetesNodeInfoRequestBody(context=context)
     response = requests.post(
         f'{server_common.get_server_url()}/kubernetes_node_info',
-        json=json.loads(body.model_dump_json()))
+        json=json.loads(body.model_dump_json()),
+        cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1418,7 +1434,8 @@ def status_kubernetes() -> server_common.RequestId:
         - context: Kubernetes context used to fetch the cluster information.
     """
     response = requests.get(
-        f'{server_common.get_server_url()}/status_kubernetes')
+        f'{server_common.get_server_url()}/status_kubernetes',
+        cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1444,7 +1461,8 @@ def get(request_id: str) -> Any:
     response = requests.get(
         f'{server_common.get_server_url()}/api/get?request_id={request_id}',
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None))
+                 None),
+        cookies=get_api_cookie_jar())
     request_task = None
     if response.status_code == 200:
         request_task = requests_lib.Request.decode(
@@ -1523,7 +1541,8 @@ def stream_and_get(
         params=params,
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
                  None),
-        stream=True)
+        stream=True,
+        cookies=get_api_cookie_jar())
     if response.status_code in [404, 400]:
         detail = response.json().get('detail')
         with ux_utils.print_exception_no_traceback():
@@ -1579,7 +1598,8 @@ def api_cancel(request_ids: Optional[Union[str, List[str]]] = None,
 
     response = requests.post(f'{server_common.get_server_url()}/api/cancel',
                              json=json.loads(body.model_dump_json()),
-                             timeout=5)
+                             timeout=5,
+                             cookies=get_api_cookie_jar())
     return server_common.get_request_id(response)
 
 
@@ -1607,7 +1627,8 @@ def api_status(
         f'{server_common.get_server_url()}/api/status',
         params=server_common.request_body_to_params(body),
         timeout=(client_common.API_SERVER_REQUEST_CONNECTION_TIMEOUT_SECONDS,
-                 None))
+                 None),
+        cookies=get_api_cookie_jar())
     server_common.handle_request_error(response)
     return [
         requests_lib.RequestPayload(**request) for request in response.json()
@@ -1634,7 +1655,8 @@ def api_info() -> Dict[str, str]:
             }
 
     """
-    response = requests.get(f'{server_common.get_server_url()}/api/health')
+    response = requests.get(f'{server_common.get_server_url()}/api/health',
+                            cookies=get_api_cookie_jar())
     response.raise_for_status()
     return response.json()
 

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -82,6 +82,7 @@ def launch(
         f'{server_common.get_server_url()}/jobs/launch',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -138,6 +139,7 @@ def queue(refresh: bool,
         f'{server_common.get_server_url()}/jobs/queue',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response=response)
 
@@ -177,6 +179,7 @@ def cancel(
         f'{server_common.get_server_url()}/jobs/cancel',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response=response)
 
@@ -224,6 +227,7 @@ def tail_logs(name: Optional[str] = None,
         json=json.loads(body.model_dump_json()),
         stream=True,
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     request_id = server_common.get_request_id(response)
     return sdk.stream_response(request_id, response, output_stream)
@@ -267,6 +271,7 @@ def download_logs(
         f'{server_common.get_server_url()}/jobs/download_logs',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     job_id_remote_path_dict = sdk.stream_and_get(
         server_common.get_request_id(response))

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -74,6 +74,7 @@ def up(
         f'{server_common.get_server_url()}/serve/up',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -132,6 +133,7 @@ def update(
         f'{server_common.get_server_url()}/serve/update',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -173,6 +175,7 @@ def down(
         f'{server_common.get_server_url()}/serve/down',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -207,6 +210,7 @@ def terminate_replica(service_name: str, replica_id: int,
         f'{server_common.get_server_url()}/serve/terminate-replica',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -279,6 +283,7 @@ def status(
         f'{server_common.get_server_url()}/serve/status',
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
     )
     return server_common.get_request_id(response)
 
@@ -365,6 +370,7 @@ def tail_logs(service_name: str,
         json=json.loads(body.model_dump_json()),
         timeout=(5, None),
         stream=True,
+        cookies=server_common.get_api_cookie_jar(),
     )
     request_id = server_common.get_request_id(response)
     sdk.stream_response(request_id, response, output_stream)

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -3,6 +3,7 @@
 import dataclasses
 import enum
 import functools
+from http.cookiejar import MozillaCookieJar
 import json
 import os
 import pathlib
@@ -80,6 +81,18 @@ class ApiServerInfo:
     api_version: ApiVersion
 
 
+def get_api_cookie_jar() -> requests.cookies.RequestsCookieJar:
+    """Returns the cookie jar for the API server."""
+    cookie_file = os.environ.get(server_constants.ENV_VAR_API_COOKIE_FILE)
+    cookie_jar = requests.cookies.RequestsCookieJar()
+    if cookie_file:
+        cookie_path = pathlib.Path(cookie_file).expanduser().resolve()
+        file_cookie_jar = MozillaCookieJar(cookie_path)
+        file_cookie_jar.load()
+        cookie_jar.update(file_cookie_jar)
+    return cookie_jar
+
+
 @annotations.lru_cache(scope='global')
 def get_server_url(host: Optional[str] = None) -> str:
     endpoint = DEFAULT_SERVER_URL
@@ -117,7 +130,9 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
     server_url = endpoint if endpoint is not None else get_server_url()
     while time_out_try_count <= RETRY_COUNT_ON_TIMEOUT:
         try:
-            response = requests.get(f'{server_url}/api/health', timeout=2.5)
+            response = requests.get(f'{server_url}/api/health',
+                                    timeout=2.5,
+                                    cookies=get_api_cookie_jar())
             if response.status_code == 200:
                 try:
                     result = response.json()

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -83,9 +83,9 @@ class ApiServerInfo:
 
 def get_api_cookie_jar() -> requests.cookies.RequestsCookieJar:
     """Returns the cookie jar for the API server."""
-    cookie_file = os.environ.get(server_constants.ENV_VAR_API_COOKIE_FILE)
+    cookie_file = os.environ.get(server_constants.API_COOKIE_FILE_ENV_VAR)
     cookie_jar = requests.cookies.RequestsCookieJar()
-    if cookie_file:
+    if cookie_file and os.path.exists(cookie_file):
         cookie_path = pathlib.Path(cookie_file).expanduser().resolve()
         file_cookie_jar = MozillaCookieJar(cookie_path)
         file_cookie_jar.load()

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -82,7 +82,7 @@ class ApiServerInfo:
 
 
 def get_api_cookie_jar() -> requests.cookies.RequestsCookieJar:
-    """Returns the cookie jar for the API server."""
+    """Returns the cookie jar used by the client to access the API server."""
     cookie_file = os.environ.get(server_constants.API_COOKIE_FILE_ENV_VAR)
     cookie_jar = requests.cookies.RequestsCookieJar()
     if cookie_file and os.path.exists(cookie_file):

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -1,5 +1,7 @@
 """Constants for the API servers."""
 
+from sky.skylet import constants
+
 # API server version, whenever there is a change in API server that requires a
 # restart of the local API server or error out when the client does not match
 # the server version.
@@ -21,4 +23,4 @@ API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
 CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS = 60
 
 # Environment variable for a file path to the API cookie file.
-API_COOKIE_FILE_ENV_VAR = 'SKYPILOT_API_COOKIE_FILE'
+API_COOKIE_FILE_ENV_VAR = f'{constants.SKYPILOT_ENV_VAR_PREFIX}API_COOKIE_FILE'

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -21,4 +21,4 @@ API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
 CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS = 60
 
 # Environment variable for a file path to the API cookie file.
-ENV_VAR_API_COOKIE_FILE = 'SKYPILOT_API_COOKIE_FILE'
+API_COOKIE_FILE_ENV_VAR = 'SKYPILOT_API_COOKIE_FILE'

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -19,3 +19,6 @@ API_SERVER_REQUEST_DB_PATH = '~/.sky/api_server/requests.db'
 # The interval (seconds) for the cluster status to be refreshed in the
 # background.
 CLUSTER_REFRESH_DAEMON_INTERVAL_SECONDS = 60
+
+# Environment variable for a file path to the API cookie file.
+ENV_VAR_API_COOKIE_FILE = 'SKYPILOT_API_COOKIE_FILE'

--- a/tests/unit_tests/test_sky/server/test_sdk.py
+++ b/tests/unit_tests/test_sky/server/test_sdk.py
@@ -1,0 +1,124 @@
+# Tests for the sky/client/sdk.py file
+from http.cookiejar import Cookie
+from http.cookiejar import MozillaCookieJar
+import os
+from pathlib import Path
+import time
+from unittest import mock
+
+import pytest
+import requests
+
+from sky.client import sdk as client_sdk
+from sky.server import common as server_common
+from sky.server.constants import API_COOKIE_FILE_ENV_VAR
+
+
+@pytest.fixture
+def set_api_cookie_jar(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # Create a temporary file with test cookie content
+    # Netscape cookie file format: https://curl.se/docs/http-cookies.html
+    # domain, include subdomains, path, useHTTPS, expires at seconds, name of cookie, value
+    cookie_file = tmp_path / "test_cookie.txt"
+    cookie_jar = MozillaCookieJar(filename=cookie_file)
+    cookie_jar.set_cookie(
+        Cookie(
+            name="user_name",
+            value="sky-user",
+            domain="api.skypilot.co",
+            version=0,
+            port=None,
+            port_specified=False,
+            domain_specified=True,
+            domain_initial_dot=False,
+            path="/",
+            path_specified=True,
+            secure=True,
+            comment="Test cookie",
+            comment_url=None,
+            discard=False,
+            expires=int(time.time() + 3600),
+            rfc2109=False,
+            rest={},
+        ))
+    cookie_jar.save(filename=cookie_file,
+                    ignore_discard=True,
+                    ignore_expires=True)
+
+    with mock.patch.dict(os.environ, clear=True):
+        envvars = {
+            API_COOKIE_FILE_ENV_VAR: cookie_file,
+        }
+        for k, v in envvars.items():
+            monkeypatch.setenv(k, v)
+        yield  # This is the magical bit which restore the environment after the test
+
+
+def test_cookie_jar():
+    # Test an empty cookie jar is created if the cookie file does not exist
+    cookie_jar = server_common.get_api_cookie_jar()
+    assert cookie_jar is not None
+    assert isinstance(cookie_jar, requests.cookies.RequestsCookieJar)
+    assert cookie_jar.get("user_name", domain="api.skypilot.co") is None
+
+
+def test_cookie_jar_file(set_api_cookie_jar):
+    # Test with insufficient memory
+    cookie_jar = server_common.get_api_cookie_jar()
+    assert cookie_jar is not None
+    assert isinstance(cookie_jar, requests.cookies.RequestsCookieJar)
+    assert cookie_jar.get("user_name", domain="api.skypilot.co") == "sky-user"
+
+
+def test_api_info():
+    with mock.patch('requests.get') as mock_get:
+        mock_get.return_value.json.return_value = {
+            "status": "healthy",
+            "api_version": "1",
+            "commit": "abc1234567890",
+            "version": "1.0.0",
+        }
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.cookies = requests.cookies.RequestsCookieJar()
+        with mock.patch('sky.server.common.check_server_healthy_or_start_fn'
+                       ) as mock_server_healthy:
+            mock_server_healthy.return_value = None
+            response = client_sdk.api_info()
+            assert response is not None
+            assert response["status"] == "healthy"
+            assert response["api_version"] == "1"
+            assert response["commit"] is not None
+            assert response["version"] is not None
+            assert mock_get.call_count == 1
+            assert mock_get.call_args[0][0].endswith("/api/health")
+            assert mock_get.call_args[1]["cookies"] is not None
+            assert isinstance(mock_get.call_args[1]["cookies"],
+                              requests.cookies.RequestsCookieJar)
+
+
+def test_api_info_with_cookie_file(set_api_cookie_jar):
+    with mock.patch('requests.get') as mock_get:
+        mock_get.return_value.json.return_value = {
+            "status": "healthy",
+            "api_version": "1",
+            "commit": "abc1234567890",
+            "version": "1.0.0",
+        }
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_get.return_value.cookies = requests.cookies.RequestsCookieJar()
+        with mock.patch('sky.server.common.check_server_healthy_or_start_fn'
+                       ) as mock_server_healthy:
+            mock_server_healthy.return_value = None
+            response = client_sdk.api_info()
+            assert response is not None
+            assert response["status"] == "healthy"
+            assert response["api_version"] == "1"
+            assert response["commit"] is not None
+            assert response["version"] is not None
+            assert mock_get.call_count == 1
+            assert mock_get.call_args[0][0].endswith("/api/health")
+            assert mock_get.call_args[1]["cookies"] is not None
+            assert isinstance(mock_get.call_args[1]["cookies"],
+                              requests.cookies.RequestsCookieJar)
+            assert mock_get.call_args[1]["cookies"].get(
+                "user_name", domain="api.skypilot.co") == "sky-user"


### PR DESCRIPTION
Adding an env var `SKYPILOT_API_COOKIE_FILE` that allows for pointing to a [curl cookie file](https://curl.se/docs/http-cookies.html) and passing those cookies to all the requests call that talk to the api server.

Tested connecting to an api server that needs a cookie for the proxy auth in front of it.


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)


Added unit tests for parsing cookie files and checking server health.

Connecting to cookie-necessary server:
```
# using cookie from env var
$ sky api info  
Using SkyPilot API server: https://skypilot-api.my.tld
├── Status: healthy, commit: 5025c819176d48aa8643fe9ec058158ce2bece9a, version: 1.0.0.dev20250406
└── User: clayros (c5fd9f9e)
# raw curl
$ curl -I -sSL https://skypilot-api.my.tld
HTTP/2 302 
server: awselb/2.0
date: Thu, 10 Apr 2025 22:32:43 GMT
content-type: text/html
content-length: 110
location: https://...oidcserver
set-cookie: AuthNonce=****; Expires=Thu, 10 Apr 2025 22:47:43 GMT; Path=/; Secure; HttpOnly

HTTP/2 302 
date: Thu, 10 Apr 2025 22:32:44 GMT
location: https://...idpserver
set-cookie: XSRF-TOKEN=***; Path=/; Secure; HttpOnly; SameSite=Lax
cache-control: no-cache, no-store, max-age=0, must-revalidate
pragma: no-cache
set-cookie: csrf-state=***; Expires=Thu, 10-Apr-2025 22:37:44 GMT; Path=/; Secure; HttpOnly; SameSite=None
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
strict-transport-security: max-age=31536000 ; includeSubDomains
x-frame-options: DENY
server: Server

HTTP/1.1 401 Unauthorized
Server: Server
Date: Thu, 10 Apr 2025 22:32:44 GMT
Content-Type: */*; charset=utf-8
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Vary: Accept
Cache-Control: no-cache
X-Request-Id: 1****af
Strict-Transport-Security: max-age=63072000; includeSubDomains
```
