### PR TITLE
Fix smoke test failures when using `--remote-server`

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -369,7 +369,7 @@ def run_one_test(test: Test) -> None:
         env_dict.update(test.env)
 
     # Create a temporary config file with API server config only if running with remote server
-    if 'PYTEST_SKYPILOT_REMOTE_SERVER_TEST' in os.environ:
+    if is_remote_server_test():
         temp_config = tempfile.NamedTemporaryFile(mode='w',
                                                   suffix='.yaml',
                                                   delete=False)
@@ -649,9 +649,13 @@ def increase_initial_delay_seconds_for_slow_cloud(cloud: str):
             os.unlink(file)
 
 
+def is_remote_server_test() -> bool:
+    return 'PYTEST_SKYPILOT_REMOTE_SERVER_TEST' in os.environ
+
+
 def get_api_server_url() -> str:
     """Get the API server URL in the test environment."""
-    if 'PYTEST_SKYPILOT_REMOTE_SERVER_TEST' in os.environ:
+    if is_remote_server_test():
         return docker_utils.get_api_server_endpoint_inside_docker()
     return server_common.get_server_url()
 

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -443,10 +443,13 @@ def test_multi_echo(generic_cloud: str):
                 job_id=i + 1,
                 job_status=[sky.JobStatus.SUCCEEDED],
                 timeout=120) for i in range(32)
-        ] +
-        # Ensure monitor/autoscaler didn't crash on the 'assert not
-        # unfulfilled' error.  If process not found, grep->ssh returns 1.
-        [f'ssh {name} \'ps aux | grep "[/]"monitor.py\''],
+        ] + [
+            # ssh record will only be created on cli command like sky status on client side.
+            f'sky status',
+            # Ensure monitor/autoscaler didn't crash on the 'assert not
+            # unfulfilled' error.  If process not found, grep->ssh returns 1.
+            f'ssh {name} \'ps aux | grep "[/]"monitor.py\''
+        ],
         f'sky down -y {name}',
         timeout=20 * 60,
     )

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -445,7 +445,7 @@ def test_multi_echo(generic_cloud: str):
                 timeout=120) for i in range(32)
         ] + [
             # ssh record will only be created on cli command like sky status on client side.
-            f'sky status',
+            f'sky status {name}',
             # Ensure monitor/autoscaler didn't crash on the 'assert not
             # unfulfilled' error.  If process not found, grep->ssh returns 1.
             f'ssh {name} \'ps aux | grep "[/]"monitor.py\''

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -64,7 +64,7 @@ def test_aws_with_ssh_proxy_command():
         f.write(
             textwrap.dedent(f"""\
             api_server:
-                endpoint: {sky.server.common.get_server_url()}
+                endpoint: {smoke_tests_utils.get_api_server_url()}
             """))
         f.flush()
         test = smoke_tests_utils.Test(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #5270

Reason:

## test_aws_with_ssh_proxy_command

The issue is with the `test_aws_with_ssh_proxy_command` test itself. It [overrides](https://github.com/skypilot-org/skypilot/blob/master/tests/smoke_tests/test_region_and_zone.py#L67) the server endpoint in the middle of the test, even though we configured `--remote-server` to a different endpoint before running the test.

## test_multi_echo

For `test_multi_echo`, I'm not sure if it's a bug.

The issue is: if the client and server are different, and we launch the sky cluster via the SDK (not CLI), we call [add_cluster](https://github.com/skypilot-org/skypilot/blob/master/sky/utils/cluster_utils.py#L111) on the server side during provisioning.

However, the SSH record isn’t added then, causing the test to fail.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test --aws -k test_multi_echo --remote-server`
- [x] All smoke tests: `/smoke-test -k test_aws_with_ssh_proxy_command --aws --remote-server`
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
