### PR TITLE
[UX] Change default config directories

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -16,7 +16,7 @@ apiService:
 
   # Set config.yaml content on the API server
   # Updating this value will take tens of seconds to take effect on the API server.
-  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/skyconfig.yaml`
+  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/.sky.yaml`
   config: null
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -16,7 +16,7 @@ apiService:
 
   # Set config.yaml content on the API server
   # Updating this value will take tens of seconds to take effect on the API server.
-  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/.sky.yaml`
+  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/config.yaml`
   config: null
   # config: |
   #   admin_policy: admin_policy_examples.AddLabelsPolicy

--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -226,7 +226,7 @@ Using a specific VPC
 By default, SkyPilot uses the "default" VPC in each region. If a region does not have a `default VPC <https://docs.aws.amazon.com/vpc/latest/userguide/work-with-default-vpc.html#create-default-vpc>`_, SkyPilot will not be able to use the region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/skyconfig.yaml`` to specify the VPC name in the ``aws.vpc_name``
+file ``~/.sky/.sky.yaml`` to specify the VPC name in the ``aws.vpc_name``
 field:
 
 .. code-block:: yaml

--- a/docs/source/cloud-setup/cloud-permissions/aws.rst
+++ b/docs/source/cloud-setup/cloud-permissions/aws.rst
@@ -226,7 +226,7 @@ Using a specific VPC
 By default, SkyPilot uses the "default" VPC in each region. If a region does not have a `default VPC <https://docs.aws.amazon.com/vpc/latest/userguide/work-with-default-vpc.html#create-default-vpc>`_, SkyPilot will not be able to use the region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/.sky.yaml`` to specify the VPC name in the ``aws.vpc_name``
+file ``~/.sky/config.yaml`` to specify the VPC name in the ``aws.vpc_name``
 field:
 
 .. code-block:: yaml

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -95,7 +95,7 @@ User
 
 .. note::
 
-    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/skyconfig.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
+    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/.sky.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
 
 .. note::
 
@@ -151,7 +151,7 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/skyconfig.yaml <config-yaml>`, you can additionally add the following permissions:
+9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/.sky.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 
@@ -270,7 +270,7 @@ By default, SkyPilot uses the following behavior to get a VPC to use for all GCP
   automatically starts with one subnet per region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/skyconfig.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
+file ``~/.sky/.sky.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
 
 .. code-block:: yaml
 
@@ -289,7 +289,7 @@ The custom VPC should contain the :ref:`required firewall rules <gcp-minimum-fir
 Using internal IPs
 -----------------------
 For security reason, users may only want to use internal IPs for SkyPilot instances.
-To do so, you can use SkyPilot's global config file ``~/.sky/skyconfig.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
+To do so, you can use SkyPilot's global config file ``~/.sky/.sky.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
 
 .. code-block:: yaml
 

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -95,7 +95,7 @@ User
 
 .. note::
 
-    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/.sky.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
+    For custom VPC users (with :code:`gcp.vpc_name` specified in :code:`~/.sky/config.yaml`, check `here <#_gcp-bring-your-vpc>`_),  :code:`compute.firewalls.create` and :code:`compute.firewalls.delete` are not necessary unless opening ports is needed via `resources.ports` in task yaml.
 
 .. note::
 
@@ -151,7 +151,7 @@ User
     compute.images.get
     compute.images.useReadOnly
 
-9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/.sky.yaml <config-yaml>`, you can additionally add the following permissions:
+9. **Optional**: If your organization sets ``gcp.prioritize_reservations`` or ``gcp.specific_reservations`` in :ref:`~/.sky/config.yaml <config-yaml>`, you can additionally add the following permissions:
 
 .. code-block:: text
 
@@ -270,7 +270,7 @@ By default, SkyPilot uses the following behavior to get a VPC to use for all GCP
   automatically starts with one subnet per region.
 
 To instruct SkyPilot to use a specific VPC, you can use SkyPilot's global config
-file ``~/.sky/.sky.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
+file ``~/.sky/config.yaml`` to specify the VPC name in the ``gcp.vpc_name`` field:
 
 .. code-block:: yaml
 
@@ -289,7 +289,7 @@ The custom VPC should contain the :ref:`required firewall rules <gcp-minimum-fir
 Using internal IPs
 -----------------------
 For security reason, users may only want to use internal IPs for SkyPilot instances.
-To do so, you can use SkyPilot's global config file ``~/.sky/.sky.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
+To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to specify the ``gcp.use_internal_ips`` and ``gcp.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
 
 .. code-block:: yaml
 

--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -19,7 +19,7 @@ SkyPilot can operate using either of the following three authentication methods:
 
 2. **Using a custom service account**: If you have a custom service account
    with the `necessary permissions <k8s-permissions_>`__, you can configure
-   SkyPilot to use it by adding this to your :ref:`~/.sky/.sky.yaml <config-yaml>` file:
+   SkyPilot to use it by adding this to your :ref:`~/.sky/config.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -29,7 +29,7 @@ SkyPilot can operate using either of the following three authentication methods:
 3. **Using your local kubeconfig file**: In this case, SkyPilot will
    copy your local ``~/.kube/config`` file to the controller pod and use it for
    authentication. To use this method, set ``remote_identity: LOCAL_CREDENTIALS`` to your
-   Kubernetes configuration in the :ref:`~/.sky/.sky.yaml <config-yaml>` file:
+   Kubernetes configuration in the :ref:`~/.sky/config.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -349,10 +349,10 @@ Create the service account using the following command:
 
 After creating the service account, the cluster admin may distribute kubeconfigs with the ``sky-sa`` service account to users who need to access the cluster.
 
-Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/.sky.yaml``:
+Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/config.yaml``:
 
 .. code-block:: yaml
 
-    # ~/.sky/.sky.yaml
+    # ~/.sky/config.yaml
     kubernetes:
       remote_identity: sky-sa   # Or your service account name

--- a/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
+++ b/docs/source/cloud-setup/cloud-permissions/kubernetes.rst
@@ -19,7 +19,7 @@ SkyPilot can operate using either of the following three authentication methods:
 
 2. **Using a custom service account**: If you have a custom service account
    with the `necessary permissions <k8s-permissions_>`__, you can configure
-   SkyPilot to use it by adding this to your :ref:`~/.sky/skyconfig.yaml <config-yaml>` file:
+   SkyPilot to use it by adding this to your :ref:`~/.sky/.sky.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -29,7 +29,7 @@ SkyPilot can operate using either of the following three authentication methods:
 3. **Using your local kubeconfig file**: In this case, SkyPilot will
    copy your local ``~/.kube/config`` file to the controller pod and use it for
    authentication. To use this method, set ``remote_identity: LOCAL_CREDENTIALS`` to your
-   Kubernetes configuration in the :ref:`~/.sky/skyconfig.yaml <config-yaml>` file:
+   Kubernetes configuration in the :ref:`~/.sky/.sky.yaml <config-yaml>` file:
 
    .. code-block:: yaml
 
@@ -349,10 +349,10 @@ Create the service account using the following command:
 
 After creating the service account, the cluster admin may distribute kubeconfigs with the ``sky-sa`` service account to users who need to access the cluster.
 
-Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/skyconfig.yaml``:
+Users should also configure SkyPilot to use the ``sky-sa`` service account through ``~/.sky/.sky.yaml``:
 
 .. code-block:: yaml
 
-    # ~/.sky/skyconfig.yaml
+    # ~/.sky/.sky.yaml
     kubernetes:
       remote_identity: sky-sa   # Or your service account name

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -20,7 +20,7 @@ To implement and use an admin policy:
 
 - Admins writes a simple Python package with a policy class that implements SkyPilot's ``sky.AdminPolicy`` interface;
 - Admins distributes this package to users;
-- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/skyconfig.yaml`` for the policy to go into effect.
+- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/.sky.yaml`` for the policy to go into effect.
 
 
 Overview
@@ -32,7 +32,7 @@ User-Side
 ~~~~~~~~~~
 
 To apply the policy, a user needs to set the ``admin_policy`` field in the SkyPilot config
-``~/.sky/skyconfig.yaml`` to the path of the Python package that implements the policy.
+``~/.sky/.sky.yaml`` to the path of the Python package that implements the policy.
 For example:
 
 .. code-block:: yaml

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -20,7 +20,7 @@ To implement and use an admin policy:
 
 - Admins writes a simple Python package with a policy class that implements SkyPilot's ``sky.AdminPolicy`` interface;
 - Admins distributes this package to users;
-- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/.sky.yaml`` for the policy to go into effect.
+- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/config.yaml`` for the policy to go into effect.
 
 
 Overview
@@ -32,7 +32,7 @@ User-Side
 ~~~~~~~~~~
 
 To apply the policy, a user needs to set the ``admin_policy`` field in the SkyPilot config
-``~/.sky/.sky.yaml`` to the path of the Python package that implements the policy.
+``~/.sky/config.yaml`` to the path of the Python package that implements the policy.
 For example:
 
 .. code-block:: yaml

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -466,11 +466,11 @@ Setting the job files bucket
 For managed jobs, SkyPilot requires an intermediate bucket to store files used in the task, such as local file mounts, temporary files, and the workdir.
 If you do not configure a bucket, SkyPilot will automatically create a temporary bucket named :code:`skypilot-filemounts-{username}-{run_id}` for each job launch. SkyPilot automatically deletes the bucket after the job completes.
 
-Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/.sky.yaml`:
+Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/config.yaml`:
 
 .. code-block:: yaml
 
-  # ~/.sky/.sky.yaml
+  # ~/.sky/config.yaml
   jobs:
     bucket: s3://my-bucket  # Supports s3://, gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cos://<region>/<bucket>
 
@@ -527,7 +527,7 @@ You may want to customize the resources of the jobs controller for several reaso
 #. Enforcing the jobs controller to run on a specific location. (Default: cheapest location)
 #. Changing the disk_size of the jobs controller to store more logs. (Default: 50GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/.sky.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/config.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -466,11 +466,11 @@ Setting the job files bucket
 For managed jobs, SkyPilot requires an intermediate bucket to store files used in the task, such as local file mounts, temporary files, and the workdir.
 If you do not configure a bucket, SkyPilot will automatically create a temporary bucket named :code:`skypilot-filemounts-{username}-{run_id}` for each job launch. SkyPilot automatically deletes the bucket after the job completes.
 
-Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/skyconfig.yaml`:
+Alternatively, you can pre-provision a bucket and use it as an intermediate for storing file by setting :code:`jobs.bucket` in :code:`~/.sky/.sky.yaml`:
 
 .. code-block:: yaml
 
-  # ~/.sky/skyconfig.yaml
+  # ~/.sky/.sky.yaml
   jobs:
     bucket: s3://my-bucket  # Supports s3://, gs://, https://<azure_storage_account>.blob.core.windows.net/<container>, r2://, cos://<region>/<bucket>
 
@@ -527,7 +527,7 @@ You may want to customize the resources of the jobs controller for several reaso
 #. Enforcing the jobs controller to run on a specific location. (Default: cheapest location)
 #. Changing the disk_size of the jobs controller to store more logs. (Default: 50GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/skyconfig.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/.sky.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -314,7 +314,7 @@ The :code:`~/.oci/config` file should contain the following fields:
   # Note that we should avoid using full home path for the key_file configuration, e.g. use ~/.oci instead of /home/username/.oci
   key_file=~/.oci/oci_api_key.pem
 
-By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/skyconfig.yaml`, put the compartment's OCID there, as the following:
+By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/.sky.yaml`, put the compartment's OCID there, as the following:
 
 .. code-block:: text
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -314,7 +314,7 @@ The :code:`~/.oci/config` file should contain the following fields:
   # Note that we should avoid using full home path for the key_file configuration, e.g. use ~/.oci instead of /home/username/.oci
   key_file=~/.oci/oci_api_key.pem
 
-By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/.sky.yaml`, put the compartment's OCID there, as the following:
+By default, the provisioned nodes will be in the root `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`__. To specify the `compartment <https://docs.oracle.com/en/cloud/foundation/cloud_architecture/governance/compartments.html>`_ other than root, create/edit the file :code:`~/.sky/config.yaml`, put the compartment's OCID there, as the following:
 
 .. code-block:: text
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -369,7 +369,7 @@ Once the EBS CSI driver is installed, the default ``gp2`` storage class will be 
 Setting the SkyPilot config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/.sky.yaml`` in the API server container.
+The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/config.yaml`` in the API server container.
 
 To set the config file, pass ``--set-file apiService.config=path/to/your/config.yaml`` to the ``helm`` command:
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -369,7 +369,7 @@ Once the EBS CSI driver is installed, the default ``gp2`` storage class will be 
 Setting the SkyPilot config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/skyconfig.yaml`` in the API server container.
+The Helm chart supports setting the global SkyPilot config YAML file on the API server. The config file is mounted as ``~/.sky/.sky.yaml`` in the API server container.
 
 To set the config file, pass ``--set-file apiService.config=path/to/your/config.yaml`` to the ``helm`` command:
 

--- a/docs/source/reference/api-server/api-server.rst
+++ b/docs/source/reference/api-server/api-server.rst
@@ -83,7 +83,7 @@ Run ``sky api login`` to connect to the API server.
     $ sky api login
     Enter your SkyPilot API server endpoint: http://skypilot:password@1.2.3.4:30050
 
-This will save the API server endpoint to your ``~/.sky/.sky.yaml`` file.
+This will save the API server endpoint to your ``~/.sky/config.yaml`` file.
 
 To verify that the API server is working, run ``sky api info``:
 
@@ -97,7 +97,7 @@ To verify that the API server is working, run ``sky api info``:
 
 .. tip::
 
-    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/.sky.yaml``:
+    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/config.yaml``:
 
     .. code-block:: console
 

--- a/docs/source/reference/api-server/api-server.rst
+++ b/docs/source/reference/api-server/api-server.rst
@@ -83,7 +83,7 @@ Run ``sky api login`` to connect to the API server.
     $ sky api login
     Enter your SkyPilot API server endpoint: http://skypilot:password@1.2.3.4:30050
 
-This will save the API server endpoint to your ``~/.sky/skyconfig.yaml`` file.
+This will save the API server endpoint to your ``~/.sky/.sky.yaml`` file.
 
 To verify that the API server is working, run ``sky api info``:
 
@@ -97,7 +97,7 @@ To verify that the API server is working, run ``sky api info``:
 
 .. tip::
 
-    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/skyconfig.yaml``:
+    You can also set the API server endpoint using the ``SKYPILOT_API_SERVER_ENDPOINT`` environment variable. It will override the value set in ``~/.sky/.sky.yaml``:
 
     .. code-block:: console
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -3,7 +3,7 @@
 Advanced Configuration
 ======================
 
-You can pass **optional configuration** to SkyPilot in the ``~/.sky/skyconfig.yaml`` file.
+You can pass **optional configuration** to SkyPilot in the ``~/.sky/.sky.yaml`` file.
 
 This configuration applies to all new clusters and does not affect existing clusters.
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -3,7 +3,7 @@
 Advanced Configuration
 ======================
 
-You can pass **optional configuration** to SkyPilot in the ``~/.sky/.sky.yaml`` file.
+You can pass **optional configuration** to SkyPilot in the ``~/.sky/config.yaml`` file.
 
 This configuration applies to all new clusters and does not affect existing clusters.
 

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -73,7 +73,7 @@ Once your cluster administrator has :ref:`setup a Kubernetes cluster <kubernetes
 
    .. note::
 
-     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/.sky.yaml`` file:
+     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/config.yaml`` file:
 
      .. code-block:: yaml
 
@@ -219,7 +219,7 @@ Your image must satisfy the following requirements:
 
 Using images from private repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/.sky.yaml` to specify the secret like so:
+To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/config.yaml` to specify the secret like so:
 
 .. code-block:: yaml
 
@@ -280,14 +280,14 @@ After launching the cluster with :code:`sky launch -c myclus task.yaml`, you can
 Customizing SkyPilot Pods
 -------------------------
 
-You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/.sky.yaml`.
+You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/config.yaml`.
 The value of :code:`pod_config` should be a dictionary that follows the `Kubernetes Pod API <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#pod-v1-core>`_. This will apply to all pods created by SkyPilot.
 
-For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/.sky.yaml` file:
+For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/config.yaml` file:
 
 .. code-block:: yaml
 
-    # ~/.sky/.sky.yaml
+    # ~/.sky/config.yaml
     kubernetes:
       pod_config:
         spec:
@@ -332,20 +332,20 @@ FAQs
 
 * **Can I use multiple Kubernetes clusters with SkyPilot?**
 
-  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/.sky.yaml`. See :ref:`multi-kubernetes`.
+  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/config.yaml`. See :ref:`multi-kubernetes`.
 
   If ``allowed_contexts`` is not set, SkyPilot will use the current active context. To use a different context, change your current context using :code:`kubectl config use-context <context-name>`.
 
 * **Are autoscaling Kubernetes clusters supported?**
 
-  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/.sky.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
+  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/config.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
   This will direct SkyPilot to wait for the cluster to scale up before failing over to the next candidate resource (e.g., next cloud).
 
   If you are using GPUs in a scale-to-zero setting, you should also set the :code:`autoscaler` key to the autoscaler type of your cluster. More details in :ref:`config-yaml`.
 
   .. code-block:: yaml
 
-      # ~/.sky/.sky.yaml
+      # ~/.sky/config.yaml
       kubernetes:
         provision_timeout: 900  # Wait 15 minutes for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
         autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs/TPUs in scale-to-zero setting

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -73,7 +73,7 @@ Once your cluster administrator has :ref:`setup a Kubernetes cluster <kubernetes
 
    .. note::
 
-     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/skyconfig.yaml`` file:
+     If your cluster administrator has also provided you with a specific service account to use, set it in your ``~/.sky/.sky.yaml`` file:
 
      .. code-block:: yaml
 
@@ -219,7 +219,7 @@ Your image must satisfy the following requirements:
 
 Using images from private repositories
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/skyconfig.yaml` to specify the secret like so:
+To use images from private repositories (e.g., Private DockerHub, Amazon ECR, Google Container Registry), create a `secret <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line>`_ in your Kubernetes cluster and edit your :code:`~/.sky/.sky.yaml` to specify the secret like so:
 
 .. code-block:: yaml
 
@@ -280,14 +280,14 @@ After launching the cluster with :code:`sky launch -c myclus task.yaml`, you can
 Customizing SkyPilot Pods
 -------------------------
 
-You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/skyconfig.yaml`.
+You can override the pod configuration used by SkyPilot by setting the :code:`pod_config` key in :code:`~/.sky/.sky.yaml`.
 The value of :code:`pod_config` should be a dictionary that follows the `Kubernetes Pod API <https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#pod-v1-core>`_. This will apply to all pods created by SkyPilot.
 
-For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/skyconfig.yaml` file:
+For example, to set custom environment variables and use GPUDirect RDMA, you can add the following to your :code:`~/.sky/.sky.yaml` file:
 
 .. code-block:: yaml
 
-    # ~/.sky/skyconfig.yaml
+    # ~/.sky/.sky.yaml
     kubernetes:
       pod_config:
         spec:
@@ -332,20 +332,20 @@ FAQs
 
 * **Can I use multiple Kubernetes clusters with SkyPilot?**
 
-  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/skyconfig.yaml`. See :ref:`multi-kubernetes`.
+  SkyPilot can work with multiple Kubernetes contexts in your kubeconfig file by setting the ``allowed_contexts`` key in :code:`~/.sky/.sky.yaml`. See :ref:`multi-kubernetes`.
 
   If ``allowed_contexts`` is not set, SkyPilot will use the current active context. To use a different context, change your current context using :code:`kubectl config use-context <context-name>`.
 
 * **Are autoscaling Kubernetes clusters supported?**
 
-  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/skyconfig.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
+  To run on autoscaling clusters, set the :code:`provision_timeout` key in :code:`~/.sky/.sky.yaml` to a large value to give enough time for the cluster autoscaler to provision new nodes.
   This will direct SkyPilot to wait for the cluster to scale up before failing over to the next candidate resource (e.g., next cloud).
 
   If you are using GPUs in a scale-to-zero setting, you should also set the :code:`autoscaler` key to the autoscaler type of your cluster. More details in :ref:`config-yaml`.
 
   .. code-block:: yaml
 
-      # ~/.sky/skyconfig.yaml
+      # ~/.sky/.sky.yaml
       kubernetes:
         provision_timeout: 900  # Wait 15 minutes for nodes to get provisioned before failover. Set to -1 to wait indefinitely.
         autoscaler: gke  # [gke, karpenter, generic]; required if using GPUs/TPUs in scale-to-zero setting

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -57,11 +57,11 @@ Internal load balancers
 
 To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `internal load balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
 
-Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/.sky.yaml``):
+Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/config.yaml``):
 
 .. code-block:: yaml
 
-    # ~/.sky/.sky.yaml
+    # ~/.sky/config.yaml
     kubernetes:
       custom_metadata:
         annotations:
@@ -114,7 +114,7 @@ To use this mode:
     and the endpoint may not be accessible from outside the cluster.
 
 
-3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/.sky.yaml` to use the ingress mode.
+3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/config.yaml` to use the ingress mode.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/kubernetes-ports.rst
+++ b/docs/source/reference/kubernetes/kubernetes-ports.rst
@@ -57,11 +57,11 @@ Internal load balancers
 
 To restrict your services to be accessible only within the cluster, you can set all SkyPilot services to use `internal load balancers <https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer>`_.
 
-Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/skyconfig.yaml``):
+Depending on your cloud, set the appropriate annotation in the SkyPilot config file (``~/.sky/.sky.yaml``):
 
 .. code-block:: yaml
 
-    # ~/.sky/skyconfig.yaml
+    # ~/.sky/.sky.yaml
     kubernetes:
       custom_metadata:
         annotations:
@@ -114,7 +114,7 @@ To use this mode:
     and the endpoint may not be accessible from outside the cluster.
 
 
-3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/skyconfig.yaml` to use the ingress mode.
+3. Update the :ref:`SkyPilot config <config-yaml>` at :code:`~/.sky/.sky.yaml` to use the ingress mode.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -252,7 +252,7 @@ Set up NFS and other volumes
 
 `Kubernetes volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`_ can be attached to your SkyPilot pods using the :ref:`pod_config <kubernetes-custom-pod-config>` field. This is useful for accessing shared storage such as NFS or local high-performance storage like NVMe drives.
 
-Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/.sky.yaml`.
+Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/config.yaml`.
 
 Examples:
 
@@ -291,7 +291,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/.sky.yaml
+           # ~/.sky/config.yaml
            kubernetes:
              pod_config:
                spec:
@@ -339,7 +339,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/.sky.yaml
+           # ~/.sky/config.yaml
            kubernetes:
              pod_config:
                spec:
@@ -387,7 +387,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/.sky.yaml
+           # ~/.sky/config.yaml
            kubernetes:
              pod_config:
                spec:

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -252,7 +252,7 @@ Set up NFS and other volumes
 
 `Kubernetes volumes <https://kubernetes.io/docs/concepts/storage/volumes/>`_ can be attached to your SkyPilot pods using the :ref:`pod_config <kubernetes-custom-pod-config>` field. This is useful for accessing shared storage such as NFS or local high-performance storage like NVMe drives.
 
-Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/skyconfig.yaml`.
+Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/.sky.yaml`.
 
 Examples:
 
@@ -291,7 +291,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/skyconfig.yaml
+           # ~/.sky/.sky.yaml
            kubernetes:
              pod_config:
                spec:
@@ -339,7 +339,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/skyconfig.yaml
+           # ~/.sky/.sky.yaml
            kubernetes:
              pod_config:
                spec:
@@ -387,7 +387,7 @@ Examples:
 
       .. code-block:: yaml
 
-           # ~/.sky/skyconfig.yaml
+           # ~/.sky/.sky.yaml
            kubernetes:
              pod_config:
                spec:

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -276,18 +276,18 @@ Your ingress's service must be of type :code:`LoadBalancer` or :code:`NodePort` 
 Is SkyPilot configured to use Nginx Ingress?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Take a look at your :code:`~/.sky/skyconfig.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
+Take a look at your :code:`~/.sky/.sky.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
 
 .. code-block:: bash
 
-    $ cat ~/.sky/skyconfig.yaml
+    $ cat ~/.sky/.sky.yaml
 
     # Output should contain:
     #
     # kubernetes:
     #   ports: ingress
 
-If not, add the :code:`ports: ingress` section to your :code:`~/.sky/skyconfig.yaml` file.
+If not, add the :code:`ports: ingress` section to your :code:`~/.sky/.sky.yaml` file.
 
 .. _kubernetes-troubleshooting-ports-dryrun:
 

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -276,18 +276,18 @@ Your ingress's service must be of type :code:`LoadBalancer` or :code:`NodePort` 
 Is SkyPilot configured to use Nginx Ingress?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Take a look at your :code:`~/.sky/.sky.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
+Take a look at your :code:`~/.sky/config.yaml` file to verify that the :code:`ports: ingress` section is configured correctly.
 
 .. code-block:: bash
 
-    $ cat ~/.sky/.sky.yaml
+    $ cat ~/.sky/config.yaml
 
     # Output should contain:
     #
     # kubernetes:
     #   ports: ingress
 
-If not, add the :code:`ports: ingress` section to your :code:`~/.sky/.sky.yaml` file.
+If not, add the :code:`ports: ingress` section to your :code:`~/.sky/config.yaml` file.
 
 .. _kubernetes-troubleshooting-ports-dryrun:
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -75,7 +75,7 @@ kubeconfig. You can get the current context with ``kubectl config
 current-context``.
 
 To allow SkyPilot to access multiple Kubernetes clusters, you can set the
-``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/skyconfig.yaml``.
+``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/.sky.yaml``.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -75,7 +75,7 @@ kubeconfig. You can get the current context with ``kubectl config
 current-context``.
 
 To allow SkyPilot to access multiple Kubernetes clusters, you can set the
-``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/.sky.yaml``.
+``kubernetes.allowed_contexts`` in the SkyPilot :ref:`global config <config-yaml>`, ``~/.sky/config.yaml``.
 
 .. code-block:: yaml
 

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -867,12 +867,12 @@ OR
 Global config overrides
 ---------------------------
 
-To override the :ref:`global configs <config-yaml>` in ``~/.sky/skyconfig.yaml`` at a task level:
+To override the :ref:`global configs <config-yaml>` in ``~/.sky/.sky.yaml`` at a task level:
 
 .. code-block:: yaml
 
   experimental:
-    # Override the configs in ~/.sky/skyconfig.yaml from a task level.
+    # Override the configs in ~/.sky/.sky.yaml from a task level.
     #
     # The following fields can be overridden. Please refer to docs of Advanced
     # Configuration for more details of those fields:

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -867,12 +867,12 @@ OR
 Global config overrides
 ---------------------------
 
-To override the :ref:`global configs <config-yaml>` in ``~/.sky/.sky.yaml`` at a task level:
+To override the :ref:`global configs <config-yaml>` in ``~/.sky/config.yaml`` at a task level:
 
 .. code-block:: yaml
 
   experimental:
-    # Override the configs in ~/.sky/.sky.yaml from a task level.
+    # Override the configs in ~/.sky/config.yaml from a task level.
     #
     # The following fields can be overridden. Please refer to docs of Advanced
     # Configuration for more details of those fields:

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -183,11 +183,11 @@ You can set up multiple Kubernetes clusters with SkyPilot by using different ``c
     sky local up --ips cluster2-ips.txt --ssh-user user2 --ssh-key-path key2.pem --context-name cluster2
 
 
-You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/skyconfig.yaml`` file:
+You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/.sky.yaml`` file:
 
 .. code-block:: yaml
 
-   # ~/.sky/skyconfig.yaml
+   # ~/.sky/.sky.yaml
     allowed_contexts:
       - cluster1
       - cluster2

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -183,11 +183,11 @@ You can set up multiple Kubernetes clusters with SkyPilot by using different ``c
     sky local up --ips cluster2-ips.txt --ssh-user user2 --ssh-key-path key2.pem --context-name cluster2
 
 
-You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/.sky.yaml`` file:
+You can then configure SkyPilot to use :ref:`multiple Kubernetes clusters <multi-kubernetes>` by adding them to ``allowed_contexts`` in your ``~/.sky/config.yaml`` file:
 
 .. code-block:: yaml
 
-   # ~/.sky/.sky.yaml
+   # ~/.sky/config.yaml
     allowed_contexts:
       - cluster1
       - cluster2

--- a/docs/source/reservations/reservations.rst
+++ b/docs/source/reservations/reservations.rst
@@ -29,7 +29,7 @@ To request capacity reservations/blocks, see the official docs:
 
 Once you have successfully created a reservation/block, you will get an ID of the reservation/block, such as ``cr-012345678``.
 
-To use the reservation/block, you can specify two fields in ``~/.sky/skyconfig.yaml``:
+To use the reservation/block, you can specify two fields in ``~/.sky/.sky.yaml``:
 
 * ``aws.prioritize_reservations``: whether to prioritize launching clusters from capacity reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your reserved capacity created with ``Instance eligibility: open``.
 * ``aws.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple capacity reservations or blocks with ``Instance eligibility: targeted`` for different instance types in multiple regions/zones.
@@ -105,7 +105,7 @@ GCP reservations are similar to AWS capacity reservations, where you can reserve
 
 To get a reservation, see the `GCP official docs <https://cloud.google.com/compute/docs/instances/reservations-single-project>`__.
 
-Like AWS, you can specify two fields in ``~/.sky/skyconfig.yaml``:
+Like AWS, you can specify two fields in ``~/.sky/.sky.yaml``:
 
 * ``gcp.prioritize_reservations``: whether to prioritize launching clusters from reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your `automatically consumed reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_any_matching_reservation>`__.
 * ``gcp.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple `specific reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_a_specific_reservation>`__ for different instance types in multiple regions/zones.
@@ -137,7 +137,7 @@ GCP `Dynamic Workload Scheduler (DWS) <https://cloud.google.com/blog/products/co
 Using DWS for VMs
 ~~~~~~~~~~~~~~~~~
 
-SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/skyconfig.yaml``:
+SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/.sky.yaml``:
 
 .. code-block:: yaml
 

--- a/docs/source/reservations/reservations.rst
+++ b/docs/source/reservations/reservations.rst
@@ -29,7 +29,7 @@ To request capacity reservations/blocks, see the official docs:
 
 Once you have successfully created a reservation/block, you will get an ID of the reservation/block, such as ``cr-012345678``.
 
-To use the reservation/block, you can specify two fields in ``~/.sky/.sky.yaml``:
+To use the reservation/block, you can specify two fields in ``~/.sky/config.yaml``:
 
 * ``aws.prioritize_reservations``: whether to prioritize launching clusters from capacity reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your reserved capacity created with ``Instance eligibility: open``.
 * ``aws.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple capacity reservations or blocks with ``Instance eligibility: targeted`` for different instance types in multiple regions/zones.
@@ -105,7 +105,7 @@ GCP reservations are similar to AWS capacity reservations, where you can reserve
 
 To get a reservation, see the `GCP official docs <https://cloud.google.com/compute/docs/instances/reservations-single-project>`__.
 
-Like AWS, you can specify two fields in ``~/.sky/.sky.yaml``:
+Like AWS, you can specify two fields in ``~/.sky/config.yaml``:
 
 * ``gcp.prioritize_reservations``: whether to prioritize launching clusters from reservations in any region/zone over on-demand/spot clusters. This is useful to fully utilize your `automatically consumed reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_any_matching_reservation>`__.
 * ``gcp.specific_reservations``: a list of reservation IDs that can be used by SkyPilot. This is useful if you have multiple `specific reservations <https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_a_specific_reservation>`__ for different instance types in multiple regions/zones.
@@ -137,7 +137,7 @@ GCP `Dynamic Workload Scheduler (DWS) <https://cloud.google.com/blog/products/co
 Using DWS for VMs
 ~~~~~~~~~~~~~~~~~
 
-SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/.sky.yaml``:
+SkyPilot allows you to launch resources via DWS by specifying the ``gcp.managed_instance_group`` field in ``~/.sky/config.yaml``:
 
 .. code-block:: yaml
 

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -500,7 +500,7 @@ You may want to customize the resources of the SkyServe controller for several r
 3. Changing the maximum number of services that can be run concurrently, which is the minimum number between 4x the vCPUs of the controller and the memory in GiB of the controller. (Default: 16)
 4. Changing the disk_size of the controller to store more logs. (Default: 200GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/skyconfig.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/.sky.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/docs/source/serving/sky-serve.rst
+++ b/docs/source/serving/sky-serve.rst
@@ -500,7 +500,7 @@ You may want to customize the resources of the SkyServe controller for several r
 3. Changing the maximum number of services that can be run concurrently, which is the minimum number between 4x the vCPUs of the controller and the memory in GiB of the controller. (Default: 16)
 4. Changing the disk_size of the controller to store more logs. (Default: 200GB)
 
-To achieve the above, you can specify custom configs in :code:`~/.sky/.sky.yaml` with the following fields:
+To achieve the above, you can specify custom configs in :code:`~/.sky/config.yaml` with the following fields:
 
 .. code-block:: yaml
 

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -382,10 +382,10 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         network_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(
             network_mode_str)
     except ValueError as e:
-        # Add message saying "Please check: ~/.sky/skyconfig.yaml" to the error
+        # Add message saying "Please check: ~/.sky/.sky.yaml" to the error
         # message.
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(str(e) + ' Please check: ~/.sky/skyconfig.yaml.') \
+            raise ValueError(str(e) + ' Please check: ~/.sky/.sky.yaml.') \
                 from None
     _, public_key_path = get_or_generate_keys()
 

--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -382,10 +382,10 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
         network_mode = kubernetes_enums.KubernetesNetworkingMode.from_str(
             network_mode_str)
     except ValueError as e:
-        # Add message saying "Please check: ~/.sky/.sky.yaml" to the error
+        # Add message saying "Please check: ~/.sky/config.yaml" to the error
         # message.
         with ux_utils.print_exception_no_traceback():
-            raise ValueError(str(e) + ' Please check: ~/.sky/.sky.yaml.') \
+            raise ValueError(str(e) + ' Please check: ~/.sky/config.yaml.') \
                 from None
     _, public_key_path = get_or_generate_keys()
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -682,7 +682,7 @@ def write_cluster_config(
             ssh_proxy_command = ssh_proxy_command_config[region_name]
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
-    # User-supplied global instance tags from ~/.sky/skyconfig.yaml.
+    # User-supplied global instance tags from ~/.sky/.sky.yaml.
     labels = skypilot_config.get_nested((str(cloud).lower(), 'labels'), {})
     # labels is a dict, which is guaranteed by the type check in
     # schemas.py

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -682,7 +682,7 @@ def write_cluster_config(
             ssh_proxy_command = ssh_proxy_command_config[region_name]
     logger.debug(f'Using ssh_proxy_command: {ssh_proxy_command!r}')
 
-    # User-supplied global instance tags from ~/.sky/.sky.yaml.
+    # User-supplied global instance tags from ~/.sky/config.yaml.
     labels = skypilot_config.get_nested((str(cloud).lower(), 'labels'), {})
     # labels is a dict, which is guaranteed by the type check in
     # schemas.py

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1473,7 +1473,7 @@ class RetryingVmProvisioner(object):
                     f'invalid cloud credentials: '
                     f'{common_utils.format_exception(e)}')
             except exceptions.InvalidCloudConfigs as e:
-                # Failed due to invalid user configs in ~/.sky/.sky.yaml.
+                # Failed due to invalid user configs in ~/.sky/config.yaml.
                 logger.warning(f'{common_utils.format_exception(e)}')
                 # We should block the entire cloud if the user config is
                 # invalid.

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1473,7 +1473,7 @@ class RetryingVmProvisioner(object):
                     f'invalid cloud credentials: '
                     f'{common_utils.format_exception(e)}')
             except exceptions.InvalidCloudConfigs as e:
-                # Failed due to invalid user configs in ~/.sky/skyconfig.yaml.
+                # Failed due to invalid user configs in ~/.sky/.sky.yaml.
                 logger.warning(f'{common_utils.format_exception(e)}')
                 # We should block the entire cloud if the user config is
                 # invalid.

--- a/sky/check.py
+++ b/sky/check.py
@@ -142,7 +142,7 @@ def check_capabilities(
     if disallowed_cloud_names:
         disallowed_clouds_hint = (
             '\nNote: The following clouds were disabled because they were not '
-            'included in allowed_clouds in ~/.sky/.sky.yaml: '
+            'included in allowed_clouds in ~/.sky/config.yaml: '
             f'{", ".join([c for c in disallowed_cloud_names])}')
     if not all_enabled_clouds:
         echo(

--- a/sky/check.py
+++ b/sky/check.py
@@ -142,7 +142,7 @@ def check_capabilities(
     if disallowed_cloud_names:
         disallowed_clouds_hint = (
             '\nNote: The following clouds were disabled because they were not '
-            'included in allowed_clouds in ~/.sky/skyconfig.yaml: '
+            'included in allowed_clouds in ~/.sky/.sky.yaml: '
             f'{", ".join([c for c in disallowed_cloud_names])}')
     if not all_enabled_clouds:
         echo(

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -472,10 +472,10 @@ class AWS(clouds.Cloud):
             with ux_utils.print_exception_no_traceback():
                 logger.warning(
                     f'Skip opening ports {resources.ports} for cluster {cluster_name!r}, '
-                    'as `aws.security_group_name` in `~/.sky/skyconfig.yaml` is specified as '
+                    'as `aws.security_group_name` in `~/.sky/.sky.yaml` is specified as '
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
-                    'in `~/.sky/skyconfig.yaml`.')
+                    'in `~/.sky/.sky.yaml`.')
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -472,10 +472,10 @@ class AWS(clouds.Cloud):
             with ux_utils.print_exception_no_traceback():
                 logger.warning(
                     f'Skip opening ports {resources.ports} for cluster {cluster_name!r}, '
-                    'as `aws.security_group_name` in `~/.sky/.sky.yaml` is specified as '
+                    'as `aws.security_group_name` in `~/.sky/config.yaml` is specified as '
                     f' {security_group!r}. Please make sure the specified security group '
                     'has requested ports setup; or, leave out `aws.security_group_name` '
-                    'in `~/.sky/.sky.yaml`.')
+                    'in `~/.sky/config.yaml`.')
 
         return {
             'instance_type': r.instance_type,

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -9,7 +9,7 @@ History:
    file path resolution (by os.path.expanduser) when construct the file
    mounts. This bug will cause the created workder nodes located in different
    compartment and VCN than the header node if user specifies compartment_id
-   in the sky config file, because the ~/.sky/.sky.yaml is not
+   in the sky config file, because the ~/.sky/config.yaml is not
    sync-ed to the remote machine.
    The workaround is set the sky config file path using ENV before running
    the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -9,7 +9,7 @@ History:
    file path resolution (by os.path.expanduser) when construct the file
    mounts. This bug will cause the created workder nodes located in different
    compartment and VCN than the header node if user specifies compartment_id
-   in the sky config file, because the ~/.sky/skyconfig.yaml is not
+   in the sky config file, because the ~/.sky/.sky.yaml is not
    sync-ed to the remote machine.
    The workaround is set the sky config file path using ENV before running
    the sky launch: export SKYPILOT_CONFIG=/home/ubuntu/.sky/config.yaml

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -43,7 +43,7 @@ def bootstrap_instances(
     if (requested_service_account ==
             kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
         # If the user has requested a different service account (via pod_config
-        # in ~/.sky/skyconfig.yaml), we assume they have already set up the
+        # in ~/.sky/.sky.yaml), we assume they have already set up the
         # necessary roles and role bindings.
         # If not, set up the roles and bindings for skypilot-service-account
         # here.

--- a/sky/provision/kubernetes/config.py
+++ b/sky/provision/kubernetes/config.py
@@ -43,7 +43,7 @@ def bootstrap_instances(
     if (requested_service_account ==
             kubernetes_utils.DEFAULT_SERVICE_ACCOUNT_NAME):
         # If the user has requested a different service account (via pod_config
-        # in ~/.sky/.sky.yaml), we assume they have already set up the
+        # in ~/.sky/config.yaml), we assume they have already set up the
         # necessary roles and role bindings.
         # If not, set up the roles and bindings for skypilot-service-account
         # here.

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -723,7 +723,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                        f'{common_utils.format_exception(e)}'
                        'Continuing without using nvidia RuntimeClass.\n'
                        'If you are on a K3s cluster, manually '
-                       'override runtimeClassName in ~/.sky/.sky.yaml. '
+                       'override runtimeClassName in ~/.sky/config.yaml. '
                        'For more details, refer to https://docs.skypilot.co/en/latest/reference/config.html')  # pylint: disable=line-too-long
 
     needs_gpus = False

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -723,7 +723,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                        f'{common_utils.format_exception(e)}'
                        'Continuing without using nvidia RuntimeClass.\n'
                        'If you are on a K3s cluster, manually '
-                       'override runtimeClassName in ~/.sky/skyconfig.yaml. '
+                       'override runtimeClassName in ~/.sky/.sky.yaml. '
                        'For more details, refer to https://docs.skypilot.co/en/latest/reference/config.html')  # pylint: disable=line-too-long
 
     needs_gpus = False

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -66,7 +66,7 @@ def get_networking_mode(
     except ValueError as e:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(str(e) +
-                             ' Please check: ~/.sky/.sky.yaml.') from None
+                             ' Please check: ~/.sky/config.yaml.') from None
     return networking_mode
 
 

--- a/sky/provision/kubernetes/network_utils.py
+++ b/sky/provision/kubernetes/network_utils.py
@@ -66,7 +66,7 @@ def get_networking_mode(
     except ValueError as e:
         with ux_utils.print_exception_no_traceback():
             raise ValueError(str(e) +
-                             ' Please check: ~/.sky/skyconfig.yaml.') from None
+                             ' Please check: ~/.sky/.sky.yaml.') from None
     return networking_mode
 
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1454,14 +1454,14 @@ def is_kubeconfig_exec_auth(
 
 
     Using exec-based authentication is problematic when used in conjunction
-    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/skyconfig.yaml.
+    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/.sky.yaml.
     This is because the exec-based authentication may not have the relevant
     dependencies installed on the remote cluster or may have hardcoded paths
     that are not available on the remote cluster.
 
     Returns:
         bool: True if exec-based authentication is used and LOCAL_CREDENTIAL
-            mode is used for remote_identity in ~/.sky/skyconfig.yaml.
+            mode is used for remote_identity in ~/.sky/.sky.yaml.
         str: Error message if exec-based authentication is used, None otherwise
     """
     k8s = kubernetes.kubernetes
@@ -1514,7 +1514,7 @@ def is_kubeconfig_exec_auth(
                     'Managed Jobs or SkyServe controller on Kubernetes. '
                     'To fix, configure SkyPilot to create a service account '
                     'for running pods by setting the following in '
-                    '~/.sky/skyconfig.yaml:\n'
+                    '~/.sky/.sky.yaml:\n'
                     '    kubernetes:\n'
                     '      remote_identity: SERVICE_ACCOUNT\n'
                     '    More: https://docs.skypilot.co/en/latest/'
@@ -2252,7 +2252,7 @@ def combine_pod_config_fields(
     cluster_config_overrides: Dict[str, Any],
 ) -> None:
     """Adds or updates fields in the YAML with fields from the
-    ~/.sky/skyconfig.yaml's kubernetes.pod_spec dict.
+    ~/.sky/.sky.yaml's kubernetes.pod_spec dict.
     This can be used to add fields to the YAML that are not supported by
     SkyPilot yet, or require simple configuration (e.g., adding an
     imagePullSecrets field).
@@ -2312,7 +2312,7 @@ def combine_pod_config_fields(
 
 def combine_metadata_fields(cluster_yaml_path: str) -> None:
     """Updates the metadata for all Kubernetes objects created by SkyPilot with
-    fields from the ~/.sky/skyconfig.yaml's kubernetes.custom_metadata dict.
+    fields from the ~/.sky/.sky.yaml's kubernetes.custom_metadata dict.
 
     Obeys the same add or update semantics as combine_pod_config_fields().
     """

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1454,14 +1454,14 @@ def is_kubeconfig_exec_auth(
 
 
     Using exec-based authentication is problematic when used in conjunction
-    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/.sky.yaml.
+    with kubernetes.remote_identity = LOCAL_CREDENTIAL in ~/.sky/config.yaml.
     This is because the exec-based authentication may not have the relevant
     dependencies installed on the remote cluster or may have hardcoded paths
     that are not available on the remote cluster.
 
     Returns:
         bool: True if exec-based authentication is used and LOCAL_CREDENTIAL
-            mode is used for remote_identity in ~/.sky/.sky.yaml.
+            mode is used for remote_identity in ~/.sky/config.yaml.
         str: Error message if exec-based authentication is used, None otherwise
     """
     k8s = kubernetes.kubernetes
@@ -1514,7 +1514,7 @@ def is_kubeconfig_exec_auth(
                     'Managed Jobs or SkyServe controller on Kubernetes. '
                     'To fix, configure SkyPilot to create a service account '
                     'for running pods by setting the following in '
-                    '~/.sky/.sky.yaml:\n'
+                    '~/.sky/config.yaml:\n'
                     '    kubernetes:\n'
                     '      remote_identity: SERVICE_ACCOUNT\n'
                     '    More: https://docs.skypilot.co/en/latest/'
@@ -2252,7 +2252,7 @@ def combine_pod_config_fields(
     cluster_config_overrides: Dict[str, Any],
 ) -> None:
     """Adds or updates fields in the YAML with fields from the
-    ~/.sky/.sky.yaml's kubernetes.pod_spec dict.
+    ~/.sky/config.yaml's kubernetes.pod_spec dict.
     This can be used to add fields to the YAML that are not supported by
     SkyPilot yet, or require simple configuration (e.g., adding an
     imagePullSecrets field).
@@ -2312,7 +2312,7 @@ def combine_pod_config_fields(
 
 def combine_metadata_fields(cluster_yaml_path: str) -> None:
     """Updates the metadata for all Kubernetes objects created by SkyPilot with
-    fields from the ~/.sky/.sky.yaml's kubernetes.custom_metadata dict.
+    fields from the ~/.sky/config.yaml's kubernetes.custom_metadata dict.
 
     Obeys the same add or update semantics as combine_pod_config_fields().
     """

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -117,7 +117,7 @@ RUNPOD_DOCKER_USERNAME_ENV_VAR = 'SKYPILOT_RUNPOD_DOCKER_USERNAME'
 
 # Commands for disable GPU ECC, which can improve the performance of the GPU
 # for some workloads by 30%. This will only be applied when a user specify
-# `nvidia_gpus.disable_ecc: true` in ~/.sky/.sky.yaml.
+# `nvidia_gpus.disable_ecc: true` in ~/.sky/config.yaml.
 # Running this command will reboot the machine, introducing overhead for
 # provisioning the machine.
 # https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LKjOCAW
@@ -337,7 +337,7 @@ RCLONE_LOG_DIR = '~/.sky/rclone_log'
 RCLONE_CACHE_DIR = '~/.cache/rclone'
 RCLONE_CACHE_REFRESH_INTERVAL = 10
 
-# The keys that can be overridden in the `~/.sky/.sky.yaml` file. The
+# The keys that can be overridden in the `~/.sky/config.yaml` file. The
 # overrides are specified in task YAMLs.
 OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('docker', 'run_options'),

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -117,7 +117,7 @@ RUNPOD_DOCKER_USERNAME_ENV_VAR = 'SKYPILOT_RUNPOD_DOCKER_USERNAME'
 
 # Commands for disable GPU ECC, which can improve the performance of the GPU
 # for some workloads by 30%. This will only be applied when a user specify
-# `nvidia_gpus.disable_ecc: true` in ~/.sky/skyconfig.yaml.
+# `nvidia_gpus.disable_ecc: true` in ~/.sky/.sky.yaml.
 # Running this command will reboot the machine, introducing overhead for
 # provisioning the machine.
 # https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LKjOCAW
@@ -337,7 +337,7 @@ RCLONE_LOG_DIR = '~/.sky/rclone_log'
 RCLONE_CACHE_DIR = '~/.cache/rclone'
 RCLONE_CACHE_REFRESH_INTERVAL = 10
 
-# The keys that can be overridden in the `~/.sky/skyconfig.yaml` file. The
+# The keys that can be overridden in the `~/.sky/.sky.yaml` file. The
 # overrides are specified in task YAMLs.
 OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('docker', 'run_options'),

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1,7 +1,7 @@
 """Immutable user configurations (EXPERIMENTAL).
 
 On module import, we attempt to parse the config located at _USER_CONFIG_PATH
-(default: ~/.sky/.sky.yaml). Caller can then use
+(default: ~/.sky/config.yaml). Caller can then use
 
   >> skypilot_config.loaded()
 
@@ -35,14 +35,14 @@ Consider the following config contents:
 
 then:
 
-    # Assuming ~/.sky/.sky.yaml exists and can be loaded:
+    # Assuming ~/.sky/config.yaml exists and can be loaded:
     skypilot_config.loaded()  # ==> True
 
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> 1
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None
     skypilot_config.get_nested(('a',), None)             # ==> {'nested': 1}
 
-    # If ~/.sky/.sky.yaml doesn't exist or failed to be loaded:
+    # If ~/.sky/config.yaml doesn't exist or failed to be loaded:
     skypilot_config.loaded()  # ==> False
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> None
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None
@@ -100,8 +100,7 @@ ENV_VAR_USER_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}USER_CONFIG'
 ENV_VAR_PROJECT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}PROJECT_CONFIG'
 
 # Path to the local config files.
-_LEGACY_USER_CONFIG_PATH = '~/.sky/config.yaml'
-_USER_CONFIG_PATH = '~/.sky/.sky.yaml'
+_USER_CONFIG_PATH = '~/.sky/config.yaml'
 _PROJECT_CONFIG_PATH = '.sky.yaml'
 
 # The loaded config.
@@ -110,20 +109,8 @@ _loaded_config_path: Optional[str] = None
 _config_overridden: bool = False
 
 
-# This function exists solely to maintain backward compatibility with the
-# legacy user config file located at ~/.sky/config.yaml.
 def get_user_config_path() -> str:
-    """Returns the path to the user config file.
-
-    If only the legacy user config file exists, return
-    the legacy user config path.
-    Otherwise, return the new user config path.
-    """
-    user_config_path = os.path.expanduser(_USER_CONFIG_PATH)
-    legacy_user_config_path = os.path.expanduser(_LEGACY_USER_CONFIG_PATH)
-    if (os.path.exists(legacy_user_config_path) and
-            not os.path.exists(user_config_path)):
-        return _LEGACY_USER_CONFIG_PATH
+    """Returns the path to the user config file."""
     return _USER_CONFIG_PATH
 
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -1,7 +1,7 @@
 """Immutable user configurations (EXPERIMENTAL).
 
 On module import, we attempt to parse the config located at _USER_CONFIG_PATH
-(default: ~/.sky/skyconfig.yaml). Caller can then use
+(default: ~/.sky/.sky.yaml). Caller can then use
 
   >> skypilot_config.loaded()
 
@@ -35,14 +35,14 @@ Consider the following config contents:
 
 then:
 
-    # Assuming ~/.sky/skyconfig.yaml exists and can be loaded:
+    # Assuming ~/.sky/.sky.yaml exists and can be loaded:
     skypilot_config.loaded()  # ==> True
 
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> 1
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None
     skypilot_config.get_nested(('a',), None)             # ==> {'nested': 1}
 
-    # If ~/.sky/skyconfig.yaml doesn't exist or failed to be loaded:
+    # If ~/.sky/.sky.yaml doesn't exist or failed to be loaded:
     skypilot_config.loaded()  # ==> False
     skypilot_config.get_nested(('a', 'nested'), None)    # ==> None
     skypilot_config.get_nested(('a', 'nonexist'), None)  # ==> None
@@ -101,8 +101,8 @@ ENV_VAR_PROJECT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}PROJECT_CONFIG'
 
 # Path to the local config files.
 _LEGACY_USER_CONFIG_PATH = '~/.sky/config.yaml'
-_USER_CONFIG_PATH = '~/.sky/skyconfig.yaml'
-_PROJECT_CONFIG_PATH = 'skyconfig.yaml'
+_USER_CONFIG_PATH = '~/.sky/.sky.yaml'
+_PROJECT_CONFIG_PATH = '.sky.yaml'
 
 # The loaded config.
 _dict = config_utils.Config()

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -46,7 +46,7 @@ logger = sky_logging.init_logger(__name__)
 # controller resources spec.
 CONTROLLER_RESOURCES_NOT_VALID_MESSAGE = (
     '{controller_type} controller resources is not valid, please check '
-    '~/.sky/.sky.yaml file and make sure '
+    '~/.sky/config.yaml file and make sure '
     '{controller_type}.controller.resources is a valid resources spec. '
     'Details:\n  {err}')
 

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -46,7 +46,7 @@ logger = sky_logging.init_logger(__name__)
 # controller resources spec.
 CONTROLLER_RESOURCES_NOT_VALID_MESSAGE = (
     '{controller_type} controller resources is not valid, please check '
-    '~/.sky/skyconfig.yaml file and make sure '
+    '~/.sky/.sky.yaml file and make sure '
     '{controller_type}.controller.resources is a valid resources spec. '
     'Details:\n  {err}')
 

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -328,9 +328,9 @@ cp kubeconfig ~/.kube/config
 # Verify that you can access the cluster
 kubectl get pods
 
-Also add this to your ~/.sky/skyconfig.yaml to use the new service account:
+Also add this to your ~/.sky/.sky.yaml to use the new service account:
 
-# ~/.sky/skyconfig.yaml
+# ~/.sky/.sky.yaml
 kubernetes:
   remote_identity: ${SKYPILOT_SA}
 "

--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -328,9 +328,9 @@ cp kubeconfig ~/.kube/config
 # Verify that you can access the cluster
 kubectl get pods
 
-Also add this to your ~/.sky/.sky.yaml to use the new service account:
+Also add this to your ~/.sky/config.yaml to use the new service account:
 
-# ~/.sky/.sky.yaml
+# ~/.sky/config.yaml
 kubernetes:
   remote_identity: ${SKYPILOT_SA}
 "

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -455,7 +455,7 @@ def get_aws_region_for_quota_failover() -> Optional[str]:
                                        instance_type='p3.16xlarge',
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/.sky.yaml.
+    # Filter the regions with proxy command in ~/.sky/config.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions
@@ -483,7 +483,7 @@ def get_gcp_region_for_quota_failover() -> Optional[str]:
                                        accelerators={'A100-80GB': 1},
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/.sky.yaml.
+    # Filter the regions with proxy command in ~/.sky/config.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -455,7 +455,7 @@ def get_aws_region_for_quota_failover() -> Optional[str]:
                                        instance_type='p3.16xlarge',
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/skyconfig.yaml.
+    # Filter the regions with proxy command in ~/.sky/.sky.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions
@@ -483,7 +483,7 @@ def get_gcp_region_for_quota_failover() -> Optional[str]:
                                        accelerators={'A100-80GB': 1},
                                        use_spot=True)
 
-    # Filter the regions with proxy command in ~/.sky/skyconfig.yaml.
+    # Filter the regions with proxy command in ~/.sky/.sky.yaml.
     filtered_regions = original_resources.get_valid_regions_for_launchable()
     candidate_regions = [
         region for region in candidate_regions

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -167,7 +167,7 @@ def test_launch_fast_with_autostop(generic_cloud: str):
 @pytest.mark.aws
 def test_launch_fast_with_cluster_changes(generic_cloud: str, tmp_path):
     name = smoke_tests_utils.get_cluster_name()
-    tmp_config_path = tmp_path / 'skyconfig.yaml'
+    tmp_config_path = tmp_path / 'sky.yaml'
     test = smoke_tests_utils.Test(
         'test_launch_fast_with_cluster_changes',
         [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Change the default config directories from
user level: `~/.sky/skyconfig.yaml`
project level: `$pwd/skyconfig.yaml`

to
user level: `~/.sky/config.yaml` (what it used to be)
project level: `$pwd/.sky.yaml`

As a followup to https://github.com/skypilot-org/skypilot/pull/5178
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
