### PR TITLE
[Core] Do not initialize conda for users if using docker image

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -702,8 +702,8 @@ def write_cluster_config(
     # to use, which is likely to already have a conda environment activated.
     conda_auto_activate = ('true' if to_provision.extract_docker_image() is None
                            else 'false')
-    is_docker = ('true' if to_provision.extract_docker_image() is not None else
-                 'false')
+    is_custom_docker = ('true' if to_provision.extract_docker_image()
+                        is not None else 'false')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
@@ -744,7 +744,8 @@ def write_cluster_config(
                 'conda_installation_commands':
                     constants.CONDA_INSTALLATION_COMMANDS.replace(
                         '{conda_auto_activate}',
-                        conda_auto_activate).replace('{is_docker}', is_docker),
+                        conda_auto_activate).replace('{is_custom_docker}',
+                                                     is_custom_docker),
                 'ray_skypilot_installation_commands':
                     (constants.RAY_SKYPILOT_INSTALLATION_COMMANDS.replace(
                         '{sky_wheel_hash}',

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -702,6 +702,8 @@ def write_cluster_config(
     # to use, which is likely to already have a conda environment activated.
     conda_auto_activate = ('true' if to_provision.extract_docker_image() is None
                            else 'false')
+    is_docker = ('true' if to_provision.extract_docker_image() is not None else
+                 'false')
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
@@ -741,7 +743,8 @@ def write_cluster_config(
                 # syntax.
                 'conda_installation_commands':
                     constants.CONDA_INSTALLATION_COMMANDS.replace(
-                        '{conda_auto_activate}', conda_auto_activate),
+                        '{conda_auto_activate}',
+                        conda_auto_activate).replace('{is_docker}', is_docker),
                 'ray_skypilot_installation_commands':
                     (constants.RAY_SKYPILOT_INSTALLATION_COMMANDS.replace(
                         '{sky_wheel_hash}',

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -156,9 +156,15 @@ CONDA_INSTALLATION_COMMANDS = (
     # Caller should replace {conda_auto_activate} with either true or false.
     'conda config --set auto_activate_base {conda_auto_activate} && '
     'conda activate base; }; '
+    '}; '
+    # run this command only if the image is not a docker image assuming
+    # that if a user is using a docker image, they know what they are doing
+    # in terms of conda setup/activation.
+    # Caller should replace {is_docker} with either true or false.
+    'if [ "{is_docker}" = "false" ]; then '
     'grep "# >>> conda initialize >>>" ~/.bashrc || '
     '{ conda init && source ~/.bashrc; };'
-    '}; '
+    'fi;'
     # Install uv for venv management and pip installation.
     f'{SKY_UV_INSTALL_CMD};'
     # Create a separate conda environment for SkyPilot dependencies.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -156,9 +156,9 @@ CONDA_INSTALLATION_COMMANDS = (
     # Caller should replace {conda_auto_activate} with either true or false.
     'conda config --set auto_activate_base {conda_auto_activate} && '
     'conda activate base; }; '
-    '}; '
     'grep "# >>> conda initialize >>>" ~/.bashrc || '
     '{ conda init && source ~/.bashrc; };'
+    '}; '
     # Install uv for venv management and pip installation.
     f'{SKY_UV_INSTALL_CMD};'
     # Create a separate conda environment for SkyPilot dependencies.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -156,12 +156,18 @@ CONDA_INSTALLATION_COMMANDS = (
     # Caller should replace {conda_auto_activate} with either true or false.
     'conda config --set auto_activate_base {conda_auto_activate} && '
     'conda activate base; }; '
+    # If conda was not installed and the image is a docker image,
+    # we deactivate any active conda environment we set.
+    # Caller should replace {is_custom_docker} with either true or false.
+    'if [ "{is_custom_docker}" = "true" ]; then '
+    'conda deactivate;'
+    'fi;'
     '}; '
     # run this command only if the image is not a docker image assuming
     # that if a user is using a docker image, they know what they are doing
     # in terms of conda setup/activation.
-    # Caller should replace {is_docker} with either true or false.
-    'if [ "{is_docker}" = "false" ]; then '
+    # Caller should replace {is_custom_docker} with either true or false.
+    'if [ "{is_custom_docker}" = "false" ]; then '
     'grep "# >>> conda initialize >>>" ~/.bashrc || '
     '{ conda init && source ~/.bashrc; };'
     'fi;'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/4814
This issue is fixed by deactivating any conda environment we activate if conda was not installed in the image and the image we are on is a custom docker image.

Fixes https://github.com/skypilot-org/skypilot/issues/5265
This issue is fixed by not running `conda init && source ~/.bashrc;` (regardless of conda was or was not installed in the base image) if the image is a custom docker image.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tests
- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Smoke tests (docker related): `/smoke-test -k docker`
- [x] Backward compatibility: `/quicktest-core`

Manual tests:
BW Compatibility: Check that launching a cluster with SkyPilot image on following clouds still give a conda environment with `base` env activated:
  - [x] AWS
  - [x] GCP 
  - [x] Azure
  - [x] k8s
 ---
Issue 5265
- [x] Check that using a docker image with conda already installed but does not have conda env activated(e.g. `docker:pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime`) with SkyPilot does not enable base conda environment.
- [x] BW compatibility: Check that conda is still successfully installed on docker image without conda (e.g. `docker:vllm/vllm-openai:latest`) and does not have base environment activated.
---
Issue 4814
- [x] Check that using a docker image without conda already installed (e.g. ubuntu:22.04) on kubernetes with SkyPilot does not enable base conda environment.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
