### PR TITLE
[helm chart] Also add securityContexts to initContainers

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- end }}        
+        {{- end }}
         resources:
           {{- toYaml .Values.apiService.resources | nindent 10 }}
         env:
@@ -123,6 +123,10 @@ spec:
       initContainers:
       {{- if .Values.awsCredentials.enabled }}
       - name: create-aws-credentials
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}      
         image: {{ .Values.apiService.image }}
         command: ["/bin/sh", "-c"]
         args:
@@ -154,6 +158,10 @@ spec:
       {{- end }}
       {{- if .Values.gcpCredentials.enabled }}
       - name: setup-gcp-credentials
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}      
         image: google/cloud-sdk:latest
         command: ["/bin/sh", "-c"]
         env:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -161,7 +161,7 @@ spec:
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- end }}      
+        {{- end }}
         image: google/cloud-sdk:latest
         command: ["/bin/sh", "-c"]
         env:

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -126,7 +126,7 @@ spec:
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
-        {{- end }}      
+        {{- end }}
         image: {{ .Values.apiService.image }}
         command: ["/bin/sh", "-c"]
         args:


### PR DESCRIPTION
Hey guys,

Further to https://github.com/skypilot-org/skypilot/pull/5018, I discovered (when I tried to add AWS credentials), that the AWS / GCP initContainers should also get default securityContexts, so this PR simply adds these :)

Cheers!
D