### PR TITLE
[k8s] sky check refactor

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -289,6 +289,12 @@ def _print_checked_cloud(
         cloud_tuple: The cloud to print the capabilities for.
         cloud_capabilities: The capabilities for the cloud.
     """
+
+    def _yellow_color(str_to_format: str) -> str:
+        return (f'{colorama.Fore.LIGHTYELLOW_EX}'
+                f'{str_to_format}'
+                f'{colorama.Style.RESET_ALL}')
+
     cloud_repr, cloud = cloud_tuple
     # Print the capabilities for the cloud.
     # consider cloud enabled if any capability is enabled.
@@ -319,7 +325,7 @@ def _print_checked_cloud(
     if activated_account is not None:
         echo(f'    Activated account: {activated_account}')
     for reason, caps in hints_to_capabilities.items():
-        echo(f'    Hint [{", ".join(caps)}]: {reason}')
+        echo(f'    Hint [{", ".join(caps)}]: {_yellow_color(reason)}')
     for reason, caps in reasons_to_capabilities.items():
         echo(f'    Reason [{", ".join(caps)}]: {reason}')
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -679,7 +679,8 @@ class Kubernetes(clouds.Cloud):
         success = False
         for context in existing_allowed_contexts:
             try:
-                check_result = kubernetes_utils.check_credentials(context)
+                check_result = kubernetes_utils.check_credentials(
+                    context, run_optional_checks=True)
                 if check_result[0]:
                     success = True
                     if check_result[1] is not None:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -689,15 +689,6 @@ class Kubernetes(clouds.Cloud):
             except Exception as e:  # pylint: disable=broad-except
                 return (False, f'Credential check failed for {context}: '
                         f'{common_utils.format_exception(e)}')
-            unlabeled_nodes = kubernetes_utils.get_unlabeled_accelerator_nodes(
-                context)
-            if len(unlabeled_nodes) > 0:
-                hints.append(f'Context {context} has {len(unlabeled_nodes)} '
-                             f'unlabeled nodes with accelerators. '
-                             f'To label these nodes, run '
-                             f'`python -m sky.utils.kubernetes.gpu_labeler '
-                             f'--context {context}` from the project root '
-                             f'directory.')
         if success:
             return (True, cls._format_credential_check_results(hints, reasons))
         return (False, 'Failed to find available context with working '

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1344,16 +1344,14 @@ def check_credentials(context: Optional[str],
     # `sky launch --gpus <gpu>` and the optimizer does not list Kubernetes as a
     # provider if their cluster GPUs are not setup correctly.
     gpu_msg = ''
-    try:
-        get_accelerator_label_key_value(context,
-                                        acc_type='',
-                                        acc_count=0,
-                                        check_mode=True)
-    except exceptions.ResourcesUnavailableError as e:
-        # If GPUs are not available, we return cluster as enabled (since it can
-        # be a CPU-only cluster) but we also return the exception message which
-        # serves as a hint for how to enable GPU access.
-        gpu_msg = str(e)
+    unlabeled_nodes = get_unlabeled_accelerator_nodes(context)
+    if unlabeled_nodes:
+        gpu_msg = (f'Cluster has {len(unlabeled_nodes)} nodes with '
+                   f'accelerators that are not labeled. '
+                   f'To label the nodes, run '
+                   f'`python -m sky.utils.kubernetes.gpu_labeler '
+                   f'--context {context}` from the project root '
+                   f'directory.')
     if exec_msg and gpu_msg:
         return True, f'{gpu_msg}\n    Additionally, {exec_msg}'
     elif gpu_msg:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. `sky/clouds/kubernetes.py: _check_compute_credentials` is the only place that cares about `kubernetes_utils.check_credentials`'s message if the check has passed. Add a `run_optional_checks` argument for `kubernetes_utils.check_credentials` so the function short-circuits in the case where additional checks are not required.
2. `kubernetes_utils.check_credentials` seems like a better place to check for unlabeled accelerators given this is where other non-critical k8s checks are being done. Moved the unlabeled accelerator detection logic there.
3. Both `get_unlabeled_accelerator_nodes` and `get_accelerator_label_key_value` produces a warning when there are unlabeled accelerator nodes. Suppress warning from `get_accelerator_label_key_value` when `get_unlabeled_accelerator_nodes` flags unlabeled accelerator nodes, as in such case we can provide a much more actionable message to the user.
4. remove "from project root directory" to unlabeled gpu hint msg, cloning the repo is not needed (as long as sky is pip installed)
5. Emphasize hints with yellow color when running `sky check`. This seems useful because while a reason (the thing that gets printed when a cloud is disabled) is impossible to ignore if a user actually wants to use the cloud, a hint (the thing that gets printed when a cloud is enabled) can be missed/ignored by the user only to bite them back later. 
<img width="973" alt="Screenshot 2025-04-02 at 3 47 58 PM" src="https://github.com/user-attachments/assets/260982ba-4ebb-4dd0-b34b-7892ff94c610" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
