### PR TITLE
Lower resource for test label

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -769,7 +769,7 @@ def test_task_labels_aws():
             'task_labels_aws',
             [
                 smoke_tests_utils.launch_cluster_for_cloud_cmd('aws', name),
-                f'sky launch -y -c {name} {file_path}',
+                f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} {file_path}',
                 # Verify with aws cli that the tags are set.
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name, 'aws ec2 describe-instances '
@@ -801,7 +801,7 @@ def test_task_labels_gcp():
             'task_labels_gcp',
             [
                 smoke_tests_utils.launch_cluster_for_cloud_cmd('gcp', name),
-                f'sky launch -y -c {name} {file_path}',
+                f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} {file_path}',
                 # Verify with gcloud cli that the tags are set
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name,
@@ -833,7 +833,7 @@ def test_task_labels_kubernetes():
             [
                 smoke_tests_utils.launch_cluster_for_cloud_cmd(
                     'kubernetes', name),
-                f'sky launch -y -c {name} {file_path}',
+                f'sky launch -y -c {name} {smoke_tests_utils.LOW_RESOURCE_ARG} {file_path}',
                 # Verify with kubectl that the labels are set.
                 smoke_tests_utils.run_cloud_cmd_on_cluster(
                     name, 'kubectl get pods '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Failure [here](https://buildkite.com/skypilot-1/smoke-tests/builds/701#01963925-bb2f-4767-85f5-1540e6d203b7)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
