### PR TITLE
Cherry-pick: Fix worker exits on duplicate scheduling (#5611)

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -568,3 +568,8 @@ class JobExitCode(enum.IntEnum):
 
         # Should not hit this case, but included to avoid errors
         return cls.FAILED
+
+
+class RequestAlreadyExistsError(Exception):
+    """Raised when a request is already exists."""
+    pass

--- a/sky/server/requests/executor.py
+++ b/sky/server/requests/executor.py
@@ -34,6 +34,7 @@ from typing import Any, Callable, Generator, List, Optional, TextIO, Tuple
 
 import setproctitle
 
+from sky import exceptions
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
@@ -446,7 +447,8 @@ def prepare_request(
                                    cluster_name=request_cluster_name)
 
     if not api_requests.create_if_not_exists(request):
-        raise RuntimeError(f'Request {request_id} already exists.')
+        raise exceptions.RequestAlreadyExistsError(
+            f'Request {request_id} already exists.')
 
     request.log_path.touch()
     return request


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

follow up: https://github.com/skypilot-org/skypilot/pull/5598#issuecomment-2888755388

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
