### PR TITLE
[Nebius] Conditionally mount AWS credential files for Nebius profile

### DIFF
--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -344,8 +344,9 @@ class Nebius(clouds.Cloud):
             f'~/.nebius/{filename}': f'~/.nebius/{filename}'
             for filename in _CREDENTIAL_FILES
         }
-        credential_file_mounts['~/.aws/credentials'] = '~/.aws/credentials'
-        credential_file_mounts['~/.aws/config'] = '~/.aws/config'
+        if nebius_profile_in_aws_cred_and_config():
+            credential_file_mounts['~/.aws/credentials'] = '~/.aws/credentials'
+            credential_file_mounts['~/.aws/config'] = '~/.aws/config'
         return credential_file_mounts
 
     @classmethod


### PR DESCRIPTION
Previously, AWS credential files were always mounted, even when unnecessary. This change ensures they are only mounted if the Nebius profile is referenced in the AWS credentials and config files. This reduces redundancy and improves configuration flexibility.

Fixing: https://github.com/skypilot-org/skypilot/issues/5338
- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
