### PR TITLE
[Core] Enable specification of candidate resources with different num_nodes

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -162,6 +162,9 @@ def _get_single_resources_schema():
             'instance_type': {
                 'type': 'string',
             },
+            'num_nodes': {
+                'type': 'integer',
+            },
             'use_spot': {
                 'type': 'boolean',
             },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Addresses https://github.com/skypilot-org/skypilot/issues/4714

Currently, `num_nodes` is specified as part of the top-level task yaml configuration. This PR moves the `num_nodes` configuration into the `resources` segment of the task yaml file. 

One potential use case is that deepseek r1 can be served with a single H200:8 node or 2x H100:8 nodes. Moving the `num_nodes` specification into the `resources` segment enables defining such equivalence relations using the `any_of` operator and preferences using the `ordered` operator. 

This PR involves changes to the config schemas, the parsing logic for the Task and Resources class, the optimizer, and the provisioner. 

TODO:
- [ ] Modify the provisioner to accurately select num_nodes based on the best_resources determined by the optimizer
- [ ] Remove redundant safety checks from the optimizer (i.e. checking if resources.num_nodes is None, and defaulting to task.num_nodes otherwise). The Task and Resources yaml parsing logic already moves the task-level `num_nodes` config into the Resources class, but this may need to be done in other places.
- [ ] Verify that alternative code paths to the yaml specification are also updated accordingly (i.e. python sdk and cli)

<!-- Describe the tests ran -->

So far, I have verified that moving the `num_nodes` specification into the `resources` segment of the task yaml is properly parsed and handled by the optimizer in the basic, `any_of`, and `ordered` cases.

The provisioner is still using the top-level task yaml `num_nodes` value and needs to be fixed. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
