### PR TITLE
Remove upper limit on urllib3 version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ isort==5.12.0
 # match the version with .pre-commit-config.yaml
 mypy==1.4.0
 types-PyYAML
-# 2.31 requires urlib3>2, which is incompatible with SkyPilot, IBM and
+# 2.31 requires urlib3>2, which is incompatible with IBM and
 # kubernetes packages, which require urllib3<2.
 types-requests<2.31
 types-setuptools

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -79,11 +79,6 @@ remote = [
 # NOTE: Change the templates/jobs-controller.yaml.j2 file if any of the
 # following packages dependencies are changed.
 aws_dependencies = [
-    # botocore does not work with urllib3>=2.0.0, according to
-    # https://github.com/boto/botocore/issues/2926
-    # We have to explicitly pin the version to optimize the time for
-    # poetry install. See https://github.com/orgs/python-poetry/discussions/7937
-    'urllib3<2',
     # NOTE: this installs CLI V1. To use AWS SSO (e.g., `aws sso login`), users
     # should instead use CLI V2 which is not pip-installable. See
     # https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This pull request removes the `urllib3<2` dependency specification from the `aws_dependencies` group.

Fixes #5467.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

(none of the above -- I had some issues setting up a test environment, and the changes here are pretty minimal, so I'm hoping CI coverage is sufficient)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
