### PR TITLE
Fix: validate dag should not block uvicorn

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -48,7 +48,7 @@ jobs:
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"
-          uv pip install pytest pytest-xdist pytest-env>=0.6 memory-profiler==0.61.0
+          uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate
@@ -79,7 +79,7 @@ jobs:
           uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Install limited dependencies only
           uv pip install -e ".[kubernetes,aws,gcp,azure]"
-          uv pip install pytest pytest-xdist pytest-env>=0.6 memory-profiler==0.61.0
+          uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate
@@ -110,7 +110,7 @@ jobs:
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"
-          uv pip install pytest pytest-xdist pytest-env>=0.6 memory-profiler==0.61.0 moto==5.1.2
+          uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0 moto==5.1.2
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -114,4 +114,4 @@ jobs:
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate
-          SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
+          SKYPILOT_DEBUG=1 SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -114,4 +114,4 @@ jobs:
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate
-          SKYPILOT_DEBUG=1 SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
+          SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,7 @@ types-aiofiles
 pytest
 pytest-xdist
 pytest-env>=0.6
+pytest-asyncio
 
 # memory profiler
 memory_profiler==0.61.0

--- a/sky/dag.py
+++ b/sky/dag.py
@@ -76,9 +76,12 @@ class Dag:
 
         return out_degree_condition and in_degree_condition
 
-    def validate(self, workdir_only: bool = False):
+    def validate(self,
+                 skip_file_mounts: bool = False,
+                 skip_workdir: bool = False):
         for task in self.tasks:
-            task.validate(workdir_only=workdir_only)
+            task.validate(skip_file_mounts=skip_file_mounts,
+                          skip_workdir=skip_workdir)
 
 
 class _DagContext(threading.local):

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -627,7 +627,7 @@ def exec(  # pylint: disable=redefined-builtin
         if dryrun.
     """
     entrypoint = task
-    entrypoint.validate(workdir_only=True)
+    entrypoint.validate(skip_file_mounts=True)
     controller_utils.check_cluster_name_not_controller(cluster_name,
                                                        operation_str='sky.exec')
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -287,8 +287,8 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     # these into a single call or have a TTL cache for (task, admin_policy)
     # pairs.
     logger.debug(f'Validating tasks: {validate_body.dag}')
-    try:
-        dag = dag_utils.load_chain_dag_from_yaml_str(validate_body.dag)
+
+    def validate_dag(dag: dag_utils.dag_lib.Dag):
         # TODO: Admin policy may contain arbitrary code, which may be expensive
         # to run and may block the server thread. However, moving it into the
         # executor adds a ~150ms penalty on the local API server because of
@@ -296,14 +296,16 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
         # server thread.
         dag, _ = admin_policy_utils.apply(
             dag, request_options=validate_body.request_options)
-        for task in dag.tasks:
-            # Will validate workdir and file_mounts in the backend, as those
-            # need to be validated after the files are uploaded to the SkyPilot
-            # API server with `upload_mounts_to_api_server`.
-            task.validate_name()
-            task.validate_run()
-            for r in task.resources:
-                r.validate()
+        # Skip validating workdir and file_mounts, as those need to be
+        # validated after the files are uploaded to the SkyPilot API server
+        # with `upload_mounts_to_api_server`.
+        dag.validate(skip_file_mounts=True, skip_workdir=True)
+
+    try:
+        dag = dag_utils.load_chain_dag_from_yaml_str(validate_body.dag)
+        loop = asyncio.get_running_loop()
+        # Apply admin policy and validate DAG can
+        await loop.run_in_executor(None, validate_dag, dag)
     except Exception as e:  # pylint: disable=broad-except
         raise fastapi.HTTPException(
             status_code=400, detail=exceptions.serialize_exception(e)) from e

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -304,7 +304,8 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     try:
         dag = dag_utils.load_chain_dag_from_yaml_str(validate_body.dag)
         loop = asyncio.get_running_loop()
-        # Apply admin policy and validate DAG can
+        # Apply admin policy and validate DAG is blocking, run it in a separate
+        # thread executor to avoid blocking the uvicorn event loop.
         await loop.run_in_executor(None, validate_dag, dag)
     except Exception as e:  # pylint: disable=broad-except
         raise fastapi.HTTPException(

--- a/sky/task.py
+++ b/sky/task.py
@@ -315,12 +315,20 @@ class Task:
         if dag is not None:
             dag.add(self)
 
-    def validate(self, workdir_only: bool = False):
-        """Validate all fields of the task."""
+    def validate(self,
+                 skip_file_mounts: bool = False,
+                 skip_workdir: bool = False):
+        """Validate all fields of the task.
+
+        Args:
+            skip_file_mounts: Whether to skip validating file mounts.
+            skip_workdir: Whether to skip validating workdir.
+        """
         self.validate_name()
         self.validate_run()
-        self.expand_and_validate_workdir()
-        if not workdir_only:
+        if not skip_workdir:
+            self.expand_and_validate_workdir()
+        if not skip_file_mounts:
             self.expand_and_validate_file_mounts()
         for r in self.resources:
             r.validate()

--- a/tests/load_tests/test_load_on_server.py
+++ b/tests/load_tests/test_load_on_server.py
@@ -15,6 +15,7 @@ from typing import Dict, List
 
 import numpy as np
 
+import sky
 from sky import jobs as managed_jobs
 from sky import serve as serve_lib
 from sky.client import sdk
@@ -221,8 +222,19 @@ def test_tail_logs_api(num_requests, cloud):
     run_single_request(0, cleanup_cmd)
 
 
+def test_validate_api(num_requests):
+    print(f"Testing {num_requests} validate API requests")
+
+    def validate():
+        with sky.Dag() as dag:
+            dag.add(sky.Task(name='echo', run='echo hello'))
+            sdk.validate(dag)
+
+    run_concurrent_api_requests(num_requests, validate, 'API /validate')
+
+
 all_requests = ['launch', 'status', 'logs', 'jobs', 'serve']
-all_apis = ['status', 'cli_status', 'tail_logs']
+all_apis = ['status', 'cli_status', 'tail_logs', 'validate']
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -304,6 +316,9 @@ if __name__ == '__main__':
             elif api == 'tail_logs':
                 thread = threading.Thread(target=test_tail_logs_api,
                                           args=(args.n, cloud))
+            elif api == 'validate':
+                thread = threading.Thread(target=test_validate_api,
+                                          args=(args.n,))
             if thread:
                 test_threads.append(thread)
                 thread.start()

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -9,11 +9,11 @@ import pytest
 
 import sky
 from sky import global_user_state
+from sky import sky_logging
 from sky.backends import cloud_vm_ray_backend
 from sky.provision.aws import instance as aws_instance
 from sky.utils import db_utils
 from sky.utils import env_options
-from sky import sky_logging
 
 
 @pytest.fixture
@@ -29,9 +29,9 @@ def test_aws_region_failover(enable_all_clouds, _mock_db_conn, mock_aws_backend,
     """Test SkyPilot's ability to failover between AWS regions."""
     # Set the debug info to True to print the debug info
     monkeypatch.setattr(env_options.Options.SHOW_DEBUG_INFO, 'get',
-                       lambda: True)
+                        lambda: True)
     sky_logging.reload_logger()
-    
+
     region_attempt_count = {'count': 0}
 
     def mock_create_instances(ec2_fail_fast, cluster_name, node_config, tags,

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -12,6 +12,8 @@ from sky import global_user_state
 from sky.backends import cloud_vm_ray_backend
 from sky.provision.aws import instance as aws_instance
 from sky.utils import db_utils
+from sky.utils import env_options
+from sky import sky_logging
 
 
 @pytest.fixture
@@ -25,6 +27,11 @@ def _mock_db_conn(tmp_path, monkeypatch):
 def test_aws_region_failover(enable_all_clouds, _mock_db_conn, mock_aws_backend,
                              monkeypatch, capfd):
     """Test SkyPilot's ability to failover between AWS regions."""
+    # Set the debug info to True to print the debug info
+    monkeypatch.setattr(env_options.Options.SHOW_DEBUG_INFO, 'get',
+                       lambda: True)
+    sky_logging.reload_logger()
+    
     region_attempt_count = {'count': 0}
 
     def mock_create_instances(ec2_fail_fast, cluster_name, node_config, tags,

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -1,108 +1,157 @@
 """Unit tests for the SkyPilot API server."""
 
 import argparse
-import unittest
+import asyncio
 from unittest import mock
 
+import fastapi
+import pytest
 import uvicorn
 
+from sky.server import server
 from sky.utils import common_utils
 
 
-class TestServerWorkers(unittest.TestCase):
-    """Test the server workers configuration."""
+@mock.patch('uvicorn.run')
+@mock.patch('sky.server.requests.executor.start')
+@mock.patch('sky.utils.common_utils.get_cpu_count')
+def test_deploy_flag_sets_workers_to_cpu_count(mock_get_cpu_count,
+                                               mock_executor_start,
+                                               mock_uvicorn_run):
+    """Test that --deploy flag sets workers to CPU count."""
+    # Setup
+    mock_get_cpu_count.return_value = 8
+    mock_executor_start.return_value = []
 
-    @mock.patch('uvicorn.run')
-    @mock.patch('sky.server.requests.executor.start')
-    @mock.patch('sky.utils.common_utils.get_cpu_count')
-    def test_deploy_flag_sets_workers_to_cpu_count(self, mock_get_cpu_count,
-                                                   mock_executor_start,
-                                                   mock_uvicorn_run):
-        """Test that --deploy flag sets workers to CPU count."""
-        # Setup
-        mock_get_cpu_count.return_value = 8
-        mock_executor_start.return_value = []
+    # Create mock args with deploy=True
+    test_args = argparse.Namespace(host='127.0.0.1', port=46580, deploy=True)
 
-        # Create mock args with deploy=True
-        test_args = argparse.Namespace(host='127.0.0.1',
-                                       port=46580,
-                                       deploy=True)
+    # Call the main block with mocked args
+    with mock.patch('argparse.ArgumentParser.parse_args',
+                    return_value=test_args):
+        with mock.patch('sky.server.requests.requests.reset_db_and_logs'):
+            with mock.patch('sky.usage.usage_lib.maybe_show_privacy_policy'):
+                # Execute the main block code directly
+                num_workers = None
+                if test_args.deploy:
+                    num_workers = mock_get_cpu_count()
 
-        # Call the main block with mocked args
-        with mock.patch('argparse.ArgumentParser.parse_args',
-                        return_value=test_args):
-            with mock.patch('sky.server.requests.requests.reset_db_and_logs'):
-                with mock.patch(
-                        'sky.usage.usage_lib.maybe_show_privacy_policy'):
-                    # Execute the main block code directly
-                    num_workers = None
-                    if test_args.deploy:
-                        num_workers = mock_get_cpu_count()
+                workers = []
+                try:
+                    workers = mock_executor_start(test_args.deploy)
+                    uvicorn.run('sky.server.server:app',
+                                host=test_args.host,
+                                port=test_args.port,
+                                workers=num_workers)
+                except Exception:
+                    pass
+                finally:
+                    for worker in workers:
+                        worker.terminate()
 
-                    workers = []
-                    try:
-                        workers = mock_executor_start(test_args.deploy)
-                        uvicorn.run('sky.server.server:app',
-                                    host=test_args.host,
-                                    port=test_args.port,
-                                    workers=num_workers)
-                    except Exception:
-                        pass
-                    finally:
-                        for worker in workers:
-                            worker.terminate()
-
-        # Verify that uvicorn.run was called with the correct number of workers
-        mock_uvicorn_run.assert_called_once()
-        call_args = mock_uvicorn_run.call_args[1]
-        self.assertEqual(call_args['workers'], 8)
-        self.assertEqual(call_args['host'], '127.0.0.1')
-        self.assertEqual(call_args['port'], 46580)
-
-    @mock.patch('uvicorn.run')
-    @mock.patch('sky.server.requests.executor.start')
-    def test_no_deploy_flag_uses_default_workers(self, mock_executor_start,
-                                                 mock_uvicorn_run):
-        """Test that without --deploy flag, workers is None (default)."""
-        # Setup
-        mock_executor_start.return_value = []
-
-        # Create mock args with deploy=False
-        test_args = argparse.Namespace(host='127.0.0.1',
-                                       port=46580,
-                                       deploy=False)
-
-        # Call the main block with mocked args
-        with mock.patch('argparse.ArgumentParser.parse_args',
-                        return_value=test_args):
-            with mock.patch('sky.server.requests.requests.reset_db_and_logs'):
-                with mock.patch(
-                        'sky.usage.usage_lib.maybe_show_privacy_policy'):
-                    # Execute the main block code directly
-                    num_workers = None
-                    if test_args.deploy:
-                        num_workers = common_utils.get_cpu_count()
-
-                    workers = []
-                    try:
-                        workers = mock_executor_start(test_args.deploy)
-                        uvicorn.run('sky.server.server:app',
-                                    host=test_args.host,
-                                    port=test_args.port,
-                                    workers=num_workers)
-                    except Exception:
-                        pass
-                    finally:
-                        for worker in workers:
-                            worker.terminate()
-
-        # Verify that uvicorn.run was called with workers=None
-        mock_uvicorn_run.assert_called_once()
-        call_args = mock_uvicorn_run.call_args[1]
-        self.assertIsNone(call_args['workers'])
-        self.assertEqual(call_args['host'], '127.0.0.1')
-        self.assertEqual(call_args['port'], 46580)
+    # Verify that uvicorn.run was called with the correct number of workers
+    mock_uvicorn_run.assert_called_once()
+    call_args = mock_uvicorn_run.call_args[1]
+    assert call_args['workers'] == 8
+    assert call_args['host'] == '127.0.0.1'
+    assert call_args['port'] == 46580
 
 
-if __name__ == '__main__':
-    unittest.main()
+@mock.patch('uvicorn.run')
+@mock.patch('sky.server.requests.executor.start')
+def test_no_deploy_flag_uses_default_workers(mock_executor_start,
+                                             mock_uvicorn_run):
+    """Test that without --deploy flag, workers is None (default)."""
+    # Setup
+    mock_executor_start.return_value = []
+
+    # Create mock args with deploy=False
+    test_args = argparse.Namespace(host='127.0.0.1', port=46580, deploy=False)
+
+    # Call the main block with mocked args
+    with mock.patch('argparse.ArgumentParser.parse_args',
+                    return_value=test_args):
+        with mock.patch('sky.server.requests.requests.reset_db_and_logs'):
+            with mock.patch('sky.usage.usage_lib.maybe_show_privacy_policy'):
+                # Execute the main block code directly
+                num_workers = None
+                if test_args.deploy:
+                    num_workers = common_utils.get_cpu_count()
+
+                workers = []
+                try:
+                    workers = mock_executor_start(test_args.deploy)
+                    uvicorn.run('sky.server.server:app',
+                                host=test_args.host,
+                                port=test_args.port,
+                                workers=num_workers)
+                except Exception:
+                    pass
+                finally:
+                    for worker in workers:
+                        worker.terminate()
+
+    # Verify that uvicorn.run was called with workers=None
+    mock_uvicorn_run.assert_called_once()
+    call_args = mock_uvicorn_run.call_args[1]
+    assert call_args['workers'] is None
+    assert call_args['host'] == '127.0.0.1'
+    assert call_args['port'] == 46580
+
+
+@pytest.mark.asyncio
+async def test_validate():
+    """Test the validate endpoint."""
+    mock_dag = mock.MagicMock()
+    mock_validate_body = mock.MagicMock()
+    mock_validate_body.dag = 'test_dag_yaml'
+    mock_validate_body.request_options = {}
+
+    with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
+                   return_value=mock_dag), \
+         mock.patch('sky.server.server.admin_policy_utils.apply',
+                   return_value=(mock_dag, None)), \
+         mock.patch.object(mock_dag, 'validate') as mock_validate:
+        # Call validate endpoint
+        await server.validate(mock_validate_body)
+        # Verify validate was called with correct args
+        mock_validate.assert_called_once_with(skip_file_mounts=True,
+                                              skip_workdir=True)
+
+    error_msg = 'Invalid DAG'
+    with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
+                   return_value=mock_dag), \
+         mock.patch('sky.server.server.admin_policy_utils.apply',
+                   return_value=(mock_dag, None)), \
+         mock.patch.object(mock_dag, 'validate',
+                          side_effect=ValueError(error_msg)):
+        with pytest.raises(fastapi.HTTPException) as exc_info:
+            await server.validate(mock_validate_body)
+        assert exc_info.value.status_code == 400
+        assert error_msg in str(exc_info.value.detail)
+
+    # Create an event to track when validation completes
+    validation_complete = asyncio.Event()
+
+    def slow_validate(*args, **kwargs):
+        # Simulate slow validation
+        import time
+        time.sleep(0.1)
+        validation_complete.set()
+
+    with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
+                   return_value=mock_dag), \
+         mock.patch('sky.server.server.admin_policy_utils.apply',
+                   return_value=(mock_dag, None)), \
+         mock.patch.object(mock_dag, 'validate',
+                          side_effect=slow_validate):
+        # Start validation in background
+        validation_task = asyncio.create_task(
+            server.validate(mock_validate_body))
+
+        # Check that validation hasn't completed immediately
+        assert not validation_complete.is_set()
+
+        # Wait for validation to complete
+        await validation_task
+        assert validation_complete.is_set()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Make `validate` non-blocking, close https://github.com/skypilot-org/skypilot/issues/5300

Benchmark result:

- this branch:
```bash
$ python tests/load_tests/test_load_on_server.py -n 100 --apis validate
Latency Statistics:
----------------------------------------------------------------------------------------------------
Kind                 Count    Total(s)   Avg(s)     Min(s)     Max(s)     P95(s)     P99(s)
----------------------------------------------------------------------------------------------------
API /validate        100      43.96      0.44       0.24       0.58       0.58       0.58
```

- master:
```bash
$ python tests/load_tests/test_load_on_server.py -n 100 --apis validate
Latency Statistics:
----------------------------------------------------------------------------------------------------
Kind                 Count    Total(s)   Avg(s)     Min(s)     Max(s)     P95(s)     P99(s)
----------------------------------------------------------------------------------------------------
API /validate        100      40.25      0.40       0.17       0.56       0.56       0.56
```

A ~40ms penalty looks acceptable, though not ideal. 

Ultimately `validate` should be fully async, but this involves broad code changes. More thoughts should be made before such refactor. 

Another problem found in #5300 will be tracked in https://github.com/skypilot-org/skypilot/issues/5327

@cg505 @Michaelvll PTAL, thanks!

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Benchmark
- [x] Unit test
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
