### PR TITLE
[API server] support for specifying lambda credential in helm deployment

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -232,7 +232,7 @@ spec:
           if [ -n "$LAMBDA_API_KEY" ]; then
             echo "Lambda credentials found in environment variable."
             mkdir -p /root/.lambda_cloud
-            echo "api_key = \"$LAMBDA_API_KEY\"" > /root/.lambda_cloud/lambda_keys
+            echo "api_key = $LAMBDA_API_KEY" > /root/.lambda_cloud/lambda_keys
           else
             echo "Lambda credentials not found in environment variables. Skipping credentials setup."
             sleep 600

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -125,6 +125,11 @@ spec:
           mountPath: /root/.runpod
           readOnly: true
         {{- end }}
+        {{- if .Values.lambdaCredentials.enabled }}
+        - name: lambda-config
+          mountPath: /root/.lambda_cloud
+          readOnly: true
+        {{- end }}
       initContainers:
       {{- if .Values.awsCredentials.enabled }}
       - name: create-aws-credentials
@@ -213,6 +218,35 @@ spec:
         - name: runpod-config
           mountPath: /root/.runpod
       {{- end }}
+      {{- if .Values.lambdaCredentials.enabled }}
+      - name: create-lambda-credentials
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        image: {{ .Values.apiService.image }}
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          echo "Setting up Lambda credentials..."
+          if [ -n "$LAMBDA_API_KEY" ]; then
+            echo "Lambda credentials found in environment variable."
+            mkdir -p /root/.lambda_cloud
+            echo "api_key = \"$LAMBDA_API_KEY\"" > /root/.lambda_cloud/lambda_keys
+          else
+            echo "Lambda credentials not found in environment variables. Skipping credentials setup."
+            sleep 600
+          fi
+        env:
+        - name: LAMBDA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.lambdaCredentials.lambdaSecretName }}
+              key: api_key
+        volumeMounts:
+        - name: lambda-config
+          mountPath: /root/.lambda_cloud
+      {{- end }}
       volumes:
       {{- if .Values.storage.enabled }}
       - name: state-volume
@@ -235,6 +269,10 @@ spec:
       {{- end }}
       {{- if .Values.runpodCredentials.enabled }}
       - name: runpod-config
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.lambdaCredentials.enabled }}
+      - name: lambda-config
         emptyDir: {}
       {{- end }}
       {{- if .Values.kubernetesCredentials.useKubeconfig }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -47,7 +47,7 @@ apiService:
     limits:
       cpu: "4"
       memory: "8Gi"
-  
+
   # [Internal] Enable developer mode for SkyPilot
   skypilotDev: false
 
@@ -214,6 +214,12 @@ runpodCredentials:
   enabled: false
   # Name of the secret containing the RunPod credentials. Only used if enabled is true.
   runpodSecretName: runpod-credentials
+
+# Populate Lambda credentials from the secret with key `api_key`
+lambdaCredentials:
+  enabled: false
+  # Name of the secret containing the Lambda credentials. Only used if enabled is true.
+  lambdaSecretName: lambda-credentials
 
 # Set securityContext for the api pod
 podSecurityContext: {}

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -348,6 +348,27 @@ Following tabs describe how to configure credentials for different clouds on the
 
         When installing or upgrading the Helm chart, enable Lambda credentials by setting ``lambdaCredentials.enabled=true``
 
+        .. code-block:: bash
+
+            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+              --namespace $NAMESPACE \
+              # keep the Helm chart values set in the previous step
+              --reuse-values \
+              --set lambdaCredentials.enabled=true
+
+        .. dropdown:: Use existing Lambda credentials
+
+            You can also set the following values to use a secret that already contains your Lambda credentials:
+
+            .. code-block:: bash
+
+                # TODO: replace with your secret name
+                helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+                    --namespace $NAMESPACE \
+                    --reuse-values \
+                    --set lambdaCredentials.enabled=true \
+                    --set lambdaCredentials.lambdaSecretName=your_secret_name
+
     .. tab-item:: Other clouds
         :sync: other-clouds-tab
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -333,6 +333,21 @@ Following tabs describe how to configure credentials for different clouds on the
                     --set runpodCredentials.enabled=true \
                     --set runpodCredentials.runpodSecretName=your_secret_name
 
+    .. tab-item:: Lambda
+        :sync: lambda-creds-tab
+
+        SkyPilot API server use **API key** to authenticate with Lambda. To configure Lambda access, go to the `API Keys <https://cloud.lambda.ai/api-keys/cloud-api>`_ page on your Lambda Cloud console and generate an **API key**.
+
+        Once the key is generated, create a Kubernetes secret to store it:
+
+        .. code-block:: bash
+
+            kubectl create secret generic lambda-credentials \
+              --namespace $NAMESPACE \
+              --from-literal api_key=YOUR_API_KEY
+
+        When installing or upgrading the Helm chart, enable Lambda credentials by setting ``lambdaCredentials.enabled=true``
+
     .. tab-item:: Other clouds
         :sync: other-clouds-tab
 

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -336,7 +336,7 @@ Following tabs describe how to configure credentials for different clouds on the
     .. tab-item:: Lambda
         :sync: lambda-creds-tab
 
-        SkyPilot API server use **API key** to authenticate with Lambda. To configure Lambda access, go to the `API Keys <https://cloud.lambda.ai/api-keys/cloud-api>`_ page on your Lambda Cloud console and generate an **API key**.
+        SkyPilot API server uses an **API key** to authenticate with Lambda. To configure Lambda access, go to the `API Keys <https://cloud.lambda.ai/api-keys/cloud-api>`_ page on your Lambda Cloud console and generate an **API key**.
 
         Once the key is generated, create a Kubernetes secret to store it:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Docs page: https://docs.skypilot.co/en/helm-lambda/reference/api-server/api-server-admin-deploy.html#optional-configure-cloud-accounts


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually deploy API server using lambda credential

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
