### PR TITLE
Fix extract build number bug in release pipeline

### DIFF
--- a/.github/workflows/extract-buildkite.yml
+++ b/.github/workflows/extract-buildkite.yml
@@ -1,0 +1,28 @@
+name: Extract Buildkite Build Number
+
+on:
+  workflow_call:
+    inputs:
+      json_data:
+        required: true
+        type: string
+        description: "JSON response from Buildkite trigger API"
+    outputs:
+      build_number:
+        description: "Extracted build number from Buildkite response"
+        value: ${{ jobs.extract.outputs.build_number }}
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.extract.outputs.build_number }}
+    steps:
+      - name: Extract build number
+        id: extract
+        run: |
+          # Write the JSON to a temporary file to avoid shell interpretation issues
+          echo '${{ inputs.json_data }}' > response.json
+          build_number=$(jq -r '.number' response.json)
+          echo "build_number=$build_number" >> $GITHUB_OUTPUT
+          rm response.json

--- a/.github/workflows/extract-buildkite.yml
+++ b/.github/workflows/extract-buildkite.yml
@@ -20,9 +20,13 @@ jobs:
     steps:
       - name: Extract build number
         id: extract
+        env:
+          JSON_DATA: ${{ inputs.json_data }}
         run: |
-          # Write the JSON to a temporary file to avoid shell interpretation issues
-          echo '${{ inputs.json_data }}' > response.json
+          # Use printf to avoid shell interpretation
+          printf '%s' "$JSON_DATA" > response.json
+
+          # Extract the build number using jq
           build_number=$(jq -r '.number' response.json)
           echo "build_number=$build_number" >> $GITHUB_OUTPUT
           rm response.json

--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -71,7 +71,7 @@ jobs:
           commit: "${{ github.sha }}"
           message: "nightly-build-pypi"
           ignore_pipeline_branch_filter: true
-          build_env_vars: '{"ARGS": "--aws -k test_minimal"}'
+          build_env_vars: '{"ARGS": "--aws"}'
 
   extract-build-number:
     needs: nightly-build-pypi

--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -71,7 +71,7 @@ jobs:
           commit: "${{ github.sha }}"
           message: "nightly-build-pypi"
           ignore_pipeline_branch_filter: true
-          build_env_vars: '{"ARGS": "--aws"}'
+          build_env_vars: '{"ARGS": "--aws -k test_minimal"}'
 
   extract-build-number:
     needs: nightly-build-pypi

--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -25,7 +25,7 @@ jobs:
     needs: check-date
     if: ${{ needs.check-date.outputs.should_run != 'false' }}
     outputs:
-      build_number: ${{ steps.extract_build_number.outputs.build_number }}
+      buildkite_json: ${{ steps.trigger_buildkite.outputs.json }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -73,20 +73,19 @@ jobs:
           ignore_pipeline_branch_filter: true
           build_env_vars: '{"ARGS": "--aws"}'
 
-      # Extract build number from response JSON
-      - name: Extract build number
-        id: extract_build_number
-        run: |
-          build_number=$(echo '${{ steps.trigger_buildkite.outputs.json }}' | jq -r '.number')
-          echo "build_number=$build_number" >> $GITHUB_OUTPUT
+  extract-build-number:
+    needs: nightly-build-pypi
+    uses: ./.github/workflows/extract-buildkite.yml
+    with:
+      json_data: ${{ needs.nightly-build-pypi.outputs.buildkite_json }}
 
   wait-for-buildkite:
-    needs: nightly-build-pypi
+    needs: extract-build-number
     uses: ./.github/workflows/wait-for-buildkite.yml
     with:
       organization: "skypilot-1"
       pipeline: "smoke-tests"
-      build_number: ${{ needs.nightly-build-pypi.outputs.build_number }}
+      build_number: ${{ needs.extract-build-number.outputs.build_number }}
       timeout_minutes: 120
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
@@ -114,4 +113,3 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
-

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -150,7 +150,7 @@ jobs:
       organization: "skypilot-1"
       pipeline: "full-smoke-tests-run"
       build_number: ${{ needs.extract-smoke-tests.outputs.build_number }}
-      timeout_minutes: 180
+      timeout_minutes: 240
       fail_on_buildkite_failure: false
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test_branch: ${{ steps.commit_changes.outputs.test_branch }}
-      smoke_test_build_number: ${{ steps.extract_smoke_test.outputs.smoke_test_build_number }}
-      quicktest_core_build_number: ${{ steps.extract_quicktest.outputs.quicktest_core_build_number }}
-      release_test_build_number: ${{ steps.extract_release_test.outputs.release_test_build_number }}
+      smoke_tests_json: ${{ steps.trigger_smoke_tests.outputs.json }}
+      quicktest_json: ${{ steps.trigger_quicktest_core.outputs.json }}
+      release_test_json: ${{ steps.trigger_release_tests.outputs.json }}
       release_version: ${{ steps.determine_version.outputs.release_version }}
     steps:
       - name: Clone repository
@@ -99,13 +99,6 @@ jobs:
           message: "Release ${{ steps.determine_version.outputs.release_version }}"
           ignore_pipeline_branch_filter: true
 
-      # Extract build number from response JSON
-      - name: Extract smoke tests build number
-        id: extract_smoke_test
-        run: |
-          build_number=$(echo '${{ steps.trigger_smoke_tests.outputs.json }}' | jq -r '.number')
-          echo "smoke_test_build_number=$build_number" >> $GITHUB_OUTPUT
-
       # Trigger Buildkite quicktest-core
       - name: Trigger Quicktest Core
         id: trigger_quicktest_core
@@ -119,13 +112,6 @@ jobs:
           ignore_pipeline_branch_filter: true
           build_env_vars: '{"ARGS": "--base-branch ${{ steps.find_release_branch.outputs.base_branch }}"}'
 
-      # Extract build number from response JSON
-      - name: Extract quicktest core build number
-        id: extract_quicktest
-        run: |
-          build_number=$(echo '${{ steps.trigger_quicktest_core.outputs.json }}' | jq -r '.number')
-          echo "quicktest_core_build_number=$build_number" >> $GITHUB_OUTPUT
-
       # Trigger Buildkite release tests
       - name: Trigger Release Tests
         id: trigger_release_tests
@@ -138,39 +124,51 @@ jobs:
           message: "Release ${{ steps.determine_version.outputs.release_version }}"
           ignore_pipeline_branch_filter: true
 
-      # Extract build number from response JSON
-      - name: Extract release tests build number
-        id: extract_release_test
-        run: |
-          build_number=$(echo '${{ steps.trigger_release_tests.outputs.json }}' | jq -r '.number')
-          echo "release_test_build_number=$build_number" >> $GITHUB_OUTPUT
+  # Call extract-buildkite workflow for each job
+  extract-smoke-tests:
+    needs: release-build
+    uses: ./.github/workflows/extract-buildkite.yml
+    with:
+      json_data: ${{ needs.release-build.outputs.smoke_tests_json }}
+
+  extract-quicktest:
+    needs: release-build
+    uses: ./.github/workflows/extract-buildkite.yml
+    with:
+      json_data: ${{ needs.release-build.outputs.quicktest_json }}
+
+  extract-release-test:
+    needs: release-build
+    uses: ./.github/workflows/extract-buildkite.yml
+    with:
+      json_data: ${{ needs.release-build.outputs.release_test_json }}
 
   wait-for-smoke-tests:
-    needs: release-build
+    needs: [release-build, extract-smoke-tests]
     uses: ./.github/workflows/wait-for-buildkite.yml
     with:
       organization: "skypilot-1"
       pipeline: "full-smoke-tests-run"
-      build_number: ${{ needs.release-build.outputs.smoke_test_build_number }}
+      build_number: ${{ needs.extract-smoke-tests.outputs.build_number }}
       timeout_minutes: 180
       fail_on_buildkite_failure: false
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   wait-for-quicktest-core:
-    needs: release-build
+    needs: [release-build, extract-quicktest]
     uses: ./.github/workflows/wait-for-buildkite.yml
     with:
       organization: "skypilot-1"
       pipeline: "quicktest-core"
-      build_number: ${{ needs.release-build.outputs.quicktest_core_build_number }}
+      build_number: ${{ needs.extract-quicktest.outputs.build_number }}
       timeout_minutes: 180
       fail_on_buildkite_failure: false
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   create-pr:
-    needs: [release-build, wait-for-smoke-tests, wait-for-quicktest-core]
+    needs: [release-build, wait-for-smoke-tests, wait-for-quicktest-core, extract-release-test]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -183,9 +181,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEST_BRANCH: ${{ needs.release-build.outputs.test_branch }}
           RELEASE_VERSION: ${{ needs.release-build.outputs.release_version }}
-          SMOKE_TEST_BUILD: ${{ needs.release-build.outputs.smoke_test_build_number }}
-          QUICKTEST_BUILD: ${{ needs.release-build.outputs.quicktest_core_build_number }}
-          RELEASE_TEST_BUILD: ${{ needs.release-build.outputs.release_test_build_number }}
+          SMOKE_TEST_BUILD: ${{ needs.extract-smoke-tests.outputs.build_number }}
+          QUICKTEST_BUILD: ${{ needs.extract-quicktest.outputs.build_number }}
+          RELEASE_TEST_BUILD: ${{ needs.extract-release-test.outputs.build_number }}
         run: |
           RELEASE_BRANCH="releases/${RELEASE_VERSION}"
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previous failure [here](https://github.com/skypilot-org/skypilot/actions/runs/14458287722/job/40545985713)

If the API endpoint response contains bash scripts, `echo` might interpret them. Use `printf` to avoid interpretation, and make this logic reusable across different pipelines.  

Manual test in my [personal repo](https://github.com/zpoint/skypilot/actions/runs/14460359978/job/40551733724)

<img width="1881" alt="image" src="https://github.com/user-attachments/assets/fc201c58-7304-425d-8ff8-d6c8f020e7e0" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
