### PR TITLE
Fix fetch gcp timeout error

### DIFF
--- a/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
+++ b/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py
@@ -554,7 +554,7 @@ def _get_tpu_response_for_zone(zone: str) -> list:
     # Sometimes the response is empty ({}) even for enabled zones. Here we
     # retry the request for a few times.
     backoff = common_utils.Backoff(initial_backoff=1)
-    for _ in range(TPU_RETRY_CNT):
+    for retry_cnt in range(TPU_RETRY_CNT):
         tpus_request = (
             tpu_client.projects().locations().acceleratorTypes().list(
                 parent=parent))
@@ -570,6 +570,10 @@ def _get_tpu_response_for_zone(zone: str) -> list:
                 print(f'  An error occurred: {error}')
             # If error happens, fail early.
             return []
+        except TimeoutError:
+            print(f'  TimeoutError: Failed to fetch TPUs for zone {zone!r}, '
+                  f'retry {retry_cnt + 1} of {TPU_RETRY_CNT}')
+
         time_to_sleep = backoff.current_backoff()
         print(f'  Retry zone {zone!r} in {time_to_sleep} seconds...')
         time.sleep(time_to_sleep)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Recently we got this error on catalog syncing, see [log](https://github.com/skypilot-org/skypilot-catalog/actions/runs/15006877021/job/42169564439): 

```bash
Traceback (most recent call last):
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 787, in <module>
    catalog_df = get_catalog_df(region_prefix_filter)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 737, in get_catalog_df
    tpu_df = get_tpu_df(gcp_skus, gcp_tpu_skus)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 619, in get_tpu_df
    df = _get_tpus()
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 608, in _get_tpus
    all_tpu_dfs = [_get_tpu_for_zone(zone) for zone in zones]
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 608, in <listcomp>
    all_tpu_dfs = [_get_tpu_for_zone(zone) for zone in zones]
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 588, in _get_tpu_for_zone
    for tpu in _get_tpu_response_for_zone(zone):
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/sky/clouds/service_catalog/data_fetchers/fetch_gcp.py", line 562, in _get_tpu_response_for_zone
    tpus_response = tpus_request.execute()
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/googleapiclient/_helpers.py", line 130, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/googleapiclient/http.py", line 923, in execute
    resp, content = _retry_request(
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/googleapiclient/http.py", line 222, in _retry_request
    raise exception
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/googleapiclient/http.py", line 191, in _retry_request
    resp, content = http.request(uri, method, *args, **kwargs)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/google_auth_httplib2.py", line 218, in request
    response, content = self.http.request(
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/httplib2/__init__.py", line 1724, in request
    (response, content) = self._request(
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/httplib2/__init__.py", line 1444, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/home/runner/catalogs-venv/lib/python3.10/site-packages/httplib2/__init__.py", line 1396, in _conn_request
    response = conn.getresponse()
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/http/client.py", line 1375, in getresponse
    response.begin()
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/http/client.py", line 318, in begin
    version, status, reason = self._read_status()
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/http/client.py", line 279, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/socket.py", line 717, in readinto
    return self._sock.recv_into(b)
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/ssl.py", line 1307, in recv_into
    return self.read(nbytes, buffer)
  File "/home/runner/.local/share/uv/python/cpython-3.10.17-linux-x86_64-gnu/lib/python3.10/ssl.py", line 1163, in read
    return self._sslobj.read(len, buffer)
TimeoutError: The read operation timed out
```

Reproduce code:

```python
import google.auth
from googleapiclient import discovery

creds, project_id = google.auth.default()

tpu_client = discovery.build('tpu', 'v1')
tpus_request = tpu_client.projects().locations().acceleratorTypes().list(
    parent=f'projects/{project_id}/locations/us-east1-b')
tpus_response = tpus_request.execute()
print(tpus_response)
```

It seems the Google API only times out in the us-east1-b region. According to Google's [TPU regions documentation](https://cloud.google.com/tpu/docs/regions-zones#us), TPU isn't supported in us-east1-b. Therefore, it's safe to skip this error to fix the CI failure.


Other strategies tried but not working:

- ❌ Increase SSL timeout  
- ❌ Recreate TPU client on SSL error


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - [x] `python -u -m sky.clouds.service_catalog.data_fetchers.fetch_gcp --all-regions --single-threaded`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
