### PR TITLE
Fix: only mark smoke test cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,6 +194,9 @@ def pytest_collection_modifyitems(config, items):
     generic_cloud_keyword = cloud_to_pytest_keyword[generic_cloud]
 
     for item in items:
+        if 'smoke_tests' not in item.location[0]:
+            # Only mark smoke test cases
+            continue
         if 'slow' in item.keywords and not config.getoption('--runslow'):
             item.add_marker(skip_marks['slow'])
         if 'local' in item.keywords and not server_common.is_api_server_local():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #2402 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
