### PR TITLE
[config] api login mutates global config only

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1819,8 +1819,8 @@ def api_login(endpoint: Optional[str] = None) -> None:
             config_path.touch()
             config = {'api_server': {'endpoint': endpoint}}
         else:
-            config = skypilot_config.set_nested(('api_server', 'endpoint'),
-                                                endpoint)
+            config = skypilot_config.get_user_config()
+            config.set_nested(('api_server', 'endpoint'), endpoint)
         common_utils.dump_yaml(str(config_path), config)
         click.secho(f'Logged in to SkyPilot API server at {endpoint}',
                     fg='green')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1815,7 +1815,7 @@ def api_login(endpoint: Optional[str] = None) -> None:
     config_path = pathlib.Path(
         skypilot_config.get_user_config_path()).expanduser()
     with filelock.FileLock(config_path.with_suffix('.lock')):
-        if not skypilot_config.loaded():
+        if not config_path.exists():
             config_path.touch()
             config = {'api_server': {'endpoint': endpoint}}
         else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before hierarchical config was introduced, api login could simply grab the parsed `_dict` on the client side and reasonably expect it to contain the global configration.

How, with hierarchical config, the `_dict` is not just sourced from global config - this config can be tainted by project config, CLI config overrides, etc. This PR ensures `sky api login` mutates the global config only.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Unit test: test_hierarchical_config should still pass
- [x] Manual test: run `sky api login` and ensure project config is not present in global config

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
