### PR TITLE
[runpod] preserve docker configured environment variables

### DIFF
--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -18,10 +18,9 @@ logger = sky_logging.init_logger(__name__)
 SETUP_ENV_VARS_CMD = (
     'prefix_cmd() '
     '{ if [ $(id -u) -ne 0 ]; then echo "sudo"; else echo ""; fi; } && '
-    'printenv | while IFS=\'=\' read -r key value; do echo "export $key=\\\"$value\\\""; done > '  # pylint: disable=line-too-long
-    '~/container_env_var.sh && '
-    '$(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;'
-)
+    'export -p > ~/container_env_var.sh && '
+    '$(prefix_cmd) '
+    'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh;')
 
 # Docker daemon may not be ready when the machine is firstly started. The error
 # message starts with the following string. We should wait for a while and retry

--- a/sky/provision/runpod/utils.py
+++ b/sky/provision/runpod/utils.py
@@ -304,6 +304,9 @@ def launch(cluster_name: str, node_type: str, instance_type: str, region: str,
         f'$(prefix_cmd) echo "{public_key}" >> ~/.ssh/authorized_keys; '
         '$(prefix_cmd) chmod 644 ~/.ssh/authorized_keys; '
         '$(prefix_cmd) service ssh restart; '
+        '$(prefix_cmd) export -p > ~/container_env_var.sh && '
+        '$(prefix_cmd) '
+        'mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh; '
         '[ $(id -u) -eq 0 ] && echo alias sudo="" >> ~/.bashrc;sleep infinity')
     # Use base64 to deal with the tricky quoting issues caused by runpod API.
     encoded = base64.b64encode(setup_cmd.encode('utf-8')).decode('utf-8')

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -538,7 +538,7 @@ available_node_types:
                     { echo 52; exit 52; };
                   fi;
                 fi;
-                printenv | while IFS='=' read -r key value; do echo "export $key=\"$value\""; done > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
+                export -p > ~/container_env_var.sh && $(prefix_cmd) mv ~/container_env_var.sh /etc/profile.d/container_env_var.sh
                 ) > /tmp/${STEPS[2]}.log 2>&1 || {
                   echo "Error: ${STEPS[2]} failed. Continuing anyway..." > /tmp/${STEPS[2]}.failed
                   cat /tmp/${STEPS[2]}.log


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes https://github.com/skypilot-org/skypilot/issues/5306

The docker container environment (environment variables including $PATH) does not apply when a user ssh'es in - a fresh environment is created for the session.

For our kubernetes implementation, the container environment is exported to all users (including ssh sessions) by creating a file in `/etc/profile.d/`. This was missed in the runpod implementation. This PR adds an equivalent command to the runpod implementation of SkyPilot.

While working on the PR, I found a better way to generate an export file from the current environment, which I've applied to both k8s and runpod implementations.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual test: tested the scenario in https://github.com/skypilot-org/skypilot/issues/5306 is resolved.
- [x] k8s docker smoke tests: `/smoke-test --kubernetes -k docker` (to test `export -p` command)
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
