### PR TITLE
fixes from #5335

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -175,7 +175,7 @@ class GCP(clouds.Cloud):
         f'{_INDENT_PREFIX}  $ pip install google-api-python-client\n'
         f'{_INDENT_PREFIX}  $ conda install -c conda-forge '
         'google-cloud-sdk -y\n'
-        'If gcloud was recently installed with wget, API server',
+        f'{_INDENT_PREFIX} If gcloud was recently installed with wget, API server'
         ' may need to be restarted with following commands:\n'
         f'{_INDENT_PREFIX}  $ sky api stop; sky api start')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The extra comma there was causing this variable to be interpreted as a struct not a string :<


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
