### PR TITLE
[logging] A way to avoid doing expensive operations for logs

### DIFF
--- a/sky/data/data_transfer.py
+++ b/sky/data/data_transfer.py
@@ -95,7 +95,7 @@ def s3_to_gcs(s3_bucket_name: str, gs_bucket_name: str) -> None:
     logger.info(f'{colorama.Fore.GREEN}Transfer job scheduled: '
                 f'{colorama.Style.RESET_ALL}'
                 f's3://{s3_bucket_name} -> gs://{gs_bucket_name} ')
-    if sky_logging.is_logging_enabled_for_level(logger, sky_logging.DEBUG):
+    if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(json.dumps(operation, indent=4))
     logger.info('Waiting for the transfer to finish')
     start = time.time()

--- a/sky/data/data_transfer.py
+++ b/sky/data/data_transfer.py
@@ -95,7 +95,8 @@ def s3_to_gcs(s3_bucket_name: str, gs_bucket_name: str) -> None:
     logger.info(f'{colorama.Fore.GREEN}Transfer job scheduled: '
                 f'{colorama.Style.RESET_ALL}'
                 f's3://{s3_bucket_name} -> gs://{gs_bucket_name} ')
-    logger.debug(json.dumps(operation, indent=4))
+    if sky_logging.get_logging_level(logger) <= sky_logging.DEBUG:
+        logger.debug(json.dumps(operation, indent=4))
     logger.info('Waiting for the transfer to finish')
     start = time.time()
     with rich_utils.safe_status('Transferring'):

--- a/sky/data/data_transfer.py
+++ b/sky/data/data_transfer.py
@@ -95,7 +95,7 @@ def s3_to_gcs(s3_bucket_name: str, gs_bucket_name: str) -> None:
     logger.info(f'{colorama.Fore.GREEN}Transfer job scheduled: '
                 f'{colorama.Style.RESET_ALL}'
                 f's3://{s3_bucket_name} -> gs://{gs_bucket_name} ')
-    if sky_logging.get_logging_level(logger) <= sky_logging.DEBUG:
+    if sky_logging.is_logging_enabled_for_level(logger, sky_logging.DEBUG):
         logger.debug(json.dumps(operation, indent=4))
     logger.info('Waiting for the transfer to finish')
     start = time.time()

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -670,8 +670,7 @@ def post_provision_runtime_setup(
                 ux_utils.error_message(
                     'Failed to set up SkyPilot runtime on cluster.',
                     provision_logging.config.log_path))
-            if sky_logging.is_logging_enabled_for_level(logger,
-                                                        sky_logging.DEBUG):
+            if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
                 logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():
                 raise

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -670,7 +670,8 @@ def post_provision_runtime_setup(
                 ux_utils.error_message(
                     'Failed to set up SkyPilot runtime on cluster.',
                     provision_logging.config.log_path))
-            if sky_logging.get_logging_level(logger) <= sky_logging.DEBUG:
+            if sky_logging.is_logging_enabled_for_level(logger,
+                                                        sky_logging.DEBUG):
                 logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():
                 raise

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -670,6 +670,7 @@ def post_provision_runtime_setup(
                 ux_utils.error_message(
                     'Failed to set up SkyPilot runtime on cluster.',
                     provision_logging.config.log_path))
-            logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
+            if sky_logging.get_logging_level(logger) <= sky_logging.DEBUG:
+                logger.debug(f'Stacktrace:\n{traceback.format_exc()}')
             with ux_utils.print_exception_no_traceback():
                 raise

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -63,8 +63,8 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
         value = config.pop_nested(nested_key, default_value=None)
         if value is not None:
             ignored_key_values['.'.join(nested_key)] = value
-    if (ignored_key_values and sky_logging.is_logging_enabled_for_level(
-            logger, sky_logging.DEBUG)):
+    if (ignored_key_values and
+            sky_logging.logging_enabled(logger, sky_logging.DEBUG)):
         logger.debug(f'The following keys ({json.dumps(ignored_key_values)}) '
                      'are specified in the client SkyPilot config at '
                      f'{skypilot_config.loaded_config_path()!r}. '

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -63,8 +63,8 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
         value = config.pop_nested(nested_key, default_value=None)
         if value is not None:
             ignored_key_values['.'.join(nested_key)] = value
-    if (ignored_key_values and
-            sky_logging.get_logging_level(logger) <= sky_logging.DEBUG):
+    if (ignored_key_values and sky_logging.is_logging_enabled_for_level(
+            logger, sky_logging.DEBUG)):
         logger.debug(f'The following keys ({json.dumps(ignored_key_values)}) '
                      'are specified in the client SkyPilot config at '
                      f'{skypilot_config.loaded_config_path()!r}. '

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -63,7 +63,8 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
         value = config.pop_nested(nested_key, default_value=None)
         if value is not None:
             ignored_key_values['.'.join(nested_key)] = value
-    if ignored_key_values:
+    if (ignored_key_values and
+            sky_logging.get_logging_level(logger) <= sky_logging.DEBUG):
         logger.debug(f'The following keys ({json.dumps(ignored_key_values)}) '
                      'are specified in the client SkyPilot config at '
                      f'{skypilot_config.loaded_config_path()!r}. '

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -133,8 +133,8 @@ def set_logging_level(logger: str, level: int):
         logger.setLevel(original_level)
 
 
-def get_logging_level(logger: logging.Logger) -> int:
-    return logger.level
+def is_logging_enabled_for_level(logger: logging.Logger, level: int) -> bool:
+    return logger.level <= level
 
 
 @contextlib.contextmanager

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -133,7 +133,7 @@ def set_logging_level(logger: str, level: int):
         logger.setLevel(original_level)
 
 
-def is_logging_enabled_for_level(logger: logging.Logger, level: int) -> bool:
+def logging_enabled(logger: logging.Logger, level: int) -> bool:
     return logger.level <= level
 
 

--- a/sky/sky_logging.py
+++ b/sky/sky_logging.py
@@ -18,6 +18,12 @@ _FORMAT = '%(levelname).1s %(asctime)s %(filename)s:%(lineno)d] %(message)s'
 _DATE_FORMAT = '%m-%d %H:%M:%S'
 _SENSITIVE_LOGGER = ['sky.provisioner', 'sky.optimizer']
 
+DEBUG = logging.DEBUG
+INFO = logging.INFO
+WARNING = logging.WARNING
+ERROR = logging.ERROR
+CRITICAL = logging.CRITICAL
+
 
 def _show_logging_prefix():
     return env_options.Options.SHOW_DEBUG_INFO.get(
@@ -125,6 +131,10 @@ def set_logging_level(logger: str, level: int):
         yield
     finally:
         logger.setLevel(original_level)
+
+
+def get_logging_level(logger: logging.Logger) -> int:
+    return logger.level
 
 
 @contextlib.contextmanager

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -518,9 +518,9 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
             [('aws', 'security_group')])
 @mock.patch('sky.skypilot_config.loaded_config_path',
             return_value='/path/to/config.yaml')
-@mock.patch('sky.sky_logging.is_logging_enabled_for_level', return_value=True)
-def test_get_override_skypilot_config_from_client(
-        mock_to_dict, mock_logger, mock_is_logging_enabled_for_level):
+@mock.patch('sky.sky_logging.logging_enabled', return_value=True)
+def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger,
+                                                  mock_logging_enabled):
     with mock.patch('sky.server.requests.payloads.logger') as mock_logger:
         # Call the function
         result = payloads.get_override_skypilot_config_from_client()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -518,7 +518,9 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
             [('aws', 'security_group')])
 @mock.patch('sky.skypilot_config.loaded_config_path',
             return_value='/path/to/config.yaml')
-def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger):
+@mock.patch('sky.sky_logging.get_logging_level', return_value=10)  # DEBUG
+def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger,
+                                                  mock_get_logging_level):
     with mock.patch('sky.server.requests.payloads.logger') as mock_logger:
         # Call the function
         result = payloads.get_override_skypilot_config_from_client()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -518,9 +518,9 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
             [('aws', 'security_group')])
 @mock.patch('sky.skypilot_config.loaded_config_path',
             return_value='/path/to/config.yaml')
-@mock.patch('sky.sky_logging.get_logging_level', return_value=10)  # DEBUG
-def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger,
-                                                  mock_get_logging_level):
+@mock.patch('sky.sky_logging.is_logging_enabled_for_level', return_value=True)
+def test_get_override_skypilot_config_from_client(
+        mock_to_dict, mock_logger, mock_is_logging_enabled_for_level):
     with mock.patch('sky.server.requests.payloads.logger') as mock_logger:
         # Call the function
         result = payloads.get_override_skypilot_config_from_client()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Mini proposal: 

There are times when we want to print a piece of info to a debug log, but that info isn't readily available. In such cases, we need to perform some operations to get this piece of information that is only used to print the debug log.

We don't want to incur the penalty of retrieving / constructing this piece of information if the debug log isn't even going to be printed. This PR introduces a way (and a few examples) to avoid expensive logging in cases where it is not required.

The advantage of introducing this mechanism now is we can be more aggressive on debug logging in the future, without having to worry much about potential penalty it incurs in the case where loglevel is on INFO.

To be clear, I'm not advocating we do this for every debug log - just for ones where this can result in some meaningful performance gain.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
