### PR TITLE
Migrate `sky/global_user_state.py` to use SQLAlchemy

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -246,15 +246,15 @@ def add_or_update_user(user: models.User):
 def get_user(user_id: str) -> models.User:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(user_table).filter_by(id=user_id).first()
-        if row is None:
-            return models.User(id=user_id)
-        return models.User(id=row.id, name=row.name)
+    if row is None:
+        return models.User(id=user_id)
+    return models.User(id=row.id, name=row.name)
 
 
 def get_all_users() -> List[models.User]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(user_table).all()
-        return [models.User(id=row.id, name=row.name) for row in rows]
+    return [models.User(id=row.id, name=row.name) for row in rows]
 
 
 def add_or_update_cluster(cluster_name: str,
@@ -493,9 +493,9 @@ def get_handle_from_cluster_name(
     assert cluster_name is not None, 'cluster_name cannot be None'
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if row is None:
-            return None
-        return pickle.loads(row.handle)
+    if row is None:
+        return None
+    return pickle.loads(row.handle)
 
 
 def get_glob_cluster_names(cluster_name: str) -> List[str]:
@@ -512,7 +512,7 @@ def get_glob_cluster_names(cluster_name: str) -> List[str]:
             raise ValueError('Unsupported database dialect')
         else:
             raise ValueError('Unsupported database dialect')
-        return [row.name for row in rows]
+    return [row.name for row in rows]
 
 
 def set_cluster_status(cluster_name: str,
@@ -525,9 +525,9 @@ def set_cluster_status(cluster_name: str,
                 cluster_table.c.status_updated_at: current_time
             })
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster {cluster_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def set_cluster_autostop_value(cluster_name: str, idle_minutes: int,
@@ -539,25 +539,25 @@ def set_cluster_autostop_value(cluster_name: str, idle_minutes: int,
                 cluster_table.c.to_down: int(to_down)
             })
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster {cluster_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def get_cluster_launch_time(cluster_name: str) -> Optional[int]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if row is None or row.launched_at is None:
-            return None
-        return int(row.launched_at)
+    if row is None or row.launched_at is None:
+        return None
+    return int(row.launched_at)
 
 
 def get_cluster_info(cluster_name: str) -> Optional[Dict[str, Any]]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if row is None or row.metadata is None:
-            return None
-        return json.loads(row.metadata)
+    if row is None or row.metadata is None:
+        return None
+    return json.loads(row.metadata)
 
 
 def set_cluster_info(cluster_name: str, metadata: Dict[str, Any]) -> None:
@@ -566,18 +566,18 @@ def set_cluster_info(cluster_name: str, metadata: Dict[str, Any]) -> None:
             name=cluster_name).update(
                 {cluster_table.c.metadata: json.dumps(metadata)})
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster {cluster_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def get_cluster_storage_mounts_metadata(
         cluster_name: str) -> Optional[Dict[str, Any]]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if row is None or row.storage_mounts_metadata is None:
-            return None
-        return pickle.loads(row.storage_mounts_metadata)
+    if row is None or row.storage_mounts_metadata is None:
+        return None
+    return pickle.loads(row.storage_mounts_metadata)
 
 
 def set_cluster_storage_mounts_metadata(
@@ -589,9 +589,9 @@ def set_cluster_storage_mounts_metadata(
                     pickle.dumps(storage_mounts_metadata)
             })
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster {cluster_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def _get_cluster_usage_intervals(
@@ -600,11 +600,11 @@ def _get_cluster_usage_intervals(
     if cluster_hash is None:
         return None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        rows = session.query(cluster_history_table).filter_by(
+        row = session.query(cluster_history_table).filter_by(
             cluster_hash=cluster_hash).first()
-        if rows is None or rows.usage_intervals is None:
-            return None
-        return pickle.loads(rows.usage_intervals)
+    if row is None or row.usage_intervals is None:
+        return None
+    return pickle.loads(row.usage_intervals)
 
 
 def _get_cluster_launch_time(cluster_hash: str) -> Optional[int]:
@@ -643,9 +643,9 @@ def _set_cluster_usage_intervals(
                     pickle.dumps(usage_intervals)
             })
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster hash {cluster_hash} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster hash {cluster_hash} not found.')
 
 
 def set_owner_identity_for_cluster(cluster_name: str,
@@ -658,17 +658,17 @@ def set_owner_identity_for_cluster(cluster_name: str,
             name=cluster_name).update(
                 {cluster_table.c.owner: owner_identity_str})
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Cluster {cluster_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def _get_hash_for_existing_cluster(cluster_name: str) -> Optional[str]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if row is None or row.cluster_hash is None:
-            return None
-        return row.cluster_hash
+    if row is None or row.cluster_hash is None:
+        return None
+    return row.cluster_hash
 
 
 def get_launched_resources_from_cluster_hash(
@@ -676,15 +676,15 @@ def get_launched_resources_from_cluster_hash(
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(cluster_history_table).filter_by(
             cluster_hash=cluster_hash).first()
-        if row is None:
-            return None
-        num_nodes = row.num_nodes
-        launched_resources = row.launched_resources
+    if row is None:
+        return None
+    num_nodes = row.num_nodes
+    launched_resources = row.launched_resources
 
-        if num_nodes is None or launched_resources is None:
-            return None
-        launched_resources = pickle.loads(launched_resources)
-        return num_nodes, launched_resources
+    if num_nodes is None or launched_resources is None:
+        return None
+    launched_resources = pickle.loads(launched_resources)
+    return num_nodes, launched_resources
 
 
 def _load_owner(record_owner: Optional[str]) -> Optional[List[str]]:
@@ -719,65 +719,65 @@ def _load_storage_mounts_metadata(
 def get_cluster_from_name(
         cluster_name: Optional[str]) -> Optional[Dict[str, Any]]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        rows = session.query(cluster_table).filter_by(name=cluster_name).first()
-        if rows is None:
-            return None
-        user_hash = _get_user_hash_or_current_user(rows.user_hash)
-        # TODO: use namedtuple instead of dict
-        record = {
-            'name': rows.name,
-            'launched_at': rows.launched_at,
-            'handle': pickle.loads(rows.handle),
-            'last_use': rows.last_use,
-            'status': status_lib.ClusterStatus[rows.status],
-            'autostop': rows.autostop,
-            'to_down': bool(rows.to_down),
-            'owner': _load_owner(rows.owner),
-            'metadata': json.loads(rows.metadata),
-            'cluster_hash': rows.cluster_hash,
-            'storage_mounts_metadata': _load_storage_mounts_metadata(
-                rows.storage_mounts_metadata),
-            'cluster_ever_up': bool(rows.cluster_ever_up),
-            'status_updated_at': rows.status_updated_at,
-            'user_hash': user_hash,
-            'user_name': get_user(user_hash).name,
-            'config_hash': rows.config_hash,
-            'workspace': rows.workspace,
-        }
-        return record
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+    if row is None:
+        return None
+    user_hash = _get_user_hash_or_current_user(row.user_hash)
+    # TODO: use namedtuple instead of dict
+    record = {
+        'name': row.name,
+        'launched_at': row.launched_at,
+        'handle': pickle.loads(row.handle),
+        'last_use': row.last_use,
+        'status': status_lib.ClusterStatus[row.status],
+        'autostop': row.autostop,
+        'to_down': bool(row.to_down),
+        'owner': _load_owner(row.owner),
+        'metadata': json.loads(row.metadata),
+        'cluster_hash': row.cluster_hash,
+        'storage_mounts_metadata': _load_storage_mounts_metadata(
+            row.storage_mounts_metadata),
+        'cluster_ever_up': bool(row.cluster_ever_up),
+        'status_updated_at': row.status_updated_at,
+        'user_hash': user_hash,
+        'user_name': get_user(user_hash).name,
+        'config_hash': row.config_hash,
+        'workspace': row.workspace,
+    }
+    return record
 
 
 def get_clusters() -> List[Dict[str, Any]]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(cluster_table).order_by(
             sqlalchemy.desc(cluster_table.c.launched_at)).all()
-        records = []
-        for row in rows:
-            user_hash = _get_user_hash_or_current_user(row.user_hash)
-            # TODO: use namedtuple instead of dict
-            record = {
-                'name': row.name,
-                'launched_at': row.launched_at,
-                'handle': pickle.loads(row.handle),
-                'last_use': row.last_use,
-                'status': status_lib.ClusterStatus[row.status],
-                'autostop': row.autostop,
-                'to_down': bool(row.to_down),
-                'owner': _load_owner(row.owner),
-                'metadata': json.loads(row.metadata),
-                'cluster_hash': row.cluster_hash,
-                'storage_mounts_metadata': _load_storage_mounts_metadata(
-                    row.storage_mounts_metadata),
-                'cluster_ever_up': bool(row.cluster_ever_up),
-                'status_updated_at': row.status_updated_at,
-                'user_hash': user_hash,
-                'user_name': get_user(user_hash).name,
-                'config_hash': row.config_hash,
-                'workspace': row.workspace,
-            }
+    records = []
+    for row in rows:
+        user_hash = _get_user_hash_or_current_user(row.user_hash)
+        # TODO: use namedtuple instead of dict
+        record = {
+            'name': row.name,
+            'launched_at': row.launched_at,
+            'handle': pickle.loads(row.handle),
+            'last_use': row.last_use,
+            'status': status_lib.ClusterStatus[row.status],
+            'autostop': row.autostop,
+            'to_down': bool(row.to_down),
+            'owner': _load_owner(row.owner),
+            'metadata': json.loads(row.metadata),
+            'cluster_hash': row.cluster_hash,
+            'storage_mounts_metadata': _load_storage_mounts_metadata(
+                row.storage_mounts_metadata),
+            'cluster_ever_up': bool(row.cluster_ever_up),
+            'status_updated_at': row.status_updated_at,
+            'user_hash': user_hash,
+            'user_name': get_user(user_hash).name,
+            'config_hash': row.config_hash,
+            'workspace': row.workspace,
+        }
 
-            records.append(record)
-        return records
+        records.append(record)
+    return records
 
 
 def get_clusters_from_history() -> List[Dict[str, Any]]:
@@ -788,39 +788,39 @@ def get_clusters_from_history() -> List[Dict[str, Any]]:
                                        cluster_table.c.cluster_hash,
                                        isouter=True)).all()
 
-        # '(cluster_hash, name, num_nodes, requested_resources, '
-        #         'launched_resources, usage_intervals) '
-        records = []
-        for row in rows:
-            # TODO: use namedtuple instead of dict
-            user_hash = _get_user_hash_or_current_user(row.user_hash)
-            status = row.status
-            if status is not None:
-                status = status_lib.ClusterStatus[status]
-            record = {
-                'name': row.name,
-                'launched_at': _get_cluster_launch_time(row.cluster_hash),
-                'duration': _get_cluster_duration(row.cluster_hash),
-                'num_nodes': row.num_nodes,
-                'resources': pickle.loads(row.launched_resources),
-                'cluster_hash': row.cluster_hash,
-                'usage_intervals': pickle.loads(row.usage_intervals),
-                'status': status,
-                'user_hash': user_hash,
-            }
+    # '(cluster_hash, name, num_nodes, requested_resources, '
+    #         'launched_resources, usage_intervals) '
+    records = []
+    for row in rows:
+        # TODO: use namedtuple instead of dict
+        user_hash = _get_user_hash_or_current_user(row.user_hash)
+        status = row.status
+        if status is not None:
+            status = status_lib.ClusterStatus[status]
+        record = {
+            'name': row.name,
+            'launched_at': _get_cluster_launch_time(row.cluster_hash),
+            'duration': _get_cluster_duration(row.cluster_hash),
+            'num_nodes': row.num_nodes,
+            'resources': pickle.loads(row.launched_resources),
+            'cluster_hash': row.cluster_hash,
+            'usage_intervals': pickle.loads(row.usage_intervals),
+            'status': status,
+            'user_hash': user_hash,
+        }
 
-            records.append(record)
+        records.append(record)
 
-        # sort by launch time, descending in recency
-        records = sorted(records, key=lambda record: -record['launched_at'])
-        return records
+    # sort by launch time, descending in recency
+    records = sorted(records, key=lambda record: -record['launched_at'])
+    return records
 
 
 def get_cluster_names_start_with(starts_with: str) -> List[str]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(cluster_table).filter(
             cluster_table.c.name.like(f'{starts_with}%')).all()
-        return [row.name for row in rows]
+    return [row.name for row in rows]
 
 
 def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
@@ -828,22 +828,22 @@ def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(config_table).filter_by(
             key=_get_enabled_clouds_key(cloud_capability, workspace)).first()
-        ret = []
-        if row:
-            ret = json.loads(row.value)
-        enabled_clouds: List['clouds.Cloud'] = []
-        for c in ret:
-            try:
-                cloud = registry.CLOUD_REGISTRY.from_str(c)
-            except ValueError:
-                # Handle the case for the clouds whose support has been
-                # removed from SkyPilot, e.g., 'local' was a cloud in the past
-                # and may be stored in the database for users before #3037.
-                # We should ignore removed clouds and continue.
-                continue
-            if cloud is not None:
-                enabled_clouds.append(cloud)
-        return enabled_clouds
+    ret = []
+    if row:
+        ret = json.loads(row.value)
+    enabled_clouds: List['clouds.Cloud'] = []
+    for c in ret:
+        try:
+            cloud = registry.CLOUD_REGISTRY.from_str(c)
+        except ValueError:
+            # Handle the case for the clouds whose support has been
+            # removed from SkyPilot, e.g., 'local' was a cloud in the past
+            # and may be stored in the database for users before #3037.
+            # We should ignore removed clouds and continue.
+            continue
+        if cloud is not None:
+            enabled_clouds.append(cloud)
+    return enabled_clouds
 
 
 def set_enabled_clouds(enabled_clouds: List[str],
@@ -930,18 +930,18 @@ def set_storage_status(storage_name: str,
         count = session.query(storage_table).filter_by(
             name=storage_name).update({storage_table.c.status: status.value})
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Storage {storage_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Storage {storage_name} not found.')
 
 
 def get_storage_status(storage_name: str) -> Optional[status_lib.StorageStatus]:
     assert storage_name is not None, 'storage_name cannot be None'
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(storage_table).filter_by(name=storage_name).first()
-        if row:
-            return status_lib.StorageStatus[row.status]
-        return None
+    if row:
+        return status_lib.StorageStatus[row.status]
+    return None
 
 
 def set_storage_handle(storage_name: str,
@@ -951,9 +951,9 @@ def set_storage_handle(storage_name: str,
             name=storage_name).update(
                 {storage_table.c.handle: pickle.dumps(handle)})
         session.commit()
-        assert count <= 1, count
-        if count == 0:
-            raise ValueError(f'Storage{storage_name} not found.')
+    assert count <= 1, count
+    if count == 0:
+        raise ValueError(f'Storage{storage_name} not found.')
 
 
 def get_handle_from_storage_name(
@@ -962,9 +962,9 @@ def get_handle_from_storage_name(
         return None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         row = session.query(storage_table).filter_by(name=storage_name).first()
-        if row:
-            return pickle.loads(row.handle)
-        return None
+    if row:
+        return pickle.loads(row.handle)
+    return None
 
 
 def get_glob_storage_name(storage_name: str) -> List[str]:
@@ -981,27 +981,27 @@ def get_glob_storage_name(storage_name: str) -> List[str]:
             raise ValueError('Unsupported database dialect')
         else:
             raise ValueError('Unsupported database dialect')
-        return [row.name for row in rows]
+    return [row.name for row in rows]
 
 
 def get_storage_names_start_with(starts_with: str) -> List[str]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(storage_table).filter(
             storage_table.c.name.like(f'{starts_with}%')).all()
-        return [row.name for row in rows]
+    return [row.name for row in rows]
 
 
 def get_storage() -> List[Dict[str, Any]]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(storage_table).all()
-        records = []
-        for row in rows:
-            # TODO: use namedtuple instead of dict
-            records.append({
-                'name': row.name,
-                'launched_at': row.launched_at,
-                'handle': pickle.loads(row.handle),
-                'last_use': row.last_use,
-                'status': status_lib.StorageStatus[row.status],
-            })
-        return records
+    records = []
+    for row in rows:
+        # TODO: use namedtuple instead of dict
+        records.append({
+            'name': row.name,
+            'launched_at': row.launched_at,
+            'handle': pickle.loads(row.handle),
+            'last_use': row.last_use,
+            'status': status_lib.StorageStatus[row.status],
+        })
+    return records

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -10,11 +10,23 @@ import json
 import os
 import pathlib
 import pickle
-import sqlite3
 import time
 import typing
 from typing import Any, Dict, List, Optional, Set, Tuple
 import uuid
+
+from sqlalchemy import Column
+from sqlalchemy import create_engine
+from sqlalchemy import desc
+from sqlalchemy import exc as sqlalchemy_exc
+from sqlalchemy import Table
+from sqlalchemy import text
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session
+from sqlalchemy.types import Integer
+from sqlalchemy.types import LargeBinary
+from sqlalchemy.types import Text
 
 from sky import models
 from sky import sky_logging
@@ -38,168 +50,213 @@ _ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds_'
 _DB_PATH = os.path.expanduser('~/.sky/state.db')
 pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
 
+_SQLALCHEMY_ENGINE = create_engine(f'sqlite:///{_DB_PATH}')
 
-def create_table(cursor, conn):
+Base = declarative_base()
+
+config_table = Table(
+    'config',
+    Base.metadata,
+    Column('key', Text, primary_key=True),
+    Column('value', Text),
+)
+
+user_table = Table(
+    'users',
+    Base.metadata,
+    Column('id', Text, primary_key=True),
+    Column('name', Text),
+)
+
+cluster_table = Table(
+    'clusters',
+    Base.metadata,
+    Column('name', Text, primary_key=True),
+    Column('launched_at', Integer),
+    Column('handle', LargeBinary),
+    Column('last_use', Text),
+    Column('status', Text),
+    Column('autostop', Integer, server_default='-1'),
+    Column('to_down', Integer, server_default='0'),
+    Column('metadata', Text, server_default='{}'),
+    Column('owner', Text, server_default=None),
+    Column('cluster_hash', Text, server_default=None),
+    Column('storage_mounts_metadata', LargeBinary, server_default=None),
+    Column('cluster_ever_up', Integer, server_default='0'),
+    Column('status_updated_at', Integer, server_default=None),
+    Column('config_hash', Text, server_default=None),
+    Column('user_hash', Text, server_default=None),
+    Column('workspace',
+           Text,
+           server_default=constants.SKYPILOT_DEFAULT_WORKSPACE),
+)
+
+storage_table = Table(
+    'storage',
+    Base.metadata,
+    Column('name', Text, primary_key=True),
+    Column('launched_at', Integer),
+    Column('handle', LargeBinary),
+    Column('last_use', Text),
+    Column('status', Text),
+)
+
+# Table for Cluster History
+# usage_intervals: List[Tuple[int, int]]
+#  Specifies start and end timestamps of cluster.
+#  When the last end time is None, the cluster is still UP.
+#  Example: [(start1, end1), (start2, end2), (start3, None)]
+
+# requested_resources: Set[resource_lib.Resource]
+#  Requested resources fetched from task that user specifies.
+
+# launched_resources: Optional[resources_lib.Resources]
+#  Actual launched resources fetched from handle for cluster.
+
+# num_nodes: Optional[int] number of nodes launched.
+cluster_history_table = Table(
+    'cluster_history',
+    Base.metadata,
+    Column('cluster_hash', Text, primary_key=True),
+    Column('name', Text),
+    Column('num_nodes', Integer),
+    Column('requested_resources', LargeBinary),
+    Column('launched_resources', LargeBinary),
+    Column('usage_intervals', LargeBinary),
+    Column('user_hash', Text),
+)
+
+
+def create_table():
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
     # https://github.com/microsoft/WSL/issues/2395
     # TODO(romilb): We do not enable WAL for WSL because of known issue in WSL.
     #  This may cause the database locked problem from WSL issue #1441.
-    if not common_utils.is_wsl():
+    if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLALCHEMY_DIALECT_SQLITE
+            and not common_utils.is_wsl()):
         try:
-            cursor.execute('PRAGMA journal_mode=WAL')
-        except sqlite3.OperationalError as e:
+            with Session(_SQLALCHEMY_ENGINE) as session:
+                session.execute(text('PRAGMA journal_mode=WAL'))
+                session.commit()
+        except sqlalchemy_exc.OperationalError as e:
             if 'database is locked' not in str(e):
                 raise
             # If the database is locked, it is OK to continue, as the WAL mode
             # is not critical and is likely to be enabled by other processes.
 
-    # Table for Clusters
-    cursor.execute("""\
-        CREATE TABLE IF NOT EXISTS clusters (
-        name TEXT PRIMARY KEY,
-        launched_at INTEGER,
-        handle BLOB,
-        last_use TEXT,
-        status TEXT,
-        autostop INTEGER DEFAULT -1,
-        metadata TEXT DEFAULT '{}',
-        to_down INTEGER DEFAULT 0,
-        owner TEXT DEFAULT null,
-        cluster_hash TEXT DEFAULT null,
-        storage_mounts_metadata BLOB DEFAULT null,
-        cluster_ever_up INTEGER DEFAULT 0,
-        status_updated_at INTEGER DEFAULT null,
-        config_hash TEXT DEFAULT null,
-        user_hash TEXT DEFAULT null,
-        workspace TEXT DEFAULT 'default')""")
+    # Create tables if they don't exist
+    Base.metadata.create_all(bind=_SQLALCHEMY_ENGINE)
 
-    # Table for Cluster History
-    # usage_intervals: List[Tuple[int, int]]
-    #  Specifies start and end timestamps of cluster.
-    #  When the last end time is None, the cluster is still UP.
-    #  Example: [(start1, end1), (start2, end2), (start3, None)]
-
-    # requested_resources: Set[resource_lib.Resource]
-    #  Requested resources fetched from task that user specifies.
-
-    # launched_resources: Optional[resources_lib.Resources]
-    #  Actual launched resources fetched from handle for cluster.
-
-    # num_nodes: Optional[int] number of nodes launched.
-
-    cursor.execute("""\
-        CREATE TABLE IF NOT EXISTS cluster_history (
-        cluster_hash TEXT PRIMARY KEY,
-        name TEXT,
-        num_nodes int,
-        requested_resources BLOB,
-        launched_resources BLOB,
-        usage_intervals BLOB,
-        user_hash TEXT)""")
-    # Table for configs (e.g. enabled clouds)
-    cursor.execute("""\
-        CREATE TABLE IF NOT EXISTS config (
-        key TEXT PRIMARY KEY, value TEXT)""")
-    # Table for Storage
-    cursor.execute("""\
-        CREATE TABLE IF NOT EXISTS storage (
-        name TEXT PRIMARY KEY,
-        launched_at INTEGER,
-        handle BLOB,
-        last_use TEXT,
-        status TEXT)""")
-    # Table for User
-    cursor.execute("""\
-        CREATE TABLE IF NOT EXISTS users (
-        id TEXT PRIMARY KEY,
-        name TEXT)""")
     # For backward compatibility.
     # TODO(zhwu): Remove this function after all users have migrated to
     # the latest version of SkyPilot.
-    # Add autostop column to clusters table
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'autostop',
-                                 'INTEGER DEFAULT -1')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        # Add autostop column to clusters table
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters', 'autostop',
+                                                'INTEGER DEFAULT -1')
 
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'metadata',
-                                 'TEXT DEFAULT \'{}\'')
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters', 'metadata',
+                                                'TEXT DEFAULT \'{}\'')
 
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'to_down',
-                                 'INTEGER DEFAULT 0')
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters', 'to_down',
+                                                'INTEGER DEFAULT 0')
 
-    # The cloud identity that created the cluster.
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'owner', 'TEXT')
+        # The cloud identity that created the cluster.
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters', 'owner',
+                                                'TEXT')
 
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'cluster_hash',
-                                 'TEXT DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters',
+                                                'cluster_hash',
+                                                'TEXT DEFAULT null')
 
-    db_utils.add_column_to_table(cursor, conn, 'clusters',
-                                 'storage_mounts_metadata', 'BLOB DEFAULT null')
-    db_utils.add_column_to_table(
-        cursor,
-        conn,
-        'clusters',
-        'cluster_ever_up',
-        'INTEGER DEFAULT 0',
-        # Set the value to 1 so that all the existing clusters before #2977
-        # are considered as ever up, i.e:
-        #   existing cluster's default (null) -> 1;
-        #   new cluster's default -> 0;
-        # This is conservative for the existing clusters: even if some INIT
-        # clusters were never really UP, setting it to 1 means they won't be
-        # auto-deleted during any failover.
-        value_to_replace_existing_entries=1)
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'status_updated_at',
-                                 'INTEGER DEFAULT null')
-    db_utils.add_column_to_table(
-        cursor,
-        conn,
-        'clusters',
-        'user_hash',
-        'TEXT DEFAULT null',
-        value_to_replace_existing_entries=common_utils.get_user_hash())
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'config_hash',
-                                 'TEXT DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters',
+                                                'storage_mounts_metadata',
+                                                'BLOB DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(
+            session,
+            'clusters',
+            'cluster_ever_up',
+            'INTEGER DEFAULT 0',
+            # Set the value to 1 so that all the existing clusters before #2977
+            # are considered as ever up, i.e:
+            #   existing cluster's default (null) -> 1;
+            #   new cluster's default -> 0;
+            # This is conservative for the existing clusters: even if some INIT
+            # clusters were never really UP, setting it to 1 means they won't be
+            # auto-deleted during any failover.
+            value_to_replace_existing_entries=1)
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters',
+                                                'status_updated_at',
+                                                'INTEGER DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(
+            session,
+            'clusters',
+            'user_hash',
+            'TEXT DEFAULT null',
+            value_to_replace_existing_entries=common_utils.get_user_hash())
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters',
+                                                'config_hash',
+                                                'TEXT DEFAULT null')
 
-    db_utils.add_column_to_table(cursor, conn, 'clusters', 'config_hash',
-                                 'TEXT DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(session, 'clusters',
+                                                'config_hash',
+                                                'TEXT DEFAULT null')
 
-    db_utils.add_column_to_table(cursor, conn, 'cluster_history', 'user_hash',
-                                 'TEXT DEFAULT null')
+        db_utils.add_column_to_table_sqlalchemy(session, 'cluster_history',
+                                                'user_hash',
+                                                'TEXT DEFAULT null')
 
-    db_utils.add_column_to_table(
-        cursor,
-        conn,
-        'clusters',
-        'workspace',
-        'TEXT DEFAULT \'default\'',
-        value_to_replace_existing_entries=constants.SKYPILOT_DEFAULT_WORKSPACE)
-    conn.commit()
+        db_utils.add_column_to_table_sqlalchemy(
+            session,
+            'clusters',
+            'workspace',
+            'TEXT DEFAULT \'default\'',
+            value_to_replace_existing_entries=constants.
+            SKYPILOT_DEFAULT_WORKSPACE)
+        session.commit()
 
 
-_DB = db_utils.SQLiteConn(_DB_PATH, create_table)
+create_table()
 
 
 def add_or_update_user(user: models.User):
     """Store the mapping from user hash to user name for display purposes."""
     if user.name is None:
         return
-    _DB.cursor.execute('INSERT OR REPLACE INTO users (id, name) VALUES (?, ?)',
-                       (user.id, user.name))
-    _DB.conn.commit()
+
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            insert_stmnt = sqlite_insert(user_table).values(id=user.id,
+                                                            name=user.name)
+            do_update_stmt = insert_stmnt.on_conflict_do_update(
+                index_elements=[user_table.c.id],
+                set_={user_table.c.name: user.name})
+            session.execute(do_update_stmt)
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        session.commit()
 
 
 def get_user(user_id: str) -> models.User:
-    row = _DB.cursor.execute('SELECT id, name FROM users WHERE id=?',
-                             (user_id,)).fetchone()
-    if row is None:
-        return models.User(id=user_id)
-    return models.User(id=row[0], name=row[1])
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(user_table).filter_by(id=user_id).first()
+        if row is None:
+            return models.User(id=user_id)
+        return models.User(id=row.id, name=row.name)
 
 
 def get_all_users() -> List[models.User]:
-    rows = _DB.cursor.execute('SELECT id, name FROM users').fetchall()
-    return [models.User(id=row[0], name=row[1]) for row in rows]
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(user_table).all()
+        return [models.User(id=row.id, name=row.name) for row in rows]
 
 
 def add_or_update_cluster(cluster_name: str,
@@ -257,145 +314,116 @@ def add_or_update_cluster(cluster_name: str,
     user_hash = common_utils.get_user_hash()
     active_workspace = skypilot_config.get_active_workspace()
 
-    _DB.cursor.execute(
-        'INSERT or REPLACE INTO clusters'
-        # All the fields need to exist here, even if they don't need
-        # be changed, as the INSERT OR REPLACE statement will replace
-        # the field of the existing row with the default value if not
-        # specified.
-        '(name, launched_at, handle, last_use, status, '
-        'autostop, to_down, metadata, owner, cluster_hash, '
-        'storage_mounts_metadata, cluster_ever_up, status_updated_at, '
-        'config_hash, user_hash, workspace) '
-        'VALUES ('
-        # name
-        '?, '
-        # launched_at
-        'COALESCE('
-        '?, (SELECT launched_at FROM clusters WHERE name=?)), '
-        # handle
-        '?, '
-        # last_use
-        'COALESCE('
-        '?, (SELECT last_use FROM clusters WHERE name=?)), '
-        # status
-        '?, '
-        # autostop
-        # Keep the old autostop value if it exists, otherwise set it to
-        # default -1.
-        'COALESCE('
-        '(SELECT autostop FROM clusters WHERE name=? AND status!=?), -1), '
-        # Keep the old to_down value if it exists, otherwise set it to
-        # default 0.
-        'COALESCE('
-        '(SELECT to_down FROM clusters WHERE name=? AND status!=?), 0),'
-        # Keep the old metadata value if it exists, otherwise set it to
-        # default {}.
-        'COALESCE('
-        '(SELECT metadata FROM clusters WHERE name=?), \'{}\'),'
-        # Keep the old owner value if it exists, otherwise set it to
-        # default null.
-        'COALESCE('
-        '(SELECT owner FROM clusters WHERE name=?), null),'
-        # cluster_hash
-        '?,'
-        # storage_mounts_metadata
-        'COALESCE('
-        '(SELECT storage_mounts_metadata FROM clusters WHERE name=?), null), '
-        # cluster_ever_up
-        '((SELECT cluster_ever_up FROM clusters WHERE name=?) OR ?), '
-        # status_updated_at
-        '?,'
-        # config_hash
-        'COALESCE(?, (SELECT config_hash FROM clusters WHERE name=?)),'
-        # user_hash: keep original user_hash if it exists
-        'COALESCE((SELECT user_hash FROM clusters WHERE name=?), ?),'
-        # keep original workspace if it exists
-        'COALESCE((SELECT workspace FROM clusters WHERE name=?), ?)'
-        ')',
-        (
-            # name
-            cluster_name,
-            # launched_at
-            cluster_launched_at,
-            cluster_name,
-            # handle
-            handle,
-            # last_use
-            last_use,
-            cluster_name,
-            # status
-            status.value,
-            # autostop
-            cluster_name,
-            status_lib.ClusterStatus.STOPPED.value,
-            # to_down
-            cluster_name,
-            status_lib.ClusterStatus.STOPPED.value,
-            # metadata
-            cluster_name,
-            # owner
-            cluster_name,
-            # cluster_hash
-            cluster_hash,
-            # storage_mounts_metadata
-            cluster_name,
-            # cluster_ever_up
-            cluster_name,
-            int(ready),
-            # status_updated_at
-            status_updated_at,
-            # config_hash
-            config_hash,
-            cluster_name,
-            # user_hash
-            cluster_name,
-            user_hash,
-            # workspace
-            cluster_name,
-            active_workspace,
-        ))
+    conditional_values = {}
+    if is_launch:
+        conditional_values.update({
+            'launched_at': cluster_launched_at,
+            'last_use': last_use
+        })
 
-    launched_nodes = getattr(cluster_handle, 'launched_nodes', None)
-    launched_resources = getattr(cluster_handle, 'launched_resources', None)
-    _DB.cursor.execute(
-        'INSERT or REPLACE INTO cluster_history'
-        '(cluster_hash, name, num_nodes, requested_resources, '
-        'launched_resources, usage_intervals, user_hash) '
-        'VALUES ('
-        # hash
-        '?, '
-        # name
-        '?, '
-        # requested resources
-        '?, '
-        # launched resources
-        '?, '
-        # number of nodes
-        '?, '
-        # usage intervals
-        '?, '
-        # user_hash
-        '?'
-        ')',
-        (
-            # hash
-            cluster_hash,
-            # name
-            cluster_name,
-            # number of nodes
-            launched_nodes,
-            # requested resources
-            pickle.dumps(requested_resources),
-            # launched resources
-            pickle.dumps(launched_resources),
-            # usage intervals
-            pickle.dumps(usage_intervals),
-            # user_hash
-            user_hash,
-        ))
+    if int(ready) == 1:
+        conditional_values.update({
+            'cluster_ever_up': 1,
+        })
 
-    _DB.conn.commit()
+    if config_hash is not None:
+        conditional_values.update({
+            'config_hash': config_hash,
+        })
+
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        # with_for_update() locks the row until commit() or rollback()
+        # is called, or until the code escapes the with block.
+        cluster_row = session.query(cluster_table).filter_by(
+            name=cluster_name).with_for_update().first()
+        if (not cluster_row or
+                cluster_row.status == status_lib.ClusterStatus.STOPPED.value):
+            conditional_values.update({
+                'autostop': -1,
+                'to_down': 0,
+            })
+        if not cluster_row or not cluster_row.user_hash:
+            conditional_values.update({
+                'user_hash': user_hash,
+            })
+        if not cluster_row or not cluster_row.workspace:
+            conditional_values.update({
+                'workspace': active_workspace,
+            })
+
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            insert_stmnt = sqlite_insert(cluster_table).values(
+                name=cluster_name,
+                **conditional_values,
+                handle=handle,
+                status=status.value,
+                # set metadata to server default ('{}')
+                # set owner to server default (null)
+                cluster_hash=cluster_hash,
+                # set storage_mounts_metadata to server default (null)
+                status_updated_at=status_updated_at,
+            )
+            do_update_stmt = insert_stmnt.on_conflict_do_update(
+                index_elements=[cluster_table.c.name],
+                set_={
+                    **conditional_values,
+                    cluster_table.c.handle: handle,
+                    cluster_table.c.status: status.value,
+                    # do not update metadata value
+                    # do not update owner value
+                    cluster_table.c.cluster_hash: cluster_hash,
+                    # do not update storage_mounts_metadata
+                    cluster_table.c.status_updated_at: status_updated_at,
+                    # do not update user_hash
+                })
+            session.execute(do_update_stmt)
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+
+        # Modify cluster history table
+        launched_nodes = getattr(cluster_handle, 'launched_nodes', None)
+        launched_resources = getattr(cluster_handle, 'launched_resources', None)
+
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            insert_stmnt = sqlite_insert(cluster_history_table).values(
+                cluster_hash=cluster_hash,
+                name=cluster_name,
+                num_nodes=launched_nodes,
+                requested_resources=pickle.dumps(requested_resources),
+                launched_resources=pickle.dumps(launched_resources),
+                usage_intervals=pickle.dumps(usage_intervals),
+                user_hash=user_hash)
+            do_update_stmt = insert_stmnt.on_conflict_do_update(
+                index_elements=[cluster_history_table.c.cluster_hash],
+                set_={
+                    cluster_history_table.c.name: cluster_name,
+                    cluster_history_table.c.num_nodes: launched_nodes,
+                    cluster_history_table.c.requested_resources:
+                        pickle.dumps(requested_resources),
+                    cluster_history_table.c.launched_resources:
+                        pickle.dumps(launched_resources),
+                    cluster_history_table.c.usage_intervals:
+                        pickle.dumps(usage_intervals),
+                    cluster_history_table.c.user_hash: user_hash
+                })
+            session.execute(do_update_stmt)
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        session.commit()
 
 
 def _get_user_hash_or_current_user(user_hash: Optional[str]) -> str:
@@ -413,16 +441,18 @@ def _get_user_hash_or_current_user(user_hash: Optional[str]) -> str:
 def update_cluster_handle(cluster_name: str,
                           cluster_handle: 'backends.ResourceHandle'):
     handle = pickle.dumps(cluster_handle)
-    _DB.cursor.execute('UPDATE clusters SET handle=(?) WHERE name=(?)',
-                       (handle, cluster_name))
-    _DB.conn.commit()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        session.query(cluster_table).filter_by(name=cluster_name).update(
+            {cluster_table.c.handle: handle})
+        session.commit()
 
 
 def update_last_use(cluster_name: str):
     """Updates the last used command for the cluster."""
-    _DB.cursor.execute('UPDATE clusters SET last_use=(?) WHERE name=(?)',
-                       (common_utils.get_current_command(), cluster_name))
-    _DB.conn.commit()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        session.query(cluster_table).filter_by(name=cluster_name).update(
+            {cluster_table.c.last_use: common_utils.get_current_command()})
+        session.commit()
 
 
 def remove_cluster(cluster_name: str, terminate: bool) -> None:
@@ -430,139 +460,140 @@ def remove_cluster(cluster_name: str, terminate: bool) -> None:
     cluster_hash = _get_hash_for_existing_cluster(cluster_name)
     usage_intervals = _get_cluster_usage_intervals(cluster_hash)
 
-    # usage_intervals is not None and not empty
-    if usage_intervals:
-        assert cluster_hash is not None, cluster_name
-        start_time = usage_intervals.pop()[0]
-        end_time = int(time.time())
-        usage_intervals.append((start_time, end_time))
-        _set_cluster_usage_intervals(cluster_hash, usage_intervals)
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        # usage_intervals is not None and not empty
+        if usage_intervals:
+            assert cluster_hash is not None, cluster_name
+            start_time = usage_intervals.pop()[0]
+            end_time = int(time.time())
+            usage_intervals.append((start_time, end_time))
+            _set_cluster_usage_intervals(cluster_hash, usage_intervals)
 
-    if terminate:
-        _DB.cursor.execute('DELETE FROM clusters WHERE name=(?)',
-                           (cluster_name,))
-    else:
-        handle = get_handle_from_cluster_name(cluster_name)
-        if handle is None:
-            return
-        # Must invalidate IP list to avoid directly trying to ssh into a
-        # stopped VM, which leads to timeout.
-        if hasattr(handle, 'stable_internal_external_ips'):
-            handle = typing.cast('backends.CloudVmRayResourceHandle', handle)
-            handle.stable_internal_external_ips = None
-        current_time = int(time.time())
-        _DB.cursor.execute(
-            'UPDATE clusters SET handle=(?), status=(?), '
-            'status_updated_at=(?) WHERE name=(?)', (
-                pickle.dumps(handle),
-                status_lib.ClusterStatus.STOPPED.value,
-                current_time,
-                cluster_name,
-            ))
-    _DB.conn.commit()
+        if terminate:
+            session.query(cluster_table).filter_by(name=cluster_name).delete()
+        else:
+            handle = get_handle_from_cluster_name(cluster_name)
+            if handle is None:
+                return
+            # Must invalidate IP list to avoid directly trying to ssh into a
+            # stopped VM, which leads to timeout.
+            if hasattr(handle, 'stable_internal_external_ips'):
+                handle = typing.cast('backends.CloudVmRayResourceHandle',
+                                     handle)
+                handle.stable_internal_external_ips = None
+            current_time = int(time.time())
+            session.query(cluster_table).filter_by(name=cluster_name).update({
+                cluster_table.c.handle: pickle.dumps(handle),
+                cluster_table.c.status: status_lib.ClusterStatus.STOPPED.value,
+                cluster_table.c.status_updated_at: current_time
+            })
+        session.commit()
 
 
 def get_handle_from_cluster_name(
         cluster_name: str) -> Optional['backends.ResourceHandle']:
     assert cluster_name is not None, 'cluster_name cannot be None'
-    rows = _DB.cursor.execute('SELECT handle FROM clusters WHERE name=(?)',
-                              (cluster_name,))
-    for (handle,) in rows:
-        return pickle.loads(handle)
-    return None
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if row is None:
+            return None
+        return pickle.loads(row.handle)
 
 
 def get_glob_cluster_names(cluster_name: str) -> List[str]:
     assert cluster_name is not None, 'cluster_name cannot be None'
-    rows = _DB.cursor.execute('SELECT name FROM clusters WHERE name GLOB (?)',
-                              (cluster_name,))
-    return [row[0] for row in rows]
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            rows = session.query(cluster_table).filter(
+                cluster_table.c.name.op('GLOB')(cluster_name)).all()
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            # postgres does not support GLOB
+            raise ValueError('Unsupported database dialect')
+        else:
+            raise ValueError('Unsupported database dialect')
+        return [row.name for row in rows]
 
 
 def set_cluster_status(cluster_name: str,
                        status: status_lib.ClusterStatus) -> None:
     current_time = int(time.time())
-    _DB.cursor.execute(
-        'UPDATE clusters SET status=(?), status_updated_at=(?) WHERE name=(?)',
-        (status.value, current_time, cluster_name))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster {cluster_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_table).filter_by(
+            name=cluster_name).update({
+                cluster_table.c.status: status.value,
+                cluster_table.c.status_updated_at: current_time
+            })
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def set_cluster_autostop_value(cluster_name: str, idle_minutes: int,
                                to_down: bool) -> None:
-    _DB.cursor.execute(
-        'UPDATE clusters SET autostop=(?), to_down=(?) WHERE name=(?)', (
-            idle_minutes,
-            int(to_down),
-            cluster_name,
-        ))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster {cluster_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_table).filter_by(
+            name=cluster_name).update({
+                cluster_table.c.autostop: idle_minutes,
+                cluster_table.c.to_down: int(to_down)
+            })
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def get_cluster_launch_time(cluster_name: str) -> Optional[int]:
-    rows = _DB.cursor.execute('SELECT launched_at FROM clusters WHERE name=(?)',
-                              (cluster_name,))
-    for (launch_time,) in rows:
-        if launch_time is None:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if row is None or row.launched_at is None:
             return None
-        return int(launch_time)
-    return None
+        return int(row.launched_at)
 
 
 def get_cluster_info(cluster_name: str) -> Optional[Dict[str, Any]]:
-    rows = _DB.cursor.execute('SELECT metadata FROM clusters WHERE name=(?)',
-                              (cluster_name,))
-    for (metadata,) in rows:
-        if metadata is None:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if row is None or row.metadata is None:
             return None
-        return json.loads(metadata)
-    return None
+        return json.loads(row.metadata)
 
 
 def set_cluster_info(cluster_name: str, metadata: Dict[str, Any]) -> None:
-    _DB.cursor.execute('UPDATE clusters SET metadata=(?) WHERE name=(?)', (
-        json.dumps(metadata),
-        cluster_name,
-    ))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster {cluster_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_table).filter_by(
+            name=cluster_name).update(
+                {cluster_table.c.metadata: json.dumps(metadata)})
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def get_cluster_storage_mounts_metadata(
         cluster_name: str) -> Optional[Dict[str, Any]]:
-    rows = _DB.cursor.execute(
-        'SELECT storage_mounts_metadata FROM clusters WHERE name=(?)',
-        (cluster_name,))
-    for (storage_mounts_metadata,) in rows:
-        if storage_mounts_metadata is None:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if row is None or row.storage_mounts_metadata is None:
             return None
-        return pickle.loads(storage_mounts_metadata)
-    return None
+        return pickle.loads(row.storage_mounts_metadata)
 
 
 def set_cluster_storage_mounts_metadata(
         cluster_name: str, storage_mounts_metadata: Dict[str, Any]) -> None:
-    _DB.cursor.execute(
-        'UPDATE clusters SET storage_mounts_metadata=(?) WHERE name=(?)', (
-            pickle.dumps(storage_mounts_metadata),
-            cluster_name,
-        ))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster {cluster_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_table).filter_by(
+            name=cluster_name).update({
+                cluster_table.c.storage_mounts_metadata:
+                    pickle.dumps(storage_mounts_metadata)
+            })
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def _get_cluster_usage_intervals(
@@ -570,14 +601,12 @@ def _get_cluster_usage_intervals(
 ) -> Optional[List[Tuple[int, Optional[int]]]]:
     if cluster_hash is None:
         return None
-    rows = _DB.cursor.execute(
-        'SELECT usage_intervals FROM cluster_history WHERE cluster_hash=(?)',
-        (cluster_hash,))
-    for (usage_intervals,) in rows:
-        if usage_intervals is None:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_history_table).filter_by(
+            cluster_hash=cluster_hash).first()
+        if rows is None or rows.usage_intervals is None:
             return None
-        return pickle.loads(usage_intervals)
-    return None
+        return pickle.loads(rows.usage_intervals)
 
 
 def _get_cluster_launch_time(cluster_hash: str) -> Optional[int]:
@@ -609,18 +638,16 @@ def _get_cluster_duration(cluster_hash: str) -> int:
 def _set_cluster_usage_intervals(
         cluster_hash: str, usage_intervals: List[Tuple[int,
                                                        Optional[int]]]) -> None:
-    _DB.cursor.execute(
-        'UPDATE cluster_history SET usage_intervals=(?) WHERE cluster_hash=(?)',
-        (
-            pickle.dumps(usage_intervals),
-            cluster_hash,
-        ))
-
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster hash {cluster_hash} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_history_table).filter_by(
+            cluster_hash=cluster_hash).update({
+                cluster_history_table.c.usage_intervals:
+                    pickle.dumps(usage_intervals)
+            })
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster hash {cluster_hash} not found.')
 
 
 def set_owner_identity_for_cluster(cluster_name: str,
@@ -628,38 +655,38 @@ def set_owner_identity_for_cluster(cluster_name: str,
     if owner_identity is None:
         return
     owner_identity_str = json.dumps(owner_identity)
-    _DB.cursor.execute('UPDATE clusters SET owner=(?) WHERE name=(?)',
-                       (owner_identity_str, cluster_name))
-
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Cluster {cluster_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(cluster_table).filter_by(
+            name=cluster_name).update(
+                {cluster_table.c.owner: owner_identity_str})
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Cluster {cluster_name} not found.')
 
 
 def _get_hash_for_existing_cluster(cluster_name: str) -> Optional[str]:
-    rows = _DB.cursor.execute(
-        'SELECT cluster_hash FROM clusters WHERE name=(?)', (cluster_name,))
-    for (cluster_hash,) in rows:
-        if cluster_hash is None:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if row is None or row.cluster_hash is None:
             return None
-        return cluster_hash
-    return None
+        return row.cluster_hash
 
 
 def get_launched_resources_from_cluster_hash(
         cluster_hash: str) -> Optional[Tuple[int, Any]]:
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(cluster_history_table).filter_by(
+            cluster_hash=cluster_hash).first()
+        if row is None:
+            return None
+        num_nodes = row.num_nodes
+        launched_resources = row.launched_resources
 
-    rows = _DB.cursor.execute(
-        'SELECT num_nodes, launched_resources '
-        'FROM cluster_history WHERE cluster_hash=(?)', (cluster_hash,))
-    for (num_nodes, launched_resources) in rows:
         if num_nodes is None or launched_resources is None:
             return None
         launched_resources = pickle.loads(launched_resources)
         return num_nodes, launched_resources
-    return None
 
 
 def _load_owner(record_owner: Optional[str]) -> Optional[List[str]]:
@@ -693,169 +720,156 @@ def _load_storage_mounts_metadata(
 @context_utils.cancellation_guard
 def get_cluster_from_name(
         cluster_name: Optional[str]) -> Optional[Dict[str, Any]]:
-    rows = _DB.cursor.execute(
-        'SELECT name, launched_at, handle, last_use, status, autostop, '
-        'metadata, to_down, owner, cluster_hash, storage_mounts_metadata, '
-        'cluster_ever_up, status_updated_at, config_hash, user_hash, workspace '
-        'FROM clusters WHERE name=(?)', (cluster_name,)).fetchall()
-    for row in rows:
-        # Explicitly specify the number of fields to unpack, so that
-        # we can add new fields to the database in the future without
-        # breaking the previous code.
-        (name, launched_at, handle, last_use, status, autostop, metadata,
-         to_down, owner, cluster_hash, storage_mounts_metadata, cluster_ever_up,
-         status_updated_at, config_hash, user_hash, workspace) = row
-        user_hash = _get_user_hash_or_current_user(user_hash)
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_table).filter_by(name=cluster_name).first()
+        if rows is None:
+            return None
+        user_hash = _get_user_hash_or_current_user(rows.user_hash)
         # TODO: use namedtuple instead of dict
         record = {
-            'name': name,
-            'launched_at': launched_at,
-            'handle': pickle.loads(handle),
-            'last_use': last_use,
-            'status': status_lib.ClusterStatus[status],
-            'autostop': autostop,
-            'to_down': bool(to_down),
-            'owner': _load_owner(owner),
-            'metadata': json.loads(metadata),
-            'cluster_hash': cluster_hash,
-            'storage_mounts_metadata':
-                _load_storage_mounts_metadata(storage_mounts_metadata),
-            'cluster_ever_up': bool(cluster_ever_up),
-            'status_updated_at': status_updated_at,
+            'name': rows.name,
+            'launched_at': rows.launched_at,
+            'handle': pickle.loads(rows.handle),
+            'last_use': rows.last_use,
+            'status': status_lib.ClusterStatus[rows.status],
+            'autostop': rows.autostop,
+            'to_down': bool(rows.to_down),
+            'owner': _load_owner(rows.owner),
+            'metadata': json.loads(rows.metadata),
+            'cluster_hash': rows.cluster_hash,
+            'storage_mounts_metadata': _load_storage_mounts_metadata(
+                rows.storage_mounts_metadata),
+            'cluster_ever_up': bool(rows.cluster_ever_up),
+            'status_updated_at': rows.status_updated_at,
             'user_hash': user_hash,
             'user_name': get_user(user_hash).name,
-            'config_hash': config_hash,
-            'workspace': workspace,
+            'config_hash': rows.config_hash,
+            'workspace': rows.workspace,
         }
         return record
-    return None
 
 
 def get_clusters() -> List[Dict[str, Any]]:
-    rows = _DB.cursor.execute(
-        'select name, launched_at, handle, last_use, status, autostop, '
-        'metadata, to_down, owner, cluster_hash, storage_mounts_metadata, '
-        'cluster_ever_up, status_updated_at, config_hash, user_hash, workspace '
-        'from clusters order by launched_at desc').fetchall()
-    records = []
-    for row in rows:
-        (name, launched_at, handle, last_use, status, autostop, metadata,
-         to_down, owner, cluster_hash, storage_mounts_metadata, cluster_ever_up,
-         status_updated_at, config_hash, user_hash, workspace) = row
-        user_hash = _get_user_hash_or_current_user(user_hash)
-        # TODO: use namedtuple instead of dict
-        record = {
-            'name': name,
-            'launched_at': launched_at,
-            'handle': pickle.loads(handle),
-            'last_use': last_use,
-            'status': status_lib.ClusterStatus[status],
-            'autostop': autostop,
-            'to_down': bool(to_down),
-            'owner': _load_owner(owner),
-            'metadata': json.loads(metadata),
-            'cluster_hash': cluster_hash,
-            'storage_mounts_metadata':
-                _load_storage_mounts_metadata(storage_mounts_metadata),
-            'cluster_ever_up': bool(cluster_ever_up),
-            'status_updated_at': status_updated_at,
-            'user_hash': user_hash,
-            'user_name': get_user(user_hash).name,
-            'config_hash': config_hash,
-            'workspace': workspace,
-        }
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_table).order_by(
+            desc(cluster_table.c.launched_at)).all()
+        records = []
+        for row in rows:
+            user_hash = _get_user_hash_or_current_user(row.user_hash)
+            # TODO: use namedtuple instead of dict
+            record = {
+                'name': row.name,
+                'launched_at': row.launched_at,
+                'handle': pickle.loads(row.handle),
+                'last_use': row.last_use,
+                'status': status_lib.ClusterStatus[row.status],
+                'autostop': row.autostop,
+                'to_down': bool(row.to_down),
+                'owner': _load_owner(row.owner),
+                'metadata': json.loads(row.metadata),
+                'cluster_hash': row.cluster_hash,
+                'storage_mounts_metadata': _load_storage_mounts_metadata(
+                    row.storage_mounts_metadata),
+                'cluster_ever_up': bool(row.cluster_ever_up),
+                'status_updated_at': row.status_updated_at,
+                'user_hash': user_hash,
+                'user_name': get_user(user_hash).name,
+                'config_hash': row.config_hash,
+                'workspace': row.workspace,
+            }
 
-        records.append(record)
-    return records
+            records.append(record)
+        return records
 
 
 def get_clusters_from_history() -> List[Dict[str, Any]]:
-    rows = _DB.cursor.execute(
-        'SELECT ch.cluster_hash, ch.name, ch.num_nodes, '
-        'ch.launched_resources, ch.usage_intervals, clusters.status, '
-        'ch.user_hash  '
-        'FROM cluster_history ch '
-        'LEFT OUTER JOIN clusters '
-        'ON ch.cluster_hash=clusters.cluster_hash ').fetchall()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(
+            cluster_history_table.join(cluster_table,
+                                       cluster_history_table.c.cluster_hash ==
+                                       cluster_table.c.cluster_hash,
+                                       isouter=True)).all()
 
-    # '(cluster_hash, name, num_nodes, requested_resources, '
-    #         'launched_resources, usage_intervals) '
-    records = []
+        # '(cluster_hash, name, num_nodes, requested_resources, '
+        #         'launched_resources, usage_intervals) '
+        records = []
+        for row in rows:
+            # TODO: use namedtuple instead of dict
+            user_hash = _get_user_hash_or_current_user(row.user_hash)
+            status = row.status
+            if status is not None:
+                status = status_lib.ClusterStatus[status]
+            record = {
+                'name': row.name,
+                'launched_at': _get_cluster_launch_time(row.cluster_hash),
+                'duration': _get_cluster_duration(row.cluster_hash),
+                'num_nodes': row.num_nodes,
+                'resources': pickle.loads(row.launched_resources),
+                'cluster_hash': row.cluster_hash,
+                'usage_intervals': pickle.loads(row.usage_intervals),
+                'status': status,
+                'user_hash': user_hash,
+            }
 
-    for row in rows:
-        # TODO: use namedtuple instead of dict
+            records.append(record)
 
-        (
-            cluster_hash,
-            name,
-            num_nodes,
-            launched_resources,
-            usage_intervals,
-            status,
-            user_hash,
-        ) = row[:7]
-        user_hash = _get_user_hash_or_current_user(user_hash)
-
-        if status is not None:
-            status = status_lib.ClusterStatus[status]
-
-        record = {
-            'name': name,
-            'launched_at': _get_cluster_launch_time(cluster_hash),
-            'duration': _get_cluster_duration(cluster_hash),
-            'num_nodes': num_nodes,
-            'resources': pickle.loads(launched_resources),
-            'cluster_hash': cluster_hash,
-            'usage_intervals': pickle.loads(usage_intervals),
-            'status': status,
-            'user_hash': user_hash,
-        }
-
-        records.append(record)
-
-    # sort by launch time, descending in recency
-    records = sorted(records, key=lambda record: -record['launched_at'])
-    return records
+        # sort by launch time, descending in recency
+        records = sorted(records, key=lambda record: -record['launched_at'])
+        return records
 
 
 def get_cluster_names_start_with(starts_with: str) -> List[str]:
-    rows = _DB.cursor.execute('SELECT name FROM clusters WHERE name LIKE (?)',
-                              (f'{starts_with}%',))
-    return [row[0] for row in rows]
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(cluster_table).filter(
+            cluster_table.c.name.like(f'{starts_with}%')).all()
+        return [row.name for row in rows]
 
 
 def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
                               workspace: str) -> List['clouds.Cloud']:
-    # The table contains the cached enabled clouds for each workspace.
-    rows = _DB.cursor.execute(
-        'SELECT value FROM config WHERE key = ?',
-        (_get_enabled_clouds_key(cloud_capability, workspace),))
-    ret = []
-    for (value,) in rows:
-        ret = json.loads(value)
-        break
-    enabled_clouds: List['clouds.Cloud'] = []
-    for c in ret:
-        try:
-            cloud = registry.CLOUD_REGISTRY.from_str(c)
-        except ValueError:
-            # Handle the case for the clouds whose support has been removed from
-            # SkyPilot, e.g., 'local' was a cloud in the past and may be stored
-            # in the database for users before #3037. We should ignore removed
-            # clouds and continue.
-            continue
-        if cloud is not None:
-            enabled_clouds.append(cloud)
-    return enabled_clouds
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(config_table).filter_by(
+            key=_get_enabled_clouds_key(cloud_capability, workspace)).first()
+        ret = []
+        if row:
+            ret = json.loads(row.value)
+        enabled_clouds: List['clouds.Cloud'] = []
+        for c in ret:
+            try:
+                cloud = registry.CLOUD_REGISTRY.from_str(c)
+            except ValueError:
+                # Handle the case for the clouds whose support has been
+                # removed from SkyPilot, e.g., 'local' was a cloud in the past
+                # and may be stored in the database for users before #3037.
+                # We should ignore removed clouds and continue.
+                continue
+            if cloud is not None:
+                enabled_clouds.append(cloud)
+        return enabled_clouds
 
 
 def set_enabled_clouds(enabled_clouds: List[str],
                        cloud_capability: 'cloud.CloudCapability',
                        workspace: str) -> None:
-    _DB.cursor.execute('INSERT OR REPLACE INTO config VALUES (?, ?)',
-                       (_get_enabled_clouds_key(cloud_capability, workspace),
-                        json.dumps(enabled_clouds)))
-    _DB.conn.commit()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            insert_stmnt = sqlite_insert(config_table).values(
+                key=_get_enabled_clouds_key(cloud_capability, workspace),
+                value=json.dumps(enabled_clouds))
+            do_update_stmt = insert_stmnt.on_conflict_do_update(
+                index_elements=[config_table.c.key],
+                set_={config_table.c.value: json.dumps(enabled_clouds)})
+            session.execute(do_update_stmt)
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        session.commit()
 
 
 def _get_enabled_clouds_key(cloud_capability: 'cloud.CloudCapability',
@@ -876,89 +890,120 @@ def add_or_update_storage(storage_name: str,
     if not status_check(storage_status):
         raise ValueError(f'Error in updating global state. Storage Status '
                          f'{storage_status} is passed in incorrectly')
-    _DB.cursor.execute('INSERT OR REPLACE INTO storage VALUES (?, ?, ?, ?, ?)',
-                       (storage_name, storage_launched_at, handle, last_use,
-                        storage_status.value))
-    _DB.conn.commit()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            insert_stmnt = sqlite_insert(storage_table).values(
+                name=storage_name,
+                handle=handle,
+                last_use=last_use,
+                launched_at=storage_launched_at,
+                status=storage_status.value)
+            do_update_stmt = insert_stmnt.on_conflict_do_update(
+                index_elements=[storage_table.c.name],
+                set_={
+                    storage_table.c.handle: handle,
+                    storage_table.c.last_use: last_use,
+                    storage_table.c.launched_at: storage_launched_at,
+                    storage_table.c.status: storage_status.value
+                })
+            session.execute(do_update_stmt)
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        else:
+            session.rollback()
+            raise ValueError('Unsupported database dialect')
+        session.commit()
 
 
 def remove_storage(storage_name: str):
     """Removes Storage from Database"""
-    _DB.cursor.execute('DELETE FROM storage WHERE name=(?)', (storage_name,))
-    _DB.conn.commit()
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        session.query(storage_table).filter_by(name=storage_name).delete()
+        session.commit()
 
 
 def set_storage_status(storage_name: str,
                        status: status_lib.StorageStatus) -> None:
-    _DB.cursor.execute('UPDATE storage SET status=(?) WHERE name=(?)', (
-        status.value,
-        storage_name,
-    ))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Storage {storage_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(storage_table).filter_by(
+            name=storage_name).update({storage_table.c.status: status.value})
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Storage {storage_name} not found.')
 
 
 def get_storage_status(storage_name: str) -> Optional[status_lib.StorageStatus]:
     assert storage_name is not None, 'storage_name cannot be None'
-    rows = _DB.cursor.execute('SELECT status FROM storage WHERE name=(?)',
-                              (storage_name,))
-    for (status,) in rows:
-        return status_lib.StorageStatus[status]
-    return None
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(storage_table).filter_by(name=storage_name).first()
+        if row:
+            return status_lib.StorageStatus[row.status]
+        return None
 
 
 def set_storage_handle(storage_name: str,
                        handle: 'Storage.StorageMetadata') -> None:
-    _DB.cursor.execute('UPDATE storage SET handle=(?) WHERE name=(?)', (
-        pickle.dumps(handle),
-        storage_name,
-    ))
-    count = _DB.cursor.rowcount
-    _DB.conn.commit()
-    assert count <= 1, count
-    if count == 0:
-        raise ValueError(f'Storage{storage_name} not found.')
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        count = session.query(storage_table).filter_by(
+            name=storage_name).update(
+                {storage_table.c.handle: pickle.dumps(handle)})
+        session.commit()
+        assert count <= 1, count
+        if count == 0:
+            raise ValueError(f'Storage{storage_name} not found.')
 
 
 def get_handle_from_storage_name(
         storage_name: Optional[str]) -> Optional['Storage.StorageMetadata']:
     if storage_name is None:
         return None
-    rows = _DB.cursor.execute('SELECT handle FROM storage WHERE name=(?)',
-                              (storage_name,))
-    for (handle,) in rows:
-        if handle is None:
-            return None
-        return pickle.loads(handle)
-    return None
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(storage_table).filter_by(name=storage_name).first()
+        if row:
+            return pickle.loads(row.handle)
+        return None
 
 
 def get_glob_storage_name(storage_name: str) -> List[str]:
     assert storage_name is not None, 'storage_name cannot be None'
-    rows = _DB.cursor.execute('SELECT name FROM storage WHERE name GLOB (?)',
-                              (storage_name,))
-    return [row[0] for row in rows]
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLALCHEMY_DIALECT_SQLITE):
+            rows = session.query(storage_table).filter(
+                storage_table.c.name.op('GLOB')(storage_name)).all()
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLALCHEMY_DIALECT_POSTGRESQL):
+            # TODO(syang) support postgres dialect
+            # postgres does not support GLOB
+            raise ValueError('Unsupported database dialect')
+        else:
+            raise ValueError('Unsupported database dialect')
+        return [row.name for row in rows]
 
 
 def get_storage_names_start_with(starts_with: str) -> List[str]:
-    rows = _DB.cursor.execute('SELECT name FROM storage WHERE name LIKE (?)',
-                              (f'{starts_with}%',))
-    return [row[0] for row in rows]
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(storage_table).filter(
+            storage_table.c.name.like(f'{starts_with}%')).all()
+        return [row.name for row in rows]
 
 
 def get_storage() -> List[Dict[str, Any]]:
-    rows = _DB.cursor.execute('SELECT * FROM storage')
-    records = []
-    for name, launched_at, handle, last_use, status in rows:
-        # TODO: use namedtuple instead of dict
-        records.append({
-            'name': name,
-            'launched_at': launched_at,
-            'handle': pickle.loads(handle),
-            'last_use': last_use,
-            'status': status_lib.StorageStatus[status],
-        })
-    return records
+    with Session(_SQLALCHEMY_ENGINE) as session:
+        rows = session.query(storage_table).all()
+        records = []
+        for row in rows:
+            # TODO: use namedtuple instead of dict
+            records.append({
+                'name': row.name,
+                'launched_at': row.launched_at,
+                'handle': pickle.loads(row.handle),
+                'last_use': row.last_use,
+                'status': status_lib.StorageStatus[row.status],
+            })
+        return records

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -131,7 +131,8 @@ def create_table():
     # https://github.com/microsoft/WSL/issues/2395
     # TODO(romilb): We do not enable WAL for WSL because of known issue in WSL.
     #  This may cause the database locked problem from WSL issue #1441.
-    if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE and
+    if (_SQLALCHEMY_ENGINE.dialect.name
+            == db_utils.SQLAlchemyDialect.SQLITE.value and
             not common_utils.is_wsl()):
         try:
             with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -224,8 +225,8 @@ def add_or_update_user(user: models.User):
         return
 
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_stmnt = sqlite.insert(user_table).values(id=user.id,
                                                             name=user.name)
             do_update_stmt = insert_stmnt.on_conflict_do_update(
@@ -233,7 +234,7 @@ def add_or_update_user(user: models.User):
                 set_={user_table.c.name: user.name})
             session.execute(do_update_stmt)
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             session.rollback()
             raise ValueError('Unsupported database dialect')
@@ -349,8 +350,8 @@ def add_or_update_cluster(cluster_name: str,
                 'workspace': active_workspace,
             })
 
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_stmnt = sqlite.insert(cluster_table).values(
                 name=cluster_name,
                 **conditional_values,
@@ -377,7 +378,7 @@ def add_or_update_cluster(cluster_name: str,
                 })
             session.execute(do_update_stmt)
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             session.rollback()
             raise ValueError('Unsupported database dialect')
@@ -389,8 +390,8 @@ def add_or_update_cluster(cluster_name: str,
         launched_nodes = getattr(cluster_handle, 'launched_nodes', None)
         launched_resources = getattr(cluster_handle, 'launched_resources', None)
 
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_stmnt = sqlite.insert(cluster_history_table).values(
                 cluster_hash=cluster_hash,
                 name=cluster_name,
@@ -414,7 +415,7 @@ def add_or_update_cluster(cluster_name: str,
                 })
             session.execute(do_update_stmt)
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             session.rollback()
             raise ValueError('Unsupported database dialect')
@@ -501,12 +502,12 @@ def get_handle_from_cluster_name(
 def get_glob_cluster_names(cluster_name: str) -> List[str]:
     assert cluster_name is not None, 'cluster_name cannot be None'
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             rows = session.query(cluster_table).filter(
                 cluster_table.c.name.op('GLOB')(cluster_name)).all()
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             # postgres does not support GLOB
             raise ValueError('Unsupported database dialect')
@@ -850,8 +851,8 @@ def set_enabled_clouds(enabled_clouds: List[str],
                        cloud_capability: 'cloud.CloudCapability',
                        workspace: str) -> None:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_stmnt = sqlite.insert(config_table).values(
                 key=_get_enabled_clouds_key(cloud_capability, workspace),
                 value=json.dumps(enabled_clouds))
@@ -860,7 +861,7 @@ def set_enabled_clouds(enabled_clouds: List[str],
                 set_={config_table.c.value: json.dumps(enabled_clouds)})
             session.execute(do_update_stmt)
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             session.rollback()
             raise ValueError('Unsupported database dialect')
@@ -889,8 +890,8 @@ def add_or_update_storage(storage_name: str,
         raise ValueError(f'Error in updating global state. Storage Status '
                          f'{storage_status} is passed in incorrectly')
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_stmnt = sqlite.insert(storage_table).values(
                 name=storage_name,
                 handle=handle,
@@ -907,7 +908,7 @@ def add_or_update_storage(storage_name: str,
                 })
             session.execute(do_update_stmt)
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             session.rollback()
             raise ValueError('Unsupported database dialect')
@@ -970,12 +971,12 @@ def get_handle_from_storage_name(
 def get_glob_storage_name(storage_name: str) -> List[str]:
     assert storage_name is not None, 'storage_name cannot be None'
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name == db_utils.SQLAlchemyDialect.SQLITE
-           ):
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
             rows = session.query(storage_table).filter(
                 storage_table.c.name.op('GLOB')(storage_name)).all()
         elif (_SQLALCHEMY_ENGINE.dialect.name ==
-              db_utils.SQLAlchemyDialect.POSTGRESQL):
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             # TODO(syang) support postgres dialect
             # postgres does not support GLOB
             raise ValueError('Unsupported database dialect')

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -56,6 +56,7 @@ install_requires = [
     'aiofiles',
     'httpx',
     'setproctitle',
+    'sqlalchemy',
 ]
 
 local_ray = [

--- a/sky/utils/db_utils.py
+++ b/sky/utils/db_utils.py
@@ -94,7 +94,7 @@ def add_column_to_table_sqlalchemy(
 ):
     """Add a column to a table."""
     dialect = session.bind.dialect
-    if dialect.name == SQLAlchemyDialect.SQLITE:
+    if dialect.name == SQLAlchemyDialect.SQLITE.value:
         try:
             session.execute(
                 sqlalchemy.text(f'ALTER TABLE {table_name} '
@@ -114,7 +114,7 @@ def add_column_to_table_sqlalchemy(
                 pass
             else:
                 raise
-    elif dialect.name == SQLAlchemyDialect.POSTGRESQL:
+    elif dialect.name == SQLAlchemyDialect.POSTGRESQL.value:
         # TODO(syang) support postgres dialect
         session.rollback()
         raise ValueError('Unsupported database dialect')

--- a/sky/utils/db_utils.py
+++ b/sky/utils/db_utils.py
@@ -2,7 +2,14 @@
 import contextlib
 import sqlite3
 import threading
+import typing
 from typing import Any, Callable, Optional
+
+from sqlalchemy import exc as sqlalchemy_exc
+from sqlalchemy import text
+
+if typing.TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 # This parameter (passed to sqlite3.connect) controls how long we will wait to
 # obtains a database lock (not necessarily during connection, but whenever it is
@@ -19,6 +26,12 @@ from typing import Any, Callable, Optional
 # 1000x parallelism, this is thus thought to be a conservative setting.
 # For more info, see the PR description for #4552.
 _DB_TIMEOUT_S = 60
+
+# sqlite dialect
+SQLALCHEMY_DIALECT_SQLITE = 'sqlite'
+# postgresql dialect
+# this dialect is not supported yet.
+SQLALCHEMY_DIALECT_POSTGRESQL = 'postgresql'
 
 
 @contextlib.contextmanager
@@ -69,6 +82,46 @@ def add_column_to_table(
             else:
                 raise
     conn.commit()
+
+
+def add_column_to_table_sqlalchemy(
+    session: 'Session',
+    table_name: str,
+    column_name: str,
+    column_type: str,
+    copy_from: Optional[str] = None,
+    value_to_replace_existing_entries: Optional[Any] = None,
+):
+    """Add a column to a table."""
+    dialect = session.bind.dialect
+    if dialect.name == SQLALCHEMY_DIALECT_SQLITE:
+        try:
+            session.execute(
+                text(f'ALTER TABLE {table_name} '
+                     f'ADD COLUMN {column_name} {column_type}'))
+            if copy_from is not None:
+                session.execute(
+                    text(f'UPDATE {table_name} '
+                         f'SET {column_name} = {copy_from}'))
+            if value_to_replace_existing_entries is not None:
+                session.execute(
+                    text(f'UPDATE {table_name} '
+                         f'SET {column_name} = :replacement_value '
+                         f'WHERE {column_name} IS NULL'),
+                    {'replacement_value': value_to_replace_existing_entries})
+        except sqlalchemy_exc.OperationalError as e:
+            if 'duplicate column name' in str(e):
+                pass
+            else:
+                raise
+    elif dialect.name == SQLALCHEMY_DIALECT_POSTGRESQL:
+        # TODO(syang) support postgres dialect
+        session.rollback()
+        raise ValueError('Unsupported database dialect')
+    else:
+        session.rollback()
+        raise ValueError('Unsupported database dialect')
+    session.commit()
 
 
 def rename_column(

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,138 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import sessionmaker
+
+from sky.utils.db_utils import add_column_to_table_sqlalchemy
+
+
+@pytest.fixture
+def sqlalchemy_sqlite_session():
+    """Create a SQLite session for testing."""
+    engine = create_engine('sqlite:///:memory:')
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    # Create a test table
+    session.execute(
+        text('''
+        CREATE TABLE test_table (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        )
+    '''))
+    session.commit()
+
+    return session
+
+
+def test_add_column_basic(sqlalchemy_sqlite_session):
+    """Test adding a basic column to a table."""
+    add_column_to_table_sqlalchemy(sqlalchemy_sqlite_session, 'test_table',
+                                   'age', 'INTEGER')
+
+    # Verify the column was added
+    result = sqlalchemy_sqlite_session.execute(
+        text('PRAGMA table_info(test_table)')).fetchall()
+    column_names = [row[1] for row in result]
+    assert 'age' in column_names
+
+
+def test_add_column_with_copy(sqlalchemy_sqlite_session):
+    """Test adding a column and copying values from another column."""
+    # Add some test data
+    sqlalchemy_sqlite_session.execute(
+        text('''
+        INSERT INTO test_table (name) VALUES ('Alice'), ('Bob')
+    '''))
+
+    add_column_to_table_sqlalchemy(sqlalchemy_sqlite_session,
+                                   'test_table',
+                                   'name_copy',
+                                   'TEXT',
+                                   copy_from='name')
+
+    # Verify the values were copied
+    result = sqlalchemy_sqlite_session.execute(
+        text('SELECT name, name_copy FROM test_table')).fetchall()
+    for row in result:
+        assert row[0] == row[1]
+
+
+def test_add_column_with_default_value(sqlalchemy_sqlite_session):
+    """Test adding a column with a default value."""
+    add_column_to_table_sqlalchemy(
+        sqlalchemy_sqlite_session,
+        'test_table',
+        'test1',
+        'TEXT DEFAULT "default_value"',
+    )
+    # add a test entry
+    sqlalchemy_sqlite_session.execute(
+        text('''
+        INSERT INTO test_table (name) VALUES ('name')
+    '''))
+
+    # Verify the default value was set
+    result = sqlalchemy_sqlite_session.execute(
+        text('SELECT test1 FROM test_table')).fetchall()
+    assert len(result) == 1
+    for row in result:
+        assert row[0] == 'default_value'
+
+
+def test_add_column_with_value_to_replace_existing_entries(
+        sqlalchemy_sqlite_session):
+    """Test adding a column with a default value for existing entries."""
+    # add a test entry
+    sqlalchemy_sqlite_session.execute(
+        text('''
+        INSERT INTO test_table (name) VALUES ('existing_value')
+    '''))
+
+    # add a new column with a default value for existing entries
+    add_column_to_table_sqlalchemy(
+        sqlalchemy_sqlite_session,
+        'test_table',
+        'test1',
+        'TEXT',
+        value_to_replace_existing_entries='replacement_value1')
+
+    # Verify the default value was set
+    result = sqlalchemy_sqlite_session.execute(
+        text('SELECT test1 FROM test_table')).fetchall()
+    assert len(result) == 1
+    for row in result:
+        assert row[0] == 'replacement_value1'
+
+    # add a new column with a different column type
+    add_column_to_table_sqlalchemy(sqlalchemy_sqlite_session,
+                                   'test_table',
+                                   'test2',
+                                   'INTEGER',
+                                   value_to_replace_existing_entries=1)
+
+    # Verify the default value was set
+    result = sqlalchemy_sqlite_session.execute(
+        text('SELECT test2 FROM test_table')).fetchall()
+    assert len(result) == 1
+    for row in result:
+        assert row[0] == 1
+
+
+def test_add_duplicate_column(sqlalchemy_sqlite_session):
+    """Test adding a column that already exists."""
+    # First add the column
+    add_column_to_table_sqlalchemy(sqlalchemy_sqlite_session, 'test_table',
+                                   'age', 'INTEGER')
+
+    # Try to add it again - should not raise an error
+    add_column_to_table_sqlalchemy(sqlalchemy_sqlite_session, 'test_table',
+                                   'age', 'INTEGER')
+
+    # Verify the column still exists
+    result = sqlalchemy_sqlite_session.execute(
+        text('PRAGMA table_info(test_table)')).fetchall()
+    column_names = [row[1] for row in result]
+    assert 'age' in column_names

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -6,6 +6,7 @@ import boto3
 import botocore.exceptions
 import moto
 import pytest
+from sqlalchemy import create_engine
 
 import sky
 from sky import global_user_state
@@ -19,9 +20,15 @@ from sky.utils import env_options
 
 @pytest.fixture
 def _mock_db_conn(tmp_path, monkeypatch):
+    # Create a temporary database file
     db_path = tmp_path / 'state_testing.db'
-    db_conn = db_utils.SQLiteConn(str(db_path), global_user_state.create_table)
-    monkeypatch.setattr(global_user_state, '_DB', db_conn)
+
+    sqlalchemy_engine = create_engine(f'sqlite:///{db_path}')
+
+    monkeypatch.setattr(global_user_state, '_SQLALCHEMY_ENGINE',
+                        sqlalchemy_engine)
+
+    global_user_state.create_table()
 
 
 @pytest.mark.parametrize('enable_all_clouds', [[sky.AWS()]], indirect=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Migrate `sky/global_user_state.py` to use SQLAlchemy, with follow-up goal to support postgressql as another backend to `global_user_state`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
