### PR TITLE
chore: minor fix to api server documentation

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -321,7 +321,7 @@ Following tabs describe how to configure credentials for different clouds on the
                     --reuse-values \
                     --set gcpCredentials.enabled=true \
                     --set gcpCredentials.gcpSecretName=your_secret_name
-    
+
     .. tab-item:: RunPod
         :sync: runpod-creds-tab
 
@@ -334,7 +334,7 @@ Following tabs describe how to configure credentials for different clouds on the
             kubectl create secret generic runpod-credentials \
               --namespace $NAMESPACE \
               --from-literal api_key=YOUR_API_KEY
-        
+
         When installing or upgrading the Helm chart, enable RunPod credentials by setting ``runpodCredentials.enabled=true``
 
         .. dropdown:: Use existing RunPod credentials
@@ -473,6 +473,7 @@ To set the config file, pass ``--set-file apiService.config=path/to/your/config.
 
     # Install the API server with the config file
     helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+      --namespace $NAMESPACE \
       # Reuse the values set in the previous steps, if any
       --reuse-values \
       --set-file apiService.config=config.yaml


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
ran into this issue while working on https://github.com/skypilot-org/skypilot/pull/5498, this change makes the command work


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
