### PR TITLE
[Core] `sky check <cloud>` show clear error if `<cloud>` is not in `allowed_clouds`

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -70,10 +70,8 @@ def check_capabilities(
         return tuple([repr(c) for c in registry.CLOUD_REGISTRY.values()] +
                      [cloudflare.NAME])
 
-    explicit_check = False
     if clouds is not None:
         cloud_list = clouds
-        explicit_check = True
     else:
         cloud_list = get_all_clouds()
     clouds_to_check = [get_cloud_tuple(c) for c in cloud_list]
@@ -92,7 +90,7 @@ def check_capabilities(
     # Throw errors for clouds explicitly checked that are not allowed.
     disallowed_explicit_check_cloud_names = [
         c for c, _ in clouds_to_check if c not in config_allowed_cloud_names
-    ] if explicit_check else []
+    ] if clouds is not None else []
     # Check only the clouds which are allowed in the config.
     clouds_to_check = [
         c for c in clouds_to_check if c[0] in config_allowed_cloud_names

--- a/sky/check.py
+++ b/sky/check.py
@@ -70,8 +70,10 @@ def check_capabilities(
         return tuple([repr(c) for c in registry.CLOUD_REGISTRY.values()] +
                      [cloudflare.NAME])
 
+    explicit_check = False
     if clouds is not None:
         cloud_list = clouds
+        explicit_check = True
     else:
         cloud_list = get_all_clouds()
     clouds_to_check = [get_cloud_tuple(c) for c in cloud_list]
@@ -87,6 +89,10 @@ def check_capabilities(
     disallowed_cloud_names = [
         c for c in get_all_clouds() if c not in config_allowed_cloud_names
     ]
+    # Throw errors for clouds explicitly checked that are not allowed.
+    disallowed_explicit_check_cloud_names = [
+        c for c, _ in clouds_to_check if c not in config_allowed_cloud_names
+    ] if explicit_check else []
     # Check only the clouds which are allowed in the config.
     clouds_to_check = [
         c for c in clouds_to_check if c[0] in config_allowed_cloud_names
@@ -156,6 +162,11 @@ def check_capabilities(
             '\nNote: The following clouds were disabled because they were not '
             'included in allowed_clouds in ~/.sky/config.yaml: '
             f'{", ".join([c for c in disallowed_cloud_names])}')
+    if disallowed_explicit_check_cloud_names:
+        echo('\n' + '\n'.join([
+            f'Error: {cloud} is not included in allowed_clouds in `~/.sky/config.yaml`'  # pylint: disable=line-too-long
+            for cloud in disallowed_explicit_check_cloud_names
+        ]))
     if not all_enabled_clouds:
         echo(
             click.style(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #5605 

![Screenshot 2025-05-21 at 4 02 32 PM](https://github.com/user-attachments/assets/6e288417-0023-4ff8-830a-437de521851f)

(Works normally when we don't specify a cloud. I checked this but didn't bother to include a screenshot)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
