### PR TITLE
[Doc] Add link to local kind deployment doc

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -227,6 +227,8 @@ SkyPilot can run workloads on on-prem or cloud-hosted Kubernetes clusters
   mkdir -p ~/.kube
   cp /path/to/kubeconfig ~/.kube/config
 
+You can refer to :ref:`Deploying locally on your laptop <kubernetes-setup-kind>` to deploy a local Kubernetes cluster with `kind <https://kind.sigs.k8s.io/>`_ and try out SkyPilot quickly.
+
 See :ref:`SkyPilot on Kubernetes <kubernetes-overview>` for more.
 
 .. _aws-installation:

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -227,9 +227,10 @@ SkyPilot can run workloads on on-prem or cloud-hosted Kubernetes clusters
   mkdir -p ~/.kube
   cp /path/to/kubeconfig ~/.kube/config
 
-You can refer to :ref:`Deploying locally on your laptop <kubernetes-setup-kind>` to deploy a local Kubernetes cluster with `kind <https://kind.sigs.k8s.io/>`_ and try out SkyPilot quickly.
-
 See :ref:`SkyPilot on Kubernetes <kubernetes-overview>` for more.
+
+.. tip::
+   If you do not have access to a Kubernetes cluster, you can :ref:`deploy a local Kubernetes cluster on your laptop <kubernetes-setup-kind>` with ``sky local up``.
 
 .. _aws-installation:
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -5,6 +5,8 @@ Deploy SkyPilot on existing machines
 
 This guide will help you deploy SkyPilot on your existing machines — whether they are on-premises or reserved instances on a cloud provider.
 
+You can also refer to :ref:`Deploying locally on your laptop <kubernetes-setup-kind>` to deploy a local Kubernetes cluster with `kind <https://kind.sigs.k8s.io/>`_ and try out SkyPilot quickly.
+
 **Given a list of IP addresses and SSH credentials,**
 SkyPilot will install necessary dependencies on the remote machines and configure itself to run jobs and services on the cluster.
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -5,7 +5,10 @@ Deploy SkyPilot on existing machines
 
 This guide will help you deploy SkyPilot on your existing machines — whether they are on-premises or reserved instances on a cloud provider.
 
-You can also refer to :ref:`Deploying locally on your laptop <kubernetes-setup-kind>` to deploy a local Kubernetes cluster with `kind <https://kind.sigs.k8s.io/>`_ and try out SkyPilot quickly.
+
+.. tip::
+
+    To run SkyPilot on your local machine, you can directly :ref:`deploy a kubernetes cluster <kubernetes-setup-kind>` with `kind <https://kind.sigs.k8s.io/>`_.
 
 **Given a list of IP addresses and SSH credentials,**
 SkyPilot will install necessary dependencies on the remote machines and configure itself to run jobs and services on the cluster.

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -8,7 +8,7 @@ This guide will help you deploy SkyPilot on your existing machines — whether t
 
 .. tip::
 
-    To run SkyPilot on your local machine, you can directly :ref:`deploy a kubernetes cluster <kubernetes-setup-kind>` with `kind <https://kind.sigs.k8s.io/>`_.
+    To run SkyPilot on your local machine, use ``sky local up`` to :ref:`deploy a kubernetes cluster <kubernetes-setup-kind>` with `kind <https://kind.sigs.k8s.io/>`_.
 
 **Given a list of IP addresses and SSH credentials,**
 SkyPilot will install necessary dependencies on the remote machines and configure itself to run jobs and services on the cluster.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix https://github.com/skypilot-org/skypilot/issues/4477
Add link to local kind deployment doc in the `Installation` and `Using Existing Machines` docs.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
