### PR TITLE
test_managed_jobs_storage on kubernetes longer timeout for kubernetes

### DIFF
--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -932,7 +932,7 @@ def test_managed_jobs_storage(generic_cloud: str):
                 name, f'{{ {storage_removed_check_s3_cmd} && exit 1; }} || '
                 f'{{ {storage_removed_check_gcs_cmd} && exit 1; }} || '
                 f'{{ {storage_removed_check_az_cmd} && exit 1; }} || true'))
-        timeout *= 3
+        timeout *= 4
 
     yaml_str = yaml_str.replace('sky-workdir-zhwu', storage_name)
     yaml_str = yaml_str.replace('sky-output-bucket', output_storage_name)

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -932,7 +932,7 @@ def test_managed_jobs_storage(generic_cloud: str):
                 name, f'{{ {storage_removed_check_s3_cmd} && exit 1; }} || '
                 f'{{ {storage_removed_check_gcs_cmd} && exit 1; }} || '
                 f'{{ {storage_removed_check_az_cmd} && exit 1; }} || true'))
-        timeout *= 2
+        timeout *= 3
 
     yaml_str = yaml_str.replace('sky-workdir-zhwu', storage_name)
     yaml_str = yaml_str.replace('sky-output-bucket', output_storage_name)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Trying to resolve this [buildkite error](https://buildkite.com/skypilot-1/smoke-tests/builds/688#019636c3-4527-46ce-a854-2d443d2b269e)

Double the timeout of `--kubernetes`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test -k test_managed_jobs_storage --kubernetes` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
