### PR TITLE
[UX][k8s] show-gpus for all allowed contexts

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3413,7 +3413,7 @@ def show_gpus(
 
     # TODO(zhwu,romilb): We should move most of these kubernetes related
     # queries into the backend, especially behind the server.
-    def _get_kubernetes_realtime_gpu_table(
+    def _get_kubernetes_realtime_gpu_tables(
             context: Optional[str] = None,
             name_filter: Optional[str] = None,
             quantity_filter: Optional[int] = None):
@@ -3423,15 +3423,14 @@ def show_gpus(
         else:
             qty_header = 'REQUESTABLE_QTY_PER_NODE'
             free_header = 'TOTAL_FREE_GPUS'
-        realtime_gpu_table = log_utils.create_table(
-            ['GPU', qty_header, 'TOTAL_GPUS', free_header])
-        realtime_gpu_availability_list = sdk.stream_and_get(
+
+        realtime_gpu_availability_lists = sdk.stream_and_get(
             sdk.realtime_kubernetes_gpu_availability(
                 context=context,
                 name_filter=name_filter,
                 quantity_filter=quantity_filter))
-        if not realtime_gpu_availability_list:
-            err_msg = 'No GPUs found in Kubernetes cluster. '
+        if not realtime_gpu_availability_lists:
+            err_msg = 'No GPUs found in any allowed Kubernetes cluster. '
             debug_msg = 'To further debug, run: sky check '
             if name_filter is not None:
                 gpu_info_msg = f' {name_filter!r}'
@@ -3439,26 +3438,32 @@ def show_gpus(
                     gpu_info_msg += (' with requested quantity'
                                      f' {quantity_filter}')
                 err_msg = (f'Resources{gpu_info_msg} not found '
-                           'in Kubernetes cluster. ')
+                           'in any allowed Kubernetes cluster. ')
                 debug_msg = ('To show available accelerators on kubernetes,'
                              ' run: sky show-gpus --cloud kubernetes ')
             full_err_msg = (err_msg + kubernetes_constants.NO_GPU_HELP_MESSAGE +
                             debug_msg)
             raise ValueError(full_err_msg)
         no_permissions_str = '<no permissions>'
-        for realtime_gpu_availability in sorted(realtime_gpu_availability_list):
-            gpu_availability = models.RealtimeGpuAvailability(
-                *realtime_gpu_availability)
-            available_qty = (gpu_availability.available
-                             if gpu_availability.available != -1 else
-                             no_permissions_str)
-            realtime_gpu_table.add_row([
-                gpu_availability.gpu,
-                _list_to_str(gpu_availability.counts),
-                gpu_availability.capacity,
-                available_qty,
-            ])
-        return realtime_gpu_table
+        realtime_gpu_infos = []
+
+        for (ctx, availability_list) in realtime_gpu_availability_lists:
+            realtime_gpu_table = log_utils.create_table(
+                ['GPU', qty_header, 'TOTAL_GPUS', free_header])
+            for realtime_gpu_availability in sorted(availability_list):
+                gpu_availability = models.RealtimeGpuAvailability(
+                    *realtime_gpu_availability)
+                available_qty = (gpu_availability.available
+                                 if gpu_availability.available != -1 else
+                                 no_permissions_str)
+                realtime_gpu_table.add_row([
+                    gpu_availability.gpu,
+                    _list_to_str(gpu_availability.counts),
+                    gpu_availability.capacity,
+                    available_qty,
+                ])
+            realtime_gpu_infos.append((ctx, realtime_gpu_table))
+        return realtime_gpu_infos
 
     def _format_kubernetes_node_info(context: Optional[str]):
         node_table = log_utils.create_table(
@@ -3479,7 +3484,7 @@ def show_gpus(
             'Kubernetes per node accelerator availability ')
         if nodes_info.hint:
             k8s_per_node_acc_message += nodes_info.hint
-        return (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+        return (f'{colorama.Fore.LIGHTMAGENTA_EX}{colorama.Style.NORMAL}'
                 f'{k8s_per_node_acc_message}'
                 f'{colorama.Style.RESET_ALL}\n'
                 f'{node_table.get_string()}')
@@ -3516,7 +3521,7 @@ def show_gpus(
                     # If --cloud kubernetes is not specified, we want to catch
                     # the case where no GPUs are available on the cluster and
                     # print the warning at the end.
-                    k8s_realtime_table = _get_kubernetes_realtime_gpu_table(
+                    k8s_realtime_infos = _get_kubernetes_realtime_gpu_tables(
                         context)
                 except ValueError as e:
                     if not cloud_is_kubernetes:
@@ -3525,13 +3530,14 @@ def show_gpus(
                     k8s_messages += str(e)
                 else:
                     print_section_titles = True
-                    context_str = f'(Context: {context})' if context else ''
-                    yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                           f'Kubernetes GPUs {context_str}'
-                           f'{colorama.Style.RESET_ALL}\n')
-                    yield from k8s_realtime_table.get_string()
-                    yield '\n\n'
-                    yield _format_kubernetes_node_info(context)
+                    for (ctx, k8s_realtime_table) in k8s_realtime_infos:
+                        context_str = f'(Context: {ctx})' if ctx else ''
+                        yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+                               f'Kubernetes GPUs {context_str}'
+                               f'{colorama.Style.RESET_ALL}\n')
+                        yield from k8s_realtime_table.get_string()
+                        yield '\n\n'
+                        yield _format_kubernetes_node_info(ctx) + '\n-----\n\n'
                 if kubernetes_autoscaling:
                     k8s_messages += (
                         '\n' + kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE)
@@ -3620,13 +3626,16 @@ def show_gpus(
             # Print section title if not showing all and instead a specific
             # accelerator is requested
             print_section_titles = True
-            yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                   f'Kubernetes GPUs{colorama.Style.RESET_ALL}\n')
             # TODO(romilb): Show filtered per node GPU availability here as well
             try:
-                k8s_realtime_table = _get_kubernetes_realtime_gpu_table(
+                k8s_realtime_infos = _get_kubernetes_realtime_gpu_tables(
                     name_filter=name, quantity_filter=quantity)
-                yield from k8s_realtime_table.get_string()
+                for (_, k8s_realtime_table) in k8s_realtime_infos:
+                    yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
+                           f'Kubernetes GPUs {context_str}'
+                           f'{colorama.Style.RESET_ALL}\n')
+                    yield from k8s_realtime_table.get_string()
+                    yield '\n\n'
             except ValueError as e:
                 # In the case of a specific accelerator, show the error message
                 # immediately (e.g., "Resources H100 not found ...")

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3466,12 +3466,12 @@ def show_gpus(
                     available_qty,
                 ])
                 gpu = gpu_availability.gpu
-                cap = gpu_availability.capacity
+                capacity = gpu_availability.capacity
                 # we want total, so skip permission denied.
-                avl = max(gpu_availability.available, 0)
-                if cap > 0:
-                    total_gpu_info[gpu][0] += cap
-                    total_gpu_info[gpu][1] += avl
+                available = max(gpu_availability.available, 0)
+                if capacity > 0:
+                    total_gpu_info[gpu][0] += capacity
+                    total_gpu_info[gpu][1] += available
             realtime_gpu_infos.append((ctx, realtime_gpu_table))
 
         if len(realtime_gpu_infos) > 1:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3474,6 +3474,8 @@ def show_gpus(
                     total_gpu_info[gpu][1] += available
             realtime_gpu_infos.append((ctx, realtime_gpu_table))
 
+        # display an aggregated table for all contexts
+        # if there are more than one contexts with GPUs
         if len(realtime_gpu_infos) > 1:
             total_realtime_gpu_table = log_utils.create_table(
                 ['GPU', 'TOTAL_GPUS', free_header])

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3629,8 +3629,9 @@ def show_gpus(
             # TODO(romilb): Show filtered per node GPU availability here as well
             try:
                 k8s_realtime_infos = _get_kubernetes_realtime_gpu_tables(
-                    name_filter=name, quantity_filter=quantity)
-                for (_, k8s_realtime_table) in k8s_realtime_infos:
+                    context=region, name_filter=name, quantity_filter=quantity)
+                for (ctx, k8s_realtime_table) in k8s_realtime_infos:
+                    context_str = f'(Context: {ctx})' if ctx else ''
                     yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                            f'Kubernetes GPUs {context_str}'
                            f'{colorama.Style.RESET_ALL}\n')

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -261,16 +261,16 @@ def _list_accelerators(
 
                 accelerators_available = accelerator_count - allocated_qty
 
-                # Initialize the entry if it doesn't exist yet
-                if accelerator_name not in total_accelerators_available:
-                    total_accelerators_available[accelerator_name] = 0
-
                 if accelerators_available >= min_quantity_filter:
                     quantized_availability = min_quantity_filter * (
                         accelerators_available // min_quantity_filter)
-                    total_accelerators_available[accelerator_name] = (
-                        total_accelerators_available.get(accelerator_name, 0) +
-                        quantized_availability)
+                    if quantized_availability != 0:
+                        # only increment when quantized availability is positive
+                        # to avoid assertion errors checking keyset sizes in
+                        # core.py _realtime_kubernetes_gpu_availability_single
+                        total_accelerators_available[accelerator_name] = (
+                            total_accelerators_available.get(
+                                accelerator_name, 0) + quantized_availability)
 
     result = []
 

--- a/sky/clouds/service_catalog/kubernetes_catalog.py
+++ b/sky/clouds/service_catalog/kubernetes_catalog.py
@@ -264,7 +264,7 @@ def _list_accelerators(
                 if accelerators_available >= min_quantity_filter:
                     quantized_availability = min_quantity_filter * (
                         accelerators_available // min_quantity_filter)
-                    if quantized_availability != 0:
+                    if quantized_availability > 0:
                         # only increment when quantized availability is positive
                         # to avoid assertion errors checking keyset sizes in
                         # core.py _realtime_kubernetes_gpu_availability_single

--- a/sky/core.py
+++ b/sky/core.py
@@ -1053,7 +1053,10 @@ def realtime_kubernetes_gpu_availability(
                                    List[models.RealtimeGpuAvailability]]] = []
     cumulative_count = 0
     parallel_queried = subprocess_utils.run_in_parallel(
-        _realtime_kubernetes_gpu_availability_single, context_list)
+        lambda ctx: _realtime_kubernetes_gpu_availability_single(
+            context=ctx,
+            name_filter=name_filter,
+            quantity_filter=quantity_filter), context_list)
 
     for ctx, queried in zip(context_list, parallel_queried):
         cumulative_count += len(queried)

--- a/sky/core.py
+++ b/sky/core.py
@@ -1035,7 +1035,7 @@ def realtime_kubernetes_gpu_availability(
             available.keys())), (f'Keys of counts ({list(counts.keys())}), '
                                  f'capacity ({list(capacity.keys())}), '
                                  f'and available ({list(available.keys())}) '
-                                 'must be same.')
+                                 'must be the same.')
         realtime_gpu_availability_list: List[
             models.RealtimeGpuAvailability] = []
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #5313 

<img width="1147" alt="Screenshot 2025-04-27 at 2 09 04 PM" src="https://github.com/user-attachments/assets/0a6e1621-0494-4cf0-8345-9c6643fd8143" />

~~**IMPORTANT! Feedback Please**
I didn't know whether it would be desirable, but I think it would be a good idea to show a final table that would merge all available accelerators across all k8s clusters? The user might want to only know the total availability across clusters. I think that might be a helpful summary feature. For instance, for the above image, we would have:~~

```
Kubernetes GPUs (all allowed contexts):
GPU: T4, TOTAL_GPUS: 2, TOTAL_FREE_GPUS: 2
```
**EDIT (25.04.27): implemented above feature as suggested in below comment**

**Some Behavioral Changes:**
- specifying an accelerator and the kubernetes context (aka region) at the same time ignored the kubernetes context. Fixed that to take into account the k8s context.
- in kubernetes_catalog. _list_accelerators(), the function was adding accelerator names to the dict and setting its availability to 0. I don't know if this is a real requirement (feedback would be great), but this creates an assertion error when checking the keyset sizes for accelerator counts, capacity, and available dicts when used in conjunction with a quantity filter. Therefore, added in checks to NOT add accelerator names to the dict when capacity is 0.
- added a "total table" feature so that users can see a cumulative sum of GPUs across their registered k8s clusters in allowed contexts.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
