### PR TITLE
Crusoe Managed Kubernetes support

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1326,10 +1326,10 @@ def check_credentials(context: Optional[str],
             return False, f'Failed to communicate with the cluster: {str(e)}'
     except kubernetes.config_exception() as e:
         return False, f'Invalid configuration file: {str(e)}'
-    except kubernetes.max_retry_error():
+    except kubernetes.max_retry_error() as e:
         return False, ('Failed to communicate with the cluster - timeout. '
                        'Check if your cluster is running and your network '
-                       'is stable.')
+                       f'is stable. Details: {str(e)}')
     except ValueError as e:
         return False, common_utils.format_exception(e)
     except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support k8s clusters from https://crusoe.ai/cloud. For some reason `sky check` on their cluster fails with an SSL error even though kubectl works on the cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
