### PR TITLE
Fix flaky of `test_cancel_launch_and_exec_async`

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -826,21 +826,25 @@ def test_launch_and_exec_async(generic_cloud: str):
 def test_cancel_launch_and_exec_async(generic_cloud: str):
     """Test if async launch and exec commands work correctly when cluster is shutdown"""
     name = smoke_tests_utils.get_cluster_name()
+
+    wait_cmd = smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+        name, [sky.ClusterStatus.INIT], 30)
+    # This test need cluster to be in INIT state, so that job will be cancelled,
+    # so we need to reduce the waiting time for the cluster to avoid it goes to UP state
+    wait_cmd = wait_cmd.replace('sleep 10', 'sleep 1')
     test = smoke_tests_utils.Test(
-        'cancel_launch_and_exec_async',
-        [
+        'cancel_launch_and_exec_async', [
             f'sky launch -c {name} -y --cloud {generic_cloud} --async',
-            (
-                f's=$(sky exec {name} echo --async) && '
-                'echo "$s" && '
-                'logs_cmd=$(echo "$s" | grep "Check logs with" | '
-                'sed -E "s/.*with: (sky api logs .*).*/\\1/") && '
-                'echo "Extracted logs command: $logs_cmd" && '
-                # sky down as soon as possible, only in INIT state will the job be cancelled
-                f'sky down -y {name} && '
-                'log_output=$(eval $logs_cmd || true) && '
-                'echo "===logs===" && echo "$log_output" && '
-                'echo "$log_output" | grep "cancelled"'),
+            (f's=$(sky exec {name} echo --async) && '
+             'echo "$s" && '
+             'logs_cmd=$(echo "$s" | grep "Check logs with" | '
+             'sed -E "s/.*with: (sky api logs .*).*/\\1/") && '
+             'echo "Extracted logs command: $logs_cmd" && '
+             f'{wait_cmd} && '
+             f'sky down -y {name} && '
+             'log_output=$(eval $logs_cmd || true) && '
+             'echo "===logs===" && echo "$log_output" && '
+             'echo "$log_output" | grep "cancelled"'),
         ],
         teardown=f'sky down -y {name}',
         timeout=smoke_tests_utils.get_timeout(generic_cloud))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #5436 

The issue only occurs in the `UP` state. If we call sky down then, the job won't show as cancelled, and the `grep "cancelled"` command will fail.

When it's in `INIT` state, the test succeeds. This failure is more likely to happen in kubernetes tests because the kubernetes cluster provisions too quickly to reach the `UP` state.

~~I'm not sure if fixing the test case is the right approach, or if we should modify the `sky` job system to also cancel jobs for clusters in the `UP` state when `sky down` called? @aylei~~
 
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test --kubernetes -k test_cancel_launch_and_exec_async` (CI) or `pytest tests/test_smoke.py::test_name` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
