### PR TITLE
[Release] Release v0.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm -rf /var/lib/apt/lists/*
 
 # Install sky
-RUN pip install --no-cache-dir "skypilot[all]==0.8.0"
+RUN pip install --no-cache-dir "skypilot[all]==0.8.1"

--- a/sky/__init__.py
+++ b/sky/__init__.py
@@ -35,7 +35,7 @@ def _get_git_commit():
 
 
 __commit__ = _get_git_commit()
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 __root_dir__ = os.path.dirname(os.path.abspath(__file__))
 
 

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -8,7 +8,7 @@ This file is imported by setup.py, so:
 from typing import Dict, List
 
 install_requires = [
-    'wheel',
+    'wheel<0.46.0',  # https://github.com/skypilot-org/skypilot/issues/5153
     'cachetools',
     # NOTE: ray requires click>=7.0.
     'click >= 7.0',


### PR DESCRIPTION
Patch release to mitigate https://github.com/skypilot-org/skypilot/issues/5153.

v0.8.1 = 0.8.0 + https://github.com/skypilot-org/skypilot/pull/5155.

Skipping tests since wheel < 0.46 is known to be good. 