### PR TITLE
[UX] `api info`: display dashboard on last line

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -5911,11 +5911,12 @@ def api_info():
     user_name = os.getenv(constants.USER_ENV_VAR, getpass.getuser())
     user_hash = common_utils.get_user_hash()
     dashboard_url = server_common.get_dashboard_url(url)
-    click.echo(f'Using SkyPilot API server: {url} Dashboard: {dashboard_url}\n'
+    click.echo(f'Using SkyPilot API server: {url}\n'
                f'{ux_utils.INDENT_SYMBOL}Status: {api_server_info["status"]}, '
                f'commit: {api_server_info["commit"]}, '
                f'version: {api_server_info["version"]}\n'
-               f'{ux_utils.INDENT_LAST_SYMBOL}User: {user_name} ({user_hash})')
+               f'{ux_utils.INDENT_SYMBOL}User: {user_name} ({user_hash})\n'
+               f'{ux_utils.INDENT_LAST_SYMBOL}Dashboard: {dashboard_url}')
 
 
 def main():

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -333,7 +333,7 @@ def _start_api_server(deploy: bool = False,
                 break
 
         server_url = get_server_url(host)
-        dashboard_msg = (f'Dashboard: {get_dashboard_url(server_url)}')
+        dashboard_msg = ''
         api_server_info = get_api_server_status(server_url)
         if api_server_info.version == _DEV_VERSION:
             dashboard_msg += (
@@ -343,12 +343,15 @@ def _start_api_server(deploy: bool = False,
                 dashboard_msg += (
                     'Dashboard is not built, '
                     'to build: npm --prefix sky/dashboard install '
-                    '&& npm --prefix sky/dashboard run build')
+                    '&& npm --prefix sky/dashboard run build\n')
             else:
                 dashboard_msg += (
                     'Dashboard may be stale when installed from source, '
                     'to rebuild: npm --prefix sky/dashboard install '
-                    '&& npm --prefix sky/dashboard run build')
+                    '&& npm --prefix sky/dashboard run build\n')
+            dashboard_msg += (
+                f'{ux_utils.INDENT_LAST_SYMBOL}{colorama.Fore.GREEN}'
+                f'Dashboard: {get_dashboard_url(server_url)}')
             dashboard_msg += f'{colorama.Style.RESET_ALL}'
         logger.info(
             ux_utils.finishing_message(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previous
```
» sky api info
Using SkyPilot API server: http://skypilot:alpha1@api.skypilot.co:30050 Dashboard: http://api.skypilot.co:30050/dashboard
├── Status: healthy, commit: 607eee0a24e50718d783e92081f141f45cac6cda, version: 1.0.0-dev0
└── User: zongheng (8a3968f2)
```

This PR
```
» sky api info
Using SkyPilot API server: http://skypilot:alpha1@api.skypilot.co:30050
├── Status: healthy, commit: 607eee0a24e50718d783e92081f141f45cac6cda, version: 1.0.0-dev0
├── User: zongheng (8a3968f2)
└── Dashboard: http://api.skypilot.co:30050/dashboard
```
Easier to discover + click.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
