### PR TITLE
[server] warn the user if the API server is stale

### DIFF
--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -74,11 +74,10 @@ def _build_sky_wheel() -> pathlib.Path:
             f'running version: {sky.__version__}\n'
             f'installed version: {version_on_disk}\n'
             f'{colorama.Style.RESET_ALL}'
-            # The following message only applies to local API server.
-            # We have no way to tell from here if this is a remote or
-            # local API server. But we expect this to happen much
-            # more commonly to a local API server, so just print
-            # the hint regardless.
+            # The following message only applies to local API server. We have no
+            # way to tell from here if this is a remote or local API server. But
+            # we expect this to happen much more commonly to a local API server,
+            # so just print the hint regardless.
             f'{colorama.Fore.YELLOW}'
             'Please restart the local API server by running:\n'
             f'{colorama.Style.BRIGHT}sky api stop; sky api start'

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -19,12 +19,14 @@ import subprocess
 import tempfile
 from typing import Optional, Tuple
 
+import colorama
 import filelock
 from packaging import version
 
 import sky
 from sky import sky_logging
 from sky.backends import backend_utils
+from sky.server import common
 
 logger = sky_logging.init_logger(__name__)
 
@@ -60,6 +62,30 @@ def _get_latest_wheel() -> pathlib.Path:
 
 def _build_sky_wheel() -> pathlib.Path:
     """Build a wheel for SkyPilot and return the path to the wheel."""
+    # Double check that the installed code is actually the same version as the
+    # running code. If not, the wheel we build will not match _WHEEL_PATTERN.
+    # See https://github.com/skypilot-org/skypilot/issues/5311.
+    version_on_disk = common.get_skypilot_version_on_disk()
+    if version_on_disk != sky.__version__:
+        logger.warning('Wheel build: The installed SkyPilot version is '
+                       'different from the running code.\n'
+                       f'{colorama.Style.DIM}'
+                       f'running version: {sky.__version__}\n'
+                       f'installed version: {version_on_disk}\n'
+                       f'{colorama.Style.RESET_ALL}'
+                       # The following message only applies to local API server.
+                       # We have no way to tell from here if this is a remote or
+                       # local API server. But we expect this to happen much
+                       # more commonly to a local API server, so just print
+                       # the hint regardless.
+                       f'{colorama.Fore.YELLOW}Please restart the local API '
+                       'server by running:\n'
+                       f'{colorama.Style.BRIGHT}sky api stop; sky api start'
+                       f'{colorama.Style.RESET_ALL}')
+        raise RuntimeError('The installed SkyPilot version is different from '
+                           'the running code. Please restart the SkyPilot API '
+                           'server with: sky api stop; sky api start')
+
     with tempfile.TemporaryDirectory() as tmp_dir_str:
         # prepare files
         tmp_dir = pathlib.Path(tmp_dir_str)
@@ -126,7 +152,7 @@ def _build_sky_wheel() -> pathlib.Path:
             raise RuntimeError(
                 f'Failed to find pip wheel for SkyPilot under {tmp_dir} with '
                 f'glob pattern {_WHEEL_PATTERN!r}. '
-                f'Found: {list(map(str, tmp_dir.glob("*")))}.'
+                f'Found: {list(map(str, tmp_dir.glob("*")))}. '
                 'No wheel file is generated.') from None
 
         # Use a unique temporary dir per wheel hash, because there may be many

--- a/sky/backends/wheel_utils.py
+++ b/sky/backends/wheel_utils.py
@@ -67,21 +67,22 @@ def _build_sky_wheel() -> pathlib.Path:
     # See https://github.com/skypilot-org/skypilot/issues/5311.
     version_on_disk = common.get_skypilot_version_on_disk()
     if version_on_disk != sky.__version__:
-        logger.warning('Wheel build: The installed SkyPilot version is '
-                       'different from the running code.\n'
-                       f'{colorama.Style.DIM}'
-                       f'running version: {sky.__version__}\n'
-                       f'installed version: {version_on_disk}\n'
-                       f'{colorama.Style.RESET_ALL}'
-                       # The following message only applies to local API server.
-                       # We have no way to tell from here if this is a remote or
-                       # local API server. But we expect this to happen much
-                       # more commonly to a local API server, so just print
-                       # the hint regardless.
-                       f'{colorama.Fore.YELLOW}Please restart the local API '
-                       'server by running:\n'
-                       f'{colorama.Style.BRIGHT}sky api stop; sky api start'
-                       f'{colorama.Style.RESET_ALL}')
+        logger.warning(
+            'Wheel build: The installed SkyPilot version is different from the '
+            'running code.\n'
+            f'{colorama.Style.DIM}'
+            f'running version: {sky.__version__}\n'
+            f'installed version: {version_on_disk}\n'
+            f'{colorama.Style.RESET_ALL}'
+            # The following message only applies to local API server.
+            # We have no way to tell from here if this is a remote or
+            # local API server. But we expect this to happen much
+            # more commonly to a local API server, so just print
+            # the hint regardless.
+            f'{colorama.Fore.YELLOW}'
+            'Please restart the local API server by running:\n'
+            f'{colorama.Style.BRIGHT}sky api stop; sky api start'
+            f'{colorama.Style.RESET_ALL}')
         raise RuntimeError('The installed SkyPilot version is different from '
                            'the running code. Please restart the SkyPilot API '
                            'server with: sky api stop; sky api start')

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -7,6 +7,7 @@ from http.cookiejar import MozillaCookieJar
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import time
@@ -64,11 +65,14 @@ _VERSION_INFO = (
     'client version: v{client_version} (API version: v{client_api_version})\n'
     'server version: v{server_version} (API version: v{server_api_version})'
     f'{colorama.Style.RESET_ALL}')
+_LOCAL_API_SERVER_RESTART_HINT = (
+    f'{colorama.Fore.YELLOW}Please restart the SkyPilot API server with:\n'
+    f'{colorama.Style.BRIGHT}sky api stop; sky api start'
+    f'{colorama.Style.RESET_ALL}')
 _LOCAL_SERVER_VERSION_MISMATCH_WARNING = (
     f'{colorama.Fore.YELLOW}Client and local API server version mismatch:\n'
     '{version_info}\n'
-    f'{colorama.Fore.YELLOW}Please restart the SkyPilot API server with:\n'
-    'sky api stop; sky api start'
+    f'{_LOCAL_API_SERVER_RESTART_HINT}'
     f'{colorama.Style.RESET_ALL}')
 _CLIENT_TOO_OLD_WARNING = (
     f'{colorama.Fore.YELLOW}Your SkyPilot client is too old:\n'
@@ -83,6 +87,17 @@ _REMOTE_SERVER_TOO_OLD_WARNING = (
     'remote API server or downgrade your local client with:\n'
     '{command}\n'
     f'{colorama.Style.RESET_ALL}')
+_SERVER_INSTALL_VERSION_MISMATCH_WARNING = (
+    f'{colorama.Fore.YELLOW}SkyPilot API server version does not match the '
+    'installation on disk:\n'
+    f'{colorama.Style.RESET_ALL}'
+    f'{colorama.Style.DIM}'
+    'running API server version: {server_version}\n'
+    'installed API server version: {version_on_disk}\n'
+    f'{colorama.Style.RESET_ALL}'
+    f'{colorama.Fore.YELLOW}This can happen if you upgraded SkyPilot without '
+    'restarting the API server.'
+    f'{colorama.Style.RESET_ALL}')
 # Parse local API version eargly to catch version format errors.
 _LOCAL_API_VERSION: int = int(server_constants.API_VERSION)
 # SkyPilot dev version.
@@ -92,6 +107,8 @@ RequestId = str
 ApiVersion = Optional[str]
 
 logger = sky_logging.init_logger(__name__)
+
+hinted_for_server_install_version_mismatch = False
 
 
 class ApiServerStatus(enum.Enum):
@@ -105,6 +122,7 @@ class ApiServerInfo:
     status: ApiServerStatus
     api_version: ApiVersion = None
     version: Optional[str] = None
+    version_on_disk: Optional[str] = None
     commit: Optional[str] = None
 
 
@@ -165,10 +183,12 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
                     result = response.json()
                     api_version = result.get('api_version')
                     version = result.get('version')
+                    version_on_disk = result.get('version_on_disk')
                     commit = result.get('commit')
                     server_info = ApiServerInfo(status=ApiServerStatus.HEALTHY,
                                                 api_version=api_version,
                                                 version=version,
+                                                version_on_disk=version_on_disk,
                                                 commit=commit)
                     if api_version is None or version is None or commit is None:
                         logger.warning(f'API server response missing '
@@ -362,9 +382,34 @@ def check_server_healthy(endpoint: Optional[str] = None,) -> None:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.ApiServerConnectionError(endpoint)
 
+    # If the user ran pip upgrade, but the server wasn't restarted, warn them.
+    # We check this using the info from /api/health, rather than in the
+    # executor, because the executor could be started after the main server
+    # process, picking up the new code, even though the main server process is
+    # still running the old code.
+    # Note that this code is running on the client side, so calling
+    # get_skypilot_version_on_disk() from here is not correct.
+
+    # Only show this hint once per process.
+    global hinted_for_server_install_version_mismatch
+
+    if (api_server_info.version_on_disk is not None and
+            api_server_info.version != api_server_info.version_on_disk and
+            not hinted_for_server_install_version_mismatch):
+
+        logger.warning(
+            _SERVER_INSTALL_VERSION_MISMATCH_WARNING.format(
+                server_version=api_server_info.version,
+                version_on_disk=api_server_info.version_on_disk))
+        if is_api_server_local():
+            logger.warning(_LOCAL_API_SERVER_RESTART_HINT)
+
+        hinted_for_server_install_version_mismatch = True
+
 
 def _get_version_info_hint(server_info: ApiServerInfo) -> str:
     assert server_info.version is not None, 'Server version is None'
+    # version_on_disk may be None if the server is older
     assert server_info.commit is not None, 'Server commit is None'
     sv = server_info.version
     cv = sky.__version__
@@ -391,6 +436,21 @@ def _install_server_version_command(server_info: ApiServerInfo) -> str:
     else:
         # Stable version.
         return f'pip install -U "skypilot=={server_info.version}"'
+
+
+# Keep in sync with sky/setup_files/setup.py find_version()
+def get_skypilot_version_on_disk() -> str:
+    """Get the version of the SkyPilot code on disk."""
+    current_file_path = pathlib.Path(__file__)
+    assert str(current_file_path).endswith(
+        'server/common.py'), current_file_path
+    sky_root = current_file_path.parent.parent
+    with open(sky_root / '__init__.py', 'r', encoding='utf-8') as fp:
+        version_match = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]',
+                                  fp.read(), re.M)
+        if version_match:
+            return version_match.group(1)
+        raise RuntimeError('Unable to find version string.')
 
 
 def check_server_healthy_or_start_fn(deploy: bool = False,

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -7,7 +7,7 @@ from sky.skylet import constants
 # API server version, whenever there is a change in API server that requires a
 # restart of the local API server or error out when the client does not match
 # the server version.
-API_VERSION = '4'
+API_VERSION = '5'
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1015,14 +1015,17 @@ async def health() -> Dict[str, str]:
         A dictionary with the following keys:
         - status: str; The status of the API server.
         - api_version: str; The API version of the API server.
-        - commit: str; The commit hash of SkyPilot used for API server.
         - version: str; The version of SkyPilot used for API server.
+        - version_on_disk: str; The version of the SkyPilot installation on
+          disk, which can be used to warn about restarting the API server
+        - commit: str; The commit hash of SkyPilot used for API server.
     """
     return {
         'status': common.ApiServerStatus.HEALTHY.value,
         'api_version': server_constants.API_VERSION,
-        'commit': sky.__commit__,
         'version': sky.__version__,
+        'version_on_disk': common.get_skypilot_version_on_disk(),
+        'commit': sky.__commit__,
     }
 
 

--- a/sky/setup_files/setup.py
+++ b/sky/setup_files/setup.py
@@ -45,6 +45,7 @@ original_init_content = None
 system = platform.system()
 
 
+# Keep in sync with sky/server/common.py get_skypilot_version_on_disk()
 def find_version():
     # Extract version information from filepath
     # Adapted from:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We compare two versions:
1. The version of the code that's currently loaded into the API server process.
2. The version of the code on the disk where the API server was started.

If these two don't match, it probably means the user upgraded SkyPilot without restarting the API server.

This can lead to unintuitive behavior if the user tries to use new features or bugfixes, since the API server running on old code may not have them. It can also cause some crashes, e.g. #5311. This PR fixes #5311.

In general, we mostly expect this to affect the local API server case. Usually when an admin upgrades the remote API server, they will know to restart it, or it will be automatically handled by the helm chart. So we will just print the warning in either case.

![image](https://github.com/user-attachments/assets/b2d2baae-c806-4e5e-a9bc-2cdf09a5ce0a)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
