### PR TITLE
[storage] Fix failing job when script is None

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -655,7 +655,10 @@ class RayCodeGen:
         rclone_flush_script = {rclone_flush_script!r}
         if run_fn is not None:
             script = run_fn({gang_scheduling_id}, gang_scheduling_id_to_ip)
-        script += rclone_flush_script
+        if script is not None:
+            script += rclone_flush_script
+        else:
+            script = rclone_flush_script
 
         if script is not None:
             sky_env_vars_dict['{constants.SKYPILOT_NUM_GPUS_PER_NODE}'] = {int(math.ceil(num_gpus))!r}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This problem was identified in `test_env_check` smoke test.

https://buildkite.com/skypilot-1/smoke-tests/builds/557#019601d3-c17d-434c-a898-fefe53e2c783
```
2025-04-04 10:25:56 PDT | (setup pid=2033) hello world
-- | --
  | 2025-04-04 10:25:56 PDT | Traceback (most recent call last):
  | 2025-04-04 10:25:56 PDT | File "/home/ubuntu/.sky/sky_app/sky_job_2", line 447, in <module>
  | 2025-04-04 10:25:56 PDT | script += rclone_flush_script
  | 2025-04-04 10:25:56 PDT | TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
  | 2025-04-04 10:30:22 PDT | ✓ Job finished (status: FAILED_DRIVER).
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_env_check`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
