### PR TITLE
Pin click version for correct argument parsing

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -12,7 +12,10 @@ install_requires = [
     'wheel<0.46.0',  # https://github.com/skypilot-org/skypilot/issues/5153
     'cachetools',
     # NOTE: ray requires click>=7.0.
-    'click >= 7.0',
+    # click 8.2.0 has a bug in parsing the command line arguments:
+    # https://github.com/skypilot-org/skypilot/issues/5596
+    # TODO(aylei): remove this once the bug is fixed in click.
+    'click == 8.1.7',
     'colorama',
     'cryptography',
     # Jinja has a bug in older versions because of the lack of pinning

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -15,7 +15,7 @@ install_requires = [
     # click 8.2.0 has a bug in parsing the command line arguments:
     # https://github.com/skypilot-org/skypilot/issues/5596
     # TODO(aylei): remove this once the bug is fixed in click.
-    'click == 8.1.7',
+    'click >= 7.0, < 8.2.0',
     'colorama',
     'cryptography',
     # Jinja has a bug in older versions because of the lack of pinning

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -13,7 +13,7 @@ install_requires = [
     'cachetools',
     # NOTE: ray requires click>=7.0.
     # click 8.2.0 has a bug in parsing the command line arguments:
-    # https://github.com/skypilot-org/skypilot/issues/5596
+    # https://github.com/pallets/click/issues/2894
     # TODO(aylei): remove this once the bug is fixed in click.
     'click >= 7.0, < 8.2.0',
     'colorama',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5596

Test:

```
$ pip install click==8.2.0
...
$ pip install -e ".[all]"
....
Installing collected packages: click, skypilot
  Attempting uninstall: click
    Found existing installation: click 8.2.0
    Uninstalling click-8.2.0:
      Successfully uninstalled click-8.2.0
  Attempting uninstall: skypilot
    Found existing installation: skypilot 1.0.0.dev0
    Uninstalling skypilot-1.0.0.dev0:
      Successfully uninstalled skypilot-1.0.0.dev0
Successfully installed click-8.1.8 skypilot-1.0.0.dev0

$ sky api start --deploy
Failed to connect to SkyPilot API server at http://0.0.0.0:46580. Starting a local server.
✓ SkyPilot API server started.
├── SkyPilot API server: http://0.0.0.0:46580 Dashboard: http://0.0.0.0:46580/dashboard
└── View API server logs at: ~/.sky/api_server/server.log
```

Users of old version:

1. Ask them to run `pip install click==8.1.8`
2. Ask them to upgrade to latest nightly

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] See above
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
