### PR TITLE
[Doc] Add runpod credentials setup for API server

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -207,7 +207,7 @@ spec:
         - name: RUNPOD_API_KEY
           valueFrom:
             secretKeyRef:
-              name: runpod-credentials
+              name: {{ .Values.runpodCredentials.runpodSecretName }}
               key: api_key
         volumeMounts:
         - name: runpod-config

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -207,9 +207,11 @@ gcpCredentials:
   # Name of the secret containing the gcp credentials. Only used if enabled is true.
   gcpSecretName: gcp-credentials
 
-# Populate RunPod credentials from a secret `runpod-credentials` with key `api_key`
+# Populate RunPod credentials from the secret with key `api_key`
 runpodCredentials:
   enabled: false
+  # Name of the secret containing the RunPod credentials. Only used if enabled is true.
+  runpodSecretName: runpod-credentials
 
 # Set securityContext for the api pod
 podSecurityContext: {}

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -313,7 +313,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
             You can also set the following values to use a secret that already contains your GCP credentials:
 
-            .. code-block::bash
+            .. code-block:: bash
 
                 # TODO: replace with your secret name
                 helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
@@ -321,6 +321,34 @@ Following tabs describe how to configure credentials for different clouds on the
                     --reuse-values \
                     --set gcpCredentials.enabled=true \
                     --set gcpCredentials.gcpSecretName=your_secret_name
+    
+    .. tab-item:: RunPod
+        :sync: runpod-creds-tab
+
+        SkyPilot API server use **API key** to authenticate with RunPod. To configure RunPod access, go to the `Settings <https://www.runpod.io/console/user/settings>`_ page on your RunPod console and generate an **API key**.
+
+        Once the key is generated, create a Kubernetes secret to store it:
+
+        .. code-block:: bash
+
+            kubectl create secret generic runpod-credentials \
+              --namespace $NAMESPACE \
+              --from-literal api_key=YOUR_API_KEY
+        
+        When installing or upgrading the Helm chart, enable RunPod credentials by setting ``runpodCredentials.enabled=true``
+
+        .. dropdown:: Use existing RunPod credentials
+
+            You can also set the following values to use a secret that already contains your RunPod API key:
+
+            .. code-block:: bash
+
+                # TODO: replace with your secret name
+                helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+                    --namespace $NAMESPACE \
+                    --reuse-values \
+                    --set runpodCredentials.enabled=true \
+                    --set runpodCredentials.runpodSecretName=your_secret_name
 
     .. tab-item:: Other clouds
         :sync: other-clouds-tab


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5429

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Local preview:

<img width="876" alt="image" src="https://github.com/user-attachments/assets/5f2e1b0a-ded4-41ef-b5d0-0f94abc6c0a1" />


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually with the new doc
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
