### PR TITLE
[Core] fixed skypilot config mutation in admin policy

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -78,14 +78,12 @@ def optimize(
     # is shown on `sky launch`. The optimizer is also invoked during failover,
     # but we do not apply the admin policy there. We should apply the admin
     # policy in the optimizer, but that will require some refactoring.
-    dag, _ = admin_policy_utils.apply(
-        dag,
-        use_mutated_config_in_current_request=True,
-        request_options=request_options)
-    return optimizer.Optimizer.optimize(dag=dag,
-                                        minimize=minimize,
-                                        blocked_resources=blocked_resources,
-                                        quiet=quiet)
+    with admin_policy_utils.apply_and_use_config_in_current_request(
+            dag, request_options=request_options) as dag:
+        return optimizer.Optimizer.optimize(dag=dag,
+                                            minimize=minimize,
+                                            blocked_resources=blocked_resources,
+                                            quiet=quiet)
 
 
 @usage_lib.entrypoint

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -81,8 +81,7 @@ def launch(
     # Always apply the policy again here, even though it might have been applied
     # in the CLI. This is to ensure that we apply the policy to the final DAG
     # and get the mutated config.
-    dag, mutated_user_config = admin_policy_utils.apply(
-        dag, use_mutated_config_in_current_request=False)
+    dag, mutated_user_config = admin_policy_utils.apply(dag)
     if not dag.is_chain():
         with ux_utils.print_exception_no_traceback():
             raise ValueError('Only single-task or chain DAG is '
@@ -189,6 +188,9 @@ def launch(
             **controller_utils.shared_controller_vars_to_fill(
                 controller,
                 remote_user_config_path=remote_user_config_path,
+                # TODO(aylei): the mutated config will not be updated
+                # afterwards without recreate the controller. Need to
+                # revisit this.
                 local_user_config=mutated_user_config,
             ),
         }

--- a/sky/serve/server/core.py
+++ b/sky/serve/server/core.py
@@ -141,8 +141,7 @@ def up(
     # Always apply the policy again here, even though it might have been applied
     # in the CLI. This is to ensure that we apply the policy to the final DAG
     # and get the mutated config.
-    dag, mutated_user_config = admin_policy_utils.apply(
-        task, use_mutated_config_in_current_request=False)
+    dag, mutated_user_config = admin_policy_utils.apply(task)
     task = dag.tasks[0]
 
     with rich_utils.safe_status(
@@ -352,8 +351,7 @@ def update(
     # and get the mutated config.
     # TODO(cblmemo,zhwu): If a user sets a new skypilot_config, the update
     # will not apply the config.
-    dag, _ = admin_policy_utils.apply(
-        task, use_mutated_config_in_current_request=False)
+    dag, _ = admin_policy_utils.apply(task)
     task = dag.tasks[0]
 
     assert task.service is not None

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -49,6 +49,7 @@ from sky.utils import admin_policy_utils
 from sky.utils import common as common_lib
 from sky.utils import common_utils
 from sky.utils import context
+from sky.utils import context_utils
 from sky.utils import dag_utils
 from sky.utils import env_options
 from sky.utils import status_lib
@@ -327,25 +328,26 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     # pairs.
     logger.debug(f'Validating tasks: {validate_body.dag}')
 
+    context.initialize()
+
     def validate_dag(dag: dag_utils.dag_lib.Dag):
         # TODO: Admin policy may contain arbitrary code, which may be expensive
         # to run and may block the server thread. However, moving it into the
         # executor adds a ~150ms penalty on the local API server because of
         # added RTTs. For now, we stick to doing the validation inline in the
         # server thread.
-        dag, _ = admin_policy_utils.apply(
-            dag, request_options=validate_body.request_options)
-        # Skip validating workdir and file_mounts, as those need to be
-        # validated after the files are uploaded to the SkyPilot API server
-        # with `upload_mounts_to_api_server`.
-        dag.validate(skip_file_mounts=True, skip_workdir=True)
+        with admin_policy_utils.apply_and_use_config_in_current_request(
+                dag, request_options=validate_body.request_options) as dag:
+            # Skip validating workdir and file_mounts, as those need to be
+            # validated after the files are uploaded to the SkyPilot API server
+            # with `upload_mounts_to_api_server`.
+            dag.validate(skip_file_mounts=True, skip_workdir=True)
 
     try:
         dag = dag_utils.load_chain_dag_from_yaml_str(validate_body.dag)
-        loop = asyncio.get_running_loop()
         # Apply admin policy and validate DAG is blocking, run it in a separate
         # thread executor to avoid blocking the uvicorn event loop.
-        await loop.run_in_executor(None, validate_dag, dag)
+        await context_utils.to_thread(validate_dag, dag)
     except Exception as e:  # pylint: disable=broad-except
         raise fastapi.HTTPException(
             status_code=400, detail=exceptions.serialize_exception(e)) from e

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -475,7 +475,7 @@ _reload_config()
 
 def loaded() -> bool:
     """Returns if the user configurations are loaded."""
-    return bool(_get_loaded_config)
+    return bool(_get_loaded_config())
 
 
 @contextlib.contextmanager

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -541,7 +541,7 @@ def override_skypilot_config(
 def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
     """Replaces the global config with the new configs."""
     original_config = _get_loaded_config()
-    _set_loaded_config(config_utils.Config(new_configs))
+    _set_loaded_config(new_configs)
     yield
     _set_loaded_config(original_config)
 

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -52,6 +52,7 @@ import contextlib
 import copy
 import json
 import os
+import tempfile
 import threading
 import typing
 from typing import Any, Dict, Iterator, List, Optional, Tuple
@@ -539,11 +540,37 @@ def override_skypilot_config(
 
 @contextlib.contextmanager
 def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
-    """Replaces the global config with the new configs."""
+    """Replaces the global config with the new configs.
+
+    This function is concurrent safe when it is:
+    1. called in different processes;
+    2. or called in a same process but with different context, refer to
+       sky_utils.context for more details.
+    """
     original_config = _get_loaded_config()
-    _set_loaded_config(new_configs)
-    yield
-    _set_loaded_config(original_config)
+    original_env_var = os.environ.get(ENV_VAR_SKYPILOT_CONFIG)
+    if new_configs != original_config:
+        # Modify the global config of current process or context
+        _set_loaded_config(new_configs)
+        with tempfile.NamedTemporaryFile(delete=False,
+                                         mode='w',
+                                         prefix='mutated-skypilot-config-',
+                                         suffix='.yaml') as temp_file:
+            common_utils.dump_yaml(temp_file.name, dict(**new_configs))
+        # Modify the env var of current process or context so that the
+        # new config will be used by spawned sub-processes.
+        # Note that this code modifies os.environ directly because it
+        # will be hijacked to be context-aware if a context is active.
+        os.environ[ENV_VAR_SKYPILOT_CONFIG] = temp_file.name
+        yield
+        # Restore the original config and env var.
+        _set_loaded_config(original_config)
+        if original_env_var:
+            os.environ[ENV_VAR_SKYPILOT_CONFIG] = original_env_var
+        else:
+            os.environ.pop(ENV_VAR_SKYPILOT_CONFIG, None)
+    else:
+        yield
 
 
 def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -62,6 +62,7 @@ from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import config_utils
+from sky.utils import context
 from sky.utils import schemas
 from sky.utils import ux_utils
 
@@ -105,11 +106,64 @@ ENV_VAR_PROJECT_CONFIG = f'{constants.SKYPILOT_ENV_VAR_PREFIX}PROJECT_CONFIG'
 _GLOBAL_CONFIG_PATH = '~/.sky/config.yaml'
 _PROJECT_CONFIG_PATH = '.sky.yaml'
 
-# The loaded config.
-_dict = config_utils.Config()
-_loaded_config_path: Optional[str] = None
-_config_overridden: bool = False
+
+class ConfigContext:
+
+    def __init__(self,
+                 config: config_utils.Config = config_utils.Config(),
+                 config_path: Optional[str] = None,
+                 config_overridden: bool = False):
+        self.config = config
+        self.config_path = config_path
+        self.config_overridden = config_overridden
+
+
+# The global loaded config.
+_global_config_context = ConfigContext()
 _reload_config_lock = threading.Lock()
+
+
+def _get_config_context() -> ConfigContext:
+    """Get config context for current context.
+
+    If no context is available, the global config context is returned.
+    """
+    ctx = context.get()
+    if not ctx:
+        return _global_config_context
+    if ctx.config_context is None:
+        # Config context for current context is not initialized, inherit from
+        # the global one.
+        ctx.config_context = ConfigContext(
+            config=copy.deepcopy(_global_config_context.config),
+            config_path=_global_config_context.config_path,
+            config_overridden=_global_config_context.config_overridden,
+        )
+    return ctx.config_context
+
+
+def _get_loaded_config() -> config_utils.Config:
+    return _get_config_context().config
+
+
+def _set_loaded_config(config: config_utils.Config) -> None:
+    _get_config_context().config = config
+
+
+def _get_loaded_config_path() -> Optional[str]:
+    return _get_config_context().config_path
+
+
+def _set_loaded_config_path(path: Optional[str]) -> None:
+    _get_config_context().config_path = path
+
+
+def _is_config_overridden() -> bool:
+    return _get_config_context().config_overridden
+
+
+def _set_config_overridden(config_overridden: bool) -> None:
+    _get_config_context().config_overridden = config_overridden
 
 
 def get_user_config_path() -> str:
@@ -224,7 +278,7 @@ def get_nested(keys: Tuple[str, ...],
     Returns:
         The value of the nested key, or 'default_value' if not found.
     """
-    return _dict.get_nested(
+    return _get_loaded_config().get_nested(
         keys,
         default_value,
         override_configs,
@@ -237,14 +291,14 @@ def set_nested(keys: Tuple[str, ...], value: Any) -> Dict[str, Any]:
 
     Like get_nested(), if any key is not found, this will not raise an error.
     """
-    copied_dict = copy.deepcopy(_dict)
+    copied_dict = copy.deepcopy(_get_loaded_config())
     copied_dict.set_nested(keys, value)
     return dict(**copied_dict)
 
 
 def to_dict() -> config_utils.Config:
     """Returns a deep-copied version of the current config."""
-    return copy.deepcopy(_dict)
+    return copy.deepcopy(_get_loaded_config())
 
 
 def _get_config_file_path(envvar: str) -> Optional[str]:
@@ -345,10 +399,9 @@ def _parse_dotlist(dotlist: List[str]) -> config_utils.Config:
 
 
 def _reload_config_from_internal_file(internal_config_path: str) -> None:
-    global _dict, _loaded_config_path
     # Reset the global variables, to avoid using stale values.
-    _dict = config_utils.Config()
-    _loaded_config_path = None
+    _set_loaded_config(config_utils.Config())
+    _set_loaded_config_path(None)
 
     config_path = os.path.expanduser(internal_config_path)
     if not os.path.exists(config_path):
@@ -359,14 +412,13 @@ def _reload_config_from_internal_file(internal_config_path: str) -> None:
                 'exist. Please double check the path or unset the env var: '
                 f'unset {ENV_VAR_SKYPILOT_CONFIG}')
     logger.debug(f'Using config path: {config_path}')
-    _dict = parse_config_file(config_path)
-    _loaded_config_path = config_path
+    _set_loaded_config(parse_config_file(config_path))
+    _set_loaded_config_path(config_path)
 
 
 def _reload_config_as_server() -> None:
-    global _dict
     # Reset the global variables, to avoid using stale values.
-    _dict = config_utils.Config()
+    _set_loaded_config(config_utils.Config())
 
     overrides: List[config_utils.Config] = []
     server_config = get_server_config()
@@ -382,13 +434,12 @@ def _reload_config_as_server() -> None:
         logger.debug(
             f'server config: \n'
             f'{common_utils.dump_yaml_str(dict(overlaid_server_config))}')
-    _dict = overlaid_server_config
+    _set_loaded_config(overlaid_server_config)
 
 
 def _reload_config_as_client() -> None:
-    global _dict
     # Reset the global variables, to avoid using stale values.
-    _dict = config_utils.Config()
+    _set_loaded_config(config_utils.Config())
 
     overrides: List[config_utils.Config] = []
     user_config = get_user_config()
@@ -407,15 +458,15 @@ def _reload_config_as_client() -> None:
         logger.debug(
             f'client config (before task and CLI overrides): \n'
             f'{common_utils.dump_yaml_str(dict(overlaid_client_config))}')
-    _dict = overlaid_client_config
+    _set_loaded_config(overlaid_client_config)
 
 
 def loaded_config_path() -> Optional[str]:
     """Returns the path to the loaded config file, or
     '<overridden>' if the config is overridden."""
-    if _config_overridden:
+    if _is_config_overridden():
         return '<overridden>'
-    return _loaded_config_path
+    return _get_loaded_config_path()
 
 
 # Load on import, synchronization is guaranteed by python interpreter.
@@ -424,21 +475,20 @@ _reload_config()
 
 def loaded() -> bool:
     """Returns if the user configurations are loaded."""
-    return bool(_dict)
+    return bool(_get_loaded_config)
 
 
 @contextlib.contextmanager
 def override_skypilot_config(
         override_configs: Optional[Dict[str, Any]]) -> Iterator[None]:
     """Overrides the user configurations."""
-    global _dict, _config_overridden
     # TODO(SKY-1215): allow admin user to extend the disallowed keys or specify
     # allowed keys.
     if not override_configs:
         # If no override configs (None or empty dict), do nothing.
         yield
         return
-    original_config = _dict
+    original_config = _get_loaded_config()
     override_configs = config_utils.Config(override_configs)
     disallowed_diff_keys = []
     for key in constants.SKIPPED_CLIENT_OVERRIDE_KEYS:
@@ -455,7 +505,7 @@ def override_skypilot_config(
             'and will be ignored. Remove these keys to disable this warning. '
             'If you want to specify it, please modify it on server side or '
             'contact your administrator.')
-    config = _dict.get_nested(
+    config = original_config.get_nested(
         keys=tuple(),
         default_value=None,
         override_configs=dict(override_configs),
@@ -469,8 +519,8 @@ def override_skypilot_config(
             'https://docs.skypilot.co/en/latest/reference/config.html. '  # pylint: disable=line-too-long
             'Error: ',
             skip_none=False)
-        _config_overridden = True
-        _dict = config
+        _set_config_overridden(True)
+        _set_loaded_config(config)
         yield
     except exceptions.InvalidSkyPilotConfigError as e:
         with ux_utils.print_exception_no_traceback():
@@ -483,8 +533,17 @@ def override_skypilot_config(
                 f'{common_utils.dump_yaml_str(dict(override_configs))}\n'
                 f'Details: {e}') from e
     finally:
-        _dict = original_config
-        _config_overridden = False
+        _set_loaded_config(original_config)
+        _set_config_overridden(False)
+
+
+@contextlib.contextmanager
+def replace_skypilot_config(new_configs: config_utils.Config) -> Iterator[None]:
+    """Replaces the global config with the new configs."""
+    original_config = _get_loaded_config()
+    _set_loaded_config(config_utils.Config(new_configs))
+    yield
+    _set_loaded_config(original_config)
 
 
 def _compose_cli_config(cli_config: Optional[List[str]]) -> config_utils.Config:
@@ -529,11 +588,11 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
         cli_config: A path to a config file or a comma-separated
         list of key-value pairs.
     """
-    global _dict
     parsed_config = _compose_cli_config(cli_config)
     if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
         logger.debug(f'applying following CLI overrides: \n'
                      f'{common_utils.dump_yaml_str(dict(parsed_config))}')
-    _dict = overlay_skypilot_config(original_config=_dict,
-                                    override_configs=parsed_config)
+    _set_loaded_config(
+        overlay_skypilot_config(original_config=_get_loaded_config(),
+                                override_configs=parsed_config))
     return parsed_config

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -57,6 +57,7 @@ class Context(object):
         self._log_file = None
         self._log_file_handle = None
         self.env_overrides = {}
+        self.config_context = None
 
     def cancel(self):
         """Cancel the context."""

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -160,17 +160,25 @@ class ContextualEnviron(MutableMapping):
         ctx = get()
         if ctx is not None:
             if key in ctx.env_overrides:
-                return ctx.env_overrides[key]
+                value = ctx.env_overrides[key]
+                # None is used to indicate that the key is deleted in the
+                # context.
+                if value is None:
+                    raise KeyError(key)
+                return value
         return self._environ[key]
 
     def __iter__(self):
         ctx = get()
+        deleted_keys = set()
         if ctx is not None:
-            for key in ctx.env_overrides:
+            for key, value in ctx.env_overrides.items():
+                if value is None:
+                    deleted_keys.add(key)
                 yield key
             for key in self._environ:
                 # Deduplicate the keys
-                if key not in ctx.env_overrides:
+                if key not in ctx.env_overrides and key not in deleted_keys:
                     yield key
         else:
             return self._environ.__iter__()
@@ -179,10 +187,27 @@ class ContextualEnviron(MutableMapping):
         return len(dict(self))
 
     def __setitem__(self, key, value):
-        return self._environ.__setitem__(key, value)
+        ctx = get()
+        if ctx is not None:
+            ctx.env_overrides[key] = value
+        else:
+            self._environ.__setitem__(key, value)
 
     def __delitem__(self, key):
-        return self._environ.__delitem__(key)
+        ctx = get()
+        if ctx is not None:
+            if key in ctx.env_overrides:
+                del ctx.env_overrides[key]
+            elif key in self._environ:
+                # If the key is not set in the context but set in the environ
+                # of the process, we mark it as deleted in the context by
+                # setting the value to None.
+                ctx.env_overrides[key] = None
+            else:
+                # The key is not set in the context nor the process.
+                raise KeyError(key)
+        else:
+            self._environ.__delitem__(key)
 
     def __repr__(self):
         return self._environ.__repr__()
@@ -191,7 +216,11 @@ class ContextualEnviron(MutableMapping):
         copied = self._environ.copy()
         ctx = get()
         if ctx is not None:
-            copied.update(ctx.env_overrides)
+            for key in ctx.env_overrides:
+                if ctx.env_overrides[key] is None:
+                    copied.pop(key)
+                else:
+                    copied[key] = ctx.env_overrides[key]
         return copied
 
     def setdefault(self, key, default=None):

--- a/sky/utils/context_utils.py
+++ b/sky/utils/context_utils.py
@@ -1,5 +1,6 @@
 """Utilities for SkyPilot context."""
 import asyncio
+import contextvars
 import functools
 import io
 import multiprocessing
@@ -170,3 +171,17 @@ def cancellation_guard(func: F) -> F:
         return func(*args, **kwargs)
 
     return typing.cast(F, wrapper)
+
+
+# TODO(aylei): replace this with asyncio.to_thread once we drop support for
+# python 3.8
+async def to_thread(func, /, *args, **kwargs):
+    """Asynchronously run function *func* in a separate thread.
+
+    This is same as asyncio.to_thread added in python 3.9
+    """
+    loop = asyncio.get_running_loop()
+    # This is critical to pass the current coroutine context to the new thread
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, func, *args, **kwargs)
+    return await loop.run_in_executor(None, func_call)

--- a/sky/utils/context_utils.py
+++ b/sky/utils/context_utils.py
@@ -175,13 +175,13 @@ def cancellation_guard(func: F) -> F:
 
 # TODO(aylei): replace this with asyncio.to_thread once we drop support for
 # python 3.8
-async def to_thread(func, /, *args, **kwargs):
+def to_thread(func, /, *args, **kwargs):
     """Asynchronously run function *func* in a separate thread.
 
     This is same as asyncio.to_thread added in python 3.9
     """
     loop = asyncio.get_running_loop()
     # This is critical to pass the current coroutine context to the new thread
-    ctx = contextvars.copy_context()
-    func_call = functools.partial(ctx.run, func, *args, **kwargs)
-    return await loop.run_in_executor(None, func_call)
+    pyctx = contextvars.copy_context()
+    func_call = functools.partial(pyctx.run, func, *args, **kwargs)
+    return loop.run_in_executor(None, func_call)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,15 +28,14 @@ PROVISION_TIMEOUT = 600
 
 
 def _reload_config() -> None:
-    skypilot_config._dict = config_utils.Config()
-    skypilot_config._loaded_config_path = None
+    skypilot_config._global_config_context = skypilot_config.ConfigContext()
     skypilot_config._reload_config()
 
 
 def _check_empty_config() -> None:
     """Check that the config is empty."""
-    assert not skypilot_config.loaded(), (skypilot_config._dict,
-                                          skypilot_config._loaded_config_path)
+    assert not skypilot_config.loaded(), (
+        skypilot_config._global_config_context)
     assert skypilot_config.get_nested(
         ('aws', 'ssh_proxy_command'), None) is None
     assert skypilot_config.get_nested(('aws', 'ssh_proxy_command'),
@@ -590,8 +589,7 @@ def test_override_skypilot_config_without_original_config(
     monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH', config_path)
     monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH', config_path)
     skypilot_config._reload_config()
-    assert not skypilot_config._dict
-    assert skypilot_config._loaded_config_path is None
+    assert not skypilot_config._get_loaded_config()
     assert skypilot_config.get_nested(('aws', 'vpc_name'), None) is None
 
     # Test empty override_configs
@@ -622,8 +620,8 @@ def test_override_skypilot_config_without_original_config(
     assert skypilot_config.get_nested(
         ('aws', 'ssh_proxy_command'), None) is None
     assert os.environ.get(skypilot_config.ENV_VAR_SKYPILOT_CONFIG) is None
-    assert skypilot_config._loaded_config_path is None
-    assert not skypilot_config._dict
+    assert skypilot_config._get_loaded_config_path() is None
+    assert not skypilot_config._get_loaded_config()
 
 
 def test_hierarchical_client_config(monkeypatch, tmp_path):
@@ -706,7 +704,7 @@ def test_hierarchical_client_config(monkeypatch, tmp_path):
     monkeypatch.setattr(skypilot_config, '_PROJECT_CONFIG_PATH',
                         non_existent_config_path)
     skypilot_config._reload_config()
-    assert not skypilot_config._dict
+    assert not skypilot_config._get_loaded_config()
 
     # if config files specified by env vars are missing,
     # error out

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -200,3 +200,6 @@ def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):
             ('kubernetes', 'allowed_contexts'),
             None) == ['kind-skypilot', 'kind-skypilot2'
                      ], 'Global skypilot config should be updated'
+    assert skypilot_config.get_nested(
+        ('kubernetes', 'allowed_contexts'),
+        None) is None, 'Global skypilot config should be restored after request'

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -34,6 +34,12 @@ def task():
     return sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
 
 
+def _load_task(task: sky.Task, config_path: str) -> sky.Task:
+    os.environ[skypilot_config.ENV_VAR_SKYPILOT_CONFIG] = config_path
+    importlib.reload(skypilot_config)
+    return task
+
+
 def _load_task_and_apply_policy(
     task: sky.Task,
     config_path: str,
@@ -81,11 +87,11 @@ def test_use_spot_for_all_gpus_policy(add_example_policy_paths, task):
 
 
 def test_add_labels_policy(add_example_policy_paths, task):
-    dag, _ = _load_task_and_apply_policy(
-        task, os.path.join(POLICY_PATH, 'add_labels.yaml'))
-    assert 'app' in skypilot_config.get_nested(
-        ('kubernetes', 'custom_metadata', 'labels'),
-        {}), ('label should be set')
+    task = _load_task(task, os.path.join(POLICY_PATH, 'add_labels.yaml'))
+    with admin_policy_utils.apply_and_use_config_in_current_request(task):
+        assert 'app' in skypilot_config.get_nested(
+            ('kubernetes', 'custom_metadata', 'labels'),
+            {}), ('label should be set')
 
 
 def test_reject_all_policy(add_example_policy_paths, task):
@@ -180,7 +186,7 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
 @mock.patch('sky.provision.kubernetes.utils.get_all_kube_context_names',
             return_value=['kind-skypilot', 'kind-skypilot2', 'kind-skypilot3'])
 def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):
-    _, config = _load_task_and_apply_policy(
+    dag, config = _load_task_and_apply_policy(
         task,
         os.path.join(POLICY_PATH, 'dynamic_kubernetes_contexts_update.yaml'))
 
@@ -189,7 +195,8 @@ def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):
         None) == ['kind-skypilot', 'kind-skypilot2'
                  ], 'Kubernetes allowed contexts should be updated'
 
-    assert skypilot_config.get_nested(
-        ('kubernetes', 'allowed_contexts'),
-        None) == ['kind-skypilot',
-                  'kind-skypilot2'], 'Global skypilot config should be updated'
+    with admin_policy_utils.apply_and_use_config_in_current_request(dag):
+        assert skypilot_config.get_nested(
+            ('kubernetes', 'allowed_contexts'),
+            None) == ['kind-skypilot', 'kind-skypilot2'
+                     ], 'Global skypilot config should be updated'

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -9,8 +9,8 @@ from sky.resources import Resources
 
 
 # Set env var to test config file.
-@mock.patch.object(skypilot_config, '_dict', None)
-@mock.patch.object(skypilot_config, '_loaded_config_path', None)
+@mock.patch.object(skypilot_config, '_global_config_context',
+                   skypilot_config.ConfigContext())
 @mock.patch('sky.clouds.service_catalog.instance_type_exists',
             return_value=True)
 @mock.patch('sky.clouds.service_catalog.get_accelerators_from_instance_type',

--- a/tests/unit_tests/test_sky/server/test_server.py
+++ b/tests/unit_tests/test_sky/server/test_server.py
@@ -12,6 +12,7 @@ import uvicorn
 
 from sky.server import server
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import context
 
 
@@ -113,7 +114,7 @@ async def test_validate():
     with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
                    return_value=mock_dag), \
          mock.patch('sky.server.server.admin_policy_utils.apply',
-                   return_value=(mock_dag, None)), \
+                   return_value=(mock_dag, config_utils.Config())), \
          mock.patch.object(mock_dag, 'validate') as mock_validate:
         # Call validate endpoint
         await server.validate(mock_validate_body)
@@ -125,7 +126,7 @@ async def test_validate():
     with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
                    return_value=mock_dag), \
          mock.patch('sky.server.server.admin_policy_utils.apply',
-                   return_value=(mock_dag, None)), \
+                   return_value=(mock_dag, config_utils.Config())), \
          mock.patch.object(mock_dag, 'validate',
                           side_effect=ValueError(error_msg)):
         with pytest.raises(fastapi.HTTPException) as exc_info:
@@ -144,7 +145,7 @@ async def test_validate():
     with mock.patch('sky.server.server.dag_utils.load_chain_dag_from_yaml_str',
                    return_value=mock_dag), \
          mock.patch('sky.server.server.admin_policy_utils.apply',
-                   return_value=(mock_dag, None)), \
+                   return_value=(mock_dag, config_utils.Config())), \
          mock.patch.object(mock_dag, 'validate',
                           side_effect=slow_validate):
         # Start validation in background

--- a/tests/unit_tests/test_sky/utils/text_context.py
+++ b/tests/unit_tests/test_sky/utils/text_context.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import pathlib
 import tempfile
+from unittest import mock
 
 import pytest
 
@@ -118,16 +119,17 @@ def test_contextual_environ_set_del(ctx):
 
     # Set a new value in the base environ
     env['NEW_VAR'] = 'direct_value'
-    assert base_environ['NEW_VAR'] == 'direct_value'
+    assert 'NEW_VAR' not in base_environ, 'set env key in context should not affect the process env'
 
     # Delete a value from base environ
     del env['BASE_VAR']
-    assert 'BASE_VAR' not in base_environ
+    assert 'BASE_VAR' in base_environ, 'delete env key in context should not affect the process env'
 
     # Context overrides should take precedence over base
     ctx.override_envs({'NEW_VAR': 'override_value'})
     assert env['NEW_VAR'] == 'override_value'
-    assert base_environ['NEW_VAR'] == 'direct_value'
+    assert base_environ['BASE_VAR'] == 'base_value'
+    assert env.get('BASE_VAR') is None
 
 
 def test_contextual_environ_methods(ctx):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close #5621

This PR makes skypilot config context-aware, so that skypilot config can be safely mutated by `AdminPolicy` in request scope.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
