### PR TITLE
[k8s] Support Exec-based Auth

### DIFF
--- a/sky/authentication.py
+++ b/sky/authentication.py
@@ -392,13 +392,14 @@ def setup_kubernetes_authentication(config: Dict[str, Any]) -> Dict[str, Any]:
     # Add the user's public key to the SkyPilot cluster.
     secret_name = clouds.Kubernetes.SKY_SSH_KEY_SECRET_NAME
     secret_field_name = clouds.Kubernetes().ssh_key_secret_field_name
-    context = config['provider'].get(
-        'context', kubernetes_utils.get_current_kube_config_context_name())
-    if context == kubernetes.in_cluster_context_name():
-        # If the context is an in-cluster context name, we are running in a pod
-        # with in-cluster configuration. We need to set the context to None
-        # to use the mounted service account.
-        context = None
+    # context = config['provider'].get(
+    #     'context', kubernetes_utils.get_current_kube_config_context_name())
+    # if context == kubernetes.in_cluster_context_name():
+    #     # If the context is an in-cluster context name, we are running in a
+    #     # pod with in-cluster configuration. We need to set the context to
+    #     # None to use the mounted service account.
+    #     context = None
+    context = kubernetes_utils.get_context_from_config(config['provider'])
     namespace = kubernetes_utils.get_namespace_from_config(config['provider'])
     k8s = kubernetes.kubernetes
     with open(public_key_path, 'r', encoding='utf-8') as f:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -533,7 +533,11 @@ class Kubernetes(clouds.Cloud):
         # Set environment variables for the pod. Note that SkyPilot env vars
         # are set separately when the task is run. These env vars are
         # independent of the SkyPilot task to be run.
-        k8s_env_vars = {kubernetes.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context}
+        if (skypilot_config.get_nested(('kubernetes', 'remote_identity'), None)
+                != schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value):
+            k8s_env_vars = {kubernetes.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context}
+        else:
+            k8s_env_vars = {}
 
         # We specify object-store-memory to be 500MB to avoid taking up too
         # much memory on the head node. 'num-cpus' should be set to limit

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1526,11 +1526,12 @@ def is_kubeconfig_exec_auth(
             == schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS.value):
         ctx_name = context_obj['name']
         exec_msg = ('exec-based authentication is used for '
-                    f'Kubernetes context {ctx_name!r}.'
-                    ' This may cause issues with autodown or when running '
+                    f'Kubernetes context {ctx_name!r}. '
+                    'Make sure that the corresponding cloud provider is '
+                    'also enabled through `sky check` (e.g.: GCP for GKE). '
                     'Managed Jobs or SkyServe controller on Kubernetes. '
-                    'To fix, configure SkyPilot to create a service account '
-                    'for running pods by setting the following in '
+                    'Alternatively, configure SkyPilot to create a service '
+                    'account for running pods by setting the following in '
                     '~/.sky/config.yaml:\n'
                     '    kubernetes:\n'
                     '      remote_identity: SERVICE_ACCOUNT\n'
@@ -2794,8 +2795,14 @@ def set_autodown_annotations(handle: 'backends.CloudVmRayResourceHandle',
 def get_context_from_config(provider_config: Dict[str, Any]) -> Optional[str]:
     context = provider_config.get('context',
                                   get_current_kube_config_context_name())
-    if context == kubernetes.in_cluster_context_name():
-        # If the context (also used as the region) is in-cluster, we need to
+    local_credentials = schemas.RemoteIdentityOptions.LOCAL_CREDENTIALS
+    use_local_credentials = (
+        local_credentials.value == skypilot_config.get_nested(
+            ('kubernetes', 'remote_identity'), None))
+    if (not use_local_credentials and
+            context == kubernetes.in_cluster_context_name()):
+        # If the context (also used as the region) is in-cluster, and we are
+        # not using local credentials (in which there is no service role)
         # we need to use in-cluster auth by setting the context to None.
         context = None
     return context

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -269,6 +269,16 @@ def _get_cloud_dependencies_installation_commands(
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
             commands.append(f'echo -en "\\r{step_prefix}GCP SDK{empty_str}" &&'
                             f'{gcp.GOOGLE_SDK_INSTALLATION_COMMAND}')
+            if clouds.cloud_in_iterable(clouds.Kubernetes(), enabled_clouds):
+                # Install gke-gcloud-auth-plugin used for exec-auth with GKE.
+                # We install the plugin here instead of the next elif branch
+                # because gcloud is required to install the plugin, so the order
+                # of command execution is critical.
+                commands.append(
+                    '(command -v gke-gcloud-auth-plugin &>/dev/null || '
+                    '(gcloud components install gke-gcloud-auth-plugin --quiet '
+                    '&& find /opt/conda -name \'gke-gcloud-auth-plugin\' '
+                    '-type f -exec ln -s {} /usr/local/bin/gke-gcloud-auth-plugin \;))')  # pylint: disable=line-too-long,anomalous-backslash-in-string
         elif isinstance(cloud, clouds.Kubernetes):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
             commands.append(

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -276,9 +276,8 @@ def _get_cloud_dependencies_installation_commands(
                 # of command execution is critical.
                 commands.append(
                     '(command -v gke-gcloud-auth-plugin &>/dev/null || '
-                    '(gcloud components install gke-gcloud-auth-plugin --quiet '
-                    '&& find /opt/conda -name \'gke-gcloud-auth-plugin\' '
-                    '-type f -exec ln -s {} /usr/local/bin/gke-gcloud-auth-plugin \;))')  # pylint: disable=line-too-long,anomalous-backslash-in-string
+                    '(gcloud components install gke-gcloud-auth-plugin --quiet && '  # pylint: disable=line-too-long
+                    'sudo find ~/google-cloud-sdk -name \'gke-gcloud-auth-plugin\' -type f -exec ln -s {} /usr/local/bin/gke-gcloud-auth-plugin \;))')  # pylint: disable=line-too-long,anomalous-backslash-in-string
         elif isinstance(cloud, clouds.Kubernetes):
             step_prefix = prefix_str.replace('<step>', str(len(commands) + 1))
             commands.append(

--- a/sky/utils/kubernetes/exec_kubeconfig_converter.py
+++ b/sky/utils/kubernetes/exec_kubeconfig_converter.py
@@ -15,38 +15,7 @@ Usage:
 import argparse
 import os
 
-import yaml
-
-
-def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
-    """Strip path information from exec plugin commands in a kubeconfig file.
-
-    Args:
-        kubeconfig_path (str): Path to the input kubeconfig file
-        output_path (str): Path where the modified kubeconfig will be saved
-    """
-    with open(kubeconfig_path, 'r', encoding='utf-8') as file:
-        config = yaml.safe_load(file)
-
-    updated = False
-    for user in config.get('users', []):
-        exec_info = user.get('user', {}).get('exec', {})
-        current_command = exec_info.get('command', '')
-
-        if current_command:
-            # Strip the path and keep only the executable name
-            executable = os.path.basename(current_command)
-            if executable != current_command:
-                exec_info['command'] = executable
-                updated = True
-
-    if updated:
-        with open(output_path, 'w', encoding='utf-8') as file:
-            yaml.safe_dump(config, file)
-        print('Kubeconfig updated with path-less exec auth. '
-              f'Saved to {output_path}')
-    else:
-        print('No updates made. No exec-based auth commands paths found.')
+from sky.provision.kubernetes import utils as kubernetes_utils
 
 
 def main():
@@ -66,7 +35,12 @@ def main():
         help='Output kubeconfig file path (default: %(default)s)')
 
     args = parser.parse_args()
-    strip_auth_plugin_paths(args.input, args.output)
+    updated = kubernetes_utils.strip_auth_plugin_paths(args.input, args.output)
+    if updated:
+        print('Kubeconfig updated with path-less exec auth. '
+              f'Saved to {args.output}')
+    else:
+        print('No updates made. No exec-based auth commands paths found.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #4379 

Need more testing and a lot of feedback please. The main hurdle with supporting exec-based auth is that when using exec-based auth we cannot use incluster configurations at all (anything that uses incluster auth without a proper RBAC role will result in a lot of logs saying that localhost:8080 is inaccessible).

Currently tested on:
1. Start jobs controller on GKE and submit job to the same cluster (this is where the incluster issues come into play)
2. Start jobs controller on AWS EC2 and submit job to GKE cluster

Need to test:
1. Whether this works on EKS (main problem will be from having the correct PATH env var set. The gke auth plugin had a similar issue and as a temporary workaround used a sudo symlink, but this could be better. Being able to set a proper PATH env var will be a more general and workable solution)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
