### PR TITLE
[UX] better config related debug logs

### DIFF
--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -358,6 +358,9 @@ def _request_execution_wrapper(request_id: str,
         # captured in the log file.
         try:
             with override_request_env_and_config(request_body):
+                config = skypilot_config.to_dict()
+                logger.debug(f'request config: \n'
+                             f'{common_utils.dump_yaml_str(dict(config))}')
                 return_value = func(**request_body.to_kwargs())
                 f.flush()
         except KeyboardInterrupt:

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -358,9 +358,10 @@ def _request_execution_wrapper(request_id: str,
         # captured in the log file.
         try:
             with override_request_env_and_config(request_body):
-                config = skypilot_config.to_dict()
-                logger.debug(f'request config: \n'
-                             f'{common_utils.dump_yaml_str(dict(config))}')
+                if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+                    config = skypilot_config.to_dict()
+                    logger.debug(f'request config: \n'
+                                 f'{common_utils.dump_yaml_str(dict(config))}')
                 return_value = func(**request_body.to_kwargs())
                 f.flush()
         except KeyboardInterrupt:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -51,7 +51,6 @@ then:
 import contextlib
 import copy
 import os
-import pprint
 import threading
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple
@@ -314,8 +313,8 @@ def _parse_config_file(config_path: str) -> config_utils.Config:
     try:
         config_dict = common_utils.read_yaml(config_path)
         config = config_utils.Config.from_dict(config_dict)
-        logger.debug(
-            f'Config loaded from {config_path}:\n{pprint.pformat(config)}')
+        logger.debug(f'Config loaded from {config_path}:\n'
+                     f'{common_utils.dump_yaml_str(dict(config))}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -359,7 +358,8 @@ def _reload_config_as_server() -> None:
     for override in overrides:
         overlaid_server_config = overlay_skypilot_config(
             original_config=overlaid_server_config, override_configs=override)
-    logger.debug(f'final server config: {overlaid_server_config}')
+    logger.debug(f'server config: \n'
+                 f'{common_utils.dump_yaml_str(dict(overlaid_server_config))}')
     _dict = overlaid_server_config
 
 
@@ -381,7 +381,8 @@ def _reload_config_as_client() -> None:
     for override in overrides:
         overlaid_client_config = overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
-    logger.debug(f'final client config: {overlaid_client_config}')
+    logger.debug(f'client config (before task and CLI overrides): \n'
+                 f'{common_utils.dump_yaml_str(dict(overlaid_client_config))}')
     _dict = overlaid_client_config
 
 
@@ -491,7 +492,8 @@ def apply_cli_config(cli_config: Optional[str]) -> Dict[str, Any]:
     """
     global _dict
     parsed_config = _compose_cli_config(cli_config)
-    logger.debug(f'applying following CLI overrides: {parsed_config}')
+    logger.debug(f'applying following CLI overrides: \n'
+                 f'{common_utils.dump_yaml_str(dict(parsed_config))}')
     _dict = overlay_skypilot_config(original_config=_dict,
                                     override_configs=parsed_config)
     return parsed_config

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -313,8 +313,9 @@ def _parse_config_file(config_path: str) -> config_utils.Config:
     try:
         config_dict = common_utils.read_yaml(config_path)
         config = config_utils.Config.from_dict(config_dict)
-        logger.debug(f'Config loaded from {config_path}:\n'
-                     f'{common_utils.dump_yaml_str(dict(config))}')
+        if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+            logger.debug(f'Config loaded from {config_path}:\n'
+                         f'{common_utils.dump_yaml_str(dict(config))}')
     except yaml.YAMLError as e:
         logger.error(f'Error in loading config file ({config_path}):', e)
     if config:
@@ -358,8 +359,10 @@ def _reload_config_as_server() -> None:
     for override in overrides:
         overlaid_server_config = overlay_skypilot_config(
             original_config=overlaid_server_config, override_configs=override)
-    logger.debug(f'server config: \n'
-                 f'{common_utils.dump_yaml_str(dict(overlaid_server_config))}')
+    if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+        logger.debug(
+            f'server config: \n'
+            f'{common_utils.dump_yaml_str(dict(overlaid_server_config))}')
     _dict = overlaid_server_config
 
 
@@ -381,8 +384,10 @@ def _reload_config_as_client() -> None:
     for override in overrides:
         overlaid_client_config = overlay_skypilot_config(
             original_config=overlaid_client_config, override_configs=override)
-    logger.debug(f'client config (before task and CLI overrides): \n'
-                 f'{common_utils.dump_yaml_str(dict(overlaid_client_config))}')
+    if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+        logger.debug(
+            f'client config (before task and CLI overrides): \n'
+            f'{common_utils.dump_yaml_str(dict(overlaid_client_config))}')
     _dict = overlaid_client_config
 
 
@@ -492,8 +497,9 @@ def apply_cli_config(cli_config: Optional[str]) -> Dict[str, Any]:
     """
     global _dict
     parsed_config = _compose_cli_config(cli_config)
-    logger.debug(f'applying following CLI overrides: \n'
-                 f'{common_utils.dump_yaml_str(dict(parsed_config))}')
+    if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+        logger.debug(f'applying following CLI overrides: \n'
+                     f'{common_utils.dump_yaml_str(dict(parsed_config))}')
     _dict = overlay_skypilot_config(original_config=_dict,
                                     override_configs=parsed_config)
     return parsed_config

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -171,7 +171,6 @@ def _get_nested(configs: Optional[Dict[str, Any]],
             curr = value
         else:
             return default_value
-    logger.debug(f'Config: {".".join(keys)} -> {curr}')
     return curr
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Reformat debug logs to be more human readable. This change allows a user to see what files are being used for each config layer, what each config layer is providing and the final configuration for both client and the server.

```
sky launch --dryrun
D 04-17 14:11:53 skypilot_config.py:143] using default user config file: ~/.sky/config.yaml
D 04-17 14:11:53 skypilot_config.py:316] Config loaded from /Users/seungjinyang/.sky/config.yaml:
D 04-17 14:11:53 skypilot_config.py:316] api_server:
D 04-17 14:11:53 skypilot_config.py:316]   endpoint: http://127.0.0.1:46580
D 04-17 14:11:53 skypilot_config.py:316] 
D 04-17 14:11:53 skypilot_config.py:316] aws:
D 04-17 14:11:53 skypilot_config.py:316]   security_group_name: seungjins-security-group
D 04-17 14:11:53 skypilot_config.py:316] 
D 04-17 14:11:53 skypilot_config.py:316] kubernetes:
D 04-17 14:11:53 skypilot_config.py:316]   pod_config:
D 04-17 14:11:53 skypilot_config.py:316]     spec:
D 04-17 14:11:53 skypilot_config.py:316]       priorityClassName: high
D 04-17 14:11:53 skypilot_config.py:316]   custom_metadata:
D 04-17 14:11:53 skypilot_config.py:316]     annotations:
D 04-17 14:11:53 skypilot_config.py:316]       annot2: ddd
D 04-17 14:11:53 skypilot_config.py:316] 
D 04-17 14:11:53 skypilot_config.py:323] Config syntax check passed for path: /Users/seungjinyang/.sky/config.yaml
D 04-17 14:11:53 skypilot_config.py:170] using default project config file: .sky.yaml
D 04-17 14:11:53 skypilot_config.py:384] client config (before task and CLI overrides): 
D 04-17 14:11:53 skypilot_config.py:384] api_server:
D 04-17 14:11:53 skypilot_config.py:384]   endpoint: http://127.0.0.1:46580
D 04-17 14:11:53 skypilot_config.py:384] 
D 04-17 14:11:53 skypilot_config.py:384] aws:
D 04-17 14:11:53 skypilot_config.py:384]   security_group_name: seungjins-security-group
D 04-17 14:11:53 skypilot_config.py:384] 
D 04-17 14:11:53 skypilot_config.py:384] kubernetes:
D 04-17 14:11:53 skypilot_config.py:384]   pod_config:
D 04-17 14:11:53 skypilot_config.py:384]     spec:
D 04-17 14:11:53 skypilot_config.py:384]       priorityClassName: high
D 04-17 14:11:53 skypilot_config.py:384]   custom_metadata:
D 04-17 14:11:53 skypilot_config.py:384]     annotations:
D 04-17 14:11:53 skypilot_config.py:384]       annot2: ddd
D 04-17 14:11:53 skypilot_config.py:384] 
D 04-17 14:11:53 skypilot_config.py:202] using default server config file: ~/.sky/config.yaml
D 04-17 14:11:53 skypilot_config.py:317] Config loaded from /Users/seungjinyang/.sky/config.yaml:
D 04-17 14:11:53 skypilot_config.py:317] api_server:
D 04-17 14:11:53 skypilot_config.py:317]   endpoint: http://127.0.0.1:46580
D 04-17 14:11:53 skypilot_config.py:317] 
D 04-17 14:11:53 skypilot_config.py:317] aws:
D 04-17 14:11:53 skypilot_config.py:317]   security_group_name: seungjins-security-group
D 04-17 14:11:53 skypilot_config.py:317] 
D 04-17 14:11:53 skypilot_config.py:317] kubernetes:
D 04-17 14:11:53 skypilot_config.py:317]   pod_config:
D 04-17 14:11:53 skypilot_config.py:317]     spec:
D 04-17 14:11:53 skypilot_config.py:317]       priorityClassName: high
D 04-17 14:11:53 skypilot_config.py:317]   custom_metadata:
D 04-17 14:11:53 skypilot_config.py:317]     annotations:
D 04-17 14:11:53 skypilot_config.py:317]       annot2: ddd
D 04-17 14:11:53 skypilot_config.py:317] 
D 04-17 14:11:53 skypilot_config.py:325] Config syntax check passed for path: /Users/seungjinyang/.sky/config.yaml
D 04-17 14:11:53 skypilot_config.py:363] server config: 
D 04-17 14:11:53 skypilot_config.py:363] api_server:
D 04-17 14:11:53 skypilot_config.py:363]   endpoint: http://127.0.0.1:46580
D 04-17 14:11:53 skypilot_config.py:363] 
D 04-17 14:11:53 skypilot_config.py:363] aws:
D 04-17 14:11:53 skypilot_config.py:363]   security_group_name: seungjins-security-group
D 04-17 14:11:53 skypilot_config.py:363] 
D 04-17 14:11:53 skypilot_config.py:363] kubernetes:
D 04-17 14:11:53 skypilot_config.py:363]   pod_config:
D 04-17 14:11:53 skypilot_config.py:363]     spec:
D 04-17 14:11:53 skypilot_config.py:363]       priorityClassName: high
D 04-17 14:11:53 skypilot_config.py:363]   custom_metadata:
D 04-17 14:11:53 skypilot_config.py:363]     annotations:
D 04-17 14:11:53 skypilot_config.py:363]       annot2: ddd
D 04-17 14:11:53 skypilot_config.py:363] 
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
