### PR TITLE
[Docs] Update deepseek r1 example with correct initial delay seconds config

### DIFF
--- a/llm/deepseek-r1/README.md
+++ b/llm/deepseek-r1/README.md
@@ -156,9 +156,10 @@ The only change needed is to add a service section for serving specific configur
 ```yaml
 service:
   # Specifying the path to the endpoint to check the readiness of the service.
-  readiness_probe: /health
-  # Allow up to 1 hour for cold start
-  initial_delay_seconds: 3600
+  readiness_probe:
+    path: /health
+    # Allow up to 1 hour for cold start
+    initial_delay_seconds: 3600
   # Autoscaling from 0 to 2 replicas
   replica_policy:
     min_replicas: 0
@@ -169,6 +170,4 @@ And run the [SkyPilot YAML](https://github.com/skypilot-org/skypilot/blob/master
 ```bash
 sky serve up -n r1-serve deepseek-r1-671B.yaml
 ```
-
-
 

--- a/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B-A100.yaml
@@ -89,3 +89,16 @@ run: |
     --enable-torch-compile \
     --torch-compile-max-bs 8 \
     $HEAD_NODE_ARGS
+
+# Optional: Service configuration for SkyServe deployment
+# This will be ignored when deploying with `sky launch`
+service:
+  # Specifying the path to the endpoint to check the readiness of the service.
+  readiness_probe:
+    path: /health
+    # Allow up to 1 hour for cold start
+    initial_delay_seconds: 3600
+  # Autoscaling from 0 to 2 replicas
+  replica_policy:
+    min_replicas: 0
+    max_replicas: 2

--- a/llm/deepseek-r1/deepseek-r1-671B.yaml
+++ b/llm/deepseek-r1/deepseek-r1-671B.yaml
@@ -37,3 +37,16 @@ run: |
     --torch-compile-max-bs 8 \
     --host 0.0.0.0 \
     --port 30000
+
+# Optional: Service configuration for SkyServe deployment
+# This will be ignored when deploying with `sky launch`
+service:
+  # Specifying the path to the endpoint to check the readiness of the service.
+  readiness_probe:
+    path: /health
+    # Allow up to 1 hour for cold start
+    initial_delay_seconds: 3600
+  # Autoscaling from 0 to 2 replicas
+  replica_policy:
+    min_replicas: 0
+    max_replicas: 2


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `conda deactivate; bash -i tests/backward_compatibility_tests.sh` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
