### PR TITLE
Optimize the throughput of websocket proxy

### DIFF
--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -82,7 +82,7 @@ async def stdin_to_websocket(reader: asyncio.StreamReader,
             # responsiveness since it will return as soon as
             # there is at least one byte.
             # The BUFFER_SIZE is chosen to be large enough to improve
-            # throughput. 
+            # throughput.
             data = await reader.read(BUFFER_SIZE)
             if not data:
                 break

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -16,7 +16,10 @@ from typing import Dict
 from urllib.request import Request
 
 import websockets
+from websockets.asyncio.client import ClientConnection
 from websockets.asyncio.client import connect
+
+BUFFER_SIZE = 2**16  # 64KB
 
 
 def _get_cookie_header(url: str) -> Dict[str, str]:
@@ -51,19 +54,31 @@ async def main(url: str) -> None:
             old_settings = None
 
         try:
-            await asyncio.gather(stdin_to_websocket(websocket),
-                                 websocket_to_stdout(websocket))
+            loop = asyncio.get_running_loop()
+            # Use asyncio.Stream primitives to wrap stdin and stdout, this is to
+            # avoid creating a new thread for each read/write operation
+            # excessively.
+            stdin_reader = asyncio.StreamReader()
+            protocol = asyncio.StreamReaderProtocol(stdin_reader)
+            await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+            transport, protocol = await loop.connect_write_pipe(
+                asyncio.streams.FlowControlMixin, sys.stdout)  # type: ignore
+            stdout_writer = asyncio.StreamWriter(transport, protocol, None,
+                                                 loop)
+
+            await asyncio.gather(stdin_to_websocket(stdin_reader, websocket),
+                                 websocket_to_stdout(websocket, stdout_writer))
         finally:
             if old_settings:
                 termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN,
                                   old_settings)
 
 
-async def stdin_to_websocket(websocket):
+async def stdin_to_websocket(reader: asyncio.StreamReader,
+                             websocket: ClientConnection):
     try:
         while True:
-            data = await asyncio.get_event_loop().run_in_executor(
-                None, sys.stdin.buffer.read, 1)
+            data = await reader.read(BUFFER_SIZE)
             if not data:
                 break
             await websocket.send(data)
@@ -73,13 +88,13 @@ async def stdin_to_websocket(websocket):
         await websocket.close()
 
 
-async def websocket_to_stdout(websocket):
+async def websocket_to_stdout(websocket: ClientConnection,
+                              writer: asyncio.StreamWriter):
     try:
         while True:
             message = await websocket.recv()
-            sys.stdout.buffer.write(message)
-            await asyncio.get_event_loop().run_in_executor(
-                None, sys.stdout.buffer.flush)
+            writer.write(message)
+            await writer.drain()
     except websockets.exceptions.ConnectionClosed:
         print('WebSocket connection closed', file=sys.stderr)
     except Exception as e:  # pylint: disable=broad-except

--- a/sky/templates/websocket_proxy.py
+++ b/sky/templates/websocket_proxy.py
@@ -78,6 +78,11 @@ async def stdin_to_websocket(reader: asyncio.StreamReader,
                              websocket: ClientConnection):
     try:
         while True:
+            # Read at most BUFFER_SIZE bytes, this not affect
+            # responsiveness since it will return as soon as
+            # there is at least one byte.
+            # The BUFFER_SIZE is chosen to be large enough to improve
+            # throughput. 
             data = await reader.read(BUFFER_SIZE)
             if not data:
                 break


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Solve part of #5538 

Benchmark:

```bash
# Master branch
$ rsync -Pav /home/ubuntu/test2/ aylei:/home/sky/
3,735,552   0%   48.31kB/s    6:09:08

# This branch
$ rsync -Pav /home/ubuntu/test2/ aylei:/home/sky/
  1,073,741,824 100%   13.11MB/s    0:01:18 (xfr#1, to-chk=0/2)

# 0.8.0 (with kubectl port-foward as proxy)
  1,073,741,824 100%   43.51MB/s    0:00:23 (xfr#1, to-chk=0/2)
```

The number is still worse than 0.8.0 but much better than master, so I think we can merge this PR first and keep investigating the regression further in the mean time. @Michaelvll @cg505 PTAL

This PR improves the performance of websocket_proxy at client-side by:

1. avoid creating a new thread for every io operation;
2. increase the read buffer size when piping from stdin to the websocket connection, which is the main-bottlenect;

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR, see above 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
