### PR TITLE
[k8s] Check k8s dependencies on `sky check`

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -658,6 +658,13 @@ class Kubernetes(clouds.Cloud):
     def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to
         Kubernetes."""
+        # Check for port forward dependencies
+        reason = kubernetes_utils.check_port_forward_mode_dependencies(False)
+        if reason is not None:
+            formatted = '\n'.join(
+                [reason[0]] + [f'{cls._INDENT_PREFIX}' + r for r in reason[1:]])
+            return (False, formatted)
+
         # Test using python API
         try:
             existing_allowed_contexts = cls.existing_allowed_contexts()

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -659,10 +659,11 @@ class Kubernetes(clouds.Cloud):
         """Checks if the user has access credentials to
         Kubernetes."""
         # Check for port forward dependencies
-        reason = kubernetes_utils.check_port_forward_mode_dependencies(False)
-        if reason is not None:
+        reasons = kubernetes_utils.check_port_forward_mode_dependencies(False)
+        if reasons is not None:
             formatted = '\n'.join(
-                [reason[0]] + [f'{cls._INDENT_PREFIX}' + r for r in reason[1:]])
+                [reasons[0]] +
+                [f'{cls._INDENT_PREFIX}' + r for r in reasons[1:]])
             return (False, formatted)
 
         # Test using python API

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2156,6 +2156,8 @@ def check_port_forward_mode_dependencies(
         raise_error: set to true when the dependencies need to be present.
             set to false for `sky check`, where reason strings are compiled
             at the end.
+
+    Returns: the reasons list if there are missing dependencies.
     """
 
     # errors
@@ -2173,7 +2175,7 @@ def check_port_forward_mode_dependencies(
         'default networking mode, GNU netcat is required. ')
 
     # save
-    reason = []
+    reasons = []
     required_binaries = []
 
     # Ensure socat is installed
@@ -2184,7 +2186,7 @@ def check_port_forward_mode_dependencies(
                        check=True)
     except (FileNotFoundError, subprocess.CalledProcessError):
         required_binaries.append('socat')
-        reason.append(socat_message)
+        reasons.append(socat_message)
 
     # Ensure netcat is installed
     #
@@ -2200,17 +2202,17 @@ def check_port_forward_mode_dependencies(
 
         if nc_mac_installed:
             required_binaries.append('netcat')
-            reason.append(netcat_macos_message)
+            reasons.append(netcat_macos_message)
         elif netcat_output.returncode != 0:
             required_binaries.append('netcat')
-            reason.append(netcat_default_message)
+            reasons.append(netcat_default_message)
 
     except FileNotFoundError:
         required_binaries.append('netcat')
-        reason.append(netcat_default_message)
+        reasons.append(netcat_default_message)
 
     if required_binaries:
-        reason.extend([
+        reasons.extend([
             'On Debian/Ubuntu, install the missing dependenc(ies) with:',
             f'  $ sudo apt install {" ".join(required_binaries)}',
             'On MacOS, install with: ',
@@ -2218,8 +2220,8 @@ def check_port_forward_mode_dependencies(
         ])
         if raise_error:
             with ux_utils.print_exception_no_traceback():
-                raise RuntimeError('\n'.join(reason))
-        return reason
+                raise RuntimeError('\n'.join(reasons))
+        return reasons
     return None
 
 


### PR DESCRIPTION
Fixes #4796 

<!-- Describe the changes in this PR -->
Check whether `socat` and `netcat` are properly downloaded when trying to use Kubernetes as a cloud.
![sky_check](https://github.com/user-attachments/assets/855a8f9b-c3ac-4e06-a7b6-8095d6c31fea)
Also handles the case when relevant dependencies are installed and pass `sky check`, and then the dependencies are uninstalled. 
<img width="682" alt="sky_launch" src="https://github.com/user-attachments/assets/ff6998a8-aadd-486c-9028-e1289eb43e5f" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
