### PR TITLE
[k8s] Hints for querying stale kube current context

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -3,8 +3,6 @@ import logging
 import os
 from typing import Any, Callable, Optional, Set
 
-import colorama
-
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
 from sky.utils import annotations
@@ -75,13 +73,12 @@ def _load_config(context: Optional[str] = None):
             context_name = '(current-context)' if context is None else context
             # Check if exception was due to no current-context
             if 'Expected key current-context' in str(e):
-                err_str = (
-                    'Failed to load Kubernetes configuration for '
-                    f'{context_name!r}. '
-                    'Kubeconfig does not contain any valid context(s).'
-                    f'\n{suffix}\n'
-                    '    If you were running a local Kubernetes '
-                    'cluster, run `sky local up` to start the cluster.')
+                err_str = ('Failed to load Kubernetes configuration for '
+                           f'{context_name!r}. '
+                           'Kubeconfig does not contain any valid context(s).'
+                           f'\n{suffix}\n'
+                           '    If you were running a local Kubernetes '
+                           'cluster, run `sky local up` to start the cluster.')
             else:
                 kubeconfig_path = os.environ.get('KUBECONFIG', '~/.kube/config')
                 err_str = (
@@ -91,9 +88,8 @@ def _load_config(context: Optional[str] = None):
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
             if context is None:  # kubernetes defaults to current-context.
                 err_str += (
-                    f'\n{colorama.Fore.YELLOW}Hint: Kubernetes attempted '
-                    'to query the current-context set in kubeconfig. Check if '
-                    f'the current-context is valid.{colorama.Style.RESET_ALL}')
+                    '\nHint: Kubernetes attempted to query the current-context '
+                    'set in kubeconfig. Check if the current-context is valid.')
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(err_str) from None
 

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -72,10 +72,12 @@ def _load_config(context: Optional[str] = None):
             kubernetes.config.load_kube_config(context=context)
         except kubernetes.config.config_exception.ConfigException as e:
             suffix = common_utils.format_exception(e, use_bracket=True)
+            context_name = '(current-context)' if context is None else context
             # Check if exception was due to no current-context
             if 'Expected key current-context' in str(e):
                 err_str = (
-                    f'Failed to load Kubernetes configuration for {context!r}. '
+                    'Failed to load Kubernetes configuration for '
+                    f'{context_name!r}. '
                     'Kubeconfig does not contain any valid context(s).'
                     f'\n{suffix}\n'
                     '    If you were running a local Kubernetes '
@@ -83,9 +85,9 @@ def _load_config(context: Optional[str] = None):
             else:
                 kubeconfig_path = os.environ.get('KUBECONFIG', '~/.kube/config')
                 err_str = (
-                    f'Failed to load Kubernetes configuration for {context!r}. '
-                    'Please check if your kubeconfig file exists at '
-                    f'{kubeconfig_path} and is valid.\n{suffix}')
+                    f'Failed to load Kubernetes configuration for '
+                    f'{context_name!r}. Please check if your kubeconfig file '
+                    f'exists at {kubeconfig_path} and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
             if context is None:  # kubernetes defaults to current-context.
                 err_str += (

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -85,6 +85,11 @@ def _load_config(context: Optional[str] = None):
                     'Please check if your kubeconfig file exists at '
                     f'{kubeconfig_path} and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
+            if context is None: # kubernetes defaults to current-context.
+                err_str += (
+                    '\nHint: Kubernetes attempted to query the '
+                    'current-context set in kubeconfig. Check if '
+                    'the current-context is valid.')
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(err_str) from None
 

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -3,6 +3,8 @@ import logging
 import os
 from typing import Any, Callable, Optional, Set
 
+import colorama
+
 from sky.adaptors import common
 from sky.sky_logging import set_logging_level
 from sky.utils import annotations
@@ -85,11 +87,11 @@ def _load_config(context: Optional[str] = None):
                     'Please check if your kubeconfig file exists at '
                     f'{kubeconfig_path} and is valid.\n{suffix}')
             err_str += '\nTo disable Kubernetes for SkyPilot: run `sky check`.'
-            if context is None: # kubernetes defaults to current-context.
+            if context is None:  # kubernetes defaults to current-context.
                 err_str += (
-                    '\nHint: Kubernetes attempted to query the '
-                    'current-context set in kubeconfig. Check if '
-                    'the current-context is valid.')
+                    f'\n{colorama.Fore.YELLOW}Hint: Kubernetes attempted '
+                    'to query the current-context set in kubeconfig. Check if '
+                    f'the current-context is valid.{colorama.Style.RESET_ALL}')
             with ux_utils.print_exception_no_traceback():
                 raise ValueError(err_str) from None
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #5258 
![Screenshot 2025-04-18 at 10 04 28 AM](https://github.com/user-attachments/assets/ac4d805b-8b2c-46a9-968e-31380c61eb86)



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
