### PR TITLE
Better buildkite notify status on PR

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -306,11 +306,16 @@ def _dump_pipeline_to_file(yaml_file_path: str,
         for pipeline in pipelines:
             all_steps.extend(pipeline['steps'])
 
-        # Wrap steps in a group with notification settings
+        # Extract key from trigger command, keeping only valid characters
+        key = re.sub(r'[^a-zA-Z0-9_\-:]', '',
+                     re.match(r'^[^ ]*', trigger_command).group(0))
+        # Generate formatted group name from key
+        group_name = ' '.join(
+            word.capitalize() for word in re.split(r'[-_]', key))
+
         grouped_steps = [{
-            'group': 'Smoke Tests',
-            'key': re.sub(r'[^a-zA-Z0-9_\-:]', '',
-                          re.match(r'^[^ ]*', trigger_command).group(0)),
+            'group': group_name,
+            'key': key,
             'notify': [{
                 'github_commit_status': {
                     'context': f'{trigger_command}'

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -307,10 +307,10 @@ def _dump_pipeline_to_file(yaml_file_path: str,
             all_steps.extend(pipeline['steps'])
 
         # Wrap steps in a group with notification settings
-
         grouped_steps = [{
             'group': 'Smoke Tests',
-            'key': trigger_command.split(' ')[0],
+            'key': re.sub(r'[^a-zA-Z0-9_\-:]', '',
+                          re.match(r'^[^ ]*', trigger_command).group(0)),
             'notify': [{
                 'github_commit_status': {
                     'context': f'{trigger_command}'

--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -162,10 +162,8 @@ def _extract_marked_tests(
     output = subprocess.run(cmd, shell=True, capture_output=True, text=True)
     matches = re.findall('Collected .+?\.py::(.+?) with marks: \[(.*?)\]',
                          output.stdout)
-    print(f'args: {args}')
     default_clouds_to_run, k_value, extra_args = _parse_args(args)
 
-    print(f'default_clouds_to_run: {default_clouds_to_run}, k_value: {k_value}')
     function_name_marks_map = collections.defaultdict(set)
     function_name_param_map = collections.defaultdict(list)
     remote_server = '--remote-server' in extra_args
@@ -294,6 +292,7 @@ def _generate_pipeline(test_file: str,
 
 def _dump_pipeline_to_file(yaml_file_path: str,
                            pipelines: List[Dict[str, Any]],
+                           trigger_command: str,
                            extra_env: Optional[Dict[str, str]] = None):
     default_env = {
         'LOG_TO_STDOUT': '1',
@@ -306,11 +305,25 @@ def _dump_pipeline_to_file(yaml_file_path: str,
         all_steps = []
         for pipeline in pipelines:
             all_steps.extend(pipeline['steps'])
-        final_pipeline = {'steps': all_steps, 'env': default_env}
+
+        # Wrap steps in a group with notification settings
+
+        grouped_steps = [{
+            'group': 'Smoke Tests',
+            'key': trigger_command.split(' ')[0],
+            'notify': [{
+                'github_commit_status': {
+                    'context': f'{trigger_command}'
+                }
+            }],
+            'steps': all_steps
+        }]
+
+        final_pipeline = {'steps': grouped_steps, 'env': default_env}
         yaml.dump(final_pipeline, file, default_flow_style=False)
 
 
-def _convert_release(test_files: List[str], args: str):
+def _convert_release(test_files: List[str], args: str, trigger_command: str):
     yaml_file_path = '.buildkite/pipeline_smoke_tests_release.yaml'
     output_file_pipelines = []
     for test_file in test_files:
@@ -319,10 +332,12 @@ def _convert_release(test_files: List[str], args: str):
         output_file_pipelines.append(pipeline)
         print(f'Converted {test_file} to {yaml_file_path}\n\n')
     # Enable all clouds by default for release pipeline.
-    _dump_pipeline_to_file(yaml_file_path, output_file_pipelines)
+    _dump_pipeline_to_file(yaml_file_path, output_file_pipelines,
+                           trigger_command)
 
 
-def _convert_quick_tests_core(test_files: List[str], args: List[str]):
+def _convert_quick_tests_core(test_files: List[str], args: List[str],
+                              trigger_command: str):
     yaml_file_path = '.buildkite/pipeline_smoke_tests_quick_tests_core.yaml'
     output_file_pipelines = []
     for test_file in test_files:
@@ -335,6 +350,7 @@ def _convert_quick_tests_core(test_files: List[str], args: List[str]):
         print(f'Converted {test_file} to {yaml_file_path}\n\n')
     _dump_pipeline_to_file(yaml_file_path,
                            output_file_pipelines,
+                           trigger_command,
                            extra_env={'SKYPILOT_SUPPRESS_SENSITIVE_LOG': '1'})
 
 
@@ -357,9 +373,13 @@ def main(args):
 
     args = args or os.getenv('ARGS', '')
     print(f'args: {args}')
+    # If trigger via buildkite, TRIGGER_COMMAND should be set.
+    # Otherwise, use the args passed in for local testing.
+    trigger_command = os.getenv('TRIGGER_COMMAND', '') or args or '/smoke-test'
+    print(f'trigger_command: {trigger_command}')
 
-    _convert_release(release_files, args)
-    _convert_quick_tests_core(quick_tests_core_files, args)
+    _convert_release(release_files, args, trigger_command)
+    _convert_quick_tests_core(quick_tests_core_files, args, trigger_command)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See status section

<img width="1036" alt="image" src="https://github.com/user-attachments/assets/bec1349e-77d4-439f-b19a-001c13fb4da6" />

We now group all steps triggered by a single GitHub comment together and display their notification status on the GitHub PR, using a key from the GitHub comment.

For example:

`/smoke-test --aws -k test_minimal` will show one status
`/smoke-test --gcp` will show another status
`/smoke-test --azure` will show a third status
If you run `/smoke-test --aws -k test_minimal` again, it will overwrite the first status (each key can only have one status).

The GitHub status issue is that if we trigger N tests from buildkite and then commit a new one, the previous statuses disappear due to GitHub's display logic.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
