### PR TITLE
[AWS] ability to specify transient per-cluster security group

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -486,6 +486,9 @@ Some example use cases are shown below. All fields are optional.
   name, SkyPilot will use the default security group name as mentioned above:
   ``sky-sg-<hash>``. To specify your default, use ``*`` as the wildcard expression.
 
+  If value of `per-cluster` is specified as the security group name, SkyPilot will
+  create a security group per cluster and delete it when the cluster is terminated.
+
 Example:
 
 .. code-block:: yaml

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -71,8 +71,12 @@ DEFAULT_AMI_GB = 45
 # (username, last 4 chars of hash of hostname): for uniquefying
 # users on shared-account scenarios.
 DEFAULT_SECURITY_GROUP_NAME = f'sky-sg-{common_utils.user_and_hostname_hash()}'
-# Security group to use when user specified ports in their resources.
-USER_PORTS_SECURITY_GROUP_NAME = 'sky-sg-{}'
+# Security group name to use for per-cluster security groups.
+PER_CLUSTER_SECURITY_GROUP_NAME = 'sky-sg-{}'
+# User-provided value for "security_group" in resources.yaml
+# if the user wants to create a security group per-cluster
+# that is deleted when the cluster is terminated.
+PER_CLUSTER_SECURITY_GROUP_DESIGNATION = 'per-cluster'
 
 
 class AWSIdentityType(enum.Enum):
@@ -465,8 +469,11 @@ class AWS(clouds.Cloud):
             security_group = DEFAULT_SECURITY_GROUP_NAME
             if resources.ports is not None:
                 # Already checked in Resources._try_validate_ports
-                security_group = USER_PORTS_SECURITY_GROUP_NAME.format(
+                security_group = PER_CLUSTER_SECURITY_GROUP_NAME.format(
                     cluster_name.display_name)
+        if security_group == PER_CLUSTER_SECURITY_GROUP_DESIGNATION:
+            security_group = PER_CLUSTER_SECURITY_GROUP_NAME.format(
+                cluster_name.display_name)
         elif resources.ports is not None:
             with ux_utils.print_exception_no_traceback():
                 logger.warning(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Related issue: https://github.com/skypilot-org/skypilot/issues/3688

Mini-proposal:

The issue raises a good point about how we deal with security groups in AWS. Currently, if the user doesn't specifically designate a security group to use, SkyPilot creates a long lived default security group to use. This security group is not deleted on cluster down.

It is worth noting this behavior is somewhat intended though. The benefit we gain by not having to delete the long lived security group for the cluster is that we can return from `sky down` command (or SDK/API call) before the instance is terminated. If SkyPilot is to delete the security group, which can only be deleted once attached instances are deleted, SkyPilot is forced to wait for instances to be terminated before deleting the security group and returning from `sky down`, significantly increasing the call duration. I.e. the current behavior is closer to a feature than a bug.

However, it is understandable that some users may want SkyPilot to clean up after itself even at the cost of increased call duration of `sky down`. I do think SkyPilot should at least give users the option to choose what side of the tradeoff they want to be at. This PR enables the user to use a per-cluster security group which is cleaned up on `sky down`

This option is especially useful for our buildkite tests which run on an ephemeral container - long lived security groups aren't reused in that case because the instance ids are essentially one time use, so it's better to use transient groups which get cleaned up on sky down.

What behavior we want to support as default (per cluster sg or long lived sg) is up for discussion.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] Manual: specify `per-cluster` security group name and verify a per-cluster security group managed by SkyPilot is used, and the sg is deleted on cluster down 

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
