### PR TITLE
[aws] script to get default security group name for aws

### DIFF
--- a/sky/utils/aws/get_default_security_group.py
+++ b/sky/utils/aws/get_default_security_group.py
@@ -1,0 +1,11 @@
+"""Script to get the default security group"""
+from sky.clouds import aws
+
+
+def main():
+    default_security_group = aws.DEFAULT_SECURITY_GROUP_NAME
+    print(f'{default_security_group}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, a user has no good way of figuring out what their default AWS security group is. A user should be able to determine the default security group name used by SkyPilot, but this seems niche enough that I don't really think such functionality deserves a place in the CLI. The compromise is to write a simple script that can be invoked using

`python -m sky.utils.aws.get_default_security_group`

similar to how we run GPU labeler script for k8s today

`python -m sky.utils.kubernetes.gpu_labeler`

The expected first user of this script is our buildkite containers, which can figure out the security group it may have created and delete the security group if one exists.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
