### PR TITLE
[k8s] don't attempt to delete nonexistent services in multinode cluster teardown

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -879,8 +879,8 @@ def stop_instances(
     raise NotImplementedError()
 
 
-def _terminate_node(namespace: str, context: Optional[str],
-                    pod_name: str) -> None:
+def _terminate_node(namespace: str, context: Optional[str], pod_name: str,
+                    is_head: bool) -> None:
     """Terminate a pod."""
     logger.debug('terminate_instances: calling delete_namespaced_pod')
 
@@ -918,16 +918,18 @@ def _terminate_node(namespace: str, context: Optional[str],
                 else:
                     raise
 
-    # Delete services for the pod
-    for service_name in [pod_name, f'{pod_name}-ssh']:
-        _delete_k8s_resource_with_retry(
-            delete_func=lambda name=service_name: kubernetes.core_api(
-                context).delete_namespaced_service(name=name,
-                                                   namespace=namespace,
-                                                   _request_timeout=config_lib.
-                                                   DELETION_TIMEOUT),
-            resource_type='service',
-            resource_name=service_name)
+    if is_head:
+        # Delete services for the head pod
+        # services are specified in sky/templates/kubernetes-ray.yml.j2
+        for service_name in [pod_name, f'{pod_name}-ssh']:
+            _delete_k8s_resource_with_retry(
+                delete_func=lambda name=service_name: kubernetes.core_api(
+                    context).delete_namespaced_service(
+                        name=name,
+                        namespace=namespace,
+                        _request_timeout=config_lib.DELETION_TIMEOUT),
+                resource_type='service',
+                resource_name=service_name)
 
     # Note - delete pod after all other resources are deleted.
     # This is to ensure there are no leftover resources if this down is run
@@ -974,7 +976,7 @@ def terminate_instances(
         if _is_head(pod) and worker_only:
             return
         logger.debug(f'Terminating instance {pod_name}: {pod}')
-        _terminate_node(namespace, context, pod_name)
+        _terminate_node(namespace, context, pod_name, _is_head(pod))
 
     # Run pod termination in parallel
     subprocess_utils.run_in_parallel(_terminate_pod_thread, list(pods.items()),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/5180

The issue asks to fix the unexpected output when tearing down a multinode k8s cluster:
```
sky down sky-fc31-zhwu 
Terminating 1 cluster: sky-fc31-zhwu. Proceed? [Y/n]: 
Terminating 1 clustexr ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--terminate_instances: Tried to delete service sky-fc31-zhwu-xxx-2cc9ba-worker, but the service was not found (404).
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━   0% -:--:--terminate_instances: Tried to delete service sky-fc31-zhwu-xxx-2cc9ba-worker-ssh, but the service was not found (404).
Terminating cluster sky-fc31-zhwu...done.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
```

This happens because Skypilot is trying to delete services defined only for the head pod for all pods (including worker pods). Looking at `sky/templates/kubernetes-ray.yml.j2`:
```
    services:
      # Service to expose the head node pod's SSH port.
      - apiVersion: v1
        kind: Service
        metadata:
          labels:
            parent: skypilot
            skypilot-cluster: {{cluster_name_on_cloud}}
            skypilot-user: {{ user }}
          name: {{cluster_name_on_cloud}}-head-ssh
        spec:
          selector:
            component: {{cluster_name_on_cloud}}-head
          ports:
            - protocol: TCP
              port: 22
              targetPort: 22
      # Service that maps to the head node of the Ray cluster, so that the
      # worker nodes can find the head node using
      # {{cluster_name_on_cloud}}-head.{{k8s_namespace}}.svc.cluster.local
      - apiVersion: v1
        kind: Service
        metadata:
            labels:
              parent: skypilot
              skypilot-cluster: {{cluster_name_on_cloud}}
              skypilot-user: {{ user }}
            # NOTE: If you're running multiple Ray clusters with services
            # on one Kubernetes cluster, they must have unique service
            # names.
            name: {{cluster_name_on_cloud}}-head
        spec:
            # Create a headless service so that the head node can be reached by
            # the worker nodes with any port number.
            clusterIP: None
            # This selector must match the head node pod's selector below.
            selector:
                component: {{cluster_name_on_cloud}}-head
```
These services are defined only for the head pods.

Therefore, when deleting pods, we should only delete corresponding services if the pod is a head pod.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: teardown a multinode k8s cluster and verify no stray output
- [ ] k8s smoke tests: `/smoke-test --kubernetes'
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
