### PR TITLE
Fix labeling of HA serve controller deployment

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -67,6 +67,9 @@ def is_high_availability_cluster_by_kubectl(
         namespace: Optional[str] = None) -> bool:
     """Check if a cluster is a high availability controller by calling
     `kubectl get deployment`.
+
+    The deployment must have the label `skypilot-cluster-name` set to
+    `cluster_name`.
     """
     try:
         deployment_list = kubernetes.apps_api(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -896,7 +896,8 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 TAG_SKYPILOT_DEPLOYMENT_NAME] = deployment_name
             template_pod_spec['metadata'] = pod_spec_copy['metadata']
             template_pod_spec['spec'].update(pod_spec_copy['spec'])
-            template_pod_spec['metadata']['labels'] = pod_spec_copy['metadata'][
+            # Propagate the labels to the deployment for identification.
+            deployment_spec['metadata']['labels'] = pod_spec_copy['metadata'][
                 'labels']
             try:
                 return kubernetes.apps_api(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -896,7 +896,8 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 TAG_SKYPILOT_DEPLOYMENT_NAME] = deployment_name
             template_pod_spec['metadata'] = pod_spec_copy['metadata']
             template_pod_spec['spec'].update(pod_spec_copy['spec'])
-            template_pod_spec['metadata']['labels'] = pod_spec_copy['metadata']['labels']
+            template_pod_spec['metadata']['labels'] = pod_spec_copy['metadata'][
+                'labels']
             try:
                 return kubernetes.apps_api(
                     context).create_namespaced_deployment(

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -896,6 +896,7 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 TAG_SKYPILOT_DEPLOYMENT_NAME] = deployment_name
             template_pod_spec['metadata'] = pod_spec_copy['metadata']
             template_pod_spec['spec'].update(pod_spec_copy['spec'])
+            template_pod_spec['metadata']['labels'] = pod_spec_copy['metadata']['labels']
             try:
                 return kubernetes.apps_api(
                     context).create_namespaced_deployment(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5618

Tested manually with:

```yaml
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 180  # Use a large delay for EKS LB to be ready
  replicas: 1
  ports: 8080

resources:
  ports:
    - 8080
    - 8081

setup: |
  wget https://raw.githubusercontent.com/skypilot-org/skypilot/refs/heads/master/examples/serve/http_server/server.py

run: |
  python3 server.py --port 8080 &
  python3 server.py --port 8081
```

```yaml
sky serve up serve.yaml -n test
```
<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
