### PR TITLE
[jobs] submit a "batch job" with many tasks at once

### DIFF
--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -47,7 +47,7 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # The version of the lib files that jobs/utils use. Whenever there is an API
 # change for the jobs/utils, we need to bump this version and update
 # job.utils.ManagedJobCodeGen to handle the version update.
-MANAGED_JOBS_VERSION = 3
+MANAGED_JOBS_VERSION = 4
 
 # The command for setting up the jobs dashboard on the controller. It firstly
 # checks if the systemd services are available, and if not (e.g., Kubernetes

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -153,7 +153,8 @@ def maybe_schedule_next_jobs() -> None:
 
                 if current_state == state.ManagedJobScheduleState.WAITING:
                     # The job controller has not been started yet. We must start
-                    # it.
+                    # it. Warning: if this crashes, the job will be stuck
+                    # LAUNCHING. TODO(cooperc): Handle this gracefully.
 
                     job_id = maybe_next_job['job_id']
                     dag_yaml_path = maybe_next_job['dag_yaml_path']

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -208,6 +208,13 @@ def launch(
 
         controller_task.managed_job_dag = dag
 
+        if dag.tasks[0].envs.get('__SKYPILOT_PARENT_JOB_ID') == -1:
+            # This is a parent job.
+            # Do not run the run section of the controller task, since the job
+            # is a dummy and it does not need to actually be submitted to the
+            # scheduler.
+            dag.tasks[0].run = None
+
         sky_logging.print(
             f'{colorama.Fore.YELLOW}'
             f'Launching managed job {dag.name!r} from jobs controller...'

--- a/sky/templates/jobs-controller.yaml.j2
+++ b/sky/templates/jobs-controller.yaml.j2
@@ -64,6 +64,9 @@ run: |
   # Note: The job is already in the `spot` table, marked as PENDING.
   # CloudVmRayBackend._exec_code_on_head() calls
   # managed_job_codegen.set_pending() before we get here.
+  # TODO(cooperc): If job submission gets interrupted, the job will be stuck on
+  # the controller in INACTIVE schedule_state. We need to gracefully handle this
+  # case.
   python -u -m sky.jobs.scheduler {{remote_user_yaml_path}} \
     --job-id $SKYPILOT_INTERNAL_JOB_ID \
     --env-file {{remote_env_file_path}}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This introduces a new flag `--num-tasks` for `sky jobs launch`. It allows many duplicate tasks to be launched under the same job.

The UX is very barebones at the moment, since this more of a proof of concept.

<details><summary>Example usages:</summary>

```
cooperc@crispy ~> sky jobs launch --cpus 2 --num-tasks 10 -n batch-job echo hello world!
Command to run: echo hello world!
Managed job 'batch-job' will be launched on (estimated):
Considered resources (1 node):
----------------------------------------------------------------------------------------
 CLOUD   INSTANCE    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
----------------------------------------------------------------------------------------
 AWS     m6i.large   2       8         -              us-east-1     0.10          ✔
----------------------------------------------------------------------------------------
Launching a managed job 'batch-job'. Proceed? [Y/n]:
Launching parent job to get its ID.
Launching managed job 'batch-job' from jobs controller...
⚙︎ Syncing files.
  Syncing (to 1 node): /tmp/managed-dag-batch-job-q16vth2i -> ~/.sky/managed_jobs/batch-job-fd6e.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-05-03-02-01-55-922466/file_mounts.log
⚙︎ Job submitted, ID: 152

Launching managed job 'batch-job-0' from jobs controller...
⚙︎ Syncing files.
  Syncing (to 1 node): /tmp/managed-dag-batch-job-0-z7h7nedv -> ~/.sky/managed_jobs/batch-job-0-96c2.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-05-03-02-02-11-381696/file_mounts.log
⚙︎ Job submitted, ID: 155

Launching managed job 'batch-job-1' from jobs controller...
⚙︎ Syncing files.
  Syncing (to 1 node): /tmp/managed-dag-batch-job-1-rq7ig9pf -> ~/.sky/managed_jobs/batch-job-1-b2bd.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-05-03-02-02-13-192938/file_mounts.log
⚙︎ Job submitted, ID: 154

... snipped ...

Launching managed job 'batch-job-9' from jobs controller...
⚙︎ Syncing files.
  Syncing (to 1 node): /tmp/managed-dag-batch-job-9-tqlfrxwv -> ~/.sky/managed_jobs/batch-job-9-2c60.yaml
✓ Synced file_mounts.  View logs: sky api logs -l sky-2025-05-03-02-02-15-453298/file_mounts.log
⚙︎ Job submitted, ID: 160

695d86fd-3825-4f83-abab-6a80dbe6193c
891b8679-0939-45fb-a1ba-c87fd1d3a2de
35b964c7-7919-4c22-83a7-d5ea349cd2b4
d7ecffad-8afd-4392-84b7-f2cdde3cea6d
62b6ce75-5a83-477b-a683-1d54fd974846
0aff27e6-f0af-4e47-9f99-240a9452527a
a2e4fe64-02ae-4a47-b056-15eb61a4fe71
ce79b85c-b718-41a7-a48c-8653f65a927c
a28d3b71-44af-4c6b-8527-673a154827ed
61ed34cf-6e69-4130-91ac-f8f29b280f8a
9d7a3549-063a-47c9-b8cb-9856fd1d41e3
Job ids:
152
155
154
153
156
158
157
162
159
161
160
```

With `--async`:

```
cooperc@crispy ~> sky jobs launch --cpus 2 --num-tasks 10 -n batch-job --async echo hello world!
Command to run: echo hello world!
Managed job 'batch-job' will be launched on (estimated):
Considered resources (1 node):
----------------------------------------------------------------------------------------
 CLOUD   INSTANCE    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN
----------------------------------------------------------------------------------------
 AWS     m6i.large   2       8         -              us-east-1     0.10          ✔
----------------------------------------------------------------------------------------
Launching a managed job 'batch-job'. Proceed? [Y/n]:
Launching parent job to get its ID.
Submitted sky.jobs.launch request: 26fb75f7-90de-4a0c-8dc0-aa52fd7a2f5e
├── Check logs with: sky api logs 26fb75f7
├── Or, visit: http://skypilot:20c0874af4437993@54.236.38.86:46581/api/stream?request_id=26fb75f7
└── To cancel the request, run: sky api cancel 26fb75f7

Submitted sky.jobs.launch request: 2e380b46-9092-423a-b445-b2db1d839969
├── Check logs with: sky api logs 2e380b46
├── Or, visit: http://skypilot:20c0874af4437993@54.236.38.86:46581/api/stream?request_id=2e380b46
└── To cancel the request, run: sky api cancel 2e380b46

Submitted sky.jobs.launch request: 304e13c3-ed47-47e8-8c8d-f75384357608
├── Check logs with: sky api logs 304e13c3
├── Or, visit: http://skypilot:20c0874af4437993@54.236.38.86:46581/api/stream?request_id=304e13c3
└── To cancel the request, run: sky api cancel 304e13c3

Submitted sky.jobs.launch request: fd0af3d0-5554-451d-b534-504a184f560c
├── Check logs with: sky api logs fd0af3d0
├── Or, visit: http://skypilot:20c0874af4437993@54.236.38.86:46581/api/stream?request_id=fd0af3d0
└── To cancel the request, run: sky api cancel fd0af3d0

... snipped ...

Submitted sky.jobs.launch request: ec2fa167-e199-4d80-9e4f-3f00662e9b3e
├── Check logs with: sky api logs ec2fa167
├── Or, visit: http://skypilot:20c0874af4437993@54.236.38.86:46581/api/stream?request_id=ec2fa167
└── To cancel the request, run: sky api cancel ec2fa167

26fb75f7-90de-4a0c-8dc0-aa52fd7a2f5e
2e380b46-9092-423a-b445-b2db1d839969
304e13c3-ed47-47e8-8c8d-f75384357608
fd0af3d0-5554-451d-b534-504a184f560c
4da0f4b4-4454-41a2-a352-cffbb42fa351
79eee7f3-79dd-40d7-8f59-2b4c352367aa
41913c1a-ba0b-44a6-a7b4-5814de6eee36
8197c98c-635e-4c24-9607-2e6e9233aa82
c63fec24-c2cd-4af9-b218-5103363cc300
621195ee-529a-42a4-a3ca-1466e55cff44
ec2fa167-e199-4d80-9e4f-3f00662e9b3e

```


```
cooperc@crispy ~> sky jobs queue
Fetching managed job statuses...
Managed jobs
In progress tasks: 14 PENDING, 86 RUNNING, 4 STARTING
ID   TASK  NAME          RESOURCES  SUBMITTED    TOT. DURATION  JOB DURATION  #RECOVERIES  STATUS
152        batch-job     -          -            -              -             0            10x PENDING
 ↳   162   batch-job-6   1x[CPU:2]  -            -              -             0            PENDING
 ↳   161   batch-job-8   1x[CPU:2]  -            -              -             0            PENDING
 ↳   160   batch-job-9   1x[CPU:2]  -            -              -             0            PENDING
 ↳   159   batch-job-7   1x[CPU:2]  -            -              -             0            PENDING
 ↳   158   batch-job-4   1x[CPU:2]  -            -              -             0            PENDING
 ↳   157   batch-job-5   1x[CPU:2]  -            -              -             0            PENDING
 ↳   156   batch-job-3   1x[CPU:2]  -            -              -             0            PENDING
 ↳   155   batch-job-0   1x[CPU:2]  -            -              -             0            PENDING
 ↳   154   batch-job-1   1x[CPU:2]  -            -              -             0            PENDING
 ↳   153   batch-job-2   1x[CPU:2]  -            -              -             0            PENDING

1          sleeper3      -          22 mins ago  22m 15s        13h 20m 42s   0            4x PENDING 4x STARTING 86x RUNNING 56x SUCCEEDED
 ↳   151   sleeper3-146  1x[CPU:2]  -            -              -             0            PENDING
 ↳   150   sleeper3-147  1x[CPU:2]  -            -              -             0            PENDING
 ↳   149   sleeper3-149  1x[CPU:2]  -            -              -             0            PENDING
 ↳   148   sleeper3-145  1x[CPU:2]  -            -              -             0            PENDING
...
```

</details>

This is ready for high-level review, though there are some things that still need to be tested/fixed.

How it works:
- Each "task" is actually a full-fledged job.
- There is a "parent job" - it's ID is the ID for the whole batch job.
- We submit this parent job as a dummy that doesn't do anything, then submit all the tasks as jobs pointing to this batch ID as the "parent job id"
- The individual tasks are all submitted as separate API server requests, to let the API server handle the parallelism (minimal changes needed).
  - Because of #5473, there's some extra code to avoid overloading a local API server
- Add some code in `sky jobs queue` and `sky jobs cancel` (TODO) to handle the batch job nicely
- There aren't any major changes in how the jobs controller works. There are a couple minor changes
  - Add a column for parent_job_id, which is null for normal jobs, -1 for parent jobs, and the batch ID for batch job tasks
  - Avoid scheduling the parent job, since it's just a dummy
- Otherwise the jobs controller all works as before

TODO:

- [ ] make sure storage works, and there are no cleanup conflicts
- [ ] make `sky jobs cancel <parent job id>` work
- [ ] fix `sky jobs queue` breakage without `--all` when there are more than 50 tasks in a job
- [ ] check the backwards compatibility if you use `--num-tasks` on an API server without this code
- [ ] test massive scale (like 10k jobs or something)

This supersedes #4735

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
