### PR TITLE
[docker] update docker login creds when relaunching cluster

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4720,12 +4720,15 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
             # Docker login should always be the same for all resources, since
             # it's set from envs.
             for resource in task.resources:
-                assert resource._docker_login_config == one_task_resource._docker_login_config
+                assert (resource.docker_login_config ==
+                        one_task_resource.docker_login_config), (
+                            resource.docker_login_config,
+                            one_task_resource.docker_login_config)
             # If we have docker login config in the new task, override the
             # existing resources to pick up new credentials.
-            if one_task_resource._docker_login_config is not None:
+            if one_task_resource.docker_login_config is not None:
                 to_provision = to_provision.copy(
-                    _docker_login_config=one_task_resource._docker_login_config)
+                    _docker_login_config=one_task_resource.docker_login_config)
             return RetryingVmProvisioner.ToProvisionConfig(
                 cluster_name,
                 to_provision,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4725,7 +4725,10 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                             resource.docker_login_config,
                             one_task_resource.docker_login_config)
             # If we have docker login config in the new task, override the
-            # existing resources to pick up new credentials.
+            # existing resources to pick up new credentials. This allows the
+            # user to specify new or fixed credentials if the existing
+            # credentials are not working. If we don't do this, the credentials
+            # from the existing resources will always be reused.
             if one_task_resource.docker_login_config is not None:
                 to_provision = to_provision.copy(
                     _docker_login_config=one_task_resource.docker_login_config)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -500,6 +500,10 @@ class Resources:
         self._requires_fuse = value
 
     @property
+    def docker_login_config(self) -> Optional[docker_utils.DockerLoginConfig]:
+        return self._docker_login_config
+
+    @property
     def docker_username_for_runpod(self) -> Optional[str]:
         return self._docker_username_for_runpod
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If you `sky launch` with new docker credentials on an existing cluster, the cluster resources will now be updated with the new credentials.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
  - [ ] Launch, then change credentials, cluster YAML updated
  - [ ] Cluster fails to start, retry with fixed creds
  - [ ] launch jobs on live cluster with credentials but no docker creds in the launched task
  - [ ] stopped cluster relaunch without creds
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k docker` (CI)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
