### PR TITLE
[UX] Skip `STOPPED` cluster when calling `sky stop`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3061,6 +3061,9 @@ def _down_or_stop_clusters(
                 'Letting --all take effect.')
         # We should not remove controllers when --all is specified.
         # Otherwise, it would be very easy to accidentally delete a controller.
+
+        # do not select already stopped clusters for stop command.
+        # stopped clusters are still included for down or autostop commands.
         names = [
             record['name']
             for record in all_clusters

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3065,6 +3065,7 @@ def _down_or_stop_clusters(
             record['name']
             for record in all_clusters
             if controller_utils.Controllers.from_name(record['name']) is None
+            and record['status'] != status_lib.ClusterStatus.STOPPED
         ]
 
     clusters = names

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3065,7 +3065,7 @@ def _down_or_stop_clusters(
             record['name']
             for record in all_clusters
             if controller_utils.Controllers.from_name(record['name']) is None
-            and record['status'] != status_lib.ClusterStatus.STOPPED
+            and (down or record['status'] != status_lib.ClusterStatus.STOPPED)
         ]
 
     clusters = names

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3065,7 +3065,8 @@ def _down_or_stop_clusters(
             record['name']
             for record in all_clusters
             if controller_utils.Controllers.from_name(record['name']) is None
-            and (down or record['status'] != status_lib.ClusterStatus.STOPPED)
+            and (down or idle_minutes_to_autostop is not None or
+                 record['status'] != status_lib.ClusterStatus.STOPPED)
         ]
 
     clusters = names


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #4090 

Simple fix to skip clusters that have `ClusterStatus.STOPPED`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
