### PR TITLE
Refine API server deployment doc

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -237,7 +237,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
             kubernetes:
               allowed_contexts:
-              # The hosting Kubernetes cluster, you cannot set if the hosting is disabled by kubernetesCredentials.useApiServerCluster=false
+              # The hosting Kubernetes cluster, you cannot set this if the hosting cluster is disabled by kubernetesCredentials.useApiServerCluster=false
               - in-cluster
               # The additional Kubernetes context names in the kubeconfig you configured
               - context1

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -58,6 +58,7 @@ Install the SkyPilot Helm chart with the following command:
     # The following variables will be used throughout the guide
     RELEASE_NAME=skypilot
     WEB_USERNAME=skypilot
+    # Replace with your password to configure the password for the API server
     WEB_PASSWORD=yourpassword
     AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
@@ -72,10 +73,6 @@ To install a specific version, pass the ``--version`` flag to the ``helm upgrade
 .. tip::
 
     The API server deployed will be configured to use the hosting Kubernetes cluster to launch tasks by default. Refer to :ref:`sky-api-server-configure-credentials` to configure credentials for more clouds and Kubernetes clusters.
-
-.. tip::
-
-    You can configure the password for the API server with the ``WEB_PASSWORD`` variable.
 
 .. dropdown:: Use existing basic auth credentials
 
@@ -184,7 +181,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
 .. note::
 
-   If you don't have SkyPillot API server deployed yet, please refer to :ref:`step 2...`, for the additional values you might want to set during the helm deployment below.
+   If you don't have SkyPilot API server deployed yet, please refer to :ref:`sky-api-server-helm-deploy-command`, for the additional values you might want to set during the helm deployment below.
 
     When you configure credentials after the API server is deployed, an API server restart will be automatically triggered to apply the new credentials. Refer to :ref:`sky-api-server-upgrade` for more details about the potential downtime and mitigation.
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -22,7 +22,7 @@ Prerequisites
 
     You can also deploy the API server on cloud VMs using an existing SkyPilot installation. See :ref:`sky-api-server-cloud-deploy`.
 
-Step 1: Prepare the environment
+Step 1: Create a namespace and add Helm repository
 --------------------------------------------------
 
 The API server will be deployed in a namespace of your choice. You can either create the namespace manually:

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -278,6 +278,7 @@ Following tabs describe how to configure credentials for different clouds on the
             You can also set the following values to use a secret that already contains your AWS credentials:
 
             .. code-block::bash
+
                 # TODO: replace with your secret name and keys in the secret
                 helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
                     --namespace $NAMESPACE \
@@ -316,6 +317,7 @@ Following tabs describe how to configure credentials for different clouds on the
             You can also set the following values to use a secret that already contains your GCP credentials:
 
             .. code-block::bash
+
                 # TODO: replace with your secret name
                 helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
                     --namespace $NAMESPACE \
@@ -446,6 +448,8 @@ To set the config file, pass ``--set-file apiService.config=path/to/your/config.
 
     # Install the API server with the config file
     helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+      # Reuse the values set in the previous steps, if any
+      --reuse-values \
       --set-file apiService.config=config.yaml
 
 You can also directly set config values in the ``values.yaml`` file.

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -22,17 +22,18 @@ Prerequisites
 
     You can also deploy the API server on cloud VMs using an existing SkyPilot installation. See :ref:`sky-api-server-cloud-deploy`.
 
-Step 1: Create a namespace and add Helm repository
+Step 1: Prepare the environment
 --------------------------------------------------
 
 The API server will be deployed in a namespace of your choice. You can either create the namespace manually:
 
 .. code-block:: bash
 
+    # The NAMESPACE variable will be used throughout the guide
     NAMESPACE=skypilot
     kubectl create namespace $NAMESPACE
 
-Or let Helm create it automatically by adding the ``--create-namespace`` flag to the helm install command in Step 3.
+Or let Helm create it automatically by adding the ``--create-namespace`` flag to the helm install command in Step 2.
 
 Next, add the SkyPilot Helm repository:
 
@@ -41,125 +42,9 @@ Next, add the SkyPilot Helm repository:
     helm repo add skypilot https://helm.skypilot.co
     helm repo update
 
-Step 2: Configure cloud accounts
---------------------------------
+.. _sky-api-server-helm-deploy-command:
 
-Following tabs describe how to configure credentials for different clouds on the API server. All cloud credentials are stored in Kubernetes secrets.
-
-
-.. tab-set::
-
-    .. tab-item:: Kubernetes
-        :sync: kubernetes-creds-tab
-
-        By default, SkyPilot API server is granted permissions to use its hosting Kubernetes cluster:
-
-        * To disable this behavior, set ``kubernetesCredentials.useApiServerCluster=false`` in the Helm chart values.
-        * When running in the same cluster, tasks are launched in the same namespace as the API server. To use a different namespace for tasks, set ``kubernetesCredentials.inclusterNamespace=<namespace>`` when deploying the API server.
-
-        .. tip::
-
-            The default permissions granted to the API server works out of box. For further hardening, you can refer to :ref:`Setting minimum permissions in helm deployment <minimum-permissions-in-helm>` to understand the permissions and how to customize them.
-
-        To use a kubeconfig file to authenticate to other clusters, first create a Kubernetes secret with the kubeconfig file with :ref:`necessary permissions <cloud-permissions-kubernetes>`:
-
-        .. code-block:: bash
-
-            NAMESPACE=skypilot
-            kubectl create secret generic kube-credentials \
-              --namespace $NAMESPACE \
-              --from-file=config=~/.kube/config
-
-
-        Once the secret is created, set ``kubernetesCredentials.useKubeconfig=true`` and ``kubernetesCredentials.kubeconfigSecretName`` in the Helm chart values to use the kubeconfig file for authentication:
-
-        .. code-block:: bash
-
-            helm --install skypilot skypilot/skypilot-nightly --devel \
-              --namespace $NAMESPACE \
-              --set kubernetesCredentials.useKubeconfig=true \
-              --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
-
-        .. tip::
-
-            If you are using a kubeconfig file that contains `exec-based authentication <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration>`_ (e.g., GKE's default ``gke-gcloud-auth-plugin`` based authentication), you will need to strip the path information from the ``command`` field in the exec configuration.
-            You can use the ``exec_kubeconfig_converter.py`` script to do this.
-
-            .. code-block:: bash
-
-                python -m sky.utils.kubernetes.exec_kubeconfig_converter --input ~/.kube/config --output ~/.kube/config.converted
-
-            Then create the Kubernetes secret with the converted kubeconfig file ``~/.kube/config.converted``.
-
-        .. tip::
-
-            To use multiple Kubernetes clusters from the config file, you will need to add the context names to ``allowed_contexts`` in the SkyPilot config file. See :ref:`sky-api-server-config` on how to set the config file.
-
-            You can also set both ``kubernetesCredentials.useKubeconfig=true`` and ``kubernetesCredentials.useApiServerCluster=true`` at the same time to configure the API server to use an external Kubernetes cluster in addition to the API server's own cluster.
-
-    .. tab-item:: AWS
-        :sync: aws-creds-tab
-
-        Make sure you have the access key id and secret access key.
-
-        Create a Kubernetes secret with your AWS credentials:
-
-        .. code-block:: bash
-
-            NAMESPACE=skypilot
-            kubectl create secret generic aws-credentials \
-              --namespace $NAMESPACE \
-              --from-literal=aws_access_key_id=YOUR_ACCESS_KEY_ID \
-              --from-literal=aws_secret_access_key=YOUR_SECRET_ACCESS_KEY
-
-        Replace ``YOUR_ACCESS_KEY_ID`` and ``YOUR_SECRET_ACCESS_KEY`` with your actual AWS credentials.
-
-        When installing or upgrading the Helm chart, enable AWS credentials by setting ``awsCredentials.enabled=true``.
-
-        .. code-block:: bash
-
-            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
-                --namespace $NAMESPACE \
-                --set awsCredentials.enabled=true \
-                --set awsCredentials.awsSecretName=aws-credentials
-
-    .. tab-item:: GCP
-        :sync: gcp-creds-tab
-
-        We use service accounts to authenticate with GCP. Refer to :ref:`GCP service account <gcp-service-account>` guide on how to set up a service account.
-
-        Once you have the JSON key for your service account, create a Kubernetes secret to store it:
-
-        .. code-block:: bash
-
-            NAMESPACE=skypilot
-            kubectl create secret generic gcp-credentials \
-              --namespace $NAMESPACE \
-              --from-file=gcp-cred.json=YOUR_SERVICE_ACCOUNT_JSON_KEY.json
-
-        When installing or upgrading the Helm chart, enable GCP credentials by setting ``gcpCredentials.enabled=true`` and ``gcpCredentials.projectId`` to your project ID:
-
-        .. code-block:: bash
-
-            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
-              --namespace $NAMESPACE
-              --set gcpCredentials.enabled=true \
-              --set gcpCredentials.projectId=YOUR_PROJECT_ID \
-              --set gcpCredentials.gcpSecretName=gcp-credentials
-
-        Replace ``YOUR_PROJECT_ID`` with your actual GCP project ID.
-
-    .. tab-item:: Other clouds
-        :sync: other-clouds-tab
-
-        You can manually configure the credentials for other clouds by `kubectl exec` into the API server pod after it is deployed and running the relevant :ref:`installation commands<installation>`.
-
-        Note that manually configured credentials will not be persisted across API server restarts.
-
-        Support for configuring other clouds through secrets is coming soon!
-
-
-Step 3: Deploy the API server Helm chart
+Step 2: Deploy the API server Helm chart
 ----------------------------------------
 
 Install the SkyPilot Helm chart with the following command:
@@ -171,7 +56,6 @@ Install the SkyPilot Helm chart with the following command:
 .. code-block:: bash
 
     # The following variables will be used throughout the guide
-    NAMESPACE=skypilot
     RELEASE_NAME=skypilot
     WEB_USERNAME=skypilot
     WEB_PASSWORD=yourpassword
@@ -185,13 +69,15 @@ The ``--namespace`` flag specifies which namespace to deploy the API server in, 
 
 To install a specific version, pass the ``--version`` flag to the ``helm upgrade`` command (e.g., ``--version 0.1.0``).
 
-If you configured any cloud credentials in the previous step, make sure to enable them by adding the relevant flags (e.g., ``--set awsCredentials.enabled=true``) to the command.
+.. tip::
+
+    The API server deployed will be configured to use the hosting Kubernetes cluster to launch tasks by default. Refer to :ref:`sky-api-server-configure-credentials` to configure credentials for different clouds.
 
 .. tip::
 
     You can configure the password for the API server with the ``WEB_PASSWORD`` variable.
 
-.. tip::
+.. dropdown:: Use existing basic auth credentials
 
     If you already have a Kubernetes secret containing basic auth credentials, you can use it directly by setting ``ingress.authSecret`` instead of ``ingress.authCredentials``:
 
@@ -208,13 +94,13 @@ After the API server is deployed, you can inspect the API server pod status with
 
 .. code-block:: bash
 
-    kubectl get pods -n $NAMESPACE -l app=${RELEASE_NAME}-api --watch
+    kubectl get pods --namespace $NAMESPACE -l app=${RELEASE_NAME}-api --watch
 
 You should see the pod is initializing and finally becomes running and ready. If not, refer to :ref:`sky-api-server-troubleshooting-helm` to diagnose the issue.
 
 .. _sky-get-api-server-url:
 
-Step 4: Get the API server URL
+Step 3: Get the API server URL
 ------------------------------
 
 Once the API server is deployed, we can fetch the API server URL. We use nginx ingress to expose the API server.
@@ -230,7 +116,7 @@ Our default of using a NodePort service is the recommended way to expose the API
 
         .. code-block:: console
 
-            $ HOST=$(kubectl get svc ${RELEASE_NAME}-ingress-nginx-controller -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+            $ HOST=$(kubectl get svc ${RELEASE_NAME}-ingress-nginx-controller --namespace $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
             $ ENDPOINT=http://${WEB_USERNAME}:${WEB_PASSWORD}@${HOST}
             $ echo $ENDPOINT
             http://skypilot:yourpassword@1.1.1.1
@@ -253,7 +139,7 @@ Our default of using a NodePort service is the recommended way to expose the API
 
         .. code-block:: bash
 
-            $ helm upgrade -n $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel \
+            $ helm upgrade --namespace $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel \
               --set ingress-nginx.controller.service.type=NodePort \
               --set ingress-nginx.controller.service.nodePorts.http=30050 \
               --set ingress-nginx.controller.service.nodePorts.https=30051
@@ -262,7 +148,7 @@ Our default of using a NodePort service is the recommended way to expose the API
 
         .. code-block:: console
 
-            $ NODE_PORT=$(kubectl get svc ${RELEASE_NAME}-ingress-controller-np -n $NAMESPACE -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+            $ NODE_PORT=$(kubectl get svc ${RELEASE_NAME}-ingress-controller-np --namespace $NAMESPACE -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
             $ NODE_IP=$(kubectl get nodes -o jsonpath='{ $.items[0].status.addresses[?(@.type=="ExternalIP")].address }')
             $ ENDPOINT=http://${WEB_USERNAME}:${WEB_PASSWORD}@${NODE_IP}:${NODE_PORT}
             $ echo $ENDPOINT
@@ -277,7 +163,7 @@ Our default of using a NodePort service is the recommended way to expose the API
             To avoid frequent IP address changes on nodes by your cloud provider, you can attach a static IP address to your nodes (`instructions for GKE <https://cloud.google.com/compute/docs/ip-addresses/configure-static-external-ip-address>`_) and use it as the ``NODE_IP`` in the command above.
 
 
-Step 5: Test the API server
+Step 4: Test the API server
 ---------------------------
 
 Test the API server by curling the health endpoint:
@@ -289,10 +175,165 @@ Test the API server by curling the health endpoint:
 
 If all looks good, you can now start using the API server. Refer to :ref:`sky-api-server-connect` to connect your local SkyPilot client to the API server.
 
-Updating the API server
+.. _sky-api-server-configure-credentials:
+
+Optional: Configure cloud accounts
+----------------------------------
+
+Following tabs describe how to configure credentials for different clouds on the API server. All cloud credentials are stored in Kubernetes secrets.
+
+.. note::
+
+    You can either configure credentials before or after the first deployment in :ref:`Step 2 <sky-api-server-helm-deploy-command>`. If you configure credentials after the first deployment, an API server restart will be automatically triggered to apply the new credentials. Refer to :ref:`sky-api-server-upgrade` for more details about the potential downtime and mitigation.
+
+.. tab-set::
+
+    .. tab-item:: Kubernetes
+        :sync: kubernetes-creds-tab
+
+        By default, SkyPilot API server is granted permissions to use its hosting Kubernetes cluster and will launch tasks in the same namespace as the API server:
+
+        * To disable using the hosting Kubernetes cluster, set ``kubernetesCredentials.useApiServerCluster=false`` in the Helm chart values.
+        * To use a different namespace for tasks, set ``kubernetesCredentials.inclusterNamespace=<namespace>`` in the Helm chart values.
+
+        .. tip::
+
+            The default permissions granted to the API server works out of box. For further hardening, you can refer to :ref:`Setting minimum permissions in helm deployment <minimum-permissions-in-helm>` to understand the permissions and how to customize them.
+
+       To authenticate to other clusters, first create a Kubernetes secret with the kubeconfig file with :ref:`necessary permissions <cloud-permissions-kubernetes>`:
+
+        .. code-block:: bash
+
+            kubectl create secret generic kube-credentials \
+              --namespace $NAMESPACE \
+              --from-file=config=~/.kube/config
+
+
+        Once the secret is created, set ``kubernetesCredentials.useKubeconfig=true`` and ``kubernetesCredentials.kubeconfigSecretName`` in the Helm chart values to use the kubeconfig for authentication:
+
+        .. code-block:: bash
+
+            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+              --namespace $NAMESPACE \
+              # keep the Helm chart values set in the previous step
+              --reuse-values \
+              --set kubernetesCredentials.useKubeconfig=true \
+              --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
+
+        .. tip::
+
+            If you are using a kubeconfig file that contains `exec-based authentication <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration>`_ (e.g., GKE's default ``gke-gcloud-auth-plugin`` based authentication), you will need to strip the path information from the ``command`` field in the exec configuration.
+            You can use the ``exec_kubeconfig_converter.py`` script to do this.
+
+            .. code-block:: bash
+
+                python -m sky.utils.kubernetes.exec_kubeconfig_converter --input ~/.kube/config --output ~/.kube/config.converted
+
+            Then create the Kubernetes secret with the converted kubeconfig file ``~/.kube/config.converted``.
+
+        To use multiple Kubernetes clusters, you will need to add the context names to ``allowed_contexts`` in the SkyPilot config. An example config file that allows using the hosting Kubernetes cluster and two additional Kubernetes clusters is shown below:
+
+        .. code-block:: yaml
+
+            kubernetes:
+              allowed_contexts:
+              # The hosting Kubernetes cluster, you cannot set if the hosting is disabled by kubernetesCredentials.useApiServerCluster=false
+              - in-cluster
+              # The additional Kubernetes context names in the kubeconfig you configured
+              - context1
+              - context2
+
+        Refer to :ref:`sky-api-server-config` for how to set the SkyPilot config in Helm chart values.
+
+    .. tab-item:: AWS
+        :sync: aws-creds-tab
+
+        Make sure you have the access key id and secret access key.
+
+        Create a Kubernetes secret with your AWS credentials:
+
+        .. code-block:: bash
+
+            kubectl create secret generic aws-credentials \
+              --namespace $NAMESPACE \
+              --from-literal=aws_access_key_id=YOUR_ACCESS_KEY_ID \
+              --from-literal=aws_secret_access_key=YOUR_SECRET_ACCESS_KEY
+
+        Replace ``YOUR_ACCESS_KEY_ID`` and ``YOUR_SECRET_ACCESS_KEY`` with your actual AWS credentials.
+
+        Enable AWS credentials by setting ``awsCredentials.enabled=true`` and ``awsCredentials.awsSecretName=aws-credentials`` in the Helm values file.
+
+        .. code-block:: bash
+
+            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+                --namespace $NAMESPACE \
+                # keep the Helm chart values set in the previous step
+                --reuse-values \
+                --set awsCredentials.enabled=true
+
+        .. dropdown:: Use existing AWS credentials
+
+            You can also set the following values to use a secret that already contains your AWS credentials:
+
+            .. code-block::bash
+                # TODO: replace with your secret name and keys in the secret
+                helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+                    --namespace $NAMESPACE \
+                    --reuse-values \
+                    --set awsCredentials.enabled=true \
+                    --set awsCredentials.awsSecretName=your_secret_name \
+                    --set awsCredentials.accessKeyIdKeyName=aws_access_key_id \
+                    --set awsCredentials.secretAccessKeyKeyName=aws_secret_access_key
+
+    .. tab-item:: GCP
+        :sync: gcp-creds-tab
+
+        We use service accounts to authenticate with GCP. Refer to :ref:`GCP service account <gcp-service-account>` guide on how to set up a service account.
+
+        Once you have the JSON key for your service account, create a Kubernetes secret to store it:
+
+        .. code-block:: bash
+
+            kubectl create secret generic gcp-credentials \
+              --namespace $NAMESPACE \
+              --from-file=gcp-cred.json=YOUR_SERVICE_ACCOUNT_JSON_KEY.json
+
+        When installing or upgrading the Helm chart, enable GCP credentials by setting ``gcpCredentials.enabled=true`` and ``gcpCredentials.projectId`` to your project ID:
+
+        .. code-block:: bash
+
+            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+              --namespace $NAMESPACE \
+              # keep the Helm chart values set in the previous step
+              --reuse-values \
+              --set gcpCredentials.enabled=true \
+              --set gcpCredentials.projectId=YOUR_PROJECT_ID
+
+        .. dropdown:: Use existing GCP credentials
+
+            You can also set the following values to use a secret that already contains your GCP credentials:
+
+            .. code-block::bash
+                # TODO: replace with your secret name
+                helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+                    --namespace $NAMESPACE \
+                    --reuse-values \
+                    --set gcpCredentials.enabled=true \
+                    --set gcpCredentials.gcpSecretName=your_secret_name
+
+    .. tab-item:: Other clouds
+        :sync: other-clouds-tab
+
+        You can manually configure the credentials for other clouds by `kubectl exec` into the API server pod after it is deployed and running the relevant :ref:`installation commands<installation>`.
+
+        Note that manually configured credentials will not be persisted across API server restarts.
+
+        Support for configuring other clouds through secrets is coming soon!
+
+Upgrade the API server
 -----------------------
 
-To update the API server, update your repositories with ``helm repo update`` and run the same ``helm upgrade`` command as in the installation step.
+Refer to :ref:`sky-api-server-upgrade` for how to upgrade the API server.
 
 Uninstall
 ---------
@@ -301,7 +342,7 @@ To uninstall the API server, run:
 
 .. code-block:: bash
 
-    helm uninstall skypilot -n skypilot
+    helm uninstall $RELEASE_NAME --namespace $NAMESPACE
 
 This will delete the API server and all associated resources.
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -184,7 +184,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
 .. note::
 
-    You can either configure credentials before or after the first deployment in :ref:`Step 2 <sky-api-server-helm-deploy-command>`. If you configure credentials after the first deployment, an API server restart will be automatically triggered to apply the new credentials. Refer to :ref:`sky-api-server-upgrade` for more details about the potential downtime and mitigation.
+    When you configure credentials after the API server is deployed, an API server restart will be automatically triggered to apply the new credentials. Refer to :ref:`sky-api-server-upgrade` for more details about the potential downtime and mitigation.
 
 .. tab-set::
 
@@ -200,7 +200,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
             The default permissions granted to the API server works out of box. For further hardening, you can refer to :ref:`Setting minimum permissions in helm deployment <minimum-permissions-in-helm>` to understand the permissions and how to customize them.
 
-       To authenticate to other clusters, first create a Kubernetes secret with the kubeconfig file with :ref:`necessary permissions <cloud-permissions-kubernetes>`:
+        To authenticate to other clusters, first create a Kubernetes secret with the kubeconfig file with :ref:`necessary permissions <cloud-permissions-kubernetes>`:
 
         .. code-block:: bash
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Refine API server deployment guide:

- Most notablely, move configuring cloud credentials to an optional (advanced) step because we've seen some of our users got misled in this complex chapter. The new structure guide users to deploy a usable API server as quickly as possible and then incrementally add various cloud permissions;
- Unify some terms and flags used;
- More details about multi-kubernetes setup;
- Use dropdown to elaborate referencing existing secrets (which is an advanced use case) to save some vertical space;

I think this can help avoiding some onboarding problems we've seen before, so I'd like to include this in our 0.9.0 doc if possible (maybe not necessarily, at least I'm always referencing the latest doc and rarely open the versioned one), cc @romilbhardwaj 

- close https://github.com/skypilot-org/skypilot/issues/5244
- close https://github.com/skypilot-org/skypilot/issues/4967

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
