### PR TITLE
[Nebius] Add support config file and remove hardcode

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/nebius.rst
+++ b/docs/source/cloud-setup/cloud-permissions/nebius.rst
@@ -37,4 +37,3 @@ To use *Service Account* authentication, follow these steps:
 **Important Notes:**
 
 * The `NEBIUS_IAM_TOKEN` file, if present, will take priority for authentication.
-* Service Accounts are restricted to a single region. Ensure you configure the Service Account for the appropriate region during creation.

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -545,7 +545,7 @@ Nebius
   nebius --format json iam whoami|jq -r '.user_profile.tenants[0].tenant_id' > ~/.nebius/NEBIUS_TENANT_ID.txt
 
 
-**Optional**: You can specify specific project ID and fabric in `~/.sky/config.yaml`, see :ref:`Configuration project_id and fabric for Nebius <config-yaml-nebius:>`.
+**Optional**: You can specify specific project ID and fabric in `~/.sky/config.yaml`, see :ref:`Configuration project_id and fabric for Nebius <config-yaml-nebius>`.
 
 Alternatively, you can also use a service account to access Nebius, see :ref:`Using Service Account for Nebius <nebius-service-account>`.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -545,15 +545,7 @@ Nebius
   nebius --format json iam whoami|jq -r '.user_profile.tenants[0].tenant_id' > ~/.nebius/NEBIUS_TENANT_ID.txt
 
 
-**Optional**: You can specify a preferable project ID and fabric in `~/.sky/config.yaml`
-
-.. code-block:: yaml
-
-  # ~/.sky/config.yaml
-  nebius:
-      eu-north1:
-        project_id: project-e00xxxxxxxxxxxx
-        fabric: fabric-2
+**Optional**: You can specify specific project ID and fabric in `~/.sky/config.yaml`, see :ref:`Configuration project_id and fabric for Nebius <config-yaml-nebius:>`.
 
 Alternatively, you can also use a service account to access Nebius, see :ref:`Using Service Account for Nebius <nebius-service-account>`.
 
@@ -573,8 +565,8 @@ In the prompt, enter your Nebius Access Key ID and Secret Access Key (see `instr
 
   aws configure set aws_access_key_id $NB_ACCESS_KEY_AWS_ID --profile nebius
   aws configure set aws_secret_access_key $NB_SECRET_ACCESS_KEY --profile nebius
-  aws configure set region eu-west1 --profile nebius
-  aws configure set endpoint_url https://storage.eu-west1.nebius.cloud:443  --profile nebius
+  aws configure set region REGION --profile nebius
+  aws configure set endpoint_url ENDPOINT  --profile nebius
 
 Request quotas for first time users
 --------------------------------------

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -549,11 +549,15 @@ If you have one tenant you can run:
 
   nebius --format json iam whoami|jq -r '.user_profile.tenants[0].tenant_id' > ~/.nebius/NEBIUS_TENANT_ID.txt
 
-You can specify a preferable project ID, which will be used if a project ID is required in the designated region.
+You can specify a preferable project ID and fabric in `~/.sky/config.yaml`
 
-.. code-block:: shell
+.. code-block:: yaml
 
-  echo $NEBIUS_PROJECT_ID > ~/.nebius/NEBIUS_PROJECT_ID.txt
+  # ~/.sky/config.yaml
+  nebius:
+      eu-north1:
+        project_id: project-e00xxxxxxxxxxxx
+        fabric: fabric-2
 
 To use *Service Account* authentication, follow these steps:
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -565,8 +565,8 @@ In the prompt, enter your Nebius Access Key ID and Secret Access Key (see `instr
 
   aws configure set aws_access_key_id $NB_ACCESS_KEY_AWS_ID --profile nebius
   aws configure set aws_secret_access_key $NB_SECRET_ACCESS_KEY --profile nebius
-  aws configure set region REGION --profile nebius
-  aws configure set endpoint_url ENDPOINT  --profile nebius
+  aws configure set region <REGION> --profile nebius
+  aws configure set endpoint_url <ENDPOINT>  --profile nebius
 
 Request quotas for first time users
 --------------------------------------

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1071,7 +1071,7 @@ Advanced Nebius configuration (optional).
     Optional: GPU cluster disabled if not specified
 
 
-The configuration can be specified in region-specific sections.
+The configuration must be specified in region-specific sections.
 
 Example:
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -122,6 +122,13 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`us-ashburn-1 <config-yaml-oci>`:
       vcn_ocid: ocid1.vcn.oc1.ap-seoul-1.amaaaaaaak7gbriarkfs2ssus5mh347ktmi3xa72tadajep6asio3ubqgarq
       vcn_subnet: ocid1.subnet.oc1.iad.aaaaaaaafbj7i3aqc4ofjaapa5edakde6g4ea2yaslcsay32cthp7qo55pxa
+  :ref:`nebius <config-yaml-nebius>`:
+    :ref:`eu-north1 <config-yaml-nebius>`:
+      project_id: project-e00xxxxxxxxxxx
+      fabric: fabric-3
+    :ref:`eu-west1 <config-yaml-nebius>`:
+      project_id: project-e01xxxxxxxxxxx
+      fabric: fabric-5
 
 Fields
 ----------
@@ -1048,6 +1055,38 @@ Example:
           vcn_ocid: ocid1.vcn.oc1.ap-seoul-1.amaaaaaaak7gbriarkfs2ssus5mh347ktmi3xa72tadajep6asio3ubqgarq
           vcn_subnet: ocid1.subnet.oc1.iad.aaaaaaaafbj7i3aqc4ofjaapa5edakde6g4ea2yaslcsay32cthp7qo55pxa
 
+.. _config-yaml-nebius:
+
+``nebius``
+~~~~~~~~~~
+
+Advanced Nebius configuration (optional).
+
+``project_id``
+    Identifier for the Nebius project (optional)
+    Default: Uses first available project if not specified
+``fabric``
+    GPU cluster configuration identifier (optional)
+    Optional: GPU cluster disabled if not specified
+
+
+The configuration can be specified in region-specific sections.
+
+Example:
+
+.. code-block:: yaml
+    nebius:
+        # Region-specific configuration
+        eu-north1:
+            # Project identifier for this region
+            # Optional: Uses first available project if not specified
+            project_id: project-e00......
+            # GPU cluster fabric identifier
+            # Optional: GPU cluster disabled if not specified
+            fabric: fabric-3
+        eu-west1:
+            project_id: project-e01...
+            fabric: fabric-5
 
 .. toctree::
    :hidden:

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1065,6 +1065,7 @@ Advanced Nebius configuration (optional).
 ``project_id``
     Identifier for the Nebius project (optional)
     Default: Uses first available project if not specified
+
 ``fabric``
     GPU cluster configuration identifier (optional)
     Optional: GPU cluster disabled if not specified
@@ -1075,6 +1076,7 @@ The configuration can be specified in region-specific sections.
 Example:
 
 .. code-block:: yaml
+
     nebius:
         # Region-specific configuration
         eu-north1:

--- a/sky/adaptors/nebius.py
+++ b/sky/adaptors/nebius.py
@@ -8,11 +8,9 @@ from sky.utils import ux_utils
 
 NEBIUS_TENANT_ID_FILENAME = 'NEBIUS_TENANT_ID.txt'
 NEBIUS_IAM_TOKEN_FILENAME = 'NEBIUS_IAM_TOKEN.txt'
-NEBIUS_PROJECT_ID_FILENAME = 'NEBIUS_PROJECT_ID.txt'
 NEBIUS_CREDENTIALS_FILENAME = 'credentials.json'
 NEBIUS_TENANT_ID_PATH = '~/.nebius/' + NEBIUS_TENANT_ID_FILENAME
 NEBIUS_IAM_TOKEN_PATH = '~/.nebius/' + NEBIUS_IAM_TOKEN_FILENAME
-NEBIUS_PROJECT_ID_PATH = '~/.nebius/' + NEBIUS_PROJECT_ID_FILENAME
 NEBIUS_CREDENTIALS_PATH = '~/.nebius/' + NEBIUS_CREDENTIALS_FILENAME
 
 DEFAULT_REGION = 'eu-north1'
@@ -90,16 +88,6 @@ def get_iam_token():
 def is_token_or_cred_file_exist():
     return (os.path.exists(os.path.expanduser(NEBIUS_IAM_TOKEN_PATH)) or
             os.path.exists(os.path.expanduser(NEBIUS_CREDENTIALS_PATH)))
-
-
-@annotations.lru_cache(scope='request')
-def get_project_id():
-    try:
-        with open(os.path.expanduser(NEBIUS_PROJECT_ID_PATH),
-                  encoding='utf-8') as file:
-            return file.read().strip()
-    except FileNotFoundError:
-        return None
 
 
 @annotations.lru_cache(scope='request')

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -17,7 +17,6 @@ _CREDENTIAL_FILES = [
     # credential files for Nebius
     nebius.NEBIUS_TENANT_ID_FILENAME,
     nebius.NEBIUS_IAM_TOKEN_FILENAME,
-    nebius.NEBIUS_PROJECT_ID_FILENAME,
     nebius.NEBIUS_CREDENTIALS_FILENAME
 ]
 

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 import uuid
 
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import nebius
 from sky.utils import common_utils
 
@@ -35,44 +36,22 @@ def get_project_by_region(region: str) -> str:
     service = nebius.iam().ProjectServiceClient(nebius.sdk())
     projects = service.list(nebius.iam().ListProjectsRequest(
         parent_id=nebius.get_tenant_id())).wait()
-    # To find a project in a specific region, we rely on the project ID to
-    # deduce the region, since there is currently no method to retrieve region
-    # information directly from the project. Additionally, there is only one
-    # project per region, and projects cannot be created at this time.
-    # The region is determined from the project ID using a region-specific
-    # identifier embedded in it.
-    # Project id looks like project-e00xxxxxxxxxxxxxx where
-    # e00 - id of region 'eu-north1'
-    # e01 - id of region 'eu-west1'
-    region_ids = {'eu-north1': 'e00', 'eu-west1': 'e01'}
-    # TODO(SalikovAlex): fix when info about region will be in projects list
-    # Currently, Nebius cloud supports 2 regions. We manually enumerate
-    # them here. Reference: https://docs.nebius.com/overview/regions
 
     #  Check is there project if in config
-    preferable_project_id = nebius.get_project_id()
+    preferable_project_id = skypilot_config.get_nested(
+        ('nebius', region, 'project_id'), None)
     if preferable_project_id is not None:
-        if preferable_project_id[8:11] == region_ids[region]:
-            return preferable_project_id
-        logger.warning(
-            f'Can\'t use customized NEBIUS_PROJECT_ID ({preferable_project_id})'
-            f' for region {region}. Please check if the project ID is correct.')
+        return preferable_project_id
     for project in projects.items:
-        if project.metadata.id[8:11] == region_ids[region]:
+        if project.status.region == region:
             return project.metadata.id
     raise Exception(f'No project found for region "{region}".')
 
 
-def get_or_create_gpu_cluster(name: str, region: str) -> str:
+def get_or_create_gpu_cluster(name: str, project_id: str, fabric: str) -> str:
     """Creates a GPU cluster.
-    When creating a GPU cluster, select an InfiniBand fabric for it:
-
-    fabric-2, fabric-3 or fabric-4 for projects in the eu-north1 region.
-    fabric-5 for projects in the eu-west1 region.
-
     https://docs.nebius.com/compute/clusters/gpu
     """
-    project_id = get_project_by_region(region)
     service = nebius.compute().GpuClusterServiceClient(nebius.sdk())
     try:
         cluster = service.get_by_name(nebius.nebius_common().GetByNameRequest(
@@ -80,14 +59,7 @@ def get_or_create_gpu_cluster(name: str, region: str) -> str:
             name=name,
         )).wait()
         cluster_id = cluster.metadata.id
-    except nebius.request_error() as no_cluster_found_error:
-        if region == 'eu-north1':
-            fabric = 'fabric-4'
-        elif region == 'eu-west1':
-            fabric = 'fabric-5'
-        else:
-            raise RuntimeError(
-                f'Unsupported region {region}.') from no_cluster_found_error
+    except nebius.request_error():
         cluster = service.create(nebius.compute().CreateGpuClusterRequest(
             metadata=nebius.nebius_common().ResourceMetadata(
                 parent_id=project_id,
@@ -196,15 +168,23 @@ def launch(cluster_name_on_cloud: str, node_type: str, platform: str,
 
     disk_name = 'disk-' + instance_name
     cluster_id = None
+    project_id = get_project_by_region(region)
     # 8 GPU virtual machines can be grouped into a GPU cluster.
     # The GPU clusters are built with InfiniBand secure high-speed networking.
     # https://docs.nebius.com/compute/clusters/gpu
     if platform in ('gpu-h100-sxm', 'gpu-h200-sxm'):
         if preset == '8gpu-128vcpu-1600gb':
-            cluster_id = get_or_create_gpu_cluster(cluster_name_on_cloud,
-                                                   region)
+            #  Check is there fabric in config
+            fabric = skypilot_config.get_nested(('nebius', region, 'fabric'),
+                                                None)
+            if fabric is None:
+                logger.warning(
+                    f'Set up fabric for region {region} in ~/.sky/config.yaml '
+                    'to use GPU clusters.')
+            else:
+                cluster_id = get_or_create_gpu_cluster(cluster_name_on_cloud,
+                                                       project_id, fabric)
 
-    project_id = get_project_by_region(region)
     service = nebius.compute().DiskServiceClient(nebius.sdk())
     disk = service.create(nebius.compute().CreateDiskRequest(
         metadata=nebius.nebius_common().ResourceMetadata(

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -38,10 +38,10 @@ def get_project_by_region(region: str) -> str:
         parent_id=nebius.get_tenant_id())).wait()
 
     #  Check is there project if in config
-    preferable_project_id = skypilot_config.get_nested(
-        ('nebius', region, 'project_id'), None)
-    if preferable_project_id is not None:
-        return preferable_project_id
+    project_id = skypilot_config.get_nested(('nebius', region, 'project_id'),
+                                            None)
+    if project_id is not None:
+        return project_id
     for project in projects.items:
         if project.status.region == region:
             return project.metadata.id

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -963,6 +963,24 @@ def get_config_schema():
                 }
             },
         },
+        'nebius': {
+            'type': 'object',
+            'required': [],
+            'properties': {},
+            'additionalProperties': {
+                'type': 'object',
+                'required': [],
+                'additionalProperties': False,
+                'properties': {
+                    'project_id': {
+                        'type': 'string',
+                    },
+                    'fabric': {
+                        'type': 'string',
+                    },
+                }
+            },
+        }
     }
 
     admin_policy_schema = {


### PR DESCRIPTION
The Nebius project ID file support has been removed in favor of configuration in `~/.sky/config.yaml`, which now includes `project_id` and `fabric` options. Enhancements include streamlined GPU cluster creation and clearer documentation for Nebius configurations.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)

