### PR TITLE
Make `aiohttp` compatible with the latest `runpod`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,4 +35,4 @@ pytest-env>=0.6
 memory_profiler==0.61.0
 
 # For testing SkyServe
-aiohttp==3.9.1
+aiohttp==3.9.3


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
### Why are the changes needed?
The latest version of `runpod` (`1.7.7`) requires the `aiohttp[speedups]` module with a minimum version of `3.9.3`, as shown below:

![Screenshot 2025-04-04 at 3 20 51 PM](https://github.com/user-attachments/assets/ba2fe154-ac8f-42e8-948c-415be5c5e7be)

### What changes were proposed in this pull request?
Upgrade `aiohttp` to version `3.9.3` in `requirements-dev.txt`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
