### PR TITLE
Fix: accept non-k8s TPU names on GKE (e.g. tpu-v6e-8) (#5024)

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -131,6 +131,29 @@ DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_INTERVAL_SECONDS = 1
 
 
+def normalize_tpu_accelerator_name(accelerator: str) -> str:
+    """Normalize TPU names to the k8s-compatible name if needed.
+
+    Examples:
+    - tpu-v6e-8 -> tpu-v6e-slice
+    - tpu-v5p-16 -> tpu-v5p-slice
+    - tpu-v5litepod-4 -> tpu-v5-lite-podslice
+    """
+    # Simple patterns for known GCP-style names
+    gcp_to_k8s_patterns = [
+        (r'^tpu-v6e-\d+$', 'tpu-v6e-slice'),
+        (r'^tpu-v5p-\d+$', 'tpu-v5p-slice'),
+        (r'^tpu-v5litepod-\d+$', 'tpu-v5-lite-podslice'),
+        (r'^tpu-v5lite-\d+$', 'tpu-v5-lite-device'),
+        (r'^tpu-v4-\d+$', 'tpu-v4-podslice'),
+    ]
+    for pattern, replacement in gcp_to_k8s_patterns:
+        if re.match(pattern, accelerator):
+            return replacement
+    return accelerator
+
+
+
 def _retry_on_error(max_retries=DEFAULT_MAX_RETRIES,
                     retry_interval=DEFAULT_RETRY_INTERVAL_SECONDS,
                     resource_type: Optional[str] = None):
@@ -2838,6 +2861,7 @@ def get_skypilot_pods(context: Optional[str] = None) -> List[Any]:
 
 def is_tpu_on_gke(accelerator: str) -> bool:
     """Determines if the given accelerator is a TPU supported on GKE."""
+    normalized = normalize_tpu_accelerator_name(accelerator)
     return accelerator in GKE_TPU_ACCELERATOR_TO_GENERATION
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
