### PR TITLE
jobs dashboard: increase the timeout

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -160,7 +160,7 @@ async def dashboard(request: fastapi.Request,
                 async with httpx.AsyncClient() as client:
                     response = await client.request('GET',
                                                     dashboard_url,
-                                                    timeout=1)
+                                                    timeout=5)
                 break  # Connection successful, proceed with the request
             except Exception as e:  # pylint: disable=broad-except
                 # We catch all exceptions to gracefully handle unknown


### PR DESCRIPTION
If you have a lot of jobs and a lot of failover logs, the 1s timeout could be insufficient.

Fixes #5108.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
