### PR TITLE
[cli] show-config command

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3762,6 +3762,14 @@ def show_gpus(
         click.echo()
 
 
+@cli.command()
+@config_option(expose_value=False)
+def show_config():
+    """Show the currently applied SkyPilot configuration."""
+    applied_config = skypilot_config.to_dict()
+    click.echo(common_utils.dump_yaml_str(dict(applied_config)))
+
+
 @cli.group(cls=_NaturalOrderGroup)
 def storage():
     """SkyPilot Storage CLI."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Now that we're adding some complexity to our configuration, users may need to debug their config. This is a mini-proposal to add a command that shows the currently applied config the CLI is using.

User can print currently applied config
```
$ sky show-config
api_server:
  endpoint: http://127.0.0.1:46580

kubernetes:
  pod_config:
    spec:
      priorityClassName: high
  custom_metadata:
    annotations:
      annot2: ddd
```

User can test CLI config overrides
```
$ sky show-config --config kubernetes.pod_config.spec.priorityClassName=medium
api_server:
  endpoint: http://127.0.0.1:46580

kubernetes:
  pod_config:
    spec:
      priorityClassName: medium
  custom_metadata:
    annotations:
      annot2: ddd
```

User can catch mistakes (don't ask me how I know this is useful 🤦 )
```
sky show-config --config kubernetes.pod_config.spec.priprityClassName=medium
api_server:
  endpoint: http://127.0.0.1:46580

kubernetes:
  pod_config:
    spec:
      priorityClassName: high
      priprityClassName: medium
  custom_metadata:
    annotations:
      annot2: ddd
```

```
sky show-config -h                                                          
Usage: sky show-config [OPTIONS]

  Show the currently applied SkyPilot configuration.

Options:
  --config TEXT  Path to a config file or a comma-separated list of key-value
                 pairs (e.g. "nested.key1=val1,another.key2=val2").
  -h, --help     Show this message and exit.
```

Exactly where this command fits in the CLI command hierarchy is open for debate. I think top-level is fine because we also have `sky show-gpus` which kinda does something similar?

The expected usage of this command is to help debug issues - when someone submits an issue that may have been caused by malformed / unexpected config, one can ask the person to post the output of `sky show-config` as a starting point for debugging config.

We may later add a `--verbose` flag which also prints out all the individual sources (e.g. user config [and the path to file the CLi is using], project config [and the filepath], CLI overrides) as well as the final config for even better debugging). Not gonna do that in this PR though because I'm lazy, unless someone feels strongly about it.

Honestly I wish I thought of this sooner so I can use it to debug config hierarchy, so I have some validation of its usefulness.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual tests: see description above

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
