### PR TITLE
Support wss:// websocket URLs for api-managed SSH proxying [WIP]

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -162,7 +162,7 @@ def _get_cluster_records_and_set_ssh_config(
                     # updating skypilot.
                     f'\'{sys.executable} {sky.__root_dir__}/templates/'
                     f'websocket_proxy.py '
-                    f'{server_common.get_server_url().split("://")[1]} '
+                    f'{server_common.get_server_url().replace("http://", "ws://").replace("https://", "wss://").split("://")[1]} '
                     f'{handle.cluster_name}\'')
                 credentials['ssh_proxy_command'] = proxy_command
             cluster_utils.SSHConfigHelper.add_cluster(
@@ -1796,7 +1796,6 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
                                                            skip_finished=True,
                                                            all_users=all_users)
     show_endpoints = endpoints or endpoint is not None
-    show_single_endpoint = endpoint is not None
     show_services = show_services and not any([clusters, ip, endpoints])
     if show_services:
         # Run the sky serve service query in parallel to speed up the
@@ -1835,7 +1834,7 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
                         property='IP address' if ip else 'endpoint(s)',
                         flag='ip' if ip else
                         ('endpoint port'
-                         if show_single_endpoint else 'endpoints')))
+                         if endpoint is not None else 'endpoints')))
     else:
         click.echo(f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Clusters'
                    f'{colorama.Style.RESET_ALL}')
@@ -2075,6 +2074,7 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
             fg='yellow')
 
 
+@cli.command()
 @cli.command()
 @click.option(
     '--sync-down',

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -59,6 +59,10 @@ async def websocket_to_stdout(websocket):
 
 if __name__ == '__main__':
     server_url = sys.argv[1].strip('/')
-    websocket_url = (f'ws://{server_url}/kubernetes-pod-ssh-proxy'
-                     f'?cluster_name={sys.argv[2]}')
+    if '://' in server_url:
+        websocket_url = (f'{server_url}/kubernetes-pod-ssh-proxy'
+                         f'?cluster_name={sys.argv[2]}')
+    else:
+        websocket_url = (f'ws://{server_url}/kubernetes-pod-ssh-proxy'
+                         f'?cluster_name={sys.argv[2]}')
     asyncio.run(main(websocket_url))


### PR DESCRIPTION
Fixes #5016

Signed-off-by: David Young <davidy@funkypenguin.co.nz>

This PR resolves (in a backwards-compatible way) the issues with `ws://` vs `wss://` raised in #5016.

I'm creating this as a WIP because I'm seeking guidance about how best to test locally.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
