### PR TITLE
[R2] make R2 use CRC32 as checksum

### DIFF
--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3481,6 +3481,7 @@ class R2Store(AbstractStore):
                 f'--endpoint {endpoint_url} '
                 # R2 does not support CRC64-NVME
                 # which is the default for aws s3 sync
+                # https://community.cloudflare.com/t/an-error-occurred-internalerror-when-calling-the-putobject-operation/764905/13
                 f'--checksum-algorithm CRC32 '
                 f'--profile={cloudflare.R2_PROFILE_NAME}')
             return sync_command
@@ -3504,6 +3505,7 @@ class R2Store(AbstractStore):
                 f'--endpoint {endpoint_url} '
                 # R2 does not support CRC64-NVME
                 # which is the default for aws s3 sync
+                # https://community.cloudflare.com/t/an-error-occurred-internalerror-when-calling-the-putobject-operation/764905/13
                 f'--checksum-algorithm CRC32 '
                 f'--profile={cloudflare.R2_PROFILE_NAME}')
             return sync_command

--- a/sky/data/storage.py
+++ b/sky/data/storage.py
@@ -3472,13 +3472,17 @@ class R2Store(AbstractStore):
             ])
             endpoint_url = cloudflare.create_endpoint()
             base_dir_path = shlex.quote(base_dir_path)
-            sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
-                            f'{cloudflare.R2_CREDENTIALS_PATH} '
-                            'aws s3 sync --no-follow-symlinks --exclude="*" '
-                            f'{includes} {base_dir_path} '
-                            f's3://{self.name}{sub_path} '
-                            f'--endpoint {endpoint_url} '
-                            f'--profile={cloudflare.R2_PROFILE_NAME}')
+            sync_command = (
+                'AWS_SHARED_CREDENTIALS_FILE='
+                f'{cloudflare.R2_CREDENTIALS_PATH} '
+                'aws s3 sync --no-follow-symlinks --exclude="*" '
+                f'{includes} {base_dir_path} '
+                f's3://{self.name}{sub_path} '
+                f'--endpoint {endpoint_url} '
+                # R2 does not support CRC64-NVME
+                # which is the default for aws s3 sync
+                f'--checksum-algorithm CRC32 '
+                f'--profile={cloudflare.R2_PROFILE_NAME}')
             return sync_command
 
         def get_dir_sync_command(src_dir_path, dest_dir_name):
@@ -3491,13 +3495,17 @@ class R2Store(AbstractStore):
             ])
             endpoint_url = cloudflare.create_endpoint()
             src_dir_path = shlex.quote(src_dir_path)
-            sync_command = ('AWS_SHARED_CREDENTIALS_FILE='
-                            f'{cloudflare.R2_CREDENTIALS_PATH} '
-                            f'aws s3 sync --no-follow-symlinks {excludes} '
-                            f'{src_dir_path} '
-                            f's3://{self.name}{sub_path}/{dest_dir_name} '
-                            f'--endpoint {endpoint_url} '
-                            f'--profile={cloudflare.R2_PROFILE_NAME}')
+            sync_command = (
+                'AWS_SHARED_CREDENTIALS_FILE='
+                f'{cloudflare.R2_CREDENTIALS_PATH} '
+                f'aws s3 sync --no-follow-symlinks {excludes} '
+                f'{src_dir_path} '
+                f's3://{self.name}{sub_path}/{dest_dir_name} '
+                f'--endpoint {endpoint_url} '
+                # R2 does not support CRC64-NVME
+                # which is the default for aws s3 sync
+                f'--checksum-algorithm CRC32 '
+                f'--profile={cloudflare.R2_PROFILE_NAME}')
             return sync_command
 
         # Generate message for upload


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://community.cloudflare.com/t/an-error-occurred-internalerror-when-calling-the-putobject-operation/764905/13

> Hi folks. R2 added CRC32 support. The AWS CLI changed recently and defaulted their client to send CRC64-NVME which we do not support. Most if not all official SDKs default to CRC32. The workaround when using the cli tool is to add --checksum-algorithm CRC32.
> 
> Apologies for any inconvenience, we will be sure to improve the response messages you get back when using the CLI to make this more apparent.
> 
> Support for CRC32C and CRC64NVME will be added shortly.

Such is life.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
