### PR TITLE
[storage] Abort all subprocesses for a request when cancelled

### DIFF
--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -512,7 +512,7 @@ def parallel_upload(source_path_list: List[str],
         commands.append(sync_command)
 
     # Run commands in parallel
-    with pool.ThreadPool(processes=max_concurrent_uploads) as p:
+    with pool.Pool(processes=max_concurrent_uploads) as p:
         p.starmap(
             run_upload_cli,
             zip(commands, [access_denied_message] * len(commands),

--- a/sky/data/data_utils.py
+++ b/sky/data/data_utils.py
@@ -512,7 +512,7 @@ def parallel_upload(source_path_list: List[str],
         commands.append(sync_command)
 
     # Run commands in parallel
-    with pool.Pool(processes=max_concurrent_uploads) as p:
+    with pool.ThreadPool(processes=max_concurrent_uploads) as p:
         p.starmap(
             run_upload_cli,
             zip(commands, [access_denied_message] * len(commands),

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -260,6 +260,8 @@ def _request_execution_wrapper(request_id: str,
                 f.flush()
         except KeyboardInterrupt:
             logger.info(f'Request {request_id} cancelled by user')
+            # Kill all children processes related to this request.
+            subprocess_utils.kill_children_processes()
             _restore_output(original_stdout, original_stderr)
             return
         except (Exception, SystemExit) as e:  # pylint: disable=broad-except

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -261,6 +261,10 @@ def _request_execution_wrapper(request_id: str,
         except KeyboardInterrupt:
             logger.info(f'Request {request_id} cancelled by user')
             # Kill all children processes related to this request.
+            # Each executor handles a single request, so we can safely kill all
+            # children processes related to this request.
+            # This is required as python does not pass the KeyboardInterrupt
+            # to the threads that are not main thread.
             subprocess_utils.kill_children_processes()
             _restore_output(original_stdout, original_stderr)
             return


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/5067

**Symptom**
When `sky api cancel` is called on a launch, any local directory upload to remote (when `source` is specified in `file_mounts`) is not cancelled with the request.

**Context**
When a request is executed, it is executed with a signal handler that translates `SIGTERM` to `KeyboardInterrupt`.
```
def _sigterm_handler(signum: int, frame: Optional['types.FrameType']) -> None:
    raise KeyboardInterrupt


def _request_execution_wrapper(request_id: str,
                               ignore_return_value: bool) -> None:
    """Wrapper for a request execution.

    It wraps the execution of a request to:
    1. Deserialize the request from the request database and serialize the
       return value/exception in the request database;
    2. Update the request status based on the execution result;
    3. Redirect the stdout and stderr of the execution to log file;
    4. Handle the SIGTERM signal to abort the request gracefully.
    """
    # Handle the SIGTERM signal to abort the request processing gracefully.
    signal.signal(signal.SIGTERM, _sigterm_handler)
```
When an api request is cancelled (using `sky api cancel`), SIGTERM is sent to the executor process. The reason this is done is documented inline.
```
def kill_requests(request_ids: Optional[List[str]] = None,
                  user_id: Optional[str] = None) -> List[str]:
...
                # Use SIGTERM instead of SIGKILL:
                # - The executor can handle SIGTERM gracefully
                # - After SIGTERM, the executor can reuse the request process
                #   for other requests, avoiding the overhead of forking a new
                #   process for each request.
                os.kill(request_record.pid, signal.SIGTERM)
```

When a local directory is uploaded, the following call stack is executed:

`upload` > `batch_gsutil_rsync` (I was using GCS to repro this issue) > `parallel_upload` > `run_upload_cli` > `run_with_log`

`run_with_log`, among other things, correctly catches `KeyboardInterrupt` to clean up the upload processes.
```
def run_with_log(
    ...
) -> Union[int, Tuple[int, str, str]]:
    ...
    stdin = kwargs.pop('stdin', subprocess.DEVNULL)
    with subprocess.Popen(cmd,
                          stdout=stdout_arg,
                          stderr=stderr_arg,
                          start_new_session=True,
                          shell=shell,
                          stdin=stdin,
                          **kwargs) as proc:
        try:
            subprocess_utils.kill_process_daemon(proc.pid)
            stdout = ''
            stderr = ''
            ...
        except KeyboardInterrupt:
            # Kill the subprocess directly, otherwise, the underlying
            # process will only be killed after the python program exits,
            # causing the stream handling stuck at `readline`.
            subprocess_utils.kill_children_processes()
            raise
```
**Problem**
When `parallel_upload` calls `run_upload_cli`, it is called in a ThreadPool. This means `run_upload_cli`, and the exception check in `run_with_log`, is run in a different, non-main thread (but not another process).
```
    # Run commands in parallel
    with pool.ThreadPool(processes=max_concurrent_uploads) as p:
        p.starmap(
            run_upload_cli,
            zip(commands, [access_denied_message] * len(commands),
                [bucket_name] * len(commands), [log_path] * len(commands)))
```
When `sky api cancel` is called, SIGTERM is sent and is translated into KeyboardInterrupt in the signal handler, this KeyboardInterrupt is _only raised in the main thread_. This means the exception check in `run_with_log` is never triggered.

`run_with_log` has another guard: `subprocess_utils.kill_process_daemon(proc.pid)`. Essentially, a daemon process is spawned to monitor both the parent and the child process, and kill the child process if the parent process is killed. When SIGTERM is sent to the parent process, the process _should_ die - but not in this case. SIGTERM here raises a KeyboardInterrupt so that the executor process can cancel the request gracefully and later handle other requests.

Since the **thread** running `run_with_log` never gets a `KeyboardInterrupt`, the child process (running the actual upload) is never killed. Since the **process** running `run_with_log` is never killed, the daemon does not kill the child process. The child process continues running until the directory is uploaded even after the api request is cancelled. 

**Fix**
in `_request_execution_wrapper`, kill children processes associated with the request. Since one executor is handling one request at a time, this is fine to do.

```
        except KeyboardInterrupt:
            logger.info(f'Request {request_id} cancelled by user')
            # Kill all children processes related to this request.
            subprocess_utils.kill_children_processes()
            _restore_output(original_stdout, original_stderr)
            return
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] Correctness: make sure the upload process is cancelled correctly on `sky api cancel`.
- [x] Backward compatibility: `/quicktest-core` (CI)
- api cancel related smoke tests
  - [x] test_skyserve_cancel
  - [x] test_job_queue_multinode
  - [x] test_large_job_queue
  - [x] test_cancel_aws
  - [x] test_cancel_gcp
  - [x] test_launch_and_exec_async
  - [x] test_cancel_launch_and_exec_async
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
