### PR TITLE
[docs] cron and github actions example

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -25,7 +25,7 @@ A collection of examples demonstrating the use cases of SkyPilot.
    Other Frameworks <frameworks/index>
    AI Applications <applications/index>
    AI Performance <performance/index>
-   Periodic and Trigger based Tasks <periodic-and-trigger/index>
+   Trigger based Tasks <periodic-and-trigger/index>
 
 .. _examples-contribute:
 

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -25,6 +25,7 @@ A collection of examples demonstrating the use cases of SkyPilot.
    Other Frameworks <frameworks/index>
    AI Applications <applications/index>
    AI Performance <performance/index>
+   Periodic and Trigger based Tasks <periodic-and-trigger/index>
 
 .. _examples-contribute:
 
@@ -51,4 +52,3 @@ We welcome contributions from the community. Instructions below:
       - ``git add index.rst my-llm.md``
 
    5. Build the docs as usual.
-

--- a/docs/source/examples/periodic-and-trigger/airflow.md
+++ b/docs/source/examples/periodic-and-trigger/airflow.md
@@ -1,0 +1,1 @@
+../../generated-examples/airflow.md

--- a/docs/source/examples/periodic-and-trigger/cron.md
+++ b/docs/source/examples/periodic-and-trigger/cron.md
@@ -1,0 +1,1 @@
+../../generated-examples/cron.md

--- a/docs/source/examples/periodic-and-trigger/github_actions.md
+++ b/docs/source/examples/periodic-and-trigger/github_actions.md
@@ -1,0 +1,1 @@
+../../generated-examples/github_actions.md

--- a/docs/source/examples/periodic-and-trigger/index.rst
+++ b/docs/source/examples/periodic-and-trigger/index.rst
@@ -1,0 +1,9 @@
+Periodic and Trigger based Execution
+====================================
+
+.. toctree::
+   :maxdepth: 1
+
+   Cron <cron>
+   Github Actions <github_actions>
+   Airflow <airflow>

--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -76,8 +76,10 @@ To run multiple commands at once, define the commands as a file:
 ```bash
 SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml
 /opt/anaconda3/envs/sky/bin/sky status
-/opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml -y
+/opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job1.yaml -y --async
+/opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job2.yaml -y --async
 ```
+> Using `--async` flag can help launch multiple jobs at once  without waiting for each job to complete before starting the next job.
 
 Then reference the script file in crontab:
 ```console

--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -31,12 +31,12 @@ To create a suitable schedule for a cron job, visit https://crontab.guru/.
 The output of the cron job is found in different places depending on the operating system. To find the job output easily, store the cronjob output to a file.
 
 ```console
-sudo mkdir -p /var/log/sky/cron/
+sudo mkdir -p /absolute/path/to/logs/
 crontab -e
 ```
 then edit the crontab file to include:
 ```console
-*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
 ```
 
 > `date` command can be specified here without using its full path, as
@@ -47,20 +47,26 @@ To pass in a configuration file to the cronjob, specify a `--config` file with p
 
 crontab example:
 ```console
-*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status --config /absolute/path/to/config/file.yaml > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status --config /absolute/path/to/config/file.yaml > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
 ```
 
 Alternatively, specify `SKYPILOT_GLOBAL_CONFIG` environment variable for the script.
 
 crontab example:
 ```console
-*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky status > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky status > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
 ```
 
 ## Run a task
 To run a task, refer to this sample cron job:
 ```console
-*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml -y > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
+## Run a task asynchronously
+Simply add the `--async` flag:
+```console
+*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml -y --async > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
 ```
 
 ## Run a cronjob against remote API server

--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -1,0 +1,71 @@
+# Example: Cron + SkyPilot
+
+Run a SkyPilot Task with Cron
+
+## Find the `sky` executable path
+
+By default, `cron` runs with a highly restrictive `PATH` - `/bin:/usr/bin`.
+It is recommended to specify any executable using its full path. To find the full path of `sky`, run
+
+```console
+which sky
+```
+
+A possible value returned by this command is `/opt/anaconda3/envs/sky/bin/sky`, which is used to denote the full `sky` path in the rest of this document.
+
+## Define a simple cron job
+
+Run `crontab -e`. This command opens an editable file.
+
+This file can be edited to define cron jobs. A sample cron job that can be defined is:
+```console
+*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status
+```
+
+The `*/5 * * * *` segment defines the schedule at which this cron job runs, in this specific case every 5 minutes.
+
+To create a suitable schedule for a cron job, visit https://crontab.guru/.
+
+## Log the job output
+
+The output of the cron job is found in different places depending on the operating system. To find the job output easily, store the cronjob output to a file.
+
+```console
+sudo mkdir -p /var/log/sky/cron/
+crontab -e
+```
+then edit the crontab file to include:
+```console
+*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
+> `date` command can be specified here without using its full path, as
+> this command is usually found at `/bin/date` which is part of a cronjob's PATH.
+
+## Pass in a config file
+To pass in a configuration file to the cronjob, specify a `--config` file with path to a config file.
+
+crontab example:
+```console
+*/5 * * * * /opt/anaconda3/envs/sky/bin/sky status --config /absolute/path/to/config/file.yaml > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
+Alternatively, specify `SKYPILOT_GLOBAL_CONFIG` environment variable for the script.
+
+crontab example:
+```console
+*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky status > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
+## Run a task
+To run a task, refer to this sample cron job:
+```console
+*/5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml > "/var/log/sky/cron/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
+## Run a cronjob against remote API server
+Simply specify the following snippet in the config file passed into the cronjob.
+```console
+api_server:
+  endpoint: <API server endpoint>
+```

--- a/examples/cron/README.md
+++ b/examples/cron/README.md
@@ -69,6 +69,21 @@ Simply add the `--async` flag:
 */5 * * * * SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml /opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml -y --async > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
 ```
 
+## Run multiple commands
+To run multiple commands at once, define the commands as a file:
+
+`cron.sh`
+```bash
+SKYPILOT_GLOBAL_CONFIG=/absolute/path/to/config/file.yaml
+/opt/anaconda3/envs/sky/bin/sky status
+/opt/anaconda3/envs/sky/bin/sky jobs launch /absolute/path/to/job.yaml -y
+```
+
+Then reference the script file in crontab:
+```console
+*/5 * * * * /absolute/path/to/cron.sh > "/absolute/path/to/logs/$(date +\%d\%m\%y_\%H\%M\%S).log" 2>&1
+```
+
 ## Run a cronjob against remote API server
 Simply specify the following snippet in the config file passed into the cronjob.
 ```console

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -1,0 +1,19 @@
+# Example: Github CI + SkyPilot
+
+Run a SkyPilot Task with Github Actions
+
+## Define a workflow YAML
+
+Given a simple repository with following directory tree:
+```
+.
+├── .git
+│   ...
+├── .github
+│   └── workflows
+│       └── run-sky.yaml
+├── sample_job.yaml
+└── skypilot_config.yaml
+```
+
+`run_sky.yaml` launches `sample_job.yaml` using `skypilot_config.yaml` as config.

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -1,6 +1,13 @@
-# Example: Github CI + SkyPilot
+# Example: Github Actions + SkyPilot
 
 Run a SkyPilot Task with Github Actions
+
+## Define a repository secret
+
+You may need to inject sensitive variables (such as authentication credentials, etc.) into the github action.
+Follow ths github tutorial to add a [repository secret](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository).
+
+In this example, create a repository secret named `SKYPILOT_API_SERVER_ENDPOINT` that stores the remote API server endpoint.
 
 ## Define a workflow YAML
 
@@ -15,7 +22,5 @@ Given a simple repository with following directory tree:
 ├── sample_job.yaml
 └── skypilot_config.yaml
 ```
-
-Replace `<server>` on line 36 of `run_sky.yaml` with a valid API server endpoint.
 
 When a PR is submitted against `main` branch of this repo or a commit is merged the `main` branch, `run_sky.yaml` launches `sample_job.yaml` using `skypilot_config.yaml` as config.

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -16,4 +16,6 @@ Given a simple repository with following directory tree:
 └── skypilot_config.yaml
 ```
 
-`run_sky.yaml` launches `sample_job.yaml` using `skypilot_config.yaml` as config.
+Replace `<server>` on line 36 of `run_sky.yaml` with a valid API server endpoint.
+
+When a PR is submitted against `main` branch of this repo or a commit is merged the `main` branch, `run_sky.yaml` launches `sample_job.yaml` using `skypilot_config.yaml` as config.

--- a/examples/github_actions/run_sky.yaml
+++ b/examples/github_actions/run_sky.yaml
@@ -1,0 +1,37 @@
+name: Run SkyPilot Task
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  run-skypilot-task:
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          uv venv --seed ~/sky
+          source ~/sky/bin/activate
+          uv pip install --prerelease=allow "azure-cli>=2.65.0"
+          uv pip install 'omegaconf>=2.4.0dev3' 'skypilot[all]'
+      - name: Run SkyPilot job
+        run: |
+          source ~/sky/bin/activate
+          sky api login --endpoint <server>
+          SKYPILOT_PROJECT_CONFIG=skypilot_config.yaml sky jobs launch sample_job.yaml -y

--- a/examples/github_actions/run_sky.yaml
+++ b/examples/github_actions/run_sky.yaml
@@ -33,5 +33,7 @@ jobs:
       - name: Run SkyPilot job
         run: |
           source ~/sky/bin/activate
-          sky api login --endpoint <server>
+          sky api login --endpoint $SKYPILOT_API_SERVER_ENDPOINT
           SKYPILOT_PROJECT_CONFIG=skypilot_config.yaml sky jobs launch sample_job.yaml -y
+        env:
+          SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Docs link: https://docs.skypilot.co/en/cron-example/examples/periodic-and-trigger/index.html

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->
We already have an airflow example, and arguably airflow can be trigger based, so I included it in the toc

Tested (run the relevant ones):

- [x] Try the github example and verify it works
- [x] Try the cron example and verify it works

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
