### PR TITLE
[AWS] Use consistent list for instance termination logic

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -672,8 +672,7 @@ def terminate_instances(
                                   included_instances=None,
                                   excluded_instances=None)
     instances_list = list(instances)
-    for instance in instances_list:
-        instance.terminate()
+    instances.terminate()
     if (sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or
             not managed_by_skypilot):
         # Using default AWS SG or user specified security group. We don't need

--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -671,7 +671,9 @@ def terminate_instances(
                                   filters,
                                   included_instances=None,
                                   excluded_instances=None)
-    instances.terminate()
+    instances_list = list(instances)
+    for instance in instances_list:
+        instance.terminate()
     if (sg_name == aws_cloud.DEFAULT_SECURITY_GROUP_NAME or
             not managed_by_skypilot):
         # Using default AWS SG or user specified security group. We don't need
@@ -681,7 +683,7 @@ def terminate_instances(
     # If ports are specified, we need to delete the newly created Security
     # Group. Here we wait for all instances to be terminated, since the
     # Security Group dependent on them.
-    for instance in instances:
+    for instance in instances_list:
         instance.wait_until_terminated()
     # TODO(suquark): Currently, the implementation of GCP and Azure will
     #  wait util the cluster is fully terminated, while other clouds just


### PR DESCRIPTION
Closes https://github.com/skypilot-org/skypilot/issues/3688

<!-- Describe the changes in this PR -->
This was a doozy one.

In the function modified in the PR, a list of instances comprising the cluster is terminated. If a security group needs to be deleted as part of the teardown process, this function also waits until the instances are actually done terminating.

The bug here is a probabilistic race condition. It's good to note that `instances` here doesn't stay constant (like a list) - instead, it seems every use of it returns a new list (like a generator) that could be different from the previous time the variable is used.

`instances` is generated by calling `_filter_instances` which filters for the VM state being in `pending`, `running`, `stopping` or `stopped`. Notably, this filter does not include `terminating` as a state we want to get. This makes sense, as we don't really want to terminate a VM that is already being terminated.

However, this becomes a problem when `instances` are iterated over after `instances.terminate()` is called. Since there is so little time between `instance.terminate()` and `instances` being iterated over, the instances are _usually_ in `running` state and is thus picked up. However, there are times (empirically about 1/5) when an instance has already transitioned into `terminating` state, is no longer included in `instances`, and therefore we do not wait for that instance to fully terminate. In that case, the associate security group is not deleted properly (because the VM is not terminated like expected).

This PR dumps `instances` into a list before using the values, which gives a more consistent expectation of what the variable contains.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: start/stop cluster with a port open (needed for SkyPilot to associate a specific sec group to the cluster) 10 times and ensure security groups are correctly deleted.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
