### PR TITLE
Fix flaky for test skyserve rolling update

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -272,7 +272,7 @@ def _check_replica_in_status(name: str,
             '    fi; '
             '    echo "Waiting for replica status conditions to be met..."; '
             '    sleep 5; '  # Check every 5 seconds
-            'done')
+            'done; ')  # Add semicolon here
     else:
         # Original logic that fails immediately if conditions aren't met
         check_cmd = ''

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -246,12 +246,12 @@ def _check_replica_in_status(name: str,
     if timeout_seconds > 0:
         # Create a timeout mechanism that will wait up to timeout_seconds
         check_cmd = (
-            'start_time=$(date +%s); '
+            f'start_time=$(date +%s); '
             f'timeout={timeout_seconds}; '  # Use the provided timeout
-            'while true; do '
-            '    s=$(sky serve status {name}); '
-            '    echo "$s"; '
-            '    all_conditions_met=true; ')
+            f'while true; do '
+            f'    s=$(sky serve status {name}); '
+            f'    echo "$s"; '
+            f'    all_conditions_met=true; ')
 
         # Add each condition to the check
         for condition in check_conditions:

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -167,27 +167,6 @@ _WAIT_NO_NOT_READY = (
     '    sleep 10; '
     'done')
 
-# Shell script snippet to wait for a specific number of replicas to be in SHUTTING_DOWN state
-# with a timeout of 120 seconds (2 minutes)
-_WAIT_FOR_SHUTTING_DOWN = (
-    'start_time=$(date +%s); '
-    'timeout=120; '  # 2 minutes timeout
-    'while true; do '
-    '    s=$(sky serve status {name}); '
-    '    shutting_down_count=$(echo "$s" | grep "SHUTTING_DOWN" | wc -l); '
-    '    [ "$shutting_down_count" -eq {count} ] && break; '
-    '    current_time=$(date +%s); '
-    '    elapsed=$((current_time - start_time)); '
-    '    if [ "$elapsed" -ge "$timeout" ]; then '
-    '        echo "Timeout: Expected {count} replicas in SHUTTING_DOWN state, but found $shutting_down_count"; '
-    '        echo "$s"; '
-    '        exit 1; '
-    '    fi; '
-    '    echo "Waiting for {count} replicas to be in SHUTTING_DOWN state (currently $shutting_down_count)..."; '
-    '    sleep 10; '
-    'done; '
-    'echo "Found {count} replicas in SHUTTING_DOWN state"')
-
 
 def _get_replica_ip(name: str, replica_id: int) -> str:
     return (f'ip{replica_id}=$(echo "$s" | '

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -764,7 +764,15 @@ def test_skyserve_rolling_update(generic_cloud: str):
                 # TODO(zhwu): we should have a more generalized way for checking the
                 # mixed version of replicas to avoid depending on the specific
                 # round robin load balancing policy.
-                'curl $endpoint | grep "Hi, SkyPilot here"',
+                'result=$(curl $endpoint); echo "Result: $result"; '
+                'if echo "$result" | grep -q "Hi, SkyPilot here"; then '
+                '    echo "Found old version output"; '
+                'else '
+                '    echo "$result" | grep "Hi, new SkyPilot here!" || exit 1; '
+                '    echo "Found new version output, trying again for old version"; '
+                '    result2=$(curl $endpoint); echo "Result2: $result2"; '
+                '    echo "$result2" | grep "Hi, SkyPilot here" || exit 1; '
+                'fi',
             ],
             _TEARDOWN_SERVICE.format(name=name),
             timeout=20 * 60,

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -764,6 +764,9 @@ def test_skyserve_rolling_update(generic_cloud: str):
                 # TODO(zhwu): we should have a more generalized way for checking the
                 # mixed version of replicas to avoid depending on the specific
                 # round robin load balancing policy.
+                # Note: If there's a timeout waiting in single_new_replica check,
+                # the round robin load balancing state might be affected and we may need
+                # multiple requests to observe both old and new versions of the service.
                 'result=$(curl $endpoint); echo "Result: $result"; '
                 'if echo "$result" | grep -q "Hi, SkyPilot here"; then '
                 '    echo "Found old version output"; '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve   #5123 

From the log, it seems the test case is checking for `SHUTTING_DOWN` right after the sky server update, but the sky server hasn't updated the original replica to `SHUTTING_DOWN` yet. 

After the test fails, the sky status shows the correct status with the replica in `SHUTTING_DOWN`. So we need to wait longer - adding a 60-second delay before failing should fix this flaky test.

<img width="1869" alt="image" src="https://github.com/user-attachments/assets/bae71560-9308-4469-8d8f-30cc05c677c0" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_rolling_update --aws`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_rolling_update --azure`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_rolling_update --gcp`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_rolling_update --kubernetes`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_update --aws`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_update --kubernetes`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
