### PR TITLE
[GCP] add helptext about API srv missing `gcloud` when installed using wget

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -174,7 +174,9 @@ class GCP(clouds.Cloud):
         # Install the Google Cloud SDK:
         f'{_INDENT_PREFIX}  $ pip install google-api-python-client\n'
         f'{_INDENT_PREFIX}  $ conda install -c conda-forge '
-        'google-cloud-sdk -y')
+        'google-cloud-sdk -y\n'
+        'If gcloud was recently installed with wget, API server',
+        ' may need to be restarted.')
 
     _CREDENTIAL_HINT = (
         'Run the following commands:\n'
@@ -776,7 +778,7 @@ class GCP(clouds.Cloud):
                         raise FileNotFoundError(file)
             except FileNotFoundError as e:
                 return False, (
-                    f'Credentails are not set. '
+                    f'Credentials are not set. '
                     f'{cls._CREDENTIAL_HINT}\n'
                     f'{cls._INDENT_PREFIX}Details: '
                     f'{common_utils.format_exception(e, use_bracket=True)}')

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -176,7 +176,8 @@ class GCP(clouds.Cloud):
         f'{_INDENT_PREFIX}  $ conda install -c conda-forge '
         'google-cloud-sdk -y\n'
         'If gcloud was recently installed with wget, API server',
-        ' may need to be restarted.')
+        ' may need to be restarted with following commands:\n'
+        f'{_INDENT_PREFIX}  $ sky api stop; sky api start')
 
     _CREDENTIAL_HINT = (
         'Run the following commands:\n'


### PR DESCRIPTION
Addresses https://github.com/skypilot-org/skypilot/issues/4952

When gcloud is installed with wget, gcloud modifies the user rc file which the user must source again. The added snippet in the rcfile essentially modifies the PATH variable to add the path to gcloud executable,

This is different from other methods of installation, such as brew, where the gcloud executable is installed within the existing PATH (e.g. path to brew executables)

If skypilot API server is started before gcloud is installed via wget, the API server's PATH does not have the correct path to gcloud executable even if the user sources the rcfile again. This is because in python, os.environ is loaded once at the beginning of the program and is not affected by the underlying environment once the program starts running.

This could cause a case where gcloud --version works on the terminal, but the API server's gcloud --version does not as it does not have the updated PATH.

There's not really a good way to update the PATH in the API server unless we pass them in somehow - which I don't think is the approach we want to take. A good step here would be to provide a better error message in case gcloud --version does not work on API server to let user know of this possibility.
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
