### PR TITLE
[UX] global and project level config

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -1,22 +1,22 @@
 apiService:
   image: berkeleyskypilot/skypilot-nightly:latest
-  # Number of replicas to deploy - replicas > 1 is not well tested, and requires 
+  # Number of replicas to deploy - replicas > 1 is not well tested, and requires
   # a PVC that supports ReadWriteMany (see accessMode in storage section below).
   replicas: 1
   preDeployHook: |-
     # Run commands before deploying the API server, e.g. installing an admin
     # policy. Remember to set the admin policy in the config section below.
     echo "Pre-deploy hook"
-    
+
     # Uncomment the following lines to install the admin policy
-    
+
     # echo "Installing admin policy"
     # pip install git+https://github.com/michaelvll/admin-policy-examples
 
-  
+
   # Set config.yaml content on the API server
   # Updating this value will take tens of seconds to take effect on the API server.
-  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/config.yaml`
+  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/skyconfig.yaml`
   config: null
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy
@@ -50,7 +50,7 @@ apiService:
   # limits:
   #  cpu: "4"
   #  memory: "8Gi"
-  
+
   # [Internal] Enable developer mode for SkyPilot
   skypilotDev: false
 
@@ -107,7 +107,7 @@ ingress-nginx:
     service:
       type: LoadBalancer
       # Default annotations for the ingress controller service. We want an L4 loadbalancer by default for maximum compatibility,
-      # especially for websocket SSH tunneling. Different cloud providers may require different annotations. 
+      # especially for websocket SSH tunneling. Different cloud providers may require different annotations.
       # Annotations with no side effects are aggregated below to simplify the usage.
       annotations:
         # For AWS service reconciled by cloud-controller-manager, use NLB by default.
@@ -147,13 +147,13 @@ rbac:
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
     # Required for managing SSH keys
     - apiGroups: [ "" ]
-      resources: [ "secrets" ]  
+      resources: [ "secrets" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
     # Required for granting namespaced permissions to SkyPilot Pods and SkyPilot system components.
     # TODO(aylei): This is too permissive, consider passing existing roles instead.
-    - apiGroups: [ "rbac.authorization.k8s.io" ] 
+    - apiGroups: [ "rbac.authorization.k8s.io" ]
       resources: [ "roles", "rolebindings" ]
-      verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ] 
+      verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
     # Required for managing SkyPilot system DaemonSets
     - apiGroups: [ "apps" ]
       resources: [ "daemonsets" ]
@@ -163,7 +163,7 @@ rbac:
     - apiGroups: [ "" ]
       resources: [ "configmaps" ]
       verbs: [ "get", "list", "watch", "create" ]
-    # Required for managing service accounts for SkyPilot Pods and SkyPilot system components. 
+    # Required for managing service accounts for SkyPilot Pods and SkyPilot system components.
     - apiGroups: [ "" ]
       resources: [ "serviceaccounts" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
@@ -175,10 +175,10 @@ rbac:
   clusterRules:
     # Required for managing skypilot-system namespace, which hosts skypilot system components like smarter-device-manager.
     - apiGroups: [ "" ]
-      resources: [ "namespaces" ]  
+      resources: [ "namespaces" ]
       resourceNames: [ "skypilot-system" ]
       verbs: [ "get", "list", "watch", "create" ]
-    # Required for getting node resources. 
+    # Required for getting node resources.
     - apiGroups: [ "" ]
       resources: [ "nodes" ]
       verbs: [ "get", "list", "watch" ]
@@ -188,7 +188,7 @@ rbac:
       verbs: [ "get", "list", "watch" ]
     # Required for autodetecting runtime classes
     - apiGroups: [ "node.k8s.io" ]
-      resources: [ "runtimeclasses" ]  
+      resources: [ "runtimeclasses" ]
       verbs: [ "get", "list", "watch" ]
     # Required for exposing services.
     - apiGroups: [ "networking.k8s.io" ]
@@ -197,9 +197,9 @@ rbac:
     # TODO(aylei): This is too permissive, consider passing existing roles instead.
     # Required for granting cluster permissions to SkyPilot Pods.
     - apiGroups: [ "rbac.authorization.k8s.io" ]
-      resources: [ "clusterroles", "clusterrolebindings" ]  
+      resources: [ "clusterroles", "clusterrolebindings" ]
       verbs: [ "get", "list", "watch", "create", "update", "patch", "delete" ]
-    
+
 kubernetesCredentials:
   # Enable/disable using the API server's cluster for workloads
   useApiServerCluster: true
@@ -226,8 +226,8 @@ podSecurityContext: {}
 securityContext:
   capabilities:
     drop:
-    - ALL  
+    - ALL
   allowPrivilegeEscalation: false
 
 # Set the runtime class
-runtimeClassName: 
+runtimeClassName:

--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -226,7 +226,7 @@ Using a specific VPC
 By default, SkyPilot uses the "default" VPC in each region. If a region does not have a `default VPC <https://docs.aws.amazon.com/vpc/latest/userguide/work-with-default-vpc.html#create-default-vpc>`_, SkyPilot will not be able to use the region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/config.yaml`` to specify the VPC name in the ``aws.vpc_name``
+file ``~/.sky/skyconfig.yaml`` to specify the VPC name in the ``aws.vpc_name``
 field:
 
 .. code-block:: yaml

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -95,7 +95,7 @@ User
 
 .. note::
 
-    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/config.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
+    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/skyconfig.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
 
 .. note::
 
@@ -151,7 +151,7 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
+9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/skyconfig.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 
@@ -270,7 +270,7 @@ By default, SkyPilot uses the following behavior to get a VPC to use for all GCP
   automatically starts with one subnet per region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/config.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
+file ``~/.sky/skyconfig.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
 
 .. code-block:: yaml
 
@@ -289,7 +289,7 @@ The custom VPC should contain the :ref:`required firewall rules <gcp-minimum-fir
 Using internal IPs
 -----------------------
 For security reason, users may only want to use internal IPs for SkyPilot instances.
-To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
+To do so, you can use SkyPilot's global config file ``~/.sky/skyconfig.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
 
 .. code-block:: yaml
 

--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -19,7 +19,7 @@ SkyPilot can operate using either of the following three authentication methods:
 
 2. **Using a custom service account**: If you have a custom service account
    with the `necessary permissions <k8s-permissions_>`__, you can configure
-   SkyPilot to use it by adding this to your :ref:`~/.sky/config.yaml <config-yaml>` file:
+   SkyPilot to use it by adding this to your :ref:`~/.sky/skyconfig.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -29,7 +29,7 @@ SkyPilot can operate using either of the following three authentication methods:
 3. **Using your local kubeconfig file**: In this case, SkyPilot will
    copy your local ``~/.kube/config`` file to the controller pod and use it for
    authentication. To use this method, set ``remote_identity: LOCAL_CREDENTIALS`` to your
-   Kubernetes configuration in the :ref:`~/.sky/config.yaml <config-yaml>` file:
+   Kubernetes configuration in the :ref:`~/.sky/skyconfig.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -349,10 +349,10 @@ Create the service account using the following command:
 
 After creating the service account, the cluster admin may distribute kubeconfigs with the ``sky-sa`` service account to users who need to access the cluster.
 
-Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/config.yaml``:
+Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/skyconfig.yaml``:
 
 .. code-block:: yaml
 
-    # ~/.sky/config.yaml
+    # ~/.sky/skyconfig.yaml
     kubernetes:
       remote_identity: sky-sa   # Or your service account name

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -20,7 +20,7 @@ To implement and use an admin policy:
 
 - Admins writes a simple Python package with a policy class that implements SkyPilot's ``sky.AdminPolicy`` interface;
 - Admins distributes this package to users;
-- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/config.yaml`` for the policy to go into effect.
+- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/skyconfig.yaml`` for the policy to go into effect.
 
 
 Overview
@@ -32,7 +32,7 @@ User-Side
 ~~~~~~~~~~
 
 To apply the policy, a user needs to set the ``admin_policy`` field in the SkyPilot config
-``~/.sky/config.yaml`` to the path of the Python package that implements the policy.
+``~/.sky/skyconfig.yaml`` to the path of the Python package that implements the policy.
 For example:
 
 .. code-block:: yaml

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -466,11 +466,11 @@ Setting the job files bucket
 For managed jobs, SkyPilot requires an intermediate bucket to store files used in the task, such as local file mounts, temporary files, and the workdir.
 If you do not configure a bucket, SkyPilot will automatically create a temporary bucket named :code:`skypilot-filemounts-{username}-{run_id}` for each job launch. SkyPilot automatically deletes the bucket after the job completes.
 
-Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/config.yaml`:
+Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/skyconfig.yaml`:
 
 .. code-block:: yaml
 
-  # ~/.sky/config.yaml
+  # ~/.sky/skyconfig.yaml
   jobs:
     bucket: s3://my-bucket  # Supports s3://, gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cos://<region>/<bucket>
 
@@ -527,7 +527,7 @@ You may want to customize the resources of the jobs controller for several reaso
 #. Enforcing the jobs controller to run on a specific location. (Default: cheapest location)
 #. Changing the disk_size of the jobs controller to store more logs. (Default: 50GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/config.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/skyconfig.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -314,7 +314,7 @@ The :code:`~/.oci/config` file should contain the following fields:
   # Note that we should avoid using full home path for the key_file configuration, e.g. use ~/.oci instead of /home/username/.oci
   key_file=~/.oci/oci_api_key.pem
 
-By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/config.yaml`, put the compartment's OCID there, as the following:
+By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/skyconfig.yaml`, put the compartment's OCID there, as the following:
 
 .. code-block:: text
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -227,12 +227,12 @@ Our default of using a NodePort service is the recommended way to expose the API
             $ ENDPOINT=http://${WEB_USERNAME}:${WEB_PASSWORD}@${HOST}
             $ echo $ENDPOINT
             http://skypilot:yourpassword@1.1.1.1
-        
+
         .. tip::
-            
+
             If you're using a Kubernetes cluster without LoadBalancer support, you may get an empty IP address in the output above.
             In that case, use the NodePort option instead.
-        
+
         .. tip::
 
             For fine-grained control over the LoadBalancer service, refer to the `helm values of ingress-nginx <https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx#values>`_. Note that all values should be put under ``ingress-nginx.`` prefix since the ingress-nginx chart is installed as a subchart.
@@ -262,7 +262,7 @@ Our default of using a NodePort service is the recommended way to expose the API
             http://skypilot:yourpassword@1.1.1.1:30050
 
         .. tip::
-            
+
             You can also omit ``ingress-nginx.controller.service.nodePorts.http`` and ``ingress-nginx.controller.service.nodePorts.https`` to use random ports in the NodePort range (default 30000-32767). Make sure these ports are open on your nodes if you do so.
 
         .. tip::
@@ -369,7 +369,7 @@ Once the EBS CSI driver is installed, the default ``gp2`` storage class will be 
 Setting the SkyPilot config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/config.yaml`` in the API server container.
+The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/skyconfig.yaml`` in the API server container.
 
 To set the config file, pass ``--set-file apiService.config=path/to/your/config.yaml`` to the ``helm`` command:
 
@@ -434,7 +434,7 @@ If you are upgrading from an early 0.8.0 nightly with a previously deployed Node
 - Keep the legacy NodePort service and gradually migrate to the new LoadBalancer service:
 
   Add ``--set ingress.nodePortEnabled=true`` to your ``helm upgrade`` command to keep the legacy NodePort service. Existing clients can continue to use the previous NodePort service. After all clients have been migrated to the new service, you can disable the legacy NodePort service by adding ``--set ingress.nodePortEnabled=false`` to the ``helm upgrade`` command.
-  
+
 - Disable the legacy NodePort service:
 
   Add ``--set ingress.nodePortEnabled=false`` to your ``helm upgrade`` command to disable the legacy NodePort service. Clients will need to use the new service to connect to the API server.

--- a/docs/source/reference/api-server/api-server.rst
+++ b/docs/source/reference/api-server/api-server.rst
@@ -83,7 +83,7 @@ Run ``sky api login`` to connect to the API server.
     $ sky api login
     Enter your SkyPilot API server endpoint: http://skypilot:password@1.2.3.4:30050
 
-This will save the API server endpoint to your ``~/.sky/config.yaml`` file.
+This will save the API server endpoint to your ``~/.sky/skyconfig.yaml`` file.
 
 To verify that the API server is working, run ``sky api info``:
 
@@ -97,7 +97,7 @@ To verify that the API server is working, run ``sky api info``:
 
 .. tip::
 
-    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/config.yaml``:
+    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/skyconfig.yaml``:
 
     .. code-block:: console
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -3,7 +3,7 @@
 Advanced Configuration
 ======================
 
-You can pass **optional configuration** to SkyPilot in the ``~/.sky/config.yaml`` file.
+You can pass **optional configuration** to SkyPilot in the ``~/.sky/skyconfig.yaml`` file.
 
 This configuration applies to all new clusters and does not affect existing clusters.
 

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -73,7 +73,7 @@ Once your cluster administrator has :ref:`setup a Kubernetes cluster <kubernetes
 
    .. note::
 
-     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/config.yaml`` file:
+     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/skyconfig.yaml`` file:
 
      .. code-block:: yaml
 
@@ -219,7 +219,7 @@ Your image must satisfy the following requirements:
 
 Using images from private repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/config.yaml` to specify the secret like so:
+To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/skyconfig.yaml` to specify the secret like so:
 
 .. code-block:: yaml
 
@@ -280,14 +280,14 @@ After launching the cluster with :code:`sky launch -c myclus task.yaml`, you can
 Customizing SkyPilot Pods
 -------------------------
 
-You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/config.yaml`.
+You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/skyconfig.yaml`.
 The value of :code:`pod_config` should be a dictionary that follows the `Kubernetes Pod API <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#pod-v1-core>`_. This will apply to all pods created by SkyPilot.
 
-For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/config.yaml` file:
+For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/skyconfig.yaml` file:
 
 .. code-block:: yaml
 
-    # ~/.sky/config.yaml
+    # ~/.sky/skyconfig.yaml
     kubernetes:
       pod_config:
         spec:
@@ -332,20 +332,20 @@ FAQs
 
 * **Can I use multiple Kubernetes clusters with SkyPilot?**
 
-  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/config.yaml`. See :ref:`multi-kubernetes`.
+  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/skyconfig.yaml`. See :ref:`multi-kubernetes`.
 
   If ``allowed_contexts`` is not set, SkyPilot will use the current active context. To use a different context, change your current context using :code:`kubectl config use-context <context-name>`.
 
 * **Are autoscaling Kubernetes clusters supported?**
 
-  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/config.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
+  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/skyconfig.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
   This will direct SkyPilot to wait for the cluster to scale up before failing over to the next candidate resource (e.g., next cloud).
 
   If you are using GPUs in a scale-to-zero setting, you should also set the :code:`autoscaler` key to the autoscaler type of your cluster. More details in :ref:`config-yaml`.
 
   .. code-block:: yaml
 
-      # ~/.sky/config.yaml
+      # ~/.sky/skyconfig.yaml
       kubernetes:
         provision_timeout: 900  # Wait 15 minutes for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
         autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs/TPUs in scale-to-zero setting

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -57,11 +57,11 @@ Internal load balancers
 
 To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `internal load balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
 
-Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/config.yaml``):
+Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/skyconfig.yaml``):
 
 .. code-block:: yaml
 
-    # ~/.sky/config.yaml
+    # ~/.sky/skyconfig.yaml
     kubernetes:
       custom_metadata:
         annotations:
@@ -114,7 +114,7 @@ To use this mode:
     and the endpoint may not be accessible from outside the cluster.
 
 
-3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/config.yaml` to use the ingress mode.
+3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/skyconfig.yaml` to use the ingress mode.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -252,7 +252,7 @@ Set up NFS and other volumes
 
 `Kubernetes volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`_ can be attached to your SkyPilot pods using the :ref:`pod_config <kubernetes-custom-pod-config>` field. This is useful for accessing shared storage such as NFS or local high-performance storage like NVMe drives.
 
-Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/config.yaml`.
+Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/skyconfig.yaml`.
 
 Examples:
 
@@ -291,7 +291,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/config.yaml
+           # ~/.sky/skyconfig.yaml
            kubernetes:
              pod_config:
                spec:
@@ -339,7 +339,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/config.yaml
+           # ~/.sky/skyconfig.yaml
            kubernetes:
              pod_config:
                spec:
@@ -387,7 +387,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/config.yaml
+           # ~/.sky/skyconfig.yaml
            kubernetes:
              pod_config:
                spec:

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -276,18 +276,18 @@ Your ingress's service must be of type :code:`LoadBalancer` or :code:`NodePort` 
 Is SkyPilot configured to use Nginx Ingress?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Take a look at your :code:`~/.sky/config.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
+Take a look at your :code:`~/.sky/skyconfig.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
 
 .. code-block:: bash
 
-    $ cat ~/.sky/config.yaml
+    $ cat ~/.sky/skyconfig.yaml
 
     # Output should contain:
     #
     # kubernetes:
     #   ports: ingress
 
-If not, add the :code:`ports: ingress` section to your :code:`~/.sky/config.yaml` file.
+If not, add the :code:`ports: ingress` section to your :code:`~/.sky/skyconfig.yaml` file.
 
 .. _kubernetes-troubleshooting-ports-dryrun:
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -75,7 +75,7 @@ kubeconfig. You can get the current context with ``kubectl config
 current-context``.
 
 To allow SkyPilot to access multiple Kubernetes clusters, you can set the
-``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/config.yaml``.
+``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/skyconfig.yaml``.
 
 .. code-block:: yaml
 
@@ -148,4 +148,3 @@ Dynamically updating clusters to use
 ----------------------------------------------
 
 You can configure SkyPilot to dynamically fetch Kubernetes cluster configs and enforce restrictions on which clusters are used. Refer to :ref:`dynamic-kubernetes-contexts-update-policy` for more.
-

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -867,12 +867,12 @@ OR
 Global config overrides
 ---------------------------
 
-To override the :ref:`global configs <config-yaml>` in ``~/.sky/config.yaml`` at a task level:
+To override the :ref:`global configs <config-yaml>` in ``~/.sky/skyconfig.yaml`` at a task level:
 
 .. code-block:: yaml
 
   experimental:
-    # Override the configs in ~/.sky/config.yaml from a task level.
+    # Override the configs in ~/.sky/skyconfig.yaml from a task level.
     #
     # The following fields can be overridden. Please refer to docs of Advanced
     # Configuration for more details of those fields:

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -183,11 +183,11 @@ You can set up multiple Kubernetes clusters with SkyPilot by using different ``c
     sky local up --ips cluster2-ips.txt --ssh-user user2 --ssh-key-path key2.pem --context-name cluster2
 
 
-You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/config.yaml`` file:
+You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/skyconfig.yaml`` file:
 
 .. code-block:: yaml
 
-   # ~/.sky/config.yaml
+   # ~/.sky/skyconfig.yaml
     allowed_contexts:
       - cluster1
       - cluster2

--- a/docs/source/reservations/reservations.rst
+++ b/docs/source/reservations/reservations.rst
@@ -29,7 +29,7 @@ To request capacity reservations/blocks, see the official docs:
 
 Once you have successfully created a reservation/block, you will get an ID of the reservation/block, such as ``cr-012345678``.
 
-To use the reservation/block, you can specify two fields in ``~/.sky/config.yaml``:
+To use the reservation/block, you can specify two fields in ``~/.sky/skyconfig.yaml``:
 
 * ``aws.prioritize_reservations``: whether to prioritize launching clusters from capacity reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your reserved capacity created with ``Instance eligibility: open``.
 * ``aws.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple capacity reservations or blocks with ``Instance eligibility: targeted`` for different instance types in multiple regions/zones.
@@ -105,7 +105,7 @@ GCP reservations are similar to AWS capacity reservations, where you can reserve
 
 To get a reservation, see the `GCP official docs <https://cloud.google.com/compute/docs/instances/reservations-single-project>`__.
 
-Like AWS, you can specify two fields in ``~/.sky/config.yaml``:
+Like AWS, you can specify two fields in ``~/.sky/skyconfig.yaml``:
 
 * ``gcp.prioritize_reservations``: whether to prioritize launching clusters from reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your `automatically consumed reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_any_matching_reservation>`__.
 * ``gcp.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple `specific reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_a_specific_reservation>`__ for different instance types in multiple regions/zones.
@@ -137,7 +137,7 @@ GCP `Dynamic Workload Scheduler (DWS) <https://cloud.google.com/blog/products/co
 Using DWS for VMs
 ~~~~~~~~~~~~~~~~~
 
-SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/config.yaml``:
+SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/skyconfig.yaml``:
 
 .. code-block:: yaml
 

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -500,7 +500,7 @@ You may want to customize the resources of the SkyServe controller for several r
 3. Changing the maximum number of services that can be run concurrently, which is the minimum number between 4x the vCPUs of the controller and the memory in GiB of the controller. (Default: 16)
 4. Changing the disk_size of the controller to store more logs. (Default: 200GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/config.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/skyconfig.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/sky/adaptors/oci.py
+++ b/sky/adaptors/oci.py
@@ -13,7 +13,7 @@ from sky.clouds.utils import oci_utils
 # effect.
 logging.getLogger('oci.circuit_breaker').setLevel(logging.WARNING)
 
-CONFIG_PATH = '~/.oci/config'
+OCI_CONFIG_PATH = '~/.oci/config'
 ENV_VAR_OCI_CONFIG = 'OCI_CONFIG'
 
 oci = common.LazyImport(
@@ -23,7 +23,7 @@ oci = common.LazyImport(
 
 
 def get_config_file() -> str:
-    conf_file_path = CONFIG_PATH
+    conf_file_path = OCI_CONFIG_PATH
     config_path_via_env_var = os.environ.get(ENV_VAR_OCI_CONFIG)
     if config_path_via_env_var is not None:
         conf_file_path = config_path_via_env_var

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -382,10 +382,10 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         network_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(
             network_mode_str)
     except ValueError as e:
-        # Add message saying "Please check: ~/.sky/config.yaml" to the error
+        # Add message saying "Please check: ~/.sky/skyconfig.yaml" to the error
         # message.
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(str(e) + ' Please check: ~/.sky/config.yaml.') \
+            raise ValueError(str(e) + ' Please check: ~/.sky/skyconfig.yaml.') \
                 from None
     _, public_key_path = get_or_generate_keys()
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -682,7 +682,7 @@ def write_cluster_config(
             ssh_proxy_command = ssh_proxy_command_config[region_name]
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
-    # User-supplied global instance tags from ~/.sky/config.yaml.
+    # User-supplied global instance tags from ~/.sky/skyconfig.yaml.
     labels = skypilot_config.get_nested((str(cloud).lower(), 'labels'), {})
     # labels is a dict, which is guaranteed by the type check in
     # schemas.py

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1473,7 +1473,7 @@ class RetryingVmProvisioner(object):
                     f'invalid cloud credentials: '
                     f'{common_utils.format_exception(e)}')
             except exceptions.InvalidCloudConfigs as e:
-                # Failed due to invalid user configs in ~/.sky/config.yaml.
+                # Failed due to invalid user configs in ~/.sky/skyconfig.yaml.
                 logger.warning(f'{common_utils.format_exception(e)}')
                 # We should block the entire cloud if the user config is
                 # invalid.

--- a/sky/check.py
+++ b/sky/check.py
@@ -142,7 +142,7 @@ def check_capabilities(
     if disallowed_cloud_names:
         disallowed_clouds_hint = (
             '\nNote: The following clouds were disabled because they were not '
-            'included in allowed_clouds in ~/.sky/config.yaml: '
+            'included in allowed_clouds in ~/.sky/skyconfig.yaml: '
             f'{", ".join([c for c in disallowed_cloud_names])}')
     if not all_enabled_clouds:
         echo(

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1780,7 +1780,7 @@ def api_login(endpoint: Optional[str] = None) -> None:
     server_common.check_server_healthy(endpoint)
 
     # Set the endpoint in the config file
-    config_path = pathlib.Path(skypilot_config.CONFIG_PATH).expanduser()
+    config_path = pathlib.Path(skypilot_config.GLOBAL_CONFIG_PATH).expanduser()
     with filelock.FileLock(config_path.with_suffix('.lock')):
         if not skypilot_config.loaded():
             config_path.touch()

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1780,7 +1780,8 @@ def api_login(endpoint: Optional[str] = None) -> None:
     server_common.check_server_healthy(endpoint)
 
     # Set the endpoint in the config file
-    config_path = pathlib.Path(skypilot_config.USER_CONFIG_PATH).expanduser()
+    config_path = pathlib.Path(
+        skypilot_config.get_user_config_path()).expanduser()
     with filelock.FileLock(config_path.with_suffix('.lock')):
         if not skypilot_config.loaded():
             config_path.touch()

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1780,7 +1780,7 @@ def api_login(endpoint: Optional[str] = None) -> None:
     server_common.check_server_healthy(endpoint)
 
     # Set the endpoint in the config file
-    config_path = pathlib.Path(skypilot_config.GLOBAL_CONFIG_PATH).expanduser()
+    config_path = pathlib.Path(skypilot_config.USER_CONFIG_PATH).expanduser()
     with filelock.FileLock(config_path.with_suffix('.lock')):
         if not skypilot_config.loaded():
             config_path.touch()

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -472,10 +472,10 @@ class AWS(clouds.Cloud):
             with ux_utils.print_exception_no_traceback():
                 logger.warning(
                     f'Skip opening ports {resources.ports} for cluster {cluster_name!r}, '
-                    'as `aws.security_group_name` in `~/.sky/config.yaml` is specified as '
+                    'as `aws.security_group_name` in `~/.sky/skyconfig.yaml` is specified as '
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
-                    'in `~/.sky/config.yaml`.')
+                    'in `~/.sky/skyconfig.yaml`.')
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -9,8 +9,8 @@ History:
    file path resolution (by os.path.expanduser) when construct the file
    mounts. This bug will cause the created workder nodes located in different
    compartment and VCN than the header node if user specifies compartment_id
-   in the sky config file, because the ~/.sky/config.yaml is not sync-ed to the
-   remote machine.
+   in the sky config file, because the ~/.sky/skyconfig.yaml is not
+   sync-ed to the remote machine.
    The workaround is set the sky config file path using ENV before running
    the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml
  - Hysun He (hysun.he@oracle.com) @ Oct 12, 2024:

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -147,7 +147,7 @@ class OCIConfig:
         if config_path_via_env_var is not None:
             config_path = config_path_via_env_var
         else:
-            config_path = skypilot_config.GLOBAL_CONFIG_PATH
+            config_path = skypilot_config.USER_CONFIG_PATH
         return config_path
 
     @classmethod

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -147,7 +147,7 @@ class OCIConfig:
         if config_path_via_env_var is not None:
             config_path = config_path_via_env_var
         else:
-            config_path = skypilot_config.USER_CONFIG_PATH
+            config_path = skypilot_config.get_user_config_path()
         return config_path
 
     @classmethod

--- a/sky/clouds/utils/oci_utils.py
+++ b/sky/clouds/utils/oci_utils.py
@@ -147,7 +147,7 @@ class OCIConfig:
         if config_path_via_env_var is not None:
             config_path = config_path_via_env_var
         else:
-            config_path = skypilot_config.CONFIG_PATH
+            config_path = skypilot_config.GLOBAL_CONFIG_PATH
         return config_path
 
     @classmethod

--- a/sky/provision/instance_setup.py
+++ b/sky/provision/instance_setup.py
@@ -44,7 +44,9 @@ _DUMP_RAY_PORTS = (
 
 _RAY_PORT_COMMAND = (
     f'RAY_PORT=$({constants.SKY_PYTHON_CMD} -c '
-    '"from sky.skylet import job_lib; print(job_lib.get_ray_port())" '
+    '"from sky import sky_logging\n'
+    'with sky_logging.silent(): '
+    'from sky.skylet import job_lib; print(job_lib.get_ray_port())" '
     '2> /dev/null || echo 6379);'
     f'{constants.SKY_PYTHON_CMD} -c "from sky.utils import message_utils; '
     'print(message_utils.encode_payload({\'ray_port\': $RAY_PORT}))"')

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -43,7 +43,7 @@ def bootstrap_instances(
     if (requested_service_account ==
             kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
         # If the user has requested a different service account (via pod_config
-        # in ~/.sky/config.yaml), we assume they have already set up the
+        # in ~/.sky/skyconfig.yaml), we assume they have already set up the
         # necessary roles and role bindings.
         # If not, set up the roles and bindings for skypilot-service-account
         # here.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -723,7 +723,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                        f'{common_utils.format_exception(e)}'
                        'Continuing without using nvidia RuntimeClass.\n'
                        'If you are on a K3s cluster, manually '
-                       'override runtimeClassName in ~/.sky/config.yaml. '
+                       'override runtimeClassName in ~/.sky/skyconfig.yaml. '
                        'For more details, refer to https://docs.skypilot.co/en/latest/reference/config.html')  # pylint: disable=line-too-long
 
     needs_gpus = False

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -66,7 +66,7 @@ def get_networking_mode(
     except ValueError as e:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(str(e) +
-                             ' Please check: ~/.sky/config.yaml.') from None
+                             ' Please check: ~/.sky/skyconfig.yaml.') from None
     return networking_mode
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1454,14 +1454,14 @@ def is_kubeconfig_exec_auth(
 
 
     Using exec-based authentication is problematic when used in conjunction
-    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/config.yaml.
+    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/skyconfig.yaml.
     This is because the exec-based authentication may not have the relevant
     dependencies installed on the remote cluster or may have hardcoded paths
     that are not available on the remote cluster.
 
     Returns:
         bool: True if exec-based authentication is used and LOCAL_CREDENTIAL
-            mode is used for remote_identity in ~/.sky/config.yaml.
+            mode is used for remote_identity in ~/.sky/skyconfig.yaml.
         str: Error message if exec-based authentication is used, None otherwise
     """
     k8s = kubernetes.kubernetes
@@ -1514,7 +1514,7 @@ def is_kubeconfig_exec_auth(
                     'Managed Jobs or SkyServe controller on Kubernetes. '
                     'To fix, configure SkyPilot to create a service account '
                     'for running pods by setting the following in '
-                    '~/.sky/config.yaml:\n'
+                    '~/.sky/skyconfig.yaml:\n'
                     '    kubernetes:\n'
                     '      remote_identity: SERVICE_ACCOUNT\n'
                     '    More: https://docs.skypilot.co/en/latest/'
@@ -2236,7 +2236,7 @@ def combine_pod_config_fields(
     cluster_config_overrides: Dict[str, Any],
 ) -> None:
     """Adds or updates fields in the YAML with fields from the
-    ~/.sky/config.yaml's kubernetes.pod_spec dict.
+    ~/.sky/skyconfig.yaml's kubernetes.pod_spec dict.
     This can be used to add fields to the YAML that are not supported by
     SkyPilot yet, or require simple configuration (e.g., adding an
     imagePullSecrets field).
@@ -2296,7 +2296,7 @@ def combine_pod_config_fields(
 
 def combine_metadata_fields(cluster_yaml_path: str) -> None:
     """Updates the metadata for all Kubernetes objects created by SkyPilot with
-    fields from the ~/.sky/config.yaml's kubernetes.custom_metadata dict.
+    fields from the ~/.sky/skyconfig.yaml's kubernetes.custom_metadata dict.
 
     Obeys the same add or update semantics as combine_pod_config_fields().
     """

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -47,6 +47,8 @@ def request_body_env_vars() -> dict:
     # Remove the path to config file, as the config content is included in the
     # request body and will be merged with the config on the server side.
     env_vars.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
+    env_vars.pop(skypilot_config.ENV_VAR_GLOBAL_CONFIG, None)
+    env_vars.pop(skypilot_config.ENV_VAR_PROJECT_CONFIG, None)
     return env_vars
 
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -47,7 +47,7 @@ def request_body_env_vars() -> dict:
     # Remove the path to config file, as the config content is included in the
     # request body and will be merged with the config on the server side.
     env_vars.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
-    env_vars.pop(skypilot_config.ENV_VAR_GLOBAL_CONFIG, None)
+    env_vars.pop(skypilot_config.ENV_VAR_USER_CONFIG, None)
     env_vars.pop(skypilot_config.ENV_VAR_PROJECT_CONFIG, None)
     return env_vars
 

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,7 +53,6 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'omegaconf',
 ]
 
 local_ray = [

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,6 +53,7 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
+    'omegaconf',
 ]
 
 local_ray = [

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -117,7 +117,7 @@ RUNPOD_DOCKER_USERNAME_ENV_VAR = 'SKYPILOT_RUNPOD_DOCKER_USERNAME'
 
 # Commands for disable GPU ECC, which can improve the performance of the GPU
 # for some workloads by 30%. This will only be applied when a user specify
-# `nvidia_gpus.disable_ecc: true` in ~/.sky/config.yaml.
+# `nvidia_gpus.disable_ecc: true` in ~/.sky/skyconfig.yaml.
 # Running this command will reboot the machine, introducing overhead for
 # provisioning the machine.
 # https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LKjOCAW
@@ -337,7 +337,7 @@ RCLONE_LOG_DIR = '~/.sky/rclone_log'
 RCLONE_CACHE_DIR = '~/.cache/rclone'
 RCLONE_CACHE_REFRESH_INTERVAL = 10
 
-# The keys that can be overridden in the `~/.sky/config.yaml` file. The
+# The keys that can be overridden in the `~/.sky/skyconfig.yaml` file. The
 # overrides are specified in task YAMLs.
 OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('docker', 'run_options'),

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1,6 +1,6 @@
 """Immutable user configurations (EXPERIMENTAL).
 
-On module import, we attempt to parse the config located at CONFIG_PATH
+On module import, we attempt to parse the config located at USER_CONFIG_PATH
 (default: ~/.sky/config.yaml). Caller can then use
 
   >> skypilot_config.loaded()
@@ -161,12 +161,12 @@ def _get_config_file_path(envvar: str) -> Optional[str]:
     return None
 
 
-def _validate_config(config: Dict[str, Any], source: str) -> None:
+def _validate_config(config: Dict[str, Any], config_path: str) -> None:
     """Validates the config."""
     common_utils.validate_schema(
         config,
         schemas.get_config_schema(),
-        f'Invalid {source} configuration. See: '
+        f'Invalid config YAML ({config_path}). See: '
         'https://docs.skypilot.co/en/latest/reference/config.html. '  # pylint: disable=line-too-long
         'Error: ',
         skip_none=False)
@@ -290,7 +290,7 @@ def _reload_config_hierarchical() -> None:
         logger.info('following overrides '
                     'are obtained from user config file:')
         logger.info(user_config)
-        _validate_config(user_config, 'user')
+        _validate_config(user_config, user_config_path)
         overrides.append(user_config)
 
     if os.path.exists(project_config_path):
@@ -300,7 +300,7 @@ def _reload_config_hierarchical() -> None:
         logger.info('following overrides '
                     'are obtained from project config file:')
         logger.info(project_config)
-        _validate_config(project_config, 'project')
+        _validate_config(project_config, project_config_path)
         overrides.append(project_config)
 
     # layer the configs on top of each other based on priority
@@ -350,7 +350,7 @@ def override_skypilot_config(
         common_utils.validate_schema(
             config,
             schemas.get_config_schema(),
-            f'Invalid config {config}. See: '
+            'Invalid config. See: '
             'https://docs.skypilot.co/en/latest/reference/config.html. '  # pylint: disable=line-too-long
             'Error: ',
             skip_none=False)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -79,8 +79,8 @@ logger = sky_logging.init_logger(__name__)
 #     path as the config file. Do not use any other config files.
 #     This behavior is subject to change and should not be relied on by users.
 # Else,
-# (1) If env var {ENV_VAR_GLOBAL_CONFIG} exists, use its path as the global
-#     config file. Else, use the default path {GLOBAL_CONFIG_PATH}.
+# (1) If env var {ENV_VAR_USER_CONFIG} exists, use its path as the user
+#     config file. Else, use the default path {USER_CONFIG_PATH}.
 # (2) If env var {ENV_VAR_PROJECT_CONFIG} exists, use its path as the project
 #     config file. Else, use the default path {PROJECT_CONFIG_PATH}.
 # (3) Override any config keys in (1) with the ones in (2).
@@ -88,7 +88,7 @@ logger = sky_logging.init_logger(__name__)
 #
 # (*) is used internally to implement the behavior of the jobs controller.
 #     It is not intended to be used by end users.
-# (1) and (2) are used by end users to set non-default global and project config
+# (1) and (2) are used by end users to set non-default user and project config
 #     files on clients.
 
 # (Used internally) An env var holding the path to the local config file. This
@@ -96,13 +96,13 @@ logger = sky_logging.init_logger(__name__)
 # use the same config file.
 ENV_VAR_SKYPILOT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}CONFIG'
 
-# (Used by users) Environment variables for setting non-default global and
+# (Used by users) Environment variables for setting non-default user and
 # project config files on clients.
-ENV_VAR_GLOBAL_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}GLOBAL_CONFIG'
+ENV_VAR_USER_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}USER_CONFIG'
 ENV_VAR_PROJECT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}PROJECT_CONFIG'
 
 # Path to the local config files.
-GLOBAL_CONFIG_PATH = '~/.sky/config.yaml'
+USER_CONFIG_PATH = '~/.sky/config.yaml'
 PROJECT_CONFIG_PATH = 'skyconfig.yaml'
 
 # The loaded config.
@@ -217,7 +217,7 @@ def _reload_config_from_internal_file() -> None:
                     'exist. Please double check the path or unset the env var: '
                     f'unset {ENV_VAR_SKYPILOT_CONFIG}')
     else:
-        config_path = GLOBAL_CONFIG_PATH
+        config_path = USER_CONFIG_PATH
     config_path = os.path.expanduser(config_path)
     if os.path.exists(config_path):
         logger.debug(f'Using config path: {config_path}')
@@ -245,23 +245,23 @@ def _reload_config_hierarchical() -> None:
     # Reset the global variables, to avoid using stale values.
     _dict = config_utils.Config()
 
-    # find the global config file
-    global_config_path = _get_config_file_path(ENV_VAR_GLOBAL_CONFIG)
-    if global_config_path and os.path.exists(global_config_path):
-        logger.info('using global config file specified by '
-                    f'{ENV_VAR_GLOBAL_CONFIG}: {global_config_path}')
-        global_config_path = os.path.expanduser(global_config_path)
-        if not os.path.exists(global_config_path):
+    # find the user config file
+    user_config_path = _get_config_file_path(ENV_VAR_USER_CONFIG)
+    if user_config_path and os.path.exists(user_config_path):
+        logger.info('using user config file specified by '
+                    f'{ENV_VAR_USER_CONFIG}: {user_config_path}')
+        user_config_path = os.path.expanduser(user_config_path)
+        if not os.path.exists(user_config_path):
             with ux_utils.print_exception_no_traceback():
                 raise FileNotFoundError(
                     'Config file specified by env var '
-                    f'{ENV_VAR_GLOBAL_CONFIG} ({global_config_path!r}) '
+                    f'{ENV_VAR_USER_CONFIG} ({user_config_path!r}) '
                     'does not exist. Please double check the path or unset the '
-                    f'env var: unset {ENV_VAR_GLOBAL_CONFIG}')
+                    f'env var: unset {ENV_VAR_USER_CONFIG}')
     else:
-        logger.info(f'using default global config file: {GLOBAL_CONFIG_PATH}')
-        global_config_path = GLOBAL_CONFIG_PATH
-        global_config_path = os.path.expanduser(global_config_path)
+        logger.info(f'using default user config file: {USER_CONFIG_PATH}')
+        user_config_path = USER_CONFIG_PATH
+        user_config_path = os.path.expanduser(user_config_path)
 
     overrides = []
 
@@ -283,15 +283,15 @@ def _reload_config_hierarchical() -> None:
         project_config_path = PROJECT_CONFIG_PATH
         project_config_path = os.path.expanduser(project_config_path)
 
-    # load the global config file
-    if os.path.exists(global_config_path):
-        logger.info(f'Using global config path: {global_config_path}')
-        global_config = OmegaConf.to_object(OmegaConf.load(global_config_path))
+    # load the user config file
+    if os.path.exists(user_config_path):
+        logger.info(f'Using user config path: {user_config_path}')
+        user_config = OmegaConf.to_object(OmegaConf.load(user_config_path))
         logger.info('following overrides '
-                    'are obtained from global config file:')
-        logger.info(global_config)
-        _validate_config(global_config, 'global')
-        overrides.append(global_config)
+                    'are obtained from user config file:')
+        logger.info(user_config)
+        _validate_config(user_config, 'user')
+        overrides.append(user_config)
 
     if os.path.exists(project_config_path):
         logger.info(f'Using project config path: {project_config_path}')

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -203,7 +203,8 @@ def _parse_config_file(config_path: str) -> config_utils.Config:
     try:
         config_dict = common_utils.read_yaml(config_path)
         config = config_utils.Config.from_dict(config_dict)
-        logger.debug(f'Config loaded:\n{pprint.pformat(config)}')
+        logger.debug(
+            f'Config loaded from {config_path}:\n{pprint.pformat(config)}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -246,8 +247,8 @@ def _reload_config_hierarchical() -> None:
     # find the user config file
     user_config_path = _get_config_file_path(ENV_VAR_USER_CONFIG)
     if user_config_path:
-        logger.info('using user config file specified by '
-                    f'{ENV_VAR_USER_CONFIG}: {user_config_path}')
+        logger.debug('using user config file specified by '
+                     f'{ENV_VAR_USER_CONFIG}: {user_config_path}')
         user_config_path = os.path.expanduser(user_config_path)
         if not os.path.exists(user_config_path):
             with ux_utils.print_exception_no_traceback():
@@ -257,7 +258,7 @@ def _reload_config_hierarchical() -> None:
                     'does not exist. Please double check the path or unset the '
                     f'env var: unset {ENV_VAR_USER_CONFIG}')
     else:
-        logger.info(f'using default user config file: {USER_CONFIG_PATH}')
+        logger.debug(f'using default user config file: {USER_CONFIG_PATH}')
         user_config_path = USER_CONFIG_PATH
         user_config_path = os.path.expanduser(user_config_path)
 
@@ -266,8 +267,8 @@ def _reload_config_hierarchical() -> None:
     # find the project config file
     project_config_path = _get_config_file_path(ENV_VAR_PROJECT_CONFIG)
     if project_config_path:
-        logger.info('using project config file specified by '
-                    f'{ENV_VAR_PROJECT_CONFIG}: {project_config_path}')
+        logger.debug('using project config file specified by '
+                     f'{ENV_VAR_PROJECT_CONFIG}: {project_config_path}')
         project_config_path = os.path.expanduser(project_config_path)
         if not os.path.exists(project_config_path):
             with ux_utils.print_exception_no_traceback():
@@ -277,31 +278,28 @@ def _reload_config_hierarchical() -> None:
                     'does not exist. Please double check the path or unset the '
                     f'env var: unset {ENV_VAR_PROJECT_CONFIG}')
     else:
-        logger.info(f'using default project config file: {PROJECT_CONFIG_PATH}')
+        logger.debug(
+            f'using default project config file: {PROJECT_CONFIG_PATH}')
         project_config_path = PROJECT_CONFIG_PATH
         project_config_path = os.path.expanduser(project_config_path)
 
     # load the user config file
     if os.path.exists(user_config_path):
         user_config = _parse_config_file(user_config_path)
-        logger.info('following overrides are obtained '
-                    f'from user config: {user_config}')
         _validate_config(user_config, user_config_path)
         overrides.append(user_config)
 
     if os.path.exists(project_config_path):
         project_config = _parse_config_file(project_config_path)
-        logger.info('following overrides are obtained '
-                    f'from project config: {project_config}')
         _validate_config(project_config, project_config_path)
         overrides.append(project_config)
 
     # layer the configs on top of each other based on priority
     overlaid_client_config: config_utils.Config = config_utils.Config()
-    for override in reversed(overrides):
+    for override in overrides:
         overlaid_client_config = _overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
-    logger.info(f'final config: {overlaid_client_config}')
+    logger.debug(f'final config: {overlaid_client_config}')
     _dict = overlaid_client_config
 
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1,7 +1,7 @@
 """Immutable user configurations (EXPERIMENTAL).
 
 On module import, we attempt to parse the config located at USER_CONFIG_PATH
-(default: ~/.sky/config.yaml). Caller can then use
+(default: ~/.sky/skyconfig.yaml). Caller can then use
 
   >> skypilot_config.loaded()
 
@@ -35,14 +35,14 @@ Consider the following config contents:
 
 then:
 
-    # Assuming ~/.sky/config.yaml exists and can be loaded:
+    # Assuming ~/.sky/skyconfig.yaml exists and can be loaded:
     skypilot_config.loaded()  # ==> True
 
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> 1
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None
     skypilot_config.get_nested(('a',), None)             # ==> {'nested': 1}
 
-    # If ~/.sky/config.yaml doesn't exist or failed to be loaded:
+    # If ~/.sky/skyconfig.yaml doesn't exist or failed to be loaded:
     skypilot_config.loaded()  # ==> False
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> None
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1,6 +1,6 @@
 """Immutable user configurations (EXPERIMENTAL).
 
-On module import, we attempt to parse the config located at USER_CONFIG_PATH
+On module import, we attempt to parse the config located at _USER_CONFIG_PATH
 (default: ~/.sky/skyconfig.yaml). Caller can then use
 
   >> skypilot_config.loaded()
@@ -78,9 +78,9 @@ logger = sky_logging.init_logger(__name__)
 #     This behavior is subject to change and should not be relied on by users.
 # Else,
 # (1) If env var {ENV_VAR_USER_CONFIG} exists, use its path as the user
-#     config file. Else, use the default path {USER_CONFIG_PATH}.
+#     config file. Else, use the default path {_USER_CONFIG_PATH}.
 # (2) If env var {ENV_VAR_PROJECT_CONFIG} exists, use its path as the project
-#     config file. Else, use the default path {PROJECT_CONFIG_PATH}.
+#     config file. Else, use the default path {_PROJECT_CONFIG_PATH}.
 # (3) Override any config keys in (1) with the ones in (2).
 # (4) Validate the final config.
 #

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -170,7 +170,7 @@ def _validate_config(config: Dict[str, Any], config_path: str) -> None:
         skip_none=False)
 
 
-def overlay_skypilot_config(
+def _overlay_skypilot_config(
         original_config: Optional[config_utils.Config],
         override_configs: Optional[config_utils.Config]) -> config_utils.Config:
     """Overlays the override configs on the original configs."""
@@ -245,7 +245,7 @@ def _reload_config_hierarchical() -> None:
 
     # find the user config file
     user_config_path = _get_config_file_path(ENV_VAR_USER_CONFIG)
-    if user_config_path and os.path.exists(user_config_path):
+    if user_config_path:
         logger.info('using user config file specified by '
                     f'{ENV_VAR_USER_CONFIG}: {user_config_path}')
         user_config_path = os.path.expanduser(user_config_path)
@@ -265,7 +265,7 @@ def _reload_config_hierarchical() -> None:
 
     # find the project config file
     project_config_path = _get_config_file_path(ENV_VAR_PROJECT_CONFIG)
-    if project_config_path and os.path.exists(project_config_path):
+    if project_config_path:
         logger.info('using project config file specified by '
                     f'{ENV_VAR_PROJECT_CONFIG}: {project_config_path}')
         project_config_path = os.path.expanduser(project_config_path)
@@ -283,28 +283,25 @@ def _reload_config_hierarchical() -> None:
 
     # load the user config file
     if os.path.exists(user_config_path):
-        logger.info(f'Using user config path: {user_config_path}')
         user_config = _parse_config_file(user_config_path)
-        logger.info('following overrides '
-                    'are obtained from user config file:')
-        logger.info(user_config)
+        logger.info('following overrides are obtained '
+                    f'from user config: {user_config}')
         _validate_config(user_config, user_config_path)
         overrides.append(user_config)
 
     if os.path.exists(project_config_path):
-        logger.info(f'Using project config path: {project_config_path}')
         project_config = _parse_config_file(project_config_path)
-        logger.info('following overrides '
-                    'are obtained from project config file:')
-        logger.info(project_config)
+        logger.info('following overrides are obtained '
+                    f'from project config: {project_config}')
         _validate_config(project_config, project_config_path)
         overrides.append(project_config)
 
     # layer the configs on top of each other based on priority
     overlaid_client_config: config_utils.Config = config_utils.Config()
     for override in reversed(overrides):
-        overlaid_client_config = overlay_skypilot_config(
+        overlaid_client_config = _overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
+    logger.info(f'final config: {overlaid_client_config}')
     _dict = overlaid_client_config
 
 

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -146,7 +146,7 @@ def _get_nested(configs: Optional[Dict[str, Any]],
             curr = value
         else:
             return default_value
-    logger.debug(f'User config: {".".join(keys)} -> {curr}')
+    logger.debug(f'Config: {".".join(keys)} -> {curr}')
     return curr
 
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -46,7 +46,7 @@ logger = sky_logging.init_logger(__name__)
 # controller resources spec.
 CONTROLLER_RESOURCES_NOT_VALID_MESSAGE = (
     '{controller_type} controller resources is not valid, please check '
-    '~/.sky/config.yaml file and make sure '
+    '~/.sky/skyconfig.yaml file and make sure '
     '{controller_type}.controller.resources is a valid resources spec. '
     'Details:\n  {err}')
 

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -328,9 +328,9 @@ cp kubeconfig ~/.kube/config
 # Verify that you can access the cluster
 kubectl get pods
 
-Also add this to your ~/.sky/config.yaml to use the new service account:
+Also add this to your ~/.sky/skyconfig.yaml to use the new service account:
 
-# ~/.sky/config.yaml
+# ~/.sky/skyconfig.yaml
 kubernetes:
   remote_identity: ${SKYPILOT_SA}
 "

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -455,7 +455,7 @@ def get_aws_region_for_quota_failover() -> Optional[str]:
                                        instance_type='p3.16xlarge',
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/config.yaml.
+    # Filter the regions with proxy command in ~/.sky/skyconfig.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions
@@ -483,7 +483,7 @@ def get_gcp_region_for_quota_failover() -> Optional[str]:
                                        accelerators={'A100-80GB': 1},
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/config.yaml.
+    # Filter the regions with proxy command in ~/.sky/skyconfig.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -168,7 +168,7 @@ def test_launch_fast_with_autostop(generic_cloud: str):
 @pytest.mark.aws
 def test_launch_fast_with_cluster_changes(generic_cloud: str, tmp_path):
     name = smoke_tests_utils.get_cluster_name()
-    tmp_config_path = tmp_path / 'config.yaml'
+    tmp_config_path = tmp_path / 'skyconfig.yaml'
     test = smoke_tests_utils.Test(
         'test_launch_fast_with_cluster_changes',
         [
@@ -186,7 +186,7 @@ def test_launch_fast_with_cluster_changes(generic_cloud: str, tmp_path):
             f'sky logs {name} 2 --status',
 
             # Copy current config as a base.
-            f'cp ${{{skypilot_config.ENV_VAR_SKYPILOT_CONFIG}:-~/.sky/skyconfig.yaml}} {tmp_config_path} && '
+            f'cp ${{{skypilot_config.ENV_VAR_SKYPILOT_CONFIG}:-~/.sky/config.yaml}} {tmp_config_path} && '
             # Set config override. This should change the cluster yaml, forcing reprovision/setup
             f'echo "aws: {{ remote_identity: test }}" >> {tmp_config_path}',
             # Launch and do full output validation. Setup/provisioning should be run.

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -186,7 +186,7 @@ def test_launch_fast_with_cluster_changes(generic_cloud: str, tmp_path):
             f'sky logs {name} 2 --status',
 
             # Copy current config as a base.
-            f'cp ${{{skypilot_config.ENV_VAR_SKYPILOT_CONFIG}:-~/.sky/config.yaml}} {tmp_config_path} && '
+            f'cp ${{{skypilot_config.ENV_VAR_SKYPILOT_CONFIG}:-~/.sky/skyconfig.yaml}} {tmp_config_path} && '
             # Set config override. This should change the cluster yaml, forcing reprovision/setup
             f'echo "aws: {{ remote_identity: test }}" >> {tmp_config_path}',
             # Launch and do full output validation. Setup/provisioning should be run.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,9 +145,9 @@ def test_nested_config(monkeypatch) -> None:
 
 def test_no_config(monkeypatch) -> None:
     """Test that the config is not loaded if the config file does not exist."""
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         '/tmp/does_not_exist')
-    monkeypatch.setattr(skypilot_config, 'PROJECT_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
                         '/tmp/does_not_exist')
     skypilot_config._reload_config()
     _check_empty_config()
@@ -157,9 +157,9 @@ def test_empty_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'empty.yaml', 'w', encoding='utf-8') as f:
         f.write('')
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'empty.yaml')
-    monkeypatch.setattr(skypilot_config, 'PROJECT_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
                         tmp_path / 'empty.yaml')
     skypilot_config._reload_config()
     _check_empty_config()
@@ -183,7 +183,7 @@ def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
                 resources:
                     disk_size: 256
         """)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'valid.yaml')
     skypilot_config._reload_config()
     proxy_config = skypilot_config.get_nested(
@@ -200,7 +200,7 @@ def test_invalid_field_config(monkeypatch, tmp_path) -> None:
             vpc_name: {VPC_NAME}
             not_a_field: 123
         """))
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -220,7 +220,7 @@ def test_invalid_indent_config(monkeypatch, tmp_path) -> None:
                 cpus: 4
                 disk_size: 50
         """))
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -237,7 +237,7 @@ def test_invalid_enum_config(monkeypatch, tmp_path) -> None:
                 resources:
                     cloud: notacloud
         """))
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -258,7 +258,7 @@ def test_gcp_vpc_name_validation(monkeypatch, tmp_path) -> None:
             gcp:
                 vpc_name: {valid_vpc}
             """))
-        monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+        monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
         # Should not raise an exception
         skypilot_config._reload_config()
         assert skypilot_config.get_nested(('gcp', 'vpc_name'),
@@ -275,7 +275,7 @@ def test_gcp_vpc_name_validation(monkeypatch, tmp_path) -> None:
             gcp:
                 vpc_name: {invalid_vpc}
             """))
-        monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+        monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
         with pytest.raises(ValueError) as e:
             skypilot_config._reload_config()
         assert 'Invalid config YAML' in e.value.args[0]
@@ -291,7 +291,7 @@ def test_valid_num_items_config(monkeypatch, tmp_path) -> None:
                 - projects/my-project/reservations/my-reservation
                 - projects/my-project/reservations/my-reservation2
         """))
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'valid.yaml')
     skypilot_config._reload_config()
 
@@ -302,7 +302,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     # Load from a config file
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
     # Check that the config is loaded with the expected values
     assert skypilot_config.loaded()
@@ -328,7 +328,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     new_config2 = skypilot_config.set_nested(('aws', 'ssh_proxy_command'), None)
     new_config_path = tmp_path / 'new_config.yaml'
     common_utils.dump_yaml(new_config_path, new_config2)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', new_config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', new_config_path)
     skypilot_config._reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
     assert skypilot_config.get_nested(('aws', 'use_internal_ips'), None)
@@ -343,7 +343,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     del new_config3['aws']['use_internal_ips']
     new_config_path = tmp_path / 'new_config3.yaml'
     common_utils.dump_yaml(new_config_path, new_config3)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', new_config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', new_config_path)
     skypilot_config._reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
     assert skypilot_config.get_nested(('aws', 'use_internal_ips'), None) is None
@@ -362,7 +362,7 @@ def test_config_with_env(monkeypatch, tmp_path) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
     monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         tmp_path / 'does_not_exist')
     skypilot_config._reload_config()
     assert skypilot_config.loaded()
@@ -387,7 +387,7 @@ def test_k8s_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -422,7 +422,7 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
                                         enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
 
     _reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -445,7 +445,7 @@ def test_gcp_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -481,7 +481,7 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
                                       enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
 
@@ -547,7 +547,7 @@ def test_override_skypilot_config(monkeypatch, tmp_path):
     # Create original config file
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
 
     # Store original values
@@ -590,8 +590,8 @@ def test_override_skypilot_config_without_original_config(
     os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
     # Create original config file
     config_path = tmp_path / 'non_existent.yaml'
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
-    monkeypatch.setattr(skypilot_config, 'PROJECT_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
     assert not skypilot_config._dict
     assert skypilot_config._loaded_config_path is None
@@ -633,7 +633,7 @@ def test_hierarchical_config(monkeypatch, tmp_path):
     """Test that hierarchical config is loaded correctly."""
     # test with default config files
     default_user_config_path = tmp_path / 'user_config.yaml'
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         default_user_config_path)
     default_user_config_path.write_text(
         textwrap.dedent(f"""\
@@ -643,7 +643,7 @@ def test_hierarchical_config(monkeypatch, tmp_path):
                     source: default-user-config
             """))
     project_config_path = tmp_path / 'project_config.yaml'
-    monkeypatch.setattr(skypilot_config, 'PROJECT_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
                         project_config_path)
     project_config_path.write_text(
         textwrap.dedent(f"""\
@@ -700,9 +700,9 @@ def test_hierarchical_config(monkeypatch, tmp_path):
 
     # test with missing default config files
     non_existent_config_path = tmp_path / 'non_existent.yaml'
-    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_USER_CONFIG_PATH',
                         non_existent_config_path)
-    monkeypatch.setattr(skypilot_config, 'PROJECT_CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
                         non_existent_config_path)
     skypilot_config._reload_config()
     assert not skypilot_config._dict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -145,7 +145,8 @@ def test_nested_config(monkeypatch) -> None:
 
 def test_no_config(monkeypatch) -> None:
     """Test that the config is not loaded if the config file does not exist."""
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', '/tmp/does_not_exist')
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+                        '/tmp/does_not_exist')
     skypilot_config._reload_config()
     _check_empty_config()
 
@@ -154,7 +155,8 @@ def test_empty_config(monkeypatch, tmp_path) -> None:
     """Test that the config is not loaded if the config file is empty."""
     with open(tmp_path / 'empty.yaml', 'w', encoding='utf-8') as f:
         f.write('')
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'empty.yaml')
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+                        tmp_path / 'empty.yaml')
     skypilot_config._reload_config()
     _check_empty_config()
 
@@ -177,7 +179,8 @@ def test_valid_null_proxy_config(monkeypatch, tmp_path) -> None:
                 resources:
                     disk_size: 256
         """)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'valid.yaml')
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+                        tmp_path / 'valid.yaml')
     skypilot_config._reload_config()
     proxy_config = skypilot_config.get_nested(
         ('aws', 'ssh_proxy_command', 'eu-west-1'), 'default')
@@ -193,7 +196,7 @@ def test_invalid_field_config(monkeypatch, tmp_path) -> None:
             vpc_name: {VPC_NAME}
             not_a_field: 123
         """))
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -213,7 +216,7 @@ def test_invalid_indent_config(monkeypatch, tmp_path) -> None:
                 cpus: 4
                 disk_size: 50
         """))
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -230,7 +233,7 @@ def test_invalid_enum_config(monkeypatch, tmp_path) -> None:
                 resources:
                     cloud: notacloud
         """))
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
                         tmp_path / 'invalid.yaml')
     with pytest.raises(ValueError) as e:
         skypilot_config._reload_config()
@@ -251,7 +254,7 @@ def test_gcp_vpc_name_validation(monkeypatch, tmp_path) -> None:
             gcp:
                 vpc_name: {valid_vpc}
             """))
-        monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+        monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
         # Should not raise an exception
         skypilot_config._reload_config()
         assert skypilot_config.get_nested(('gcp', 'vpc_name'),
@@ -268,7 +271,7 @@ def test_gcp_vpc_name_validation(monkeypatch, tmp_path) -> None:
             gcp:
                 vpc_name: {invalid_vpc}
             """))
-        monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+        monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
         with pytest.raises(ValueError) as e:
             skypilot_config._reload_config()
         assert 'Invalid config YAML' in e.value.args[0]
@@ -284,7 +287,8 @@ def test_valid_num_items_config(monkeypatch, tmp_path) -> None:
                 - projects/my-project/reservations/my-reservation
                 - projects/my-project/reservations/my-reservation2
         """))
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', tmp_path / 'valid.yaml')
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
+                        tmp_path / 'valid.yaml')
     skypilot_config._reload_config()
 
 
@@ -294,7 +298,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     # Load from a config file
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
     # Check that the config is loaded with the expected values
     assert skypilot_config.loaded()
@@ -320,7 +324,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     new_config2 = skypilot_config.set_nested(('aws', 'ssh_proxy_command'), None)
     new_config_path = tmp_path / 'new_config.yaml'
     common_utils.dump_yaml(new_config_path, new_config2)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', new_config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', new_config_path)
     skypilot_config._reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
     assert skypilot_config.get_nested(('aws', 'use_internal_ips'), None)
@@ -335,7 +339,7 @@ def test_config_get_set_nested(monkeypatch, tmp_path) -> None:
     del new_config3['aws']['use_internal_ips']
     new_config_path = tmp_path / 'new_config3.yaml'
     common_utils.dump_yaml(new_config_path, new_config3)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', new_config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', new_config_path)
     skypilot_config._reload_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) == VPC_NAME
     assert skypilot_config.get_nested(('aws', 'use_internal_ips'), None) is None
@@ -354,7 +358,7 @@ def test_config_with_env(monkeypatch, tmp_path) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
     monkeypatch.setenv(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH',
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH',
                         tmp_path / 'does_not_exist')
     skypilot_config._reload_config()
     assert skypilot_config.loaded()
@@ -379,7 +383,7 @@ def test_k8s_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -414,7 +418,7 @@ def test_k8s_config_with_invalid_config(monkeypatch, tmp_path,
                                         enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
 
     _reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -437,7 +441,7 @@ def test_gcp_config_with_override(monkeypatch, tmp_path,
                                   enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
     task_path = tmp_path / 'task.yaml'
@@ -473,7 +477,7 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
                                       enable_all_clouds) -> None:
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
 
     skypilot_config._reload_config()
 
@@ -539,7 +543,7 @@ def test_override_skypilot_config(monkeypatch, tmp_path):
     # Create original config file
     config_path = tmp_path / 'config.yaml'
     _create_config_file(config_path)
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
 
     # Store original values
@@ -582,7 +586,7 @@ def test_override_skypilot_config_without_original_config(
     os.environ.pop(skypilot_config.ENV_VAR_SKYPILOT_CONFIG, None)
     # Create original config file
     config_path = tmp_path / 'non_existent.yaml'
-    monkeypatch.setattr(skypilot_config, 'CONFIG_PATH', config_path)
+    monkeypatch.setattr(skypilot_config, 'USER_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
     assert not skypilot_config._dict
     assert skypilot_config._loaded_config_path is None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add support for a two-tiered hierarchical configuration.

Config at `~/.sky/skyconfig.yaml` (or a path set by `SKYPILOT_USER_CONFIG` is still parsed as a "user" config. 
Config at `$pwd/skyconfig.yaml` (or a path set by `SKYPILOT_PROJECT_CONFIG` is parsed as a "project" config.
The final loaded config is the merge of global config and project config, where values set in project config wins in case of conflicts.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

Any manual or new tests for this PR (please specify below)

Config file selection
- [x] specifying no environment variables leads to `~/.sky/skyconfig` and `skyconfig.yaml` being chosen for parsing.
- [x] specifying `SKYPILOT_USER_CONFIG` leads to the chosen path to be used for parsing user config.
- [x] specifying `SKYPILOT_PROJECT_CONFIG` leads to the chosen path to be used for parsing project config.
- [x] (BW compat) specifying `SKYPILOT_CONFIG` leads to chosen path to be used for config, and ignores all other config files.

File parsing
- [x] If `SKYPILOT_USER_CONFIG` is not specified and file exists at user config default path, file is parsed as user config.
- [x] If `SKYPILOT_USER_CONFIG` is not specified and file does not exist at user config default path, **empty config is used as user config**.
- [x] If `SKYPILOT_PROJECT_CONFIG` is not specified and file exists at project config default path, file is parsed as project config.
- [x] If `SKYPILOT_PROJECT_CONFIG` is not specified and file does not exist at project config default path, **empty config is used as project config**.
- [x] If `SKYPILOT_USER_CONFIG` is specified and file exists at specified path, file is parsed as user config.
- [x] If `SKYPILOT_USER_CONFIG` is specified and file does not exist at specified path, **SkyPilot errors out**.
```
FileNotFoundError: Config file specified by env var SKYPILOT_USER_CONFIG ('/Users/seungjinyang/.sky/config2.yaml') does not exist. Please double check the path or unset the env var: unset SKYPILOT_USER_CONFIG
```
- [x] If `SKYPILOT_PROJECT_CONFIG` is specified and file exists at specified path, file is parsed as project config.
- [x] If `SKYPILOT_PROJECT_CONFIG` is specified and file does not exist at specified path, **SkyPilot errors out**.
```
FileNotFoundError: Config file specified by env var SKYPILOT_PROJECT_CONFIG ('skyconfig.yaml') does not exist. Please double check the path or unset the env var: unset SKYPILOT_PROJECT_CONFIG
```
- [x] (BW compat) If `SKYPILOT_CONFIG` is and file exists at specified path, file is parsed as config.
- [x] (BW compat) If `SKYPILOT_CONFIG` is and file does not at specified path, SkyPilot errors out.

Config overlay
- [x] If only user config is found, user config is used as config.
- [x] If only project config is found, project config is used as config.
- [x] If neither config is found, empty config is used as config.
- [x] If both configs are found, user and project configs are merged with project config taking priority.

Smoke
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)

Unit test creation
- [x] create `test_hierarchical_config`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
