### PR TITLE
remove azure-cli pre release dependency

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -30,7 +30,6 @@ jobs:
       run: |
         uv venv --seed ~/test-env
         source ~/test-env/bin/activate
-        uv pip install --prerelease=allow "azure-cli>=2.65.0"
         uv pip install ".[all]"
         uv pip install pylint==2.14.5
         uv pip install pylint-quotes==0.2.3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           uv venv --seed ~/test-env
           source ~/test-env/bin/activate
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"
@@ -76,7 +75,6 @@ jobs:
         run: |
           uv venv --seed ~/test-env
           source ~/test-env/bin/activate
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Install limited dependencies only
           uv pip install -e ".[kubernetes,aws,gcp,azure]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0
@@ -106,7 +104,6 @@ jobs:
         run: |
           uv venv --seed ~/test-env
           source ~/test-env/bin/activate
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Use -e to include examples and tests folder in the path for unit
           # tests to access them.
           uv pip install -e ".[all]"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -117,7 +117,6 @@ jobs:
           source ~/pypi-check-env/bin/activate
 
           echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install --prerelease=allow "azure-cli>=2.65.0" "omegaconf>=2.4.0dev3"
           uv pip install skypilot==${LATEST_PYPI_VERSION}
 
           echo "Extracting API version from installed PyPI package..."

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -30,7 +30,6 @@ jobs:
       run: |
         uv venv --seed ~/test-env
         source ~/test-env/bin/activate
-        uv pip install --prerelease=allow "azure-cli>=2.65.0"
         uv pip install ".[all]"
         cd docs
         uv pip install -r ./requirements-docs.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     rm kubectl && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ~/.local/bin/uv pip install --prerelease allow 'azure-cli>=2.65.0' 'omegaconf>=2.4.0dev3' --system && \
     ~/.local/bin/uv pip install skypilot-nightly[all] --system && \
     # Cleanup all caches to reduce the image size
     conda clean -afy && \

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -132,10 +132,7 @@ Installing via ``uv`` is also supported:
 .. code-block:: shell
 
   uv venv --seed --python 3.10
-  uv pip install --prerelease allow 'azure-cli>=2.65.0'
-  # Explicitly install prerelease dependency to work around https://docs.astral.sh/uv/pip/compatibility/#pre-release-compatibility
-  # Optionally only install specific clouds - e.g. 'skypilot[aws,gcp,kubernetes]'
-  uv pip install 'omegaconf>=2.4.0dev3' 'skypilot[all]'
+  uv pip install 'skypilot[all]'
 
 
 Alternatively, we also provide a :ref:`Docker image <docker-image>` as a quick way to try out SkyPilot.

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -106,7 +106,6 @@ RUN source ~/miniconda3/etc/profile.d/conda.sh && \
     conda activate base && \
     export PATH="$PATH:$HOME/.local/bin" && \
     uv pip uninstall skypilot && \
-    uv pip install --prerelease=allow "azure-cli>=2.65.0" && \
     uv pip install -r requirements-dev.txt && \
     uv pip install -e ".[all]" && \
     # Install httpx with SOCKS support for proxy environments - necessary when system has proxy enabled

--- a/tests/smoke_tests/docker/entrypoint.sh
+++ b/tests/smoke_tests/docker/entrypoint.sh
@@ -95,7 +95,6 @@ fi
 
 cd /skypilot
 uv pip uninstall skypilot
-uv pip install --prerelease=allow "azure-cli>=2.65.0"
 uv pip install -r requirements-dev.txt
 uv pip install -e ".[all]"
 sky api start

--- a/tests/smoke_tests/test_backward_compat.py
+++ b/tests/smoke_tests/test_backward_compat.py
@@ -96,14 +96,12 @@ class TestBackwardCompatibility:
         self._run_cmd(
             f'{self.ACTIVATE_BASE} && '
             'uv pip uninstall skypilot && '
-            'uv pip install --prerelease=allow "azure-cli>=2.65.0" && '
             'uv pip install -e .[all]',)
 
         # Install current version in current environment
         self._run_cmd(
             f'{self.ACTIVATE_CURRENT} && '
             'uv pip uninstall skypilot && '
-            'uv pip install --prerelease=allow "azure-cli>=2.65.0" && '
             'uv pip install -e .[all]',)
 
         yield  # Optional teardown logic


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
