### PR TITLE
[UX] Remove credentials from the dashboard URL and update the dashboard build hint

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5910,7 +5910,7 @@ def api_info():
     api_server_info = sdk.api_info()
     user_name = os.getenv(constants.USER_ENV_VAR, getpass.getuser())
     user_hash = common_utils.get_user_hash()
-    dashboard_url = f'{url}/dashboard'
+    dashboard_url = server_common.get_dashboard_url(url)
     click.echo(f'Using SkyPilot API server: {url} Dashboard: {dashboard_url}\n'
                f'{ux_utils.INDENT_SYMBOL}Status: {api_server_info["status"]}, '
                f'commit: {api_server_info["commit"]}, '

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -301,7 +301,7 @@ def validate(
 def dashboard() -> None:
     """Starts the dashboard for SkyPilot."""
     api_server_url = server_common.get_server_url()
-    url = f'{api_server_url}/dashboard'
+    url = server_common.get_dashboard_url(api_server_url)
     logger.info(f'Opening dashboard in browser: {url}')
     webbrowser.open(url)
 
@@ -1725,9 +1725,11 @@ def api_start(
     if foreground:
         # Explain why current process exited
         logger.info('API server is already running:')
-    dashboard_msg = f'Dashboard: {server_common.get_server_url(host)}/dashboard'
+    api_server_url = server_common.get_server_url(host)
+    dashboard_url = server_common.get_dashboard_url(api_server_url)
+    dashboard_msg = f'Dashboard: {dashboard_url}'
     logger.info(f'{ux_utils.INDENT_SYMBOL}SkyPilot API server: '
-                f'{server_common.get_server_url(host)} {dashboard_msg}\n'
+                f'{api_server_url} {dashboard_msg}\n'
                 f'{ux_utils.INDENT_LAST_SYMBOL}'
                 f'View API server logs at: {constants.API_SERVER_LOGS}')
 
@@ -1835,7 +1837,8 @@ def api_login(endpoint: Optional[str] = None) -> None:
             config = skypilot_config.get_user_config()
             config.set_nested(('api_server', 'endpoint'), endpoint)
         common_utils.dump_yaml(str(config_path), dict(config))
-        dashboard_msg = f'Dashboard: {endpoint}/dashboard'
+        dashboard_url = server_common.get_dashboard_url(endpoint)
+        dashboard_msg = f'Dashboard: {dashboard_url}'
         click.secho(
             f'Logged in to SkyPilot API server at {endpoint}.'
             f' {dashboard_msg}',

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -13,6 +13,7 @@ import sys
 import time
 import typing
 from typing import Any, Dict, Optional
+from urllib import parse
 import uuid
 
 import colorama
@@ -148,6 +149,23 @@ def get_server_url(host: Optional[str] = None) -> str:
         constants.SKY_API_SERVER_URL_ENV_VAR,
         skypilot_config.get_nested(('api_server', 'endpoint'), endpoint))
     return url.rstrip('/')
+
+
+@annotations.lru_cache(scope='global')
+def get_dashboard_url(server_url: str) -> str:
+    # The server_url may include username or password with the
+    # format of https://username:password@example.com:8080/path
+    # We need to remove the username and password and only
+    # return `https://example.com:8080/path`
+    parsed = parse.urlparse(server_url)
+    # Reconstruct the URL without credentials but keeping the scheme
+    dashboard_url = f'{parsed.scheme}://{parsed.hostname}'
+    if parsed.port:
+        dashboard_url = f'{dashboard_url}:{parsed.port}'
+    if parsed.path:
+        dashboard_url = f'{dashboard_url}{parsed.path}'
+    dashboard_url = dashboard_url.rstrip('/')
+    return f'{dashboard_url}/dashboard'
 
 
 @annotations.lru_cache(scope='global')
@@ -314,8 +332,9 @@ def _start_api_server(deploy: bool = False,
             else:
                 break
 
-        dashboard_msg = (f'Dashboard: {get_server_url(host)}/dashboard')
-        api_server_info = get_api_server_status(get_server_url(host))
+        server_url = get_server_url(host)
+        dashboard_msg = (f'Dashboard: {get_dashboard_url(server_url)}')
+        api_server_info = get_api_server_status(server_url)
         if api_server_info.version == _DEV_VERSION:
             dashboard_msg += (
                 f'\n{colorama.Style.RESET_ALL}{ux_utils.INDENT_SYMBOL}'
@@ -323,11 +342,13 @@ def _start_api_server(deploy: bool = False,
             if not os.path.isdir(server_constants.DASHBOARD_DIR):
                 dashboard_msg += (
                     'Dashboard is not built, '
-                    'to build: npm --prefix sky/dashboard run build')
+                    'to build: npm --prefix sky/dashboard install '
+                    '&& npm --prefix sky/dashboard run build')
             else:
                 dashboard_msg += (
                     'Dashboard may be stale when installed from source, '
-                    'to rebuild: npm --prefix sky/dashboard run build')
+                    'to rebuild: npm --prefix sky/dashboard install '
+                    '&& npm --prefix sky/dashboard run build')
             dashboard_msg += f'{colorama.Style.RESET_ALL}'
         logger.info(
             ux_utils.finishing_message(

--- a/tests/unit_tests/test_sky/server/test_common.py
+++ b/tests/unit_tests/test_sky/server/test_common.py
@@ -213,3 +213,40 @@ allowed_clouds:
     )
     assert skypilot_config.get_nested(keys=('allowed_clouds',),
                                       default_value=None) == ['gcp']
+
+
+def test_get_dashboard_url():
+    """Test get_dashboard_url with default URL."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(server_url='http://127.0.0.1:46580'
+                                   ) == 'http://127.0.0.1:46580/dashboard'
+    """Test get_dashboard_url with basic URL."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(server_url='http://example.com:8080'
+                                   ) == 'http://example.com:8080/dashboard'
+    """Test get_dashboard_url with URL containing path."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(server_url='http://example.com:8080/api/'
+                                   ) == 'http://example.com:8080/api/dashboard'
+    """Test get_dashboard_url with URL containing credentials."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(
+        server_url='https://user:pass@example.com:8080'
+    ) == 'https://example.com:8080/dashboard'
+    """Test get_dashboard_url with URL containing username."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(server_url='https://user@example.com:8080'
+                                   ) == 'https://example.com:8080/dashboard'
+    """Test get_dashboard_url with host parameter."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(server_url='http://custom-host:8080'
+                                   ) == 'http://custom-host:8080/dashboard'
+    """Test get_dashboard_url with complex path."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(
+        server_url='https://user:pass@example.com:8080/api/v1'
+    ) == 'https://example.com:8080/api/v1/dashboard'
+    """Test get_dashboard_url without port."""
+    common.get_server_url.cache_clear()
+    assert common.get_dashboard_url(
+        server_url='http://example.com') == 'http://example.com/dashboard'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Remove credentials from the dashboard URL and update the dashboard build hint

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Local API Server (Verify the output of the following commands)
    - sky api info
    - sky dashboard
    - sky api start
    - sky api login
  - Remote API Server 
    - sky api info
    - sky dashboard
    - sky api login
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
