### PR TITLE
remove mypy exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
             # From tests/mypy_files.txt
             - "sky"
             - "--exclude"
-            - "sky/benchmark|sky/callbacks|sky/skylet/providers/azure|sky/resources.py|sky/backends/monkey_patches"
+            - "sky/benchmark|sky/callbacks|sky/skylet/providers/azure|sky/backends/monkey_patches"
         pass_filenames: false
         additional_dependencies:
             - types-aiofiles

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
             # From tests/mypy_files.txt
             - "sky"
             - "--exclude"
-            - "sky/benchmark|sky/callbacks|sky/skylet/providers/azure|sky/backends/monkey_patches"
+            - "sky/benchmark|sky/callbacks|sky/backends/monkey_patches"
         pass_filenames: false
         additional_dependencies:
             - types-aiofiles

--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -2,6 +2,7 @@
 import typing
 from typing import Dict, Generic, Optional, Tuple
 
+from sky import resources
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
 from sky.utils import rich_utils
@@ -9,7 +10,6 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    from sky import resources
     from sky import task as task_lib
     from sky.data import storage as storage_lib
 
@@ -37,8 +37,9 @@ class Backend(Generic[_ResourceHandleType]):
     ResourceHandle = ResourceHandle  # pylint: disable=invalid-name
 
     # --- APIs ---
-    def check_resources_fit_cluster(self, handle: _ResourceHandleType,
-                                    task: 'task_lib.Task') -> None:
+    def check_resources_fit_cluster(
+            self, handle: _ResourceHandleType,
+            task: 'task_lib.Task') -> Optional[resources.Resources]:
         """Check whether resources of the task are satisfied by cluster."""
         raise NotImplementedError
 

--- a/sky/backends/backend.py
+++ b/sky/backends/backend.py
@@ -2,7 +2,6 @@
 import typing
 from typing import Dict, Generic, Optional, Tuple
 
-from sky import resources
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
 from sky.utils import rich_utils
@@ -10,6 +9,7 @@ from sky.utils import timeline
 from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
+    from sky import resources
     from sky import task as task_lib
     from sky.data import storage as storage_lib
 
@@ -39,7 +39,7 @@ class Backend(Generic[_ResourceHandleType]):
     # --- APIs ---
     def check_resources_fit_cluster(
             self, handle: _ResourceHandleType,
-            task: 'task_lib.Task') -> Optional[resources.Resources]:
+            task: 'task_lib.Task') -> Optional['resources.Resources']:
         """Check whether resources of the task are satisfied by cluster."""
         raise NotImplementedError
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2966,9 +2966,8 @@ def get_endpoints(cluster: str,
                              f'for cluster {cluster!r} with backend '
                              f'{get_backend_from_handle(handle).NAME}.')
 
-    launched_resources = handle.launched_resources
+    launched_resources = handle.launched_resources.assert_launchable()
     cloud = launched_resources.cloud
-    assert cloud is not None, 'cloud should have been set by the optimizer.'
     try:
         cloud.check_features_are_supported(
             launched_resources, {clouds.CloudImplementationFeatures.OPEN_PORTS})

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1556,8 +1556,8 @@ def check_owner_identity(cluster_name: str) -> None:
     if not isinstance(handle, backends.CloudVmRayResourceHandle):
         return
 
-    cloud = handle.launched_resources.cloud
-    assert cloud is not None, 'cloud should have been set by the optimizer.'
+    launched_resources = handle.launched_resources.assert_launchable()
+    cloud = launched_resources.cloud
     user_identities = cloud.get_user_identities()
     owner_identity = record['owner']
     if user_identities is None:
@@ -1721,13 +1721,12 @@ def check_can_clone_disk_and_override_task(
                     'a new target cluster name.')
 
     new_task_resources = []
-    original_cloud = handle.launched_resources.cloud
-    assert original_cloud is not None, 'cloud should have been set by the optimizer.'
+    launched_resources = handle.launched_resources.assert_launchable()
+    original_cloud = launched_resources.cloud
     original_cloud.check_features_are_supported(
-        handle.launched_resources,
+        launched_resources,
         {clouds.CloudImplementationFeatures.CLONE_DISK_FROM_CLUSTER})
 
-    assert original_cloud is not None, handle.launched_resources
     has_override = False
     has_disk_size_met = False
     has_cloud_met = False
@@ -1935,10 +1934,8 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
         return global_user_state.get_cluster_from_name(cluster_name)
 
     # All cases below are transitioning the cluster to non-UP states.
-    assert handle.launched_resources.cloud is not None, (
-        handle.launched_resources,
-        'cloud should have been set by the optimizer.')
-    if (not node_statuses and handle.launched_resources.cloud.STATUS_VERSION >=
+    launched_resources = handle.launched_resources.assert_launchable()
+    if (not node_statuses and launched_resources.cloud.STATUS_VERSION >=
             clouds.StatusVersion.SKYPILOT):
         # Note: launched_at is set during sky launch, even on an existing
         # cluster. This will catch the case where the cluster was terminated on
@@ -2987,14 +2984,11 @@ def get_endpoints(cluster: str,
                                              head_ip=handle.head_ip,
                                              provider_config=config['provider'])
 
-    assert handle.launched_resources.cloud is not None, (
-        handle.launched_resources,
-        'cloud should have been set by the optimizer.')
+    launched_resources = handle.launched_resources.assert_launchable()
     # Validation before returning the endpoints
     if port is not None:
         # If the requested endpoint was not to be exposed
-        port_set = resources_utils.port_ranges_to_set(
-            handle.launched_resources.ports)
+        port_set = resources_utils.port_ranges_to_set(launched_resources.ports)
         if port not in port_set:
             logger.warning(f'Port {port} is not exposed on '
                            f'cluster {cluster!r}.')
@@ -3003,8 +2997,7 @@ def get_endpoints(cluster: str,
         if port not in port_details:
             error_msg = (f'Port {port} not exposed yet. '
                          f'{_ENDPOINTS_RETRY_MESSAGE} ')
-            if handle.launched_resources.cloud.is_same_cloud(
-                    clouds.Kubernetes()):
+            if launched_resources.cloud.is_same_cloud(clouds.Kubernetes()):
                 # Add Kubernetes specific debugging info
                 error_msg += (kubernetes_utils.get_endpoint_debug_message())
             logger.warning(error_msg)
@@ -3013,7 +3006,7 @@ def get_endpoints(cluster: str,
     else:
         if not port_details:
             # If cluster had no ports to be exposed
-            if handle.launched_resources.ports is None:
+            if launched_resources.ports is None:
                 logger.warning(f'Cluster {cluster!r} does not have any '
                                'ports to be exposed.')
                 return {}
@@ -3022,8 +3015,7 @@ def get_endpoints(cluster: str,
             else:
                 error_msg = (f'No endpoints exposed yet. '
                              f'{_ENDPOINTS_RETRY_MESSAGE} ')
-                if handle.launched_resources.cloud.is_same_cloud(
-                        clouds.Kubernetes()):
+                if launched_resources.cloud.is_same_cloud(clouds.Kubernetes()):
                     # Add Kubernetes specific debugging info
                     error_msg += \
                         kubernetes_utils.get_endpoint_debug_message()

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1359,6 +1359,8 @@ class RetryingVmProvisioner(object):
             to_provision, 'region should have been set by the optimizer.')
         region = clouds.Region(to_provision.region)
 
+        assert to_provision.cloud is not None, (
+            to_provision, 'cloud should have been set by the optimizer.')
         # Optimization - check if user has non-zero quota for
         # the instance type in the target region. If not, fail early
         # instead of trying to provision and failing later.
@@ -2030,6 +2032,8 @@ class RetryingVmProvisioner(object):
                             f' that never expire or a service account.\033[0m')
                 logger.warning(warnings)
 
+        assert to_provision.cloud is not None, (
+            to_provision, 'cloud should have been set by the optimizer.')
         # Retrying launchable resources.
         while True:
             try:
@@ -2159,9 +2163,10 @@ class RetryingVmProvisioner(object):
                 raise exceptions.ResourcesUnavailableError(
                     _RESOURCES_UNAVAILABLE_LOG + '\n' + table.get_string(),
                     failover_history=failover_history)
-            to_provision = task.best_resources
+            best_resources = task.best_resources
             assert task in self._dag.tasks, 'Internal logic error.'
-            assert to_provision is not None, task
+            assert best_resources is not None, task
+            to_provision = best_resources
         return config_dict
 
 

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2431,6 +2431,9 @@ class CloudVmRayResourceHandle(backends.backend.ResourceHandle):
             self.cluster_yaml, self.docker_user, self.ssh_user)
         if avoid_ssh_control:
             ssh_credentials.pop('ssh_control_name', None)
+        assert self.launched_resources.cloud is not None, (
+            self.launched_resources,
+            'cloud should have been set by the optimizer.')
         updated_to_skypilot_provisioner_after_provisioned = (
             self.launched_resources.cloud.PROVISIONER_VERSION >=
             clouds.ProvisionerVersion.SKYPILOT and
@@ -3148,6 +3151,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             resources_utils.port_ranges_to_set(prev_ports))
         if open_new_ports:
             cloud = handle.launched_resources.cloud
+            assert cloud is not None, (
+                'cloud should have been set by the optimizer.')
             if not (cloud.OPEN_PORTS_VERSION <=
                     clouds.OpenPortsVersion.LAUNCH_ONLY):
                 with rich_utils.safe_status(
@@ -3253,6 +3258,9 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         assert here that all storage_mounts are MOUNT mode.
         """
         with rich_utils.safe_status(ux_utils.spinner_message('Syncing files')):
+            assert handle.launched_resources.cloud is not None, (
+                handle.launched_resources,
+                'cloud should have been set by the optimizer.')
             controller_utils.replace_skypilot_config_path_in_file_mounts(
                 handle.launched_resources.cloud, all_file_mounts)
             self._execute_file_mounts(handle, all_file_mounts)
@@ -4154,6 +4162,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                                 'teardown.log')
         log_abs_path = os.path.abspath(log_path)
         cloud = handle.launched_resources.cloud
+        assert cloud is not None, 'cloud should have been set by the optimizer.'
         config = common_utils.read_yaml(handle.cluster_yaml)
         cluster_name = handle.cluster_name
         cluster_name_on_cloud = handle.cluster_name_on_cloud
@@ -4366,6 +4375,8 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             if handle.cluster_yaml is not None:
                 try:
                     cloud = handle.launched_resources.cloud
+                    assert cloud is not None, (
+                        'cloud should have been set by the optimizer.')
                     config = common_utils.read_yaml(handle.cluster_yaml)
                     cloud.check_features_are_supported(
                         handle.launched_resources,
@@ -4705,6 +4716,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             all_ports = resources_utils.port_set_to_ranges(current_ports_set |
                                                            requested_ports_set)
             to_provision = handle.launched_resources
+            assert (to_provision is not None and
+                    to_provision.cloud is not None), (
+                        to_provision,
+                        'to_provision should have been set by the optimizer.')
             if (to_provision.cloud.OPEN_PORTS_VERSION <=
                     clouds.OpenPortsVersion.LAUNCH_ONLY):
                 if not requested_ports_set <= current_ports_set:

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -2032,8 +2032,7 @@ class RetryingVmProvisioner(object):
                             f' that never expire or a service account.\033[0m')
                 logger.warning(warnings)
 
-        assert to_provision.cloud is not None, (
-            to_provision, 'cloud should have been set by the optimizer.')
+        to_provision = to_provision.assert_launchable()
         # Retrying launchable resources.
         while True:
             try:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -440,18 +440,20 @@ class AWS(clouds.Cloud):
         region_name = region.name
         zone_names = [zone.name for zone in zones]
 
-        r = resources
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
         # r.accelerators is cleared but .instance_type encodes the info.
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        if r.extract_docker_image() is not None:
+        if resources.extract_docker_image() is not None:
             image_id_to_use = None
         else:
-            image_id_to_use = r.image_id
+            image_id_to_use = resources.image_id
         image_id = self._get_image_id(image_id_to_use, region_name,
-                                      r.instance_type)
+                                      resources.instance_type)
 
         disk_encrypted = skypilot_config.get_nested(('aws', 'disk_encrypted'),
                                                     False)
@@ -483,17 +485,17 @@ class AWS(clouds.Cloud):
                     'in `~/.sky/config.yaml`.')
 
         return {
-            'instance_type': r.instance_type,
+            'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
             'disk_encrypted': disk_encrypted,
-            'use_spot': r.use_spot,
+            'use_spot': resources.use_spot,
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,
             'security_group': security_group,
             'security_group_managed_by_skypilot':
                 str(security_group != user_security_group).lower(),
-            **AWS._get_disk_specs(r.disk_tier)
+            **AWS._get_disk_specs(resources.disk_tier)
         }
 
     def _get_feasible_launchable_resources(
@@ -978,6 +980,7 @@ class AWS(clouds.Cloud):
         # pylint: disable=import-outside-toplevel,unused-import
         from sky.clouds.service_catalog import aws_catalog
 
+        assert instance_type is not None, 'Instance type must be specified'
         quota_code = aws_catalog.get_quota_code(instance_type, use_spot)
 
         if quota_code is None:

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -440,9 +440,8 @@ class AWS(clouds.Cloud):
         region_name = region.name
         zone_names = [zone.name for zone in zones]
 
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
-        # r.accelerators is cleared but .instance_type encodes the info.
+        resources = resources.assert_launchable()
+        # resources.accelerators is cleared but .instance_type encodes the info.
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
@@ -973,6 +972,7 @@ class AWS(clouds.Cloud):
             botocore.exceptions.ClientError: error in Boto3 client request.
         """
 
+        resources = resources.assert_launchable()
         instance_type = resources.instance_type
         region = resources.region
         use_spot = resources.use_spot
@@ -980,7 +980,6 @@ class AWS(clouds.Cloud):
         # pylint: disable=import-outside-toplevel,unused-import
         from sky.clouds.service_catalog import aws_catalog
 
-        assert instance_type is not None, 'Instance type must be specified'
         quota_code = aws_catalog.get_quota_code(instance_type, use_spot)
 
         if quota_code is None:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -325,9 +325,11 @@ class Azure(clouds.Cloud):
 
         region_name = region.name
 
-        r = resources
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
         # r.accelerators is cleared but .instance_type encodes the info.
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         acc_count = None
         if acc_dict is not None:
             acc_count = str(sum(acc_dict.values()))
@@ -339,8 +341,9 @@ class Azure(clouds.Cloud):
             # pylint: disable=import-outside-toplevel
             from sky.clouds.service_catalog import azure_catalog
             gen_version = azure_catalog.get_gen_version_from_instance_type(
-                r.instance_type)
-            image_id = self._get_default_image_tag(gen_version, r.instance_type)
+                resources.instance_type)
+            image_id = self._get_default_image_tag(gen_version,
+                                                   resources.instance_type)
         else:
             if None in resources.image_id:
                 image_id = resources.image_id[None]
@@ -407,18 +410,19 @@ class Azure(clouds.Cloud):
             """).split('\n')
 
         def _failover_disk_tier() -> Optional[resources_utils.DiskTier]:
-            if (r.disk_tier is not None and
-                    r.disk_tier != resources_utils.DiskTier.BEST):
-                return r.disk_tier
+            if (resources.disk_tier is not None and
+                    resources.disk_tier != resources_utils.DiskTier.BEST):
+                return resources.disk_tier
             # Failover disk tier from high to low. Default disk tier
             # (Premium_LRS, medium) only support s-series instance types,
             # so we failover to lower tiers for non-s-series.
             all_tiers = list(reversed(resources_utils.DiskTier))
             start_index = all_tiers.index(
-                Azure._translate_disk_tier(r.disk_tier))
+                Azure._translate_disk_tier(resources.disk_tier))
             while start_index < len(all_tiers):
                 disk_tier = all_tiers[start_index]
-                ok, _ = Azure.check_disk_tier(r.instance_type, disk_tier)
+                ok, _ = Azure.check_disk_tier(resources.instance_type,
+                                              disk_tier)
                 if ok:
                     return disk_tier
                 start_index += 1
@@ -426,11 +430,11 @@ class Azure(clouds.Cloud):
 
         disk_tier = _failover_disk_tier()
 
-        resources_vars = {
-            'instance_type': r.instance_type,
+        resources_vars: Dict[str, Any] = {
+            'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
             'num_gpus': acc_count,
-            'use_spot': r.use_spot,
+            'use_spot': resources.use_spot,
             'region': region_name,
             # Azure does not support specific zones.
             'zones': None,

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -325,9 +325,8 @@ class Azure(clouds.Cloud):
 
         region_name = region.name
 
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
-        # r.accelerators is cleared but .instance_type encodes the info.
+        resources = resources.assert_launchable()
+        # resources.accelerators is cleared but .instance_type encodes the info.
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         acc_count = None

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -11,7 +11,8 @@ import collections
 import enum
 import math
 import typing
-from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import (Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple,
+                    Union)
 
 from typing_extensions import assert_never
 
@@ -302,7 +303,7 @@ class Cloud:
         zones: Optional[List['Zone']],
         num_nodes: int,
         dryrun: bool = False,
-    ) -> Dict[str, Optional[str]]:
+    ) -> Dict[str, Any]:
         """Converts planned sky.Resources to cloud-specific resource variables.
 
         These variables are used to fill the node type section (instance type,

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -722,7 +722,7 @@ class Cloud:
         Raises:
             ResourcesMismatchError: If the accelerator is not supported.
         """
-        assert resources.is_launchable(), resources
+        resources = resources.assert_launchable()
 
         def _equal_accelerators(
             acc_requested: Optional[Dict[str, Union[int, float]]],
@@ -748,8 +748,6 @@ class Cloud:
                     return False
             return True
 
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
         acc_from_instance_type = cls.get_accelerators_from_instance_type(
             resources.instance_type)
         if not _equal_accelerators(resources.accelerators,

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -748,6 +748,8 @@ class Cloud:
                     return False
             return True
 
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
         acc_from_instance_type = cls.get_accelerators_from_instance_type(
             resources.instance_type)
         if not _equal_accelerators(resources.accelerators,

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -201,8 +201,10 @@ class Cudo(clouds.Cloud):
         dryrun: bool = False,
     ) -> Dict[str, Optional[str]]:
         del zones, cluster_name  # unused
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -201,8 +201,7 @@ class Cudo(clouds.Cloud):
         dryrun: bool = False,
     ) -> Dict[str, Optional[str]]:
         del zones, cluster_name  # unused
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -181,8 +181,7 @@ class DO(clouds.Cloud):
             dryrun: bool = False) -> Dict[str, Optional[str]]:
         del zones, dryrun, cluster_name
 
-        assert resources.instance_type is not None, (
-            'Instance type must be specified')
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         if acc_dict is not None:

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -181,8 +181,10 @@ class DO(clouds.Cloud):
             dryrun: bool = False) -> Dict[str, Optional[str]]:
         del zones, dryrun, cluster_name
 
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, (
+            'Instance type must be specified')
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         if acc_dict is not None:
             custom_resources = json.dumps(acc_dict, separators=(',', ':'))
         else:

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -188,8 +188,7 @@ class Fluidstack(clouds.Cloud):
     ) -> Dict[str, Optional[str]]:
 
         assert zones is None, 'FluidStack does not support zones.'
-        assert resources.instance_type is not None, (
-            resources, 'instance_type should have been set by the optimizer.')
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -188,9 +188,10 @@ class Fluidstack(clouds.Cloud):
     ) -> Dict[str, Optional[str]]:
 
         assert zones is None, 'FluidStack does not support zones.'
-
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, (
+            resources, 'instance_type should have been set by the optimizer.')
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1010,8 +1010,7 @@ class GCP(clouds.Cloud):
     @staticmethod
     def _check_instance_type_accelerators_combination(
             resources: 'resources.Resources') -> None:
-        assert resources.is_launchable(), resources
-        assert resources.instance_type is not None, 'Instance type must be specified'
+        resources = resources.assert_launchable()
         service_catalog.check_accelerator_attachable_to_host(
             resources.instance_type, resources.accelerators, resources.zone,
             'gcp')

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1011,6 +1011,7 @@ class GCP(clouds.Cloud):
     def _check_instance_type_accelerators_combination(
             resources: 'resources.Resources') -> None:
         assert resources.is_launchable(), resources
+        assert resources.instance_type is not None, 'Instance type must be specified'
         service_catalog.check_accelerator_attachable_to_host(
             resources.instance_type, resources.accelerators, resources.zone,
             'gcp')

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -175,7 +175,7 @@ class IBM(clouds.Cloud):
         zones: Optional[List['clouds.Zone']],
         num_nodes: int,
         dryrun: bool = False,
-    ) -> Dict[str, Optional[str]]:
+    ) -> Dict[str, Any]:
         """Converts planned sky.Resources to cloud-specific resource variables.
 
         These variables are used to fill the node type section (instance type,
@@ -208,6 +208,8 @@ class IBM(clouds.Cloud):
         assert not r.use_spot, \
             'IBM does not currently support spot instances in this framework'
 
+        assert r.instance_type is not None, (
+            resources, 'instance_type should have been set by the optimizer.')
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -204,32 +204,32 @@ class IBM(clouds.Cloud):
         # clouds implementing 'zones_provision_loop()'
         zone_names = [zone.name for zone in zones]  # type: ignore[union-attr]
 
-        r = resources
-        assert not r.use_spot, \
+        resources = resources.assert_launchable()
+        assert not resources.use_spot, \
             'IBM does not currently support spot instances in this framework'
 
-        assert r.instance_type is not None, (
-            resources, 'instance_type should have been set by the optimizer.')
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        instance_resources = _get_profile_resources(r.instance_type)
+        instance_resources = _get_profile_resources(resources.instance_type)
 
         worker_instance_type = get_cred_file_field('worker_instance_type',
-                                                   r.instance_type)
+                                                   resources.instance_type)
         worker_instance_resources = _get_profile_resources(worker_instance_type)
         # r.image_id: {clouds.Region:image_id} - property of Resources class
-        image_id = r.image_id[
-            region.name] if r.image_id else self.get_default_image(region_name)
+        image_id = resources.image_id[
+            region.name] if resources.image_id else self.get_default_image(
+                region_name)
 
         return {
-            'instance_type': r.instance_type,
+            'instance_type': resources.instance_type,
             'instance_resources': instance_resources,
             'worker_instance_type': worker_instance_type,
             'worker_instance_resources': worker_instance_resources,
             'custom_resources': custom_resources,
-            'use_spot': r.use_spot,
+            'use_spot': resources.use_spot,
             'region': region_name,
             'zones': ','.join(zone_names),
             'image_id': image_id,

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -414,8 +414,10 @@ class Kubernetes(clouds.Cloud):
             context = region.name
         assert context is not None, 'No context found in kubeconfig'
 
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -414,8 +414,7 @@ class Kubernetes(clouds.Cloud):
             context = region.name
         assert context is not None, 'No context found in kubeconfig'
 
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -165,7 +165,7 @@ class Lambda(clouds.Cloud):
             dryrun: bool = False) -> Dict[str, Any]:
         del cluster_name, dryrun  # Unused.
         assert zones is None, 'Lambda does not support zones.'
-        assert resources.instance_type is not None, 'Instance type must be specified'
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -1,6 +1,6 @@
 """Lambda Cloud."""
 import typing
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
 from sky.adaptors import common as adaptors_common
@@ -162,16 +162,16 @@ class Lambda(clouds.Cloud):
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             num_nodes: int,
-            dryrun: bool = False) -> Dict[str, Optional[str]]:
+            dryrun: bool = False) -> Dict[str, Any]:
         del cluster_name, dryrun  # Unused.
         assert zones is None, 'Lambda does not support zones.'
-
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, 'Instance type must be specified'
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        resources_vars = {
+        resources_vars: Dict[str, Any] = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
             'region': region.name,

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -195,8 +195,10 @@ class Nebius(clouds.Cloud):
         del dryrun, cluster_name
         assert zones is None, ('Nebius does not support zones', zones)
 
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        assert resources.instance_type is not None, \
+            'Instance type must be specified'
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
         platform, _ = resources.instance_type.split('_')

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -195,8 +195,7 @@ class Nebius(clouds.Cloud):
         del dryrun, cluster_name
         assert zones is None, ('Nebius does not support zones', zones)
 
-        assert resources.instance_type is not None, \
-            'Instance type must be specified'
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -1,7 +1,7 @@
 """ Nebius Cloud. """
 import os
 import typing
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
 from sky.adaptors import nebius
@@ -191,7 +191,7 @@ class Nebius(clouds.Cloud):
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             num_nodes: int,
-            dryrun: bool = False) -> Dict[str, Optional[str]]:
+            dryrun: bool = False) -> Dict[str, Any]:
         del dryrun, cluster_name
         assert zones is None, ('Nebius does not support zones', zones)
 
@@ -211,7 +211,7 @@ class Nebius(clouds.Cloud):
             raise RuntimeError('Unsupported instance type for Nebius cloud:'
                                f' {resources.instance_type}')
 
-        resources_vars = {
+        resources_vars: Dict[str, Any] = {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,
             'region': region.name,

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -217,8 +217,7 @@ class OCI(clouds.Cloud):
         del cluster_name, dryrun  # Unused.
         assert region is not None, resources
 
-        assert resources.instance_type is not None, (
-            resources, 'instance_type should have been set by the optimizer.')
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
@@ -248,8 +247,6 @@ class OCI(clouds.Cloud):
 
         cpus = resources.cpus
         original_instance_type = resources.instance_type
-        assert original_instance_type is not None, (
-            resources, 'instance_type should have been set by the optimizer.')
         instance_type_arr = original_instance_type.split(
             oci_utils.oci_config.INSTANCE_TYPE_RES_SPERATOR)
         instance_type = instance_type_arr[0]

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -23,7 +23,7 @@ History:
 import logging
 import os
 import typing
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from sky import clouds
 from sky import exceptions
@@ -213,7 +213,7 @@ class OCI(clouds.Cloud):
             region: Optional['clouds.Region'],
             zones: Optional[List['clouds.Zone']],
             num_nodes: int,
-            dryrun: bool = False) -> Dict[str, Optional[str]]:
+            dryrun: bool = False) -> Dict[str, Any]:
         del cluster_name, dryrun  # Unused.
         assert region is not None, resources
 
@@ -247,7 +247,10 @@ class OCI(clouds.Cloud):
             image_id, os_type = image_id.replace(' ', '').split(':')
 
         cpus = resources.cpus
-        instance_type_arr = resources.instance_type.split(
+        original_instance_type = resources.instance_type
+        assert original_instance_type is not None, (
+            resources, 'instance_type should have been set by the optimizer.')
+        instance_type_arr = original_instance_type.split(
             oci_utils.oci_config.INSTANCE_TYPE_RES_SPERATOR)
         instance_type = instance_type_arr[0]
 
@@ -261,12 +264,12 @@ class OCI(clouds.Cloud):
         else:
             if cpus is None:
                 cpus, mems = OCI.get_vcpus_mem_from_instance_type(
-                    resources.instance_type)
+                    original_instance_type)
                 resources = resources.copy(
                     cpus=cpus,
                     memory=mems,
                 )
-            if cpus is None and resources.instance_type.startswith(
+            if cpus is None and original_instance_type.startswith(
                     oci_utils.oci_config.VM_PREFIX):
                 cpus = f'{oci_utils.oci_config.DEFAULT_NUM_VCPUS}'
 
@@ -275,7 +278,7 @@ class OCI(clouds.Cloud):
             # If zone is not specified, try to get the first zone.
             if zones is None:
                 regions = service_catalog.get_region_zones_for_instance_type(
-                    instance_type=resources.instance_type,
+                    instance_type=original_instance_type,
                     use_spot=resources.use_spot,
                     clouds='oci')
                 zones = [r for r in iter(regions) if r.name == region.name
@@ -315,7 +318,7 @@ class OCI(clouds.Cloud):
             # OS type is not determined yet. So try to get it from vms.csv
             image_str = self._get_image_str(
                 image_id=resources.image_id,
-                instance_type=resources.instance_type,
+                instance_type=original_instance_type,
                 region=region.name)
 
             # pylint: disable=import-outside-toplevel

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -217,6 +217,8 @@ class OCI(clouds.Cloud):
         del cluster_name, dryrun  # Unused.
         assert region is not None, resources
 
+        assert resources.instance_type is not None, (
+            resources, 'instance_type should have been set by the optimizer.')
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -185,9 +185,9 @@ class Paperspace(clouds.Cloud):
             dryrun: bool = False) -> Dict[str, Optional[str]]:
         del zones, dryrun, cluster_name
 
-        r = resources
-        assert r.instance_type is not None, 'Instance type must be specified'
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        resources = resources.assert_launchable()
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -186,6 +186,7 @@ class Paperspace(clouds.Cloud):
         del zones, dryrun, cluster_name
 
         r = resources
+        assert r.instance_type is not None, 'Instance type must be specified'
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -170,22 +170,21 @@ class RunPod(clouds.Cloud):
 
         zone_names = [zone.name for zone in zones]
 
-        r = resources
-        assert r.instance_type is not None, 'Instance type must be specified'
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        resources = resources.assert_launchable()
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        if r.image_id is None:
+        if resources.image_id is None:
             image_id: Optional[str] = 'runpod/base:0.0.2'
-        elif r.extract_docker_image() is not None:
-            image_id = r.extract_docker_image()
+        elif resources.extract_docker_image() is not None:
+            image_id = resources.extract_docker_image()
         else:
-            image_id = r.image_id[r.region]
+            image_id = resources.image_id[resources.region]
 
         instance_type = resources.instance_type
         use_spot = resources.use_spot
-        assert instance_type is not None, 'Instance type must be specified'
         hourly_cost = self.instance_type_to_hourly_cost(
             instance_type=instance_type, use_spot=use_spot)
 

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -164,19 +164,20 @@ class RunPod(clouds.Cloud):
             region: 'clouds.Region',
             zones: Optional[List['clouds.Zone']],
             num_nodes: int,
-            dryrun: bool = False) -> Dict[str, Optional[str]]:
+            dryrun: bool = False) -> Dict[str, Optional[Union[str, bool]]]:
         del dryrun, cluster_name  # unused
         assert zones is not None, (region, zones)
 
         zone_names = [zone.name for zone in zones]
 
         r = resources
+        assert r.instance_type is not None, 'Instance type must be specified'
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
         if r.image_id is None:
-            image_id = 'runpod/base:0.0.2'
+            image_id: Optional[str] = 'runpod/base:0.0.2'
         elif r.extract_docker_image() is not None:
             image_id = r.extract_docker_image()
         else:
@@ -184,7 +185,7 @@ class RunPod(clouds.Cloud):
 
         instance_type = resources.instance_type
         use_spot = resources.use_spot
-
+        assert instance_type is not None, 'Instance type must be specified'
         hourly_cost = self.instance_type_to_hourly_cost(
             instance_type=instance_type, use_spot=use_spot)
 

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -189,13 +189,14 @@ class SCP(clouds.Cloud):
         del cluster_name, dryrun  # Unused.
         assert zones is None, 'SCP does not support zones.'
 
-        r = resources
-        assert r.instance_type is not None, 'Instance type must be specified'
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        resources = resources.assert_launchable()
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        image_id = self._get_image_id(r.image_id, region.name, r.instance_type)
+        image_id = self._get_image_id(resources.image_id, region.name,
+                                      resources.instance_type)
         return {
             'instance_type': resources.instance_type,
             'custom_resources': custom_resources,

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -190,6 +190,7 @@ class SCP(clouds.Cloud):
         assert zones is None, 'SCP does not support zones.'
 
         r = resources
+        assert r.instance_type is not None, 'Instance type must be specified'
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -161,18 +161,18 @@ class Vast(clouds.Cloud):
             dryrun: bool = False) -> Dict[str, Optional[str]]:
         del zones, dryrun, cluster_name, num_nodes  # unused
 
-        r = resources
-        assert r.instance_type is not None, 'Instance type must be specified'
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+        resources = resources.assert_launchable()
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
-        if r.image_id is None:
+        if resources.image_id is None:
             image_id: Optional[str] = 'vastai/base:0.0.2'
-        elif r.extract_docker_image() is not None:
-            image_id = r.extract_docker_image()
+        elif resources.extract_docker_image() is not None:
+            image_id = resources.extract_docker_image()
         else:
-            image_id = r.image_id[r.region]
+            image_id = resources.image_id[resources.region]
 
         return {
             'instance_type': resources.instance_type,

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -162,12 +162,13 @@ class Vast(clouds.Cloud):
         del zones, dryrun, cluster_name, num_nodes  # unused
 
         r = resources
+        assert r.instance_type is not None, 'Instance type must be specified'
         acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 
         if r.image_id is None:
-            image_id = 'vastai/base:0.0.2'
+            image_id: Optional[str] = 'vastai/base:0.0.2'
         elif r.extract_docker_image() is not None:
             image_id = r.extract_docker_image()
         else:

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -187,8 +187,7 @@ class Vsphere(clouds.Cloud):
         assert zones is not None, (region, zones)
         zone_names = [zone.name for zone in zones]
 
-        assert resources.instance_type is not None, (
-            resources, 'instance_type should have been set by the optimizer.')
+        resources = resources.assert_launchable()
         acc_dict = self.get_accelerators_from_instance_type(
             resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -186,8 +186,11 @@ class Vsphere(clouds.Cloud):
         del cluster_name, dryrun  # unused
         assert zones is not None, (region, zones)
         zone_names = [zone.name for zone in zones]
-        r = resources
-        acc_dict = self.get_accelerators_from_instance_type(r.instance_type)
+
+        assert resources.instance_type is not None, (
+            resources, 'instance_type should have been set by the optimizer.')
+        acc_dict = self.get_accelerators_from_instance_type(
+            resources.instance_type)
         custom_resources = resources_utils.make_ray_custom_resources_str(
             acc_dict)
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -627,30 +627,26 @@ def autostop(
     )
     backend = backend_utils.get_backend_from_handle(handle)
 
+    resources = handle.launched_resources.assert_launchable()
     # Check cloud supports stopping spot instances
-    cloud = handle.launched_resources.cloud
-    assert cloud is not None, handle
+    cloud = resources.cloud
 
     if not isinstance(backend, backends.CloudVmRayBackend):
         raise exceptions.NotSupportedError(
             f'{operation} cluster {cluster_name!r} with backend '
             f'{backend.__class__.__name__!r} is not supported.')
-    cloud = handle.launched_resources.cloud
-    assert cloud is not None, handle
+
     # Check if autostop/autodown is required and supported
     if not is_cancel:
         try:
             if down:
                 cloud.check_features_are_supported(
-                    handle.launched_resources,
-                    {clouds.CloudImplementationFeatures.AUTODOWN})
+                    resources, {clouds.CloudImplementationFeatures.AUTODOWN})
             else:
                 cloud.check_features_are_supported(
-                    handle.launched_resources,
-                    {clouds.CloudImplementationFeatures.STOP})
+                    resources, {clouds.CloudImplementationFeatures.STOP})
                 cloud.check_features_are_supported(
-                    handle.launched_resources,
-                    {clouds.CloudImplementationFeatures.AUTOSTOP})
+                    resources, {clouds.CloudImplementationFeatures.AUTOSTOP})
         except exceptions.NotSupportedError as e:
             raise exceptions.NotSupportedError(
                 f'{colorama.Fore.YELLOW}{operation} on cluster '

--- a/sky/core.py
+++ b/sky/core.py
@@ -636,6 +636,7 @@ def autostop(
             f'{operation} cluster {cluster_name!r} with backend '
             f'{backend.__class__.__name__!r} is not supported.')
     cloud = handle.launched_resources.cloud
+    assert cloud is not None, handle
     # Check if autostop/autodown is required and supported
     if not is_cancel:
         try:

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -89,7 +89,7 @@ class StrategyExecutor:
             name = job_recovery.pop(
                 'strategy', registry.JOBS_RECOVERY_STRATEGY_REGISTRY.default)
             assert name is None or isinstance(name, str), (
-                'The job recovery strategy name must be a string or None')
+                name, 'The job recovery strategy name must be a string or None')
             job_recovery_name: Optional[str] = name
             max_restarts_on_errors = job_recovery.pop('max_restarts_on_errors',
                                                       0)

--- a/sky/jobs/recovery_strategy.py
+++ b/sky/jobs/recovery_strategy.py
@@ -86,8 +86,11 @@ class StrategyExecutor:
         # original task.resources
         task.set_resources(type(task.resources)(new_resources_list))
         if isinstance(job_recovery, dict):
-            job_recovery_name = job_recovery.pop(
+            name = job_recovery.pop(
                 'strategy', registry.JOBS_RECOVERY_STRATEGY_REGISTRY.default)
+            assert name is None or isinstance(name, str), (
+                'The job recovery strategy name must be a string or None')
+            job_recovery_name: Optional[str] = name
             max_restarts_on_errors = job_recovery.pop('max_restarts_on_errors',
                                                       0)
         else:

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -817,10 +817,8 @@ class Optimizer:
 
             accelerators = resources.get_accelerators_str()
             spot = resources.get_spot_str()
+            resources = resources.assert_launchable()
             cloud = resources.cloud
-            assert cloud is not None, 'Cloud must be specified'
-            assert (resources.instance_type is not None), \
-                    'Instance type must be specified'
             vcpus_, mem_ = cloud.get_vcpus_mem_from_instance_type(
                 resources.instance_type)
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -671,7 +671,7 @@ class Optimizer:
         plan: Dict[task_lib.Task, resources_lib.Resources],
     ) -> float:
         """Estimates the total cost of running the DAG by the plan."""
-        total_cost = 0
+        total_cost = 0.
         for node in topo_order:
             resources = plan[node]
             if node.time_estimator_func is None:
@@ -777,6 +777,9 @@ class Optimizer:
             accelerators = resources.get_accelerators_str()
             spot = resources.get_spot_str()
             cloud = resources.cloud
+            assert cloud is not None, 'Cloud must be specified'
+            assert (resources.instance_type is not None), \
+                'Instance type must be specified'
             vcpus, mem = cloud.get_vcpus_mem_from_instance_type(
                 resources.instance_type)
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -780,10 +780,10 @@ class Optimizer:
             assert cloud is not None, 'Cloud must be specified'
             assert (resources.instance_type is not None), \
                 'Instance type must be specified'
-            vcpus, mem = cloud.get_vcpus_mem_from_instance_type(
+            vcpus_, mem_ = cloud.get_vcpus_mem_from_instance_type(
                 resources.instance_type)
 
-            def format_number(x):
+            def format_number(x: Optional[float]) -> str:
                 if x is None:
                     return '-'
                 elif x.is_integer():
@@ -791,8 +791,8 @@ class Optimizer:
                 else:
                     return f'{x:.1f}'
 
-            vcpus = format_number(vcpus)
-            mem = format_number(mem)
+            vcpus = format_number(vcpus_)
+            mem = format_number(mem_)
 
             if resources.zone is None:
                 region_or_zone = resources.region
@@ -818,10 +818,13 @@ class Optimizer:
             accelerators = resources.get_accelerators_str()
             spot = resources.get_spot_str()
             cloud = resources.cloud
-            vcpus, mem = cloud.get_vcpus_mem_from_instance_type(
+            assert cloud is not None, 'Cloud must be specified'
+            assert (resources.instance_type is not None), \
+                    'Instance type must be specified'
+            vcpus_, mem_ = cloud.get_vcpus_mem_from_instance_type(
                 resources.instance_type)
 
-            def format_number(x):
+            def format_number(x: Optional[float]) -> str:
                 if x is None:
                     return '-'
                 elif x.is_integer():
@@ -829,8 +832,8 @@ class Optimizer:
                 else:
                     return f'{x:.1f}'
 
-            vcpus = format_number(vcpus)
-            mem = format_number(mem)
+            vcpus = format_number(vcpus_)
+            mem = format_number(mem_)
 
             if resources.zone is None:
                 region_or_zone = resources.region

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -182,9 +182,10 @@ class Resources:
             if isinstance(job_recovery, str):
                 job_recovery = {'strategy': job_recovery}
             if 'strategy' not in job_recovery:
-                job_recovery['strategy'] = 'none'
+                strategy_name = None
+            else:
+                strategy_name = job_recovery['strategy']
 
-            strategy_name = job_recovery['strategy']
             if strategy_name == 'none':
                 self._job_recovery = None
             else:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -448,7 +448,7 @@ class Resources:
         return None
 
     @property
-    def accelerator_args(self) -> Optional[Dict[str, str]]:
+    def accelerator_args(self) -> Optional[Dict[str, Any]]:
         return self._accelerator_args
 
     @property
@@ -577,7 +577,7 @@ class Resources:
     def _set_accelerators(
         self,
         accelerators: Union[None, str, Dict[str, Union[int, float]]],
-        accelerator_args: Optional[Dict[str, str]],
+        accelerator_args: Optional[Dict[str, Any]],
     ) -> None:
         """Sets accelerators.
 
@@ -654,7 +654,7 @@ class Resources:
 
         self._accelerators: Optional[Dict[str, Union[int,
                                                      float]]] = accelerators
-        self._accelerator_args: Optional[Dict[str, str]] = accelerator_args
+        self._accelerator_args: Optional[Dict[str, Any]] = accelerator_args
 
     def is_launchable(self) -> bool:
         return self.cloud is not None and self._instance_type is not None

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1790,9 +1790,9 @@ class LaunchableResources(Resources):
     """
 
     def __init__(self, *args, **kwargs) -> None:  # pylint: disable=super-init-not-called
-        raise RuntimeError(
+        assert False, (
             'LaunchableResources should not be instantiated directly. '
-            'It is a type hint for MyPy.')
+            'It is only used for type checking by MyPy.')
 
     @property
     def cloud(self) -> clouds.Cloud:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1783,3 +1783,7 @@ class LaunchableResources(Resources):
         assert self._instance_type is not None, (
             'Instance type must be specified')
         return self._instance_type
+
+    def copy(self, **override) -> 'LaunchableResources':
+        self.assert_launchable()
+        return cast(LaunchableResources, super().copy(**override))

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1803,5 +1803,11 @@ class LaunchableResources(Resources):
         return self._instance_type
 
     def copy(self, **override) -> 'LaunchableResources':
+        """Ensure MyPy understands the return type is LaunchableResources.
+
+        This method is not expected to be called at runtime, as
+        LaunchableResources should not be directly instantiated. It primarily
+        serves as a type hint for static analysis.
+        """
         self.assert_launchable()
         return cast(LaunchableResources, super().copy(**override))

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -600,7 +600,8 @@ class Resources:
                             raise ValueError(parse_error)
                     try:
                         num = float(splits[1])
-                        accelerators = {splits[0]: int(num)}
+                        num = int(num) if num.is_integer() else num
+                        accelerators = {splits[0]: num}
                     except ValueError:
                         with ux_utils.print_exception_no_traceback():
                             raise ValueError(parse_error) from None

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -489,15 +489,19 @@ class Resources:
             return False
         return self._requires_fuse
 
+    def set_requires_fuse(self, value: bool) -> None:
+        """Sets whether this resource requires FUSE mounting support.
+
+        Args:
+            value: Whether the resource requires FUSE mounting support.
+        """
+        self._requires_fuse = value
+
     @property
     def cluster_config_overrides(self) -> Dict[str, Any]:
         if self._cluster_config_overrides is None:
             return {}
         return self._cluster_config_overrides
-
-    @requires_fuse.setter
-    def requires_fuse(self, value: Optional[bool]) -> None:
-        self._requires_fuse = value
 
     @property
     def docker_username_for_runpod(self) -> Optional[str]:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -62,10 +62,11 @@ class Resources:
         accelerators: Union[None, str, Dict[str, int]] = None,
         accelerator_args: Optional[Dict[str, str]] = None,
         use_spot: Optional[bool] = None,
-        job_recovery: Optional[Union[Dict[str, Union[str, int]], str]] = None,
+        job_recovery: Optional[Union[Dict[str, Optional[Union[str, int]]],
+                                     str]] = None,
         region: Optional[str] = None,
         zone: Optional[str] = None,
-        image_id: Union[Dict[str, str], str, None] = None,
+        image_id: Union[Optional[Dict[Optional[str], str]], str, None] = None,
         disk_size: Optional[int] = None,
         disk_tier: Optional[Union[str, resources_utils.DiskTier]] = None,
         ports: Optional[Union[int, str, List[str], Tuple[str]]] = None,
@@ -177,7 +178,8 @@ class Resources:
 
         self._use_spot_specified = use_spot is not None
         self._use_spot = use_spot if use_spot is not None else False
-        self._job_recovery: Optional[Dict[str, Union[str, int]]] = None
+        self._job_recovery: Optional[Union[Dict[str, Optional[Union[str, int]]],
+                                           str]] = None
         if job_recovery is not None:
             if isinstance(job_recovery, str):
                 job_recovery = {'strategy': job_recovery}
@@ -188,7 +190,7 @@ class Resources:
             if strategy_name == 'none':
                 self._job_recovery = None
             else:
-                if strategy_name is not None:
+                if strategy_name is not None and isinstance(strategy_name, str):
                     job_recovery['strategy'] = strategy_name.upper()
                 self._job_recovery = job_recovery
 
@@ -201,7 +203,8 @@ class Resources:
         else:
             self._disk_size = _DEFAULT_DISK_SIZE_GB
 
-        self._image_id = image_id
+        self._image_id: Union[Optional[Dict[Optional[str], str]],
+                              str] = image_id
         if isinstance(image_id, str):
             self._image_id = {self._region: image_id.strip()}
         elif isinstance(image_id, dict):
@@ -209,7 +212,8 @@ class Resources:
                 self._image_id = {self._region: image_id[None].strip()}
             else:
                 self._image_id = {
-                    k.strip(): v.strip() for k, v in image_id.items()
+                    k.strip() if k is not None else k: v.strip()
+                    for k, v in image_id.items()
                 }
         self._is_image_managed = _is_image_managed
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -501,7 +501,7 @@ class Resources:
         Args:
             value: Whether the resource requires FUSE mounting support.
         """
-        # TODO(username): This violates the immutability of Resources.
+        # TODO(zeping): This violates the immutability of Resources.
         #  Refactor to use Resources.copy instead.
         self._requires_fuse = value
 
@@ -1789,7 +1789,7 @@ class LaunchableResources(Resources):
     None). It should not be instantiated directly.
     """
 
-    def __init__(self, *args, **kwargs) -> None:  # pylint: disable=super-init-not-called
+    def __init__(self, *args, **kwargs) -> None:  # pylint: disable=super-init-not-called,unused-argument
         assert False, (
             'LaunchableResources should not be instantiated directly. '
             'It is only used for type checking by MyPy.')

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1,7 +1,8 @@
 """Resources: compute requirements of Tasks."""
 import dataclasses
 import textwrap
-from typing import Any, cast, Dict, List, Optional, Set, Tuple, Union
+import typing
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import colorama
 
@@ -211,7 +212,7 @@ class Resources:
                 self._image_id = {self._region: image_id[None].strip()}
             else:
                 self._image_id = {
-                    cast(str, k).strip(): v.strip()
+                    typing.cast(str, k).strip(): v.strip()
                     for k, v in image_id.items()
                 }
         else:
@@ -500,6 +501,8 @@ class Resources:
         Args:
             value: Whether the resource requires FUSE mounting support.
         """
+        # TODO(username): This violates the immutability of Resources.
+        #  Refactor to use Resources.copy instead.
         self._requires_fuse = value
 
     @property
@@ -667,7 +670,7 @@ class Resources:
         types, and the returned object will still be an instance of `Resources`.
         """
         assert self.is_launchable(), self
-        return cast(LaunchableResources, self)
+        return typing.cast(LaunchableResources, self)
 
     def need_cleanup_after_preemption_or_failure(self) -> bool:
         """Whether a resource needs cleanup after preemption or failure."""
@@ -1810,4 +1813,4 @@ class LaunchableResources(Resources):
         serves as a type hint for static analysis.
         """
         self.assert_launchable()
-        return cast(LaunchableResources, super().copy(**override))
+        return typing.cast(LaunchableResources, super().copy(**override))

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -718,10 +718,10 @@ class Resources:
                     else:
                         table = log_utils.create_table(['Cloud', 'Hint'])
                         table.add_row(['-----', '----'])
-                        for cloud_str, error in cloud_to_errors.items():
+                        for cloud_msg, error in cloud_to_errors.items():
                             reason_str = '\n'.join(textwrap.wrap(
                                 str(error), 80))
-                            table.add_row([cloud_str, reason_str])
+                            table.add_row([cloud_msg, reason_str])
                         hint = table.get_string()
                     raise ValueError(
                         f'Invalid (region {self._region!r}, zone '

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -599,9 +599,6 @@ class Resources:
                             raise ValueError(parse_error)
                     try:
                         num = float(splits[1])
-                        assert num.is_integer(), (
-                            f'Number of accelerators must be an integer, '
-                            f'got {num}')
                         accelerators = {splits[0]: int(num)}
                     except ValueError:
                         with ux_utils.print_exception_no_traceback():

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1170,9 +1170,12 @@ class Resources:
         specific_reservations = set(
             skypilot_config.get_nested(
                 (str(self.cloud).lower(), 'specific_reservations'), set()))
+
+        assert (self.cloud is not None and self.instance_type is not None and
+                self.region
+                is not None), ('Cloud, instance type, region must be specified')
         return self.cloud.get_reservations_available_resources(
-            self._instance_type, self._region, self._zone,
-            specific_reservations)
+            self.instance_type, self.region, self.zone, specific_reservations)
 
     def less_demanding_than(
         self,
@@ -1192,6 +1195,9 @@ class Resources:
         if isinstance(other, list):
             resources_list = [self.less_demanding_than(o) for o in other]
             return requested_num_nodes <= sum(resources_list)
+
+        assert other.cloud is not None, 'Other cloud must be specified'
+
         if self.cloud is not None and not self.cloud.is_same_cloud(other.cloud):
             return False
         # self.cloud <= other.cloud
@@ -1280,6 +1286,7 @@ class Resources:
         If a field in `blocked` is None, it should be considered as a wildcard
         for that field.
         """
+        assert self.cloud is not None, 'Cloud must be specified'
         is_matched = True
         if (blocked.cloud is not None and
                 not self.cloud.is_same_cloud(blocked.cloud)):
@@ -1318,7 +1325,7 @@ class Resources:
         use_spot = self.use_spot if self._use_spot_specified else None
 
         current_override_configs = self._cluster_config_overrides
-        if self._cluster_config_overrides is None:
+        if current_override_configs is None:
             current_override_configs = {}
         new_override_configs = override.pop('_cluster_config_overrides', {})
         overlaid_configs = skypilot_config.overlay_skypilot_config(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -203,10 +203,10 @@ class Resources:
         else:
             self._disk_size = _DEFAULT_DISK_SIZE_GB
 
-        self._image_id: Union[Optional[Dict[Optional[str], str]],
-                              str] = image_id
         if isinstance(image_id, str):
-            self._image_id = {self._region: image_id.strip()}
+            self._image_id: Optional[Dict[Optional[str], str]] = {
+                self._region: image_id.strip()
+            }
         elif isinstance(image_id, dict):
             if None in image_id:
                 self._image_id = {self._region: image_id[None].strip()}
@@ -215,6 +215,8 @@ class Resources:
                     k.strip() if k is not None else k: v.strip()
                     for k, v in image_id.items()
                 }
+        else:
+            self._image_id = image_id
         self._is_image_managed = _is_image_managed
 
         if isinstance(disk_tier, str):
@@ -232,7 +234,7 @@ class Resources:
             if isinstance(ports, tuple):
                 ports = list(ports)
             if not isinstance(ports, list):
-                ports = [ports]
+                ports = [str(ports)]
             ports = resources_utils.simplify_ports(
                 [str(port) for port in ports])
             if not ports:
@@ -254,7 +256,7 @@ class Resources:
         self._requires_fuse = _requires_fuse
 
         self._cluster_config_overrides = _cluster_config_overrides
-        self._cached_repr = None
+        self._cached_repr: Optional[str] = None
 
         self._set_cpus(cpus)
         self._set_memory(memory)
@@ -460,7 +462,8 @@ class Resources:
         return self._use_spot_specified
 
     @property
-    def job_recovery(self) -> Optional[Dict[str, Union[str, int]]]:
+    def job_recovery(
+            self) -> Optional[Union[Dict[str, Optional[Union[str, int]]], str]]:
         return self._job_recovery
 
     @property
@@ -468,11 +471,11 @@ class Resources:
         return self._disk_size
 
     @property
-    def image_id(self) -> Optional[Dict[str, str]]:
+    def image_id(self) -> Optional[Dict[Optional[str], str]]:
         return self._image_id
 
     @property
-    def disk_tier(self) -> resources_utils.DiskTier:
+    def disk_tier(self) -> Optional[resources_utils.DiskTier]:
         return self._disk_tier
 
     @property
@@ -649,8 +652,9 @@ class Resources:
                                     'Cannot specify instance type (got '
                                     f'{self.instance_type!r}) for TPU VM.')
 
-        self._accelerators = accelerators
-        self._accelerator_args = accelerator_args
+        self._accelerators: Optional[Dict[str, Union[int,
+                                                     float]]] = accelerators
+        self._accelerator_args: Optional[Dict[str, str]] = accelerator_args
 
     def is_launchable(self) -> bool:
         return self.cloud is not None and self._instance_type is not None

--- a/sky/serve/spot_placer.py
+++ b/sky/serve/spot_placer.py
@@ -46,6 +46,8 @@ class Location:
 
     @classmethod
     def from_resources(cls, resources: 'resources_lib.Resources') -> 'Location':
+        assert (resources.cloud is not None), 'Cloud must be specified'
+        assert (resources.region is not None), 'Region must be specified'
         return cls(resources.cloud, resources.region, resources.zone)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -147,6 +149,7 @@ def _get_possible_location_from_task(task: 'task_lib.Task') -> List[Location]:
                 cloud_str = str(launchable.cloud)
                 region = launchable.region
                 zone = launchable.zone
+                assert region is not None, 'Region must be specified'
                 if (cloud_str not in location_requirements and
                         location_requirements):
                     continue

--- a/sky/serve/spot_placer.py
+++ b/sky/serve/spot_placer.py
@@ -46,8 +46,8 @@ class Location:
 
     @classmethod
     def from_resources(cls, resources: 'resources_lib.Resources') -> 'Location':
-        assert (resources.cloud is not None), 'Cloud must be specified'
-        assert (resources.region is not None), 'Region must be specified'
+        assert resources.cloud is not None, 'Cloud must be specified'
+        assert resources.region is not None, 'Region must be specified'
         return cls(resources.cloud, resources.region, resources.zone)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/sky/task.py
+++ b/sky/task.py
@@ -1235,13 +1235,14 @@ class Task:
 
         add_if_not_none('name', self.name)
 
-        tmp_resource_config = {}
+        tmp_resource_config: Union[Dict[str, Union[str, int]],
+                                   Dict[str, List[Dict[str, Union[str, int]]]]]
         if len(self.resources) > 1:
             resource_list = []
             for r in self.resources:
                 resource_list.append(r.to_yaml_config())
             key = 'ordered' if isinstance(self.resources, list) else 'any_of'
-            tmp_resource_config[key] = resource_list
+            tmp_resource_config = {key: resource_list}
         else:
             tmp_resource_config = list(self.resources)[0].to_yaml_config()
 

--- a/sky/task.py
+++ b/sky/task.py
@@ -165,7 +165,8 @@ def _with_docker_login_config(
                            f'ignored.{colorama.Style.RESET_ALL}')
             return resources
         # Already checked in extract_docker_image
-        assert len(resources.image_id) == 1, resources.image_id
+        assert resources.image_id is not None and len(
+            resources.image_id) == 1, resources.image_id
         region = list(resources.image_id.keys())[0]
         return resources.copy(image_id={region: 'docker:' + docker_image},
                               _docker_login_config=docker_login_config)
@@ -775,7 +776,7 @@ class Task:
         for _, storage_obj in self.storage_mounts.items():
             if storage_obj.mode in storage_lib.MOUNTABLE_STORAGE_MODES:
                 for r in self.resources:
-                    r.requires_fuse = True
+                    r.set_requires_fuse(True)
                 break
 
         return self
@@ -931,7 +932,7 @@ class Task:
             self.storage_mounts = {}
             # Clear the requires_fuse flag if no storage mounts are set.
             for r in self.resources:
-                r.requires_fuse = False
+                r.set_requires_fuse(False)
             return self
         for target, storage_obj in storage_mounts.items():
             # TODO(zhwu): /home/username/sky_workdir as the target path need
@@ -956,7 +957,7 @@ class Task:
                 # If any storage is using MOUNT mode, we need to enable FUSE in
                 # the resources.
                 for r in self.resources:
-                    r.requires_fuse = True
+                    r.set_requires_fuse(True)
         # Storage source validation is done in Storage object
         self.storage_mounts = storage_mounts
         return self

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -608,8 +608,9 @@ def get_controller_resources(
     controller_zone = controller_resources_to_use.zone
 
     # Filter clouds if controller_resources_to_use.cloud is specified.
-    filtered_clouds = ({controller_cloud} if controller_cloud is not None else
-                       requested_clouds_with_region_zone.keys())
+    filtered_clouds: Set[str] = set(
+        {controller_cloud} if controller_cloud is not None else set(
+            requested_clouds_with_region_zone.keys()))
 
     # Filter regions and zones and construct the result.
     result: Set[resources.Resources] = set()
@@ -619,14 +620,15 @@ def get_controller_resources(
 
         # Filter regions if controller_resources_to_use.region is specified.
         filtered_regions = ({controller_region} if controller_region is not None
-                            else regions.keys())
+                            else set(str(k) for k in regions.keys()))
 
         for region in filtered_regions:
             zones = regions.get(region, {None})
 
             # Filter zones if controller_resources_to_use.zone is specified.
-            filtered_zones = ({controller_zone}
-                              if controller_zone is not None else zones)
+            filtered_zones: Set[Optional[str]] = ({
+                controller_zone
+            } if controller_zone is not None else set(zones))
 
             # Create combinations of cloud, region, and zone.
             for zone in filtered_zones:
@@ -703,7 +705,7 @@ def _setup_proxy_command_on_controller(
     # NOTE: suppose that we have a controller in old VPC, then user
     # changes 'vpc_name' in the config and does a 'job launch' /
     # 'serve up'. In general, the old controller may not successfully
-    # launch the job in the new VPC. This happens if the two VPCs don’t
+    # launch the job in the new VPC. This happens if the two VPCs don't
     # have peering set up. Like other places in the code, we assume
     # properly setting up networking is user's responsibilities.
     # TODO(zongheng): consider adding a basic check that checks

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -619,8 +619,9 @@ def get_controller_resources(
                                                         {None: {None}})
 
         # Filter regions if controller_resources_to_use.region is specified.
-        filtered_regions = ({controller_region} if controller_region is not None
-                            else set(str(k) for k in regions.keys()))
+        filtered_regions: Set[Optional[str]] = ({
+            controller_region
+        } if controller_region is not None else set(regions.keys()))
 
         for region in filtered_regions:
             zones = regions.get(region, {None})

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -608,9 +608,9 @@ def get_controller_resources(
     controller_zone = controller_resources_to_use.zone
 
     # Filter clouds if controller_resources_to_use.cloud is specified.
-    filtered_clouds: Set[str] = set(
-        {controller_cloud} if controller_cloud is not None else set(
-            requested_clouds_with_region_zone.keys()))
+    filtered_clouds: Set[str] = {controller_cloud
+                                } if controller_cloud is not None else set(
+                                    requested_clouds_with_region_zone.keys())
 
     # Filter regions and zones and construct the result.
     result: Set[resources.Resources] = set()

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -195,7 +195,7 @@ def fill_default_config_in_dag_for_job_launch(dag: dag_lib.Dag) -> None:
         assert default_strategy is not None
         for resources in list(task_.resources):
             original_job_recovery = resources.job_recovery
-            job_recovery: Dict[str, Union[str, int]] = {
+            job_recovery: Dict[str, Optional[Union[str, int]]] = {
                 'strategy': default_strategy
             }
             if isinstance(original_job_recovery, str):

--- a/sky/utils/dag_utils.py
+++ b/sky/utils/dag_utils.py
@@ -1,6 +1,6 @@
 """Utilities for loading and dumping DAGs from/to YAML files."""
 import copy
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sky import dag as dag_lib
 from sky import sky_logging
@@ -195,7 +195,9 @@ def fill_default_config_in_dag_for_job_launch(dag: dag_lib.Dag) -> None:
         assert default_strategy is not None
         for resources in list(task_.resources):
             original_job_recovery = resources.job_recovery
-            job_recovery = {'strategy': default_strategy}
+            job_recovery: Dict[str, Union[str, int]] = {
+                'strategy': default_strategy
+            }
             if isinstance(original_job_recovery, str):
                 job_recovery['strategy'] = original_job_recovery
             elif isinstance(original_job_recovery, dict):

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -141,9 +141,13 @@ def format_resource(resource: 'resources_lib.Resources',
                     simplify: bool = False) -> str:
     if simplify:
         cloud = resource.cloud
+        assert cloud is not None, 'Cloud must be specified'
+        assert (resource.instance_type is not None), \
+            'Instance type must be specified'
         if resource.accelerators is None:
             vcpu, _ = cloud.get_vcpus_mem_from_instance_type(
                 resource.instance_type)
+            assert vcpu is not None, 'vCPU must be specified'
             hardware = f'vCPU={int(vcpu)}'
         else:
             hardware = f'{resource.accelerators}'
@@ -248,6 +252,7 @@ def make_launchables_for_valid_region_zones(
     launchables = []
     regions = launchable_resources.get_valid_regions_for_launchable()
     for region in regions:
+        assert launchable_resources.cloud is not None, 'Cloud must be specified'
         optimize_by_zone = (override_optimize_by_zone or
                             launchable_resources.cloud.optimize_by_zone())
         # It is possible that we force the optimize_by_zone but some clouds

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -140,10 +140,8 @@ def simplify_ports(ports: List[str]) -> List[str]:
 def format_resource(resource: 'resources_lib.Resources',
                     simplify: bool = False) -> str:
     if simplify:
+        resource = resource.assert_launchable()
         cloud = resource.cloud
-        assert cloud is not None, 'Cloud must be specified'
-        assert (resource.instance_type is not None), \
-            'Instance type must be specified'
         if resource.accelerators is None:
             vcpu, _ = cloud.get_vcpus_mem_from_instance_type(
                 resource.instance_type)

--- a/tests/mypy_files.txt
+++ b/tests/mypy_files.txt
@@ -2,5 +2,4 @@ sky
 
 --exclude sky/benchmark
 --exclude sky/callbacks
---exclude sky/skylet/providers/azure
 --exclude sky/backends/monkey_patches

--- a/tests/mypy_files.txt
+++ b/tests/mypy_files.txt
@@ -3,5 +3,4 @@ sky
 --exclude sky/benchmark
 --exclude sky/callbacks
 --exclude sky/skylet/providers/azure
---exclude sky/resources.py
 --exclude sky/backends/monkey_patches

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -42,8 +42,6 @@ def test_jobs_recovery_fill_default_values():
     assert len(resources) == 1
     assert resources[0].job_recovery['strategy'].lower(
     ) == registry.JOBS_RECOVERY_STRATEGY_REGISTRY.default
-    import sys
-    print(resources[0].job_recovery, file=sys.stderr, flush=True)
     assert resources[0].job_recovery['max_restarts_on_errors'] == 3
 
     task_str = textwrap.dedent(f"""\

--- a/tests/unit_tests/test_dag_utils.py
+++ b/tests/unit_tests/test_dag_utils.py
@@ -42,6 +42,8 @@ def test_jobs_recovery_fill_default_values():
     assert len(resources) == 1
     assert resources[0].job_recovery['strategy'].lower(
     ) == registry.JOBS_RECOVERY_STRATEGY_REGISTRY.default
+    import sys
+    print(resources[0].job_recovery, file=sys.stderr, flush=True)
     assert resources[0].job_recovery['max_restarts_on_errors'] == 3
 
     task_str = textwrap.dedent(f"""\


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #5442

* Remove the `--exclude sky/resources.py` and `--exclude sky/skylet/providers/azure`

Since the `Resource` class allows `None` for `instance_type`, `cloud`, `region`, etc., during construction—which goes against many cloud usage patterns—I had to add many asserts to avoid breaking mypy checks.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local) 
  - [x] `/smoke-test` https://buildkite.com/skypilot-1/smoke-tests/builds/876
  - [x] `/smoke-test --gcp` https://buildkite.com/skypilot-1/smoke-tests/builds/879
  - [x] `/smoke-test --azure` https://buildkite.com/skypilot-1/smoke-tests/builds/880
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
  - [x] `/quicktest-core` https://buildkite.com/skypilot-1/quicktest-core/builds/313

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
