### PR TITLE
[k8s] gpu bin packing via affinity

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -270,6 +270,9 @@ available_node_types:
             {% if high_availability %}
             app: {{cluster_name_on_cloud}}
             {% endif %}
+            {% if (k8s_acc_label_key is not none and k8s_acc_label_values is not none) %}
+            skypilot-binpack: "gpu"
+            {% endif %}
       spec:
         # serviceAccountName: skypilot-service-account
         serviceAccountName: {{k8s_service_account_name}}
@@ -298,8 +301,18 @@ available_node_types:
                   {% for label_value in k8s_acc_label_values %}
                   - {{label_value}}
                   {% endfor %}
+          podAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: "skypilot-binpack"
+                        operator: In
+                        values:
+                          - "gpu"
+                  topologyKey: kubernetes.io/hostname
         {% endif %}
-
         {% if k8s_spot_label_key is not none %}
         tolerations:
           - key: {{k8s_spot_label_key}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Closes https://github.com/skypilot-org/skypilot/issues/4851

There have been reports that launching jobs on k8s clusters with GPUs don't bin pack jobs properly. I was able to reproduce this report by preparing a 2 node cluster, with each node having 4 X L40S GPUs, and creating 8 jobs each requesting 1 X L40S GPU sequentially. The following is the sequence at which these jobs were placed (either on node 1 or node 2)

Run 1: 1 2 1 2 1 1 2 2
Run 2: 1 2 1 1 2 2 1 2

With the changes in this PR, the following is the sequence:

Run 1: 1 1 1 1 2 2 2 2
Runs 2/3: (same as run 1)

The following is the sequence seeded with 1 pod already running on node 2

Run: [2] 2 2 2 1 1 1 1

These tests demonstrate the affinity specified in the PR works to bin-pack the GPUs.

As with https://github.com/skypilot-org/skypilot/pull/5357, we use `preferredDuringSchedulingIgnoredDuringExecution` instead of `requiredDuringSchedulingIgnoredDuringExecution` so that pods can be scheduled on other nodes if nodes with other pods are all full.

**Alternative considered**

I did consider going the route of implementing a custom [kube-scheduler](https://cast.ai/blog/custom-kube-scheduler-why-and-how-to-set-it-up-in-kubernetes/). I have no reason to suspect this approach won't work, but this approach involves creating a [long running] custom scheduler deployment on user k8s cluster before the user can start using k8s with SkyPilot. Given that SkyPilot wants to minimize setup steps needed for a user to start using the software on k8s, I did not find this an attractive approach.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] Relevant kubernetes smoke tests: `/smoke-test --kubernetes -k multi` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
