### PR TITLE
Allow bypass version check on release pipeline

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -9,6 +9,11 @@ on:
         description: 'Release version (e.g., 0.9.0)'
         required: false
         type: string
+      skip_version_checks:
+        description: 'Skip version verification steps'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release-build:
@@ -134,6 +139,7 @@ jobs:
 
       - name: Verify release version > latest PyPI version
         id: verify_version
+        if: ${{ !github.event.inputs.skip_version_checks }}
         run: |
           RELEASE_VERSION="${{ steps.determine_version.outputs.release_version }}"
           echo "Validated release version: ${RELEASE_VERSION}"
@@ -164,6 +170,7 @@ jobs:
 
       - name: Verify API Version Compatibility
         id: verify_api_version
+        if: ${{ !github.event.inputs.skip_version_checks }}
         run: |
           RELEASE_VERSION="${{ steps.determine_version.outputs.release_version }}"
           LATEST_PYPI_VERSION="${{ steps.find_previous_release_branch.outputs.latest_pypi_version }}"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Add one more param: `skip_version_checks` to resolve [comment](https://github.com/skypilot-org/skypilot/pull/5470#pullrequestreview-2810772543)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
