### PR TITLE
Bump image tag in helm default values

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -243,6 +243,7 @@ jobs:
           echo "Updating __version__ in sky/__init__.py and Dockerfile to ${RELEASE_VERSION}..."
           sed -i "s/__version__ = '.*'/__version__ = '${RELEASE_VERSION}'/g" sky/__init__.py
           sed -i "s/skypilot-nightly\[all\]/skypilot[all]==${RELEASE_VERSION}/g" Dockerfile
+          sed -i "s/image: berkeleyskypilot\/skypilot:.*/image: berkeleyskypilot\/skypilot:${RELEASE_VERSION}/g" charts/skypilot/values.yaml
 
           # Create the test branch from the *current* state (base branch with version bump)
           TEST_BRANCH="test_releases/${RELEASE_VERSION}"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -253,6 +253,7 @@ jobs:
           # Commit the version change on the new test branch
           git add sky/__init__.py
           git add Dockerfile
+          git add charts/skypilot/values.yaml
           git commit -m "Release ${RELEASE_VERSION}"
 
           # Get the new commit SHA from the test branch


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5503

The tag will be eventually replaced with the release version in the publish-helm workflow: https://github.com/skypilot-org/skypilot/blob/f40f78e27b076a2171f209d87db4c34758abf92b/.github/workflows/publish-helm.yml#L106

So this is no relevant to release, update the tag just to:

1. avoid confusion;
2. in case some users install the helm chart from source code

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually with the new bash command
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
