### PR TITLE
Fix failure of `test_kubernetes_context_failover`

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -743,6 +743,8 @@ def test_kubernetes_context_failover(unreachable_context):
                 f'kubectl config use-context {context}',
                 # H100 should not in the current context
                 f'! sky show-gpus --cloud kubernetes --region {context} | grep H100',
+                # H100 should be displayed as long as it is available in one of the contexts
+                'sky show-gpus --cloud kubernetes | grep H100',
                 f'sky launch -y -c {name}-1 --cpus 1 echo hi',
                 f'sky logs {name}-1 --status',
                 # It should be launched not on kind-skypilot

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -741,8 +741,8 @@ def test_kubernetes_context_failover(unreachable_context):
                 'sky show-gpus --cloud kubernetes --region kind-skypilot | grep H100 | grep "1, 2, 4, 8"',
                 # Get contexts and set current context to the other cluster that is not kind-skypilot
                 f'kubectl config use-context {context}',
-                # H100 should be displayed as long as it is available in one of the contexts
-                'sky show-gpus --cloud kubernetes | grep H100',
+                # H100 should not in the current context
+                f'! sky show-gpus --cloud kubernetes --region {context} | grep H100',
                 f'sky launch -y -c {name}-1 --cpus 1 echo hi',
                 f'sky logs {name}-1 --status',
                 # It should be launched not on kind-skypilot

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -741,7 +741,7 @@ def test_kubernetes_context_failover(unreachable_context):
                 'sky show-gpus --cloud kubernetes --region kind-skypilot | grep H100 | grep "1, 2, 4, 8"',
                 # Get contexts and set current context to the other cluster that is not kind-skypilot
                 f'kubectl config use-context {context}',
-                # H100 should not in the current context
+                # H100 should not be in the current context
                 f'! sky show-gpus --cloud kubernetes --region {context} | grep H100',
                 # H100 should be displayed as long as it is available in one of the contexts
                 'sky show-gpus --cloud kubernetes | grep H100',

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -741,7 +741,7 @@ def test_kubernetes_context_failover(unreachable_context):
                 'sky show-gpus --cloud kubernetes --region kind-skypilot | grep H100 | grep "1, 2, 4, 8"',
                 # Get contexts and set current context to the other cluster that is not kind-skypilot
                 f'kubectl config use-context {context}',
-                # H100 should be in the current context
+                # H100 should be displayed as long as it is available in one of the contexts
                 'sky show-gpus --cloud kubernetes | grep H100',
                 f'sky launch -y -c {name}-1 --cpus 1 echo hi',
                 f'sky logs {name}-1 --status',

--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -741,8 +741,8 @@ def test_kubernetes_context_failover(unreachable_context):
                 'sky show-gpus --cloud kubernetes --region kind-skypilot | grep H100 | grep "1, 2, 4, 8"',
                 # Get contexts and set current context to the other cluster that is not kind-skypilot
                 f'kubectl config use-context {context}',
-                # H100 should not in the current context
-                '! sky show-gpus --cloud kubernetes | grep H100',
+                # H100 should be in the current context
+                'sky show-gpus --cloud kubernetes | grep H100',
                 f'sky launch -y -c {name}-1 --cpus 1 echo hi',
                 f'sky logs {name}-1 --status',
                 # It should be launched not on kind-skypilot


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #5437

Test broken after #5362 because the display logic changed.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -- --kubernetes -k test_kubernetes_context_failover` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
