### PR TITLE
avoid using removed LEGACY_SINGLETON_REGION constant

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1707,7 +1707,7 @@ class Resources:
             # multiple contexts, we now set the region to the context name.
             # Since we do not have information on which context the cluster
             # was run in, we default it to the current active context.
-            legacy_region = clouds.Kubernetes().LEGACY_SINGLETON_REGION
+            legacy_region = 'kubernetes'
             original_cloud = state.get('_cloud', None)
             original_region = state.get('_region', None)
             if (isinstance(original_cloud, clouds.Kubernetes) and


### PR DESCRIPTION
Fixes #5439.
This was missed in #5212 due to #5442.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
