### PR TITLE
Fix querying kubernetes nodes at client-side

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3463,7 +3463,7 @@ def show_gpus(
             ])
         return realtime_gpu_table
 
-    def _get_kubernetes_node_info(context: Optional[str]):
+    def _format_kubernetes_node_info(context: Optional[str]):
         node_table = log_utils.create_table(
             ['NODE_NAME', 'GPU_NAME', 'TOTAL_GPUS', 'FREE_GPUS'])
 
@@ -3534,7 +3534,7 @@ def show_gpus(
                            f'{colorama.Style.RESET_ALL}\n')
                     yield from k8s_realtime_table.get_string()
                     yield '\n\n'
-                    yield _get_kubernetes_node_info(context)
+                    yield _format_kubernetes_node_info(context)
                 if kubernetes_autoscaling:
                     k8s_messages += (
                         '\n' + kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3467,17 +3467,8 @@ def show_gpus(
         node_table = log_utils.create_table(
             ['NODE_NAME', 'GPU_NAME', 'TOTAL_GPUS', 'FREE_GPUS'])
 
-        try:
-            nodes_info = sdk.stream_and_get(
-                sdk.kubernetes_node_info_v2(context=context))
-        except exceptions.ApiEndpointNotFoundError:
-            # Fallback to the old endpoint.
-            node_info_dict = sdk.stream_and_get(
-                sdk.kubernetes_node_info(context=context))
-            nodes_info = models.KubernetesNodesInfo(
-                node_info_dict=node_info_dict,
-                hint='',
-            )
+        nodes_info = sdk.stream_and_get(
+            sdk.kubernetes_node_info(context=context))
         no_permissions_str = '<no permissions>'
         for node_name, node_info in nodes_info.node_info_dict.items():
             available = node_info.free[

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1387,43 +1387,10 @@ def realtime_kubernetes_gpu_availability(
     return server_common.get_request_id(response)
 
 
-# TODO(aylei): Remove this in v0.11.0
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
 def kubernetes_node_info(
-        context: Optional[str] = None) -> server_common.RequestId:
-    """Gets the resource information for all the nodes in the cluster.
-
-    Currently only GPU resources are supported. The function returns the total
-    number of GPUs available on the node and the number of free GPUs on the
-    node.
-
-    If the user does not have sufficient permissions to list pods in all
-    namespaces, the function will return free GPUs as -1.
-
-    Args:
-        context: The Kubernetes context. If None, the default context is used.
-
-    Returns:
-        The request ID of the Kubernetes node info request.
-
-    Request Returns:
-        Dict[str, KubernetesNodeInfo]: Dictionary containing the node name as
-            key and the KubernetesNodeInfo object as value
-    """
-    body = payloads.KubernetesNodeInfoRequestBody(context=context)
-    response = requests.post(
-        f'{server_common.get_server_url()}/kubernetes_node_info',
-        json=json.loads(body.model_dump_json()),
-        cookies=server_common.get_api_cookie_jar())
-    return server_common.get_request_id(response)
-
-
-@usage_lib.entrypoint
-@server_common.check_server_healthy_or_start
-@annotations.client_api
-def kubernetes_node_info_v2(
         context: Optional[str] = None) -> server_common.RequestId:
     """Gets the resource information for all the nodes in the cluster.
 
@@ -1446,19 +1413,9 @@ def kubernetes_node_info_v2(
     """
     body = payloads.KubernetesNodeInfoRequestBody(context=context)
     response = requests.post(
-        f'{server_common.get_server_url()}/kubernetes_node_info_v2',
+        f'{server_common.get_server_url()}/kubernetes_node_info',
         json=json.loads(body.model_dump_json()),
         cookies=server_common.get_api_cookie_jar())
-    if response.status_code == 404:
-        # Do not fallback to the old endpoint because the old endpoint has
-        # different request return type. Compatibilities should be handled
-        # in upper layer.
-        # TODO(aylei): Update this after removing /kubernetes_node_info in
-        # v0.11.0.
-        raise exceptions.ApiEndpointNotFoundError(
-            'API endpoint /kubernetes_node_info_v2 not found. '
-            'Upgrade your SkyPilot API server or using '
-            'sdk.kubernetes_node_info instead.')
     return server_common.get_request_id(response)
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1387,6 +1387,7 @@ def realtime_kubernetes_gpu_availability(
     return server_common.get_request_id(response)
 
 
+# TODO(aylei): Remove this in v0.11.0
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
@@ -1416,6 +1417,48 @@ def kubernetes_node_info(
         f'{server_common.get_server_url()}/kubernetes_node_info',
         json=json.loads(body.model_dump_json()),
         cookies=server_common.get_api_cookie_jar())
+    return server_common.get_request_id(response)
+
+
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
+@annotations.client_api
+def kubernetes_node_info_v2(
+        context: Optional[str] = None) -> server_common.RequestId:
+    """Gets the resource information for all the nodes in the cluster.
+
+    Currently only GPU resources are supported. The function returns the total
+    number of GPUs available on the node and the number of free GPUs on the
+    node.
+
+    If the user does not have sufficient permissions to list pods in all
+    namespaces, the function will return free GPUs as -1.
+
+    Args:
+        context: The Kubernetes context. If None, the default context is used.
+
+    Returns:
+        The request ID of the Kubernetes node info request.
+
+    Request Returns:
+        KubernetesNodesInfo: A model that contains the node info map and other
+            information.
+    """
+    body = payloads.KubernetesNodeInfoRequestBody(context=context)
+    response = requests.post(
+        f'{server_common.get_server_url()}/kubernetes_node_info_v2',
+        json=json.loads(body.model_dump_json()),
+        cookies=server_common.get_api_cookie_jar())
+    if response.status_code == 404:
+        # Do not fallback to the old endpoint because the old endpoint has
+        # different request return type. Compatibilities should be handled
+        # in upper layer.
+        # TODO(aylei): Update this after removing /kubernetes_node_info in
+        # v0.11.0.
+        raise exceptions.ApiEndpointNotFoundError(
+            'API endpoint /kubernetes_node_info_v2 not found. '
+            'Upgrade your SkyPilot API server or using '
+            'sdk.kubernetes_node_info instead.')
     return server_common.get_request_id(response)
 
 

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -552,4 +552,3 @@ class JobExitCode(enum.IntEnum):
 
         # Should not hit this case, but included to avoid errors
         return cls.FAILED
-

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -552,3 +552,8 @@ class JobExitCode(enum.IntEnum):
 
         # Should not hit this case, but included to avoid errors
         return cls.FAILED
+
+
+class ApiEndpointNotFoundError(Exception):
+    """Raised when the API endpoint is not found."""
+    pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -553,7 +553,3 @@ class JobExitCode(enum.IntEnum):
         # Should not hit this case, but included to avoid errors
         return cls.FAILED
 
-
-class ApiEndpointNotFoundError(Exception):
-    """Raised when the API endpoint is not found."""
-    pass

--- a/sky/models.py
+++ b/sky/models.py
@@ -28,3 +28,31 @@ class KubernetesNodeInfo:
     # Resources available on the node. E.g., {'nvidia.com/gpu': '2'}
     total: Dict[str, int]
     free: Dict[str, int]
+
+
+@dataclasses.dataclass
+class KubernetesNodesInfo:
+    """Dataclass to store Kubernetes node info map."""
+    # The nodes in the cluster, keyed by node name.
+    node_info_dict: Dict[str, KubernetesNodeInfo]
+    # Additional hint for the node info.
+    hint: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'node_info_dict': {
+                node_name: dataclasses.asdict(node_info)
+                for node_name, node_info in self.node_info_dict.items()
+            },
+            'hint': self.hint,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'KubernetesNodesInfo':
+        return cls(
+            node_info_dict={
+                node_name: KubernetesNodeInfo(**node_info)
+                for node_name, node_info in data['node_info_dict'].items()
+            },
+            hint=data['hint'],
+        )

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2542,21 +2542,15 @@ def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
     return unlabeled_nodes
 
 
-# TODO(aylei): For backward compatibility, remove this in v0.11.0
 def get_kubernetes_node_info(
-        context: Optional[str] = None) -> Dict[str, models.KubernetesNodeInfo]:
-    return get_kubernetes_node_info_v2(context=context).node_info_dict
-
-
-def get_kubernetes_node_info_v2(
         context: Optional[str] = None) -> models.KubernetesNodesInfo:
     """Gets the resource information for all the nodes in the cluster.
 
-    Compared to get_kubernetes_node_info, this function returns a model with
-    node info map as a nested field. This allows future extensions while
-    keeping the client-server compatibility, e.g. when adding a new field to
-    the model, the legacy clients will not be affected and new clients can
-    opt-in new behavior if the new field is presented.
+    This function returns a model with node info map as a nested field. This
+    allows future extensions while keeping the client-server compatibility,
+    e.g. when adding a new field to the model, the legacy clients will not be
+    affected and new clients can opt-in new behavior if the new field is
+    presented.
 
     Currently only GPU resources are supported. The function returns the total
     number of GPUs available on the node and the number of free GPUs on the
@@ -2633,8 +2627,8 @@ def get_kubernetes_node_info_v2(
             free={'accelerators_available': int(accelerators_available)})
     hint = ''
     if has_multi_host_tpu:
-        hint = ('Note: Multi-host TPUs are detected and excluded from the '
-                'display as multi-host TPUs are not supported.')
+        hint = ('(Note: Multi-host TPUs are detected and excluded from the '
+                'display as multi-host TPUs are not supported.)')
 
     return models.KubernetesNodesInfo(
         node_info_dict=node_info_dict,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2542,9 +2542,21 @@ def get_unlabeled_accelerator_nodes(context: Optional[str] = None) -> List[Any]:
     return unlabeled_nodes
 
 
+# TODO(aylei): For backward compatibility, remove this in v0.11.0
 def get_kubernetes_node_info(
         context: Optional[str] = None) -> Dict[str, models.KubernetesNodeInfo]:
+    return get_kubernetes_node_info_v2(context=context).node_info_dict
+
+
+def get_kubernetes_node_info_v2(
+        context: Optional[str] = None) -> models.KubernetesNodesInfo:
     """Gets the resource information for all the nodes in the cluster.
+
+    Compared to get_kubernetes_node_info, this function returns a model with
+    node info map as a nested field. This allows future extensions while
+    keeping the client-server compatibility, e.g. when adding a new field to
+    the model, the legacy clients will not be affected and new clients can
+    opt-in new behavior if the new field is presented.
 
     Currently only GPU resources are supported. The function returns the total
     number of GPUs available on the node and the number of free GPUs on the
@@ -2554,8 +2566,8 @@ def get_kubernetes_node_info(
     namespaces, the function will return free GPUs as -1.
 
     Returns:
-        Dict[str, KubernetesNodeInfo]: Dictionary containing the node name as
-            key and the KubernetesNodeInfo object as value
+        KubernetesNodesInfo: A model that contains the node info map and other
+            information.
     """
     nodes = get_kubernetes_nodes(context=context)
     # Get the pods to get the real-time resource usage
@@ -2574,6 +2586,7 @@ def get_kubernetes_node_info(
         label_keys = lf.get_label_keys()
 
     node_info_dict: Dict[str, models.KubernetesNodeInfo] = {}
+    has_multi_host_tpu = False
 
     for node in nodes:
         accelerator_name = None
@@ -2610,6 +2623,7 @@ def get_kubernetes_node_info(
         # TODO(Doyoung): Remove the logic when adding support for
         # multi-host TPUs.
         if is_multi_host_tpu(node.metadata.labels):
+            has_multi_host_tpu = True
             continue
 
         node_info_dict[node.metadata.name] = models.KubernetesNodeInfo(
@@ -2617,8 +2631,15 @@ def get_kubernetes_node_info(
             accelerator_type=accelerator_name,
             total={'accelerator_count': int(accelerator_count)},
             free={'accelerators_available': int(accelerators_available)})
+    hint = ''
+    if has_multi_host_tpu:
+        hint = ('Note: Multi-host TPUs are detected and excluded from the '
+                'display as multi-host TPUs are not supported.')
 
-    return node_info_dict
+    return models.KubernetesNodesInfo(
+        node_info_dict=node_info_dict,
+        hint=hint,
+    )
 
 
 def to_label_selector(tags):
@@ -2861,15 +2882,6 @@ def is_multi_host_tpu(node_metadata_labels: dict) -> bool:
         # reflects the total across all hosts, while
         # node_tpu_chip_count reflects only the chips in a single node.
         if node_tpu_chip_count != topology_chip_count:
-            return True
-    return False
-
-
-def multi_host_tpu_exists_in_cluster(context: Optional[str] = None) -> bool:
-    """Checks if there exists a multi-host TPU within the cluster."""
-    nodes = get_kubernetes_nodes(context=context)
-    for node in nodes:
-        if is_multi_host_tpu(node.metadata.labels):
             return True
     return False
 

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -5,7 +5,7 @@ from sky.skylet import constants
 # API server version, whenever there is a change in API server that requires a
 # restart of the local API server or error out when the client does not match
 # the server version.
-API_VERSION = '3'
+API_VERSION = '4'
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -188,20 +188,5 @@ def decode_job_status(
 
 @register_decoders('kubernetes_node_info')
 def decode_kubernetes_node_info(
-        return_value: Dict[str, Any]) -> Dict[str, models.KubernetesNodeInfo]:
-    return {
-        node_name: models.KubernetesNodeInfo(**node_info)
-        for node_name, node_info in return_value.items()
-    }
-
-
-@register_decoders('kubernetes_node_info_v2')
-def decode_kubernetes_node_info_v2(
         return_value: Dict[str, Any]) -> models.KubernetesNodesInfo:
-    return models.KubernetesNodesInfo(
-        node_info_dict={
-            node_name: models.KubernetesNodeInfo(**node_info)
-            for node_name, node_info in return_value['node_info_dict'].items()
-        },
-        hint=return_value['hint'],
-    )
+    return models.KubernetesNodesInfo.from_dict(return_value)

--- a/sky/server/requests/serializers/decoders.py
+++ b/sky/server/requests/serializers/decoders.py
@@ -193,3 +193,15 @@ def decode_kubernetes_node_info(
         node_name: models.KubernetesNodeInfo(**node_info)
         for node_name, node_info in return_value.items()
     }
+
+
+@register_decoders('kubernetes_node_info_v2')
+def decode_kubernetes_node_info_v2(
+        return_value: Dict[str, Any]) -> models.KubernetesNodesInfo:
+    return models.KubernetesNodesInfo(
+        node_info_dict={
+            node_name: models.KubernetesNodeInfo(**node_info)
+            for node_name, node_info in return_value['node_info_dict'].items()
+        },
+        hint=return_value['hint'],
+    )

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -159,8 +159,14 @@ def encode_job_status(return_value: Dict[int, Any]) -> Dict[int, str]:
 
 @register_encoder('kubernetes_node_info')
 def encode_kubernetes_node_info(
-        return_value: Dict[str, 'models.KubernetesNodeInfo']) -> Dict[str, Any]:
+        return_value: 'models.KubernetesNodesInfo') -> Dict[str, Any]:
     return {
         node_name: dataclasses.asdict(node_info)
-        for node_name, node_info in return_value.items()
+        for node_name, node_info in return_value.node_info_dict.items()
     }
+
+
+@register_encoder('kubernetes_node_info_v2')
+def encode_kubernetes_node_info_v2(
+        return_value: 'models.KubernetesNodesInfo') -> Dict[str, Any]:
+    return return_value.to_dict()

--- a/sky/server/requests/serializers/encoders.py
+++ b/sky/server/requests/serializers/encoders.py
@@ -160,13 +160,4 @@ def encode_job_status(return_value: Dict[int, Any]) -> Dict[int, str]:
 @register_encoder('kubernetes_node_info')
 def encode_kubernetes_node_info(
         return_value: 'models.KubernetesNodesInfo') -> Dict[str, Any]:
-    return {
-        node_name: dataclasses.asdict(node_info)
-        for node_name, node_info in return_value.node_info_dict.items()
-    }
-
-
-@register_encoder('kubernetes_node_info_v2')
-def encode_kubernetes_node_info_v2(
-        return_value: 'models.KubernetesNodesInfo') -> Dict[str, Any]:
     return return_value.to_dict()

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -205,6 +205,8 @@ async def realtime_kubernetes_gpu_availability(
     )
 
 
+# Deprecated, use kubernetes_node_info_v2 instead.
+# TODO(aylei): Remove this in v0.11.0
 @app.post('/kubernetes_node_info')
 async def kubernetes_node_info(
         request: fastapi.Request,
@@ -216,6 +218,21 @@ async def kubernetes_node_info(
         request_name='kubernetes_node_info',
         request_body=kubernetes_node_info_body,
         func=kubernetes_utils.get_kubernetes_node_info,
+        schedule_type=requests_lib.ScheduleType.SHORT,
+    )
+
+
+@app.post('/kubernetes_node_info_v2')
+async def kubernetes_node_info_v2(
+        request: fastapi.Request,
+        kubernetes_node_info_body: payloads.KubernetesNodeInfoRequestBody
+) -> None:
+    """Gets Kubernetes nodes information and hints."""
+    executor.schedule_request(
+        request_id=request.state.request_id,
+        request_name='kubernetes_node_info_v2',
+        request_body=kubernetes_node_info_body,
+        func=kubernetes_utils.get_kubernetes_node_info_v2,
         schedule_type=requests_lib.ScheduleType.SHORT,
     )
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -205,34 +205,17 @@ async def realtime_kubernetes_gpu_availability(
     )
 
 
-# Deprecated, use kubernetes_node_info_v2 instead.
-# TODO(aylei): Remove this in v0.11.0
 @app.post('/kubernetes_node_info')
 async def kubernetes_node_info(
-        request: fastapi.Request,
-        kubernetes_node_info_body: payloads.KubernetesNodeInfoRequestBody
-) -> None:
-    """Gets Kubernetes node information."""
-    executor.schedule_request(
-        request_id=request.state.request_id,
-        request_name='kubernetes_node_info',
-        request_body=kubernetes_node_info_body,
-        func=kubernetes_utils.get_kubernetes_node_info,
-        schedule_type=requests_lib.ScheduleType.SHORT,
-    )
-
-
-@app.post('/kubernetes_node_info_v2')
-async def kubernetes_node_info_v2(
         request: fastapi.Request,
         kubernetes_node_info_body: payloads.KubernetesNodeInfoRequestBody
 ) -> None:
     """Gets Kubernetes nodes information and hints."""
     executor.schedule_request(
         request_id=request.state.request_id,
-        request_name='kubernetes_node_info_v2',
+        request_name='kubernetes_node_info',
         request_body=kubernetes_node_info_body,
-        func=kubernetes_utils.get_kubernetes_node_info_v2,
+        func=kubernetes_utils.get_kubernetes_node_info,
         schedule_type=requests_lib.ScheduleType.SHORT,
     )
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5245

**NOTE**: this is a break change so the API version is bumped. Requires an upgrade for both client-server. I've actually implemented a compatible version in https://github.com/skypilot-org/skypilot/pull/5255/commits/3e03113bf7522e1cb8a5a3032dfab8f5fc500315. But considering the maintenance burden, I think it is a good time to do some break changes before we release 0.9.0 so I remove the code about compatibility. How do you like? @cg505 @romilbhardwaj @Michaelvll 

Behavior with mocked labels:

```
sky show-gpus
Kubernetes GPUs
GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
H100  1, 2, 4, 8                8           8
L4    1, 2, 4, 8                8           8

Kubernetes per node accelerator availability (Note: Multi-host TPUs are detected and excluded from the display as multi-host TPUs are not supported.)
NODE_NAME                                     GPU_NAME  TOTAL_GPUS  FREE_GPUS
gke-skypilotalpha-default-pool-ff931856-y51p  None      0           0
gke-skypilotalpha-largecpu-05dae726-0f7l      H100      8           8
gke-skypilotalpha-largecpu-05dae726-hyv6      L4        8           8
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
