### PR TITLE
[API Server] simpler override function that doesn't rely on tmpfile

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -200,7 +200,7 @@ def override_skypilot_config(
         # If no override configs (None or empty dict), do nothing.
         yield
         return
-    original_config = copy.deepcopy(_dict)
+    original_config = _dict
     config = _dict.get_nested(
         keys=tuple(),
         default_value=None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -554,22 +554,10 @@ def test_override_skypilot_config(monkeypatch, tmp_path):
         assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
                                           None) == 'override-command'
 
-        # Get the temp file path
-        temp_config_path = os.environ.get(
-            skypilot_config.ENV_VAR_SKYPILOT_CONFIG)
-        assert temp_config_path is not None
-        assert os.path.exists(temp_config_path)
-
     # Check values are restored
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == original_vpc
     assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
                                       None) == original_proxy
-
-    # Check temp file is cleaned up
-    assert not os.path.exists(temp_config_path)
-    env_config_path = os.environ.get(skypilot_config.ENV_VAR_SKYPILOT_CONFIG)
-    assert env_config_path == str(config_path), (
-        f'{env_config_path} is not cleaned up')
 
     # Test with None override_configs
     with skypilot_config.override_skypilot_config(None):
@@ -613,12 +601,6 @@ def test_override_skypilot_config_without_original_config(
                                           None) == 'override-vpc'
         assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
                                           None) == 'override-command'
-
-        # Get the temp file path
-        temp_config_path = os.environ.get(
-            skypilot_config.ENV_VAR_SKYPILOT_CONFIG)
-        assert temp_config_path is not None
-        assert os.path.exists(temp_config_path)
 
     # Check values are restored
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -366,6 +366,15 @@ def test_config_with_env(monkeypatch, tmp_path) -> None:
     assert skypilot_config.get_nested(('gcp', 'use_internal_ips'), None)
 
 
+def test_invalid_override_config(monkeypatch, tmp_path) -> None:
+    """Test that an invalid override config is rejected."""
+    with pytest.raises(sky.exceptions.InvalidSkyPilotConfigError) as e:
+        with skypilot_config.override_skypilot_config({
+                'invalid_key': 'invalid_value',
+        }):
+            pass
+
+
 def test_k8s_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Simplify the logic of temporarily overriding config - notably, without relying on the use of tmpfile / env var.

Note: The existing code **does** account for the case where child processes are spun up, as assign to `os.environ` does propagate to children processes. I am running a full smoke test suite to catch any case where this would cause any problems - I did some looking and I do not think this would cause any issues.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test` (CI)
- [x] Unit tests: existing tests `test_override_skypilot_config` and `test_override_skypilot_config_without_original_config` are passing

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
