### PR TITLE
[config] remove omegaconf as dependency

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -117,7 +117,7 @@ jobs:
           source ~/pypi-check-env/bin/activate
 
           echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install --prerelease=allow "azure-cli>=2.65.0" "omegaconf>=2.4.0dev3"
+          uv pip install --prerelease=allow "azure-cli>=2.65.0"
           uv pip install skypilot==${LATEST_PYPI_VERSION}
 
           echo "Extracting API version from installed PyPI package..."

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -117,7 +117,7 @@ jobs:
           source ~/pypi-check-env/bin/activate
 
           echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install --prerelease allow "azure-cli>=2.65.0"
+          uv pip install --prerelease=allow "azure-cli>=2.65.0"
           uv pip install skypilot==${LATEST_PYPI_VERSION}
 
           echo "Extracting API version from installed PyPI package..."

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -117,7 +117,7 @@ jobs:
           source ~/pypi-check-env/bin/activate
 
           echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
+          uv pip install "azure-cli>=2.65.0"
           uv pip install skypilot==${LATEST_PYPI_VERSION}
 
           echo "Extracting API version from installed PyPI package..."

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -117,7 +117,7 @@ jobs:
           source ~/pypi-check-env/bin/activate
 
           echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install "azure-cli>=2.65.0"
+          uv pip install --prerelease allow "azure-cli>=2.65.0"
           uv pip install skypilot==${LATEST_PYPI_VERSION}
 
           echo "Extracting API version from installed PyPI package..."

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install 'azure-cli>=2.65.0' --system && \
+    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' --system && \
+    ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' 'omegaconf>=2.4.0dev3' --system && \
+    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' --system && \
+    ~/.local/bin/uv pip install 'azure-cli>=2.65.0' --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -132,10 +132,10 @@ Installing via ``uv`` is also supported:
 .. code-block:: shell
 
   uv venv --seed --python 3.10
-  uv pip install --prerelease allow 'azure-cli>=2.65.0'
-  # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
-  # Optionally only install specific clouds - e.g. 'skypilot[aws,gcp,kubernetes]'
-  uv pip install 'skypilot[all]'
+  uv pip install "skypilot[kubernetes,aws,gcp]"
+  # Azure CLI has an issue with uv, and requires '--prerelease allow'.
+  uv pip install --prerelease allow azure-cli
+  uv pip install "skypilot[all]"
 
 
 Alternatively, we also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -135,7 +135,7 @@ Installing via ``uv`` is also supported:
   uv pip install --prerelease allow 'azure-cli>=2.65.0'
   # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
   # Optionally only install specific clouds - e.g. 'skypilot[aws,gcp,kubernetes]'
-  uv pip install 'omegaconf>=2.4.0dev3' 'skypilot[all]'
+  uv pip install 'skypilot[all]'
 
 
 Alternatively, we also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -53,7 +53,6 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
-    'omegaconf>=2.4.0dev3,<2.5',
 ]
 
 local_ray = [

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -72,6 +72,7 @@ else:
 
 logger = sky_logging.init_logger(__name__)
 
+# The config is generated as described below:
 #
 # (*) (Used internally) If env var {ENV_VAR_SKYPILOT_CONFIG} exists, use its
 #     path as the config file. Do not use any other config files.

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -329,7 +329,11 @@ def _parse_dotlist(dotlist: List[str]) -> config_utils.Config:
     """
     config: config_utils.Config = config_utils.Config()
     for arg in dotlist:
-        key, value = arg.split('=', 1)
+        try:
+            key, value = arg.split('=', 1)
+        except ValueError as e:
+            raise ValueError(f'Invalid config override: {arg}. '
+                             'Please use the format: key=value') from e
         if len(key) == 0 or len(value) == 0:
             raise ValueError(f'Invalid config override: {arg}. '
                              'Please use the format: key=value')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -751,6 +751,42 @@ def test_hierarchical_client_config(monkeypatch, tmp_path):
                                       None) == ['azure', 'kubernetes']
 
 
+def test_parse_dotlist():
+    dotlist = ['key1=value1', 'key2']
+    with pytest.raises(ValueError, match='Invalid config override'):
+        skypilot_config._parse_dotlist(dotlist)
+
+    dotlist = ['key1=value1', 'key2=']
+    with pytest.raises(ValueError, match='Invalid config override'):
+        skypilot_config._parse_dotlist(dotlist)
+
+    # test parsing multiple parameters
+    dotlist = ['key1=value1', 'key2=value2']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1',), None) == 'value1'
+    assert config.get_nested(('key2',), None) == 'value2'
+
+    # test parsing nested parameters
+    dotlist = ['key1.key2=value1']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1', 'key2'), None) == 'value1'
+
+    # test parsing list parameters
+    dotlist = ['key1=[1,2,3]']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1',), None) == [1, 2, 3]
+
+    # test parsing map parameters
+    dotlist = ['key1.key2={"key3": "value3"}']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1', 'key2', 'key3'), None) == 'value3'
+
+    # test parsing values with special characters
+    dotlist = ['key1="a,b,c=d"']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1',), None) == 'a,b,c=d'
+
+
 @mock.patch('sky.skylet.constants.SKIPPED_CLIENT_OVERRIDE_KEYS',
             [('aws', 'vpc_name')])
 def test_override_skypilot_config_with_disallowed_keys(monkeypatch, tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -781,6 +781,12 @@ def test_parse_dotlist():
     config = skypilot_config._parse_dotlist(dotlist)
     assert config.get_nested(('key1', 'key2', 'key3'), None) == 'value3'
 
+    # test parsing complex parameters
+    dotlist = ['key1.key2={"key3": [1,2,3], "key4": {"key5": "value5"}}']
+    config = skypilot_config._parse_dotlist(dotlist)
+    assert config.get_nested(('key1', 'key2', 'key3'), None) == [1, 2, 3]
+    assert config.get_nested(('key1', 'key2', 'key4', 'key5'), None) == 'value5'
+
     # test parsing values with special characters
     dotlist = ['key1="a,b,c=d"']
     config = skypilot_config._parse_dotlist(dotlist)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The only logic that needs to be implemented to remove omegaConf is the dotlist parsing logic. This actually turned out to be pretty simple to implement using `yaml.safe_load()`.

Added some unit test to make sure the logic implemented to replace omegaConf still acts as expected.
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)


<!-- CI commands (/-prefixed) can only be triggered by repo members -->
