### PR TITLE
reload AWS_SESSION_TOKEN and KUBECONFIG on local API server

### DIFF
--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -40,8 +40,11 @@ EXTERNAL_LOCAL_ENV_VARS = [
     'AWS_PROFILE',
     'AWS_ACCESS_KEY_ID',
     'AWS_SECRET_ACCESS_KEY',
+    'AWS_SESSION_TOKEN',
     # Allow overriding the GCP authentication.
     'GOOGLE_APPLICATION_CREDENTIALS',
+    # Allow overriding the kubeconfig.
+    'KUBECONFIG',
 ]
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #5448.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
