### PR TITLE
[k8s] [config] override initContainers wholesale

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -223,6 +223,10 @@ def merge_k8s_configs(
                             merge_k8s_configs(destination_volume, new_volume)
                         else:
                             base_config[key].append(new_volume)
+            elif key in ['initContainers']:
+                # initContainers is a list with no merge key, so we just
+                # replace the base_config list with the override list.
+                base_config[key] = value
             else:
                 base_config[key].extend(value)
         else:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
