### PR TITLE
Remove `test_tpu`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,14 +19,14 @@ Machine learning examples:
 - [**`detectron2_app.yaml`**](./detectron2_app.yaml): Run Detectron2 on a V100 GPU.
 
 - TPU examples
-  - [**`tpu/tpu_app.yaml`**](./tpu/tpu_app.yaml): Train on a **TPU node** on GCP.  Finetune BERT on Amazon Reviews for sentiment analysis.
+  - [**`tpu/tpu_app.yaml`**](./tpu/tpu_app.yaml): Train on a **TPU VM** on GCP.  Finetune BERT on Amazon Reviews for sentiment analysis.
   - [**`tpu/tpuvm_mnist.yaml`**](./tpu/tpuvm_mnist.yaml): Train on a **TPU VM** on GCP.  Train on MNIST in Flax (based on JAX).
 
-- [**`resnet_app.py`**](./resnet_app.py): ResNet50 training on GPUs, adapted from [tensorflow/tpu](https://github.com/tensorflow/tpu). 
-  
+- [**`resnet_app.py`**](./resnet_app.py): ResNet50 training on GPUs, adapted from [tensorflow/tpu](https://github.com/tensorflow/tpu).
+
     The training data is currently a public, "fake_imagenet" dataset (`gs://cloud-tpu-test-datasets/fake_imagenet`, 70GB).
 
-  
+
 - [**`resnet_distributed_tf_app.py`**](./resnet_distributed_tf_app.py): **Distributed training** variant of the above, via TensorFlow Distributed.
 
 - [**`huggingface_glue_imdb_grid_search_app.py`**](./huggingface_glue_imdb_grid_search_app.py): **Grid search**: run many trials concurrently on the same VM.

--- a/examples/tpu/tpu_app.yaml
+++ b/examples/tpu/tpu_app.yaml
@@ -5,9 +5,6 @@ workdir: ./examples/tpu/tpu_app_code
 
 resources:
   accelerators: tpu-v2-8
-  accelerator_args:
-    runtime_version: 2.12.0
-    tpu_vm: False
 
 # The setup command.  Will be run under the working directory.
 setup: |

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -531,25 +531,6 @@ def test_inferentia():
     smoke_tests_utils.run_one_test(test)
 
 
-# ---------- TPU. ----------
-@pytest.mark.gcp
-@pytest.mark.tpu
-def test_tpu():
-    name = smoke_tests_utils.get_cluster_name()
-    test = smoke_tests_utils.Test(
-        'tpu_app',
-        [
-            f'sky launch -y -c {name} examples/tpu/tpu_app.yaml',
-            f'sky logs {name} 1',  # Ensure the job finished.
-            f'sky logs {name} 1 --status',  # Ensure the job succeeded.
-            f'sky launch -y -c {name} examples/tpu/tpu_app.yaml | grep "TPU .* already exists"',  # Ensure sky launch won't create another TPU.
-        ],
-        f'sky down -y {name}',
-        timeout=30 * 60,  # can take >20 mins
-    )
-    smoke_tests_utils.run_one_test(test)
-
-
 # ---------- TPU VM. ----------
 @pytest.mark.gcp
 @pytest.mark.tpu


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See fail detail in #5562

According to the doc, the [region](https://cloud.google.com/tpu/docs/regions-zones) and [accelerator-type](https://cloud.google.com/tpu/docs/v2) is valid, TPU nodes are still [supported](https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#tpu-node-arch) on v2 and v3, It might be Google's internal change without updating the docs.

```bash
gcloud compute tpus create t-tpu-97-a5bbd67e --project=sky-dev-465 --zone=us-central1-b --version=2.12.0 --accelerator-type=v2-8 --network=default
ERROR: (gcloud.compute.tpus.create) FAILED_PRECONDITION: Your request to provision TPU Node has been denied. Please migrate to TPU VM Architecture or contact Cloud TPU team to gain TPU Node access. https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#from-tpu-node-to-tpu-vm
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
