### PR TITLE
remove deprecations for 0.9.0

### DIFF
--- a/charts/skypilot/templates/ingress-nodeport.yaml
+++ b/charts/skypilot/templates/ingress-nodeport.yaml
@@ -1,11 +1,11 @@
-{{- /* TODO(aylei): remove this template in v0.9.0 release */ -}}
+{{- /* TODO(aylei): remove this template in v0.10.0 release */ -}}
 {{- $createNodePort := false -}}
 {{- if eq .Values.ingress.nodePortEnabled nil -}}
   {{- /* Keep existing NodePort service if ingress.nodePortEnabled is not set */ -}}
   {{- $existingService := lookup "v1" "Service" .Release.Namespace (printf "%s-ingress-controller-np" .Release.Name) -}}
   {{- if $existingService -}}
     {{- /* If there is an existing legacy NodePort service, error out and ask user to set ingress.nodePortEnabled explicitly */ -}}
-    {{- fail (printf "Service %s-ingress-controller-np is deprecated and will be removed in SkyPilot v0.9.0. Refer to https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#sky-migrate-legacy-service for migration steps." .Release.Name) -}}
+    {{- fail (printf "Service %s-ingress-controller-np is deprecated and will be removed in SkyPilot v0.10.0. Refer to https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#sky-migrate-legacy-service for migration steps." .Release.Name) -}}
   {{- end -}}
 {{- else -}}
   {{- /* Use explicitly set value */ -}}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -92,7 +92,7 @@ ingress:
   # It is recommended to keep only one endpoint by explicitly setting ingress.nodePortEnabled=false and swtich to ingress-nginx.controller.service.type
   # if you are upgrading from 0.8.0 nightly.
   # Deprecated: use ingress-nginx.controller.service.type=NodePort instead
-  # TODO(aylei): document the migration steps in v0.9.0 release note and remove these fields
+  # TODO(aylei): remove these fields in v0.10.0
   nodePortEnabled: null
   # Specific nodePort to use for the ingress controller
   # If not set, Kubernetes will assign random ports in the NodePort range (default 30000-32767)

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -440,16 +440,6 @@ class RayCodeGen:
                 plural = 's' if {num_nodes} > 1 else ''
                 node_str = f'{num_nodes} node{{plural}}'
 
-                # We have this `INFO: Tip:` message only for backward
-                # compatibility, because if a cluster has the old SkyPilot version,
-                # it relies on this message to start log streaming.
-                # This message will be skipped for new clusters, because we use
-                # start_streaming_at for the `Waiting for task resources on`
-                # message.
-                # TODO: Remove this message in v0.9.0.
-                message = ('{ux_utils.INDENT_SYMBOL}{colorama.Style.DIM}INFO: '
-                           'Tip: use Ctrl-C to exit log streaming, not kill '
-                           'the job.{colorama.Style.RESET_ALL}\\n')
                 message += ('{ux_utils.INDENT_SYMBOL}{colorama.Style.DIM}'
                             'Waiting for task resources on '
                            f'{{node_str}}.{colorama.Style.RESET_ALL}')
@@ -608,9 +598,6 @@ class RayCodeGen:
             textwrap.dedent(f"""\
             sky_env_vars_dict = {{}}
             sky_env_vars_dict['{constants.SKYPILOT_NODE_IPS}'] = job_ip_list_str
-            # Backward compatibility: Environment starting with `SKY_` is
-            # deprecated. Remove it in v0.9.0.
-            sky_env_vars_dict['SKY_NODE_IPS'] = job_ip_list_str
             sky_env_vars_dict['{constants.SKYPILOT_NUM_NODES}'] = len(job_ip_rank_list)
             """)
         ]
@@ -659,9 +646,6 @@ class RayCodeGen:
         if script is not None:
             script += rclone_flush_script
             sky_env_vars_dict['{constants.SKYPILOT_NUM_GPUS_PER_NODE}'] = {int(math.ceil(num_gpus))!r}
-            # Backward compatibility: Environment starting with `SKY_` is
-            # deprecated. Remove it in v0.9.0.
-            sky_env_vars_dict['SKY_NUM_GPUS_PER_NODE'] = {int(math.ceil(num_gpus))!r}
 
             ip = gang_scheduling_id_to_ip[{gang_scheduling_id!r}]
             rank = job_ip_rank_map[ip]
@@ -678,14 +662,8 @@ class RayCodeGen:
                 name_str = f'{{node_name}}, rank={{rank}},'
                 log_path = os.path.expanduser(os.path.join({log_dir!r}, f'{{rank}}-{{node_name}}.log'))
             sky_env_vars_dict['{constants.SKYPILOT_NODE_RANK}'] = rank
-            # Backward compatibility: Environment starting with `SKY_` is
-            # deprecated. Remove it in v0.9.0.
-            sky_env_vars_dict['SKY_NODE_RANK'] = rank
 
             sky_env_vars_dict['SKYPILOT_INTERNAL_JOB_ID'] = {self.job_id}
-            # Backward compatibility: Environment starting with `SKY_` is
-            # deprecated. Remove it in v0.9.0.
-            sky_env_vars_dict['SKY_INTERNAL_JOB_ID'] = {self.job_id}
 
             futures.append(run_bash_command_with_log \\
                     .options(name=name_str, {options_str}) \\

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -439,8 +439,7 @@ class RayCodeGen:
                 pg = ray_util.placement_group({json.dumps(bundles)}, 'STRICT_SPREAD')
                 plural = 's' if {num_nodes} > 1 else ''
                 node_str = f'{num_nodes} node{{plural}}'
-
-                message += ('{ux_utils.INDENT_SYMBOL}{colorama.Style.DIM}'
+                message = ('{ux_utils.INDENT_SYMBOL}{colorama.Style.DIM}'
                             'Waiting for task resources on '
                            f'{{node_str}}.{colorama.Style.RESET_ALL}')
                 print(message, flush=True)

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -47,8 +47,6 @@ class Kubernetes(clouds.Cloud):
     SKY_SSH_KEY_SECRET_NAME = 'sky-ssh-keys'
     SKY_SSH_JUMP_NAME = 'sky-ssh-jump-pod'
 
-    LEGACY_SINGLETON_REGION = 'kubernetes'
-
     # Limit the length of the cluster name to avoid exceeding the limit of 63
     # characters for Kubernetes resources. We limit to 42 characters (63-21) to
     # allow additional characters for creating ingress services to expose ports.
@@ -753,12 +751,6 @@ class Kubernetes(clouds.Cloud):
             instance_type)
 
     def validate_region_zone(self, region: Optional[str], zone: Optional[str]):
-        if region == self.LEGACY_SINGLETON_REGION:
-            # For backward compatibility, we allow the region to be set to the
-            # legacy singleton region.
-            # TODO: Remove this after 0.9.0.
-            return region, zone
-
         if region == kubernetes.in_cluster_context_name():
             # If running incluster, we set region to IN_CLUSTER_REGION
             # since there is no context name available.

--- a/sky/serve/load_balancing_policies.py
+++ b/sky/serve/load_balancing_policies.py
@@ -15,10 +15,6 @@ logger = sky_logging.init_logger(__name__)
 # Define a registry for load balancing policies
 LB_POLICIES = {}
 DEFAULT_LB_POLICY = None
-# Prior to #4439, the default policy was round_robin. We store the legacy
-# default policy here to maintain backwards compatibility. Remove this after
-# 2 minor release, i.e., 0.9.0.
-LEGACY_DEFAULT_POLICY = 'round_robin'
 
 
 def _request_repr(request: 'fastapi.Request') -> str:

--- a/sky/serve/serve_state.py
+++ b/sky/serve/serve_state.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import colorama
 
 from sky.serve import constants
-from sky.serve import load_balancing_policies as lb_policies
 from sky.utils import db_utils
 
 if typing.TYPE_CHECKING:
@@ -335,11 +334,6 @@ def _get_service_from_row(row) -> Dict[str, Any]:
     (current_version, name, controller_job_id, controller_port,
      load_balancer_port, status, uptime, policy, _, _, requested_resources_str,
      _, active_versions, load_balancing_policy, tls_encrypted) = row[:15]
-    if load_balancing_policy is None:
-        # This entry in database was added in #4439, and it will always be set
-        # to a str value. If it is None, it means it is an legacy entry and is
-        # using the legacy default policy.
-        load_balancing_policy = lb_policies.LEGACY_DEFAULT_POLICY
     return {
         'name': name,
         'controller_job_id': controller_job_id,

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -606,35 +606,24 @@ def update_job_status(job_ids: List[int],
                         f'INIT job {job_id} is stale, setting to FAILED_DRIVER')
                     status = JobStatus.FAILED_DRIVER
 
-            # job_pid is 0 if the job is not submitted yet.
-            # job_pid is -1 if the job is submitted with SkyPilot older than
-            # #4318, using ray job submit. We skip the checking for those
-            # jobs.
-            if job_pid > 0:
-                if _is_job_driver_process_running(job_pid, job_id):
-                    status = JobStatus.PENDING
-                else:
-                    # By default, if the job driver process does not exist,
-                    # the actual SkyPilot job is one of the following:
-                    # 1. Still pending to be submitted.
-                    # 2. Submitted and finished.
-                    # 3. Driver failed without correctly setting the job
-                    #    status in the job table.
-                    # Although we set the status to FAILED_DRIVER, it can be
-                    # overridden to PENDING if the job is not submitted, or
-                    # any other terminal status if the job driver process
-                    # finished correctly.
-                    failed_driver_transition_message = (
-                        f'Job {job_id} driver process is not running, but '
-                        'the job state is not in terminal states, setting '
-                        'it to FAILED_DRIVER')
-                    status = JobStatus.FAILED_DRIVER
-            elif job_pid < 0:
-                # TODO(zhwu): Backward compatibility, remove after 0.9.0.
-                # We set the job status to PENDING instead of actually
-                # checking ray job status and let the status in job table
-                # take effect in the later max.
+            if _is_job_driver_process_running(job_pid, job_id):
                 status = JobStatus.PENDING
+            else:
+                # By default, if the job driver process does not exist,
+                # the actual SkyPilot job is one of the following:
+                # 1. Still pending to be submitted.
+                # 2. Submitted and finished.
+                # 3. Driver failed without correctly setting the job
+                #    status in the job table.
+                # Although we set the status to FAILED_DRIVER, it can be
+                # overridden to PENDING if the job is not submitted, or
+                # any other terminal status if the job driver process
+                # finished correctly.
+                failed_driver_transition_message = (
+                    f'Job {job_id} driver process is not running, but '
+                    'the job state is not in terminal states, setting '
+                    'it to FAILED_DRIVER')
+                status = JobStatus.FAILED_DRIVER
 
             pending_job = _get_pending_job(job_id)
             if pending_job is not None:
@@ -880,18 +869,7 @@ def cancel_jobs_encoded_results(jobs: Optional[List[int]],
                 # We don't have to start a daemon to forcefully kill the process
                 # as our job driver process will clean up the underlying
                 # child processes.
-            elif job['pid'] < 0:
-                try:
-                    # TODO(zhwu): Backward compatibility, remove after 0.9.0.
-                    # The job was submitted with ray job submit before #4318.
-                    job_client = _create_ray_job_submission_client()
-                    job_client.stop_job(_make_ray_job_id(job['job_id']))
-                except RuntimeError as e:
-                    # If the request to the job server fails, we should not
-                    # set the job to CANCELLED.
-                    if 'does not exist' not in str(e):
-                        logger.warning(str(e))
-                        continue
+
             # Get the job status again to avoid race condition.
             job_status = get_status_no_lock(job['job_id'])
             if job_status in [
@@ -1008,7 +986,7 @@ class JobLibCodeGen:
             # Print cancelled IDs. Caller should parse by decoding.
             'print(cancelled, flush=True)',
         ]
-        # TODO(zhwu): Backward compatibility, remove after 0.9.0.
+        # TODO(zhwu): Backward compatibility, remove after 0.10.0.
         if user_hash is None:
             code = [
                 (f'cancelled = job_lib.cancel_jobs_encoded_results('

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -1008,7 +1008,7 @@ class JobLibCodeGen:
             # Print cancelled IDs. Caller should parse by decoding.
             'print(cancelled, flush=True)',
         ]
-        # TODO(zhwu): Backward compatibility, remove after 0.10.0.
+        # TODO(zhwu): Backward compatibility, remove after 0.12.0.
         if user_hash is None:
             code = [
                 (f'cancelled = job_lib.cancel_jobs_encoded_results('


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Closes #5211.

Key removals (for release notes):
- deprecated env vars starting with `SKY_` are no longer supported. Use `SKYPILOT_` env vars instead.
- old services from 0.7.0 (before #4439) may not work
- `kubernetes` is no longer a valid _region_ name - you must instead use the k8s context name

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
