### PR TITLE
Fix blobfuse2 mount permissions

### DIFF
--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -194,9 +194,14 @@ def get_az_mount_cmd(container_name: str,
         bucket_sub_path_arg = ''
     else:
         bucket_sub_path_arg = f'--subdirectory={_bucket_sub_path}/ '
-    mount_options = '-o allow_other -o default_permissions'
+    mount_options = ['allow_other', 'default_permissions']
+    # Format: -o flag1, flag2
+    fusermount_options = '-o ' + ','.join(mount_options)
+    # Format: -o flag1 -o flag2
+    blobfuse2_options = ' '.join(f'-o {opt}' for opt in mount_options)
     # TODO(zpoint): clear old cache that has been created in the previous boot.
-    blobfuse2_cmd = ('blobfuse2 --no-symlinks -o umask=022 '
+    # Do not set umask to avoid permission problems for non-root users.
+    blobfuse2_cmd = ('blobfuse2 --no-symlinks '
                      f'--tmp-path {cache_path}_$({remote_boot_time_cmd}) '
                      f'{bucket_sub_path_arg}'
                      f'--container-name {container_name}')
@@ -208,9 +213,9 @@ def get_az_mount_cmd(container_name: str,
     # 3. set --foreground to workaround lock confliction of multiple blobfuse2
     # daemon processes (#5307) and use -d to daemonsize blobfuse2 in
     # fusermount-wrapper.
-    wrapped = (f'fusermount-wrapper -d -m {mount_path} {mount_options} '
+    wrapped = (f'fusermount-wrapper -d -m {mount_path} {fusermount_options} '
                f'-- {blobfuse2_cmd} -o nonempty --foreground {{}}')
-    original = f'{blobfuse2_cmd} {mount_options} {mount_path}'
+    original = f'{blobfuse2_cmd} {blobfuse2_options} {mount_path}'
     # If fusermount-wrapper is available, use it to wrap the blobfuse2 command
     # to avoid requiring root privilege.
     # TODO(aylei): feeling hacky, refactor this.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5324

Root cause: `umask 022` results a 755 permission of the moint-point, which blocks non-root user accessing the mount point. But why did this works pervious?

1. It worked for VM because blobfuse2 ignores the `default_permissions` option https://github.com/Azure/azure-storage-fuse/blob/eda8c03b6b59da9a254fdefc58da7eaf8994a14c/common/types.go#L79, so non-root user can still access the mountpoint despite the permission;
2. It worked for Kubernetes because there was a bug that we provider multiple `-o` options to fusermount, where a random one will be finally picked. Previously the one was `-o allow_other` and it became `-o default_permissions` after https://github.com/skypilot-org/skypilot/pull/5308

This PR removes umask to fix the permission of blobfuse mount point. This also fixes the test_managed_job_storage smoke test.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
