### PR TITLE
[Nebius] Don't cache session across multiple requests

### DIFF
--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -81,9 +81,9 @@ def vpc():
     return vpc_v1
 
 
-def get_iam_token():
+def get_iam_token(force_update=False):
     global _iam_token
-    if _iam_token is None:
+    if _iam_token is None or force_update:
         try:
             with open(os.path.expanduser(NEBIUS_IAM_TOKEN_PATH),
                       encoding='utf-8') as file:
@@ -110,9 +110,9 @@ def get_project_id():
     return _project_id
 
 
-def get_tenant_id():
+def get_tenant_id(force_update=False):
     global _tenant_id
-    if _tenant_id is None:
+    if _tenant_id is None or force_update:
         try:
             with open(os.path.expanduser(NEBIUS_TENANT_ID_PATH),
                       encoding='utf-8') as file:
@@ -122,11 +122,12 @@ def get_tenant_id():
     return _tenant_id
 
 
-def sdk():
+def sdk(force_update=False):
     global _sdk
-    if _sdk is None:
-        if get_iam_token() is not None:
-            _sdk = nebius.sdk.SDK(credentials=get_iam_token())
+    if _sdk is None or force_update:
+        token = get_iam_token(force_update)
+        if token is not None:
+            _sdk = nebius.sdk.SDK(credentials=token)
             return _sdk
         _sdk = nebius.sdk.SDK(
             credentials_file_name=os.path.expanduser(NEBIUS_CREDENTIALS_PATH))

--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -81,57 +81,49 @@ def vpc():
     return vpc_v1
 
 
-def get_iam_token(force_update=False):
-    global _iam_token
-    if _iam_token is None or force_update:
-        try:
-            with open(os.path.expanduser(NEBIUS_IAM_TOKEN_PATH),
-                      encoding='utf-8') as file:
-                _iam_token = file.read().strip()
-        except FileNotFoundError:
-            return None
-    return _iam_token
+@annotations.lru_cache(scope='request')
+def get_iam_token():
+    try:
+        with open(os.path.expanduser(NEBIUS_IAM_TOKEN_PATH),
+                  encoding='utf-8') as file:
+            return file.read().strip()
+    except FileNotFoundError:
+        return None
 
 
+@annotations.lru_cache(scope='request')
 def is_token_or_cred_file_exist():
     return (os.path.exists(os.path.expanduser(NEBIUS_IAM_TOKEN_PATH)) or
             os.path.exists(os.path.expanduser(NEBIUS_CREDENTIALS_PATH)))
 
 
+@annotations.lru_cache(scope='request')
 def get_project_id():
-    global _project_id
-    if _project_id is None:
-        try:
-            with open(os.path.expanduser(NEBIUS_PROJECT_ID_PATH),
-                      encoding='utf-8') as file:
-                _project_id = file.read().strip()
-        except FileNotFoundError:
-            return None
-    return _project_id
+    try:
+        with open(os.path.expanduser(NEBIUS_PROJECT_ID_PATH),
+                  encoding='utf-8') as file:
+            return file.read().strip()
+    except FileNotFoundError:
+        return None
 
 
-def get_tenant_id(force_update=False):
-    global _tenant_id
-    if _tenant_id is None or force_update:
-        try:
-            with open(os.path.expanduser(NEBIUS_TENANT_ID_PATH),
-                      encoding='utf-8') as file:
-                _tenant_id = file.read().strip()
-        except FileNotFoundError:
-            return None
-    return _tenant_id
+@annotations.lru_cache(scope='request')
+def get_tenant_id():
+    try:
+        with open(os.path.expanduser(NEBIUS_TENANT_ID_PATH),
+                  encoding='utf-8') as file:
+            return file.read().strip()
+    except FileNotFoundError:
+        return None
 
 
-def sdk(force_update=False):
-    global _sdk
-    if _sdk is None or force_update:
-        token = get_iam_token(force_update)
-        if token is not None:
-            _sdk = nebius.sdk.SDK(credentials=token)
-            return _sdk
-        _sdk = nebius.sdk.SDK(
-            credentials_file_name=os.path.expanduser(NEBIUS_CREDENTIALS_PATH))
-    return _sdk
+@annotations.lru_cache(scope='request')
+def sdk():
+    token = get_iam_token()
+    if token is not None:
+        return nebius.sdk.SDK(credentials=token)
+    return nebius.sdk.SDK(
+        credentials_file_name=os.path.expanduser(NEBIUS_CREDENTIALS_PATH))
 
 
 def get_nebius_credentials(boto3_session):

--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -29,11 +29,6 @@ MAX_RETRIES_TO_INSTANCE_WAIT = 120  # Maximum number of retries
 
 POLL_INTERVAL = 5
 
-_iam_token = None
-_sdk = None
-_tenant_id = None
-_project_id = None
-
 _IMPORT_ERROR_MESSAGE = ('Failed to import dependencies for Nebius AI Cloud.'
                          'Try pip install "skypilot[nebius]"')
 

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -290,8 +290,8 @@ class Nebius(clouds.Cloud):
                       f'{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.NEBIUS_TENANT_ID_PATH} \n')  # pylint: disable=line-too-long
         if not nebius.is_token_or_cred_file_exist():
             return False, f'{token_cred_msg}'
-        sdk = nebius.sdk()
-        tenant_id = nebius.get_tenant_id()
+        sdk = nebius.sdk(force_update=True)
+        tenant_id = nebius.get_tenant_id(force_update=True)
         if tenant_id is None:
             return False, f'{tenant_msg}'
         try:

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,5 +1,4 @@
 """ Nebius Cloud. """
-import logging
 import os
 import typing
 from typing import Dict, Iterator, List, Optional, Tuple, Union
@@ -7,6 +6,7 @@ from typing import Dict, Iterator, List, Optional, Tuple, Union
 from sky import clouds
 from sky.adaptors import nebius
 from sky.clouds import service_catalog
+from sky.utils import annotations
 from sky.utils import registry
 from sky.utils import resources_utils
 
@@ -275,23 +275,23 @@ class Nebius(clouds.Cloud):
                                                  fuzzy_candidate_list, None)
 
     @classmethod
+    @annotations.lru_cache(scope='request')
     def _check_compute_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to
         Nebius's compute service."""
-        logging.debug('Nebius cloud check credentials')
         token_cred_msg = (
             f'{_INDENT_PREFIX}Credentials can be set up by running: \n'
             f'{_INDENT_PREFIX}  $ nebius iam get-access-token > {nebius.NEBIUS_IAM_TOKEN_PATH} \n'  # pylint: disable=line-too-long
-            f'{_INDENT_PREFIX} or generate  ~/.nebius/credentials.json')
+            f'{_INDENT_PREFIX} or generate  ~/.nebius/credentials.json \n')
 
-        tenant_msg = (f'{_INDENT_PREFIX}Copy your tenat ID from the web console and save it to file \n'  # pylint: disable=line-too-long
+        tenant_msg = (f'{_INDENT_PREFIX} Copy your tenat ID from the web console and save it to file \n'  # pylint: disable=line-too-long
                       f'{_INDENT_PREFIX}  $ echo $NEBIUS_TENANT_ID_PATH > {nebius.NEBIUS_TENANT_ID_PATH} \n'  # pylint: disable=line-too-long
                       f'{_INDENT_PREFIX} Or if you have 1 tenant you can run:\n'  # pylint: disable=line-too-long
                       f'{_INDENT_PREFIX}  $ nebius --format json iam whoami|jq -r \'.user_profile.tenants[0].tenant_id\' > {nebius.NEBIUS_TENANT_ID_PATH} \n')  # pylint: disable=line-too-long
         if not nebius.is_token_or_cred_file_exist():
             return False, f'{token_cred_msg}'
-        sdk = nebius.sdk(force_update=True)
-        tenant_id = nebius.get_tenant_id(force_update=True)
+        sdk = nebius.sdk()
+        tenant_id = nebius.get_tenant_id()
         if tenant_id is None:
             return False, f'{tenant_msg}'
         try:
@@ -301,11 +301,12 @@ class Nebius(clouds.Cloud):
         except nebius.request_error() as e:
             return False, (
                 f'{e.status} \n'  # First line is indented by 4 spaces
-                f'{token_cred_msg}'
+                f'{token_cred_msg} \n'
                 f'{tenant_msg}')
         return True, None
 
     @classmethod
+    @annotations.lru_cache(scope='request')
     def _check_storage_credentials(cls) -> Tuple[bool, Optional[str]]:
         """Checks if the user has access credentials to Nebius Object Storage.
 


### PR DESCRIPTION
This update introduces a `force_update` flag to `sdk`, `get_iam_token`, and `get_tenant_id` functions, ensuring credentials can be refreshed on demand. It addresses scenarios where cached values are outdated or invalid, improving reliability during authentication. This change ensures up-to-date credentials are used when necessary.

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

