### PR TITLE
move ssh timeout for provisioning to config

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -373,8 +373,7 @@ Example:
 Timeout in seconds for SSH connection probing during provisioning (optional).
 
 Cluster SSH connection is probed during provisioning to check if a cluster is up. This timeout
-determines how long to wait for the connection to be established. Being able to configure this 
-timeout can prove useful when working remotely with a jump server.
+determines how long to wait for the connection to be established.
 
 Default: ``10``.
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -55,6 +55,9 @@ Below is the configuration syntax and some example values. See detailed explanat
 
   :ref:`admin_policy <config-yaml-admin-policy>`: my_package.SkyPilotPolicyV1
 
+  :ref:`provision <config-yaml-provision>`:
+    :ref:`ssh_timeout <config-yaml-provision-ssh-timeout>`: 10
+
   :ref:`kubernetes <config-yaml-kubernetes>`:
     :ref:`ports <config-yaml-kubernetes-ports>`: loadbalancer
     :ref:`remote_identity <config-yaml-kubernetes-remote-identity>`: my-k8s-service-account
@@ -356,6 +359,24 @@ Example:
 .. code-block:: yaml
 
   admin_policy: my_package.SkyPilotPolicyV1
+
+.. _config-yaml-provision:
+
+``provision``
+~~~~~~~~~~~~~
+
+.. _config-yaml-provision-ssh-timeout:
+
+``provision.ssh_timeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Timeout in seconds for SSH connection probing during provisioning (optional).
+
+Cluster SSH connection is probed during provisioning to check if a cluster is up. This timeout
+determines how long to wait for the connection to be established. Being able to configure this 
+timeout can prove useful when working remotely with a jump server.
+
+Default: ``10``.
 
 .. _config-yaml-aws:
 

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -315,8 +315,7 @@ def _wait_ssh_connection_direct(ip: str,
     except Exception as e:  # pylint: disable=broad-except
         stderr = f'Error: {common_utils.format_exception(e)}'
     command = _ssh_probe_command(ip, ssh_port, ssh_user, ssh_private_key,
-                                 ssh_probe_timeout,
-                                 ssh_proxy_command)
+                                 ssh_probe_timeout, ssh_proxy_command)
     logger.debug(f'Waiting for SSH to {ip}. Try: '
                  f'{_shlex_join(command)}. '
                  f'{stderr}')
@@ -388,9 +387,13 @@ def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
     def _retry_ssh_thread(ip_ssh_port: Tuple[str, int]):
         ip, ssh_port = ip_ssh_port
         success = False
-        ssh_probe_timeout = skypilot_config.get_nested(('provision', 'ssh_timeout'), 10)
+        ssh_probe_timeout = skypilot_config.get_nested(
+            ('provision', 'ssh_timeout'), 10)
         while not success:
-            success, stderr = waiter(ip, ssh_port, **ssh_credentials, ssh_probe_timeout=ssh_probe_timeout)
+            success, stderr = waiter(ip,
+                                     ssh_port,
+                                     **ssh_credentials,
+                                     ssh_probe_timeout=ssh_probe_timeout)
             if not success and time.time() - start > timeout:
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(

--- a/sky/provision/provisioner.py
+++ b/sky/provision/provisioner.py
@@ -17,6 +17,7 @@ from sky import clouds
 from sky import exceptions
 from sky import provision
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import aws
 from sky.backends import backend_utils
 from sky.provision import common as provision_common
@@ -228,9 +229,9 @@ def _ssh_probe_command(ip: str,
                        ssh_port: int,
                        ssh_user: str,
                        ssh_private_key: str,
+                       provision_ssh_timeout: int,
                        ssh_proxy_command: Optional[str] = None) -> List[str]:
-    # NOTE: Ray uses 'uptime' command and 10s timeout, we use the same
-    # setting here.
+    # NOTE: Ray uses 'uptime' command, we use the same setting here.
     command = [
         'ssh',
         '-T',
@@ -244,7 +245,7 @@ def _ssh_probe_command(ip: str,
         '-o',
         'PasswordAuthentication=no',
         '-o',
-        'ConnectTimeout=10s',
+        f'ConnectTimeout={provision_ssh_timeout}s',
         '-o',
         f'UserKnownHostsFile={os.devnull}',
         '-o',
@@ -277,6 +278,7 @@ def _wait_ssh_connection_direct(ip: str,
                                 ssh_port: int,
                                 ssh_user: str,
                                 ssh_private_key: str,
+                                provision_ssh_timeout: int,
                                 ssh_control_name: Optional[str] = None,
                                 ssh_proxy_command: Optional[str] = None,
                                 **kwargs) -> Tuple[bool, str]:
@@ -305,6 +307,7 @@ def _wait_ssh_connection_direct(ip: str,
         if success:
             return _wait_ssh_connection_indirect(ip, ssh_port, ssh_user,
                                                  ssh_private_key,
+                                                 provision_ssh_timeout,
                                                  ssh_control_name,
                                                  ssh_proxy_command)
     except socket.timeout:  # this is the most expected exception
@@ -312,6 +315,7 @@ def _wait_ssh_connection_direct(ip: str,
     except Exception as e:  # pylint: disable=broad-except
         stderr = f'Error: {common_utils.format_exception(e)}'
     command = _ssh_probe_command(ip, ssh_port, ssh_user, ssh_private_key,
+                                 provision_ssh_timeout,
                                  ssh_proxy_command)
     logger.debug(f'Waiting for SSH to {ip}. Try: '
                  f'{_shlex_join(command)}. '
@@ -323,6 +327,7 @@ def _wait_ssh_connection_indirect(ip: str,
                                   ssh_port: int,
                                   ssh_user: str,
                                   ssh_private_key: str,
+                                  provision_ssh_timeout: int,
                                   ssh_control_name: Optional[str] = None,
                                   ssh_proxy_command: Optional[str] = None,
                                   **kwargs) -> Tuple[bool, str]:
@@ -333,14 +338,14 @@ def _wait_ssh_connection_indirect(ip: str,
     """
     del ssh_control_name, kwargs  # unused
     command = _ssh_probe_command(ip, ssh_port, ssh_user, ssh_private_key,
-                                 ssh_proxy_command)
+                                 provision_ssh_timeout, ssh_proxy_command)
     message = f'Waiting for SSH using command: {_shlex_join(command)}'
     logger.debug(message)
     try:
         proc = subprocess.run(command,
                               shell=False,
                               check=False,
-                              timeout=10,
+                              timeout=provision_ssh_timeout,
                               stdout=subprocess.DEVNULL,
                               stderr=subprocess.PIPE)
         if proc.returncode != 0:
@@ -383,8 +388,9 @@ def wait_for_ssh(cluster_info: provision_common.ClusterInfo,
     def _retry_ssh_thread(ip_ssh_port: Tuple[str, int]):
         ip, ssh_port = ip_ssh_port
         success = False
+        provision_ssh_timeout = skypilot_config.get_nested(('provision_ssh_timeout'), 10)
         while not success:
-            success, stderr = waiter(ip, ssh_port, **ssh_credentials)
+            success, stderr = waiter(ip, ssh_port, **ssh_credentials, provision_ssh_timeout=provision_ssh_timeout)
             if not success and time.time() - start > timeout:
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1065,7 +1065,6 @@ def get_config_schema():
         'properties': {
             'ssh_timeout': {
                 'type': 'integer',
-                'description': 'Timeout in seconds for SSH connection during provisioning.',
                 'minimum': 1,
             },
         }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1072,9 +1072,8 @@ def get_config_schema():
 
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
-            config['properties'].update({
-                'remote_identity': _PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY
-            })
+            config['properties'].update(
+                {'remote_identity': _PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY})
         elif cloud == 'kubernetes':
             config['properties'].update(_REMOTE_IDENTITY_SCHEMA_KUBERNETES)
         else:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1080,6 +1080,11 @@ def get_config_schema():
             'docker': docker_configs,
             'nvidia_gpus': gpu_configs,
             'api_server': api_server,
+            'provision_ssh_timeout': {
+                'type': 'integer',
+                'description': 'Timeout in seconds for SSH connection during provisioning',
+                'minimum': 1,
+            },
             **cloud_configs,
         },
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1058,6 +1058,17 @@ def get_config_schema():
         }
     }
 
+    provision_configs = {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'ssh_timeout': {
+                'type': 'integer',
+            },
+        }
+    }
+
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update({
@@ -1080,11 +1091,7 @@ def get_config_schema():
             'docker': docker_configs,
             'nvidia_gpus': gpu_configs,
             'api_server': api_server,
-            'provision_ssh_timeout': {
-                'type': 'integer',
-                'description': 'Timeout in seconds for SSH connection during provisioning',
-                'minimum': 1,
-            },
+            'provision': provision_configs,
             **cloud_configs,
         },
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1065,6 +1065,8 @@ def get_config_schema():
         'properties': {
             'ssh_timeout': {
                 'type': 'integer',
+                'description': 'Timeout in seconds for SSH connection during provisioning.',
+                'minimum': 1,
             },
         }
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -676,7 +676,7 @@ _LABELS_SCHEMA = {
     }
 }
 
-_PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY = {
+_PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY = {
     'oneOf': [
         {
             'type': 'string'
@@ -800,7 +800,7 @@ def get_config_schema():
                     'type': 'boolean',
                 },
                 'security_group_name':
-                    (_PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
+                    (_PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY),
                 'vpc_name': {
                     'oneOf': [{
                         'type': 'string',
@@ -1073,7 +1073,7 @@ def get_config_schema():
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update({
-                'remote_identity': _PRORPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY
+                'remote_identity': _PROPERTY_NAME_OR_CLUSTER_NAME_TO_PROPERTY
             })
         elif cloud == 'kubernetes':
             config['properties'].update(_REMOTE_IDENTITY_SCHEMA_KUBERNETES)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR moves the ssh timeout for the probe during provisioning into config. This resolves the issue where users who are using VPNs or otherwise experiencing a delay to ssh into their clusters see provisioning fail due to the hardcoded 10s timeout despite their clusters actually being up and running. 

This adds a top-level config variable called `provision_ssh_timeout` which allows users to specify their own ssh timeouts for provisioning clusters. 

Updated docs: https://docs.skypilot.co/en/provision-ssh-timeout-config/reference/config.html

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
