### PR TITLE
[config] re-check clouds if list of allowed clouds changed

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -13,6 +13,7 @@ import colorama
 from sky import clouds as sky_clouds
 from sky import exceptions
 from sky import global_user_state
+from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import cloudflare
 from sky.clouds import cloud as sky_cloud
@@ -23,6 +24,8 @@ from sky.utils import ux_utils
 
 CHECK_MARK_EMOJI = '\U00002714'  # Heavy check mark unicode
 PARTY_POPPER_EMOJI = '\U0001F389'  # Party popper unicode
+
+logger = sky_logging.init_logger(__name__)
 
 
 def check_capabilities(
@@ -233,11 +236,23 @@ def get_cached_enabled_clouds_or_refresh(
         exceptions.NoCloudAccessError: if no public cloud is enabled and
             raise_if_no_cloud_access is set to True.
     """
+    allowed_clouds_changed = False
+    cached_allowed_clouds = global_user_state.get_allowed_clouds()
+    skypilot_config_allowed_clouds = skypilot_config.get_nested(
+        ('allowed_clouds',), [])
+    if sorted(cached_allowed_clouds) != sorted(skypilot_config_allowed_clouds):
+        logger.debug(f'Allowed clouds changed from {cached_allowed_clouds} '
+                     f'to {skypilot_config_allowed_clouds}')
+        allowed_clouds_changed = True
+
     cached_enabled_clouds = global_user_state.get_cached_enabled_clouds(
         capability)
-    if not cached_enabled_clouds:
+    if not cached_enabled_clouds or allowed_clouds_changed:
         try:
             check_capability(sky_cloud.CloudCapability.COMPUTE, quiet=True)
+            if allowed_clouds_changed:
+                global_user_state.set_allowed_clouds(
+                    skypilot_config_allowed_clouds)
         except SystemExit:
             # If no cloud is enabled, check() will raise SystemExit.
             # Here we catch it and raise the exception later only if

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -33,6 +33,7 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 _ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds_'
+_ALLOWED_CLOUDS_KEY = 'allowed_clouds'
 
 _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
@@ -838,6 +839,20 @@ def set_enabled_clouds(enabled_clouds: List[str],
 
 def _get_capability_key(cloud_capability: 'cloud.CloudCapability') -> str:
     return _ENABLED_CLOUDS_KEY_PREFIX + cloud_capability.value
+
+
+def get_allowed_clouds() -> List[str]:
+    rows = _DB.cursor.execute('SELECT value FROM config WHERE key = ?',
+                              (_ALLOWED_CLOUDS_KEY,))
+    for (value,) in rows:
+        return json.loads(value)
+    return []
+
+
+def set_allowed_clouds(allowed_clouds: List[str]) -> None:
+    _DB.cursor.execute('INSERT OR REPLACE INTO config VALUES (?, ?)',
+                       (_ALLOWED_CLOUDS_KEY, json.dumps(allowed_clouds)))
+    _DB.conn.commit()
 
 
 def add_or_update_storage(storage_name: str,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Resolves https://github.com/skypilot-org/skypilot/issues/4487

This PR invalidates cached enabled cloud entries if `allowed_clouds` list changed.

This PR only works if we assume `allowed_clouds` list changes infrequently. I make this assumption because `allowed_clouds` are set on server side and cannot be overridden by client.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
