### PR TITLE
[fix] potential race condition for aws internal_ip configuration 

### DIFF
--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -17,6 +17,8 @@ import typing
 from typing import Any, Callable, Dict, List, Optional, Union
 import uuid
 
+import jsonschema
+
 from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
@@ -28,12 +30,10 @@ from sky.utils import validator
 
 if typing.TYPE_CHECKING:
     import jinja2
-    import jsonschema
     import psutil
     import yaml
 else:
     jinja2 = adaptors_common.LazyImport('jinja2')
-    jsonschema = adaptors_common.LazyImport('jsonschema')
     psutil = adaptors_common.LazyImport('psutil')
     yaml = adaptors_common.LazyImport('yaml')
 

--- a/sky/utils/validator.py
+++ b/sky/utils/validator.py
@@ -4,14 +4,7 @@ The main motivation behind extending the existing JSON Schema validator is to
 allow for case-insensitive enum matching since this is currently not supported
 by the JSON Schema specification.
 """
-import typing
-
-from sky.adaptors import common as adaptors_common
-
-if typing.TYPE_CHECKING:
-    import jsonschema
-else:
-    jsonschema = adaptors_common.LazyImport('jsonschema')
+import jsonschema
 
 
 def case_insensitive_enum(validator, enums, instance, schema):


### PR DESCRIPTION
this pr fix a potential race conditon caused by importing `jsonschema`. This could be resolved by adding sleep to some lines in between, which leads to a hypothesis in race condition when doing lazy import in `jsonschema` and its dependencies. Directly importing the library resolves this issue. 


to reproduce the earlier error 
```
# config.yaml
aws:
  use_internal_ips: true
```

commands
```
(sky) kych@kych-dev:~/skypilot$ sky status 
Clusters
ImportError: cannot import name 'NothingType' from 'attr' (/home/kych/miniconda3/envs/sky/lib/python3.10/site-packages/attr/__init__.py)
(sky) kych@kych-dev:~/skypilot$ sky status 
Clusters
NAME           LAUNCHED     RESOURCES                                   STATUS  AUTOSTOP   COMMAND                       
sky-3b3b-kych  14 mins ago  1x Azure(Standard_NC16as_T4_v3, {'T4': 1})  UP      1m (down)  sky launch -d -y test.py  

Managed jobs
Failed to query managed jobs: [ImportError] cannot import name 'NothingType' from 'attr' (/home/kych/miniconda3/envs/sky/lib/python3.10/site-packages/attr/__init__.py)

Services
No live services. (See: sky serve -h)

* 8 clusters have auto{stop,down} scheduled. Refresh statuses with: sky status --refresh
(sky) kych@kych-dev:~/skypilot$ sky status 
Clusters
ImportError: cannot import name 'NothingType' from 'attr' (/home/kych/miniconda3/envs/sky/lib/python3.10/site-packages/attr/__init__.py)
(sky) kych@kych-dev:~/skypilot$ sky status 
Clusters
ImportError: cannot import name 'NothingType' from 'attr' (/home/kych/miniconda3/envs/sky/lib/python3.10/site-packages/attr/__init__.py)
(sky) kych@kych-dev:~/skypilot$ sky status 
Clusters
ImportError: cannot import name 'NothingType' from 'attr' (/home/kych/miniconda3/envs/sky/lib/python3.10/site-packages/attr/__init__.py)
(sky) kych@kych-dev:~/skypilot$ sky status 
```


retrying the same command have different behaviors (sometimes it works sometimes it doesn't) removing use_internal_ips works fine 


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR 

