### PR TITLE
Adding support for wss protocol for websockets

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -43,6 +43,7 @@ install_requires = [
     'requests',
     'fastapi',
     'uvicorn[standard]',
+    'websockets',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -43,7 +43,6 @@ install_requires = [
     'requests',
     'fastapi',
     'uvicorn[standard]',
-    'websockets',
     # Some pydantic versions are not compatible with ray. Adopted from ray's
     # setup.py:
     # https://github.com/ray-project/ray/blob/ray-2.9.3/python/setup.py#L254
@@ -132,7 +131,7 @@ extras_require: Dict[str, List[str]] = {
     'scp': local_ray,
     'oci': ['oci'] + local_ray,
     # Kubernetes 32.0.0 has an authentication bug: https://github.com/kubernetes-client/python/issues/2333 # pylint: disable=line-too-long
-    'kubernetes': ['kubernetes>=20.0.0,!=32.0.0'],
+    'kubernetes': ['kubernetes>=20.0.0,!=32.0.0', 'websockets'],
     'remote': remote,
     # For the container registry auth api. Reference:
     # https://github.com/runpod/runpod-python/releases/tag/1.6.1

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -60,11 +60,17 @@ async def websocket_to_stdout(websocket):
 
 if __name__ == '__main__':
     server_url = sys.argv[1].strip('/')
-    server_proto, server_fqdn = server_url.split('://')
-    websocket_proto = 'ws'
-    if server_proto == 'https':
-        websocket_proto = 'wss'
+    if '://' in server_url:
+        server_proto, server_fqdn = server_url.split('://')
+        websocket_proto = 'ws'
+        if server_proto == 'https':
+            websocket_proto = 'wss'
+        server_url = f'{websocket_proto}://{server_fqdn}'
+    else:
+        # Keep backward compatibility for legacy server URLs without protocol
+        # TODO(aylei): Remove this after 0.10.0
+        server_url = f'ws://{server_url}'
     websocket_url = (
-        f'{websocket_proto}://{server_fqdn}/kubernetes-pod-ssh-proxy'
+        f'{server_url}/kubernetes-pod-ssh-proxy'
         f'?cluster_name={sys.argv[2]}')
     asyncio.run(main(websocket_url))

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -1,18 +1,46 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "websockets>=14.0",
+# ]
+# ///
 """Starting a websocket with SkyPilot API server to proxy SSH to a k8s pod.
 
 This script is useful for users who do not have local Kubernetes credentials.
 """
 import asyncio
+from http.cookiejar import MozillaCookieJar
 import os
 import sys
+from typing import Dict
+from urllib.request import Request
 
 import websockets
 from websockets.asyncio.client import connect
 
 
+def _get_cookie_header(url: str) -> Dict[str, str]:
+    """Extract Cookie header value from a cookie jar for a specific URL"""
+    cookie_path = os.environ.get('SKYPILOT_API_COOKIE_FILE')
+    if cookie_path is None:
+        return {}
+
+    request = Request(url)
+    cookie_jar = MozillaCookieJar(os.path.expanduser(cookie_path))
+    cookie_jar.load(ignore_discard=True, ignore_expires=True)
+    cookie_jar.add_cookie_header(request)
+    cookie_header = request.get_header('Cookie')
+    # if cookie file is empty, return empty dict
+    if cookie_header is None:
+        return {}
+    return {'Cookie': cookie_header}
+
+
 async def main(url: str) -> None:
-    async with connect(url, ping_interval=None) as websocket:
+    cookie_header = _get_cookie_header(url)
+    async with connect(url,
+                       ping_interval=None,
+                       additional_headers=cookie_header) as websocket:
         if os.isatty(sys.stdin.fileno()):
             # pylint: disable=import-outside-toplevel
             import termios
@@ -60,17 +88,16 @@ async def websocket_to_stdout(websocket):
 
 if __name__ == '__main__':
     server_url = sys.argv[1].strip('/')
-    if '://' in server_url:
-        server_proto, server_fqdn = server_url.split('://')
-        websocket_proto = 'ws'
-        if server_proto == 'https':
-            websocket_proto = 'wss'
-        server_url = f'{websocket_proto}://{server_fqdn}'
-    else:
+    if '://' not in server_url:
         # Keep backward compatibility for legacy server URLs without protocol
         # TODO(aylei): Remove this after 0.10.0
-        server_url = f'ws://{server_url}'
-    websocket_url = (
-        f'{server_url}/kubernetes-pod-ssh-proxy'
-        f'?cluster_name={sys.argv[2]}')
+        server_url = f'http://{server_url}'
+
+    server_proto, server_fqdn = server_url.split('://')
+    websocket_proto = 'ws'
+    if server_proto == 'https':
+        websocket_proto = 'wss'
+    server_url = f'{websocket_proto}://{server_fqdn}'
+    websocket_url = (f'{server_url}/kubernetes-pod-ssh-proxy'
+                     f'?cluster_name={sys.argv[2]}')
     asyncio.run(main(websocket_url))

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -8,10 +8,11 @@ import os
 import sys
 
 import websockets
+from websockets.asyncio.client import connect
 
 
 async def main(url: str) -> None:
-    async with websockets.connect(url, ping_interval=None) as websocket:
+    async with connect(url, ping_interval=None) as websocket:
         if os.isatty(sys.stdin.fileno()):
             # pylint: disable=import-outside-toplevel
             import termios
@@ -59,6 +60,11 @@ async def websocket_to_stdout(websocket):
 
 if __name__ == '__main__':
     server_url = sys.argv[1].strip('/')
-    websocket_url = (f'ws://{server_url}/kubernetes-pod-ssh-proxy'
-                     f'?cluster_name={sys.argv[2]}')
+    server_proto, server_fqdn = server_url.split('://')
+    websocket_proto = 'ws'
+    if server_proto == 'https':
+        websocket_proto = 'wss'
+    websocket_url = (
+        f'{websocket_proto}://{server_fqdn}/kubernetes-pod-ssh-proxy'
+        f'?cluster_name={sys.argv[2]}')
     asyncio.run(main(websocket_url))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from click import testing as cli_testing
 import requests
 
 from sky import cli
+from sky import clouds
 from sky import exceptions
 from sky import server
 
@@ -189,3 +190,127 @@ class TestServerVersion:
         assert "SkyPilot API server is too old: v3 (client version is v2)." in str(
             result.exception)
         assert result.exit_code == 1
+
+
+class TestHelperFunctions:
+
+    def test_get_cluster_records_and_set_ssh_config(self, monkeypatch):
+        """Tests _get_cluster_records_and_set_ssh_config with mocked components."""
+        # Mock cluster records that would be returned by stream_and_get
+        mock_handle = mock.MagicMock()
+        mock_handle.cluster_name = 'test-cluster'
+        mock_handle.cached_external_ips = ['1.2.3.4']
+        mock_handle.cached_external_ssh_ports = [22]
+        mock_handle.docker_user = None
+        mock_handle.ssh_user = 'ubuntu'
+        mock_handle.launched_resources.cloud = mock.MagicMock()
+
+        mock_records = [{
+            'name': 'test-cluster',
+            'handle': mock_handle,
+            'credentials': {
+                'ssh_user': 'ubuntu',
+                'ssh_private_key': '/path/to/key.pem'
+            }
+        }]
+
+        # Mock the SDK calls
+        def mock_status(*args, **kwargs):
+            return 'request-id'
+
+        def mock_stream_and_get(*args, **kwargs):
+            return mock_records
+
+        monkeypatch.setattr('sky.client.sdk.status', mock_status)
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            mock_stream_and_get)
+
+        # Mock SSHConfigHelper methods
+        mock_add_cluster = mock.MagicMock()
+        mock_remove_cluster = mock.MagicMock()
+        mock_list_cluster_names = mock.MagicMock(
+            return_value=['test-cluster', 'old-cluster'])
+
+        monkeypatch.setattr(
+            'sky.utils.cluster_utils.SSHConfigHelper.add_cluster',
+            mock_add_cluster)
+        monkeypatch.setattr(
+            'sky.utils.cluster_utils.SSHConfigHelper.remove_cluster',
+            mock_remove_cluster)
+        monkeypatch.setattr(
+            'sky.utils.cluster_utils.SSHConfigHelper.list_cluster_names',
+            mock_list_cluster_names)
+
+        # Test case 1: Get records for specific clusters
+        records = cli._get_cluster_records_and_set_ssh_config(['test-cluster'])
+        assert records == mock_records
+        mock_add_cluster.assert_called_once_with('test-cluster', ['1.2.3.4'], {
+            'ssh_user': 'ubuntu',
+            'ssh_private_key': '/path/to/key.pem'
+        }, [22], None, 'ubuntu')
+        # Shouldn't remove anything because all clusters provided are in the returned records
+        mock_remove_cluster.assert_not_called()
+
+        # Reset mocks for next test
+        mock_add_cluster.reset_mock()
+        mock_remove_cluster.reset_mock()
+
+        # Test case 2: Get records for all users
+        records = cli._get_cluster_records_and_set_ssh_config(None,
+                                                              all_users=True)
+        assert records == mock_records
+        mock_add_cluster.assert_called_once()
+        # Should remove old-cluster since it's not in the returned records
+        mock_remove_cluster.assert_called_once_with('old-cluster')
+
+        # Test case 3: Test with a cluster that has no handle/credentials
+        mock_records_no_handle = [{'name': 'test-cluster', 'handle': None}]
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            lambda *args, **kwargs: mock_records_no_handle)
+
+        records = cli._get_cluster_records_and_set_ssh_config(['test-cluster'])
+        assert records == mock_records_no_handle
+        # Should remove the cluster from SSH config since it has no handle
+        mock_remove_cluster.assert_called_with('test-cluster')
+
+        # Reset mocks for next test
+        mock_add_cluster.reset_mock()
+        mock_remove_cluster.reset_mock()
+
+        # Test case 4: Test with a cluster that is using kubernetes
+        mock_k8s_handle = mock.MagicMock()
+        mock_k8s_handle.cluster_name = 'test-cluster'
+        mock_k8s_handle.cached_external_ips = ['1.2.3.4']
+        mock_k8s_handle.cached_external_ssh_ports = [22]
+        mock_k8s_handle.docker_user = None
+        mock_k8s_handle.ssh_user = 'ubuntu'
+        mock_k8s_handle.launched_resources.cloud = clouds.Kubernetes()
+        mock_records_kubernetes = [{
+            'name': 'test-cluster',
+            'handle': mock_k8s_handle,
+            'credentials': {
+                'ssh_user': 'ubuntu',
+                'ssh_private_key': '/path/to/key.pem'
+            },
+        }]
+        server_url = 'http://localhost:8000'
+        monkeypatch.setattr('sky.server.common.get_server_url',
+                            lambda: server_url)
+        monkeypatch.setattr('sky.client.sdk.stream_and_get',
+                            lambda *args, **kwargs: mock_records_kubernetes)
+        records = cli._get_cluster_records_and_set_ssh_config(['test-cluster'])
+        assert records == mock_records_kubernetes
+        mock_add_cluster.assert_called_once()
+        added_cluster_args = mock_add_cluster.call_args
+        assert added_cluster_args[0][0] == 'test-cluster'
+        assert added_cluster_args[0][1] == ['1.2.3.4']
+        # proxy command should be set, but is dependent on the server url, so we don't check the exact value
+        assert added_cluster_args[0][2].get('ssh_proxy_command') is not None
+        assert server_url in added_cluster_args[0][2].get('ssh_proxy_command')
+        assert added_cluster_args[0][2].get(
+            'ssh_private_key') == '/path/to/key.pem'
+        assert added_cluster_args[0][2].get('ssh_user') == 'ubuntu'
+        assert added_cluster_args[0][3] == [22]
+        assert added_cluster_args[0][4] is None
+        assert added_cluster_args[0][5] == 'ubuntu'
+        mock_remove_cluster.assert_not_called()


### PR DESCRIPTION
Adding support for using `wss` instead of `ws` for websocket proxying. I pass the full URL instead of just the fqdn to the proxycommand, then in the proxy command use the appropriate protocol based on http vs https. 


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

I also added some tests for the function where that ssh config is updated, and did some rearranging to [de-nest](https://en.wikibooks.org/wiki/Computer_Programming/Coding_Style/Minimize_nesting) some code.

Added a test to check the functionality I added.

They're all in `tests/test_cli.py:TestHelperFunctions.test_get_cluster_records_and_set_ssh_config`. If needed I could break them into separate tests

without fix:
```
$ ssh test-from-api
Traceback (most recent call last):
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/websockets/asyncio/client.py", line 543, in __await_impl__
    await self.connection.handshake(
    ...<2 lines>...
    )
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/websockets/asyncio/client.py", line 104, in handshake
    await asyncio.wait(
    ...<2 lines>...
    )
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/tasks.py", line 451, in wait
    return await _wait(fs, timeout, return_when, loop)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/tasks.py", line 537, in _wait
    await waiter
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/websockets/asyncio/client.py", line 539, in __await_impl__
    async with asyncio_timeout(self.open_timeout):
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/timeouts.py", line 116, in __aexit__
    raise TimeoutError from exc_val
TimeoutError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/sky/templates/websocket_proxy.py", line 64, in <module>
    asyncio.run(main(websocket_url))
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/sky/templates/websocket_proxy.py", line 14, in main
    async with websockets.connect(url, ping_interval=None) as websocket:
               ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/websockets/asyncio/client.py", line 587, in __aenter__
    return await self
           ^^^^^^^^^^
  File "/Users/clayros/.local/pipx/venvs/skypilot-nightly-testing/lib/python3.13/site-packages/websockets/asyncio/client.py", line 578, in __await_impl__
    raise TimeoutError("timed out during opening handshake") from exc
TimeoutError: timed out during opening handshake
Connection closed by UNKNOWN port 65535
Connection closed by UNKNOWN port 65535
```

with fix:
```
$ ssh test-from-api
Warning: Permanently added '127.0.0.1' (ED25519) to the list of known hosts.
Warning: Permanently added '10.40.212.180' (ED25519) to the list of known hosts.
Welcome to Ubuntu 22.04.4 LTS (GNU/Linux 6.8.0-52-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

This system has been minimized by removing packages and content that are
not required on a system that users do not log into.

To restore this content, you can run the 'unminimize' command.
Last login: Fri Apr 11 02:52:18 2025 from 10.40.212.180
root@test-from-api-c5fd9f9e-head:~/sky_workdir/repos#
```