### PR TITLE
update installation docs and Dockerfile to reflect omegaconf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \
+    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' 'omegaconf>=2.4.0dev3' --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -132,9 +132,12 @@ Installing via ``uv`` is also supported:
 .. code-block:: shell
 
   uv venv --seed --python 3.10
-  uv pip install "skypilot[kubernetes,aws,gcp]"
-  # Azure CLI has an issue with uv, and requires '--prerelease allow'.
-  uv pip install --prerelease allow azure-cli
+  # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
+  uv pip install 'omegaconf>=2.4.0dev3'
+  # Install skypilot!
+  uv pip install 'skypilot[kubernetes,aws,gcp]'
+  # Azure CLI requires '--prerelease allow' with uv.
+  uv pip install --prerelease allow 'azure-cli>=2.65.0'
   uv pip install "skypilot[all]"
 
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -132,13 +132,10 @@ Installing via ``uv`` is also supported:
 .. code-block:: shell
 
   uv venv --seed --python 3.10
-  # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
-  uv pip install 'omegaconf>=2.4.0dev3'
-  # Install skypilot!
-  uv pip install 'skypilot[kubernetes,aws,gcp]'
-  # Azure CLI requires '--prerelease allow' with uv.
   uv pip install --prerelease allow 'azure-cli>=2.65.0'
-  uv pip install "skypilot[all]"
+  # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
+  # Optionally only install specific clouds - e.g. 'skypilot[aws,gcp,kubernetes]'
+  uv pip install 'omegaconf>=2.4.0dev3' 'skypilot[all]'
 
 
 Alternatively, we also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This helps mitigate #5355 from the docs side.
Also fixes the Dockerfile.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
