### PR TITLE
[UX][k8s] backwards compatibility for k8s show-gpus

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3449,7 +3449,7 @@ def show_gpus(
         realtime_gpu_infos = []
         total_gpu_info: Dict[str, List[int]] = collections.defaultdict(
             lambda: [0, 0])
-        
+
         # TODO(kyuds): remove backwards compatibility code (else branch)
         # when API version is bumped
         if realtime_gpu_availability_lists:
@@ -3462,8 +3462,8 @@ def show_gpus(
                         gpu_availability = models.RealtimeGpuAvailability(
                             *realtime_gpu_availability)
                         available_qty = (gpu_availability.available
-                                        if gpu_availability.available != -1 else
-                                        no_permissions_str)
+                                         if gpu_availability.available != -1
+                                         else no_permissions_str)
                         realtime_gpu_table.add_row([
                             gpu_availability.gpu,
                             _list_to_str(gpu_availability.counts),
@@ -3483,13 +3483,13 @@ def show_gpus(
                 # 2025.05.03
                 availability_list = realtime_gpu_availability_lists
                 realtime_gpu_table = log_utils.create_table(
-                        ['GPU', qty_header, 'TOTAL_GPUS', free_header])
+                    ['GPU', qty_header, 'TOTAL_GPUS', free_header])
                 for realtime_gpu_availability in sorted(availability_list):
                     gpu_availability = models.RealtimeGpuAvailability(
                         *realtime_gpu_availability)
                     available_qty = (gpu_availability.available
-                                    if gpu_availability.available != -1 else
-                                    no_permissions_str)
+                                     if gpu_availability.available != -1 else
+                                     no_permissions_str)
                     realtime_gpu_table.add_row([
                         gpu_availability.gpu,
                         _list_to_str(gpu_availability.counts),

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3529,7 +3529,7 @@ def show_gpus(
             'Kubernetes per node accelerator availability ')
         if nodes_info.hint:
             k8s_per_node_acc_message += nodes_info.hint
-        return (f'{colorama.Fore.CYAN}{colorama.Style.NORMAL}'
+        return (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                 f'{k8s_per_node_acc_message}'
                 f'{colorama.Style.RESET_ALL}\n'
                 f'{node_table.get_string()}')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3481,7 +3481,6 @@ def show_gpus(
             else:
                 # can remove this with api server version bump.
                 # 2025.05.03
-                click.echo("else branch")
                 availability_list = realtime_gpu_availability_lists
                 realtime_gpu_table = log_utils.create_table(
                         ['GPU', qty_header, 'TOTAL_GPUS', free_header])
@@ -3530,7 +3529,7 @@ def show_gpus(
             'Kubernetes per node accelerator availability ')
         if nodes_info.hint:
             k8s_per_node_acc_message += nodes_info.hint
-        return (f'{colorama.Fore.LIGHTMAGENTA_EX}{colorama.Style.NORMAL}'
+        return (f'{colorama.Fore.CYAN}{colorama.Style.NORMAL}'
                 f'{k8s_per_node_acc_message}'
                 f'{colorama.Style.RESET_ALL}\n'
                 f'{node_table.get_string()}')
@@ -3582,7 +3581,7 @@ def show_gpus(
                                'Total Kubernetes GPUs'
                                f'{colorama.Style.RESET_ALL}\n')
                         yield from total_table.get_string()
-                        yield '\n-----\n\n'
+                        yield '\n\n'
 
                     # print individual infos.
                     for (ctx, k8s_realtime_table) in k8s_realtime_infos:
@@ -3592,7 +3591,7 @@ def show_gpus(
                                f'{colorama.Style.RESET_ALL}\n')
                         yield from k8s_realtime_table.get_string()
                         yield '\n\n'
-                        yield _format_kubernetes_node_info(ctx) + '\n-----\n\n'
+                        yield _format_kubernetes_node_info(ctx) + '\n\n'
                 if kubernetes_autoscaling:
                     k8s_messages += (
                         '\n' + kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE)
@@ -3694,7 +3693,7 @@ def show_gpus(
                            'Total Kubernetes GPUs'
                            f'{colorama.Style.RESET_ALL}\n')
                     yield from total_table.get_string()
-                    yield '\n-----\n\n'
+                    yield '\n\n'
 
                 # print individual tables
                 for (ctx, k8s_realtime_table) in k8s_realtime_infos:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3521,10 +3521,12 @@ def show_gpus(
             available = node_info.free[
                 'accelerators_available'] if node_info.free[
                     'accelerators_available'] != -1 else no_permissions_str
-            node_table.add_row([
-                node_name, node_info.accelerator_type,
-                node_info.total['accelerator_count'], available
-            ])
+            total = node_info.total['accelerator_count']
+            if total > 0:
+                node_table.add_row([
+                    node_name, node_info.accelerator_type,
+                    node_info.total['accelerator_count'], available
+                ])
         k8s_per_node_acc_message = (
             'Kubernetes per node accelerator availability ')
         if nodes_info.hint:
@@ -3584,14 +3586,18 @@ def show_gpus(
                         yield '\n\n'
 
                     # print individual infos.
-                    for (ctx, k8s_realtime_table) in k8s_realtime_infos:
+                    for (idx,
+                         (ctx,
+                          k8s_realtime_table)) in enumerate(k8s_realtime_infos):
                         context_str = f'(Context: {ctx})' if ctx else ''
                         yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                                f'Kubernetes GPUs {context_str}'
                                f'{colorama.Style.RESET_ALL}\n')
                         yield from k8s_realtime_table.get_string()
                         yield '\n\n'
-                        yield _format_kubernetes_node_info(ctx) + '\n\n'
+                        yield _format_kubernetes_node_info(ctx)
+                        if idx != len(k8s_realtime_infos) - 1:
+                            yield '\n\n'
                 if kubernetes_autoscaling:
                     k8s_messages += (
                         '\n' + kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
As mentioned in this [pr](https://github.com/skypilot-org/skypilot/pull/5362)

also fixes the color misalignment and removes the `----`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
