### PR TITLE
Fix dependency installation in k8s pod

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -384,8 +384,12 @@ available_node_types:
                 set +e
                 
                 if [ ! -z "$MISSING_PACKAGES" ]; then
-                  echo "Installing missing packages: $MISSING_PACKAGES";
-                  DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" $MISSING_PACKAGES;
+                  # Install missing packages individually to avoid failure installation breaks the whole install process,
+                  # e.g. fuse3 is not available on some distributions.
+                  echo "Installing missing packages individually: $MISSING_PACKAGES";
+                  for pkg in $MISSING_PACKAGES; do
+                    DEBIAN_FRONTEND=noninteractive $(prefix_cmd) apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" $pkg || echo "Optional package $pkg installation failed, skip.";
+                  done
                 fi;
 
                 {% if k8s_fuse_device_required %}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5232

Thanks @zpoint for the investigation!

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
