### PR TITLE
Use more specific header name

### DIFF
--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -23,7 +23,7 @@ export async function getClusters({ clusterNames = null } = {}) {
         all_users: true,
       }),
     });
-    const id = response.headers.get('x-request-id');
+    const id = response.headers.get('X-Skypilot-Request-ID');
     const fetchedData = await fetch(`${ENDPOINT}/api/get?request_id=${id}`);
     const data = await fetchedData.json();
     const clusters = data.return_value ? JSON.parse(data.return_value) : [];
@@ -98,7 +98,7 @@ export async function getClusterJobs({ clusterName }) {
         all_users: true,
       }),
     });
-    const id = response.headers.get('x-request-id');
+    const id = response.headers.get('X-Skypilot-Request-ID');
     const fetchedData = await fetch(`${ENDPOINT}/api/get?request_id=${id}`);
     const data = await fetchedData.json();
     const jobs = JSON.parse(data.return_value);

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -18,7 +18,7 @@ export async function getManagedJobs({ allUsers = true } = {}) {
         all_users: allUsers,
       }),
     });
-    const id = response.headers.get('x-request-id');
+    const id = response.headers.get('X-Skypilot-Request-ID');
     const fetchedData = await fetch(`${ENDPOINT}/api/get?request_id=${id}`);
     if (fetchedData.status === 500) {
       try {
@@ -230,7 +230,7 @@ export async function handleJobAction(action, jobId, cluster) {
         body: JSON.stringify(requestBody),
       });
 
-      const id = response.headers.get('x-request-id');
+      const id = response.headers.get('X-Skypilot-Request-ID');
       const finalResponse = await fetch(`${ENDPOINT}/api/get?request_id=${id}`);
 
       // Check the status code of the final response

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -245,7 +245,7 @@ def handle_request_error(response: 'requests.Response') -> None:
 
 def get_request_id(response: 'requests.Response') -> RequestId:
     handle_request_error(response)
-    request_id = response.headers.get('X-Request-ID')
+    request_id = response.headers.get('X-Skypilot-Request-ID')
     if request_id is None:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -7,7 +7,7 @@ from sky.skylet import constants
 # API server version, whenever there is a change in API server that requires a
 # restart of the local API server or error out when the client does not match
 # the server version.
-API_VERSION = '5'
+API_VERSION = '6'
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -99,7 +99,7 @@ class RequestIDMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         request_id = str(uuid.uuid4())
         request.state.request_id = request_id
         response = await call_next(request)
-        response.headers['X-Request-ID'] = request_id
+        response.headers['X-Skypilot-Request-ID'] = request_id
         return response
 
 
@@ -174,7 +174,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=['*'],
     allow_headers=['*'],
-    expose_headers=['X-Request-ID'])
+    expose_headers=['X-Skypilot-Request-ID'])
 app.add_middleware(RequestIDMiddleware)
 app.include_router(jobs_rest.router, prefix='/jobs', tags=['jobs'])
 app.include_router(serve_rest.router, prefix='/serve', tags=['serve'])


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

x-request-id is a very common header name that we're already using internally, causing conflicts. This namespaces the header to the actual service

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
