### PR TITLE
Add version check for release pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -70,14 +70,23 @@ jobs:
           LATEST_PYPI_VERSION=$(curl -s https://pypi.org/pypi/skypilot/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
           echo "Latest PyPI version: ${LATEST_PYPI_VERSION}"
 
-          # Compare versions using Bash sort -V
-          echo "Comparing determined version ${RELEASE_VERSION} with latest PyPI version ${LATEST_PYPI_VERSION}"
-          HIGHEST_VERSION=$(printf "%s\\n%s" "${RELEASE_VERSION}" "${LATEST_PYPI_VERSION}" | sort -V | tail -n1)
+          # Parse latest PyPI version
+          PYPI_MAJOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f1)
+          PYPI_MINOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f2)
+          PYPI_PATCH=$(echo $LATEST_PYPI_VERSION | cut -d. -f3)
 
-          if [ "${RELEASE_VERSION}" = "${HIGHEST_VERSION}" ] && [ "${RELEASE_VERSION}" != "${LATEST_PYPI_VERSION}" ]; then
-            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is greater than latest PyPI version ${LATEST_PYPI_VERSION}."
+          # Calculate expected next versions
+          NEXT_PATCH_VERSION="${PYPI_MAJOR}.${PYPI_MINOR}.$((PYPI_PATCH + 1))"
+          NEXT_MINOR_VERSION="${PYPI_MAJOR}.$((PYPI_MINOR + 1)).0"
+
+          echo "Expected next patch version: ${NEXT_PATCH_VERSION}"
+          echo "Expected next minor version: ${NEXT_MINOR_VERSION}"
+
+          # Check if the determined release version is one of the expected next versions
+          if [ "${RELEASE_VERSION}" = "${NEXT_PATCH_VERSION}" ] || [ "${RELEASE_VERSION}" = "${NEXT_MINOR_VERSION}" ]; then
+            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is a valid next version."
           else
-            echo "Error: Determined release version ${RELEASE_VERSION} must be strictly greater than the latest PyPI version ${LATEST_PYPI_VERSION}."
+            echo "Error: Determined release version ${RELEASE_VERSION} must be either the next patch version (${NEXT_PATCH_VERSION}) or the next minor version (${NEXT_MINOR_VERSION}) compared to the latest PyPI version ${LATEST_PYPI_VERSION}."
             exit 1
           fi
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,10 +23,6 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
-      - name: Create pip cache directory
-        run: |
-          mkdir -p /home/runner/.cache/pip
-
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: 'pip'
 
       # Find the latest release branch to use as base branch for tests
       - name: Find latest release branch

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
 
+      - name: Create pip cache directory
+        run: |
+          mkdir -p /home/runner/.cache/pip
+
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
@@ -59,6 +63,27 @@ jobs:
             echo "Incrementing from ${LATEST_VERSION} to ${RELEASE_VERSION}"
           fi
           echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Verify release version > latest PyPI version
+        id: verify_version
+        run: |
+          RELEASE_VERSION="${{ steps.determine_version.outputs.release_version }}"
+          echo "Determined release version: ${RELEASE_VERSION}"
+
+          # Get the latest version from PyPI using JSON API
+          LATEST_PYPI_VERSION=$(curl -s https://pypi.org/pypi/skypilot/json | python -c "import sys, json; print(json.load(sys.stdin)['info']['version'])")
+          echo "Latest PyPI version: ${LATEST_PYPI_VERSION}"
+
+          # Compare versions using Bash sort -V
+          echo "Comparing determined version ${RELEASE_VERSION} with latest PyPI version ${LATEST_PYPI_VERSION}"
+          HIGHEST_VERSION=$(printf "%s\\n%s" "${RELEASE_VERSION}" "${LATEST_PYPI_VERSION}" | sort -V | tail -n1)
+
+          if [ "${RELEASE_VERSION}" = "${HIGHEST_VERSION}" ] && [ "${RELEASE_VERSION}" != "${LATEST_PYPI_VERSION}" ]; then
+            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is greater than latest PyPI version ${LATEST_PYPI_VERSION}."
+          else
+            echo "Error: Determined release version ${RELEASE_VERSION} must be strictly greater than the latest PyPI version ${LATEST_PYPI_VERSION}."
+            exit 1
+          fi
 
       - name: Set release version and commit changes
         id: commit_changes
@@ -168,7 +193,7 @@ jobs:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   create-pr:
-    needs: [release-build, wait-for-smoke-tests, wait-for-quicktest-core, extract-release-test]
+    needs: [release-build, wait-for-smoke-tests, wait-for-quicktest-core, extract-release-test, extract-smoke-tests, extract-quicktest]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Release version must be greater than pypi exist version

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

Test on my personal repo

[Failure](https://github.com/zpoint/skypilot/actions/runs/14508096073/job/40701128162): 
<img width="1913" alt="image" src="https://github.com/user-attachments/assets/8b25469c-3a95-48fd-9e46-603310b6d478" />

<img width="1891" alt="image" src="https://github.com/user-attachments/assets/bf580a38-15ce-4c67-8fbf-b31f0749a610" />

[Success](https://github.com/zpoint/skypilot/actions/runs/14508137401):
<img width="1870" alt="image" src="https://github.com/user-attachments/assets/62bae02b-6a67-4f37-a7c3-354d06807919" />
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/e90be6a4-7b76-40ca-a895-7b181c66797e" />


<!-- CI commands (/-prefixed) can only be triggered by repo members -->
