### PR TITLE
[k8s] fix helm chart deployment of API server

### DIFF
--- a/charts/skypilot/templates/system-rbac.yaml
+++ b/charts/skypilot/templates/system-rbac.yaml
@@ -54,7 +54,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "skypilot.serviceAccountName" . }}
-  namespace: {{ $namespace }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Release.Name }}-system-cluster-role


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
**Before**:
```
$ export NAMESPACE=team2  
$ export RELEASE_NAME=skypilot-team2
$ export WEB_USERNAME=skypilot
$ export WEB_PASSWORD=yourpassword
$ export AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
$ helm upgrade --install $RELEASE_NAME ./charts/skypilot --devel \
  --namespace $NAMESPACE \
  --create-namespace \
  --set ingress.authCredentials=$AUTH_STRING
...
$ sky api login --endpoint http://skypilot:yourpassword@<host>
$ sky jobs launch "echo hello"
Command to run: echo hello
Managed job 'sky-cmd' will be launched on (estimated):
Considered resources (1 node):
---------------------------------------------------------------------------------------------
 CLOUD        INSTANCE    vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
---------------------------------------------------------------------------------------------
 Kubernetes   2CPU--2GB   2       2         -              in-cluster    0.00          ✔     
---------------------------------------------------------------------------------------------
Launching a managed job 'sky-cmd'. Proceed? [Y/n]: 
Launching managed job 'sky-cmd' from jobs controller...
Choosing resources for managed jobs controller...
Considered resources (1 node):
----------------------------------------------------------------------------------------------
 CLOUD        INSTANCE     vCPUs   Mem(GB)   ACCELERATORS   REGION/ZONE   COST ($)   CHOSEN   
----------------------------------------------------------------------------------------------
 Kubernetes   6CPU--16GB   6       16        -              in-cluster    0.00          ✔     
----------------------------------------------------------------------------------------------
⚙︎ Launching managed jobs controller on Kubernetes.
sky.exceptions.ResourcesUnavailableError: Failed to acquire resources in all zones in in-cluster for {<Cloud>(cpus=6, mem=16, disk_size=50)}. 

↺ Trying other potential resources.
Failed to provision all possible launchable resources. Relax the task's resource requirements: 1x <Cloud>(cpus=6, mem=16, disk_size=50)
```
and provision log shows the following error:
```
D 05-07 00:27:40 provisioner.py:164] HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces \"skypilot-system\" is forbidden: User \"system:serviceaccount:team2:skypilot-team2-api-sa\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"skypilot-system\"","reason":"Forbidden","details":{"name":"skypilot-system","kind":"namespaces"},"code":403}
```

**After** (on a fresh cluster):
```
export NAMESPACE=team2  
export RELEASE_NAME=skypilot-team2
export WEB_USERNAME=skypilot
export WEB_PASSWORD=yourpassword
export AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
helm upgrade --install $RELEASE_NAME ./charts/skypilot --devel \
  --namespace $NAMESPACE \
  --create-namespace \
  --set ingress.authCredentials=$AUTH_STRING
...
$ sky api login --endpoint http://skypilot:yourpassword@<host>
$ sky jobs launch "echo hello"
<completes successfully>
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
