### PR TITLE
[k8s] Disallow`KUBECONFIG` Path List

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3024,7 +3024,7 @@ def get_gpu_resource_key():
     return os.getenv('CUSTOM_GPU_RESOURCE_KEY', default=GPU_RESOURCE_KEY)
 
 
-def _get_kubeconfig_path():
+def _get_kubeconfig_path() -> str:
     """Get the stored path from KUBECONFIG env var
     Currently, specifying multiple KUBECONFIG paths in the envvar is not
     allowed, hence will raise a ValueError.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3025,7 +3025,8 @@ def get_gpu_resource_key():
 
 
 def _get_kubeconfig_path() -> str:
-    """Get the stored path from KUBECONFIG env var
+    """Get the path to the kubeconfig file.
+    Parses `KUBECONFIG` env var if present, else uses the default path.
     Currently, specifying multiple KUBECONFIG paths in the envvar is not
     allowed, hence will raise a ValueError.
     """


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Related to #5005 
Gives users a more detailed error message on why `sky check kubernetes` fails when we have multiple PATHS in a `KUBECONFIG` envvar. This is a preliminary fix, and moving forwards we would ideally want to handle multiple kube configs. 

<img width="822" alt="sky_check_k8s" src="https://github.com/user-attachments/assets/3c19f733-d345-4b51-ae7e-a21dd1a05f09" />

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
