### PR TITLE
[storage] Don't wait for rclone flush if run section is empty

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -132,7 +132,7 @@ its performance requirements and size of the data.
    * - Disk Size
      - |:white_check_mark:| No disk size requirements [3]_ .
      - |:yellow_circle:| VM disk size must be greater than the size of the bucket.
-     - |:yellow_circle:| No disk size requirements, but cached data needs to fit on disk. 
+     - |:yellow_circle:| No disk size requirements, but cached data needs to fit on disk.
 
 .. [1] ``MOUNT`` mode does not support the full POSIX interface and some file
     operations may fail. Most notably, random writes and append operations are
@@ -170,7 +170,7 @@ MOUNT_CACHED mode in detail
 to provide a virtual filesystem that is asynchronously synced with the bucket.
 Calling :code:`close()` does not guarantee that the file is written to the bucket.
 rclone will sync written files back to the bucket asynchronously in the order they were written.
-The local filesystem should be fully consistent, but a bucket using 
+The local filesystem should be fully consistent, but a bucket using
 `MOUNT_CACHED` on multiple nodes may only be eventually consistent.
 
 Important considerations for :code:`MOUNT_CACHED` mode:
@@ -181,7 +181,7 @@ Important considerations for :code:`MOUNT_CACHED` mode:
 * The write performance depends on the disk tier used for caching - faster disks provide better performance.
 
 Files only begin uploading after they are closed by all processes.
-When a task completes, SkyPilot ensures all cached data is successfully uploaded to the remote bucket before marking the task as finished. This guarantees that all task outputs are safely stored in cloud storage, even if the task finished execution before uploads completed. For long-running tasks with frequent writes, this may result in additional time spent flushing the cache after the main computation has finished.
+When a task completes, SkyPilot ensures all cached data from the `run` section of the task is successfully uploaded to the remote bucket before marking the task as finished. This guarantees that all task outputs are safely stored in cloud storage, even if the task finished execution before uploads completed. For long-running tasks with frequent writes, this may result in additional time spent flushing the cache after the main computation has finished.
 
 
 Common patterns
@@ -269,7 +269,7 @@ workers running on different nodes.
 Storing model checkpoints
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:code:`MOUNT_CACHED` mode can efficiently store large model checkpoints in a cloud bucket 
+:code:`MOUNT_CACHED` mode can efficiently store large model checkpoints in a cloud bucket
 without blocking the training loop.
 
 **💡 Example use case**: Saving model checkpoints to a cloud bucket.

--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -181,7 +181,7 @@ Important considerations for :code:`MOUNT_CACHED` mode:
 * The write performance depends on the disk tier used for caching - faster disks provide better performance.
 
 Files only begin uploading after they are closed by all processes.
-When a task completes, SkyPilot ensures all cached data from the `run` section of the task is successfully uploaded to the remote bucket before marking the task as finished. This guarantees that all task outputs are safely stored in cloud storage, even if the task finished execution before uploads completed. For long-running tasks with frequent writes, this may result in additional time spent flushing the cache after the main computation has finished.
+When a task completes, SkyPilot ensures all cached data from the `run` section of the SkyPilot YAML is successfully uploaded to the remote bucket before marking the task as finished. This guarantees that all task outputs are safely stored in cloud storage, even if the task finished execution before uploads completed. For long-running tasks with frequent writes, this may result in additional time spent flushing the cache after the main computation has finished.
 
 
 Common patterns

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -655,12 +655,9 @@ class RayCodeGen:
         rclone_flush_script = {rclone_flush_script!r}
         if run_fn is not None:
             script = run_fn({gang_scheduling_id}, gang_scheduling_id_to_ip)
-        if script is not None:
-            script += rclone_flush_script
-        else:
-            script = rclone_flush_script
 
         if script is not None:
+            script += rclone_flush_script
             sky_env_vars_dict['{constants.SKYPILOT_NUM_GPUS_PER_NODE}'] = {int(math.ceil(num_gpus))!r}
             # Backward compatibility: Environment starting with `SKY_` is
             # deprecated. Remove it in v0.9.0.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If the `run` section is empty (e.g. only setup section of the task is specified), don't create a run section just to trigger an rclone flush.

Additionally, modify the documentation to clarify the task waits for any data written in `run` section specifically.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: run a task with only `setup` section specified with a `MOUNT_CACHED` mount and ensure rclone flush is not executed.
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
