### PR TITLE
[WIP] workspaces implementation

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -31,16 +31,10 @@ def check_capabilities(
     clouds: Optional[Iterable[str]] = None,
     capabilities: Optional[List[sky_cloud.CloudCapability]] = None,
 ) -> Dict[str, List[sky_cloud.CloudCapability]]:
-    quiet = False
-    verbose = True
     echo = (lambda *_args, **_kwargs: None
            ) if quiet else lambda *args, **kwargs: click.echo(
                *args, **kwargs, color=True)
     echo('Checking credentials to enable clouds for SkyPilot.')
-    echo(f'Capabilities: {capabilities}')
-    echo(f'Clouds: {clouds}')
-    echo(f'Quiet: {quiet}')
-    echo(f'Verbose: {verbose}')
     if capabilities is None:
         capabilities = sky_cloud.ALL_CAPABILITIES
     assert capabilities is not None
@@ -96,7 +90,6 @@ def check_capabilities(
         if cloud_disabled:
             echo(f'Disabling {cloud} according to the workspace config.')
             config_allowed_cloud_names.remove(cloud)
-    echo(f'workspace config: {skypilot_config.get_active_workspace()}')
     # Use disallowed_cloud_names for logging the clouds that will be disabled
     # because they are not included in allowed_clouds in config.yaml.
     disallowed_cloud_names = [

--- a/sky/check.py
+++ b/sky/check.py
@@ -96,7 +96,7 @@ def check_capabilities(
         if cloud_disabled:
             echo(f'Disabling {cloud} according to the workspace config.')
             config_allowed_cloud_names.remove(cloud)
-
+    echo(f'workspace config: {skypilot_config.get_active_workspace()}')
     # Use disallowed_cloud_names for logging the clouds that will be disabled
     # because they are not included in allowed_clouds in config.yaml.
     disallowed_cloud_names = [
@@ -154,20 +154,17 @@ def check_capabilities(
             cloud for cloud in config_allowed_cloud_names
             if not cloud.startswith('Cloudflare')
         }
-        echo(f'workspace config: {skypilot_config.get_workspace()}')
         previously_enabled_clouds_set = {
             repr(cloud)
             for cloud in global_user_state.get_cached_enabled_clouds(
-                capability, skypilot_config.get_workspace())
+                capability, skypilot_config.get_active_workspace())
         }
-        echo(f'Previously enabled clouds: {previously_enabled_clouds_set}')
         enabled_clouds_for_capability = (config_allowed_clouds_set & (
             (previously_enabled_clouds_set | enabled_clouds_set) -
             disabled_clouds_set))
-        echo(f'Enabled clouds for capability: {enabled_clouds_for_capability}')
         global_user_state.set_enabled_clouds(
             list(enabled_clouds_for_capability), capability,
-            skypilot_config.get_workspace())
+            skypilot_config.get_active_workspace())
         all_enabled_clouds = all_enabled_clouds.union(
             enabled_clouds_for_capability)
     disallowed_clouds_hint = None
@@ -254,7 +251,7 @@ def get_cached_enabled_clouds_or_refresh(
             raise_if_no_cloud_access is set to True.
     """
     cached_enabled_clouds = global_user_state.get_cached_enabled_clouds(
-        capability, skypilot_config.get_workspace())
+        capability, skypilot_config.get_active_workspace())
     if not cached_enabled_clouds:
         try:
             check_capability(sky_cloud.CloudCapability.COMPUTE, quiet=True)
@@ -264,7 +261,7 @@ def get_cached_enabled_clouds_or_refresh(
             # raise_if_no_cloud_access is set to True.
             pass
         cached_enabled_clouds = global_user_state.get_cached_enabled_clouds(
-            capability, skypilot_config.get_workspace())
+            capability, skypilot_config.get_active_workspace())
     if raise_if_no_cloud_access and not cached_enabled_clouds:
         with ux_utils.print_exception_no_traceback():
             raise exceptions.NoCloudAccessError(

--- a/sky/check.py
+++ b/sky/check.py
@@ -31,10 +31,16 @@ def check_capabilities(
     clouds: Optional[Iterable[str]] = None,
     capabilities: Optional[List[sky_cloud.CloudCapability]] = None,
 ) -> Dict[str, List[sky_cloud.CloudCapability]]:
+    quiet = False
+    verbose = True
     echo = (lambda *_args, **_kwargs: None
            ) if quiet else lambda *args, **kwargs: click.echo(
                *args, **kwargs, color=True)
     echo('Checking credentials to enable clouds for SkyPilot.')
+    echo(f'Capabilities: {capabilities}')
+    echo(f'Clouds: {clouds}')
+    echo(f'Quiet: {quiet}')
+    echo(f'Verbose: {verbose}')
     if capabilities is None:
         capabilities = sky_cloud.ALL_CAPABILITIES
     assert capabilities is not None
@@ -148,14 +154,17 @@ def check_capabilities(
             cloud for cloud in config_allowed_cloud_names
             if not cloud.startswith('Cloudflare')
         }
+        echo(f'workspace config: {skypilot_config.get_workspace()}')
         previously_enabled_clouds_set = {
             (repr(cloud)
              for cloud in global_user_state.get_cached_enabled_clouds(
                  capability, skypilot_config.get_workspace()))
         }
+        echo(f'Previously enabled clouds: {previously_enabled_clouds_set}')
         enabled_clouds_for_capability = (config_allowed_clouds_set & (
             (previously_enabled_clouds_set | enabled_clouds_set) -
             disabled_clouds_set))
+        echo(f'Enabled clouds for capability: {enabled_clouds_for_capability}')
         global_user_state.set_enabled_clouds(
             list(enabled_clouds_for_capability), capability,
             skypilot_config.get_workspace())

--- a/sky/check.py
+++ b/sky/check.py
@@ -84,12 +84,17 @@ def check_capabilities(
     ])
 
     # filter out the clouds that are disabled in the workspace config
+    workspace_disabled_clouds = []
     for cloud in config_allowed_cloud_names:
         cloud_config = skypilot_config.get_workspace_cloud(cloud)
         cloud_disabled = cloud_config.get('disabled', False)
         if cloud_disabled:
-            echo(f'Disabling {cloud} according to the workspace config.')
-            config_allowed_cloud_names.remove(cloud)
+            workspace_disabled_clouds.append(cloud)
+    config_allowed_cloud_names = [
+        c for c in config_allowed_cloud_names
+        if c not in workspace_disabled_clouds
+    ]
+
     # Use disallowed_cloud_names for logging the clouds that will be disabled
     # because they are not included in allowed_clouds in config.yaml.
     disallowed_cloud_names = [

--- a/sky/check.py
+++ b/sky/check.py
@@ -156,9 +156,9 @@ def check_capabilities(
         }
         echo(f'workspace config: {skypilot_config.get_workspace()}')
         previously_enabled_clouds_set = {
-            (repr(cloud)
-             for cloud in global_user_state.get_cached_enabled_clouds(
-                 capability, skypilot_config.get_workspace()))
+            repr(cloud)
+            for cloud in global_user_state.get_cached_enabled_clouds(
+                capability, skypilot_config.get_workspace())
         }
         echo(f'Previously enabled clouds: {previously_enabled_clouds_set}')
         enabled_clouds_for_capability = (config_allowed_clouds_set & (

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1001,7 +1001,6 @@ class GCP(clouds.Cloud):
         from google import auth  # type: ignore
         config_project_id = skypilot_config.get_workspace_cloud('gcp').get(
             'project_id', None)
-        logger.info(f'config_project_id: {config_project_id}')
         if config_project_id:
             return config_project_id
         _, project_id = auth.default()

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -999,6 +999,11 @@ class GCP(clouds.Cloud):
             return 'dryrun-project-id'
         # pylint: disable=import-outside-toplevel
         from google import auth  # type: ignore
+        config_project_id = skypilot_config.get_workspace_cloud('gcp').get(
+            'project_id', None)
+        logger.info(f'config_project_id: {config_project_id}')
+        if config_project_id:
+            return config_project_id
         _, project_id = auth.default()
         if project_id is None:
             raise exceptions.CloudUserIdentityError(

--- a/sky/core.py
+++ b/sky/core.py
@@ -1006,7 +1006,7 @@ def storage_delete(name: str) -> None:
 def enabled_clouds() -> List[clouds.Cloud]:
     return global_user_state.get_cached_enabled_clouds(
         sky_cloud.CloudCapability.COMPUTE,
-        workspace=skypilot_config.get_workspace())
+        workspace=skypilot_config.get_active_workspace())
 
 
 @usage_lib.entrypoint

--- a/sky/core.py
+++ b/sky/core.py
@@ -17,6 +17,7 @@ from sky import global_user_state
 from sky import models
 from sky import optimizer
 from sky import sky_logging
+from sky import skypilot_config
 from sky import task as task_lib
 from sky.backends import backend_utils
 from sky.clouds import cloud as sky_cloud
@@ -1004,7 +1005,8 @@ def storage_delete(name: str) -> None:
 @usage_lib.entrypoint
 def enabled_clouds() -> List[clouds.Cloud]:
     return global_user_state.get_cached_enabled_clouds(
-        sky_cloud.CloudCapability.COMPUTE)
+        sky_cloud.CloudCapability.COMPUTE,
+        workspace=skypilot_config.get_workspace())
 
 
 @usage_lib.entrypoint

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -802,11 +802,12 @@ def get_cluster_names_start_with(starts_with: str) -> List[str]:
     return [row[0] for row in rows]
 
 
-def get_cached_enabled_clouds(
-        cloud_capability: 'cloud.CloudCapability') -> List['clouds.Cloud']:
+def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
+                              workspace: str) -> List['clouds.Cloud']:
 
-    rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
-                              (_get_capability_key(cloud_capability),))
+    rows = _DB.cursor.execute(
+        'SELECT value FROM config WHERE key = ?',
+        (_get_enabled_clouds_key(cloud_capability, workspace),))
     ret = []
     for (value,) in rows:
         ret = json.loads(value)
@@ -827,15 +828,17 @@ def get_cached_enabled_clouds(
 
 
 def set_enabled_clouds(enabled_clouds: List[str],
-                       cloud_capability: 'cloud.CloudCapability') -> None:
-    _DB.cursor.execute(
-        'INSERT OR REPLACE INTO config VALUES (?, ?)',
-        (_get_capability_key(cloud_capability), json.dumps(enabled_clouds)))
+                       cloud_capability: 'cloud.CloudCapability',
+                       workspace: str) -> None:
+    _DB.cursor.execute('INSERT OR REPLACE INTO config VALUES (?, ?)',
+                       (_get_enabled_clouds_key(cloud_capability, workspace),
+                        json.dumps(enabled_clouds)))
     _DB.conn.commit()
 
 
-def _get_capability_key(cloud_capability: 'cloud.CloudCapability') -> str:
-    return _ENABLED_CLOUDS_KEY_PREFIX + cloud_capability.value
+def _get_enabled_clouds_key(cloud_capability: 'cloud.CloudCapability',
+                            workspace: str) -> str:
+    return _ENABLED_CLOUDS_KEY_PREFIX + workspace + '_' + cloud_capability.value
 
 
 def add_or_update_storage(storage_name: str,

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -375,7 +375,8 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
 # we skip the following keys because they are meant to be client-side configs.
 SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [('admin_policy',),
                                                        ('api_server',),
-                                                       ('allowed_clouds',)]
+                                                       ('allowed_clouds',),
+                                                       ('workspaces',)]
 
 # Constants for Azure blob storage
 WAIT_FOR_STORAGE_ACCOUNT_CREATION = 60

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -101,15 +101,22 @@ ENV_VAR_GLOBAL_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}GLOBAL_CONFIG'
 # Environment variables for setting non-default project config files.
 ENV_VAR_PROJECT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}PROJECT_CONFIG'
 
+# Environment variables for setting non-default workspace config files.
+ENV_VAR_WORKSPACE_CONFIG = (
+    f'{constants.SKYPILOT_ENV_VAR_PREFIX}WORKSPACE_CONFIG')
+
 # Path to the client config files.
 _GLOBAL_CONFIG_PATH = '~/.sky/config.yaml'
 _PROJECT_CONFIG_PATH = '.sky.yaml'
+_WORKSPACE_CONFIG_PATH = '~/.sky/workspace.yaml'
 
 # The loaded config.
 _dict = config_utils.Config()
 _loaded_config_path: Optional[str] = None
 _config_overridden: bool = False
 _reload_config_lock = threading.Lock()
+
+_workspace_dict = config_utils.Config()
 
 
 def get_user_config_path() -> str:
@@ -139,8 +146,7 @@ def get_user_config() -> config_utils.Config:
 
     # load the user config file
     if os.path.exists(user_config_path):
-        user_config = parse_config_file(user_config_path)
-        _validate_config(user_config, user_config_path)
+        user_config = parse_and_validate_config_file(user_config_path)
     else:
         user_config = config_utils.Config()
     return user_config
@@ -168,11 +174,37 @@ def _get_project_config() -> config_utils.Config:
 
     # load the project config file
     if os.path.exists(project_config_path):
-        project_config = parse_config_file(project_config_path)
-        _validate_config(project_config, project_config_path)
+        project_config = parse_and_validate_config_file(project_config_path)
     else:
         project_config = config_utils.Config()
     return project_config
+
+
+def _get_workspace_config() -> config_utils.Config:
+    """Returns the workspace config."""
+    workspace_config_path = _get_config_file_path(ENV_VAR_WORKSPACE_CONFIG)
+    if workspace_config_path:
+        logger.debug('using workspace config file specified by '
+                     f'{ENV_VAR_WORKSPACE_CONFIG}: {workspace_config_path}')
+        workspace_config_path = os.path.expanduser(workspace_config_path)
+        if not os.path.exists(workspace_config_path):
+            with ux_utils.print_exception_no_traceback():
+                raise FileNotFoundError(
+                    'Config file specified by env var '
+                    f'{ENV_VAR_WORKSPACE_CONFIG} ({workspace_config_path!r}) '
+                    'does not exist. Please double check the path or unset the '
+                    f'env var: unset {ENV_VAR_WORKSPACE_CONFIG}')
+    else:
+        logger.debug(
+            f'using default workspace config file: {_WORKSPACE_CONFIG_PATH}')
+        workspace_config_path = _WORKSPACE_CONFIG_PATH
+        workspace_config_path = os.path.expanduser(workspace_config_path)
+
+    if os.path.exists(workspace_config_path):
+        workspace_config = parse_workspace_config_file(workspace_config_path)
+    else:
+        workspace_config = config_utils.Config()
+    return workspace_config
 
 
 def get_server_config() -> config_utils.Config:
@@ -197,8 +229,7 @@ def get_server_config() -> config_utils.Config:
 
     # load the server config file
     if os.path.exists(server_config_path):
-        server_config = parse_config_file(server_config_path)
-        _validate_config(server_config, server_config_path)
+        server_config = parse_and_validate_config_file(server_config_path)
     else:
         server_config = config_utils.Config()
     return server_config
@@ -265,6 +296,18 @@ def _validate_config(config: Dict[str, Any], config_source: str) -> None:
         skip_none=False)
 
 
+def _validate_workspace_config(config: Dict[str, Any],
+                               config_source: str) -> None:
+    """Validates the workspace config."""
+    common_utils.validate_schema(
+        config,
+        schemas.get_workspace_schema(),
+        f'Invalid workspace config YAML from ({config_source}). See: '
+        'https://docs.skypilot.co/en/latest/reference/config.html. '  # pylint: disable=line-too-long
+        'Error: ',
+        skip_none=False)
+
+
 def overlay_skypilot_config(
         original_config: Optional[config_utils.Config],
         override_configs: Optional[config_utils.Config]) -> config_utils.Config:
@@ -302,7 +345,7 @@ def _reload_config() -> None:
         _reload_config_as_client()
 
 
-def parse_config_file(config_path: str) -> config_utils.Config:
+def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
     config = config_utils.Config()
     try:
         config_dict = common_utils.read_yaml(config_path)
@@ -316,6 +359,24 @@ def parse_config_file(config_path: str) -> config_utils.Config:
         _validate_config(config, config_path)
 
     logger.debug(f'Config syntax check passed for path: {config_path}')
+    return config
+
+
+def parse_workspace_config_file(config_path: str) -> config_utils.Config:
+    config = config_utils.Config()
+    try:
+        config_dict = common_utils.read_yaml(config_path)
+        config = config_utils.Config.from_dict(config_dict)
+        if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+            logger.debug(f'Config loaded from {config_path}:\n'
+                         f'{common_utils.dump_yaml_str(dict(config))}')
+    except yaml.YAMLError as e:
+        logger.error(f'Error in loading config file ({config_path}):', e)
+    if config:
+        _validate_workspace_config(config, config_path)
+
+    logger.debug(
+        f'Workspace config syntax check passed for path: {config_path}')
     return config
 
 
@@ -359,12 +420,12 @@ def _reload_config_from_internal_file(internal_config_path: str) -> None:
                 'exist. Please double check the path or unset the env var: '
                 f'unset {ENV_VAR_SKYPILOT_CONFIG}')
     logger.debug(f'Using config path: {config_path}')
-    _dict = parse_config_file(config_path)
+    _dict = parse_and_validate_config_file(config_path)
     _loaded_config_path = config_path
 
 
 def _reload_config_as_server() -> None:
-    global _dict
+    global _dict, _workspace_dict
     # Reset the global variables, to avoid using stale values.
     _dict = config_utils.Config()
 
@@ -383,6 +444,8 @@ def _reload_config_as_server() -> None:
             f'server config: \n'
             f'{common_utils.dump_yaml_str(dict(overlaid_server_config))}')
     _dict = overlaid_server_config
+
+    _workspace_dict = _get_workspace_config()
 
 
 def _reload_config_as_client() -> None:
@@ -461,6 +524,15 @@ def override_skypilot_config(
         override_configs=dict(override_configs),
         allowed_override_keys=None,
         disallowed_override_keys=constants.SKIPPED_CLIENT_OVERRIDE_KEYS)
+    # TODO get the workspace from someplace in config
+    # workspace = config.get_nested(keys=('SOMEPLACE'), default_value='default')
+    workspace = 'default'
+    workspace_config = _workspace_dict.get_nested(keys=('profiles', workspace,
+                                                        'config'),
+                                                  default_value=None)
+    if workspace_config:
+        config = overlay_skypilot_config(original_config=config,
+                                         override_configs=workspace_config)
     try:
         common_utils.validate_schema(
             config,
@@ -506,7 +578,7 @@ def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
                     'Cannot use multiple --config flags with a config file.')
             config_source = maybe_config_path
             # cli_config is a path to a config file
-            parsed_config = parse_config_file(maybe_config_path)
+            parsed_config = parse_and_validate_config_file(maybe_config_path)
         else:  # cli_config is a comma-separated list of key-value pairs
             parsed_config = _parse_dotlist(cli_config)
         _validate_config(parsed_config, config_source)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -241,12 +241,11 @@ def get_workspace_cloud(cloud: str) -> config_utils.Config:
                               default_value=None)
     if clouds is None:
         return config_utils.Config()
-    for candidate_cloud in clouds:
-        if isinstance(candidate_cloud, str) and candidate_cloud == cloud:
-            return config_utils.Config()
-        elif isinstance(candidate_cloud, dict) and cloud in candidate_cloud:
-            return candidate_cloud[cloud]
-    return config_utils.Config()
+    return clouds.get(cloud.lower(), config_utils.Config())
+
+
+def get_workspace() -> str:
+    return _dict.get_nested(keys=('workspace',), default_value='default')
 
 
 def set_nested(keys: Tuple[str, ...], value: Any) -> Dict[str, Any]:
@@ -478,7 +477,7 @@ def override_skypilot_config(
         override_configs=dict(override_configs),
         allowed_override_keys=None,
         disallowed_override_keys=constants.SKIPPED_CLIENT_OVERRIDE_KEYS)
-    # TODO (syang) update the allowed_clouds here
+
     try:
         common_utils.validate_schema(
             config,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -477,7 +477,12 @@ def override_skypilot_config(
         override_configs=dict(override_configs),
         allowed_override_keys=None,
         disallowed_override_keys=constants.SKIPPED_CLIENT_OVERRIDE_KEYS)
-    # TODO error out if workspace does not exist
+    workspace = config.get_nested(keys=('active_workspace',),
+                                  default_value=None)
+    if workspace and workspace not in get_nested(keys=('workspaces',),
+                                                 default_value={}):
+        raise ValueError(f'Workspace {workspace} does not exist. '
+                         'Please check your config and try again.')
     try:
         common_utils.validate_schema(
             config,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -231,7 +231,7 @@ def get_nested(keys: Tuple[str, ...],
 
 def get_workspace_cloud(cloud: str) -> config_utils.Config:
     """Returns the workspace config."""
-    current_workspace = _dict.get('workspace', None)
+    current_workspace = get_active_workspace()
     if current_workspace is None:
         return config_utils.Config()
     clouds = _dict.get_nested(keys=(
@@ -244,8 +244,8 @@ def get_workspace_cloud(cloud: str) -> config_utils.Config:
     return clouds.get(cloud.lower(), config_utils.Config())
 
 
-def get_workspace() -> str:
-    return _dict.get_nested(keys=('workspace',), default_value='default')
+def get_active_workspace() -> str:
+    return _dict.get_nested(keys=('active_workspace',), default_value='default')
 
 
 def set_nested(keys: Tuple[str, ...], value: Any) -> Dict[str, Any]:
@@ -477,7 +477,7 @@ def override_skypilot_config(
         override_configs=dict(override_configs),
         allowed_override_keys=None,
         disallowed_override_keys=constants.SKIPPED_CLIENT_OVERRIDE_KEYS)
-
+    # TODO error out if workspace does not exist
     try:
         common_utils.validate_schema(
             config,

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1043,6 +1043,42 @@ def get_config_schema():
 
     workspace_schema = {'type': 'string'}
 
+    workspaces_schema = {
+        'type': 'object',
+        'required': [],
+        # each key is a workspace name
+        'additionalProperties': {
+            'type': 'array',
+            'items': {
+                'anyOf': [
+                    {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            # TODO (syang) add more properties
+                            'gcp': {
+                                'type': 'object',
+                                'properties': {
+                                    'project_id': {
+                                        'type': 'string'
+                                    },
+                                    'disabled': {
+                                        'type': 'boolean'
+                                    }
+                                },
+                            },
+                        },
+                    },
+                    {
+                        'type': 'string',
+                        'case_insensitive_enum': list(
+                            service_catalog.ALL_CLOUDS) + ['cloudflare']
+                    },
+                ],
+            }
+        },
+    }
+
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update({
@@ -1066,45 +1102,7 @@ def get_config_schema():
             'nvidia_gpus': gpu_configs,
             'api_server': api_server,
             'workspace': workspace_schema,
+            'workspaces': workspaces_schema,
             **cloud_configs,
-        },
-    }
-
-
-def get_workspace_schema():
-    # pylint: disable=import-outside-toplevel
-    from sky.clouds import service_catalog
-
-    return {
-        '$schema': 'https://json-schema.org/draft/2020-12/schema',
-        'type': 'object',
-        'required': [],
-        # each key is a workspace name
-        'additionalProperties': {
-            'type': 'array',
-            'items': {
-                'anyOf': [
-                    {
-                        'type': 'object',
-                        'additionalProperties': False,
-                        'properties': {
-                            # TODO (syang) add more properties
-                            'gcp': {
-                                'type': 'object',
-                                'properties': {
-                                    'project_id': {
-                                        'type': 'string'
-                                    }
-                                },
-                            },
-                        },
-                    },
-                    {
-                        'type': 'string',
-                        'case_insensitive_enum': list(
-                            service_catalog.ALL_CLOUDS) + ['cloudflare']
-                    },
-                ],
-            }
         },
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1048,34 +1048,31 @@ def get_config_schema():
         'required': [],
         # each key is a workspace name
         'additionalProperties': {
-            'type': 'array',
-            'items': {
-                'anyOf': [
-                    {
-                        'type': 'object',
-                        'additionalProperties': False,
-                        'properties': {
-                            # TODO (syang) add more properties
-                            'gcp': {
-                                'type': 'object',
-                                'properties': {
-                                    'project_id': {
-                                        'type': 'string'
-                                    },
-                                    'disabled': {
-                                        'type': 'boolean'
-                                    }
-                                },
-                            },
+            'type': 'object',
+            'additionalProperties': False,
+            'patternProperties': {
+                '^[a-z]+$': {
+                    'type': 'object',
+                    'properties': {
+                        'disabled': {
+                            'type': 'boolean'
+                        }
+                    },
+                },
+            },
+            'properties': {
+                'gcp': {
+                    'type': 'object',
+                    'properties': {
+                        'project_id': {
+                            'type': 'string'
                         },
+                        'disabled': {
+                            'type': 'boolean'
+                        }
                     },
-                    {
-                        'type': 'string',
-                        'case_insensitive_enum': list(
-                            service_catalog.ALL_CLOUDS) + ['cloudflare']
-                    },
-                ],
-            }
+                },
+            },
         },
     }
 

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1041,6 +1041,8 @@ def get_config_schema():
         }
     }
 
+    workspace_schema = {'type': 'string'}
+
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update({
@@ -1063,6 +1065,46 @@ def get_config_schema():
             'docker': docker_configs,
             'nvidia_gpus': gpu_configs,
             'api_server': api_server,
+            'workspace': workspace_schema,
             **cloud_configs,
+        },
+    }
+
+
+def get_workspace_schema():
+    # pylint: disable=import-outside-toplevel
+    from sky.clouds import service_catalog
+
+    return {
+        '$schema': 'https://json-schema.org/draft/2020-12/schema',
+        'type': 'object',
+        'required': [],
+        # each key is a workspace name
+        'additionalProperties': {
+            'type': 'array',
+            'items': {
+                'anyOf': [
+                    {
+                        'type': 'object',
+                        'additionalProperties': False,
+                        'properties': {
+                            # TODO (syang) add more properties
+                            'gcp': {
+                                'type': 'object',
+                                'properties': {
+                                    'project_id': {
+                                        'type': 'string'
+                                    }
+                                },
+                            },
+                        },
+                    },
+                    {
+                        'type': 'string',
+                        'case_insensitive_enum': list(
+                            service_catalog.ALL_CLOUDS) + ['cloudflare']
+                    },
+                ],
+            }
         },
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1098,7 +1098,7 @@ def get_config_schema():
             'docker': docker_configs,
             'nvidia_gpus': gpu_configs,
             'api_server': api_server,
-            'workspace': workspace_schema,
+            'active_workspace': workspace_schema,
             'workspaces': workspaces_schema,
             **cloud_configs,
         },

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1043,6 +1043,8 @@ def get_config_schema():
 
     workspace_schema = {'type': 'string'}
 
+    allowed_workspace_names = list(service_catalog.ALL_CLOUDS) + ['cloudflare']
+    allowed_workspace_regex = '|'.join(allowed_workspace_names)
     workspaces_schema = {
         'type': 'object',
         'required': [],
@@ -1051,7 +1053,7 @@ def get_config_schema():
             'type': 'object',
             'additionalProperties': False,
             'patternProperties': {
-                '^[a-z]+$': {
+                allowed_workspace_regex: {
                     'type': 'object',
                     'properties': {
                         'disabled': {

--- a/tests/test_global_user_state.py
+++ b/tests/test_global_user_state.py
@@ -9,4 +9,4 @@ import sky
 def test_enabled_clouds_empty():
     # In test environment, no cloud should be enabled.
     assert sky.global_user_state.get_cached_enabled_clouds(
-        sky.clouds.cloud.CloudCapability.COMPUTE) == []
+        sky.clouds.cloud.CloudCapability.COMPUTE, workspace='default') == []


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Sample server-side config:
```
workspaces:
  my_workspace:
    gcp:
      project_id: <project>
      disabled: true
    aws:
      disabled: true
    fluidstack:
      disabled: true
```

Sample client-side config:
```
...
active_workspace: my_workspace
```

If no workspace is specified, `default` workspace is used.

Enabled clouds are now cached per workspace.

If a non-default workspace is specified and the corresponding workspace does not exist in the server, request errors out.

Each workspace can disable a cloud specified in `allowed_clouds` using `disabled` field.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
