### PR TITLE
chore: use the python constant instead of hardcoded string for SKYPILOT_CONFIG envvar

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -17,6 +17,7 @@ import yaml
 
 import sky
 from sky import serve
+from sky import skypilot_config
 from sky.clouds import AWS
 from sky.clouds import GCP
 from sky.skylet import constants
@@ -50,7 +51,7 @@ LOW_RESOURCE_PARAM = {
     'memory': '4+',
 }
 LOW_CONTROLLER_RESOURCE_ENV = {
-    'SKYPILOT_CONFIG': 'tests/test_yamls/low_resource_sky_config.yaml',
+    skypilot_config.ENV_VAR_SKYPILOT_CONFIG: 'tests/test_yamls/low_resource_sky_config.yaml',
 }
 LOW_CONTROLLER_RESOURCE_OVERRIDE_CONFIG = {
     'jobs': {
@@ -367,9 +368,10 @@ def run_one_test(test: Test) -> None:
         temp_config = tempfile.NamedTemporaryFile(mode='w',
                                                   suffix='.yaml',
                                                   delete=False)
-        if 'SKYPILOT_CONFIG' in env_dict:
+        if skypilot_config.ENV_VAR_SKYPILOT_CONFIG in env_dict:
             # Read the original config
-            with open(env_dict['SKYPILOT_CONFIG'], 'r') as f:
+            with open(env_dict[skypilot_config.ENV_VAR_SKYPILOT_CONFIG],
+                      'r') as f:
                 config = yaml.safe_load(f)
         else:
             config = {}
@@ -382,7 +384,7 @@ def run_one_test(test: Test) -> None:
         yaml.dump(config, temp_config)
         temp_config.close()
         # Update the environment variable to use the temporary file
-        env_dict['SKYPILOT_CONFIG'] = temp_config.name
+        env_dict[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = temp_config.name
 
     for command in test.commands:
         write(f'+ {command}\n')

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -26,6 +26,7 @@ import pytest
 from smoke_tests import smoke_tests_utils
 
 import sky
+from sky import skypilot_config
 from sky.skylet import constants
 
 
@@ -360,7 +361,7 @@ def test_gcp_mig():
         ],
         f'sky down -y {name} && {smoke_tests_utils.down_cluster_for_cloud_cmd(name)}',
         env={
-            'SKYPILOT_CONFIG': 'tests/test_yamls/use_mig_config.yaml',
+            skypilot_config.ENV_VAR_SKYPILOT_CONFIG: 'tests/test_yamls/use_mig_config.yaml',
             constants.SKY_API_SERVER_URL_ENV_VAR:
                 sky.server.common.get_server_url()
         })
@@ -400,15 +401,16 @@ def test_gcp_force_enable_external_ips():
         ),
         f'sky down -y {name}',
     ]
-    skypilot_config = 'tests/test_yamls/force_enable_external_ips_config.yaml'
-    test = smoke_tests_utils.Test('gcp_force_enable_external_ips',
-                                  test_commands,
-                                  f'sky down -y {name}',
-                                  env={
-                                      'SKYPILOT_CONFIG': skypilot_config,
-                                      constants.SKY_API_SERVER_URL_ENV_VAR:
-                                          sky.server.common.get_server_url()
-                                  })
+    skypilot_config_file = 'tests/test_yamls/force_enable_external_ips_config.yaml'
+    test = smoke_tests_utils.Test(
+        'gcp_force_enable_external_ips',
+        test_commands,
+        f'sky down -y {name}',
+        env={
+            skypilot_config.ENV_VAR_SKYPILOT_CONFIG: skypilot_config_file,
+            constants.SKY_API_SERVER_URL_ENV_VAR:
+                sky.server.common.get_server_url()
+        })
     smoke_tests_utils.run_one_test(test)
 
 

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -32,6 +32,7 @@ from smoke_tests import test_mount_and_storage
 
 import sky
 from sky import jobs
+from sky import skypilot_config
 from sky.clouds import gcp
 from sky.data import storage as storage_lib
 from sky.skylet import constants
@@ -1040,7 +1041,7 @@ def test_managed_jobs_intermediate_storage(generic_cloud: str):
                  f'sky storage delete {output_storage_name} -y || true; '
                  f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}'),
                 env={
-                    'SKYPILOT_CONFIG': user_config_path,
+                    skypilot_config.ENV_VAR_SKYPILOT_CONFIG: user_config_path,
                     constants.SKY_API_SERVER_URL_ENV_VAR:
                         sky.server.common.get_server_url()
                 },

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -72,10 +72,10 @@ def test_aws_with_ssh_proxy_command():
             [
                 f'sky launch -y -c jump-{name} --cloud aws {smoke_tests_utils.LOW_RESOURCE_ARG} --region us-east-1',
                 # Use jump config
-                f'export SKYPILOT_CONFIG={f.name}; '
+                f'export {skypilot_config.ENV_VAR_SKYPILOT_CONFIG}={f.name}; '
                 f'sky launch -y -c {name} --cloud aws {smoke_tests_utils.LOW_RESOURCE_ARG} --region us-east-1 echo hi',
                 f'sky logs {name} 1 --status',
-                f'export SKYPILOT_CONFIG={f.name}; sky exec {name} echo hi',
+                f'export {skypilot_config.ENV_VAR_SKYPILOT_CONFIG}={f.name}; sky exec {name} echo hi',
                 f'sky logs {name} 2 --status',
                 # Start a small job to make sure the controller is created.
                 f'sky jobs launch -n {name}-0 --cloud aws {smoke_tests_utils.LOW_RESOURCE_ARG} --use-spot -y echo hi',
@@ -86,7 +86,7 @@ def test_aws_with_ssh_proxy_command():
                     cluster_name_wildcard='sky-jobs-controller-*',
                     cluster_status=[sky.ClusterStatus.UP],
                     timeout=300),
-                f'export SKYPILOT_CONFIG={f.name}; sky jobs launch -n {name} --cloud aws {smoke_tests_utils.LOW_RESOURCE_ARG} --region us-east-1 -yd echo hi',
+                f'export {skypilot_config.ENV_VAR_SKYPILOT_CONFIG}={f.name}; sky jobs launch -n {name} --cloud aws {smoke_tests_utils.LOW_RESOURCE_ARG} --region us-east-1 -yd echo hi',
                 smoke_tests_utils.
                 get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                     job_name=name,

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -39,7 +39,7 @@ def _load_task_and_apply_policy(
     config_path: str,
     idle_minutes_to_autostop: Optional[int] = None,
 ) -> Tuple[sky.Dag, config_utils.Config]:
-    os.environ['SKYPILOT_CONFIG'] = config_path
+    os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = config_path
     importlib.reload(skypilot_config)
     return admin_policy_utils.apply(
         task,

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -27,7 +27,9 @@ from sky.resources import Resources
 @mock.patch('sky.utils.common_utils.fill_template')
 def test_write_cluster_config_w_remote_identity(mock_fill_template,
                                                 *mocks) -> None:
-    os.environ['SKYPILOT_CONFIG'] = './tests/test_yamls/test_aws_config.yaml'
+    os.environ[
+        skypilot_config.
+        ENV_VAR_SKYPILOT_CONFIG] = './tests/test_yamls/test_aws_config.yaml'
     skypilot_config._reload_config()
 
     cloud = clouds.AWS()

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -133,7 +133,9 @@ def test_no_cloud_labels_resources_single_enabled_cloud():
             return_value='fake-image')
 @mock.patch.object(clouds.aws, 'DEFAULT_SECURITY_GROUP_NAME', 'fake-default-sg')
 def test_aws_make_deploy_variables(*mocks) -> None:
-    os.environ['SKYPILOT_CONFIG'] = './tests/test_yamls/test_aws_config.yaml'
+    os.environ[
+        skypilot_config.
+        ENV_VAR_SKYPILOT_CONFIG] = './tests/test_yamls/test_aws_config.yaml'
     importlib.reload(skypilot_config)
 
     cloud = clouds.AWS()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
As part of a larger effort to revamp config management, I have a potential need to modify the behavior of `skypilot_config.ENV_VAR_SKYPILOT_CONFIG` environment variable. This requires keeping track of where this variable is used today and how they are used.

This PR changes every instance of `SKYPILOT_CONFIG` environment variable in hardcoded string format to `skypilot_config.ENV_VAR_SKYPILOT_CONFIG`, such that every usage of the environment variable is command+click able.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
