### PR TITLE
[GCP] Automatically infer the GPU type from the instance type

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -583,10 +583,7 @@ class GCP(clouds.Cloud):
                                         resources.disk_tier)
             if not ok:
                 return resources_utils.FeasibleResources([], [], None)
-
-            if resources.instance_type not in service_catalog.gcp_catalog.GCP_ACC_INSTANCE_TYPES:
-                # General CPU instance types without accelerators
-                return resources_utils.FeasibleResources([resources], [], None)
+            return resources_utils.FeasibleResources([resources], [], None)
 
         if resources.accelerators is None:
             # Return a default instance type with the given number of vCPUs.

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -280,21 +280,6 @@ def get_default_instance_type(
                                                       memory_gb_or_ratio)
 
 
-def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
-    """Infer the GPU type from the instance type.
-
-    This inference logic is GCP-specific. Unlike other clouds, we don't call
-    the internal implementation defined in common.py.
-
-    Args:
-        instance_type: the instance type to use.
-
-    Returns:
-        A dictionary mapping from the accelerator name to the accelerator count.
-    """
-    return _INSTANCE_TYPE_TO_ACC[instance_type]
-
-
 def get_instance_type_for_accelerator(
         acc_name: str,
         acc_count: int,
@@ -554,7 +539,8 @@ def check_accelerator_attachable_to_host(instance_type: str,
     """
     if accelerators is None:
         if instance_type in _ACC_INSTANCE_TYPES:
-            accelerators = get_accelerators_from_instance_type(instance_type)
+            # Infer the GPU type from the instance type
+            accelerators = _INSTANCE_TYPE_TO_ACC[instance_type]
         else:
             # Skip the following checks if instance_type is a general CPU
             # instance without accelerators

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -115,8 +115,7 @@ _INSTANCE_TYPE_TO_ACC = {
     for acc_count, instance_types in acc_count_to_instance_type.items()
     for instance_type in instance_types
 }
-_ACC_INSTANCE_TYPES = list(_INSTANCE_TYPE_TO_ACC.keys())
-GCP_ACC_INSTANCE_TYPES = _ACC_INSTANCE_TYPES
+GCP_ACC_INSTANCE_TYPES = list(_INSTANCE_TYPE_TO_ACC.keys())
 
 # Number of CPU cores per GPU based on the AWS setting.
 # GCP A100 has its own instance type mapping.
@@ -294,7 +293,7 @@ def get_accelerators_from_instance_type(
     Returns:
         A dictionary mapping from the accelerator name to the accelerator count.
     """
-    if instance_type in _ACC_INSTANCE_TYPES:
+    if instance_type in GCP_ACC_INSTANCE_TYPES:
         return _INSTANCE_TYPE_TO_ACC[instance_type]
     else:
         # General CPU instance types don't come with pre-attached accelerators.
@@ -559,7 +558,7 @@ def check_accelerator_attachable_to_host(instance_type: str,
             attached to the host.
     """
     if accelerators is None:
-        if instance_type in _ACC_INSTANCE_TYPES:
+        if instance_type in GCP_ACC_INSTANCE_TYPES:
             # Infer the GPU type from the instance type
             accelerators = _INSTANCE_TYPE_TO_ACC[instance_type]
         else:

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -106,6 +106,16 @@ _ACC_INSTANCE_TYPE_DICTS = {
         8: ['a3-megagpu-8g'],
     }
 }
+# Enable GPU type inference from instance types
+_INTANCE_TYPE_TO_ACC = {
+    instance_type: {
+        acc_name: acc_count
+    } for acc_name, acc_count_to_instance_type in
+    _ACC_INSTANCE_TYPE_DICTS.items()
+    for acc_count, instance_types in acc_count_to_instance_type.items()
+    for instance_type in instance_types
+}
+_ACC_INSTANCE_TYPES = list(_INTANCE_TYPE_TO_ACC.keys())
 
 # Number of CPU cores per GPU based on the AWS setting.
 # GCP A100 has its own instance type mapping.
@@ -268,6 +278,21 @@ def get_default_instance_type(
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
+
+
+def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
+    """Infer the GPU type from the instance type.
+
+    This inference logic is GCP-specific. Unlike other clouds, we don't call
+    the internal implementation defined in common.py.
+
+    Args:
+        instance_type: the instance type to use.
+
+    Returns:
+        A dictionary mapping from the accelerator name to the accelerator count.
+    """
+    return _INTANCE_TYPE_TO_ACC[instance_type]
 
 
 def get_instance_type_for_accelerator(
@@ -528,16 +553,12 @@ def check_accelerator_attachable_to_host(instance_type: str,
             attached to the host.
     """
     if accelerators is None:
-        for acc_name, val in _ACC_INSTANCE_TYPE_DICTS.items():
-            if instance_type in sum(val.values(), []):
-                # NOTE: While it is allowed to use A2/G2 VMs as CPU-only nodes,
-                # we exclude this case as it is uncommon and undesirable.
-                with ux_utils.print_exception_no_traceback():
-                    raise exceptions.ResourcesMismatchError(
-                        f'{instance_type} instance types should be used with '
-                        f'{acc_name} GPUs. Either use other instance types or '
-                        f'specify the accelerators as {acc_name}.')
-        return
+        if instance_type in _ACC_INSTANCE_TYPES:
+            accelerators = get_accelerators_from_instance_type(instance_type)
+        else:
+            # Skip the following checks if instance_type is a general CPU
+            # instance without accelerators
+            return
 
     acc = list(accelerators.items())
     assert len(acc) == 1, acc

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -281,7 +281,8 @@ def get_default_instance_type(
                                                       memory_gb_or_ratio)
 
 
-def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
+def get_accelerators_from_instance_type(
+        instance_type: str) -> Optional[Dict[str, int]]:
     """Infer the GPU type from the instance type.
 
     This inference logic is GCP-specific. Unlike other clouds, we don't call
@@ -293,7 +294,11 @@ def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
     Returns:
         A dictionary mapping from the accelerator name to the accelerator count.
     """
-    return _INSTANCE_TYPE_TO_ACC[instance_type]
+    if instance_type in _ACC_INSTANCE_TYPES:
+        return _INSTANCE_TYPE_TO_ACC[instance_type]
+    else:
+        # General CPU instance types don't come with pre-attached accelerators.
+        return None
 
 
 def get_instance_type_for_accelerator(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -116,6 +116,7 @@ _INSTANCE_TYPE_TO_ACC = {
     for instance_type in instance_types
 }
 _ACC_INSTANCE_TYPES = list(_INSTANCE_TYPE_TO_ACC.keys())
+GCP_ACC_INSTANCE_TYPES = _ACC_INSTANCE_TYPES
 
 # Number of CPU cores per GPU based on the AWS setting.
 # GCP A100 has its own instance type mapping.
@@ -278,6 +279,21 @@ def get_default_instance_type(
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
                                                       memory_gb_or_ratio)
+
+
+def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
+    """Infer the GPU type from the instance type.
+
+    This inference logic is GCP-specific. Unlike other clouds, we don't call
+    the internal implementation defined in common.py.
+
+    Args:
+        instance_type: the instance type to use.
+
+    Returns:
+        A dictionary mapping from the accelerator name to the accelerator count.
+    """
+    return _INSTANCE_TYPE_TO_ACC[instance_type]
 
 
 def get_instance_type_for_accelerator(

--- a/sky/clouds/service_catalog/gcp_catalog.py
+++ b/sky/clouds/service_catalog/gcp_catalog.py
@@ -107,7 +107,7 @@ _ACC_INSTANCE_TYPE_DICTS = {
     }
 }
 # Enable GPU type inference from instance types
-_INTANCE_TYPE_TO_ACC = {
+_INSTANCE_TYPE_TO_ACC = {
     instance_type: {
         acc_name: acc_count
     } for acc_name, acc_count_to_instance_type in
@@ -115,7 +115,7 @@ _INTANCE_TYPE_TO_ACC = {
     for acc_count, instance_types in acc_count_to_instance_type.items()
     for instance_type in instance_types
 }
-_ACC_INSTANCE_TYPES = list(_INTANCE_TYPE_TO_ACC.keys())
+_ACC_INSTANCE_TYPES = list(_INSTANCE_TYPE_TO_ACC.keys())
 
 # Number of CPU cores per GPU based on the AWS setting.
 # GCP A100 has its own instance type mapping.
@@ -292,7 +292,7 @@ def get_accelerators_from_instance_type(instance_type: str) -> Dict[str, int]:
     Returns:
         A dictionary mapping from the accelerator name to the accelerator count.
     """
-    return _INTANCE_TYPE_TO_ACC[instance_type]
+    return _INSTANCE_TYPE_TO_ACC[instance_type]
 
 
 def get_instance_type_for_accelerator(

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -95,6 +95,7 @@ def test_resources_azure(enable_all_clouds):
 
 def test_resources_gcp(enable_all_clouds):
     _test_resources_launch(sky.GCP(), 'n1-standard-16')
+    _test_resources_launch(sky.GCP(), 'a3-highgpu-8g')
 
 
 def test_partial_cpus(enable_all_clouds):
@@ -314,6 +315,9 @@ def test_instance_type_matches_accelerators(enable_all_clouds):
     _test_resources_launch(sky.GCP(),
                            instance_type='a2-highgpu-1g',
                            accelerators='a100')
+    _test_resources_launch(sky.GCP(),
+                           instance_type='a3-highgpu-8g',
+                           accelerators={'H100': 8})
 
     _test_resources_launch(sky.AWS(),
                            instance_type='p3.16xlarge',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
### Tracking issue
https://github.com/skypilot-org/skypilot/issues/4098

### Why are the changes needed?
Recent GCP GPU instances come with accelerators built into the machine type itself, which means users no longer need to explicitly specify the GPU type. For example, launching the following should just work:

```bash
# Specify instance_type only
sky launch -t a3-highgpu-8g
```

However, this isn't supported. 

### What changes were proposed in this pull request?
Automatically infer the GPU type from the specified `instance_type`. The result is shown as follows:

#### Before
![Screenshot 2025-04-04 at 10 42 44 PM](https://github.com/user-attachments/assets/77f01105-5c64-4beb-b908-590dff3e049b)

#### After
![Screenshot 2025-04-06 at 11 00 11 AM](https://github.com/user-attachments/assets/b5a4154c-c925-43e1-a263-32eecf96b593)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
