### PR TITLE
[API server] Set default min resources and warning on low resources

### DIFF
--- a/charts/skypilot/templates/NOTES.txt
+++ b/charts/skypilot/templates/NOTES.txt
@@ -1,1 +1,3 @@
+{{- if not .Values.apiService.skipResourceCheck }}
 {{- include "skypilot.checkResources" . }}
+{{- end }}

--- a/charts/skypilot/templates/NOTES.txt
+++ b/charts/skypilot/templates/NOTES.txt
@@ -1,0 +1,1 @@
+{{- include "skypilot.checkResources" . }}

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -26,9 +26,9 @@
   {{- $memNum = float64 (divf (trimSuffix "M" $memory | atoi) 1024) -}}
 {{- end -}}
 
-{{- if lt $memNum 2.0 -}}
+{{- if or (lt $cpuNum 1.0) (lt $memNum 2.0) -}}
 {{/* TODO(aylei): add a reference to the tuning guide once complete */}}
-  {{- fail "API server requires at least 2 GiB of memory" -}}
+  {{- fail "API server requires at least 1 CPU core and 2 GiB memory" -}}
 {{- end -}}
 
 {{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{- define "skypilot.checkResources" -}}
+{{- $cpu := .Values.apiService.resources.requests.cpu | default "0" -}}
+{{- $memory := .Values.apiService.resources.requests.memory | default "0" -}}
+
+{{- /* Convert CPU to numeric value */ -}}
+{{- $cpuNum := 0.0 -}}
+{{- if kindIs "string" $cpu -}}
+  {{- if hasSuffix "m" $cpu -}}
+    {{- $cpuNum = float64 (divf (trimSuffix "m" $cpu | atoi) 1000) -}}
+  {{- else -}}
+    {{- $cpuNum = float64 ($cpu | atoi) -}}
+  {{- end -}}
+{{- else -}}
+  {{- $cpuNum = float64 $cpu -}}
+{{- end -}}
+
+{{- /* Convert memory to Gi */ -}}
+{{- $memNum := 0.0 -}}
+{{- if hasSuffix "Gi" $memory -}}
+  {{- $memNum = float64 (trimSuffix "Gi" $memory | atoi) -}}
+{{- else if hasSuffix "Mi" $memory -}}
+  {{- $memNum = float64 (divf (trimSuffix "Mi" $memory | atoi) 1024) -}}
+{{- else if hasSuffix "G" $memory -}}
+  {{- $memNum = float64 ($memory | trimSuffix "G" | atoi) -}}
+{{- else if hasSuffix "M" $memory -}}
+  {{- $memNum = float64 (divf (trimSuffix "M" $memory | atoi) 1024) -}}
+{{- end -}}
+
+{{- if lt $memNum 2.0 -}}
+{{/* TODO(aylei): add a reference to the tuning guide once complete */}}
+  {{- fail "API server requires at least 2 GiB of memory" -}}
+{{- end -}}
+
+{{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}
+  {{- printf "\nWARNING: SkyPilot API server only has %.1f CPU cores and %.1f GiB memory requested. At least 4 CPU cores and 8 GiB memory is recommended to support higher load with better performance.\n" $cpuNum $memNum -}}
+{{- end -}}
+{{- end -}} 

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -26,12 +26,9 @@
   {{- $memNum = float64 (divf (trimSuffix "M" $memory | atoi) 1024) -}}
 {{- end -}}
 
-{{- if or (lt $cpuNum 1.0) (lt $memNum 2.0) -}}
+{{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}
 {{/* TODO(aylei): add a reference to the tuning guide once complete */}}
-  {{- fail "API server requires at least 1 CPU core and 2 GiB memory" -}}
+  {{- fail "Error\nAPI server requires at least 4 CPU cores and 8 GiB memory. You can either:\n1. increase .apiService.resources.requests.* to meet the requirements or unset them to use defaults\n2. add `--set apiService.skipResourceCheck=true` in command args to bypass this check (not recommended for production)\nto resolve this issue and then try again." -}}
 {{- end -}}
 
-{{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}
-  {{- printf "\nWARNING: %.1f CPU cores and %.1f GiB memory are allocated for SkyPilot API server. At least 4 CPU cores and 8 GiB memory is recommended to support higher load with better performance.\n" $cpuNum $memNum -}}
-{{- end -}}
 {{- end -}} 

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -32,6 +32,6 @@
 {{- end -}}
 
 {{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}
-  {{- printf "\nWARNING: SkyPilot API server only has %.1f CPU cores and %.1f GiB memory requested. At least 4 CPU cores and 8 GiB memory is recommended to support higher load with better performance.\n" $cpuNum $memNum -}}
+  {{- printf "\nWARNING: %.1f CPU cores and %.1f GiB memory are allocated for SkyPilot API server. At least 4 CPU cores and 8 GiB memory is recommended to support higher load with better performance.\n" $cpuNum $memNum -}}
 {{- end -}}
 {{- end -}} 

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -28,7 +28,7 @@
 
 {{- if or (lt $cpuNum 4.0) (lt $memNum 8.0) -}}
 {{/* TODO(aylei): add a reference to the tuning guide once complete */}}
-  {{- fail "Error\nAPI server requires at least 4 CPU cores and 8 GiB memory. You can either:\n1. increase .apiService.resources.requests.* to meet the requirements or unset them to use defaults\n2. add `--set apiService.skipResourceCheck=true` in command args to bypass this check (not recommended for production)\nto resolve this issue and then try again." -}}
+  {{- fail "Error\nDeploying a SkyPilot API server requires at least 4 CPU cores and 8 GiB memory. You can either:\n1. Change `--set apiService.resources.requests.cpu` and `--set apiService.resources.requests.memory` to meet the requirements or unset them to use defaults\n2. add `--set apiService.skipResourceCheck=true` in command args to bypass this check (not recommended for production)\nto resolve this issue and then try again." -}}
 {{- end -}}
 
 {{- end -}} 

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -34,17 +34,18 @@ apiService:
   #     - kubernetes
 
   # Set resource requests and limits for the API server
+  resources:
+    # Request a moderate amount of resources for an remote API server by default, which meets the
+    # basic requirements for team usage at medium scale.
+    requests:
+      cpu: "4"
+      memory: "8Gi"
+      # Additional resource types like ephemeral-storage can be specified here
   # TODO: Setting limits causes issues with the API server. For now we advise
   # not to set limits.
-  resources: null
-  # resources:
-  #   requests:
-  #     cpu: "1"
-  #     memory: "2Gi"
-  #   limits:
-  #     cpu: "2"
-  #     memory: "4Gi"
-  #     # Additional resource types like ephemeral-storage can be specified here
+  # limits:
+  #  cpu: "4"
+  #  memory: "8Gi"
   
   # [Internal] Enable developer mode for SkyPilot
   skypilotDev: false

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -33,6 +33,8 @@ apiService:
   #     - aws
   #     - kubernetes
 
+  # Skip resource check for the API server, not recommended for production deployment
+  skipResourceCheck: false
   # Set resource requests and limits for the API server
   resources:
     # Request a moderate amount of resources for an remote API server by default, which meets the

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -197,6 +197,14 @@ If you configured any cloud credentials in the previous step, make sure to enabl
 
     The secret must be in the same namespace as the API server and must contain a key named ``auth`` with the basic auth credentials in htpasswd format.
 
+After the API server is deployed, you can inspect the API server Pod status with:
+
+.. code-block:: bash
+
+    kubectl get pods -n $NAMESPACE -l app=${RELEASE_NAME}-api --watch
+
+You should see the Pod is initializing and finally becomes running and ready. If not, refer to :ref:`sky-api-server-pod-pending` to diagnose the issue.
+
 .. _sky-get-api-server-url:
 
 Step 4: Get the API server URL

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -197,13 +197,13 @@ If you configured any cloud credentials in the previous step, make sure to enabl
 
     The secret must be in the same namespace as the API server and must contain a key named ``auth`` with the basic auth credentials in htpasswd format.
 
-After the API server is deployed, you can inspect the API server Pod status with:
+After the API server is deployed, you can inspect the API server pod status with:
 
 .. code-block:: bash
 
     kubectl get pods -n $NAMESPACE -l app=${RELEASE_NAME}-api --watch
 
-You should see the Pod is initializing and finally becomes running and ready. If not, refer to :ref:`sky-api-server-pod-pending` to diagnose the issue.
+You should see the pod is initializing and finally becomes running and ready. If not, refer to :ref:`sky-api-server-troubleshooting-helm` to diagnose the issue.
 
 .. _sky-get-api-server-url:
 

--- a/docs/source/reference/api-server/api-server-troubleshooting.rst
+++ b/docs/source/reference/api-server/api-server-troubleshooting.rst
@@ -1,0 +1,39 @@
+.. _sky-api-server-troubleshooting:
+
+Troubleshooting SkyPilot API Server
+==================================
+
+.. note::
+   If none of the troubleshooting steps below resolve your issue, please do not hesitate to file a GitHub issue at our `issue tracker <https://github.com/skypilot-org/skypilot/issues>`_. Your feedback is valuable in helping us improve SkyPilot!
+
+Helm Deployment
+---------------
+
+.. _sky-api-server-pod-pending:
+
+API server Pod is Pending
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the API server Pod is pending, you can inspect the pending reason with:
+
+.. code-block:: bash
+
+    kubectl describe pod -n $NAMESPACE -l app=${RELEASE_NAME}-api
+
+If the pending reason is ``FailedScheduling`` and the information indicates there is insufficient cpu/memory, you can either:
+
+- Adding more resources to the Kubernetes cluster, or
+- Using a smaller API server resources request:
+
+.. code-block:: bash
+
+    # Update the resources requests while keeping existing values set in the previous commands
+    helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly \
+    --namespace $NAMESPACE \
+    --reuse-values \
+    --set apiService.resources.requests.cpu=2 \
+    --set apiService.resources.requests.memory=4Gi
+
+.. note::
+
+    At least 2GB memory request is required for the API server to function properly, otherwise the chart will fail to install.

--- a/docs/source/reference/api-server/api-server-troubleshooting.rst
+++ b/docs/source/reference/api-server/api-server-troubleshooting.rst
@@ -1,20 +1,22 @@
 .. _sky-api-server-troubleshooting:
 
 Troubleshooting SkyPilot API Server
-==================================
+===================================
 
 .. note::
    If none of the troubleshooting steps below resolve your issue, please do not hesitate to file a GitHub issue at our `issue tracker <https://github.com/skypilot-org/skypilot/issues>`_. Your feedback is valuable in helping us improve SkyPilot!
 
-Helm Deployment
----------------
+.. _sky-api-server-troubleshooting-helm:
 
-.. _sky-api-server-pod-pending:
+Helm deployment troubleshooting
+-------------------------------
 
-API server Pod is Pending
+.. _sky-api-server-troubleshooting-pod-pending:
+
+API server pod is pending
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If the API server Pod is pending, you can inspect the pending reason with:
+If the API server pod is pending, you can inspect the pending reason with:
 
 .. code-block:: bash
 

--- a/docs/source/reference/api-server/api-server-troubleshooting.rst
+++ b/docs/source/reference/api-server/api-server-troubleshooting.rst
@@ -26,7 +26,7 @@ If the API server pod is pending, you can inspect the pending reason with:
 If the pending reason is ``FailedScheduling`` and the information indicates there is insufficient cpu/memory, you can either:
 
 - Adding more resources to the Kubernetes cluster, or
-- Using a smaller API server resources request:
+- Using a smaller API server resources request, for example (change the cpu and memory to your desired values):
 
 .. code-block:: bash
 
@@ -34,9 +34,9 @@ If the pending reason is ``FailedScheduling`` and the information indicates ther
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly \
     --namespace $NAMESPACE \
     --reuse-values \
-    --set apiService.resources.requests.cpu=2 \
-    --set apiService.resources.requests.memory=4Gi
+    --set apiService.resources.requests.cpu=4 \
+    --set apiService.resources.requests.memory=8Gi
 
 .. note::
 
-    At least 1 CPU core and 2 GiB memory request is required for the API server to function properly, otherwise the chart will fail to install.
+    API server requires at least 4 CPU cores and 8 GiB memory, setting lower values may cause degraded performance.

--- a/docs/source/reference/api-server/api-server-troubleshooting.rst
+++ b/docs/source/reference/api-server/api-server-troubleshooting.rst
@@ -3,8 +3,9 @@
 Troubleshooting SkyPilot API Server
 ===================================
 
-.. note::
-   If none of the troubleshooting steps below resolve your issue, please do not hesitate to file a GitHub issue at our `issue tracker <https://github.com/skypilot-org/skypilot/issues>`_. Your feedback is valuable in helping us improve SkyPilot!
+If you're unable to run SkyPilot API server, this guide will help you debug common issues.
+
+If this guide does not help resolve your issue, please reach out to us on `Slack <https://slack.skypilot.co>`_ or `GitHub <http://www.github.com/skypilot-org/skypilot>`_.
 
 .. _sky-api-server-troubleshooting-helm:
 
@@ -38,4 +39,4 @@ If the pending reason is ``FailedScheduling`` and the information indicates ther
 
 .. note::
 
-    At least 2GB memory request is required for the API server to function properly, otherwise the chart will fail to install.
+    At least 1 CPU core and 2 GiB memory request is required for the API server to function properly, otherwise the chart will fail to install.

--- a/docs/source/reference/api-server/api-server-troubleshooting.rst
+++ b/docs/source/reference/api-server/api-server-troubleshooting.rst
@@ -3,7 +3,7 @@
 Troubleshooting SkyPilot API Server
 ===================================
 
-If you're unable to run SkyPilot API server, this guide will help you debug common issues.
+This guide includes tips for troubleshooting common issues with API server deployment.
 
 If this guide does not help resolve your issue, please reach out to us on `Slack <https://slack.skypilot.co>`_ or `GitHub <http://www.github.com/skypilot-org/skypilot>`_.
 
@@ -25,8 +25,8 @@ If the API server pod is pending, you can inspect the pending reason with:
 
 If the pending reason is ``FailedScheduling`` and the information indicates there is insufficient cpu/memory, you can either:
 
-- Adding more resources to the Kubernetes cluster, or
-- Using a smaller API server resources request, for example (change the cpu and memory to your desired values):
+- Add more resources to the Kubernetes cluster, or
+- Use a smaller API server resources request; for example (change the cpu and memory to your desired values):
 
 .. code-block:: bash
 
@@ -39,4 +39,4 @@ If the pending reason is ``FailedScheduling`` and the information indicates ther
 
 .. note::
 
-    API server requires at least 4 CPU cores and 8 GiB memory, setting lower values may cause degraded performance.
+    API server requires at least 4 CPU cores and 8 GiB memory. Setting lower values may cause degraded performance.

--- a/docs/source/reference/api-server/api-server.rst
+++ b/docs/source/reference/api-server/api-server.rst
@@ -112,3 +112,4 @@ To verify that the API server is working, run ``sky api info``:
    :hidden:
 
    Deploying API Server <api-server-admin-deploy>
+   Troubleshooting <api-server-troubleshooting>


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5093

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] Normal case, without specifying `.apiService.resources.requests`, succeed with no warning
- [x]  Setting cpu=1, memory=3GiB, installation failed
```bash
helm upgrade --install skypilot-test ./charts/skypilot -f values.yaml --set ingress.nodePortEnabled=true

Release "skypilot-test" does not exist. Installing it now.
Error: execution error at (skypilot/templates/NOTES.txt:2:4): Error
API server requires at least 4 CPU cores and 8 GiB memory. You can either:
1. increase .apiService.resources.requests.* to meet the requirements or unset them to use defaults
2. add `--set apiService.skipResourceCheck=true` in command args to bypass this check (not recommended for production)
```
- [x] Follow the hint and specify `--set apiService.skipResourceCheck=true`, succeed
```
helm upgrade --install skypilot-test ./charts/skypilot -f values.yaml --set ingress.nodePortEnabled=true --set apiService.skipResourceCheck=true
Release "skypilot-test" does not exist. Installing it now.
NAME: skypilot-test
LAST DEPLOYED: Thu Apr  3 12:47:41 2025
NAMESPACE: skypilot
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
