### PR TITLE
[Docs] Add warning warning for developer preview version for docs

### DIFF
--- a/docs/source/_templates/header.html
+++ b/docs/source/_templates/header.html
@@ -1,0 +1,45 @@
+<style>
+    .notification-bar {
+        width: 100vw;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 16px;
+        padding: 0 6px 0 6px;
+    }
+
+    .notification-bar p {
+        margin: 0;
+    }
+
+    .notification-bar a {
+        font-weight: bold;
+        text-decoration: none;
+    }
+
+    /* Light mode styles (default) */
+    .notification-bar {
+        background-color: #fff3cd;
+        color: #856404;
+    }
+
+    .notification-bar a {
+        color: #d97706;
+    }
+
+    /* Dark mode styles */
+    html[data-theme=dark] .notification-bar {
+        background-color: #333;
+        color: #ddd;
+    }
+
+    html[data-theme=dark] .notification-bar a {
+        color: #ffa500;
+        /* Brighter color for visibility */
+    }
+</style>
+
+<div class="notification-bar">
+    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/en/stable/">Click here</a> to
+        view docs for the latest stable release.</p>
+</div>

--- a/docs/source/_templates/header.html
+++ b/docs/source/_templates/header.html
@@ -40,6 +40,6 @@
 </style>
 
 <div class="notification-bar">
-    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/en/stable/">Click here</a> to
+    <p>You are viewing the latest developer preview docs. <a href="https://docs.skypilot.co/en/stable/docs/index.html">Click here</a> to
         view docs for the latest stable release.</p>
 </div>

--- a/docs/source/_templates/header.html
+++ b/docs/source/_templates/header.html
@@ -4,7 +4,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        font-size: 16px;
+        font-size: 0.8rem;
         padding: 0 6px 0 6px;
     }
 

--- a/docs/source/_templates/header.html
+++ b/docs/source/_templates/header.html
@@ -4,7 +4,7 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        font-size: 0.8rem;
+        font-size: 1rem;
         padding: 0 6px 0 6px;
     }
 

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "pydata_sphinx_theme/layout.html" %}
+
+{% block docs_navbar %}
+{% include "header.html" ignore missing %}
+{{ super() }}
+{% endblock %} 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,6 +220,19 @@ autosectionlabel_prefix_document = True
 suppress_warnings = ['autosectionlabel.*']
 
 
+# Adapted from vllm-project/vllm
+# see https://docs.readthedocs.io/en/stable/reference/environment-variables.html # noqa
+READTHEDOCS_VERSION_TYPE = os.environ.get('READTHEDOCS_VERSION_TYPE')
+if READTHEDOCS_VERSION_TYPE == "tag":
+    # remove the warning banner if the version is a tagged release
+    header_file = os.path.join(os.path.dirname(__file__),
+                               "_templates/header.html")
+    # The file might be removed already if the build is triggered multiple times
+    # (readthedocs build both HTML and PDF versions separately)
+    if os.path.exists(header_file):
+        os.remove(header_file)
+
+
 def setup(app):
     # Run generate_examples directly during setup instead of connecting to builder-inited
     # This ensures it completes fully before any build steps start

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,7 +219,6 @@ autosectionlabel_prefix_document = True
 
 suppress_warnings = ['autosectionlabel.*']
 
-
 # Adapted from vllm-project/vllm
 # see https://docs.readthedocs.io/en/stable/reference/environment-variables.html # noqa
 READTHEDOCS_VERSION_TYPE = os.environ.get('READTHEDOCS_VERSION_TYPE')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Thanks to https://github.com/vllm-project/vllm/pull/5979

It adds a banner for docs on master branch, so people know that issues might be caused by version mismatch.

<img width="1489" alt="image" src="https://github.com/user-attachments/assets/01bf7ad5-704b-4118-849d-03b50d75d489" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
