### PR TITLE
[aws] fix logic to detect rule with all traffic from security group

### DIFF
--- a/sky/provision/aws/instance.py
+++ b/sky/provision/aws/instance.py
@@ -799,6 +799,7 @@ def open_ports(
                 range(existing_rule['FromPort'], existing_rule['ToPort'] + 1))
         elif existing_rule['IpProtocol'] == '-1':
             # For AWS, IpProtocol = -1 means all traffic
+            all_traffic_allowed: bool = False
             for group_pairs in existing_rule['UserIdGroupPairs']:
                 if group_pairs['GroupId'] != sg.id:
                     # We skip the port opening when the rule allows access from
@@ -807,8 +808,10 @@ def open_ports(
                     # The security group created by SkyPilot allows all traffic
                     # from the same security group, which should not be skipped.
                     existing_ports.add(-1)
+                    all_traffic_allowed = True
                     break
-            break
+            if all_traffic_allowed:
+                break
 
     ports_to_open = []
     # Do not need to open any ports when all traffic is already allowed.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

https://github.com/skypilot-org/skypilot/commit/f0f4de8d310032e467627c999918281a100bbbb3#diff-83ddf91a29dd4a792b795f4f2a403ae13f22692e2854bf8e342c88d19be78ef0R726-R740
<img width="742" alt="Screenshot 2025-04-23 at 12 32 55 PM" src="https://github.com/user-attachments/assets/04b33e87-8e98-44dd-9d93-0a3b0552dc2b" />

This commit has the right idea, but the introduction of another for loop ends up complicating the `break` logic a tad bit. This PR fixes the logic.

Closes https://github.com/skypilot-org/skypilot/issues/5331

The current codepath opens a chance for a probabilistic bug in cases where some ports need to be opened for a cluster and those rules already exist for the chosen security group. If the SkyPilot added rule with `IpProtocol` of `-1` is returned in the list before the other rules, the current codepath breaks and never becomes aware of the other rules that are opening the ports requires. SkyPilot attempts to open these ports again, leading to duplicatePermission error from boto.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
