### PR TITLE
[UX] Minor fix.

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1840,6 +1840,7 @@ def api_login(endpoint: Optional[str] = None) -> None:
         dashboard_url = server_common.get_dashboard_url(endpoint)
         dashboard_msg = f'Dashboard: {dashboard_url}'
         click.secho(
-            f'Logged in to SkyPilot API server at {endpoint}.'
-            f' {dashboard_msg}',
+            f'Logged in to SkyPilot API server at: {endpoint}'
+            f'\n{ux_utils.INDENT_LAST_SYMBOL}{colorama.Fore.GREEN}'
+            f'{dashboard_msg}',
             fg='green')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1840,7 +1840,7 @@ def api_login(endpoint: Optional[str] = None) -> None:
         dashboard_url = server_common.get_dashboard_url(endpoint)
         dashboard_msg = f'Dashboard: {dashboard_url}'
         click.secho(
-            f'Logged in to SkyPilot API server at: {endpoint}'
+            f'Logged into SkyPilot API server at: {endpoint}'
             f'\n{ux_utils.INDENT_LAST_SYMBOL}{colorama.Fore.GREEN}'
             f'{dashboard_msg}',
             fg='green')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Missed this in #5417.

Before
```
» sky api login -e http://127.0.0.1:46580
Logged in to SkyPilot API server at http://127.0.0.1:46580. Dashboard: http://127.0.0.1:46580/dashboard
```

This PR
```
» sky api login -e http://127.0.0.1:46580
Logged in to SkyPilot API server at: http://127.0.0.1:46580
└── Dashboard: http://127.0.0.1:46580/dashboard
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
