### PR TITLE
[UX] Retry dashboard forwarding when ping returns non-200 status code

### DIFF
--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -161,15 +161,11 @@ async def dashboard(request: fastapi.Request,
                     response = await client.request('GET',
                                                     dashboard_url,
                                                     timeout=5)
-                if response.status_code == 200:
-                    break  # Connection successful, proceed with the request
-                else:
-                    msg = ('Dashboard ping failed with status code: '
-                           f'{response.status_code}')
-                    # Raise an HTTPException here which will be caught by the
-                    # following except block to retry with new connection
-                    raise fastapi.HTTPException(
-                        status_code=response.status_code, detail=msg)
+                if response.is_success:
+                    break # Connection successful, proceed with the request
+                # Raise an HTTPException here which will be caught by the
+                # following except block to retry with new connection
+                response.raise_for_status()
             except Exception as e:  # pylint: disable=broad-except
                 # We catch all exceptions to gracefully handle unknown
                 # errors and retry or raise an HTTPException to the client.

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -161,7 +161,15 @@ async def dashboard(request: fastapi.Request,
                     response = await client.request('GET',
                                                     dashboard_url,
                                                     timeout=5)
-                break  # Connection successful, proceed with the request
+                if response.status_code == 200:
+                    break  # Connection successful, proceed with the request
+                else:
+                    msg = ('Dashboard ping failed with status code: '
+                           f'{response.status_code}')
+                    # Raise an HTTPException here which will be caught by the
+                    # following except block to retry with new connection
+                    raise fastapi.HTTPException(
+                        status_code=response.status_code, detail=msg)
             except Exception as e:  # pylint: disable=broad-except
                 # We catch all exceptions to gracefully handle unknown
                 # errors and retry or raise an HTTPException to the client.

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -162,7 +162,7 @@ async def dashboard(request: fastapi.Request,
                                                     dashboard_url,
                                                     timeout=5)
                 if response.is_success:
-                    break # Connection successful, proceed with the request
+                    break  # Connection successful, proceed with the request
                 # Raise an HTTPException here which will be caught by the
                 # following except block to retry with new connection
                 response.raise_for_status()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix https://github.com/skypilot-org/skypilot/issues/5111
Retry dashboard forwarding when ping returns non-200 status code

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Launch `sky jobs dashboard`
  - Restart the API server
  - Launch `sky jobs dashboard` again and it succeeds
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
