### PR TITLE
[Dashboard] Add vscode connection snippet

### DIFF
--- a/sky/dashboard/src/components/elements/modals.jsx
+++ b/sky/dashboard/src/components/elements/modals.jsx
@@ -94,9 +94,21 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                   Setup SSH access
                 </h3>
                 <Card className="p-3 bg-gray-50">
-                  <pre className="text-sm">
-                    <code>sky status {cluster}</code>
-                  </pre>
+                  <div className="flex items-center justify-between">
+                    <pre className="text-sm">
+                      <code>sky status {cluster}</code>
+                    </pre>
+                    <Tooltip content="Copy command">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => navigator.clipboard.writeText(`sky status ${cluster}`)}
+                        className="h-8 w-8 rounded-full"
+                      >
+                        <CopyIcon className="h-4 w-4" />
+                      </Button>
+                    </Tooltip>
+                  </div>
                 </Card>
               </div>
               <div>
@@ -127,7 +139,7 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                 </h3>
                 <div
                   className={`relative ${isMobile ? '-mt-5' : '-mt-10'}`}
-                  style={{ paddingBottom: '75%' }}
+                  style={{ paddingBottom: '70%' }}
                 >
                   <video
                     className="absolute top-0 left-0 w-full h-full rounded-lg"

--- a/sky/dashboard/src/components/elements/modals.jsx
+++ b/sky/dashboard/src/components/elements/modals.jsx
@@ -104,10 +104,27 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                   Connect with VSCode/Cursor
                 </h3>
                 <Card className="p-3 bg-gray-50">
-                  <pre className="text-sm">
-                    <code>code --remote ssh-remote+{cluster}</code>
-                  </pre>
+                  <div className="flex items-center justify-between">
+                    <pre className="text-sm">
+                      <code>code --remote ssh-remote+{cluster}</code>
+                    </pre>
+                    <Tooltip content="Copy command">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => navigator.clipboard.writeText(`code --remote ssh-remote+${cluster}`)}
+                        className="h-8 w-8 rounded-full"
+                      >
+                        <CopyIcon className="h-4 w-4" />
+                      </Button>
+                    </Tooltip>
+                  </div>
                 </Card>
+              </div>
+              <div>
+                <h3 className="text-sm font-medium">
+                  Or use the GUI to connect
+                </h3>
                 <div
                   className={`relative ${isMobile ? '-mt-5' : '-mt-10'}`}
                   style={{ paddingBottom: '75%' }}

--- a/sky/dashboard/src/components/elements/modals.jsx
+++ b/sky/dashboard/src/components/elements/modals.jsx
@@ -100,9 +100,14 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                 </Card>
               </div>
               <div>
-                <h3 className="text-sm font-medium">
+                <h3 className="text-sm font-medium mb-2 my-2">
                   Connect with VSCode/Cursor
                 </h3>
+                <Card className="p-3 bg-gray-50">
+                  <pre className="text-sm">
+                    <code>code --remote ssh-remote+{cluster}</code>
+                  </pre>
+                </Card>
                 <div
                   className={`relative ${isMobile ? '-mt-5' : '-mt-10'}`}
                   style={{ paddingBottom: '75%' }}

--- a/sky/dashboard/src/components/elements/modals.jsx
+++ b/sky/dashboard/src/components/elements/modals.jsx
@@ -102,7 +102,9 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => navigator.clipboard.writeText(`sky status ${cluster}`)}
+                        onClick={() =>
+                          navigator.clipboard.writeText(`sky status ${cluster}`)
+                        }
                         className="h-8 w-8 rounded-full"
                       >
                         <CopyIcon className="h-4 w-4" />
@@ -124,7 +126,11 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => navigator.clipboard.writeText(`code --remote ssh-remote+${cluster}`)}
+                        onClick={() =>
+                          navigator.clipboard.writeText(
+                            `code --remote ssh-remote+${cluster}`
+                          )
+                        }
                         className="h-8 w-8 rounded-full"
                       >
                         <CopyIcon className="h-4 w-4" />


### PR DESCRIPTION
Adds a quick copypaste-able snippet for connecting vscode to remote cluster and fixes a minor padding being too large between the video and the h3. 

Desktop:
<img width="1916" alt="image" src="https://github.com/user-attachments/assets/e1ab218e-ca45-43b9-9826-6d4e917546ee" />

Mobile:
<img width="496" alt="image" src="https://github.com/user-attachments/assets/f176c0b7-eb8c-44fe-b40d-2ccd2561062c" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
