### PR TITLE
fix optimized file mounts without permission

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -278,11 +278,11 @@ def _optimize_file_mounts(yaml_path: str) -> None:
             # the dst.
             mkdir_parent = f'mkdir -p {dst}'
             src_basename = f'{src_basename}/*'
-        mv = (f'cp -r {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
+        mv = (f'cp -rf {_REMOTE_RUNTIME_FILES_DIR}/{src_basename} '
               f'{dst_parent_dir}/{dst_basename}')
         fragment = f'({mkdir_parent} && {mv})'
         commands.append(fragment)
-    postprocess_runtime_files_command = ' && '.join(commands)
+    postprocess_runtime_files_command = '; '.join(commands)
 
     setup_commands = yaml_config.get('setup_commands', [])
     if setup_commands:


### PR DESCRIPTION
Before this change, reprovisioning an existing jobs controller could silently fail to update file mounts, because the `cp` invocation would error out with
```
cp: cannot create regular file '/home/ubuntu/.ssh/sky-cluster-key': Permission denied
```
Likely this also affected non-controller clusters.

Add the `-f` flag to `cp` so that it will still replace this file even if it is missing permissions. Use `;` instead of `&&` between multiple file mounts to avoid one failure skipping all the rest.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
