### PR TITLE
[GCP] Support hyperdisk-balanced for a3 series

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1012,8 +1012,9 @@ class GCP(clouds.Cloud):
         if disk_tier != resources_utils.DiskTier.ULTRA or instance_type is None:
             return True, ''
         # Ultra disk tier (pd-extreme) only support m2, m3 and part of n2
-        # instance types, so we failover to lower tiers for other instance
-        # types. Reference:
+        # instance types. For a3 instances, we map the ULTRA tier to
+        # hyperdisk-balanced. For all other instance types, we failover to
+        # lower tiers. Reference:
         # https://cloud.google.com/compute/docs/disks/extreme-persistent-disk#machine_shape_support  # pylint: disable=line-too-long
         series = instance_type.split('-')[0]
         if series in ['m2', 'm3', 'n2', 'a3']:
@@ -1023,9 +1024,11 @@ class GCP(clouds.Cloud):
                     return False, ('n2 series with less than 64 vCPUs are '
                                    'not supported with pd-extreme.')
             return True, ''
-        return False, (f'{series} series is not supported with pd-extreme. '
-                       'Only m2, m3 series and n2 series with 64 or more vCPUs '
-                       'are supported.')
+        return False, (f'{series} series is not supported with pd-extreme '
+                       'or hyperdisk-balanced. Only m2, m3 series and n2 '
+                       'series with 64 or more vCPUs are supported with '
+                       'pd-extreme. Also, only a3 is supported with '
+                       'hyperdisk-balanced.')
 
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: Optional[str],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
### Tracking issue
https://github.com/skypilot-org/skypilot/issues/4705

### Why are the changes needed?
According to the [GCP doc](https://cloud.google.com/compute/docs/disks#hd-vs-pd), Hyperdisk offers better performance and flexibility compared to Persistent Disks. It allows tuning performance independently of size and provides higher IOPS and throughput.

GCP recommends using Hyperdisk when it’s supported by the machine. Notably, `hyperdisk-balanced` is the only Hyperdisk type that supports boot disks.

This PR proposes integrating `hyperdisk-balanced` as one of the disk types for GCP A3 series instances.

### What changes were proposed in this pull request?
* Map `ULTRA` disk tier to `hyperdisk-balanced` type
* Propagate `MEDIUM` disk tier (which maps to `pd-balanced`) to `LOW` as A3 series doesn't support `pd-standard`

#### Screenshots
* `sky launch -t a3-highgpu-8g --disk-tier ultra --dryrun`

![Screenshot 2025-04-24 at 9 57 06 PM](https://github.com/user-attachments/assets/09102875-6974-4e2b-bf5c-5b378e9b4931)

* `sky launch -t a3-highgpu-8g --disk-tier best --dryrun`

![Screenshot 2025-04-24 at 9 58 01 PM](https://github.com/user-attachments/assets/a151cbaa-1f01-4cfa-afe7-44be3c3bf64f)

* `sky launch -t a3-megagpu-8g --disk-tier ultra --dryrun`

![Screenshot 2025-04-24 at 9 59 01 PM](https://github.com/user-attachments/assets/2deaccea-86bc-4531-bb93-5b0ddc8b29b1)

* `sky launch -t a3-megagpu-8g --disk-tier best --dryrun`

![Screenshot 2025-04-24 at 9 59 47 PM](https://github.com/user-attachments/assets/cec56aea-52b5-419d-997d-d0bf1de08aba)

* `sky launch -t a3-megagpu-8g --disk-tier low --dryrun`

![Screenshot 2025-04-24 at 10 06 04 PM](https://github.com/user-attachments/assets/3009bbb3-93df-4b6e-8889-a70181f8edb1)



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
