### PR TITLE
[Serve] BugFix: Negative num od to provision

### DIFF
--- a/sky/serve/autoscalers.py
+++ b/sky/serve/autoscalers.py
@@ -676,8 +676,12 @@ class FallbackRequestRateAutoscaler(RequestRateAutoscaler):
             # because the provisioning spot can fail to UP due to the capacity
             # issue, and on-demand should fill the gap between the required
             # number of spot and ready spot.
-            num_ondemand_to_provision += (num_spot_to_provision -
-                                          num_ready_spot)
+            # When scaling down spot instances, it is possible that the number
+            # of ready spot is more than the number of spot to provision, thus
+            # generate a negative number. In this case, we don't need to
+            # provision on-demand instances.
+            num_ondemand_to_provision += max(
+                0, num_spot_to_provision - num_ready_spot)
 
         # Make sure we don't launch on-demand fallback for
         # overprovisioned replicas.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a bug where sometimes the `num_ondemand_to_provision` can be negative. in such case the `num_ondemand_to_scale_down` will exceed `num_nonterminal_ondemand` and thus generate an assertion error.

```bash
I 04-03 09:11:38 autoscalers.py:657] Number of spot instances to scale down: 1 [5]
E 04-03 09:11:38 controller.py:94] Error in autoscaler: AssertionError: ('Not enough replicas to scale down. Available replicas: ', '[ReplicaInfo(replica_id=6, cluster_name=sky-service-dfea-6, version=1, replica_port=8080, is_spot=False, status=ReplicaStatus.READY, launched_at=1743670813)], num_replica_to_scale_down: 2.')
E 04-03 09:11:38 controller.py:97]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/serve/controller.py", line 78, in _run_autoscaler
E 04-03 09:11:38 controller.py:97]     scaling_options = self._autoscaler.generate_scaling_decisions(
E 04-03 09:11:38 controller.py:97]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/serve/autoscalers.py", line 328, in generate_scaling_decisions
E 04-03 09:11:38 controller.py:97]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/serve/autoscalers.py", line 683, in _generate_scaling_decisions
E 04-03 09:11:38 controller.py:97]     _select_nonterminal_replicas_to_scale_down(
E 04-03 09:11:38 controller.py:97]   File "/home/ubuntu/skypilot-runtime/lib/python3.10/site-packages/sky/serve/autoscalers.py", line 109, in _select_nonterminal_replicas_to_scale_down
E 04-03 09:11:38 controller.py:97]     assert len(replicas) >= num_replica_to_scale_down, (
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
