### PR TITLE
`--remote-server` option in buildkite support parallel execution

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -40,6 +40,13 @@ QUEUE_GENERIC_CLOUD = 'generic_cloud'
 QUEUE_KUBERNETES = 'kubernetes'
 QUEUE_EKS = 'eks'
 QUEUE_GKE = 'gke'
+# We use a separate queue for generic cloud tests on remote servers because:
+# - generic_cloud queue has high concurrency on a single VM
+# - remote-server requires launching a docker container per test
+# - Reusing generic_cloud queue to run remote-server tests would overload the VM
+# Kubernetes has low concurrency on a single VM originally,
+# so remote-server won't drain VM resources, we can reuse the same queue.
+QUEUE_GENERIC_CLOUD_REMOTE_SERVER = 'generic_cloud_remote_server'
 # We use KUBE_BACKEND to specify the queue for kubernetes tests mark as
 # resource_heavy. It can be either EKS or GKE.
 QUEUE_KUBE_BACKEND = os.getenv('KUBE_BACKEND', QUEUE_EKS).lower()
@@ -56,6 +63,27 @@ CLOUD_QUEUE_MAP = {
 GENERATED_FILE_HEAD = ('# This is an auto-generated Buildkite pipeline by '
                        '.buildkite/generate_pipeline.py, Please do not '
                        'edit directly.\n')
+
+
+def _get_buildkite_queue(cloud: str, remote_server: bool,
+                         run_on_cloud_kube_backend: bool) -> str:
+    """Get the Buildkite queue for a given cloud.
+
+    We use a separate queue for generic cloud tests on remote servers because:
+    - generic_cloud queue has high concurrency on a single VM
+    - remote-server requires launching a docker container per test
+    - Reusing generic_cloud queue to run remote-server tests would overload the VM
+
+    Kubernetes has low concurrency on a single VM originally,
+    so remote-server won't drain VM resources, we can reuse the same queue.
+    """
+    if run_on_cloud_kube_backend:
+        return QUEUE_KUBE_BACKEND
+
+    queue = CLOUD_QUEUE_MAP[cloud]
+    if queue == QUEUE_GENERIC_CLOUD and remote_server:
+        return QUEUE_GENERIC_CLOUD_REMOTE_SERVER
+    return queue
 
 
 def _parse_args(args: Optional[str] = None):
@@ -140,6 +168,7 @@ def _extract_marked_tests(
     print(f'default_clouds_to_run: {default_clouds_to_run}, k_value: {k_value}')
     function_name_marks_map = collections.defaultdict(set)
     function_name_param_map = collections.defaultdict(list)
+    remote_server = '--remote-server' in extra_args
 
     for function_name, marks in matches:
         clean_function_name = re.sub(r'\[.*?\]', '', function_name)
@@ -212,8 +241,8 @@ def _extract_marked_tests(
             param_list += [None
                           ] * (len(final_clouds_to_include) - len(param_list))
         function_cloud_map[function_name] = (final_clouds_to_include, [
-            QUEUE_KUBE_BACKEND
-            if run_on_cloud_kube_backend else CLOUD_QUEUE_MAP[cloud]
+            _get_buildkite_queue(cloud, remote_server,
+                                 run_on_cloud_kube_backend)
             for cloud in final_clouds_to_include
         ], param_list, [
             extra_args for _ in range(len(final_clouds_to_include))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,7 +373,7 @@ def setup_docker_container(request):
         logger.info('Waiting for container to be ready...')
         url = docker_utils.get_api_server_endpoint_inside_docker()
         health_endpoint = f'{url}/api/health'
-        max_retries = 20
+        max_retries = 40
         retry_count = 0
 
         while retry_count < max_retries:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -363,7 +363,7 @@ def setup_docker_container(request):
         # Use create_and_setup_new_container to create and start the container
         docker_utils.create_and_setup_new_container(
             target_container_name=docker_utils.get_container_name(),
-            host_port=46581,
+            host_port=docker_utils.get_host_port(),
             container_port=46580,
             username=default_user)
 

--- a/tests/smoke_tests/docker/docker_utils.py
+++ b/tests/smoke_tests/docker/docker_utils.py
@@ -1,6 +1,6 @@
+import hashlib
 import logging
 import os
-import socket
 import subprocess
 
 IMAGE_NAME = 'sky-remote-test-image'
@@ -27,10 +27,20 @@ def get_container_name() -> str:
     return container_name
 
 
+def get_host_port() -> int:
+    """Get the host port that will be listened by the test container."""
+    container_name = get_container_name()
+    # Create a deterministic hash using MD5
+    md5_hash = hashlib.md5(container_name.encode('utf-8')).hexdigest()
+    # Convert first 8 chars of hash to integer and map to port range 40000-50000
+    port = 40000 + (int(md5_hash[:8], 16) % 10000)
+    return port
+
+
 def get_api_server_endpoint_inside_docker() -> str:
     """Get the API server endpoint inside a Docker container."""
     host = 'host.docker.internal' if is_inside_docker() else '0.0.0.0'
-    return f'http://{host}:46581'
+    return f'http://{host}:{get_host_port()}'
 
 
 def create_and_setup_new_container(target_container_name: str, host_port: int,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #5126

Currently, multiple containers in the same VM are binding to the same port, causing only the first container to succeed while the others fail.

* Hash a port instead of using constant value.
* Add a new queue to lower the concurrency of `remote-test` jobs


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test --aws --remote-server --managed-jobs` (CI)
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
