### PR TITLE
[docs] avoid "configurations"

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/vsphere.rst
+++ b/docs/source/cloud-setup/cloud-permissions/vsphere.rst
@@ -3,7 +3,7 @@
 vSphere
 =======
 
-This document is provided for users who use VMware vSphere provider and helps them set up basic configurations on VMware vSphere to meet the needs of running SkyPilot tasks.
+This document is provided for users who use VMware vSphere provider and helps them set up basic configuration on VMware vSphere to meet the needs of running SkyPilot tasks.
 
 .. _cloud-prepare-vsphere-tags:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1,11 +1,11 @@
 .. _config-yaml:
 
-Advanced Configurations
-=======================
+Advanced Configuration
+======================
 
-You can pass **optional configurations** to SkyPilot in the ``~/.sky/config.yaml`` file.
+You can pass **optional configuration** to SkyPilot in the ``~/.sky/config.yaml`` file.
 
-Such configurations apply to all new clusters and do not affect existing clusters.
+This configuration applies to all new clusters and does not affect existing clusters.
 
 .. tip::
 
@@ -239,7 +239,7 @@ The following run options are applied by default and cannot be overridden:
 ~~~~~~~~~~~~~~~~~~~~~~
 
 This field can be useful for mounting volumes and other advanced Docker
-configurations. You can specify a list of arguments or a string, where the
+configuration. You can specify a list of arguments or a string, where the
 former will be combined into a single string with spaces. The following is
 an example option for mounting the Docker socket and increasing the size of ``/dev/shm``:
 
@@ -309,7 +309,7 @@ Example:
 ``aws``
 ~~~~~~~
 
-Advanced AWS configurations (optional).
+Advanced AWS configuration (optional).
 
 Apply to all new instances but not existing ones.
 
@@ -583,7 +583,7 @@ Supported values:
 ``gcp``
 ~~~~~~~
 
-Advanced GCP configurations (optional).
+Advanced GCP configuration (optional).
 
 Apply to all new instances but not existing ones.
 
@@ -615,7 +615,7 @@ Example:
 
 VPC to use (optional).
 
-Default: ``null``, which implies the following behavior. First, all existing
+Default: ``null``, which implies the following behavior: All existing
 VPCs in the project are checked against the minimal recommended firewall
 rules for SkyPilot to function. If any VPC satisfies these rules, it is
 used. Otherwise, a new VPC named ``skypilot-vpc`` is automatically created
@@ -794,7 +794,7 @@ Default: ``false``.
 ``azure``
 ~~~~~~~~~~~
 
-Advanced Azure configurations (optional).
+Advanced Azure configuration (optional).
 
 .. _config-yaml-azure-resource-group-vm:
 
@@ -829,7 +829,7 @@ Example:
 ``kubernetes``
 ~~~~~~~~~~~~~~~
 
-Advanced Kubernetes configurations (optional).
+Advanced Kubernetes configuration (optional).
 
 .. _config-yaml-kubernetes-ports:
 
@@ -956,7 +956,7 @@ Example:
 ``oci``
 ~~~~~~~
 
-Advanced OCI configurations (optional).
+Advanced OCI configuration (optional).
 
 ``oci_config_profile``
     The profile name in ``~/.oci/config`` to use for launching instances.
@@ -980,7 +980,7 @@ Example:
 .. code-block:: yaml
 
     oci:
-        # Region-specific configurations
+        # Region-specific configuration
         ap-seoul-1:
           # The OCID of the VCN to use for instances (optional).
           vcn_ocid: ocid1.vcn.oc1.ap-seoul-1.amaaaaaaak7gbriarkfs2ssus5mh347ktmi3xa72tadajep6asio3ubqgarq

--- a/docs/source/reservations/reservations.rst
+++ b/docs/source/reservations/reservations.rst
@@ -63,7 +63,7 @@ For more details of the fields, see :ref:`config-yaml`.
 Utilizing reservations
 ~~~~~~~~~~~~~~~~~~~~~~
 
-By specifying configurations above, SkyPilot will prioritize using any available capacity in reservation/block (i.e., consider them as zero cost) whenever you launch a cluster/job.
+By specifying the configuration above, SkyPilot will prioritize using any available capacity in reservation/block (i.e., consider them as zero cost) whenever you launch a cluster/job.
 
 Specifically, SkyPilot's behavior is as follows:
 

--- a/docs/source/running-jobs/distributed-jobs.rst
+++ b/docs/source/running-jobs/distributed-jobs.rst
@@ -124,7 +124,7 @@ To execute a job on the head node only (a common scenario for tools like
 
 SSH into worker nodes
 ---------------------
-In addition to the head node, the SSH configurations for the worker nodes of a multi-node cluster are also added to ``~/.ssh/config`` as ``<cluster_name>-worker<n>``.
+In addition to the head node, the SSH configuration values for the worker nodes of a multi-node cluster are also added to ``~/.ssh/config`` as ``<cluster_name>-worker<n>``.
 This allows you directly to SSH into the worker nodes, if required.
 
 .. code-block:: console

--- a/docs/source/running-jobs/environment-variables.rst
+++ b/docs/source/running-jobs/environment-variables.rst
@@ -6,7 +6,7 @@ Secrets and Environment Variables
 
 Environment variables are a powerful way to pass configuration and secrets to your tasks. There are two types of environment variables in SkyPilot:
 
-- :ref:`User-specified environment variables <user-specified-env-vars>`: Passed by users to tasks, useful for secrets and configurations.
+- :ref:`User-specified environment variables <user-specified-env-vars>`: Passed by users to tasks, useful for secrets and configuration.
 - :ref:`SkyPilot environment variables <sky-env-vars>`: Predefined by SkyPilot with information about the current cluster and task.
 
 .. _user-specified-env-vars:
@@ -14,7 +14,7 @@ Environment variables are a powerful way to pass configuration and secrets to yo
 User-specified environment variables
 ------------------------------------------------------------------
 
-User-specified environment variables are useful for passing secrets and any arguments or configurations needed for your tasks. They are made available in ``file_mounts``, ``setup``, and ``run``.
+User-specified environment variables are useful for passing secrets and any arguments or configuration needed for your tasks. They are made available in ``file_mounts``, ``setup``, and ``run``.
 
 You can specify environment variables to be made available to a task in several ways:
 
@@ -105,7 +105,7 @@ Using in ``setup`` and ``run``
 
 All user-specified environment variables are exported to a task's ``setup`` and ``run`` commands (i.e., accessible when they are being run).
 
-For example, this is useful for passing secrets (see below) or passing configurations:
+For example, this is useful for passing secrets (see below) or passing configuration:
 
 .. code-block:: yaml
 
@@ -227,7 +227,7 @@ Environment variables for ``run``
        Each task's logs are stored on the cluster at ``~/sky_logs/${SKYPILOT_TASK_ID%%_*}/tasks/*.log``.
 
        If a task is run as a :ref:`managed spot job <spot-jobs>`, then all
-       recoveries of that job will have the same ID value. The ID is in the format "sky-managed-<timestamp>_<job-name>(_<task-name>)_<job-id>-<task-id>", where ``<task-name>`` will appear when a pipeline is used, i.e., more than one task in a managed spot job. 
+       recoveries of that job will have the same ID value. The ID is in the format "sky-managed-<timestamp>_<job-name>(_<task-name>)_<job-id>-<task-id>", where ``<task-name>`` will appear when a pipeline is used, i.e., more than one task in a managed spot job.
      - sky-2023-07-06-21-18-31-563597_myclus_1
 
        For managed spot jobs: sky-managed-2023-07-06-21-18-31-563597_my-job-name_1-0

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -221,7 +221,7 @@ This example will spin up two replicas of the service,
 each listening on port 8080. A replica is considered ready when it responds to
 :code:`GET /` with a 200 status code. You can customize the readiness
 probe by specifying a different path in the :code:`readiness_probe` field.
-You can find more configurations at :ref:`Service YAML Specification
+You can find more configuration options at :ref:`Service YAML Specification
 <service-yaml-spec>`.
 
 Use ``sky serve up`` to spin up the service:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
"Advanced Configurations" in the docs has bothered me for a while because "configuration" is almost never plural. I believe these changes feel much more natural.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
