### PR TITLE
[UX] gpu labeling script waits for job to complete

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -160,6 +160,13 @@ def api_client(context: Optional[str] = None):
     return kubernetes.client.ApiClient()
 
 
+@_api_logging_decorator('urllib3', logging.ERROR)
+@annotations.lru_cache(scope='request')
+def watch(context: Optional[str] = None):
+    _load_config(context)
+    return kubernetes.watch.Watch()
+
+
 def api_exception():
     return kubernetes.client.rest.ApiException
 

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -143,12 +143,15 @@ def label(context: Optional[str] = None, wait_for_completion: bool = True):
         # Wait for the job to complete
         with rich_utils.client_status(
                 'Waiting for GPU labeler jobs to complete'):
-            wait_for_jobs_completion(jobs_to_node_names,
-                                     'kube-system',
-                                     context=context)
-        print(
-            _format_string('✅ GPU labeling completed successfully',
-                           colorama.Fore.GREEN))
+            success = wait_for_jobs_completion(jobs_to_node_names,
+                                               'kube-system',
+                                               context=context)
+        if success:
+            print(
+                _format_string('✅ GPU labeling completed successfully',
+                               colorama.Fore.GREEN))
+        else:
+            print(_format_string('❌ GPU labeling failed', colorama.Fore.RED))
         cleanup(context=context)
     else:
         print(
@@ -165,13 +168,13 @@ def label(context: Optional[str] = None, wait_for_completion: bool = True):
 def wait_for_jobs_completion(jobs_to_node_names: Dict[str, str],
                              namespace: str,
                              context: Optional[str] = None,
-                             timeout: int = 300):
+                             timeout: int = 60 * 20):
     """Waits for a Kubernetes Job to complete or fail.
 
     Args:
         jobs_to_node_names: A dictionary mapping job names to node names.
         namespace: The namespace the Job is in (default: "default").
-        timeout: Timeout in seconds (default: 300).
+        timeout: Timeout in seconds (default: 1200 seconds = 20 minutes).
 
     Returns:
         True if the Job completed successfully, False if it failed or timed out.
@@ -201,13 +204,13 @@ def wait_for_jobs_completion(jobs_to_node_names: Dict[str, str],
                 print(
                     _format_string(
                         f'GPU labeler job for node {node_name} failed',
-                        colorama.Fore.RED))
+                        colorama.Style.DIM))
                 w.stop()
                 return False
     print(
         _format_string(
             f'Timed out after waiting {timeout} seconds '
-            'for job to complete', colorama.Fore.RED))
+            'for job to complete', colorama.Style.DIM))
     return False  #Timed out
 
 

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -230,6 +230,10 @@ def main():
     parser.add_argument('--context',
                         type=str,
                         help='the context to use for the Kubernetes cluster.')
+    parser.add_argument('--async',
+                        dest='async_completion',
+                        action='store_true',
+                        help='do not wait for the GPU labeling to complete.')
     args = parser.parse_args()
     context = None
     if args.context:
@@ -244,7 +248,7 @@ def main():
     if args.cleanup:
         cleanup(context=context)
     else:
-        label(context=context)
+        label(context=context, wait_for_completion=not args.async_completion)
 
 
 if __name__ == '__main__':

--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -3,14 +3,19 @@ import argparse
 import hashlib
 import os
 import subprocess
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
+import colorama
 import yaml
 
 import sky
 from sky.adaptors import kubernetes
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.utils import rich_utils
+
+
+def _format_string(str_to_format: str, colorama_format: str) -> str:
+    return f'{colorama_format}{str_to_format}{colorama.Style.RESET_ALL}'
 
 
 def cleanup(context: Optional[str] = None) -> Tuple[bool, str]:
@@ -45,7 +50,7 @@ def get_node_hash(node_name: str):
     return md5_hash[:32]
 
 
-def label(context: Optional[str] = None):
+def label(context: Optional[str] = None, wait_for_completion: bool = True):
     deletion_success, reason = cleanup(context=context)
     if not deletion_success:
         print(reason)
@@ -60,8 +65,10 @@ def label(context: Optional[str] = None):
               'in their capacity.')
         return
 
-    print(f'Found {len(unlabeled_gpu_nodes)} '
-          'unlabeled GPU nodes in the cluster')
+    print(
+        _format_string(
+            f'Found {len(unlabeled_gpu_nodes)} '
+            'unlabeled GPU nodes in the cluster', colorama.Fore.YELLOW))
 
     sky_dir = os.path.dirname(sky.__file__)
     manifest_dir = os.path.join(sky_dir, 'utils/kubernetes')
@@ -80,6 +87,7 @@ def label(context: Optional[str] = None):
             print('Error setting up GPU labeling: ' + output)
             return
 
+    jobs_to_node_names: Dict[str, str] = {}
     with rich_utils.client_status('Creating GPU labeler jobs'):
         batch_v1 = kubernetes.batch_api(context=context)
         # Load the job manifest
@@ -113,8 +121,11 @@ def label(context: Optional[str] = None):
             node_name = node.metadata.name
 
             # Modify the job manifest for the current node
-            job_manifest['metadata']['name'] = ('sky-gpu-labeler-'
-                                                f'{get_node_hash(node_name)}')
+            job_name = ('sky-gpu-labeler-'
+                        f'{get_node_hash(node_name)}')
+            jobs_to_node_names[job_name] = node_name
+            job_manifest['metadata']['name'] = job_name
+
             job_manifest['spec']['template']['spec']['nodeSelector'] = {
                 'kubernetes.io/hostname': node_name
             }
@@ -122,17 +133,82 @@ def label(context: Optional[str] = None):
 
             # Create the job for this node`
             batch_v1.create_namespaced_job(namespace, job_manifest)
-            print(f'Created GPU labeler job for node {node_name}')
+            print(
+                _format_string(f'Created GPU labeler job for node {node_name}',
+                               colorama.Style.DIM))
 
     context_str = f' --context {context}' if context else ''
-    print(f'GPU labeling started - this may take 10 min or more to complete.'
-          '\nTo check the status of GPU labeling jobs, run '
-          f'`kubectl get jobs -n kube-system '
-          f'-l job=sky-gpu-labeler{context_str}`'
-          '\nYou can check if nodes have been labeled by running '
-          f'`kubectl describe nodes{context_str}` '
-          'and looking for labels of the format '
-          '`skypilot.co/accelerator: <gpu_name>`. ')
+
+    if wait_for_completion:
+        # Wait for the job to complete
+        with rich_utils.client_status(
+                'Waiting for GPU labeler jobs to complete'):
+            wait_for_jobs_completion(jobs_to_node_names,
+                                     'kube-system',
+                                     context=context)
+        print(
+            _format_string('✅ GPU labeling completed successfully',
+                           colorama.Fore.GREEN))
+        cleanup(context=context)
+    else:
+        print(
+            f'GPU labeling started - this may take 10 min or more to complete.'
+            '\nTo check the status of GPU labeling jobs, run '
+            f'`kubectl get jobs -n kube-system '
+            f'-l job=sky-gpu-labeler{context_str}`'
+            '\nYou can check if nodes have been labeled by running '
+            f'`kubectl describe nodes{context_str}` '
+            'and looking for labels of the format '
+            '`skypilot.co/accelerator: <gpu_name>`. ')
+
+
+def wait_for_jobs_completion(jobs_to_node_names: Dict[str, str],
+                             namespace: str,
+                             context: Optional[str] = None,
+                             timeout: int = 300):
+    """Waits for a Kubernetes Job to complete or fail.
+
+    Args:
+        jobs_to_node_names: A dictionary mapping job names to node names.
+        namespace: The namespace the Job is in (default: "default").
+        timeout: Timeout in seconds (default: 300).
+
+    Returns:
+        True if the Job completed successfully, False if it failed or timed out.
+    """
+    batch_v1 = kubernetes.batch_api(context=context)
+    w = kubernetes.watch()
+    completed_jobs = []
+    for event in w.stream(func=batch_v1.list_namespaced_job,
+                          namespace=namespace,
+                          timeout_seconds=timeout):
+        job = event['object']
+        job_name = job.metadata.name
+        if job_name in jobs_to_node_names:
+            node_name = jobs_to_node_names[job_name]
+            if job.status and job.status.completion_time:
+                print(
+                    _format_string(
+                        f'GPU labeler job for node {node_name} '
+                        'completed successfully', colorama.Style.DIM))
+                completed_jobs.append(job_name)
+                num_remaining_jobs = len(jobs_to_node_names) - len(
+                    completed_jobs)
+                if num_remaining_jobs == 0:
+                    w.stop()
+                    return True
+            elif job.status and job.status.failed:
+                print(
+                    _format_string(
+                        f'GPU labeler job for node {node_name} failed',
+                        colorama.Fore.RED))
+                w.stop()
+                return False
+    print(
+        _format_string(
+            f'Timed out after waiting {timeout} seconds '
+            'for job to complete', colorama.Fore.RED))
+    return False  #Timed out
 
 
 def main():


### PR DESCRIPTION
Fixes https://github.com/skypilot-org/skypilot/issues/5179

The asks from the issue were:
- Add color
- Wait for the label to be attached
- Have a green tick at the end showing the labelling is finished.

<!-- Describe the changes in this PR -->
![ezgif-1a6c7b066da0da](https://github.com/user-attachments/assets/34a20e69-a874-47e6-88b1-679e35c4e369)

Functionality changes:
`python -m sky.utils.kubernetes.gpu_labeler` now waits for the labeling job to complete. One side effect of waiting for the labler jobs to complete is the fact that this command can clean up the resources used for labeling once the labeling is finished.

UX changes:
Added various styling to the command output - check out the GIF.

Note to reviewers:
I kept the original behavior (of not waiting for the job to complete) under `wait_for_completion` switch - should we:
- Get rid of this behavior outright
- Expose this behavior with `--async` flag or something similar

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test run: see GIF
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
