### PR TITLE
fix controller cluster name breaking

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -713,7 +713,7 @@ def write_cluster_config(
     # this feature has been checked by
     # CloudImplementationFeatures.HIGH_AVAILABILITY_CONTROLLERS
     high_availability_specified = controller_utils.high_availability_specified(
-        cluster_name_on_cloud)
+        cluster_name)
 
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -164,10 +164,19 @@ class Controllers(enum.Enum):
         if name is None:
             return None
         controller = None
-        if name == common.SKY_SERVE_CONTROLLER_PREFIX:
+        # The controller name is always the same. However, on the client-side,
+        # we may not know the exact name, because we are missing the server-side
+        # common.SERVER_ID. So, we will assume anything that matches the prefix
+        # is a controller.
+        if name.startswith(common.SKY_SERVE_CONTROLLER_PREFIX):
             controller = cls.SKY_SERVE_CONTROLLER
-        elif name == common.JOB_CONTROLLER_PREFIX:
+        elif name.startswith(common.JOB_CONTROLLER_PREFIX):
             controller = cls.JOBS_CONTROLLER
+        if controller is not None and name != controller.value.cluster_name:
+            # The client-side cluster_name is not accurate. Assume that `name`
+            # is the actual cluster name, so need to set the controller's
+            # cluster name to the input name.
+            controller.value.cluster_name = name
         return controller
 
     @classmethod

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -164,19 +164,10 @@ class Controllers(enum.Enum):
         if name is None:
             return None
         controller = None
-        # The controller name is always the same. However, on the client-side,
-        # we may not know the exact name, because we are missing the server-side
-        # common.SERVER_ID. So, we will assume anything that matches the prefix
-        # is a controller.
-        if name.startswith(common.SKY_SERVE_CONTROLLER_PREFIX):
+        if name == common.SKY_SERVE_CONTROLLER_PREFIX:
             controller = cls.SKY_SERVE_CONTROLLER
-        elif name.startswith(common.JOB_CONTROLLER_PREFIX):
+        elif name == common.JOB_CONTROLLER_PREFIX:
             controller = cls.JOBS_CONTROLLER
-        if controller is not None and name != controller.value.cluster_name:
-            # The client-side cluster_name is not accurate. Assume that `name`
-            # is the actual cluster name, so need to set the controller's
-            # cluster name to the input name.
-            controller.value.cluster_name = name
         return controller
 
     @classmethod


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This attempts to fix an issue I hit that caused two jobs controllers to be created.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
