### PR TITLE
CI `-k` support file name matcing

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -148,7 +148,8 @@ def _extract_marked_tests(
         # conftest.py
         if 'skip' in marks:
             continue
-        if k_value is not None and k_value not in function_name and k_value not in file_path:
+        if k_value is not None and (k_value not in function_name or
+                                    k_value not in file_path):
             # TODO(zpoint): support and/or in k_value
             continue
 

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -148,8 +148,7 @@ def _extract_marked_tests(
         # conftest.py
         if 'skip' in marks:
             continue
-        if k_value is not None and (k_value not in function_name or
-                                    k_value not in file_path):
+        if k_value is not None and k_value not in function_name and k_value not in file_path:
             # TODO(zpoint): support and/or in k_value
             continue
 

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -148,7 +148,7 @@ def _extract_marked_tests(
         # conftest.py
         if 'skip' in marks:
             continue
-        if k_value is not None and k_value not in function_name:
+        if k_value is not None and k_value not in function_name and k_value not in file_path:
             # TODO(zpoint): support and/or in k_value
             continue
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

More consistent with real pytest behavior

Before:

`/smoke-test --aws -k test_basic` 

triggers no test.

After 

`/smoke-test --aws -k test_basic` 

triggers all tests in file `tests/smoke_tests/test_basic.py`

<img width="908" alt="image" src="https://github.com/user-attachments/assets/ea89dab8-2b9b-4a8c-bed0-086cf8ad0d69" />

^ Manual test screenshot

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test --aws -k test_basic` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
