### PR TITLE
[Core] Add backward compatibility for instance naming in k8s

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1736,9 +1736,15 @@ class KubernetesInstanceType:
     @staticmethod
     def is_valid_instance_type(name: str) -> bool:
         """Returns whether the given name is a valid instance type."""
+        # Before https://github.com/skypilot-org/skypilot/pull/4756,
+        # the accelerators are appended with format "--{a}{type}",
+        # e.g. "4CPU--16GB--1V100".
+        # Check both patterns to keep backward compatibility.
+        prev_pattern = re.compile(
+            r'^(\d+(\.\d+)?CPU--\d+(\.\d+)?GB)(--\d+\S+)?$')
         pattern = re.compile(
             r'^(\d+(\.\d+)?CPU--\d+(\.\d+)?GB)(--[\w\d-]+:\d+)?$')
-        return bool(pattern.match(name))
+        return bool(pattern.match(name)) or bool(prev_pattern.match(name))
 
     @classmethod
     def _parse_instance_type(
@@ -1755,6 +1761,10 @@ class KubernetesInstanceType:
             r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_type>[\w\d-]+):(?P<accelerator_count>\d+))?$'  # pylint: disable=line-too-long
         )
         match = pattern.match(name)
+        prev_pattern = re.compile(
+            r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+)(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
+        )
+        prev_match = prev_pattern.match(name)
         if match:
             cpus = float(match.group('cpus'))
             memory = float(match.group('memory'))
@@ -1764,6 +1774,18 @@ class KubernetesInstanceType:
                 accelerator_count = int(accelerator_count)
                 # This is to revert the accelerator types with spaces back to
                 # the original format.
+                accelerator_type = str(accelerator_type).replace('_', ' ')
+            else:
+                accelerator_count = None
+                accelerator_type = None
+            return cpus, memory, accelerator_count, accelerator_type
+        elif prev_match:
+            cpus = float(prev_match.group('cpus'))
+            memory = float(prev_match.group('memory'))
+            accelerator_count = prev_match.group('accelerator_count')
+            accelerator_type = prev_match.group('accelerator_type')
+            if accelerator_count:
+                accelerator_count = int(accelerator_count)
                 accelerator_type = str(accelerator_type).replace('_', ' ')
             else:
                 accelerator_count = None

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1740,6 +1740,7 @@ class KubernetesInstanceType:
         # the accelerators are appended with format "--{a}{type}",
         # e.g. "4CPU--16GB--1V100".
         # Check both patterns to keep backward compatibility.
+        # TODO(romilb): Backward compatibility, remove after 0.11.0.
         prev_pattern = re.compile(
             r'^(\d+(\.\d+)?CPU--\d+(\.\d+)?GB)(--\d+\S+)?$')
         pattern = re.compile(
@@ -1761,6 +1762,7 @@ class KubernetesInstanceType:
             r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_type>[\w\d-]+):(?P<accelerator_count>\d+))?$'  # pylint: disable=line-too-long
         )
         match = pattern.match(name)
+        # TODO(romilb): Backward compatibility, remove after 0.11.0.
         prev_pattern = re.compile(
             r'^(?P<cpus>\d+(\.\d+)?)CPU--(?P<memory>\d+(\.\d+)?)GB(?:--(?P<accelerator_count>\d+)(?P<accelerator_type>\S+))?$'  # pylint: disable=line-too-long
         )
@@ -1779,6 +1781,7 @@ class KubernetesInstanceType:
                 accelerator_count = None
                 accelerator_type = None
             return cpus, memory, accelerator_count, accelerator_type
+        # TODO(romilb): Backward compatibility, remove after 0.11.0.
         elif prev_match:
             cpus = float(prev_match.group('cpus'))
             memory = float(prev_match.group('memory'))

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -58,6 +58,7 @@ def test_kubernetes_instance_type():
     # Before https://github.com/skypilot-org/skypilot/pull/4756, the
     # accelerators are appended with format "--{a}{type}",
     # e.g. "4CPU--16GB--1V100".
+    # TODO(romilb): Backward compatibility, remove after 0.11.0.
     prev_instance_type_name = '4CPU--16GB--1V100'
     assert KubernetesInstanceType.is_valid_instance_type(
         prev_instance_type_name

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -53,3 +53,18 @@ def test_kubernetes_instance_type():
             assert instance_type_from_resources.memory == memory, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
             assert instance_type_from_resources.accelerator_count == accelerator_count, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
             assert instance_type_from_resources.accelerator_type == accelerator_type, f'Failed from resources check for {cpus}, {memory}, {accelerator_count}, {accelerator_type}'
+
+    # Backward compatibility test
+    # Before https://github.com/skypilot-org/skypilot/pull/4756, the
+    # accelerators are appended with format "--{a}{type}",
+    # e.g. "4CPU--16GB--1V100".
+    prev_instance_type_name = '4CPU--16GB--1V100'
+    assert KubernetesInstanceType.is_valid_instance_type(
+        prev_instance_type_name
+    ), f'Failed valid instance type check for {prev_instance_type_name}'
+    cpus, memory, accelerator_count, accelerator_type = KubernetesInstanceType._parse_instance_type(
+        prev_instance_type_name)
+    assert cpus == 4, f'Failed parse check for {prev_instance_type_name}'
+    assert memory == 16, f'Failed parse check for {prev_instance_type_name}'
+    assert accelerator_count == 1, f'Failed parse check for {prev_instance_type_name}'
+    assert accelerator_type == 'V100', f'Failed parse check for {prev_instance_type_name}'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fix https://github.com/skypilot-org/skypilot/issues/5574
Add backward compatibility for instance naming in k8s

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - sky launch/exec with new clusters
  - sky launch/exec/status/queue/down with old clusters
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
