### PR TITLE
Fix `test_long_setup_run_script` on `kubernetes`

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1829,6 +1829,10 @@ def test_gcp_zero_quota_failover():
 
 
 def test_long_setup_run_script(generic_cloud: str):
+    if generic_cloud == 'kubernetes':
+        low_resource_arg = ''
+    else:
+        low_resource_arg = smoke_tests_utils.LOW_RESOURCE_ARG
     name = smoke_tests_utils.get_cluster_name()
     with tempfile.NamedTemporaryFile('w', prefix='sky_app_',
                                      suffix='.yaml') as f:
@@ -1853,13 +1857,13 @@ def test_long_setup_run_script(generic_cloud: str):
         test = smoke_tests_utils.Test(
             'long-setup-run-script',
             [
-                f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} {f.name}',
+                f'sky launch -y -c {name} --infra {generic_cloud} {low_resource_arg} {f.name}',
                 f'sky exec {name} "echo hello"',
                 f'sky exec {name} {f.name}',
                 f'sky logs {name} --status 1',
                 f'sky logs {name} --status 2',
                 f'sky logs {name} --status 3',
-                f'sky jobs launch -y -n {name} --cloud {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} {f.name}',
+                f'sky jobs launch -y -n {name} --cloud {generic_cloud} {low_resource_arg} {f.name}',
                 f'sky jobs queue | grep {name} | grep SUCCEEDED',
             ],
             f'sky down -y {name}; sky jobs cancel -n {name} -y',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1829,10 +1829,6 @@ def test_gcp_zero_quota_failover():
 
 
 def test_long_setup_run_script(generic_cloud: str):
-    if generic_cloud == 'kubernetes':
-        low_resource_arg = ''
-    else:
-        low_resource_arg = smoke_tests_utils.LOW_RESOURCE_ARG
     name = smoke_tests_utils.get_cluster_name()
     with tempfile.NamedTemporaryFile('w', prefix='sky_app_',
                                      suffix='.yaml') as f:
@@ -1857,16 +1853,18 @@ def test_long_setup_run_script(generic_cloud: str):
         test = smoke_tests_utils.Test(
             'long-setup-run-script',
             [
-                f'sky launch -y -c {name} --infra {generic_cloud} {low_resource_arg} {f.name}',
+                f'sky launch -y -c {name} --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} {f.name}',
                 f'sky exec {name} "echo hello"',
                 f'sky exec {name} {f.name}',
                 f'sky logs {name} --status 1',
                 f'sky logs {name} --status 2',
                 f'sky logs {name} --status 3',
-                f'sky jobs launch -y -n {name} --cloud {generic_cloud} {low_resource_arg} {f.name}',
+                f'sky jobs launch -y -n {name} --cloud {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} {f.name}',
                 f'sky jobs queue | grep {name} | grep SUCCEEDED',
             ],
             f'sky down -y {name}; sky jobs cancel -n {name} -y',
+            # This job is slow on kind cluster, so we give it more time.
+            timeout=30 * 60,
         )
         smoke_tests_utils.run_one_test(test)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Draft

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
