### PR TITLE
Slack notification when nightly build fail

### DIFF
--- a/.github/workflows/pypi-nightly-build.yml
+++ b/.github/workflows/pypi-nightly-build.yml
@@ -123,12 +123,15 @@ jobs:
         id: message_content
         run: |
           TITLE_TEXT="Workflow ${{ github.workflow }} failed."
+          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
+          SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
           if [[ "${{ needs.wait-for-buildkite.result }}" == "failure" ]]; then
-            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed at Buildkite step. <https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.extract-build-number.outputs.build_number }}|Buildkite Log>"
+            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed at Buildkite step for commit <${COMMIT_URL}|${SHORT_SHA}>. <https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.extract-build-number.outputs.build_number }}|Buildkite Log>"
             echo "message_text=${TITLE_TEXT}" >> $GITHUB_OUTPUT
             echo "message_block=${MARKDOWN_TEXT}" >> $GITHUB_OUTPUT
           else
-            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed."
+            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed for commit <${COMMIT_URL}|${SHORT_SHA}>."
             echo "message_text=${TITLE_TEXT}" >> $GITHUB_OUTPUT
             echo "message_block=${MARKDOWN_TEXT}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Send slack notification when nightly build fail

<img width="397" alt="image" src="https://github.com/user-attachments/assets/48487a0a-b273-49fe-8d2a-bdccd326eefa" />

<img width="592" alt="image" src="https://github.com/user-attachments/assets/23659f8b-a50f-40bd-9fcc-2ef026bf4d92" />

Need to configure `SLACK_BOT_TOKEN` and `SLACK_CHANNEL_ID` on github secrets

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
