### PR TITLE
[UX] UX updates in ssh targets

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -394,6 +394,16 @@ def _format_context_details(cloud: Union[str, sky_clouds.Cloud],
     if not filtered_contexts:
         return ''
 
+    def _red_color(str_to_format: str) -> str:
+        return (f'{colorama.Fore.LIGHTRED_EX}'
+                f'{str_to_format}'
+                f'{colorama.Style.RESET_ALL}')
+
+    def _dim_color(str_to_format: str) -> str:
+        return (f'{colorama.Style.DIM}'
+                f'{str_to_format}'
+                f'{colorama.Style.RESET_ALL}')
+
     # Format the context info with consistent styling
     contexts_formatted = []
     for i, context in enumerate(filtered_contexts):
@@ -410,10 +420,10 @@ def _format_context_details(cloud: Union[str, sky_clouds.Cloud],
         if show_details:
             if ctx2text is not None:
                 text_suffix = (
-                    f': {ctx2text[context]}' if context in ctx2text else ': ' +
-                    'disabled. Reason: Not set up. '
-                    f'Use `sky ssh up --infra {context.lstrip("ssh-")}` to '
-                    'set up.')
+                    f': {ctx2text[context]}' if context in ctx2text else
+                    (': ' + _red_color('disabled. ') +
+                     _dim_color('Reason: Not set up. Use `sky ssh up --infra '
+                                f'{context.lstrip("ssh-")}` to set up.')))
         contexts_formatted.append(
             f'\n    {symbol}{cleaned_context}{text_suffix}')
     identity_str = ('SSH Node Pools' if isinstance(cloud_type, sky_clouds.SSH)

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1797,7 +1797,8 @@ def _show_enabled_infra():
             enabled_k8s_infras.extend(cloud_infra)
         else:
             enabled_cloud_infras.extend(cloud_infra)
-    all_infras = enabled_ssh_infras + enabled_k8s_infras + enabled_cloud_infras
+    all_infras = sorted(enabled_ssh_infras) + sorted(
+        enabled_k8s_infras) + sorted(enabled_cloud_infras)
     click.echo(f'{title}{", ".join(all_infras)}\n')
 
 
@@ -3802,15 +3803,17 @@ def show_gpus(
             print_section_titles = False
             stop_iter = False
             k8s_messages = ''
+            prev_print_section_titles = False
             for is_ssh in [False, True]:
+                if prev_print_section_titles:
+                    yield '\n\n'
                 stop_iter_one, print_section_titles_one, k8s_messages_one = (
                     yield from _possibly_show_k8s_like_realtime(is_ssh))
                 stop_iter = stop_iter or stop_iter_one
                 print_section_titles = (print_section_titles or
                                         print_section_titles_one)
                 k8s_messages += k8s_messages_one
-                if print_section_titles_one:
-                    yield '\n\n'
+                prev_print_section_titles = print_section_titles_one
             if stop_iter:
                 return
 
@@ -3887,15 +3890,17 @@ def show_gpus(
 
         print_section_titles = False
         stop_iter = False
+        prev_print_section_titles = False
         for is_ssh in [False, True]:
+            if prev_print_section_titles:
+                yield '\n\n'
             stop_iter_one, print_section_titles_one = (
                 yield from _possibly_show_k8s_like_realtime_for_acc(
                     name, quantity, is_ssh))
             stop_iter = stop_iter or stop_iter_one
             print_section_titles = (print_section_titles or
                                     print_section_titles_one)
-            if print_section_titles_one:
-                yield '\n\n'
+            prev_print_section_titles = print_section_titles_one
         if stop_iter:
             return
 

--- a/sky/clouds/ssh.py
+++ b/sky/clouds/ssh.py
@@ -108,10 +108,15 @@ class SSH(kubernetes.Kubernetes):
         as the admin policy may update the allowed contexts.
         """
         if skipped_contexts:
+            count = len(set(skipped_contexts))
+            is_singular = count == 1
             logger.warning(
-                f'SSH Node Pools {set(skipped_contexts)!r} specified in '
-                '~/.sky/ssh_node_pools.yaml has not been set up. '
-                'Skipping those pools. Run `sky ssh up` to set up.')
+                f'SSH Node {("Pool" if is_singular else "Pools")} '
+                f'{set(skipped_contexts)!r} specified in '
+                f'{SSH_NODE_POOLS_PATH} {("has" if is_singular else "have")} '
+                'not been set up. Skipping '
+                f'{("that pool" if is_singular else "those pools")}. '
+                'Run `sky ssh up` to set up.')
 
     @classmethod
     def existing_allowed_contexts(cls, silent: bool = False) -> List[str]:

--- a/sky/clouds/ssh.py
+++ b/sky/clouds/ssh.py
@@ -84,7 +84,7 @@ class SSH(kubernetes.Kubernetes):
             # since there is no context name available.
             return region, zone
 
-        all_contexts = self.existing_allowed_contexts(silent=True)
+        all_contexts = self.existing_allowed_contexts()
 
         if region is not None and region not in all_contexts:
             region_name = region.lstrip('ssh-')
@@ -167,8 +167,7 @@ class SSH(kubernetes.Kubernetes):
 
         # Get SSH contexts
         try:
-            existing_allowed_contexts = cls.existing_allowed_contexts(
-                silent=True)
+            existing_allowed_contexts = cls.existing_allowed_contexts()
         except Exception as e:  # pylint: disable=broad-except
             return (False, f'Failed to get SSH contexts: {str(e)}')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixing:
1. red & dim style for disabled node pools
2. k8s leakage: `Kubernetes contexts {'ssh-my-pool'} specified in "allowed_contexts" not found in kubeconfig. Ignoring these contexts.`
3. Weird triple space in show-gpus
4. sort the SSH / cloud segments

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/10ef915c-d569-431f-824a-2d33a8d975b8" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
