### PR TITLE
[UX] GPU alias applies to any_of

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1402,9 +1402,13 @@ class Resources:
 
         Resources._apply_resource_config_aliases(config)
         anyof = config.get('any_of')
-        if anyof is not None:
+        if anyof is not None and isinstance(anyof, list):
             for anyof_config in anyof:
                 Resources._apply_resource_config_aliases(anyof_config)
+        ordered = config.get('ordered')
+        if ordered is not None and isinstance(ordered, list):
+            for ordered_config in ordered:
+                Resources._apply_resource_config_aliases(ordered_config)
         common_utils.validate_schema(config, schemas.get_resources_schema(),
                                      'Invalid resources YAML: ')
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1370,7 +1370,8 @@ class Resources:
         return features
 
     @staticmethod
-    def apply_resource_config_aliases(config: Optional[Dict[str, Any]]) -> None:
+    def _apply_resource_config_aliases(
+            config: Optional[Dict[str, Any]]) -> None:
         """Mutatively applies overriding aliases to the passed in config.
 
         Note: Nested aliases are not supported.
@@ -1399,7 +1400,11 @@ class Resources:
         if config is None:
             return {Resources()}
 
-        Resources.apply_resource_config_aliases(config)
+        Resources._apply_resource_config_aliases(config)
+        anyof = config.get('any_of')
+        if anyof is not None:
+            for anyof_config in anyof:
+                Resources._apply_resource_config_aliases(anyof_config)
         common_utils.validate_schema(config, schemas.get_resources_schema(),
                                      'Invalid resources YAML: ')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Followup to https://github.com/skypilot-org/skypilot/pull/5207
Fixes https://github.com/skypilot-org/skypilot/issues/5194
Closes https://github.com/skypilot-org/skypilot/issues/5236

Allows `gpus` -> `accelerators` alias to also apply on `any_of` fields.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
