### PR TITLE
[admin policy] add DoNothingPolicy to example policy

### DIFF
--- a/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
@@ -4,6 +4,17 @@ import subprocess
 import sky
 
 
+class DoNothingPolicy(sky.AdminPolicy):
+    """Example policy: do nothing."""
+
+    @classmethod
+    def validate_and_mutate(
+            cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
+        """Returns the user request unchanged."""
+        return sky.MutatedUserRequest(user_request.task,
+                                      user_request.skypilot_config)
+
+
 class RejectAllPolicy(sky.AdminPolicy):
     """Example policy: rejects all user requests."""
 
@@ -72,7 +83,7 @@ class EnforceAutostopPolicy(sky.AdminPolicy):
     def validate_and_mutate(
             cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
         """Enforces autostop for all tasks.
-        
+
         Note that with this policy enforced, users can still change the autostop
         setting for an existing cluster by using `sky autostop`.
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I find this policy useful for starting to learn about admin policies because I have a blank slate to start modifying behaviors, e.g. add a print statement to try figure out where this function is called, etc. I think we should include it as an example for all to use.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
