### PR TITLE
[UX] Allow resources.gpus in SkyPilot YAML to alias resources.accelerators

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -28,7 +28,7 @@ logger = sky_logging.init_logger(__name__)
 
 _DEFAULT_DISK_SIZE_GB = 256
 
-RESOURCE_CONFIG_OVERRIDING_ALIASES = {
+RESOURCE_CONFIG_ALIASES = {
     'gpus': 'accelerators',
 }
 
@@ -1354,14 +1354,18 @@ class Resources:
         return features
 
     @staticmethod
-    def apply_overriding_aliases(
+    def apply_resource_config_aliases(
             config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Mutatively applies overriding aliases to the passed in config."""
         if not config:
             return config
 
-        for alias, canonical in RESOURCE_CONFIG_OVERRIDING_ALIASES.items():
+        for alias, canonical in RESOURCE_CONFIG_ALIASES.items():
             if alias in config:
+                if canonical in config:
+                    raise exceptions.InvalidSkyPilotConfigError(
+                        f'Cannot specify both {alias} '
+                        f'and {canonical} in config.')
                 config[canonical] = config[alias]
                 del config[alias]
         return config
@@ -1373,7 +1377,7 @@ class Resources:
         if config is None:
             return {Resources()}
 
-        Resources.apply_overriding_aliases(config)
+        Resources.apply_resource_config_aliases(config)
         common_utils.validate_schema(config, schemas.get_resources_schema(),
                                      'Invalid resources YAML: ')
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1354,11 +1354,18 @@ class Resources:
         return features
 
     @staticmethod
-    def apply_resource_config_aliases(
-            config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """Mutatively applies overriding aliases to the passed in config."""
+    def apply_resource_config_aliases(config: Optional[Dict[str, Any]]) -> None:
+        """Mutatively applies overriding aliases to the passed in config.
+
+        Note: Nested aliases are not supported.
+        The preferred way to support nested aliases would be to cast
+        the parsed resource config dictionary to a config_utils.Config object
+        and use the get_, set_, and pop_ nested methods accordingly.
+        However, this approach comes at a significant memory cost as get_
+        and pop_nested create deep copies of the config.
+        """
         if not config:
-            return config
+            return
 
         for alias, canonical in RESOURCE_CONFIG_ALIASES.items():
             if alias in config:
@@ -1368,7 +1375,6 @@ class Resources:
                         f'and {canonical} in config.')
                 config[canonical] = config[alias]
                 del config[alias]
-        return config
 
     @classmethod
     def from_yaml_config(

--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -69,6 +69,34 @@ def test_empty_fields_resources(tmp_path):
     assert resources.cpus == '32'
 
 
+def test_gpu_resources(tmp_path):
+    config_path = _create_config_file(
+        textwrap.dedent("""\
+            resources:
+                gpus: V100:1
+            """), tmp_path)
+    task = Task.from_yaml(config_path)
+
+    resources = list(task.resources)[0]
+    assert resources.accelerators == {'V100': 1}
+
+
+def test_gpu_resources_overrides_accelerators(tmp_path):
+    """Ensure consistency with cli behavior."""
+    config_path = _create_config_file(
+        textwrap.dedent("""\
+            resources:
+                accelerators: V100:1
+                gpus: [T4:4, V100:8]
+            """), tmp_path)
+    task = Task.from_yaml(config_path)
+
+    resources = list(task.resources)
+    assert len(resources) == 2
+    assert resources[0].accelerators == {'T4': 4}
+    assert resources[1].accelerators == {'V100': 8}
+
+
 def test_invalid_fields_resources(tmp_path):
     config_path = _create_config_file(
         textwrap.dedent(f"""\


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
closes: https://github.com/skypilot-org/skypilot/issues/5194

Introduce yaml config aliasing for top-level fields: "gpus" can stand in for "accelerators." Nested configurations are not supported. 

Unlike the cli behavior, "gpus" does not override "accelerators." Either the canonical or the alias can be used otherwise and `InvalidSkyPilotConfigError` is raised.

A nice follow-up here would be to use pydantic as it offers schema validation and [aliasing](https://docs.pydantic.dev/latest/concepts/alias/)

<!-- Describe the tests ran -->
Added unittests to `test_yaml_parser.py`
- verify that `gpus` is parsed and added to the compiled `resources.accelerators`
- verify that `gpus` overrides `accelerators` when specified

<img width="640" alt="Screenshot 2025-04-14 at 4 46 09 PM" src="https://github.com/user-attachments/assets/c1113b7e-a5f7-4c5e-b007-c97bbdc6ba75" />
<img width="319" alt="Screenshot 2025-04-14 at 4 48 40 PM" src="https://github.com/user-attachments/assets/788a68da-cc0c-47d5-a113-39d5800561ed" />


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
