### PR TITLE
[API server] Propagate configmap update to API server

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -62,9 +62,8 @@ spec:
           {{- if .Values.apiService.config }}
           mkdir -p /root/.sky
           echo "Copying config.yaml from ConfigMap \`skypilot-config\` to /root/.sky/config.yaml"
-          # The configmap serves as the ground truth for the config.yaml file.
-          # Any local changes to the config.yaml file will be overwritten by the contents of the configmap.
-          cp /tmp/config.yaml /root/.sky/config.yaml
+          # The configmap serves as the ground truth for the config.yaml file, read-only
+          ln -sf /var/skypilot/config/config.yaml /root/.sky/config.yaml
           {{- end }}
 
           if sky api start -h | grep -q -- "--foreground"; then
@@ -101,8 +100,7 @@ spec:
         {{- end }}
         {{- if .Values.apiService.config }}
         - name: skypilot-config
-          mountPath: /tmp/config.yaml
-          subPath: config.yaml
+          mountPath: /var/skypilot/config
         {{- end }}
         {{- if .Values.awsCredentials.enabled }}
         - name: aws-config

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -15,6 +15,8 @@ apiService:
 
   
   # Set config.yaml content on the API server
+  # Note that updating this value will take tens of seconds to take effect on the API server,
+  # you can check whether the config.yaml is updated in the server by exec into the pod and cat ~/.sky/config.yaml
   config: null
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -15,8 +15,8 @@ apiService:
 
   
   # Set config.yaml content on the API server
-  # Note that updating this value will take tens of seconds to take effect on the API server,
-  # you can check whether the config.yaml is updated in the server by exec into the pod and cat ~/.sky/config.yaml
+  # Updating this value will take tens of seconds to take effect on the API server.
+  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/config.yaml`
   config: null
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5157

1. Mount entire configmap instead of subPath so that the change will be reflected to the container by kubelet (about ~10s delay)
2. Use symbolic link instead of cp to reflect the changes to API server

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually on k8s, updating config takes effect with ~10s delay
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
