### PR TITLE
[k8s] idea: allow an accelerator to map to multiple label values

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -454,7 +454,7 @@ class Kubernetes(clouds.Cloud):
             self.IMAGE_CPU, clouds='kubernetes')
 
         k8s_acc_label_key = None
-        k8s_acc_label_value = None
+        k8s_acc_label_values = None
         k8s_topology_label_key = None
         k8s_topology_label_value = None
         k8s_resource_key = None
@@ -462,9 +462,9 @@ class Kubernetes(clouds.Cloud):
 
         # If GPU/TPUs are requested, set node label to match the GPU/TPU type.
         if acc_count > 0 and acc_type is not None:
-            (k8s_acc_label_key, k8s_acc_label_value, k8s_topology_label_key,
+            (k8s_acc_label_key, k8s_acc_label_values, k8s_topology_label_key,
              k8s_topology_label_value) = (
-                 kubernetes_utils.get_accelerator_label_key_value(
+                 kubernetes_utils.get_accelerator_label_key_values(
                      context, acc_type, acc_count))
             if (k8s_acc_label_key ==
                     kubernetes_utils.GKELabelFormatter.TPU_LABEL_KEY):
@@ -562,7 +562,7 @@ class Kubernetes(clouds.Cloud):
             'k8s_networking_mode': network_utils.get_networking_mode().value,
             'k8s_ssh_key_secret_name': self.SKY_SSH_KEY_SECRET_NAME,
             'k8s_acc_label_key': k8s_acc_label_key,
-            'k8s_acc_label_value': k8s_acc_label_value,
+            'k8s_acc_label_values': k8s_acc_label_values,
             'k8s_ssh_jump_name': self.SKY_SSH_JUMP_NAME,
             'k8s_ssh_jump_image': ssh_jump_image,
             'k8s_service_account_name': k8s_service_account_name,

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1222,12 +1222,12 @@ def get_accelerator_label_key_values(
                                 # different topologies that maps to identical
                                 # number of TPU chips.
                                 if tpu_topology_chip_count == acc_count:
-                                    return (label, value, topology_label_key,
+                                    return (label, [value], topology_label_key,
                                             topology_value)
                                 else:
                                     continue
                         else:
-                            return label, value, None, None
+                            return label, [value], None, None
 
             # If no node is found with the requested acc_type, raise error
             with ux_utils.print_exception_no_traceback():

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -258,7 +258,7 @@ available_node_types:
         # service is required.
         labels:
             parent: skypilot
-            # component will be set for the head node pod to be the same as the head node service selector above if a 
+            # component will be set for the head node pod to be the same as the head node service selector above if a
             skypilot-cluster: {{cluster_name_on_cloud}}
             # Identifies the SSH jump pod used by this pod. Used in life cycle management of the ssh jump pod.
             skypilot-ssh-jump: {{k8s_ssh_jump_name}}
@@ -277,17 +277,27 @@ available_node_types:
         restartPolicy: {{ "Always" if high_availability else "Never" }}
 
         # Add node selector if GPU/TPUs are requested:
-        {% if (k8s_acc_label_key is not none and k8s_acc_label_value is not none) or (k8s_spot_label_key is not none) %}
+        {% if (k8s_topology_label_key is not none and k8s_topology_label_value is not none) or (k8s_spot_label_key is not none) %}
         nodeSelector:
-            {% if k8s_acc_label_key is not none and k8s_acc_label_value is not none %}
-            {{k8s_acc_label_key}}: {{k8s_acc_label_value}}
-            {% endif %}
             {% if k8s_topology_label_key is not none and k8s_topology_label_value is not none %}
             {{k8s_topology_label_key}}: {{k8s_topology_label_value}}
             {% endif %}
             {% if k8s_spot_label_key is not none %}
             {{k8s_spot_label_key}}: {{k8s_spot_label_value|tojson}}
             {% endif %}
+        {% endif %}
+        {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) %}
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: {{k8s_acc_label_key}}
+                  operator: In
+                  values:
+                  {% for label_value in k8s_acc_label_values %}
+                  - {{label_value}}
+                  {% endfor %}
         {% endif %}
 
         {% if k8s_spot_label_key is not none %}
@@ -339,15 +349,15 @@ available_node_types:
           # Do not change this command - it keeps the pod alive until it is
           # explicitly killed.
           command: ["/bin/bash", "-c", "--"]
-          args: 
+          args:
             - |
               # For backwards compatibility, we put a marker file in the pod
-              # to indicate that the pod is running with the changes introduced 
+              # to indicate that the pod is running with the changes introduced
               # in project nimbus: https://github.com/skypilot-org/skypilot/pull/4393
               # TODO: Remove this marker file and it's usage in setup_commands
               # after v0.10.0 release.
               touch /tmp/skypilot_is_nimbus
-              
+
               # Helper function to conditionally use sudo
               # TODO(zhwu): consolidate the two prefix_cmd and sudo replacements
               prefix_cmd() { if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; }
@@ -390,7 +400,7 @@ available_node_types:
                 fi;
                 # SSH and other packages are not necessary, so we disable set -e
                 set +e
-                
+
                 if [ ! -z "$MISSING_PACKAGES" ]; then
                   # Install missing packages individually to avoid failure installation breaks the whole install process,
                   # e.g. fuse3 is not available on some distributions.
@@ -443,7 +453,7 @@ available_node_types:
                     $(prefix_cmd) rm -f /bin/fusermount-wrapper
                     $(prefix_cmd) cp -p {{k8s_fusermount_shared_dir}}/fusermount-wrapper /bin/fusermount-wrapper
                 fi
-                {% endif %}            
+                {% endif %}
 
                 $(prefix_cmd) mkdir -p /var/run/sshd;
                 $(prefix_cmd) sed -i "s/PermitRootLogin prohibit-password/PermitRootLogin yes/" /etc/ssh/sshd_config;
@@ -574,7 +584,7 @@ available_node_types:
                       # File is already being monitored
                       continue
                     fi
-                    
+
                     # Monitor the new file
                     monitor_file $file &
                     already_monitored="${already_monitored} ${file}"
@@ -756,7 +766,7 @@ setup_commands:
     echo "=== Logs for asynchronous ray and skypilot installation ===";
     if [ -f /tmp/skypilot_is_nimbus ]; then
       echo "=== Logs for asynchronous ray and skypilot installation ===";
-      [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log || 
+      [ -f /tmp/ray_skypilot_installation_complete ] && cat /tmp/${STEPS[1]}.log ||
       { tail -f -n +1 /tmp/${STEPS[1]}.log & TAIL_PID=$!; echo "Tail PID: $TAIL_PID"; until [ -f /tmp/ray_skypilot_installation_complete ]; do sleep 0.5; done; kill $TAIL_PID || true; };
       [ -f /tmp/${STEPS[1]}.failed ] && { echo "Error: ${STEPS[1]} failed. Exiting."; exit 1; } || true;
     fi
@@ -786,7 +796,7 @@ setup_commands:
     # properly written.
     # TODO(Doyoung): Investigate to see why TPU workload fails to run without
     # execution permission, such as granting 766 to log file. Check if it's a
-    # must and see if there's a workaround to grant minimum permission. 
+    # must and see if there's a workaround to grant minimum permission.
     sudo chmod 777 /tmp/tpu_logs;
     {% endif %}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I was looking at `GFDLabelFormatter` and found this comment snippet
```
    This LabelFormatter can't be used in autoscaling clusters since accelerators
    may map to multiple label, so we're not implementing `get_label_values`

...
    def get_label_value(cls, accelerator: str) -> str:
        """An accelerator can map to many Nvidia GFD labels
        (e.g., A100-80GB-PCIE vs. A100-SXM4-80GB).
        As a result, we do not support get_label_value for GFDLabelFormatter."""
```

GFDLabelFormatter is a pretty versatile formatter as it essentially comes for free with NVIDIA GPU operator. So I'd actually like this formatter to support get_label_value. This PR removes the current blocker preventing GFDLabelFormatter's `get_label_value` implementation.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] k8s smoke tests: `/smoke-test --kubernetes`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
