### PR TITLE
[k8s] CPU only jobs to prefer nodes without GPUs

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -459,6 +459,7 @@ class Kubernetes(clouds.Cloud):
         k8s_topology_label_value = None
         k8s_resource_key = None
         tpu_requested = False
+        avoid_label_keys = None
 
         # If GPU/TPUs are requested, set node label to match the GPU/TPU type.
         if acc_count > 0 and acc_type is not None:
@@ -472,6 +473,9 @@ class Kubernetes(clouds.Cloud):
                 k8s_resource_key = kubernetes_utils.TPU_RESOURCE_KEY
             else:
                 k8s_resource_key = kubernetes_utils.get_gpu_resource_key()
+        else:
+            avoid_label_keys = kubernetes_utils.get_accelerator_label_keys(
+                context)
 
         port_mode = network_utils.get_port_mode(None)
 
@@ -597,6 +601,7 @@ class Kubernetes(clouds.Cloud):
                 (constants.PERSISTENT_RUN_SCRIPT_DIR),
             'k8s_high_availability_storage_class_name':
                 (k8s_ha_storage_class_name),
+            'avoid_label_keys': avoid_label_keys,
         }
 
         # Add kubecontext if it is set. It may be None if SkyPilot is running

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -476,7 +476,8 @@ class Kubernetes(clouds.Cloud):
         else:
             avoid_label_keys = kubernetes_utils.get_accelerator_label_keys(
                 context)
-
+            if len(avoid_label_keys) == 0:
+                avoid_label_keys = None
         port_mode = network_utils.get_port_mode(None)
 
         remote_identity = skypilot_config.get_nested(

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1084,6 +1084,16 @@ def check_instance_fits(context: Optional[str],
         return fits, reason
 
 
+def get_accelerator_label_keys(context: Optional[str],) -> List[str]:
+    """Returns the label keys that should be avoided for scheduling
+    CPU-only tasks.
+    """
+    label_formatter, _ = detect_gpu_label_formatter(context)
+    if label_formatter is None:
+        return []
+    return label_formatter.get_label_keys()
+
+
 def get_accelerator_label_key_values(
     context: Optional[str],
     acc_type: str,

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -289,9 +289,10 @@ available_node_types:
             {{k8s_spot_label_key}}: {{k8s_spot_label_value|tojson}}
             {% endif %}
         {% endif %}
-        {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) %}
+        {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) or (avoid_label_keys is not none) %}
         affinity:
           nodeAffinity:
+            {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
               - matchExpressions:
@@ -301,6 +302,18 @@ available_node_types:
                   {% for label_value in k8s_acc_label_values %}
                   - {{label_value}}
                   {% endfor %}
+            {% endif %}
+            {% if avoid_label_keys is not none %}
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                {% for avoid_label_key in avoid_label_keys %}
+                - key: {{avoid_label_key}}
+                  operator: DoesNotExist
+                {% endfor %}
+            {% endif %}
+          {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
               - weight: 1
@@ -312,6 +325,7 @@ available_node_types:
                         values:
                           - "gpu"
                   topologyKey: kubernetes.io/hostname
+          {% endif %}
         {% endif %}
         {% if k8s_spot_label_key is not none %}
         tolerations:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Problem statement: In a k8s cluster with multiple node pools, it is possible to have a heterogenous cluster where some nodes are CPU instances and some nodes are GPU instances.

In such cases, we would like to _prefer_ that CPU only tasks get scheduled on CPU nodes, so they don't take up resources from GPU nodes.

Solution: We already have access to GPU label formatters which provide us with the label key(s) a node with accelerators should have. It should therefore be possible to specify an affinity to the nodes without these labels for CPU only jobs.



Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual testing:
1. Create a k8s cluster with 1 CPU only instance (16 vCPUs) and 2 GPU instances
2. Create 8 pods each with 2 CPUs on (a) master branch and (b) on this branch.

On master branch,
    - pods 1 and 2 are scheduled on a CPU node
    - pod 3 is scheduled on a GPU node
    - pods 4 and 5 are scheduled on a CPU node
    - pod 6 is scheduled on a GPU node
    - pods 7 and 8 are scheduled on a CPU node

On this branch, first 7 pods are scheduled on the CPU node. The 8th pod is scheduled on the GPU node, as there is less than 2 CPUs on the CPU node. This is because there are 7*2 = 14 vCPUs used by SkyPilot pods and some other vCPUs used by other pods on the node.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
