### PR TITLE
Fix connect issue for pypi-nightly-build.yml

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -23,9 +23,9 @@ jobs:
   nightly-build-pypi:
     runs-on: ubuntu-latest
     needs: check-date
-    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    if: ${{ needs.check-date.outputs.should_run != 'false' }}
     outputs:
-      build_number: ${{ steps.trigger_buildkite.outputs.build_number }}
+      build_number: ${{ steps.extract_build_number.outputs.build_number }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -114,4 +114,3 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
-

--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -114,3 +114,4 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Problem, the build number is not conencted correctly in our [nighty-build](https://github.com/skypilot-org/skypilot/actions/runs/14355169009/job/40242872696)

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/ae0dc3da-f939-405a-80c8-e08daa98fc3b" />


[Test on my personal repo](https://github.com/zpoint/skypilot/actions/runs/14369488125/job/40289746203):

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/6fd68ee2-e086-4174-ba66-db33a79f2b6f" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
