### PR TITLE
[k8s] Better error message for stale jobs controller

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -293,6 +293,11 @@ class ClusterDoesNotExist(ValueError):
     pass
 
 
+class CachedClusterUnavailable(Exception):
+    """Raised wehn a cached cluster record is unavailable."""
+    pass
+
+
 class NotSupportedError(Exception):
     """Raised when a feature is not supported."""
     pass

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -294,7 +294,7 @@ class ClusterDoesNotExist(ValueError):
 
 
 class CachedClusterUnavailable(Exception):
-    """Raised wehn a cached cluster record is unavailable."""
+    """Raised when a cached cluster record is unavailable."""
     pass
 
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -118,7 +118,9 @@ def launch(
                     cluster_name=cluster_name,
                     force_refresh_statuses=set(status_lib.ClusterStatus),
                     acquire_per_cluster_status_lock=False)
-            except Exception as e:  # pylint: disable=broad-except
+            except (exceptions.ClusterOwnerIdentityMismatchError,
+                    exceptions.CloudUserIdentityError,
+                    exceptions.ClusterStatusFetchingError) as e:
                 # we weren't able to refresh the cluster for its status.
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.CachedClusterUnavailable(

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -14,6 +14,7 @@ from sky import backends
 from sky import core
 from sky import exceptions
 from sky import execution
+from sky import global_user_state
 from sky import provision as provision_lib
 from sky import sky_logging
 from sky import task as task_lib
@@ -64,6 +65,8 @@ def launch(
         ValueError: cluster does not exist. Or, the entrypoint is not a valid
             chain dag.
         sky.exceptions.NotSupportedError: the feature is not supported.
+        sky.exceptions.CachedClusterUnavailable: cached jobs controller cluster
+            is unavailable
 
     Returns:
       job_id: Optional[int]; the job ID of the submitted job. None if the
@@ -102,6 +105,30 @@ def launch(
 
     with rich_utils.safe_status(
             ux_utils.spinner_message('Initializing managed job')):
+
+        # Check whether cached jobs controller cluster is accessible
+        cluster_name = (
+            controller_utils.Controllers.JOBS_CONTROLLER.value.cluster_name)
+        record = global_user_state.get_cluster_from_name(cluster_name)
+        if record is not None:
+            # there is a cached jobs controller cluster
+            try:
+                # TODO: do something with returned status?
+                _, _ = backend_utils.refresh_cluster_status_handle(
+                    cluster_name=cluster_name,
+                    force_refresh_statuses=set(status_lib.ClusterStatus),
+                    acquire_per_cluster_status_lock=False)
+            except Exception as e:  # pylint: disable=broad-except
+                # we weren't able to refresh the cluster for its status.
+                with ux_utils.print_exception_no_traceback():
+                    raise exceptions.CachedClusterUnavailable(
+                        f'{colorama.Fore.RED}Cached jobs controller cluster '
+                        f'{cluster_name} cannot be refreshed. Please check if '
+                        'the cluster is accessible. If the cluster was '
+                        'removed, consider removing the cluster from SkyPilot '
+                        f'with:\n\n`sky down {cluster_name} --purge`'
+                        f'{colorama.Style.RESET_ALL}\n\nReason: '
+                        f'{common_utils.format_exception(e)}')
 
         local_to_controller_file_mounts = {}
 
@@ -142,11 +169,11 @@ def launch(
         remote_user_config_path = f'{prefix}/{dag.name}-{dag_uuid}.config_yaml'
         remote_env_file_path = f'{prefix}/{dag.name}-{dag_uuid}.env'
         controller_resources = controller_utils.get_controller_resources(
-            controller=controller_utils.Controllers.JOBS_CONTROLLER,
+            controller=controller,
             task_resources=sum([list(t.resources) for t in dag.tasks], []))
         controller_idle_minutes_to_autostop, controller_down = (
             controller_utils.get_controller_autostop_config(
-                controller=controller_utils.Controllers.JOBS_CONTROLLER))
+                controller=controller))
 
         vars_to_fill = {
             'remote_user_yaml_path': remote_user_yaml_path,
@@ -162,7 +189,7 @@ def launch(
             'dashboard_setup_cmd': managed_job_constants.DASHBOARD_SETUP_CMD,
             'dashboard_user_id': common.SERVER_ID,
             **controller_utils.shared_controller_vars_to_fill(
-                controller_utils.Controllers.JOBS_CONTROLLER,
+                controller,
                 remote_user_config_path=remote_user_config_path,
                 local_user_config=mutated_user_config,
             ),

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -124,13 +124,12 @@ def launch(
                 # we weren't able to refresh the cluster for its status.
                 with ux_utils.print_exception_no_traceback():
                     raise exceptions.CachedClusterUnavailable(
-                        f'{colorama.Fore.RED}Cached jobs controller cluster '
+                        f'Cached jobs controller cluster '
                         f'{cluster_name} cannot be refreshed. Please check if '
                         'the cluster is accessible. If the cluster was '
                         'removed, consider removing the cluster from SkyPilot '
-                        f'with:\n\n`sky down {cluster_name} --purge`'
-                        f'{colorama.Style.RESET_ALL}\n\nReason: '
-                        f'{common_utils.format_exception(e)}')
+                        f'with:\n\n`sky down {cluster_name} --purge`\n\n'
+                        f'Reason: {common_utils.format_exception(e)}')
 
         local_to_controller_file_mounts = {}
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -22,7 +22,6 @@ from sky.provision import docker_utils
 from sky.serve import service_spec
 from sky.skylet import constants
 from sky.utils import common_utils
-from sky.utils import controller_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
 
@@ -324,23 +323,7 @@ class Task:
         if not workdir_only:
             self.expand_and_validate_file_mounts()
         for r in self.resources:
-            try:
-                r.validate()
-            except ValueError as e:
-                if self.managed_job_dag is not None:
-                    # this task is a jobs controller
-                    cluster_name = (controller_utils.Controllers.
-                                    JOBS_CONTROLLER.value.cluster_name)
-                    logger.warning(
-                        f'{colorama.Fore.YELLOW}Failed to validate jobs '
-                        f'controller resource {r.repr_with_region_zone}.'
-                        '\nIf the cluster exists, please check and allow '
-                        'SkyPilot to connect. If this was a '
-                        'previously launched cluster that was '
-                        'taken down or removed, consider removing the '
-                        'cluster from SkyPilot with:\n\n`sky down '
-                        f'{cluster_name} --purge`{colorama.Style.RESET_ALL}')
-                raise e
+            r.validate()
 
     def validate_name(self):
         """Validates if the task name is valid."""

--- a/sky/task.py
+++ b/sky/task.py
@@ -22,6 +22,7 @@ from sky.provision import docker_utils
 from sky.serve import service_spec
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import controller_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
 
@@ -328,14 +329,17 @@ class Task:
             except ValueError as e:
                 if self.managed_job_dag is not None:
                     # this task is a jobs controller
-                    logger.warning(f'{colorama.Fore.YELLOW}Failed to validate '
-                                   f'jobs controller resource {r}. If '
-                                   'the cluster exists, please check if '
-                                   'SkyPilot can connect. If this was a '
-                                   'previously launched cluster that was '
-                                   'taken down, consider removing it with '
-                                   '`sky down --purge`.'
-                                   f'{colorama.Style.RESET_ALL}')
+                    cluster_name = controller_utils.Controllers.\
+                        JOBS_CONTROLLER.value.cluster_name
+                    logger.warning(
+                        f'{colorama.Fore.YELLOW}Failed to validate jobs '
+                        f'controller resource {r.repr_with_region_zone}.'
+                        '\nIf the cluster exists, please check and allow '
+                        'SkyPilot to connect. If this was a '
+                        'previously launched cluster that was '
+                        'taken down or removed, consider removing the '
+                        'cluster from SkyPilot with:\n\n`sky down '
+                        f'{cluster_name} --purge`{colorama.Style.RESET_ALL}')
                 raise e
 
     def validate_name(self):

--- a/sky/task.py
+++ b/sky/task.py
@@ -323,7 +323,20 @@ class Task:
         if not workdir_only:
             self.expand_and_validate_file_mounts()
         for r in self.resources:
-            r.validate()
+            try:
+                r.validate()
+            except ValueError as e:
+                if self.managed_job_dag is not None:
+                    # this task is a jobs controller
+                    logger.warning(f'{colorama.Fore.YELLOW}Failed to validate '
+                                   f'jobs controller resource {r}. If '
+                                   'the cluster exists, please check if '
+                                   'SkyPilot can connect. If this was a '
+                                   'previously launched cluster that was '
+                                   'taken down, consider removing it with '
+                                   '`sky down --purge`.'
+                                   f'{colorama.Style.RESET_ALL}')
+                raise e
 
     def validate_name(self):
         """Validates if the task name is valid."""

--- a/sky/task.py
+++ b/sky/task.py
@@ -329,8 +329,8 @@ class Task:
             except ValueError as e:
                 if self.managed_job_dag is not None:
                     # this task is a jobs controller
-                    cluster_name = controller_utils.Controllers.\
-                        JOBS_CONTROLLER.value.cluster_name
+                    cluster_name = (controller_utils.Controllers.
+                                    JOBS_CONTROLLER.value.cluster_name)
                     logger.warning(
                         f'{colorama.Fore.YELLOW}Failed to validate jobs '
                         f'controller resource {r.repr_with_region_zone}.'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #4268 

~~Noticed that `task.py` is the only place that actually validates resources AND we can know for sure that the task in question is indeed a jobs controller.~~

Got feedback and changed to updating and checking cluster status on jobs.launch

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
