### PR TITLE
[k8s] New UX for`show-gpus`, and add back the 0 GPU nodes

### DIFF
--- a/docs/source/compute/gpus.rst
+++ b/docs/source/compute/gpus.rst
@@ -32,18 +32,18 @@ You can query the accelerators available in your Kubernetes clusters with:
 .. code-block:: text
 
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-    L4    1, 2, 4                   12          12
-    H100  1, 2, 4, 8                16          16
+    GPU   REQUESTABLE_QTY_PER_NODE     #GPUS
+    L4    1, 2, 4                   12 of 12
+    H100  1, 2, 4, 8                16 of 16
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-    my-cluster-0               L4        4           4
-    my-cluster-1               L4        4           4
-    my-cluster-2               L4        2           2
-    my-cluster-3               L4        2           2
-    my-cluster-4               H100      8           8
-    my-cluster-5               H100      8           8
+    NODE_NAME                  GPU_NAME   #GPUS
+    my-cluster-0               L4        4 of 4
+    my-cluster-1               L4        4 of 4
+    my-cluster-2               L4        2 of 2
+    my-cluster-3               L4        2 of 2
+    my-cluster-4               H100      8 of 8
+    my-cluster-5               H100      8 of 8
 
 Querying accelerator details
 ----------------------------

--- a/docs/source/compute/gpus.rst
+++ b/docs/source/compute/gpus.rst
@@ -32,12 +32,12 @@ You can query the accelerators available in your Kubernetes clusters with:
 .. code-block:: text
 
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE     #GPUS
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
     L4    1, 2, 4                   12 of 12
     H100  1, 2, 4, 8                16 of 16
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME   #GPUS
+    NODE                       GPU       UTILIZATION
     my-cluster-0               L4        4 of 4
     my-cluster-1               L4        4 of 4
     my-cluster-2               L4        2 of 2

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -148,16 +148,16 @@ Deploying on Google Cloud GKE
    .. code-block:: console
 
        $ sky show-gpus --cloud k8s
-       GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-       L4    1, 2, 4                   8           6
-       A100  1, 2                      4           2
+       GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+       L4    1, 2, 4                   6 of 8 free
+       A100  1, 2                      2 of 4 free
 
        Kubernetes per node GPU availability
-       NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-       my-cluster-0               L4        4           4
-       my-cluster-1               L4        4           2
-       my-cluster-2               A100      2           2
-       my-cluster-3               A100      2           0
+       NODE_NAME                  GPU_NAME  #GPUS
+       my-cluster-0               L4        4 of 4 free
+       my-cluster-1               L4        2 of 4 free
+       my-cluster-2               A100      2 of 2 free
+       my-cluster-3               A100      0 of 2 free
 
 .. note::
     GKE autopilot clusters are currently not supported. Only GKE standard clusters are supported.
@@ -203,12 +203,12 @@ Deploying on Amazon EKS
    .. code-block:: console
 
        $ sky show-gpus --cloud k8s
-       GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-       A100  1, 2                      4           2
+       GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+       A100  1, 2                      2 of 2 free
 
        Kubernetes per node GPU availability
-       NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-       my-cluster-0               A100      2           2
+       NODE_NAME                  GPU_NAME  #GPUS
+       my-cluster-0               A100      2 of 2 free
 
 .. _kubernetes-setup-onprem:
 

--- a/docs/source/reference/kubernetes/kubernetes-deployment.rst
+++ b/docs/source/reference/kubernetes/kubernetes-deployment.rst
@@ -148,12 +148,12 @@ Deploying on Google Cloud GKE
    .. code-block:: console
 
        $ sky show-gpus --cloud k8s
-       GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+       GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
        L4    1, 2, 4                   6 of 8 free
        A100  1, 2                      2 of 4 free
 
        Kubernetes per node GPU availability
-       NODE_NAME                  GPU_NAME  #GPUS
+       NODE                       GPU       UTILIZATION
        my-cluster-0               L4        4 of 4 free
        my-cluster-1               L4        2 of 4 free
        my-cluster-2               A100      2 of 2 free
@@ -203,11 +203,11 @@ Deploying on Amazon EKS
    .. code-block:: console
 
        $ sky show-gpus --cloud k8s
-       GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+       GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
        A100  1, 2                      2 of 2 free
 
        Kubernetes per node GPU availability
-       NODE_NAME                  GPU_NAME  #GPUS
+       NODE                       GPU       UTILIZATION
        my-cluster-0               A100      2 of 2 free
 
 .. _kubernetes-setup-onprem:

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -175,12 +175,12 @@ You can also inspect the real-time GPU usage on the cluster with :code:`sky show
 
     $ sky show-gpus --cloud k8s
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
     L4    1, 2, 4                   12 of 12 free
     H100  1, 2, 4, 8                16 of 16 free
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME  #GPUS
+    NODE                       GPU       UTILIZATION
     my-cluster-0               L4        4 of 4 free
     my-cluster-1               L4        4 of 4 free
     my-cluster-2               L4        2 of 2 free

--- a/docs/source/reference/kubernetes/kubernetes-getting-started.rst
+++ b/docs/source/reference/kubernetes/kubernetes-getting-started.rst
@@ -175,18 +175,18 @@ You can also inspect the real-time GPU usage on the cluster with :code:`sky show
 
     $ sky show-gpus --cloud k8s
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-    L4    1, 2, 4                   12          12
-    H100  1, 2, 4, 8                16          16
+    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+    L4    1, 2, 4                   12 of 12 free
+    H100  1, 2, 4, 8                16 of 16 free
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-    my-cluster-0               L4        4           4
-    my-cluster-1               L4        4           4
-    my-cluster-2               L4        2           2
-    my-cluster-3               L4        2           2
-    my-cluster-4               H100      8           8
-    my-cluster-5               H100      8           8
+    NODE_NAME                  GPU_NAME  #GPUS
+    my-cluster-0               L4        4 of 4 free
+    my-cluster-1               L4        4 of 4 free
+    my-cluster-2               L4        2 of 2 free
+    my-cluster-3               L4        2 of 2 free
+    my-cluster-4               H100      8 of 8 free
+    my-cluster-5               H100      8 of 8 free
 
 
 Using custom images

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -219,18 +219,18 @@ You can also check the GPUs available on your nodes by running:
 
     $ sky show-gpus --cloud k8s
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-    L4    1, 2, 4                   12          12
-    H100  1, 2, 4, 8                16          16
+    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+    L4    1, 2, 4                   12 of 12 free
+    H100  1, 2, 4, 8                16 of 16 free
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-    my-cluster-0               L4        4           4
-    my-cluster-1               L4        4           4
-    my-cluster-2               L4        2           2
-    my-cluster-3               L4        2           2
-    my-cluster-4               H100      8           8
-    my-cluster-5               H100      8           8
+    NODE_NAME                  GPU_NAME  #GPUS
+    my-cluster-0               L4        4 of 4 free
+    my-cluster-1               L4        4 of 4 free
+    my-cluster-2               L4        2 of 2 free
+    my-cluster-3               L4        2 of 2 free
+    my-cluster-4               H100      8 of 8 free
+    my-cluster-5               H100      8 of 8 free
 
 .. _kubernetes-optional-steps:
 

--- a/docs/source/reference/kubernetes/kubernetes-setup.rst
+++ b/docs/source/reference/kubernetes/kubernetes-setup.rst
@@ -219,12 +219,12 @@ You can also check the GPUs available on your nodes by running:
 
     $ sky show-gpus --cloud k8s
     Kubernetes GPUs
-    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
     L4    1, 2, 4                   12 of 12 free
     H100  1, 2, 4, 8                16 of 16 free
 
     Kubernetes per node GPU availability
-    NODE_NAME                  GPU_NAME  #GPUS
+    NODE                       GPU       UTILIZATION
     my-cluster-0               L4        4 of 4 free
     my-cluster-1               L4        4 of 4 free
     my-cluster-2               L4        2 of 2 free

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -152,16 +152,16 @@ by specifying the ``--region`` with the context name for that cluster.
     $ sky launch --cloud k8s --region my-tpu-cluster echo 'Hello World'
 
     $ # Check the GPUs available in a Kubernetes cluster
-    $ sky show-gpus --cloud k8s --region my-h100-cluster
-
-    Kubernetes GPUs (Context: my-h100-cluster)
-    GPU    QTY_PER_NODE            #GPUS
-    H100   1, 2, 3, 4, 5, 6, 7, 8  8 of 8 free
-
-    Kubernetes per node GPU availability
-    NODE_NAME             GPU_NAME  #GPUS
-    my-h100-cluster-hbzn  H100      8 of 8 free
-    my-h100-cluster-w5x7  None      0 of 0 free
+    $ sky show-gpus --cloud k8s --region my-h100-cluster                                                  ✭ ✱
+    Kubernetes GPUs
+    Context: my-h100-cluster
+    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS          
+    H100  1, 2, 4, 8                16 of 16 free  
+    Kubernetes per-node GPU availability
+    CONTEXT          NODE_NAME                                     GPU_NAME  #GPUS        
+    my-h100-cluster  gke-skypilotalpha-default-pool-ff931856-6uvd  -         0 of 0 free  
+    my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-1usy      H100      8 of 8 free  
+    my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-4rxa      H100      8 of 8 free  
 
 When launching a SkyPilot cluster or task, you can also specify the context name with ``--region`` to launch the cluster or task in.
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -96,6 +96,28 @@ To check the enabled Kubernetes clusters, you can run ``sky check k8s``.
         ├── my-h100-cluster
         └── my-tpu-cluster
 
+To check GPUs available in a Kubernetes cluster, you can run ``sky show-gpus --cloud k8s``.
+
+.. code-block:: console
+
+    $ sky show-gpus --cloud k8s
+    Kubernetes GPUs
+    GPU   #GPUS          
+    H100  16 of 16 free  
+    A100  8 of 8 free    
+    Context: my-h100-cluster
+    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS          
+    H100  1, 2, 4, 8                16 of 16 free  
+    Context: kind-skypilot
+    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS        
+    A100  1, 2, 4, 8                8 of 8 free  
+    Kubernetes per-node GPU availability
+    CONTEXT          NODE_NAME                                     GPU_NAME  #GPUS        
+    my-h100-cluster  gke-skypilotalpha-default-pool-ff931856-6uvd  -         0 of 0 free  
+    my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-1usy      H100      8 of 8 free  
+    my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-4rxa      H100      8 of 8 free  
+    kind-skypilot    skypilot-control-plane                        A100      8 of 8 free  
+
 
 Failover across multiple Kubernetes clusters
 --------------------------------------------
@@ -133,13 +155,13 @@ by specifying the ``--region`` with the context name for that cluster.
     $ sky show-gpus --cloud k8s --region my-h100-cluster
 
     Kubernetes GPUs (Context: my-h100-cluster)
-    GPU    QTY_PER_NODE            TOTAL_GPUS  TOTAL_FREE_GPUS
-    H100   1, 2, 3, 4, 5, 6, 7, 8  8           8
+    GPU    QTY_PER_NODE            #GPUS
+    H100   1, 2, 3, 4, 5, 6, 7, 8  8 of 8 free
 
     Kubernetes per node GPU availability
-    NODE_NAME                                 GPU_NAME  TOTAL_GPUS  FREE_GPUS
-    my-h100-cluster-hbzn  H100      8           8
-    my-h100-cluster-w5x7  None      0           0
+    NODE_NAME             GPU_NAME  #GPUS
+    my-h100-cluster-hbzn  H100      8 of 8 free
+    my-h100-cluster-w5x7  None      0 of 0 free
 
 When launching a SkyPilot cluster or task, you can also specify the context name with ``--region`` to launch the cluster or task in.
 

--- a/docs/source/reference/kubernetes/multi-kubernetes.rst
+++ b/docs/source/reference/kubernetes/multi-kubernetes.rst
@@ -102,17 +102,17 @@ To check GPUs available in a Kubernetes cluster, you can run ``sky show-gpus --c
 
     $ sky show-gpus --cloud k8s
     Kubernetes GPUs
-    GPU   #GPUS          
+    GPU   UTILIZATION
     H100  16 of 16 free  
     A100  8 of 8 free    
     Context: my-h100-cluster
-    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS          
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION          
     H100  1, 2, 4, 8                16 of 16 free  
     Context: kind-skypilot
-    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS        
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION          
     A100  1, 2, 4, 8                8 of 8 free  
     Kubernetes per-node GPU availability
-    CONTEXT          NODE_NAME                                     GPU_NAME  #GPUS        
+    CONTEXT          NODE                                          GPU       UTILIZATION        
     my-h100-cluster  gke-skypilotalpha-default-pool-ff931856-6uvd  -         0 of 0 free  
     my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-1usy      H100      8 of 8 free  
     my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-4rxa      H100      8 of 8 free  
@@ -155,10 +155,10 @@ by specifying the ``--region`` with the context name for that cluster.
     $ sky show-gpus --cloud k8s --region my-h100-cluster                                                  ✭ ✱
     Kubernetes GPUs
     Context: my-h100-cluster
-    GPU   REQUESTABLE_QTY_PER_NODE  #GPUS          
+    GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
     H100  1, 2, 4, 8                16 of 16 free  
     Kubernetes per-node GPU availability
-    CONTEXT          NODE_NAME                                     GPU_NAME  #GPUS        
+    CONTEXT          NODE                                          GPU       UTILIZATION
     my-h100-cluster  gke-skypilotalpha-default-pool-ff931856-6uvd  -         0 of 0 free  
     my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-1usy      H100      8 of 8 free  
     my-h100-cluster  gke-skypilotalpha-largecpu-05dae726-4rxa      H100      8 of 8 free  

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -117,18 +117,18 @@ Deploying SkyPilot
 
       $ sky show-gpus --cloud k8s
       Kubernetes GPUs
-      GPU   REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-      L4    1, 2, 4                   12          12
-      H100  1, 2, 4, 8                16          16
+      GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+      L4    1, 2, 4                   12 of 12
+      H100  1, 2, 4, 8                16 of 16
 
       Kubernetes per node GPU availability
-      NODE_NAME                  GPU_NAME  TOTAL_GPUS  FREE_GPUS
-      my-cluster-0               L4        4           4
-      my-cluster-1               L4        4           4
-      my-cluster-2               L4        2           2
-      my-cluster-3               L4        2           2
-      my-cluster-4               H100      8           8
-      my-cluster-5               H100      8           8
+      NODE_NAME                  GPU_NAME  #GPUS
+      my-cluster-0               L4        4 of 4
+      my-cluster-1               L4        4 of 4
+      my-cluster-2               L4        2 of 2
+      my-cluster-3               L4        2 of 2
+      my-cluster-4               H100      8 of 8
+      my-cluster-5               H100      8 of 8
 
       $ sky launch --cloud k8s --gpus H100:1 -- nvidia-smi
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -117,12 +117,12 @@ Deploying SkyPilot
 
       $ sky show-gpus --cloud k8s
       Kubernetes GPUs
-      GPU   REQUESTABLE_QTY_PER_NODE  #GPUS
+      GPU   REQUESTABLE_QTY_PER_NODE  UTILIZATION
       L4    1, 2, 4                   12 of 12
       H100  1, 2, 4, 8                16 of 16
 
       Kubernetes per node GPU availability
-      NODE_NAME                  GPU_NAME  #GPUS
+      NODE                       GPU       UTILIZATION
       my-cluster-0               L4        4 of 4
       my-cluster-1               L4        4 of 4
       my-cluster-2               L4        2 of 2

--- a/examples/k8s_cloud_deploy/README.md
+++ b/examples/k8s_cloud_deploy/README.md
@@ -44,13 +44,13 @@ NAME              STATUS   ROLES                  AGE   VERSION
 
 $ sky show-gpus --cloud kubernetes
 Kubernetes GPUs
-GPU  REQUESTABLE_QTY_PER_NODE  TOTAL_GPUS  TOTAL_FREE_GPUS
-A10  1                         2           2              
+GPU  REQUESTABLE_QTY_PER_NODE        #GPUS
+A10  1                         2 of 2 free
 
 Kubernetes per node GPU availability
-NODE_NAME        GPU_NAME  TOTAL_GPUS  FREE_GPUS
-129-80-133-44    A10       1           1
-150-230-191-161  A10       1           1
+NODE_NAME        GPU_NAME        #GPUS
+129-80-133-44    A10       1 of 1 free
+150-230-191-161  A10       1 of 1 free
 ```
 
 ## Run AI workloads on your Kubernetes cluster with SkyPilot

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3449,6 +3449,7 @@ def show_gpus(
         realtime_gpu_infos = []
         total_gpu_info: Dict[str, List[int]] = collections.defaultdict(
             lambda: [0, 0])
+        all_nodes_info = []
 
         if realtime_gpu_availability_lists:
             if len(realtime_gpu_availability_lists[0]) != 2:
@@ -3481,6 +3482,9 @@ def show_gpus(
                         total_gpu_info[gpu][0] += capacity
                         total_gpu_info[gpu][1] += available
                 realtime_gpu_infos.append((ctx, realtime_gpu_table))
+                # Collect node info for this context
+                nodes_info = sdk.stream_and_get(sdk.kubernetes_node_info(context=ctx))
+                all_nodes_info.append((ctx, nodes_info))
 
         # display an aggregated table for all contexts
         # if there are more than one contexts with GPUs
@@ -3492,30 +3496,39 @@ def show_gpus(
         else:
             total_realtime_gpu_table = None
 
-        return realtime_gpu_infos, total_realtime_gpu_table
+        return realtime_gpu_infos, total_realtime_gpu_table, all_nodes_info
 
-    def _format_kubernetes_node_info(context: Optional[str]):
+
+
+    def _format_kubernetes_node_info_combined(contexts_info):
         node_table = log_utils.create_table(
-            ['NODE_NAME', 'GPU_NAME', 'TOTAL_GPUS', 'FREE_GPUS'])
+            ['CONTEXT', 'NODE_NAME', 'GPU_NAME', 'TOTAL_GPUS', 'FREE_GPUS'])
 
-        nodes_info = sdk.stream_and_get(
-            sdk.kubernetes_node_info(context=context))
         no_permissions_str = '<no permissions>'
-        for node_name, node_info in nodes_info.node_info_dict.items():
-            available = node_info.free[
-                'accelerators_available'] if node_info.free[
-                    'accelerators_available'] != -1 else no_permissions_str
-            acc_type = node_info.accelerator_type
-            if acc_type is None:
-                acc_type = '-'
-            node_table.add_row([
-                node_name, acc_type, node_info.total['accelerator_count'],
-                available
-            ])
+        hints = []
+        
+        for context, nodes_info in contexts_info:
+            context_name = context if context else 'default'
+            if nodes_info.hint:
+                hints.append(f'{context_name}: {nodes_info.hint}')
+                
+            for node_name, node_info in nodes_info.node_info_dict.items():
+                available = node_info.free[
+                    'accelerators_available'] if node_info.free[
+                        'accelerators_available'] != -1 else no_permissions_str
+                acc_type = node_info.accelerator_type
+                if acc_type is None:
+                    acc_type = '-'
+                node_table.add_row([
+                    context_name, node_name, acc_type, 
+                    node_info.total['accelerator_count'], available
+                ])
+        
         k8s_per_node_acc_message = (
-            'Kubernetes per node accelerator availability ')
-        if nodes_info.hint:
-            k8s_per_node_acc_message += nodes_info.hint
+            'Kubernetes per-node accelerator availability')
+        if hints:
+            k8s_per_node_acc_message += ' (' + '; '.join(hints) + ')'
+            
         return (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
                 f'{k8s_per_node_acc_message}'
                 f'{colorama.Style.RESET_ALL}\n'
@@ -3553,7 +3566,7 @@ def show_gpus(
                     # If --cloud kubernetes is not specified, we want to catch
                     # the case where no GPUs are available on the cluster and
                     # print the warning at the end.
-                    k8s_realtime_infos, total_table = _get_kubernetes_realtime_gpu_tables(context)  # pylint: disable=line-too-long
+                    k8s_realtime_infos, total_table, all_nodes_info = _get_kubernetes_realtime_gpu_tables(context)  # pylint: disable=line-too-long
                 except ValueError as e:
                     if not cloud_is_kubernetes:
                         # Make it a note if cloud is not kubernetes
@@ -3562,27 +3575,26 @@ def show_gpus(
                 else:
                     print_section_titles = True
 
+                    yield (f'{colorama.Fore.GREEN}{colorama.Style.BRIGHT}'
+                            'Kubernetes GPUs'
+                            f'{colorama.Style.RESET_ALL}\n')
                     # print total table
                     if total_table is not None:
-                        yield (f'{colorama.Fore.GREEN}{colorama.Style.BRIGHT}'
-                               'Total Kubernetes GPUs'
-                               f'{colorama.Style.RESET_ALL}\n')
                         yield from total_table.get_string()
-                        yield '\n\n'
+                        yield '\n'
 
                     # print individual infos.
-                    for (idx,
-                         (ctx,
-                          k8s_realtime_table)) in enumerate(k8s_realtime_infos):
-                        context_str = f'(Context: {ctx})' if ctx else ''
-                        yield (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}'
-                               f'Kubernetes GPUs {context_str}'
-                               f'{colorama.Style.RESET_ALL}\n')
+                    for (ctx, k8s_realtime_table) in k8s_realtime_infos:
+                        # Print context header separately
+                        context_str = f'Context: {ctx}' if ctx else 'Default Context'
+                        yield (f'{colorama.Fore.CYAN}{context_str}{colorama.Style.RESET_ALL}\n')
                         yield from k8s_realtime_table.get_string()
-                        yield '\n\n'
-                        yield _format_kubernetes_node_info(ctx)
-                        if idx != len(k8s_realtime_infos) - 1:
-                            yield '\n\n'
+                        yield '\n'
+                    
+                    # Add combined node table after showing individual GPU tables
+                    if all_nodes_info:
+                        yield '\n'
+                        yield _format_kubernetes_node_info_combined(all_nodes_info)
                 if kubernetes_autoscaling:
                     k8s_messages += (
                         '\n' + kubernetes_utils.KUBERNETES_AUTOSCALER_NOTE)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3453,7 +3453,8 @@ def show_gpus(
         if realtime_gpu_availability_lists:
             if len(realtime_gpu_availability_lists[0]) != 2:
                 # TODO(kyuds): for backwards compatibility, as we add new
-                # context to the response. Remove this if block after 0.10.0.
+                # context to the API server response in #5362. Remove this after
+                # 0.10.0.
                 realtime_gpu_availability_lists = [
                     (context, realtime_gpu_availability_lists)
                 ]

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3523,8 +3523,7 @@ def show_gpus(
                     node_info.total['accelerator_count'], available
                 ])
 
-        k8s_per_node_acc_message = (
-            'Kubernetes per-node GPU availability')
+        k8s_per_node_acc_message = ('Kubernetes per-node GPU availability')
         if hints:
             k8s_per_node_acc_message += ' (' + '; '.join(hints) + ')'
 
@@ -3534,7 +3533,7 @@ def show_gpus(
                 f'{node_table.get_string()}')
 
     def _format_kubernetes_realtime_gpu(total_table, k8s_realtime_infos,
-                                      all_nodes_info, show_node_info: bool):
+                                        all_nodes_info, show_node_info: bool):
         yield (f'{colorama.Fore.GREEN}{colorama.Style.BRIGHT}'
                'Kubernetes GPUs'
                f'{colorama.Style.RESET_ALL}\n')
@@ -3700,9 +3699,9 @@ def show_gpus(
                      context=region, name_filter=name, quantity_filter=quantity)
 
                 yield from _format_kubernetes_realtime_gpu(total_table,
-                                                         k8s_realtime_infos,
-                                                         all_nodes_info,
-                                                         show_node_info=False)
+                                                           k8s_realtime_infos,
+                                                           all_nodes_info,
+                                                           show_node_info=False)
             except ValueError as e:
                 # In the case of a specific accelerator, show the error message
                 # immediately (e.g., "Resources H100 not found ...")

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3546,14 +3546,15 @@ def show_gpus(
             show_node_info: bool) -> Generator[str, None, None]:
         yield (f'{colorama.Fore.GREEN}{colorama.Style.BRIGHT}'
                'Kubernetes GPUs'
-               f'{colorama.Style.RESET_ALL}\n')
+               f'{colorama.Style.RESET_ALL}')
         # print total table
         if total_table is not None:
-            yield from total_table.get_string()
             yield '\n'
+            yield from total_table.get_string()
 
         # print individual infos.
         for (ctx, k8s_realtime_table) in k8s_realtime_infos:
+            yield '\n'
             # Print context header separately
             if ctx:
                 context_str = f'Context: {ctx}'
@@ -3563,8 +3564,9 @@ def show_gpus(
                 f'{colorama.Fore.CYAN}{context_str}{colorama.Style.RESET_ALL}\n'
             )
             yield from k8s_realtime_table.get_string()
-            yield '\n'
+
         if show_node_info:
+            yield '\n'
             yield _format_kubernetes_node_info_combined(all_nodes_info)
 
     def _output() -> Generator[str, None, None]:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3524,7 +3524,7 @@ def show_gpus(
                 ])
 
         k8s_per_node_acc_message = (
-            'Kubernetes per-node accelerator availability')
+            'Kubernetes per-node GPU availability')
         if hints:
             k8s_per_node_acc_message += ' (' + '; '.join(hints) + ')'
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3450,53 +3450,36 @@ def show_gpus(
         total_gpu_info: Dict[str, List[int]] = collections.defaultdict(
             lambda: [0, 0])
 
-        # TODO(kyuds): remove backwards compatibility code (else branch)
-        # when API version is bumped
         if realtime_gpu_availability_lists:
-            # can't check for isinstance tuple as the tuple is converted to list
-            if len(realtime_gpu_availability_lists[0]) == 2:
-                for (ctx, availability_list) in realtime_gpu_availability_lists:
-                    realtime_gpu_table = log_utils.create_table(
-                        ['GPU', qty_header, 'TOTAL_GPUS', free_header])
-                    for realtime_gpu_availability in sorted(availability_list):
-                        gpu_availability = models.RealtimeGpuAvailability(
-                            *realtime_gpu_availability)
-                        available_qty = (gpu_availability.available
-                                         if gpu_availability.available != -1
-                                         else no_permissions_str)
-                        realtime_gpu_table.add_row([
-                            gpu_availability.gpu,
-                            _list_to_str(gpu_availability.counts),
-                            gpu_availability.capacity,
-                            available_qty,
-                        ])
-                        gpu = gpu_availability.gpu
-                        capacity = gpu_availability.capacity
-                        # we want total, so skip permission denied.
-                        available = max(gpu_availability.available, 0)
-                        if capacity > 0:
-                            total_gpu_info[gpu][0] += capacity
-                            total_gpu_info[gpu][1] += available
-                    realtime_gpu_infos.append((ctx, realtime_gpu_table))
-            else:
-                # can remove this with api server version bump.
-                # 2025.05.03
-                availability_list = realtime_gpu_availability_lists
+            if len(realtime_gpu_availability_lists[0]) != 2:
+                # TODO(kyuds): for backwards compatibility, as we add new
+                # context to the response. Remove this if block after 0.10.0.
+                realtime_gpu_availability_lists = [
+                    (context, realtime_gpu_availability_lists)
+                ]
+            for (ctx, availability_list) in realtime_gpu_availability_lists:
                 realtime_gpu_table = log_utils.create_table(
                     ['GPU', qty_header, 'TOTAL_GPUS', free_header])
                 for realtime_gpu_availability in sorted(availability_list):
                     gpu_availability = models.RealtimeGpuAvailability(
                         *realtime_gpu_availability)
                     available_qty = (gpu_availability.available
-                                     if gpu_availability.available != -1 else
-                                     no_permissions_str)
+                                        if gpu_availability.available != -1
+                                        else no_permissions_str)
                     realtime_gpu_table.add_row([
                         gpu_availability.gpu,
                         _list_to_str(gpu_availability.counts),
                         gpu_availability.capacity,
                         available_qty,
                     ])
-                realtime_gpu_infos.append((context, realtime_gpu_table))
+                    gpu = gpu_availability.gpu
+                    capacity = gpu_availability.capacity
+                    # we want total, so skip permission denied.
+                    available = max(gpu_availability.available, 0)
+                    if capacity > 0:
+                        total_gpu_info[gpu][0] += capacity
+                        total_gpu_info[gpu][1] += available
+                realtime_gpu_infos.append((ctx, realtime_gpu_table))
 
         # display an aggregated table for all contexts
         # if there are more than one contexts with GPUs
@@ -3521,12 +3504,13 @@ def show_gpus(
             available = node_info.free[
                 'accelerators_available'] if node_info.free[
                     'accelerators_available'] != -1 else no_permissions_str
-            total = node_info.total['accelerator_count']
-            if total > 0:
-                node_table.add_row([
-                    node_name, node_info.accelerator_type,
-                    node_info.total['accelerator_count'], available
-                ])
+            acc_type = node_info.accelerator_type
+            if acc_type is None:
+                acc_type = '-'
+            node_table.add_row([
+                node_name, acc_type,
+                node_info.total['accelerator_count'], available
+            ])
         k8s_per_node_acc_message = (
             'Kubernetes per node accelerator availability ')
         if nodes_info.hint:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3465,8 +3465,8 @@ def show_gpus(
                     gpu_availability = models.RealtimeGpuAvailability(
                         *realtime_gpu_availability)
                     available_qty = (gpu_availability.available
-                                        if gpu_availability.available != -1
-                                        else no_permissions_str)
+                                     if gpu_availability.available != -1 else
+                                     no_permissions_str)
                     realtime_gpu_table.add_row([
                         gpu_availability.gpu,
                         _list_to_str(gpu_availability.counts),
@@ -3509,8 +3509,8 @@ def show_gpus(
             if acc_type is None:
                 acc_type = '-'
             node_table.add_row([
-                node_name, acc_type,
-                node_info.total['accelerator_count'], available
+                node_name, acc_type, node_info.total['accelerator_count'],
+                available
             ])
         k8s_per_node_acc_message = (
             'Kubernetes per node accelerator availability ')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -91,6 +91,8 @@ from sky.utils.cli_utils import status_utils
 if typing.TYPE_CHECKING:
     import types
 
+    import prettytable
+
 pd = adaptors_common.LazyImport('pandas')
 logger = sky_logging.init_logger(__name__)
 
@@ -3415,9 +3417,12 @@ def show_gpus(
     # TODO(zhwu,romilb): We should move most of these kubernetes related
     # queries into the backend, especially behind the server.
     def _get_kubernetes_realtime_gpu_tables(
-            context: Optional[str] = None,
-            name_filter: Optional[str] = None,
-            quantity_filter: Optional[int] = None):
+        context: Optional[str] = None,
+        name_filter: Optional[str] = None,
+        quantity_filter: Optional[int] = None
+    ) -> Tuple[List[Tuple[str, 'prettytable.PrettyTable']],
+               Optional['prettytable.PrettyTable'], List[Tuple[
+                   str, 'models.KubernetesNodesInfo']]]:
         if quantity_filter:
             qty_header = 'QTY_FILTER'
             free_header = 'FILTERED_FREE_GPUS'
@@ -3499,7 +3504,9 @@ def show_gpus(
 
         return realtime_gpu_infos, total_realtime_gpu_table, all_nodes_info
 
-    def _format_kubernetes_node_info_combined(contexts_info):
+    def _format_kubernetes_node_info_combined(
+            contexts_info: List[Tuple[str,
+                                      'models.KubernetesNodesInfo']]) -> str:
         node_table = log_utils.create_table(
             ['CONTEXT', 'NODE_NAME', 'GPU_NAME', 'TOTAL_GPUS', 'FREE_GPUS'])
 
@@ -3532,8 +3539,11 @@ def show_gpus(
                 f'{colorama.Style.RESET_ALL}\n'
                 f'{node_table.get_string()}')
 
-    def _format_kubernetes_realtime_gpu(total_table, k8s_realtime_infos,
-                                        all_nodes_info, show_node_info: bool):
+    def _format_kubernetes_realtime_gpu(
+            total_table: 'prettytable.PrettyTable',
+            k8s_realtime_infos: List[Tuple[str, 'prettytable.PrettyTable']],
+            all_nodes_info: List[Tuple[str, 'models.KubernetesNodesInfo']],
+            show_node_info: bool) -> Generator[str, None, None]:
         yield (f'{colorama.Fore.GREEN}{colorama.Style.BRIGHT}'
                'Kubernetes GPUs'
                f'{colorama.Style.RESET_ALL}\n')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3373,8 +3373,8 @@ def show_gpus(
     * ``QTY_PER_NODE`` (Kubernetes only): GPU quantities that can be requested
       on a single node.
 
-    * ``#GPUS`` (Kubernetes only): Total number of GPUs free / available in the
-      Kubernetes cluster
+    * ``UTILIZATION`` (Kubernetes only): Total number of GPUs free / available
+      in the Kubernetes cluster.
     """
     # validation for the --region flag
     if region is not None and cloud is None:
@@ -3460,7 +3460,7 @@ def show_gpus(
                 ]
             for (ctx, availability_list) in realtime_gpu_availability_lists:
                 realtime_gpu_table = log_utils.create_table(
-                    ['GPU', qty_header, '#GPUS'])
+                    ['GPU', qty_header, 'UTILIZATION'])
                 for realtime_gpu_availability in sorted(availability_list):
                     gpu_availability = models.RealtimeGpuAvailability(
                         *realtime_gpu_availability)
@@ -3488,7 +3488,8 @@ def show_gpus(
         # display an aggregated table for all contexts
         # if there are more than one contexts with GPUs
         if len(realtime_gpu_infos) > 1:
-            total_realtime_gpu_table = log_utils.create_table(['GPU', '#GPUS'])
+            total_realtime_gpu_table = log_utils.create_table(
+                ['GPU', 'UTILIZATION'])
             for gpu, stats in total_gpu_info.items():
                 total_realtime_gpu_table.add_row(
                     [gpu, f'{stats[1]} of {stats[0]} free'])
@@ -3501,7 +3502,7 @@ def show_gpus(
             contexts_info: List[Tuple[str,
                                       'models.KubernetesNodesInfo']]) -> str:
         node_table = log_utils.create_table(
-            ['CONTEXT', 'NODE_NAME', 'GPU_NAME', '#GPUS'])
+            ['CONTEXT', 'NODE', 'GPU', 'UTILIZATION'])
 
         no_permissions_str = '<no permissions>'
         hints = []

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3488,10 +3488,10 @@ def show_gpus(
         # display an aggregated table for all contexts
         # if there are more than one contexts with GPUs
         if len(realtime_gpu_infos) > 1:
-            total_realtime_gpu_table = log_utils.create_table(
-                ['GPU', '#GPUS'])
+            total_realtime_gpu_table = log_utils.create_table(['GPU', '#GPUS'])
             for gpu, stats in total_gpu_info.items():
-                total_realtime_gpu_table.add_row([gpu, f'{stats[1]} of {stats[0]} free'])
+                total_realtime_gpu_table.add_row(
+                    [gpu, f'{stats[1]} of {stats[0]} free'])
         else:
             total_realtime_gpu_table = None
 
@@ -3520,7 +3520,8 @@ def show_gpus(
                     acc_type = '-'
                 node_table.add_row([
                     context_name, node_name, acc_type,
-                    f'{available} of {node_info.total["accelerator_count"]} free'
+                    f'{available} of {node_info.total["accelerator_count"]} '
+                    'free'
                 ])
 
         k8s_per_node_acc_message = ('Kubernetes per-node GPU availability')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is a minor refactoring of #5488 to improve the code readability and add back the 0 GPU nodes.

It also proposes a new UX:

## Single k8s cluster
New:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/bef24eb4-4340-4484-954c-35885e63c187" />

Original:
<img width="521" alt="image" src="https://github.com/user-attachments/assets/327ef7ce-67c0-4194-af14-c28906b89a90" />


## Multiple k8s cluster

<img width="603" alt="image" src="https://github.com/user-attachments/assets/bd1c603e-5dc8-4752-9f2b-231eeaa5d7a3" />

Original
<img width="555" alt="image" src="https://github.com/user-attachments/assets/f6601bad-fb4b-41ac-bcf0-2388514586a4" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
