### PR TITLE
[Core] Support gcp gpu direct tcpx

### DIFF
--- a/examples/gcp_gpu_direct_tcpx/gpu_direct_tcpx.yaml
+++ b/examples/gcp_gpu_direct_tcpx/gpu_direct_tcpx.yaml
@@ -1,0 +1,119 @@
+name: nccl-gpu-direct-tcpx
+
+resources:
+  cloud: gcp
+  instance_type: a3-highgpu-8g
+  image_id: docker:us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx
+
+num_nodes: 2
+
+envs:
+  USE_GPU_DIRECT: "true"
+
+setup: |
+  # Check if the /usr/local/tcpx/lib64/libnccl.so.2 is
+  # present to ensure the user-data script has completed
+  while [ ! -f /usr/local/tcpx/lib64/libnccl.so.2 ]; do
+    echo "Waiting for user-data script to complete"
+    sleep 10
+  done
+  # Remount the directories with exec permissions
+  sudo mount -o remount,exec /usr/local/tcpx/lib64
+  sudo mount -o remount,exec /usr/local/nvidia/lib64
+  sudo mount -o remount,exec /usr/local/nvidia/bin
+
+
+run: |
+  if [ "${SKYPILOT_NODE_RANK}" == "0" ]; then
+    echo "Head node"
+
+    # Total number of processes, NP should be the total number of GPUs in the cluster
+    NP=$(($SKYPILOT_NUM_GPUS_PER_NODE * $SKYPILOT_NUM_NODES))
+
+    # Append :${SKYPILOT_NUM_GPUS_PER_NODE} to each IP as slots
+    nodes=""
+    for ip in $SKYPILOT_NODE_IPS; do
+      nodes="${nodes}${ip}:${SKYPILOT_NUM_GPUS_PER_NODE},"
+    done
+    nodes=${nodes::-1}
+    echo "All nodes: ${nodes}"
+
+    # Set environment variables
+    export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:$PATH
+    export NCCL_SOCKET_IFNAME=eth0
+    export NCCL_CROSS_NIC=0
+    export NCCL_ALGO=Ring
+    export NCCL_PROTO=Simple
+    export NCCL_NSOCKS_PERTHREAD=4
+    export NCCL_SOCKET_NTHREADS=1
+    export NCCL_NET_GDR_LEVEL=PIX
+    export NCCL_DYNAMIC_CHUNK_SIZE=524288
+    export NCCL_P2P_PXN_LEVEL=0    
+    export NCCL_P2P_NET_CHUNKSIZE=524288
+    export NCCL_P2P_PCI_CHUNKSIZE=524288
+    export NCCL_P2P_NVL_CHUNKSIZE=1048576
+    export NCCL_BUFFSIZE=8388608
+    export NCCL_MAX_NCHANNELS=8
+    export NCCL_MIN_NCHANNELS=8
+    export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+    export NCCL_GPUDIRECTTCPX_SOCKET_IFNAME=eth1,eth2,eth3,eth4
+    export NCCL_GPUDIRECTTCPX_CTRL_DEV=eth0
+    export NCCL_GPUDIRECTTCPX_TX_BINDINGS="eth1:8-21,112-125;eth2:8-21,112-125;eth3:60-73,164-177;eth4:60-73,164-177"
+    export NCCL_GPUDIRECTTCPX_RX_BINDINGS="eth1:22-35,126-139;eth2:22-35,126-139;eth3:74-87,178-191;eth4:74-87,178-191"
+    export NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS=50000
+    export NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX="/run/tcpx"
+    export NCCL_GPUDIRECTTCPX_FORCE_ACK=0
+
+    if [ "${USE_GPU_DIRECT}" == "true" ]; then
+      export LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/tcpx/lib64
+    else
+      # Use the default NCCL library
+      export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64
+    fi
+    
+    mpirun \
+      --allow-run-as-root \
+      --tag-output \
+      -H $nodes \
+      -np $NP \
+      -N $SKYPILOT_NUM_GPUS_PER_NODE \
+      -x PATH \
+      -x LD_LIBRARY_PATH \
+      -x NCCL_SOCKET_IFNAME \
+      -x NCCL_CROSS_NIC \
+      -x NCCL_ALGO \
+      -x NCCL_PROTO \
+      -x NCCL_NSOCKS_PERTHREAD \
+      -x NCCL_SOCKET_NTHREADS \
+      -x NCCL_MAX_NCHANNELS \
+      -x NCCL_MIN_NCHANNELS \
+      -x NCCL_DYNAMIC_CHUNK_SIZE \
+      -x NCCL_P2P_NET_CHUNKSIZE \
+      -x NCCL_P2P_PCI_CHUNKSIZE \
+      -x NCCL_P2P_NVL_CHUNKSIZE \
+      -x NCCL_BUFFSIZE \
+      -x CUDA_VISIBLE_DEVICES \
+      -x NCCL_GPUDIRECTTCPX_SOCKET_IFNAME \
+      -x NCCL_GPUDIRECTTCPX_CTRL_DEV \
+      -x NCCL_GPUDIRECTTCPX_TX_BINDINGS \
+      -x NCCL_GPUDIRECTTCPX_RX_BINDINGS \
+      -x NCCL_GPUDIRECTTCPX_PROGRAM_FLOW_STEERING_WAIT_MICROS \
+      -x NCCL_GPUDIRECTTCPX_UNIX_CLIENT_PREFIX \
+      -x NCCL_GPUDIRECTTCPX_FORCE_ACK \
+      -x NCCL_NET_GDR_LEVEL \
+      -x NCCL_P2P_PXN_LEVEL \
+      -x NCCL_DEBUG=INFO -x NCCL_DEBUG_SUBSYS=ENV \
+      --mca btl tcp,self \
+      --mca btl_tcp_if_include eth0 \
+      --mca plm_rsh_args "-p 10022" \
+      /third_party/nccl-tests-mpi/build/all_reduce_perf \
+      -b 8 \
+      -e 2G \
+      -f 2 \
+      -g 1 \
+      -c 1 \
+      -w 5 \
+      -n 20
+  else
+    echo "Worker nodes"
+  fi

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -112,6 +112,66 @@ _DEFAULT_CPU_IMAGE_ID = 'skypilot:custom-cpu-ubuntu-2204'
 # For GPU-related package version, see sky/clouds/service_catalog/images/provisioners/cuda.sh
 _DEFAULT_GPU_IMAGE_ID = 'skypilot:custom-gpu-ubuntu-2204'
 _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
+# Use COS image with GPU Direct support. Need to contact GCP support to build our own image for GPUDirect-TCPX support.
+# https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/machine-learning/a3-highgpu-8g/README.md#before-starting
+_DEFAULT_GPU_DIRECT_IMAGE_ID = 'projects/cos-cloud/global/images/cos-109-17800-519-1'
+
+
+def get_gpu_direct_tcpx_user_data() -> str:
+    return """#!/bin/bash
+    set -e
+    set -x
+    # Install GPU Direct TCPX
+    cos-extensions install gpu -- --version=latest;
+    sudo mount --bind /var/lib/nvidia /var/lib/nvidia;
+    sudo mount -o remount,exec /var/lib/nvidia;
+    docker ps -a | grep -q receive-datapath-manager || \
+    docker run \
+    --detach \
+    --pull=always \
+    --name receive-datapath-manager \
+    --privileged \
+    --cap-add=NET_ADMIN --network=host \
+    --volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 \
+    --device /dev/nvidia0:/dev/nvidia0 --device /dev/nvidia1:/dev/nvidia1 \
+    --device /dev/nvidia2:/dev/nvidia2 --device /dev/nvidia3:/dev/nvidia3 \
+    --device /dev/nvidia4:/dev/nvidia4 --device /dev/nvidia5:/dev/nvidia5 \
+    --device /dev/nvidia6:/dev/nvidia6 --device /dev/nvidia7:/dev/nvidia7 \
+    --device /dev/nvidia-uvm:/dev/nvidia-uvm --device /dev/nvidiactl:/dev/nvidiactl \
+    --env LD_LIBRARY_PATH=/usr/local/nvidia/lib64 \
+    --volume /run/tcpx:/run/tcpx \
+    --entrypoint /tcpgpudmarxd/build/app/tcpgpudmarxd \
+    us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd \
+    --gpu_nic_preset a3vm --gpu_shmem_type fd --uds_path "/run/tcpx" --setup_param "--verbose 128 2 0";
+    sudo iptables -I INPUT -p tcp -m tcp -j ACCEPT;
+    docker run --rm -v /var/lib:/var/lib us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx install --install-nccl;
+    sudo mount --bind /var/lib/tcpx /var/lib/tcpx;
+    sudo mount -o remount,exec /var/lib/tcpx;
+    echo "GPU Direct TCPX installed"
+    """
+
+
+def get_gpu_direct_tcpx_specific_options() -> List[str]:
+    return [
+        '--cap-add=IPC_LOCK',
+        '--userns=host',
+        '--volume /run/tcpx:/run/tcpx',
+        '--volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64',
+        '--volume /var/lib/tcpx/lib64:/usr/local/tcpx/lib64',
+        '--volume /var/lib/nvidia/bin:/usr/local/nvidia/bin',
+        '--shm-size=1g --ulimit memlock=-1 --ulimit stack=67108864',
+        '--device /dev/nvidia0:/dev/nvidia0',
+        '--device /dev/nvidia1:/dev/nvidia1',
+        '--device /dev/nvidia2:/dev/nvidia2',
+        '--device /dev/nvidia3:/dev/nvidia3',
+        '--device /dev/nvidia4:/dev/nvidia4',
+        '--device /dev/nvidia5:/dev/nvidia5',
+        '--device /dev/nvidia6:/dev/nvidia6',
+        '--device /dev/nvidia7:/dev/nvidia7',
+        '--device /dev/nvidia-uvm:/dev/nvidia-uvm',
+        '--device /dev/nvidiactl:/dev/nvidiactl',
+        '--env LD_LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/tcpx/lib64:$LD_LIBRARY_PATH',
+    ]
 
 
 def _run_output(cmd):
@@ -581,6 +641,16 @@ class GCP(clouds.Cloud):
         # Add gVNIC from config
         resources_vars['enable_gvnic'] = skypilot_config.get_nested(
             ('gcp', 'enable_gvnic'), False)
+        enable_gpu_direct = skypilot_config.get_nested(
+            ('gcp', 'enable_gpu_direct'), False)
+        resources_vars['enable_gpu_direct'] = enable_gpu_direct
+        if enable_gpu_direct:
+            # Use COS image with GPU Direct support.
+            resources_vars['image_id'] = _DEFAULT_GPU_DIRECT_IMAGE_ID
+            resources_vars['machine_image'] = None
+            resources_vars['user_data'] = get_gpu_direct_tcpx_user_data()
+            resources_vars[
+                'docker_run_options'] = get_gpu_direct_tcpx_specific_options()
 
         return resources_vars
 

--- a/sky/provision/docker_utils.py
+++ b/sky/provision/docker_utils.py
@@ -331,7 +331,8 @@ class DockerInitializer:
         port = constants.DEFAULT_DOCKER_PORT
         # pylint: disable=anomalous-backslash-in-string
         self._run(
-            f'sudo sed -i "s/#Port 22/Port {port}/" /etc/ssh/sshd_config;'
+            'sudo sed -i "/^Port .*/d" /etc/ssh/sshd_config;'
+            f'sudo echo "Port {port}" >> /etc/ssh/sshd_config;'
             'mkdir -p ~/.ssh;'
             'cat /tmp/host_ssh_authorized_keys >> ~/.ssh/authorized_keys;'
             'sudo service ssh start;'

--- a/sky/provision/gcp/config.py
+++ b/sky/provision/gcp/config.py
@@ -75,6 +75,30 @@ def wait_for_compute_global_operation(project_name, operation, compute):
     return result
 
 
+def wait_for_compute_region_operation(project_name, region, operation, compute):
+    """Poll for region compute operation until finished."""
+    logger.info('wait_for_compute_region_operation: '
+                'Waiting for operation {} to finish...'.format(
+                    operation['name']))
+
+    for _ in range(constants.MAX_POLLS):
+        result = (compute.regionOperations().get(
+            project=project_name,
+            region=region,
+            operation=operation['name'],
+        ).execute())
+        if 'error' in result:
+            raise Exception(result['error'])
+
+        if result['status'] == 'DONE':
+            logger.info('wait_for_compute_region_operation: Operation done.')
+            break
+
+        time.sleep(constants.POLL_INTERVAL)
+
+    return result
+
+
 def _create_crm(gcp_credentials=None):
     return gcp.build('cloudresourcemanager',
                      'v1',
@@ -660,6 +684,53 @@ def get_usable_vpc_and_subnet(
     return usable_vpc_name, usable_subnet
 
 
+def get_gpu_direct_usable_vpcs_and_subnets(
+    region: str,
+    config: common.ProvisionConfig,
+    compute,
+) -> List[Tuple[str, 'google.cloud.compute_v1.types.compute.Subnetwork']]:
+    """Return a list of usable VPCs and subnets for GPU Direct."""
+    project_id = config.provider_config['project_id']
+    vpc_prefix = constants.SKYPILOT_GPU_DIRECT_VPC_PREFIX
+    vpc_subnet_pairs = []
+
+    # TODO(hailong): Determine the num_vpcs per different GPU Direct types
+    num_vpcs = constants.SKYPILOT_GPU_DIRECT_VPC_NUM
+
+    cidr_prefix = constants.SKYPILOT_GPU_DIRECT_VPC_CIDR_PREFIX
+    for i in range(num_vpcs):
+        if i == 0:
+            vpc_name = f'{vpc_prefix}-mgmt-net'
+        else:
+            vpc_name = f'{vpc_prefix}-data-net-{i}'
+        subnet_name = f'{vpc_name}-subnet'
+        subnet_cidr_range = f'{cidr_prefix}.{i}.0/24'
+        # Check if VPC exists
+        vpc_list = _list_vpcnets(project_id, compute, filter=f'name={vpc_name}')
+        if not vpc_list:
+            body = constants.VPC_TEMPLATE.copy()
+            body['mtu'] = 8244
+            body['autoCreateSubnetworks'] = False
+            body['name'] = vpc_name
+            body['selfLink'] = body['selfLink'].format(PROJ_ID=project_id,
+                                                       VPC_NAME=vpc_name)
+            _create_vpcnet(project_id, compute, body)
+        # Check if subnet exists
+        subnets = _list_subnets(project_id, region, compute, network=vpc_name)
+        if not subnets:
+            _create_subnet(project_id, region, compute, vpc_name, subnet_name,
+                           subnet_cidr_range)
+            subnets = _list_subnets(project_id,
+                                    region,
+                                    compute,
+                                    network=vpc_name)
+        # Apply firewall rules
+        _create_rules(project_id, compute, constants.FIREWALL_RULES_TEMPLATE,
+                      vpc_name)
+        vpc_subnet_pairs.append((vpc_name, subnets[0]))
+    return vpc_subnet_pairs
+
+
 def _configure_subnet(region: str, cluster_name: str,
                       config: common.ProvisionConfig, compute):
     """Pick a reasonable subnet if not specified by the config."""
@@ -671,25 +742,50 @@ def _configure_subnet(region: str, cluster_name: str,
     if 'networkInterfaces' in node_config or 'networkConfig' in node_config:
         return config
 
-    # SkyPilot: make sure there's a usable VPC
-    _, default_subnet = get_usable_vpc_and_subnet(cluster_name, region, config,
-                                                  compute)
-
-    default_interfaces = [{
-        'subnetwork': default_subnet['selfLink'],
-        'accessConfigs': [{
-            'name': 'External NAT',
-            'type': 'ONE_TO_ONE_NAT',
-        }]
-    }]
-    # Add gVNIC if specified in config
+    default_interfaces = []
+    enable_gpu_direct = config.provider_config.get('enable_gpu_direct', False)
     enable_gvnic = config.provider_config.get('enable_gvnic', False)
-    if enable_gvnic:
-        default_interfaces[0]['nicType'] = 'gVNIC'
+    if enable_gpu_direct:
+        if not enable_gvnic:
+            raise ValueError('Enable GPU Direct requires gvnic to be enabled')
+        if 'machineType' not in node_config or not node_config[
+                'machineType'] in constants.GPU_DIRECT_TCPX_INSTANCE_TYPES:
+            raise ValueError(
+                'Enable GPU Direct requires machineType to be one of '
+                f'{constants.GPU_DIRECT_TCPX_INSTANCE_TYPES}')
+        logger.info(f'Enable GPU Direct for cluster {cluster_name} '
+                    f'with machineType {node_config["machineType"]}')
+        vpc_subnet_pairs = get_gpu_direct_usable_vpcs_and_subnets(
+            region, config, compute)
+        for _, subnet in vpc_subnet_pairs:
+            default_interfaces.append({
+                'subnetwork': subnet['selfLink'],
+                'accessConfigs': [{
+                    'name': 'External NAT',
+                    'type': 'ONE_TO_ONE_NAT',
+                }],
+                'nicType': 'gVNIC'
+            })
+    else:
+        # SkyPilot: make sure there's a usable VPC
+        _, default_subnet = get_usable_vpc_and_subnet(cluster_name, region,
+                                                      config, compute)
+
+        default_interfaces = [{
+            'subnetwork': default_subnet['selfLink'],
+            'accessConfigs': [{
+                'name': 'External NAT',
+                'type': 'ONE_TO_ONE_NAT',
+            }]
+        }]
+        # Add gVNIC if specified in config
+        if enable_gvnic:
+            default_interfaces[0]['nicType'] = 'gVNIC'
     enable_external_ips = _enable_external_ips(config)
     if not enable_external_ips:
         # Removing this key means the VM will not be assigned an external IP.
-        default_interfaces[0].pop('accessConfigs')
+        for interface in default_interfaces:
+            interface.pop('accessConfigs')
 
     # The not applicable key will be removed during node creation
 
@@ -840,3 +936,19 @@ def _add_iam_policy_binding(service_account, policy, crm, iam):
     ).execute())
 
     return result
+
+
+def _create_subnet(project_id: str, region: str, compute, vpc_name: str,
+                   subnet_name: str, ip_cidr_range: str):
+    body = {
+        'name': subnet_name,
+        'ipCidrRange': ip_cidr_range,
+        'network': f'projects/{project_id}/global/networks/{vpc_name}',
+        'region': region,
+    }
+    operation = compute.subnetworks().insert(project=project_id,
+                                             region=region,
+                                             body=body).execute()
+    response = wait_for_compute_region_operation(project_id, region, operation,
+                                                 compute)
+    return response

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -41,6 +41,13 @@ HAS_TPU_PROVIDER_FIELD = '_has_tpus'
 # with ServiceAccounts.
 
 SKYPILOT_VPC_NAME = 'skypilot-vpc'
+SKYPILOT_GPU_DIRECT_VPC_PREFIX = 'skypilot-gpu-direct-'
+SKYPILOT_GPU_DIRECT_VPC_NUM = 5
+SKYPILOT_GPU_DIRECT_VPC_CIDR_PREFIX = '10.129'
+GPU_DIRECT_TCPX_INSTANCE_TYPES = [
+    'a3-edgegpu-8g',
+    'a3-highgpu-8g',
+]
 
 # Below parameters are from the default VPC on GCP.
 # https://cloud.google.com/vpc/docs/firewalls#more_rules_default_vpc

--- a/sky/templates/gcp-ray.yml.j2
+++ b/sky/templates/gcp-ray.yml.j2
@@ -66,6 +66,9 @@ provider:
 {%- if enable_gvnic %}
   enable_gvnic: {{ enable_gvnic }}
 {%- endif %}
+{%- if enable_gpu_direct %}
+  enable_gpu_direct: {{ enable_gpu_direct }}
+{%- endif %}
 
 auth:
   ssh_user: gcpuser
@@ -144,6 +147,11 @@ available_node_types:
   {%- if gpu is not none %}
           - key: install-nvidia-driver
             value: "True"
+  {%- endif %}
+  {%- if user_data is not none %}
+          - key: user-data
+            value: |-
+              {{ user_data | indent(10) }}
   {%- endif %}
   {%- if use_spot or gpu is not none %}
       scheduling:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -837,6 +837,9 @@ def get_config_schema():
                 'enable_gvnic': {
                     'type': 'boolean'
                 },
+                'enable_gpu_direct': {
+                    'type': 'boolean'
+                },
                 'vpc_name': {
                     'oneOf': [
                         {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support GCP GPUDirec-TCPX with `a3-highgpu-8g` or `a3-edgegpu-8g` VMs

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Run NCCL test with GPUDirec-TCPX `sky launch -c tcpx --cloud gcp gpu_direct_tcpx.yaml`
  - Run NCCL test without GPUDirec-TCPX `sky launch -c no_tcpx --env USE_GPU_DIRECT=false --cloud gcp gpu_direct_tcpx.yaml`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

TODO:
- [ ] Delete the subnets when failover occurs during provisioning
- [ ] Support placement group
- [ ] Support VM runtime
- [ ] Docs and readme for the new example
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
