### PR TITLE
[UX] CLI config overrides

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -54,6 +54,7 @@ from sky import jobs as managed_jobs
 from sky import models
 from sky import serve as serve_lib
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.benchmark import benchmark_state
 from sky.benchmark import benchmark_utils
@@ -276,6 +277,36 @@ def _merge_env_vars(env_dict: Optional[Dict[str, str]],
     for (key, value) in env_list:
         env_dict[key] = value
     return list(env_dict.items())
+
+
+def config_option(expose_value: bool):
+
+    def preprocess_config_options(ctx, param, value):
+        del ctx  # Unused.
+        param.name = 'config_override'
+        try:
+            if len(value) == 0:
+                return None
+            elif len(value) > 1:
+                raise ValueError
+            else:
+                return skypilot_config.apply_cli_config(value[0])
+        except ValueError as e:
+            raise click.BadParameter('argument specified multiple times') from e
+
+    def return_option_decorator(func):
+        return click.option(
+            '--config',
+            required=False,
+            type=str,
+            multiple=True,
+            expose_value=expose_value,
+            callback=preprocess_config_options,
+            help=('Path to a config file or a comma-separated '
+                  'list of key-value pairs.'),
+        )(func)
+
+    return return_option_decorator
 
 
 _COMMON_OPTIONS = [
@@ -1010,6 +1041,7 @@ def cli():
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('entrypoint',
                 required=False,
                 type=str,
@@ -1245,6 +1277,7 @@ def launch(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('cluster',
                 required=False,
                 type=str,
@@ -1657,6 +1690,7 @@ def _show_endpoint(query_clusters: Optional[List[str]],
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.option('--verbose',
               '-v',
               default=False,
@@ -1949,6 +1983,7 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.option('--all',
               '-a',
               default=False,
@@ -2019,6 +2054,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.option('--all-users',
               '-u',
               default=False,
@@ -2080,6 +2116,7 @@ def queue(clusters: List[str], skip_finished: bool, all_users: bool):
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.option(
     '--sync-down',
     '-s',
@@ -2217,6 +2254,7 @@ def logs(
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.argument('cluster',
                 required=True,
                 type=str,
@@ -2320,6 +2358,7 @@ def cancel(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('clusters',
                 nargs=-1,
                 required=False,
@@ -2387,6 +2426,7 @@ def stop(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('clusters',
                 nargs=-1,
                 required=False,
@@ -2499,6 +2539,7 @@ def autostop(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('clusters',
                 nargs=-1,
                 required=False,
@@ -2744,6 +2785,7 @@ def start(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('clusters',
                 nargs=-1,
                 required=False,
@@ -3182,6 +3224,7 @@ def _down_or_stop_clusters(
 
 
 @cli.command(cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('clouds', required=False, type=str, nargs=-1)
 @click.option('--verbose',
               '-v',
@@ -3222,6 +3265,7 @@ def check(clouds: Tuple[str], verbose: bool):
 
 
 @cli.command()
+@config_option(expose_value=False)
 @click.argument('accelerator_str', required=False)
 @click.option('--all',
               '-a',
@@ -3693,6 +3737,7 @@ def storage():
 
 
 @storage.command('ls', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--verbose',
               '-v',
               default=False,
@@ -3711,6 +3756,7 @@ def storage_ls(verbose: bool):
 
 
 @storage.command('delete', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('names',
                 required=False,
                 type=str,
@@ -3795,6 +3841,7 @@ def jobs():
 
 
 @jobs.command('launch', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('entrypoint',
                 required=True,
                 type=str,
@@ -3929,6 +3976,7 @@ def jobs_launch(
 
 
 @jobs.command('queue', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--verbose',
               '-v',
               default=False,
@@ -4045,6 +4093,7 @@ def jobs_queue(verbose: bool, refresh: bool, skip_finished: bool,
 
 
 @jobs.command('cancel', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--name',
               '-n',
               required=False,
@@ -4119,6 +4168,7 @@ def jobs_cancel(name: Optional[str], job_ids: Tuple[int], all: bool, yes: bool,
 
 
 @jobs.command('logs', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--name',
               '-n',
               required=False,
@@ -4183,6 +4233,7 @@ def jobs_logs(name: Optional[str], job_id: Optional[int], follow: bool,
 
 
 @jobs.command('dashboard', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @usage_lib.entrypoint
 def jobs_dashboard():
     """Opens a dashboard for managed jobs."""
@@ -4312,6 +4363,7 @@ def _generate_task_with_service(
 
 
 @serve.command('up', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('service_yaml',
                 required=True,
                 type=str,
@@ -4423,6 +4475,7 @@ def serve_up(
 # TODO(MaoZiming): Expose mix replica traffic option to user.
 # Currently, we do not mix traffic from old and new replicas.
 @serve.command('update', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('service_name', required=True, type=str)
 @click.argument('service_yaml',
                 required=True,
@@ -4523,6 +4576,7 @@ def serve_update(service_name: str, service_yaml: Tuple[str, ...],
 
 
 @serve.command('status', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--verbose',
               '-v',
               default=False,
@@ -4648,6 +4702,7 @@ def serve_status(verbose: bool, endpoint: bool, service_names: List[str]):
 
 
 @serve.command('down', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('service_names', required=False, type=str, nargs=-1)
 @click.option('--all',
               '-a',
@@ -4761,6 +4816,7 @@ def serve_down(
 
 
 @serve.command('logs', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option(
     '--follow/--no-follow',
     is_flag=True,
@@ -4874,6 +4930,7 @@ def _get_candidate_configs(yaml_path: str) -> Optional[List[Dict[str, str]]]:
 
 
 @bench.command('launch', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('entrypoint',
                 required=True,
                 type=str,
@@ -5113,6 +5170,7 @@ def benchmark_launch(
 
 
 @bench.command('ls', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @usage_lib.entrypoint
 def benchmark_ls() -> None:
     """List the benchmark history."""
@@ -5176,6 +5234,7 @@ def benchmark_ls() -> None:
 
 
 @bench.command('show', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('benchmark', required=True, type=str)
 # TODO(woosuk): Add --all option to show all the collected information
 # (e.g., setup time, warmup steps, total steps, etc.).
@@ -5301,6 +5360,7 @@ def benchmark_show(benchmark: str) -> None:
 
 
 @bench.command('down', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('benchmark', required=True, type=str)
 @click.option(
     '--exclude',
@@ -5343,6 +5403,7 @@ def benchmark_down(
 
 
 @bench.command('delete', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('benchmarks', required=False, type=str, nargs=-1)
 @click.option('--all',
               '-a',
@@ -5477,6 +5538,7 @@ def local():
               help='Password for the ssh-user to execute sudo commands. '
               'Required only if passwordless sudo is not setup.')
 @local.command('up', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
@@ -5532,6 +5594,7 @@ def local_up(gpus: bool, ips: str, ssh_user: str, ssh_key_path: str,
 
 
 @local.command('down', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @_add_click_options(_COMMON_OPTIONS)
 @usage_lib.entrypoint
 def local_down(async_call: bool):
@@ -5547,6 +5610,7 @@ def api():
 
 
 @api.command('start', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--deploy',
               type=bool,
               is_flag=True,
@@ -5579,6 +5643,7 @@ def api_start(deploy: bool, host: Optional[str], foreground: bool):
 
 
 @api.command('stop', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @usage_lib.entrypoint
 def api_stop():
     """Stops the SkyPilot API server locally."""
@@ -5586,6 +5651,7 @@ def api_stop():
 
 
 @api.command('logs', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('request_id', required=False, type=str)
 @click.option('--server-logs',
               is_flag=True,
@@ -5625,6 +5691,7 @@ def api_logs(request_id: Optional[str], server_logs: bool,
 
 
 @api.command('cancel', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('request_ids', required=False, type=str, nargs=-1)
 @click.option('--all',
               '-a',
@@ -5666,6 +5733,7 @@ def api_cancel(request_ids: Optional[List[str]], all: bool, all_users: bool):
 
 
 @api.command('status', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.argument('request_ids', required=False, type=str, nargs=-1)
 @click.option('--all-status',
               '-a',
@@ -5709,6 +5777,7 @@ def api_status(request_ids: Optional[List[str]], all_status: bool,
 
 
 @api.command('login', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @click.option('--endpoint',
               '-e',
               required=False,
@@ -5720,6 +5789,7 @@ def api_login(endpoint: Optional[str]):
 
 
 @api.command('info', cls=_DocumentedCodeCommand)
+@config_option(expose_value=False)
 @usage_lib.entrypoint
 def api_info():
     """Shows the SkyPilot API server URL."""

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -302,7 +302,9 @@ def config_option(expose_value: bool):
             if len(value) == 0:
                 return None
             elif len(value) > 1:
-                raise ValueError('argument specified multiple times')
+                raise ValueError('argument specified multiple times. '
+                                 'To specify multiple configs, use '
+                                 '--config nested.key1=val1,another.key2=val2')
             else:
                 # Apply the config overrides to the skypilot config.
                 return skypilot_config.apply_cli_config(value[0])
@@ -319,7 +321,7 @@ def config_option(expose_value: bool):
             callback=preprocess_config_options,
             help=('Path to a config file or a comma-separated '
                   'list of key-value pairs '
-                  '(e.g. "nested.key=val,another.key=val").'),
+                  '(e.g. "nested.key1=val1,another.key2=val2").'),
         )(func)
 
     return return_option_decorator

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1306,7 +1306,7 @@ class Resources:
             if elem is not None:
                 override_configs.set_nested(key, elem)
 
-        override_configs = dict(override_configs)
+        override_configs = dict(override_configs) if override_configs else None
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1306,7 +1306,7 @@ class Resources:
             if elem is not None:
                 override_configs.set_nested(key, elem)
 
-        override_configs = dict(override_configs) if override_configs else None
+        override_configs = dict(override_configs)
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1306,7 +1306,6 @@ class Resources:
             if elem is not None:
                 override_configs.set_nested(key, elem)
 
-        override_configs = dict(override_configs) if override_configs else None
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1303,7 +1303,7 @@ class Resources:
         override_configs = config_utils.Config()
         for key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
             elem = overlaid_configs.get_nested(key, None)
-            if elem:
+            if elem is not None:
                 override_configs.set_nested(key, elem)
 
         override_configs = dict(override_configs) if override_configs else None

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -18,6 +18,7 @@ from sky.skylet import constants
 from sky.utils import accelerator_registry
 from sky.utils import annotations
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import log_utils
 from sky.utils import registry
 from sky.utils import resources_utils
@@ -1290,6 +1291,21 @@ class Resources:
     def copy(self, **override) -> 'Resources':
         """Returns a copy of the given Resources."""
         use_spot = self.use_spot if self._use_spot_specified else None
+
+        current_override_configs = self._cluster_config_overrides
+        if self._cluster_config_overrides is None:
+            current_override_configs = {}
+        new_override_configs = override.pop('_cluster_config_overrides', {})
+        overlaid_configs = skypilot_config.overlay_skypilot_config(
+            original_config=config_utils.Config(current_override_configs),
+            override_configs=new_override_configs,
+        )
+        override_configs = config_utils.Config()
+        for key in constants.OVERRIDEABLE_CONFIG_KEYS_IN_TASK:
+            elem = overlaid_configs.get_nested(key, None)
+            if elem:
+                override_configs.set_nested(key, elem)
+
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),
@@ -1315,8 +1331,7 @@ class Resources:
             _is_image_managed=override.pop('_is_image_managed',
                                            self._is_image_managed),
             _requires_fuse=override.pop('_requires_fuse', self._requires_fuse),
-            _cluster_config_overrides=override.pop(
-                '_cluster_config_overrides', self._cluster_config_overrides),
+            _cluster_config_overrides=dict(override_configs),
         )
         assert not override
         return resources

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1306,6 +1306,7 @@ class Resources:
             if elem:
                 override_configs.set_nested(key, elem)
 
+        override_configs = dict(override_configs) if override_configs else None
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),
@@ -1331,7 +1332,7 @@ class Resources:
             _is_image_managed=override.pop('_is_image_managed',
                                            self._is_image_managed),
             _requires_fuse=override.pop('_requires_fuse', self._requires_fuse),
-            _cluster_config_overrides=dict(override_configs),
+            _cluster_config_overrides=override_configs,
         )
         assert not override
         return resources

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1306,6 +1306,7 @@ class Resources:
             if elem is not None:
                 override_configs.set_nested(key, elem)
 
+        override_configs = dict(override_configs) if override_configs else None
         resources = Resources(
             cloud=override.pop('cloud', self.cloud),
             instance_type=override.pop('instance_type', self.instance_type),

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,8 +53,8 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'antlr4-python3-runtime == 4.9.3',
-    'omegaconf == 2.3.0',
+    'omegaconf',
+    'fugue >= 0.9.0',
 ]
 
 local_ray = [

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,8 +53,7 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'omegaconf',
-    'fugue >= 0.9.0',
+    'omegaconf>=2.4.0dev3,<2.5',
 ]
 
 local_ray = [

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,7 +53,8 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'omegaconf',
+    'antlr4-python3-runtime == 4.9.3',
+    'omegaconf == 2.3.0',
 ]
 
 local_ray = [

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,6 +53,7 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
+    'omegaconf',
 ]
 
 local_ray = [

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -375,10 +375,13 @@ def _compose_cli_config(cli_config: Optional[str],) -> config_utils.Config:
     if not cli_config:
         return config_utils.Config()
 
-    if os.path.isfile(cli_config):
+    config_source = 'CLI'
+    maybe_config_path = os.path.expanduser(cli_config)
+    if os.path.isfile(maybe_config_path):
+        config_source = maybe_config_path
         # cli_config is a path to a config file
-        logger.info(f'Parsing CLI provided config file: {cli_config}')
-        parsed_config = OmegaConf.to_object(OmegaConf.load(cli_config))
+        logger.info(f'Parsing CLI provided config file: {maybe_config_path}')
+        parsed_config = OmegaConf.to_object(OmegaConf.load(maybe_config_path))
     else:
         # cli_config is a comma-separated list of key-value pairs
         logger.info(f'Parsing CLI provided config: {cli_config}')
@@ -387,14 +390,14 @@ def _compose_cli_config(cli_config: Optional[str],) -> config_utils.Config:
         parsed_config = OmegaConf.to_object(OmegaConf.from_dotlist(variables))
     logger.info(f'Parsed CLI config: {parsed_config}')
 
-    _validate_config(parsed_config, 'CLI')
+    _validate_config(parsed_config, config_source)
     logger.debug('Config syntax check passed.')
 
     return parsed_config
 
 
 def apply_cli_config(cli_config: Optional[str]) -> Dict[str, Any]:
-    """Applies the skypilot CLI config.
+    """Applies the CLI provided config.
     SAFETY:
     This function directly modifies the global _dict variable.
     This is considered fine in CLI context because the program will exit after

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -177,7 +177,7 @@ def _validate_config(config: Dict[str, Any], config_source: str) -> None:
         skip_none=False)
 
 
-def _overlay_skypilot_config(
+def overlay_skypilot_config(
         original_config: Optional[config_utils.Config],
         override_configs: Optional[config_utils.Config]) -> config_utils.Config:
     """Overlays the override configs on the original configs."""
@@ -298,7 +298,7 @@ def _reload_config_hierarchical() -> None:
     # layer the configs on top of each other based on priority
     overlaid_client_config: config_utils.Config = config_utils.Config()
     for override in overrides:
-        overlaid_client_config = _overlay_skypilot_config(
+        overlaid_client_config = overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
     logger.debug(f'final config: {overlaid_client_config}')
     _dict = overlaid_client_config
@@ -410,8 +410,7 @@ def apply_cli_config(cli_config: Optional[str]) -> Dict[str, Any]:
     parsed_config = _compose_cli_config(cli_config)
     logger.info(
         f'applying following overrides from CLI config: {parsed_config}')
-    print(f'original _dict: {_dict}')
-    _dict = _overlay_skypilot_config(original_config=_dict,
-                                     override_configs=parsed_config)
-    print(f'new _dict: {_dict}')
+    logger.debug(f'applying following CLI overrides: {parsed_config}')
+    _dict = overlay_skypilot_config(original_config=_dict,
+                                    override_configs=parsed_config)
     return parsed_config

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -390,15 +390,9 @@ def _compose_cli_config(cli_config: Optional[str],) -> config_utils.Config:
                 OmegaConf.from_dotlist(variables))
         _validate_config(parsed_config, config_source)
     except ValueError as e:
-        if '=' in cli_config:
-            # treat the config as an attempt at a dotlist.
-            raise ValueError(f'Invalid config override: {cli_config}. '
-                             f'{str(e)}') from e
-        else:
-            # treat the config as a path to a (missing) config file.
-            raise ValueError(f'Invalid config file: {cli_config}. '
-                             'Does the config file exist?') from e
-
+        raise ValueError(f'Invalid config override: {cli_config}. '
+                         f'Check if config file exists or if the dotlist '
+                         f'is formatted as: key1=value1,key2=value2') from e
     logger.debug('CLI overrides config syntax check passed.')
 
     return parsed_config


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Support overriding configuration per-request using CLI argument.
CLI now accepts a `--config` flag. This flag could either point to a file (relative to $pwd) or a comma separated dotlist (e.g. `--kubernetes.provision_timeout=900,gcp.remote_identity=SERVICE_ACCOUNT`.

Only one instance of `--config` flag is allowed. Among other things, this means a user is not allowed to specify a config file and a dotlist. This saves us the hassle of having to define what takes priority if a config file and a dotlist (or multiple config files, or multiple dotlists, or multiple of both) are specified, making the hierarchy more intuitive.

The specified config modifies the global `_dict`. This is considered fine as the each CLI command is a fresh invocation of the program.

The modified `_dict` is passed to the server as `override_skypilot_config`. Note the DAG also passes its own config overrides in `dag` field, which takes precedence on the server.

Therefore, to ensure CLI provided config maintains precedence over task.yaml configs, the CLI provided configs also override any config overrides specified in task.yaml separately/

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] All smoke tests: `/smoke-test` (CI)
- [x] Backward compatibility: `/quicktest-core` (CI)

Any manual or new tests for this PR (please specify below)
- [x] passing in multiple `--config` arguments result in an error.
```
sky launch --cloud gcp --config kubernetes.provision_timeout=200 --config gcp.remote_identity=SERVICE_ACCOUNT override-test.yaml
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: Invalid value for '--config': argument specified multiple times
```
- [x] CLI provided config is interpreted as a file if a corresponding file exists.
- [x] CLI provided config is interpreted as a dotlist if corresponding file does not exist.
- [x] CLI errors out if provided config does not point to a file nor is it a valid dotlist.\
```
sky launch --cloud gcp --config kubernetes override-test.yaml
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: Invalid value for '--config': Invalid config YAML from (CLI). See: https://docs.skypilot.co/en/latest/reference/config.html. Error: None is not of type 'dict'. Check problematic field(s): $.kubernetes
$ sky launch --cloud gcp --config ,,, override-test.yaml
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: Invalid value for '--config': Invalid config YAML from (CLI). See: https://docs.skypilot.co/en/latest/reference/config.html. Error: Found unsupported field ''.
```
- [x] CLI provides a helpful error message if `--config` could not be parsed depending on if the (malformed) config looks more like a file or a dotlist.
- [x] CLI provided config is checked against config schema, and errors out if an invalid field override is specified.
```
$ sky launch --cloud gcp --config nonsense=200 override-test.yaml
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: Invalid value for '--config': Invalid config YAML from (CLI). See: https://docs.skypilot.co/en/latest/reference/config.html. Error: Found unsupported field 'nonsense'.
$ sky launch --cloud gcp --config kubernetes.provision_timeout=not-a-number override-test.yaml 
Usage: sky launch [OPTIONS] [ENTRYPOINT]...
Try 'sky launch -h' for help.

Error: Invalid value for '--config': Invalid config YAML from (CLI). See: https://docs.skypilot.co/en/latest/reference/config.html. Error: 'not-a-number' is not of type 'integer'. Check problematic field(s): $.kubernetes.provision_timeout
```
- [x] CLI provided config overrides take priority over task.yaml
- [x] CLI provided config overrides take priority over project config
- [x] CLI provided config overrides take priority over user config

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
