### PR TITLE
[UX] remove references to SKYPILOT_GLOBAL_CONFIG envvar in docs

### DIFF
--- a/docs/source/reference/config-sources.rst
+++ b/docs/source/reference/config-sources.rst
@@ -78,8 +78,6 @@ Server configuration
 
 If you are using a remote :ref:`SkyPilot API server <sky-api-server>`, it looks for ``~/.sky/config.yaml`` in the API server instance/container to find the server configuration.
 
-To specify a different file, set ``SKYPILOT_GLOBAL_CONFIG`` environment variable to the desired path.
-
 If you are using a local API server, you can use :ref:`User configuration<config-client-user-config>` to set global configuration.
 
 .. _config-client-user-config:
@@ -88,8 +86,6 @@ User configuration
 ~~~~~~~~~~~~~~~~~~
 
 SkyPilot client looks for ``~/.sky/config.yaml`` to find the user configuration.
-
-To specify a different file, set ``SKYPILOT_GLOBAL_CONFIG`` environment variable to the desired path.
 
 .. _config-client-project-config:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Note: the functionality associated with SKYPILOT_GLOBAL_CONFIG is still there in code, this PR simply removes the mentions of it in the doc.

The idea here is that using SKYPILOT_GLOBAL_CONFIG to change the global config directory away from `~/.sky/config.yaml` should be a rare thing for a user to do, so we remove it from docs.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
