### PR TITLE
[API server] Fix default kubernetes permissions

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -153,7 +153,7 @@ rbac:
       resources: [ "roles", "rolebindings" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ] 
     # Required for managing SkyPilot system DaemonSets
-    - apiGroups: [ "" ]
+    - apiGroups: [ "apps" ]
       resources: [ "daemonsets" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
     # Required for managing configmaps for smarter-device-manager
@@ -165,6 +165,10 @@ rbac:
     - apiGroups: [ "" ]
       resources: [ "serviceaccounts" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
+    # Required for getting reason when Pod scheduling fails.
+    - apiGroups: [ "" ]
+      resources: [ "events" ]
+      verbs: [ "get", "list", "watch" ]
   # Cluster-scoped rules for API server.
   clusterRules:
     # Required for managing skypilot-system namespace, which hosts skypilot system components like smarter-device-manager.
@@ -175,6 +179,10 @@ rbac:
     # Required for getting node resources. 
     - apiGroups: [ "" ]
       resources: [ "nodes" ]
+      verbs: [ "get", "list", "watch" ]
+    # Required for querying GPUs.
+    - apiGroups: [ "" ]
+      resources: [ "pods" ]
       verbs: [ "get", "list", "watch" ]
     # Required for autodetecting runtime classes
     - apiGroups: [ "node.k8s.io" ]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #5146 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually tested `sky show-gpus` success
- [x] Manually tested Pod scheduling failed case, success 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
