### PR TITLE
[Nebius] Add support for internal IP usage in Nebius configurations

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/nebius.rst
+++ b/docs/source/cloud-setup/cloud-permissions/nebius.rst
@@ -37,3 +37,23 @@ To use *Service Account* authentication, follow these steps:
 **Important Notes:**
 
 * The `NEBIUS_IAM_TOKEN` file, if present, will take priority for authentication.
+
+Using internal IPs
+-----------------------
+For security reason, users may only want to use internal IPs for SkyPilot instances.
+To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to specify the ``nebius.use_internal_ips`` and ``nebius.ssh_proxy_command`` fields (to see the detailed syntax, see :ref:`config-yaml`):
+
+.. code-block:: yaml
+
+    nebius:
+      use_internal_ips: true
+      ssh_proxy_command: ssh -W %h:%p -o StrictHostKeyChecking=no myself@my.proxy
+
+The ``nebius.ssh_proxy_command`` field is optional. If SkyPilot is run on a machine that can directly access the internal IPs of the instances, it can be omitted. Otherwise, it should be set to a command that can be used to proxy SSH connections to the internal IPs of the instances.
+
+Don't forget to switch on `AllowTcpForwarding`
+
+.. code-block:: bash
+
+    sudo sed -i 's/^#\?AllowTcpForwarding.*/AllowTcpForwarding yes/' /etc/ssh/sshd_config
+    sudo systemctl restart sshd

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1095,7 +1095,7 @@ Example:
 .. _config-yaml-nebius-use-internal-ips:
 
 ``nebius.use_internal_ips``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Should instances be assigned private IPs only? (optional).
 
@@ -1110,7 +1110,7 @@ Default: ``false``.
 .. _config-yaml-nebius-ssh-proxy-command:
 
 ``nebius.ssh_proxy_command``
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 SSH proxy command (optional).
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -129,6 +129,8 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`eu-west1 <config-yaml-nebius>`:
       project_id: project-e01xxxxxxxxxxx
       fabric: fabric-5
+    :ref:`use_internal_ips <config-yaml-nebius-use-internal-ips>`: true
+    :ref:`ssh_proxy_command <config-yaml-nebius-ssh-proxy-command>`: ssh -W %h:%p user@host
 
 Fields
 ----------
@@ -1089,6 +1091,52 @@ Example:
         eu-west1:
             project_id: project-e01...
             fabric: fabric-5
+
+.. _config-yaml-nebius-use-internal-ips:
+
+``nebius.use_internal_ips``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Should instances be assigned private IPs only? (optional).
+
+Set to ``true`` to use private IPs to communicate between the local client and
+any SkyPilot nodes. This requires the networking stack be properly set up.
+
+This flag is typically set together with ``vpc_name`` above and
+``ssh_proxy_command`` below.
+
+Default: ``false``.
+
+.. _config-yaml-nebius-ssh-proxy-command:
+
+``nebius.ssh_proxy_command``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SSH proxy command (optional).
+
+Please refer to the :ref:`aws.ssh_proxy_command <config-yaml-aws-ssh-proxy-command>` section above for more details.
+
+Format 1:
+  A string; the same proxy command is used for all regions.
+Format 2:
+  A dict mapping region names to region-specific proxy commands.
+  NOTE: This restricts SkyPilot's search space for this cloud to only use
+  the specified regions and not any other regions in this cloud.
+
+Example:
+
+.. code-block:: yaml
+
+  nebius:
+    # Format 1
+    ssh_proxy_command: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no nebiususer@<jump server public ip>
+
+    # Format 2
+    ssh_proxy_command:
+      eu-north1: ssh -W %h:%p -p 1234 -o StrictHostKeyChecking=no myself@my.us-central1.proxy
+      eu-west1: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no nebiususer@<jump server public ip>
+
+
 
 .. toctree::
    :hidden:

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1080,6 +1080,10 @@ Example:
 .. code-block:: yaml
 
     nebius:
+        :ref:`use_internal_ips <config-yaml-nebius-use-internal-ips>`: true
+        :ref:`ssh_proxy_command <config-yaml-nebius-ssh-proxy-command>`: ssh -W %h:%p user@host
+          eu-north1: ssh -W %h:%p -p 1234 -o StrictHostKeyChecking=no myself@my.us-central1.proxy
+          eu-west1: ssh -W %h:%p -i ~/.ssh/sky-key -o StrictHostKeyChecking=no nebiususer@<jump server public ip>
         # Region-specific configuration
         eu-north1:
             # Project identifier for this region
@@ -1102,8 +1106,7 @@ Should instances be assigned private IPs only? (optional).
 Set to ``true`` to use private IPs to communicate between the local client and
 any SkyPilot nodes. This requires the networking stack be properly set up.
 
-This flag is typically set together with ``vpc_name`` above and
-``ssh_proxy_command`` below.
+This flag is typically set together with ``ssh_proxy_command`` below.
 
 Default: ``false``.
 

--- a/sky/provision/nebius/instance.py
+++ b/sky/provision/nebius/instance.py
@@ -132,7 +132,9 @@ def run_instances(region: str, cluster_name_on_cloud: str,
                 region=region,
                 image_family=config.node_config['ImageId'],
                 disk_size=config.node_config['DiskSize'],
-                user_data=config.node_config['UserData'])
+                user_data=config.node_config['UserData'],
+                associate_public_ip_address=(
+                    not config.provider_config['use_internal_ips']))
         except Exception as e:  # pylint: disable=broad-except
             logger.warning(f'run_instances error: {e}')
             raise

--- a/sky/provision/nebius/utils.py
+++ b/sky/provision/nebius/utils.py
@@ -158,7 +158,7 @@ def start(instance_id: str) -> None:
 
 def launch(cluster_name_on_cloud: str, node_type: str, platform: str,
            preset: str, region: str, image_family: str, disk_size: int,
-           user_data: str) -> str:
+           user_data: str, associate_public_ip_address: bool) -> str:
     # Each node must have a unique name to avoid conflicts between
     # multiple worker VMs. To ensure uniqueness,a UUID is appended
     # to the node name.
@@ -242,7 +242,9 @@ def launch(cluster_name_on_cloud: str, node_type: str, platform: str,
                     subnet_id=sub_net.items[0].metadata.id,
                     ip_address=nebius.compute().IPAddress(),
                     name='network-interface-0',
-                    public_ip_address=nebius.compute().PublicIPAddress())
+                    public_ip_address=nebius.compute().PublicIPAddress()
+                    if associate_public_ip_address else None,
+                )
             ]))).wait()
     instance_id = ''
     retry_count = 0

--- a/sky/templates/nebius-ray.yml.j2
+++ b/sky/templates/nebius-ray.yml.j2
@@ -9,6 +9,7 @@ provider:
   type: external
   module: sky.provision.nebius
   region: "{{region}}"
+  use_internal_ips: {{use_internal_ips}}
 
 {%- if docker_image is not none %}
 docker:
@@ -34,6 +35,9 @@ docker:
 auth:
   ssh_user: ubuntu
   ssh_private_key: {{ssh_private_key}}
+{% if ssh_proxy_command is not none %}
+  ssh_proxy_command: {{ssh_proxy_command}}
+{% endif %}
 
 available_node_types:
   ray_head_default:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -966,7 +966,9 @@ def get_config_schema():
         'nebius': {
             'type': 'object',
             'required': [],
-            'properties': {},
+            'properties': {
+                **_NETWORK_CONFIG_SCHEMA,
+            },
             'additionalProperties': {
                 'type': 'object',
                 'required': [],


### PR DESCRIPTION
Introduced `use_internal_ips` and `ssh_proxy_command` fields in Nebius configuration to enable private IP communication for SkyPilot instances. Updated relevant documentation, templates, and schemas to reflect these changes. Ensured proper handling of public IP association in the provisioning process based on the new configuration.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
