### PR TITLE
[logging] more concise logging for resource optimization

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -335,9 +335,6 @@ class Optimizer:
                             orig_resources)
 
                 for resources in launchable_list:
-                    if do_print:
-                        logger.debug(f'resources: {resources}')
-
                     if minimize_cost:
                         cost_per_node = resources.get_cost(estimated_runtime)
                         num_available_reserved_nodes = (
@@ -355,13 +352,14 @@ class Optimizer:
                         # Minimize run time.
                         estimated_cost_or_time = estimated_runtime
                     if do_print:
-                        logger.debug(
-                            '  estimated_runtime: {:.0f} s ({:.1f} hr)'.format(
-                                estimated_runtime, estimated_runtime / 3600))
+                        debug_msg = (
+                            f'resources: {resources}, '
+                            f'estimated_runtime: {estimated_runtime} s '
+                            f'({estimated_runtime / 3600:.1f} hr)')
                         if minimize_cost:
-                            logger.debug(
-                                '  estimated_cost (not incl. egress): ${:.1f}'.
-                                format(estimated_cost_or_time))
+                            debug_msg += (', estimated_cost: '
+                                          f'${estimated_cost_or_time:.1f}')
+                        logger.debug(debug_msg)
                     node_to_cost_map[node][resources] = estimated_cost_or_time
             if not node_to_cost_map[node]:
                 source_hint = 'catalog'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Before:
```
D 04-17 16:17:54 optimizer.py:339] resources: Kubernetes(2CPU--2GB)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.0
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: AWS(m6i.2xlarge)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.4
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
D 04-17 16:17:54 optimizer.py:339] resources: Azure(Standard_D8s_v5)
D 04-17 16:17:54 optimizer.py:358]   estimated_runtime: 3600 s (1.0 hr)
D 04-17 16:17:54 optimizer.py:362]   estimated_cost (not incl. egress): $0.5
```

After:
```
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: AWS(m6i.2xlarge), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: Kubernetes(2CPU--2GB), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.0
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.4
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
D 04-17 16:19:41 optimizer.py:360] resources: Azure(Standard_D8s_v5), estimated_runtime: 3600 s (1.0 hr), estimated_cost: $0.5
```
Exact same amount of information, less loglines.


Alternatives to consider:
1. Don't log these at all
2. Consider an even more shorthand syntax like
```
D 04-17 16:19:41 optimizer.py:360] Azure(Standard_D8s_v5) : 3600 s (1.0 hr) : $0.5
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
