### PR TITLE
Fix worker exits on duplicate scheduling

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -568,3 +568,8 @@ class JobExitCode(enum.IntEnum):
 
         # Should not hit this case, but included to avoid errors
         return cls.FAILED
+
+
+class RequestAlreadyExistsError(Exception):
+    """Raised when a request is already exists."""
+    pass

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -34,6 +34,7 @@ from typing import Any, Callable, Generator, List, Optional, TextIO, Tuple
 
 import setproctitle
 
+from sky import exceptions
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
@@ -446,7 +447,8 @@ def prepare_request(
                                    cluster_name=request_cluster_name)
 
     if not api_requests.create_if_not_exists(request):
-        raise RuntimeError(f'Request {request_id} already exists.')
+        raise exceptions.RequestAlreadyExistsError(
+            f'Request {request_id} already exists.')
 
     request.log_path.touch()
     return request


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #5609 

follow up: https://github.com/skypilot-org/skypilot/issues/5610

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually tested locally, no error is raised
```
(sky) ➜  skypilot git:(fix-duplicate-scheduling) sky api start --deploy
Failed to connect to SkyPilot API server at http://0.0.0.0:46580. Starting a local server.
✓ SkyPilot API server started.
├── SkyPilot API server: http://0.0.0.0:46580 Dashboard: http://0.0.0.0:46580/dashboard
└── View API server logs at: ~/.sky/api_server/server.log
(sky) ➜  skypilot git:(fix-duplicate-scheduling) cat ~/.sky/api_server/server.log
I 05-17 08:34:23 config.py:143] SkyPilot API server will start 12 server processes with 21 background workers for long requests and will allow at max 22 short requests in parallel.
I 05-17 08:34:23 executor.py:514] Creating shared request queues
I 05-17 08:34:23 mp_queue.py:74] Waiting for request queue, named 'long', to be ready...
I 05-17 08:34:23 mp_queue.py:74] Waiting for request queue, named 'long', to be ready...
I 05-17 08:34:23 mp_queue.py:74] Waiting for request queue, named 'long', to be ready...
I 05-17 08:34:23 mp_queue.py:74] Waiting for request queue, named 'long', to be ready...
I 05-17 08:34:23 executor.py:539] Request queues created
INFO:__main__:Starting SkyPilot API server, workers=12
INFO:     Uvicorn running on http://0.0.0.0:46580 (Press CTRL+C to quit)
INFO:     Started parent process [94605]
I 05-17 08:34:24 server.py:83] Started server process [94633]
I 05-17 08:34:24 on.py:48] Waiting for application startup.
I 05-17 08:34:24 executor.py:493] Queuing request: skypilot-status-refresh-daemon
I 05-17 08:34:24 on.py:62] Application startup complete.
I 05-17 08:34:24 httptools_impl.py:476] 127.0.0.1:55919 - "GET /api/health HTTP/1.1" 200
I 05-17 08:34:24 executor.py:167] [Worker(schedule_type=short)] Submitting request: skypilot-status-refresh-daemon
I 05-17 08:34:24 executor.py:177] [Worker(schedule_type=short)] Submitted request: skypilot-status-refresh-daemon
I 05-17 08:34:25 executor.py:299] Running request skypilot-status-refresh-daemon with pid 9463
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
