### PR TITLE
[k8s] GPU labeler script to check correct ctx

### DIFF
--- a/sky/utils/kubernetes/gpu_labeler.py
+++ b/sky/utils/kubernetes/gpu_labeler.py
@@ -56,7 +56,8 @@ def label(context: Optional[str] = None, wait_for_completion: bool = True):
         print(reason)
         return
 
-    unlabeled_gpu_nodes = kubernetes_utils.get_unlabeled_accelerator_nodes()
+    unlabeled_gpu_nodes = kubernetes_utils.get_unlabeled_accelerator_nodes(
+        context=context)
 
     if not unlabeled_gpu_nodes:
         print('No unlabeled GPU nodes found in the cluster. If you have '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When running GPU labeler with context specified, the labeler script should check if there are any unlabeled GPU nodes on that cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
