### PR TITLE
release pipeline trigger filter based on name

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   extract-version:
     runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'test_releases/')
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
     steps:
@@ -27,7 +28,7 @@ jobs:
 
   publish-to-pypi:
     needs: extract-version
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'test_releases/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -113,7 +114,7 @@ jobs:
 
   cleanup-branches:
     needs: extract-version
-    if: github.event.pull_request.merged == false
+    if: github.event.pull_request.merged == false && startsWith(github.head_ref, 'test_releases/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We want github pipeline to trigger on this #5333: `releases/0.9.0` from `test_releases/0.9.0`
We don't want github pipeline to trigger on this #5350, `releases/0.9.0` from `DanielZhangQD:dashboard2`

So we add a rule to filter based on branch name: `test_releases/xxx`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
