### PR TITLE
add task envs to event_callback

### DIFF
--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -421,10 +421,8 @@ def event_callback_func(job_id: int, task_id: int, task: 'sky.Task'):
         log_path = os.path.join(constants.SKY_LOGS_DIRECTORY,
                                 'managed_job_event',
                                 f'jobs-callback-{job_id}-{task_id}.log')
-        result = log_lib.run_bash_command_with_log(
-            bash_command=event_callback,
-            log_path=log_path,
-            env_vars=dict(
+        env_vars = task.envs.copy() if task.envs else {}
+        env_vars.update(dict(
                 SKYPILOT_TASK_ID=str(
                     task.envs.get(constants.TASK_ID_ENV_VAR, 'N.A.')),
                 SKYPILOT_TASK_IDS=str(
@@ -435,7 +433,12 @@ def event_callback_func(job_id: int, task_id: int, task: 'sky.Task'):
                 CLUSTER_NAME=cluster_name or '',
                 TASK_NAME=task.name or '',
                 # TODO(MaoZiming): Future event type Job or Spot.
-                EVENT_TYPE='Spot'))
+                EVENT_TYPE='Spot')
+        )
+        result = log_lib.run_bash_command_with_log(
+            bash_command=event_callback,
+            log_path=log_path,
+            env_vars=env_vars)
         logger.info(
             f'Bash:{event_callback},log_path:{log_path},result:{result}')
         logger.info(f'=== END: event callback for {status!r} ===')

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -422,7 +422,8 @@ def event_callback_func(job_id: int, task_id: int, task: 'sky.Task'):
                                 'managed_job_event',
                                 f'jobs-callback-{job_id}-{task_id}.log')
         env_vars = task.envs.copy() if task.envs else {}
-        env_vars.update(dict(
+        env_vars.update(
+            dict(
                 SKYPILOT_TASK_ID=str(
                     task.envs.get(constants.TASK_ID_ENV_VAR, 'N.A.')),
                 SKYPILOT_TASK_IDS=str(
@@ -433,12 +434,10 @@ def event_callback_func(job_id: int, task_id: int, task: 'sky.Task'):
                 CLUSTER_NAME=cluster_name or '',
                 TASK_NAME=task.name or '',
                 # TODO(MaoZiming): Future event type Job or Spot.
-                EVENT_TYPE='Spot')
-        )
-        result = log_lib.run_bash_command_with_log(
-            bash_command=event_callback,
-            log_path=log_path,
-            env_vars=env_vars)
+                EVENT_TYPE='Spot'))
+        result = log_lib.run_bash_command_with_log(bash_command=event_callback,
+                                                   log_path=log_path,
+                                                   env_vars=env_vars)
         logger.info(
             f'Bash:{event_callback},log_path:{log_path},result:{result}')
         logger.info(f'=== END: event callback for {status!r} ===')


### PR DESCRIPTION
When event_callback is called, we want to pass in the task environment to get the callback access to extra context (like secrets).

There are no unit tests that specifically cover the event_callback.

Tested (run the relevant ones):

- [ x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

issue: 5475
