### PR TITLE
Add optional version parameter to docker build pipeline to prevent version mismatch

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -11,11 +11,19 @@ on:
           - 'skypilot-nightly'
           - 'skypilot'
         default: 'skypilot-nightly'
+      version:
+        description: 'SkyPilot version to build (optional, uses latest from PyPI if not specified)'
+        required: false
+        type: string
   workflow_call:
     inputs:
       package_name:
         description: 'SkyPilot PyPI package name'
         required: true
+        type: string
+      version:
+        description: 'SkyPilot version to build (optional, uses latest from PyPI if not specified)'
+        required: false
         type: string
     outputs:
       version:
@@ -28,7 +36,7 @@ on:
         required: true
 
 jobs:
-  
+
   build:
     runs-on: ubuntu-latest
     outputs:
@@ -40,13 +48,19 @@ jobs:
       - name: Find the release version
         id: version
         run: |
-          # Fetch package info from PyPI
-          echo "Fetching package info for ${{ inputs.package_name }}"
-          PACKAGE_INFO=$(curl -s https://pypi.org/pypi/${{ inputs.package_name }}/json)
-          # Parse JSON and get the latest version
-          LATEST_VERSION=$(echo $PACKAGE_INFO | jq -r '.info.version')
-          echo "Latest version found: $LATEST_VERSION"
-          echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.version }}" ]; then
+            # Use the provided version
+            echo "Using provided version: ${{ inputs.version }}"
+            echo "latest_version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            # Fetch package info from PyPI
+            echo "Fetching package info for ${{ inputs.package_name }}"
+            PACKAGE_INFO=$(curl -s https://pypi.org/pypi/${{ inputs.package_name }}/json)
+            # Parse JSON and get the latest version
+            LATEST_VERSION=$(echo $PACKAGE_INFO | jq -r '.info.version')
+            echo "Latest version found: $LATEST_VERSION"
+            echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          fi
           cat $GITHUB_OUTPUT
 
       - name: Update Dockerfile version

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -114,6 +114,7 @@ jobs:
     uses: ./.github/workflows/docker-build.yaml
     with:
       package_name: 'skypilot'
+      version: ${{ needs.extract-version.outputs.version }}
     secrets: inherit
 
   cleanup-branches:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The `docker-build.yaml` pipeline accepts an optional input parameter to use as the version for publishing.

In [release 0.9.2](https://github.com/skypilot-org/skypilot/actions/runs/14744833982/job/41390569148), it publishes to PyPI and then fetches the latest version for the Docker build. However, the latest version is still 0.9.1. This could be because the process is too quick, so passing a parameter might help avoid this issue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
