### PR TITLE
[docs] add docs for setting up TCP IAP tunneling

### DIFF
--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -339,7 +339,7 @@ To do so, you can use SkyPilot's global config file ``~/.sky/config.yaml`` to sp
 
 The ``gcp.ssh_proxy_command`` field is optional. If SkyPilot is run on a machine that can directly access the internal IPs of the instances, it can be omitted. Otherwise, it should be set to a command that can be used to proxy SSH connections to the internal IPs of the instances.
 
-Two ways to reach those private hosts from your laptop are supported:
+Here are two ways to enable SkyPilot's access those private hosts:
 
 * **Option 1** – :ref:`SSH proxy / bastion host <gcp-proxy-host>`
 * **Option 2** – :ref:`IAP tunneling (Identity‑Aware Proxy) <gcp-iap-tunnel>`
@@ -381,7 +381,7 @@ Option 2: IAP tunneling
 `IAP TCP forwarding <https://cloud.google.com/iap/docs/using-tcp-forwarding>`__
 creates an authenticated tunnel from your workstation to any private IP inside
 a GCP VPC—no public IP, VPN, or self-managed bastion required. SkyPilot
-implements the `IP-based (destination-group) mode <https://cloud.google.com/iap/docs/tcp-by-host>`__; the per-instance mode is not supported.
+implements the `IP-based (destination-group) mode <https://cloud.google.com/iap/docs/tcp-by-host>`__; the per-instance mode is not supported yet.
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/docs/source/cloud-setup/cloud-permissions/gcp.rst
+++ b/docs/source/cloud-setup/cloud-permissions/gcp.rst
@@ -383,72 +383,96 @@ creates an authenticated tunnel from your workstation to any private IP inside
 a GCP VPC—no public IP, VPN, or self-managed bastion required. SkyPilot
 implements the `IP-based (destination-group) mode <https://cloud.google.com/iap/docs/tcp-by-host>`__; the per-instance mode is not supported yet.
 
-Prerequisites
-^^^^^^^^^^^^^
+Setup
+^^^^^
 * Enable the API once per project:
 
   .. code-block:: console
 
      $ gcloud services enable iap.googleapis.com
 
-* Users launching SkyPilot clusters need **IAP tunnel permissions**.
-  The built-in role ``roles/iap.tunnelResourceAccessor`` on the destination
-  group (or project-wide) is the simplest approach.
-* A **Cloud NAT** gateway exists in every region where you launch
-  internal-only VMs so they can reach the Internet for package installs.
+* This method requires **IAP tunnel permissions**.
+  Adding the built-in role ``roles/iap.tunnelResourceAccessor`` on the destination
+  group (or project-wide) is the simplest approach, in addition to the :ref:`other permissions required by SkyPilot <cloud-permissions-gcp>`.
+* A **Cloud NAT** gateway must exist in every region where you launch
+  internal-only VMs so they can reach the internet for package installs.
   See :ref:`gcp-cloud-nat`.
 
-Automated setup script (per region)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Run the following once for each ``REGION`` × ``VPC`` pair you intend to use:
+The following script can be used to set up IAP tunneling in a specific VPC region:
 
-.. code-block:: bash
+.. dropdown:: Automated setup script (per region)
 
-    #!/usr/bin/env bash
-    # Set your region and VPC.
-    REGION=us-east1        # e.g. us-west1, europe-west4, ...
-    VPC=default            # change if using a custom VPC
+    .. code-block:: bash
 
-    #######################################################################
-    # 1. Cloud NAT (if none exists)                                       #
-    #######################################################################
-    nat_exists=false
-    for r in $(gcloud compute routers list --regions="$REGION" \
-                 --format='value(name)'); do
-      if gcloud compute routers nats list --router="$r" --region="$REGION" \
-             --format='value(name)' | grep -q .; then
-        nat_exists=true
-      fi
-    done
-    if [ "$nat_exists" = false ]; then
-      gcloud compute routers create nat-router --network="$VPC" --region="$REGION"
-      gcloud compute routers nats create nat-config \
-        --router=nat-router --router-region="$REGION" \
-        --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
-    fi
+        #!/usr/bin/env bash
+        # Set your region and VPC.
+        REGION=us-east1        # e.g. us-west1, europe-west4, ...
+        VPC=default            # change if using a custom VPC
 
-    #######################################################################
-    # 2. IAP destination group covering the subnet CIDR                   #
-    #######################################################################
-    CIDR=$(gcloud compute networks subnets list --network="$VPC" \
-             --regions="$REGION" --format='value(ipCidrRange)')
-    gcloud iap tcp dest-groups create "internal-vpc-$VPC" \
-        --region="$REGION" --ip-range-list="$CIDR"
+        #######################################################################
+        # 1. Cloud NAT (if none exists)                                       #
+        #######################################################################
+        nat_exists=false
+        for r in $(gcloud compute routers list --regions="$REGION" \
+                     --format='value(name)'); do
+          if gcloud compute routers nats list --router="$r" --region="$REGION" \
+                 --format='value(name)' | grep -q .; then
+            nat_exists=true
+          fi
+        done
+        if [ "$nat_exists" = false ]; then
+          gcloud compute routers create nat-router --network="$VPC" --region="$REGION"
+          gcloud compute routers nats create nat-config \
+            --router=nat-router --router-region="$REGION" \
+            --nat-all-subnet-ip-ranges --auto-allocate-nat-external-ips
+        fi
 
-    #######################################################################
-    # 3. Show the SkyPilot config snippet                                 #
-    #######################################################################
-    echo "Update your config.yaml to add the new gcp.ssh_proxy_command.$REGION value:"
-    echo
-    cat <<EOF
+        #######################################################################
+        # 2. IAP destination group covering the subnet CIDR                   #
+        #######################################################################
+        CIDR=$(gcloud compute networks subnets list --network="$VPC" \
+                 --regions="$REGION" --format='value(ipCidrRange)')
+        gcloud iap tcp dest-groups create "internal-vpc-$VPC" \
+            --region="$REGION" --ip-range-list="$CIDR"
+
+        #######################################################################
+        # 3. Show the SkyPilot config snippet                                 #
+        #######################################################################
+        echo "Update your config.yaml to add the new gcp.ssh_proxy_command.$REGION value:"
+        echo
+        cat <<EOF
+        gcp:
+          use_internal_ips: true
+          ssh_proxy_command:
+            $REGION: gcloud compute start-iap-tunnel %h %p --listen-on-stdin --region=$REGION --network=$VPC --dest-group=internal-vpc-$VPC
+        EOF
+
+        # Automatically do it
+        read -p 'Automatically update ~/.sky/config.yaml? [y/N] ' choice
+        if echo "$choice" | grep -xqE '[yY]'; then
+          yq -Yi ".gcp.use_internal_ips=true | .gcp.ssh_proxy_command[\"$REGION\"]=\"gcloud compute start-iap-tunnel %h %p --listen-on-stdin --region=$REGION --network=$VPC --dest-group=internal-vpc-$VPC\"" ~/.sky/config.yaml
+        else
+          echo 'Aborting.'
+        fi
+
+    Paste the printed snippet into your ``~/.sky/config.yaml`` (or let the script
+    modify it automatically).
+
+Once the destination group is created, make sure to set the ``ssh_proxy_command`` :ref:`in the SkyPilot config <config-yaml-gcp-ssh-proxy-command>`. For instance, if you have
+
+- destination group: ``internal-vpc-default``
+- region: ``us-east1``
+- VPC: ``default``
+
+you could use this configuration:
+
+.. code-block:: yaml
+
     gcp:
       use_internal_ips: true
       ssh_proxy_command:
-        $REGION: gcloud compute start-iap-tunnel %h %p --listen-on-stdin --region=$REGION --network=$VPC --dest-group=internal-vpc-$VPC
-    EOF
+        us-east1: gcloud compute start-iap-tunnel %h %p --listen-on-stdin --region=us-east1 --network=default --dest-group=internal-vpc-default
 
-Paste the printed snippet into your ``~/.sky/config.yaml`` (or let the script
-modify it automatically).
 
 How it works
 ^^^^^^^^^^^^
@@ -461,7 +485,7 @@ How it works
 
 Troubleshooting
 ^^^^^^^^^^^^^^^
-* *Permission denied / 403* when opening the tunnel → the caller is missing
+* *Permission denied / 403* when opening the tunnel → the caller is missing
   ``roles/iap.tunnelResourceAccessor`` (or an equivalent custom role) on the
   destination group.
 * VM cannot reach the Internet → ensure the Cloud NAT gateway is in **the same


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
https://docs.skypilot.co/en/iap-docs/cloud-setup/cloud-permissions/gcp.html#using-internal-ips


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
