### PR TITLE
FIX: api server does not work when venv has space in path

### DIFF
--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -302,6 +302,13 @@ def _start_api_server(deploy: bool = False,
         # If this is called from a CLI invocation, we need
         # start_new_session=True so that SIGINT on the CLI will not also kill
         # the API server.
+        # Because the log file is opened using a with statement, it may seem
+        # that the file will be closed when the with statement is exited causing
+        # the child process to be unable to write to the log file.
+        # However, Popen makes the file descriptor inheritable which means
+        # the child process will inherit its own copy of the fd,
+        # independent of the parent's fd table which enables to child process
+        # to continue writing to the log file.
         server_env = os.environ.copy()
         server_env[constants.ENV_VAR_IS_SKYPILOT_SERVER] = 'true'
         with open(log_path, 'w', encoding='utf-8') as log_file:

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -297,7 +297,6 @@ def _start_api_server(deploy: bool = False,
 
         log_path = os.path.expanduser(constants.API_SERVER_LOGS)
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
-        cmd = f'{" ".join(args)} > {log_path} 2>&1 < /dev/null'
 
         # Start the API server process in the background and don't wait for it.
         # If this is called from a CLI invocation, we need
@@ -305,10 +304,13 @@ def _start_api_server(deploy: bool = False,
         # the API server.
         server_env = os.environ.copy()
         server_env[constants.ENV_VAR_IS_SKYPILOT_SERVER] = 'true'
-        proc = subprocess.Popen(cmd,
-                                shell=True,
-                                start_new_session=True,
-                                env=server_env)
+        with open(log_path, 'w', encoding='utf-8') as log_file:
+            proc = subprocess.Popen(args,
+                                    stdout=log_file,
+                                    stderr=subprocess.STDOUT,
+                                    stdin=subprocess.DEVNULL,
+                                    start_new_session=True,
+                                    env=server_env)
 
         start_time = time.time()
         while True:

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -302,16 +302,16 @@ def _start_api_server(deploy: bool = False,
         # If this is called from a CLI invocation, we need
         # start_new_session=True so that SIGINT on the CLI will not also kill
         # the API server.
-        # Because the log file is opened using a with statement, it may seem
-        # that the file will be closed when the with statement is exited causing
-        # the child process to be unable to write to the log file.
-        # However, Popen makes the file descriptor inheritable which means
-        # the child process will inherit its own copy of the fd,
-        # independent of the parent's fd table which enables to child process
-        # to continue writing to the log file.
         server_env = os.environ.copy()
         server_env[constants.ENV_VAR_IS_SKYPILOT_SERVER] = 'true'
         with open(log_path, 'w', encoding='utf-8') as log_file:
+            # Because the log file is opened using a with statement, it may seem
+            # that the file will be closed when the with statement is exited
+            # causing the child process to be unable to write to the log file.
+            # However, Popen makes the file descriptor inheritable which means
+            # the child process will inherit its own copy of the fd,
+            # independent of the parent's fd table which enables to child
+            # process to continue writing to the log file.
             proc = subprocess.Popen(args,
                                     stdout=log_file,
                                     stderr=subprocess.STDOUT,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes: https://github.com/skypilot-org/skypilot/issues/5572

This PR fixes an issue where the local API server fails to start when SkyPilot is installed in a venv with a space in its path. For example, for the venv at `~/my folder/.venv/bin/sky`, running `sky api start` results in the API server log complaining that `~/my: No such file or directory`.

The issue was that the call to `Popen` was being made with `shell=True`. This was done to handle the redirection operators `>`, `2>&1`, and `<` to redirect stdout to a log file, stderr to stdout (log file), and stdin to /dev/null respectively. However, this also meant that spaces are interpreted as argument separators. `Popen` has parameters to specify sdout, stderr, and stdin redirections, so this PR utilizes those parameters and removes `shell=True` (`shell=False` is the default for `Popen`). Using `shell=False` directly passes the  venv path to the system call which knows to interpret the space as part of the path rather than an argument separator.

One concern is that the log file is opened within a `with` block, so it may seem that after the child process is forked, it will be prevented to write to the file because the file would be closed at the end of the `with` block. However, `subprocess.Popen` makes the file descriptor "inheritable" which means that  child processes will get their own copy of the fd, independent of the parent's fd table.

<!-- Describe the tests ran -->

The PR was tested locally using the following reproduction steps:

```
cd ~
mkdir "my folder"
cd "my folder"
uv venv --seed --python=3.10
source .venv/bin/activate
```

and then running 

```
sky api start
sky api stop
```

and verifying that the api server starts successfully. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
