### PR TITLE
[GCP] Remap series-specific disk types

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1022,26 +1022,6 @@ class GCP(clouds.Cloud):
         disk_tier: Optional[resources_utils.DiskTier]  # pylint: disable=unused-argument
     ) -> Tuple[bool, str]:
         return True, ''
-        # if disk_tier != resources_utils.DiskTier.ULTRA or instance_type is None:
-        #     return True, ''
-        # # Ultra disk tier (pd-extreme) only support m2, m3 and part of n2
-        # # instance types. For a3 instances, we map the ULTRA tier to
-        # # hyperdisk-balanced. For all other instance types, we failover to
-        # # lower tiers. Reference:
-        # # https://cloud.google.com/compute/docs/disks/extreme-persistent-disk#machine_shape_support  # pylint: disable=line-too-long
-        # series = instance_type.split('-')[0]
-        # if series in ['m2', 'm3', 'n2', 'a3']:
-        #     if series == 'n2':
-        #         num_cpus = int(instance_type.split('-')[2])
-        #         if num_cpus < 64:
-        #             return False, ('n2 series with less than 64 vCPUs are '
-        #                            'not supported with pd-extreme.')
-        #     return True, ''
-        # return False, (f'{series} series is not supported with pd-extreme '
-        #                'or hyperdisk-balanced. Only m2, m3 series and n2 '
-        #                'series with 64 or more vCPUs are supported with '
-        #                'pd-extreme. Also, only a3 is supported with '
-        #                'hyperdisk-balanced.')
 
     @classmethod
     def check_disk_tier_enabled(cls, instance_type: Optional[str],

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1053,6 +1053,7 @@ class GCP(clouds.Cloud):
         }
 
         # Remap series-specific disk types.
+        # Reference: https://github.com/skypilot-org/skypilot/issues/4705
         series = instance_type.split('-')[0]  # type: ignore
 
         # General handling of unsupported disk types

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1075,7 +1075,7 @@ class GCP(clouds.Cloud):
                     highest=tier2name[resources_utils.DiskTier.HIGH])
         elif series == 'a3':
             # LOW disk tier is already handled in general case, so in this branch
-            # only the hyperdisk tier is addressed
+            # only the hyperdisk tier is addressed.
             tier2name[resources_utils.DiskTier.ULTRA] = 'hyperdisk-balanced'
 
         return tier2name[tier]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
### Tracking issue
Closes https://github.com/skypilot-org/skypilot/issues/4705.

### Why are the changes needed?
GCP instances have series-specific disk type supports which are summarized as follows:
| Machine series | pd-standard | pd-balanced | pd-ssd | pd-extreme |
|----------------|-------------|-------------|--------|------------|
| N2             | V           | V           | V      | V   (>= 64 vCPUs)      |
| N1             | V           | V           | V      | —          |
| N1+GPU         | V           | V           | V      | —          |
| A2             | V           | V           | V      | —          |
| G2             | —           | V           | V      | —          |

To make SkyPilot smart at figuring out the best disk type for each specific machine series, we consider remapping disk types for those unsupported, other than raising an error.

### What changes were proposed in this pull request?
* Propagate `HIGH` disk tier (which maps to `pd-ssd`) to `ULTRA` as `N2` (with less than 64 vCPUs), `N1`, `A2`, and `G2` don't support `pd-extreme`
* Propagate `MEDIUM` disk tier (which maps to `pd-balanced`) to `LOW` as `G2` doesn't support `pd-standard`


#### Screenshots
* `sky launch -t n2-standard-32 --disk-tier ultra --dryrun`

![Screenshot 2025-04-30 at 9 42 55 PM](https://github.com/user-attachments/assets/2becca71-714f-44a9-8137-6d0ae369514d)

* `sky launch -t n2-standard-128 --disk-tier ultra --dryrun`

![Screenshot 2025-04-30 at 9 41 57 PM](https://github.com/user-attachments/assets/c0e5c3e5-7dec-42d7-b095-2e70013461e6)

* `sky launch -t n1-standard-32 --disk-tier ultra --dryrun`

![Screenshot 2025-04-30 at 9 43 32 PM](https://github.com/user-attachments/assets/d7c9a163-d6a1-418e-b996-dfd2e55011cd)

* `sky launch -t g2-standard-4 --disk-tier ultra --dryrun`

![Screenshot 2025-04-30 at 9 47 47 PM](https://github.com/user-attachments/assets/ff670a3c-0c1b-41c6-9fd6-346238890061)

* `sky launch -t g2-standard-4 --disk-tier low --dryrun`

![Screenshot 2025-04-30 at 9 47 17 PM](https://github.com/user-attachments/assets/8ce1f1eb-56a5-4c05-bd70-56323c95bf64)

Because we refactor the propagation logic, experiments on `A3` series are rerun (see https://github.com/skypilot-org/skypilot/pull/5351):

* `sky launch -t a3-highgpu-8g --disk-tier ultra --dryrun`

![Screenshot 2025-04-30 at 9 36 11 PM](https://github.com/user-attachments/assets/ec8eddf2-c88a-4eac-85a1-3c37d928355f)

* `sky launch -t a3-highgpu-8g --disk-tier low --dryrun`

![Screenshot 2025-04-30 at 9 40 50 PM](https://github.com/user-attachments/assets/7ed5f92a-5c64-4f58-80a9-1d82770c88aa)



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
