### PR TITLE
[API server] reload config for new request

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -436,6 +436,9 @@ def reload_for_new_request(client_entrypoint: Optional[str],
                            client_command: Optional[str],
                            using_remote_api_server: bool):
     """Reload modules, global variables, and usage message for a new request."""
+    # Reload the skypilot config to make sure the latest config is used.
+    skypilot_config.safe_reload_config()
+
     # Reset the client entrypoint and command for the usage message.
     common_utils.set_client_status(
         client_entrypoint=client_entrypoint,

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -436,9 +436,6 @@ def reload_for_new_request(client_entrypoint: Optional[str],
                            client_command: Optional[str],
                            using_remote_api_server: bool):
     """Reload modules, global variables, and usage message for a new request."""
-    # Make sure the logger takes the new environment variables. This is
-    # necessary because the logger is initialized before the environment
-    # variables are set, such as SKYPILOT_DEBUG.
     # This should be called first to make sure the logger is up-to-date.
     sky_logging.reload_logger()
 

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -436,6 +436,12 @@ def reload_for_new_request(client_entrypoint: Optional[str],
                            client_command: Optional[str],
                            using_remote_api_server: bool):
     """Reload modules, global variables, and usage message for a new request."""
+    # Make sure the logger takes the new environment variables. This is
+    # necessary because the logger is initialized before the environment
+    # variables are set, such as SKYPILOT_DEBUG.
+    # This should be called first to make sure the logger is up-to-date.
+    sky_logging.reload_logger()
+
     # Reload the skypilot config to make sure the latest config is used.
     skypilot_config.safe_reload_config()
 
@@ -454,11 +460,6 @@ def reload_for_new_request(client_entrypoint: Optional[str],
     # We need to reset usage message, so that the message is up-to-date with the
     # latest information in the context, e.g. client entrypoint and run id.
     usage_lib.messages.reset(usage_lib.MessageType.USAGE)
-
-    # Make sure the logger takes the new environment variables. This is
-    # necessary because the logger is initialized before the environment
-    # variables are set, such as SKYPILOT_DEBUG.
-    sky_logging.reload_logger()
 
 
 def clear_local_api_server_database() -> None:

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -97,8 +97,8 @@ def _setup_logger():
 def reload_logger():
     """Reload the logger.
 
-    This is useful when the logging configuration is changed.
-    e.g., the logging level is changed or stdout/stderr is reset.
+    This ensures that the logger takes the new environment variables,
+    such as SKYPILOT_DEBUG.
     """
     global _default_handler
     _root_logger.removeHandler(_default_handler)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -52,6 +52,7 @@ import contextlib
 import copy
 import os
 import pprint
+import threading
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
@@ -109,6 +110,7 @@ _PROJECT_CONFIG_PATH = '.sky.yaml'
 _dict = config_utils.Config()
 _loaded_config_path: Optional[str] = None
 _config_overridden: bool = False
+_reload_config_lock = threading.Lock()
 
 
 def get_user_config_path() -> str:
@@ -189,6 +191,12 @@ def overlay_skypilot_config(
                                         allowed_override_keys=None,
                                         disallowed_override_keys=None)
     return config
+
+
+def safe_reload_config() -> None:
+    """Reloads the config, safe to be called concurrently."""
+    with _reload_config_lock:
+        _reload_config()
 
 
 def _reload_config() -> None:
@@ -312,7 +320,7 @@ def loaded_config_path() -> Optional[str]:
     return _loaded_config_path
 
 
-# Load on import.
+# Load on import, synchronization is guaranteed by python interpreter.
 _reload_config()
 
 

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -23,7 +23,8 @@ def mock_all_dependencies():
         }
 
 
-def test_reload_config_for_new_request(mock_all_dependencies, tmp_path, monkeypatch):
+def test_reload_config_for_new_request(mock_all_dependencies, tmp_path,
+                                       monkeypatch):
     """Test basic functionality with all parameters provided."""
     config_path = tmp_path / 'config.yaml'
     config_path.write_text('''
@@ -38,7 +39,8 @@ allowed_clouds:
         client_command='test_cmd',
         using_remote_api_server=False,
     )
-    assert skypilot_config.get_nested(keys=('allowed_clouds',), default_value=None) == ['aws']
+    assert skypilot_config.get_nested(keys=('allowed_clouds',),
+                                      default_value=None) == ['aws']
     config_path.write_text('''
 allowed_clouds:
   - gcp
@@ -48,4 +50,5 @@ allowed_clouds:
         client_command='test_cmd',
         using_remote_api_server=False,
     )
-    assert skypilot_config.get_nested(keys=('allowed_clouds',), default_value=None) == ['gcp']
+    assert skypilot_config.get_nested(keys=('allowed_clouds',),
+                                      default_value=None) == ['gcp']

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -1,0 +1,51 @@
+"""Unit tests for sky.server.common module."""
+from unittest import mock
+
+import pytest
+
+from sky import sky_logging
+from sky import skypilot_config
+from sky.server import common
+from sky.usage import usage_lib
+from sky.utils import common_utils
+
+
+@pytest.fixture
+def mock_all_dependencies():
+    """Mock all dependencies used in reload_for_new_request."""
+    with mock.patch('sky.utils.common_utils.set_client_status') as mock_status, \
+         mock.patch('sky.usage.usage_lib.messages.reset') as mock_reset, \
+         mock.patch('sky.sky_logging.reload_logger') as mock_logger:
+        yield {
+            'set_status': mock_status,
+            'reset_messages': mock_reset,
+            'reload_logger': mock_logger
+        }
+
+
+def test_reload_config_for_new_request(mock_all_dependencies, tmp_path, monkeypatch):
+    """Test basic functionality with all parameters provided."""
+    config_path = tmp_path / 'config.yaml'
+    config_path.write_text('''
+allowed_clouds:
+  - aws
+''')
+
+    # Set env var to point to the temp config
+    monkeypatch.setenv('SKYPILOT_CONFIG', str(config_path))
+    common.reload_for_new_request(
+        client_entrypoint='test_entry',
+        client_command='test_cmd',
+        using_remote_api_server=False,
+    )
+    assert skypilot_config.get_nested(keys=('allowed_clouds',), default_value=None) == ['aws']
+    config_path.write_text('''
+allowed_clouds:
+  - gcp
+''')
+    common.reload_for_new_request(
+        client_entrypoint='test_entry',
+        client_command='test_cmd',
+        using_remote_api_server=False,
+    )
+    assert skypilot_config.get_nested(keys=('allowed_clouds',), default_value=None) == ['gcp']


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5231

The issue of adding allowed_clouds does not take effect without `sky check` is tracked separately here: https://github.com/skypilot-org/skypilot/issues/4487

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually with local API server / remote API server reloading
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
