### PR TITLE
[k8s] do not consider nodes with exact cpu/mem requirements

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -980,8 +980,12 @@ def check_instance_fits(context: Optional[str],
             if node_cpus > max_cpu:
                 max_cpu = node_cpus
                 max_mem = node_memory_gb
-            if (node_cpus >= candidate_instance_type.cpus and
-                    node_memory_gb >= candidate_instance_type.memory):
+            # We don't consider nodes that have exactly the same amount of
+            # CPU or memory as the candidate instance type.
+            # This is to account for the fact that each node always has some
+            # amount kube-system pods running on it and consuming resources.
+            if (node_cpus > candidate_instance_type.cpus and
+                    node_memory_gb > candidate_instance_type.memory):
                 return True, None
         return False, (
             'Maximum resources found on a single node: '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The k8s codepath decides if a node can fit a job/task by looking at the CPU/mem capacity, not CPU/mem allocatable. The assumption here is that even if a node doesn't have the CPU/mem necessary right now, maybe there is another SkyPilot job running that will complete, free up the resources, and let the job schedule.

A good example where this approach fails is when a job requiring 8 CPUs being matched by a node with 8 CPU capacity. This seems theoretically sound at first glance, but in reality a node always has _some_ kube-system (or *-system) pods running that prevents this job from being scheduled. This PR attempts to account for this real life scenario.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
