### PR TITLE
reload AWS_PROFILE on each request

### DIFF
--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -28,7 +28,6 @@ This is informed by the following boto3 docs:
 
 # pylint: disable=import-outside-toplevel
 
-import functools
 import logging
 import threading
 import time
@@ -67,6 +66,7 @@ def _thread_local_lru_cache(maxsize=32):
     # Create thread-local storage for the LRU cache
     local_cache = _ThreadLocalLRUCache(maxsize)
     return local_cache.cache
+
 
 def _assert_kwargs_builtin_type(kwargs):
     assert all(isinstance(v, (int, float, str)) for v in kwargs.values()), (

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -66,18 +66,7 @@ class _ThreadLocalLRUCache(threading.local):
 def _thread_local_lru_cache(maxsize=32):
     # Create thread-local storage for the LRU cache
     local_cache = _ThreadLocalLRUCache(maxsize)
-
-    def decorator(func):
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            # Use the thread-local LRU cache
-            return local_cache.cache(func)(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
+    return local_cache.cache
 
 def _assert_kwargs_builtin_type(kwargs):
     assert all(isinstance(v, (int, float, str)) for v in kwargs.values()), (

--- a/sky/adaptors/aws.py
+++ b/sky/adaptors/aws.py
@@ -60,7 +60,7 @@ class _ThreadLocalLRUCache(threading.local):
 
     def __init__(self, maxsize=32):
         super().__init__()
-        self.cache = annotations.lru_cache(scope='global', maxsize=maxsize)
+        self.cache = annotations.lru_cache(scope='request', maxsize=maxsize)
 
 
 def _thread_local_lru_cache(maxsize=32):

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -571,7 +571,7 @@ class AWS(clouds.Cloud):
         return cls._check_credentials()
 
     @classmethod
-    @annotations.lru_cache(scope='global',
+    @annotations.lru_cache(scope='request',
                            maxsize=1)  # Cache since getting identity is slow.
     def _check_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to AWS."""
@@ -710,7 +710,7 @@ class AWS(clouds.Cloud):
         return AWSIdentityType.SHARED_CREDENTIALS_FILE
 
     @classmethod
-    @annotations.lru_cache(scope='global', maxsize=1)
+    @annotations.lru_cache(scope='request', maxsize=1)
     def _aws_configure_list(cls) -> Optional[bytes]:
         proc = subprocess.run('aws configure list',
                               shell=True,
@@ -722,7 +722,7 @@ class AWS(clouds.Cloud):
         return proc.stdout
 
     @classmethod
-    @annotations.lru_cache(scope='global',
+    @annotations.lru_cache(scope='request',
                            maxsize=1)  # Cache since getting identity is slow.
     def _sts_get_caller_identity(cls) -> Optional[List[List[str]]]:
         try:
@@ -804,7 +804,7 @@ class AWS(clouds.Cloud):
         return [user_ids]
 
     @classmethod
-    @annotations.lru_cache(scope='global',
+    @annotations.lru_cache(scope='request',
                            maxsize=1)  # Cache since getting identity is slow.
     def get_user_identities(cls) -> Optional[List[List[str]]]:
         """Returns a [UserId, Account] list that uniquely identifies the user.
@@ -909,7 +909,7 @@ class AWS(clouds.Cloud):
             if os.path.exists(os.path.expanduser(f'~/.aws/{filename}'))
         }
 
-    @annotations.lru_cache(scope='global', maxsize=1)
+    @annotations.lru_cache(scope='request', maxsize=1)
     def can_credential_expire(self) -> bool:
         identity_type = self._current_identity_type()
         return (identity_type is not None and

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -35,7 +35,10 @@ logger = sky_logging.init_logger(__name__)
 # These non-skypilot environment variables will be updated from the local
 # environment on each request.
 external_env_vars = [
+    # Allow overriding the AWS authentication.
     'AWS_PROFILE',
+    'AWS_ACCESS_KEY_ID',
+    'AWS_SECRET_ACCESS_KEY',
 ]
 
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -33,12 +33,16 @@ else:
 logger = sky_logging.init_logger(__name__)
 
 # These non-skypilot environment variables will be updated from the local
-# environment on each request.
-external_env_vars = [
+# environment on each request when running a local API server.
+# We should avoid adding variables here, but we should include credential-
+# related variables.
+EXTERNAL_LOCAL_ENV_VARS = [
     # Allow overriding the AWS authentication.
     'AWS_PROFILE',
     'AWS_ACCESS_KEY_ID',
     'AWS_SECRET_ACCESS_KEY',
+    # Allow overriding the GCP authentication.
+    'GOOGLE_APPLICATION_CREDENTIALS',
 ]
 
 
@@ -46,8 +50,9 @@ external_env_vars = [
 def request_body_env_vars() -> dict:
     env_vars = {}
     for env_var in os.environ:
-        if (env_var.startswith(constants.SKYPILOT_ENV_VAR_PREFIX) or
-                env_var in external_env_vars):
+        if env_var.startswith(constants.SKYPILOT_ENV_VAR_PREFIX):
+            env_vars[env_var] = os.environ[env_var]
+        if common.is_api_server_local() and env_var in EXTERNAL_LOCAL_ENV_VARS:
             env_vars[env_var] = os.environ[env_var]
     env_vars[constants.USER_ID_ENV_VAR] = common_utils.get_user_hash()
     env_vars[constants.USER_ENV_VAR] = os.getenv(constants.USER_ENV_VAR,

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -32,12 +32,19 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
+# These non-skypilot environment variables will be updated from the local
+# environment on each request.
+external_env_vars = [
+    'AWS_PROFILE',
+]
+
 
 @annotations.lru_cache(scope='global')
 def request_body_env_vars() -> dict:
     env_vars = {}
     for env_var in os.environ:
-        if env_var.startswith(constants.SKYPILOT_ENV_VAR_PREFIX):
+        if (env_var.startswith(constants.SKYPILOT_ENV_VAR_PREFIX) or
+                env_var in external_env_vars):
             env_vars[env_var] = os.environ[env_var]
     env_vars[constants.USER_ID_ENV_VAR] = common_utils.get_user_hash()
     env_vars[constants.USER_ENV_VAR] = os.getenv(constants.USER_ENV_VAR,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This fixes the "Using several profiles or accounts" story for local API server without restarting - e.g. switching between different AWS profiles for different clusters.

Some concern that this could lead to unexpected behavior in the remote API server case, where local AWS profiles may not correspond to the profiles on the API server.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
