### PR TITLE
[Docs] Fix wrong `eksctl` command

### DIFF
--- a/tests/kubernetes/README.md
+++ b/tests/kubernetes/README.md
@@ -159,7 +159,7 @@ gcloud container node-pools delete "largecpu" --region ${REGION} --cluster ${CLU
 1. Create a EKS cluster with at least 1 node. We recommend creating nodes with at least 4 vCPUs.
    * Tip - to create an example GPU cluster for testing, this command will create a 3 node cluster with 1x T4-8cpu, 1x V100-8cpu and 1x 16cpu CPU-only node. It will also automatically update your kubeconfig file:
      ```bash
-     eksctl create -f tests/kubernetes/eks_test_cluster.yaml
+     eksctl create cluster -f tests/kubernetes/eks_test_cluster.yaml
      ```
 2. Verify by running `kubectl get nodes`. You should see your nodes.
 3. **If you want GPU support**, EKS clusters already come with GPU drivers setup. However, you'll need to label the nodes with the GPU type. Use the SkyPilot node labelling tool to do so:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixed wrong eksctl command in the docs


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
