### PR TITLE
Dummy cloud special handle for `specific_reservations`

### DIFF
--- a/sky/clouds/__init__.py
+++ b/sky/clouds/__init__.py
@@ -3,6 +3,7 @@
 from sky.clouds.cloud import Cloud
 from sky.clouds.cloud import cloud_in_iterable
 from sky.clouds.cloud import CloudImplementationFeatures
+from sky.clouds.cloud import DummyCloud
 from sky.clouds.cloud import OpenPortsVersion
 from sky.clouds.cloud import ProvisionerVersion
 from sky.clouds.cloud import Region
@@ -34,6 +35,7 @@ __all__ = [
     'Azure',
     'Cloud',
     'Cudo',
+    'DummyCloud',
     'GCP',
     'Lambda',
     'DO',

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -888,6 +888,11 @@ class Cloud:
         return state
 
 
+class DummyCloud(Cloud):
+    """A dummy Cloud that has zero egress cost from/to."""
+    pass
+
+
 # === Helper functions ===
 def cloud_in_iterable(cloud: Cloud, cloud_list: Iterable[Cloud]) -> bool:
     """Returns whether the cloud is in the given cloud list."""

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -889,7 +889,8 @@ class Cloud:
 
 
 class DummyCloud(Cloud):
-    """A dummy Cloud that has zero egress cost from/to."""
+    """A dummy Cloud that has zero egress cost from/to for optimization
+    purpose."""
     pass
 
 

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -73,8 +73,8 @@ class Optimizer:
     def _egress_cost(src_cloud: clouds.Cloud, dst_cloud: clouds.Cloud,
                      gigabytes: float) -> float:
         """Returns estimated egress cost."""
-        if isinstance(src_cloud, DummyCloud) or isinstance(
-                dst_cloud, DummyCloud):
+        if isinstance(src_cloud, clouds.DummyCloud) or isinstance(
+                dst_cloud, clouds.DummyCloud):
             return 0.0
 
         if not src_cloud.is_same_cloud(dst_cloud):
@@ -88,8 +88,8 @@ class Optimizer:
                      gigabytes: float) -> float:
         """Returns estimated egress time in seconds."""
         # FIXME: estimate bandwidth between each cloud-region pair.
-        if isinstance(src_cloud, DummyCloud) or isinstance(
-                dst_cloud, DummyCloud):
+        if isinstance(src_cloud, clouds.DummyCloud) or isinstance(
+                dst_cloud, clouds.DummyCloud):
             return 0.0
         if not src_cloud.is_same_cloud(dst_cloud):
             # 10Gbps is close to the average of observed b/w from S3
@@ -167,7 +167,7 @@ class Optimizer:
 
         def make_dummy(name):
             dummy = task_lib.Task(name)
-            dummy.set_resources({DummyResources(cloud=DummyCloud())})
+            dummy.set_resources({DummyResources(cloud=clouds.DummyCloud())})
             dummy.set_time_estimator(lambda _: 0)
             return dummy
 
@@ -197,7 +197,7 @@ class Optimizer:
         node: task_lib.Task,
         resources: resources_lib.Resources,
     ) -> Tuple[Optional[clouds.Cloud], Optional[clouds.Cloud], Optional[float]]:
-        if isinstance(parent_resources.cloud, DummyCloud):
+        if isinstance(parent_resources.cloud, clouds.DummyCloud):
             # Special case.  The current 'node' is a real
             # source node, and its input may be on a different
             # cloud from 'resources'.
@@ -1156,11 +1156,6 @@ class DummyResources(resources_lib.Resources):
 
     def get_cost(self, seconds):
         return 0
-
-
-class DummyCloud(clouds.Cloud):
-    """A dummy Cloud that has zero egress cost from/to."""
-    pass
 
 
 def _filter_out_blocked_launchable_resources(

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1295,7 +1295,10 @@ class Resources:
 
         if isinstance(self.cloud, clouds.DummyCloud):
             return self.cloud.get_reservations_available_resources(
-                '', '', None, specific_reservations)
+                instance_type='',
+                region='',
+                zone=None,
+                specific_reservations=specific_reservations)
 
         assert (self.cloud is not None and self.instance_type is not None and
                 self.region is not None), (

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1298,8 +1298,10 @@ class Resources:
                 '', '', None, specific_reservations)
 
         assert (self.cloud is not None and self.instance_type is not None and
-                self.region
-                is not None), ('Cloud, instance type, region must be specified')
+                self.region is not None), (
+                    f'Cloud, instance type, region must be specified. '
+                    f'Resources={self}, cloud={self.cloud}, '
+                    f'instance_type={self.instance_type}, region={self.region}')
         return self.cloud.get_reservations_available_resources(
             self.instance_type, self.region, self.zone, specific_reservations)
 

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1293,6 +1293,10 @@ class Resources:
             skypilot_config.get_nested(
                 (str(self.cloud).lower(), 'specific_reservations'), set()))
 
+        if isinstance(self.cloud, clouds.DummyCloud):
+            return self.cloud.get_reservations_available_resources(
+                '', '', None, specific_reservations)
+
         assert (self.cloud is not None and self.instance_type is not None and
                 self.region
                 is not None), ('Cloud, instance type, region must be specified')

--- a/tests/test_optimizer_random_dag.py
+++ b/tests/test_optimizer_random_dag.py
@@ -173,43 +173,6 @@ def compare_optimization_results(dag: sky.Dag, minimize_cost: bool):
     assert abs(objective - min_objective) < 1
 
 
-def test_optimizer_dummy_sink_with_reservations(enable_all_clouds):
-    """
-    Tests that Optimizer.optimize does not raise an AssertionError
-    when processing DummySink and reservations need to be queried.
-    This covers the scenario where DummyResources might be passed to
-    reservation checking logic.
-    """
-    override_config_dict = {
-        'aws': {
-            'specific_reservations': ['cr-xxx', 'cr-yyy']
-        }
-    }
-
-    # Ensure AWS is treated as an enabled cloud by the optimizer logic.
-    # The enable_all_clouds fixture should typically handle this.
-
-    with skypilot_config.override_skypilot_config(override_config_dict):
-        # Create a simple DAG
-        dag = sky.Dag()
-        with dag:
-            task = sky.Task(name='test_task_for_dummy_sink_reservation')
-            # Use a common, likely available AWS resource to minimize other
-            # potential resource unavailability issues.
-            aws_resources = sky.Resources(infra='aws', instance_type='m5.large')
-            task.set_resources({aws_resources})
-
-        try:
-            # Optimizer.optimize will add dummy source/sink nodes.
-            # The key is that this call should not raise the AssertionError
-            sky.Optimizer.optimize(dag, quiet=True)
-        except Exception as e:
-            pytest.fail(
-                'Optimizer.optimize raised an unexpected exception: {}'.format(
-                    e))
-    # If no exception is raised, the test passes.
-
-
 def test_optimizer(enable_all_clouds):
     for seed in range(3):
         dag = generate_random_dag(num_tasks=5, seed=seed)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Bug:  

`/.sky/config.yaml`:  

```yaml
aws:
  specific_reservations:
    - cr-xxx
    - cr-yyy
```  

Command: `sky launch --gpus A100:8 --cloud aws`  

```bash
AssertionError: Cloud, instance type, region must be specified
```  

This test broke after #5528.  

The issue is that we have a [dummy sink node in the DAG](https://github.com/skypilot-org/skypilot/blob/master/sky/optimizer.py#L307), and then call `get_available_reservations` with this node.  

This calls `DummyCloud.get_reservations_available_resources`. Since `DummyCloud`'s `instance_type` and `region` are `None` by default, it violates the signature of `get_reservations_available_resources`. We need special handling for `DummyCloud`.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
- [x] `SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no tests/test_optimizer_random_dag.py::test_optimizer_dummy_sink_with_reservations`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
