### PR TITLE
[Docs] Add ssh node pools config doc for helm deployment

### DIFF
--- a/charts/skypilot/templates/api-configmap.yaml
+++ b/charts/skypilot/templates/api-configmap.yaml
@@ -7,4 +7,16 @@ metadata:
 data:
   config.yaml: |
 {{ .Values.apiService.config | indent 4 }} 
+---
+{{- end }}
+{{- if .Values.apiService.sshNodePools}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ssh-node-pools
+  namespace: {{ .Release.Namespace }}
+data:
+  ssh_node_pools.yaml: |
+{{ .Values.apiService.sshNodePools | indent 4 }} 
+---
 {{- end }}

--- a/charts/skypilot/templates/api-configmap.yaml
+++ b/charts/skypilot/templates/api-configmap.yaml
@@ -7,16 +7,4 @@ metadata:
 data:
   config.yaml: |
 {{ .Values.apiService.config | indent 4 }} 
----
-{{- end }}
-{{- if .Values.apiService.sshNodePools}}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-ssh-node-pools
-  namespace: {{ .Release.Namespace }}
-data:
-  ssh_node_pools.yaml: |
-{{ .Values.apiService.sshNodePools | indent 4 }} 
----
 {{- end }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -73,6 +73,16 @@ spec:
           # The configmap serves as the ground truth for the ssh_node_pools.yaml file, read-only
           ln -sf /var/skypilot/ssh_node_pool/ssh_node_pools.yaml /root/.sky/ssh_node_pools.yaml
           {{- end }}
+          {{- if .Values.apiService.sshKeySecret }}
+          mkdir -p /root/.ssh
+          echo "Linking ssh keys to /root/.ssh"
+          for file in /var/skypilot/ssh_keys/*; do
+            if [ -f "$file" ]; then
+              filename=$(basename "$file")
+              ln -sf "$file" "/root/.ssh/$filename"
+            fi
+          done
+          {{- end }}
 
           if sky api start -h | grep -q -- "--foreground"; then
             exec sky api start --deploy --foreground
@@ -113,6 +123,10 @@ spec:
         {{- if .Values.apiService.sshNodePools }}
         - name: skypilot-ssh-node-pools
           mountPath: /var/skypilot/ssh_node_pool
+        {{- end }}
+        {{- if .Values.apiService.sshKeySecret }}
+        - name: skypilot-ssh-identity
+          mountPath: /var/skypilot/ssh_keys
         {{- end }}
         {{- if .Values.awsCredentials.enabled }}
         - name: aws-config
@@ -330,6 +344,12 @@ spec:
       {{- end }}
       {{- if .Values.apiService.sshNodePools }}
       - name: skypilot-ssh-node-pools
-        configMap:
-          name: {{ .Release.Name }}-ssh-node-pools
+        secret:
+          secretName: {{ .Release.Name }}-ssh-node-pools
+      {{- end }}
+      {{- if .Values.apiService.sshKeySecret }}
+      - name: skypilot-ssh-identity
+        secret:
+          secretName: {{ .Values.apiService.sshKeySecret }}
+          defaultMode: 0600 
       {{- end }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -63,9 +63,15 @@ spec:
           {{- end }}
           {{- if .Values.apiService.config }}
           mkdir -p /root/.sky
-          echo "Copying config.yaml from ConfigMap \`skypilot-config\` to /root/.sky/config.yaml"
+          echo "Linking config.yaml from ConfigMap \`skypilot-config\` to /root/.sky/config.yaml"
           # The configmap serves as the ground truth for the config.yaml file, read-only
           ln -sf /var/skypilot/config/config.yaml /root/.sky/config.yaml
+          {{- end }}
+          {{- if .Values.apiService.sshNodePools }}
+          mkdir -p /root/.sky
+          echo "Linking ssh_node_pools.yaml from ConfigMap \`skypilot-ssh-node-pools\` to /root/.sky/ssh_node_pools.yaml"
+          # The configmap serves as the ground truth for the ssh_node_pools.yaml file, read-only
+          ln -sf /var/skypilot/ssh_node_pool/ssh_node_pools.yaml /root/.sky/ssh_node_pools.yaml
           {{- end }}
 
           if sky api start -h | grep -q -- "--foreground"; then
@@ -103,6 +109,10 @@ spec:
         {{- if .Values.apiService.config }}
         - name: skypilot-config
           mountPath: /var/skypilot/config
+        {{- end }}
+        {{- if .Values.apiService.sshNodePools }}
+        - name: skypilot-ssh-node-pools
+          mountPath: /var/skypilot/ssh_node_pool
         {{- end }}
         {{- if .Values.awsCredentials.enabled }}
         - name: aws-config
@@ -317,4 +327,9 @@ spec:
       - name: skypilot-config
         configMap:
           name: {{ .Release.Name }}-config
+      {{- end }}
+      {{- if .Values.apiService.sshNodePools }}
+      - name: skypilot-ssh-node-pools
+        configMap:
+          name: {{ .Release.Name }}-ssh-node-pools
       {{- end }}

--- a/charts/skypilot/templates/api-secrets.yaml
+++ b/charts/skypilot/templates/api-secrets.yaml
@@ -1,0 +1,11 @@
+{{- /* Use serect since sshNodePools config may contain credentials */ -}}
+{{- if .Values.apiService.sshNodePools}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-ssh-node-pools
+  namespace: {{ .Release.Namespace }}
+stringData:
+  ssh_node_pools.yaml: |
+{{ .Values.apiService.sshNodePools | indent 4 }} 
+{{- end }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -47,7 +47,9 @@ apiService:
   #  my-box:
   #    hosts:
   #      - hostname_in_ssh_config
-
+  # Optional secret that contains SSH keys for the API server to use, all the entries in the secret will be mounted to ~/.ssh/ directory in the API server.
+  sshKeySecret: null
+  
 
   # Skip resource check for the API server, not recommended for production deployment
   skipResourceCheck: false

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -14,8 +14,8 @@ apiService:
     # pip install git+https://github.com/michaelvll/admin-policy-examples
 
 
-  # Set config.yaml content on the API server
-  # Updating this value will take tens of seconds to take effect on the API server.
+  # Set ~/.sky/config.yaml content on the API server
+  # Updating this value will not restart the API server but it will take tens of seconds to take effect on the API server.
   # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/config.yaml`
   config: null
   # config: |
@@ -34,6 +34,20 @@ apiService:
   #   allowed_clouds:
   #     - aws
   #     - kubernetes
+
+  # Set ~/.sky/ssh_node_pools.yaml content on the API server
+  # Updating this value will not restart the API server but it will take tens of seconds to take effect on the API server.
+  # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/ssh_node_pools.yaml`
+  sshNodePools: null
+  # sshNodePools: |
+  #  my-cluster:
+  #    hosts:
+  #      - 1.2.3.4
+  #      - 1.2.3.5
+  #  my-box:
+  #    hosts:
+  #      - hostname_in_ssh_config
+
 
   # Skip resource check for the API server, not recommended for production deployment
   skipResourceCheck: false

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -47,6 +47,7 @@ Below is the available helm value keys and the default value of each key:
       # pip install git+https://github.com/michaelvll/admin-policy-examples
     :ref:`config <helm-values-apiService-config>`: null
     :ref:`sshNodePools <helm-values-apiService-sshNodePools>`: null
+    :ref:`sshKeySecret <helm-values-apiService-sshKeySecret>`: null
     :ref:`skipResourceCheck <helm-values-apiService-skipResourceCheck>`: false
     :ref:`resources <helm-values-apiService-resources>`:
       requests:
@@ -255,6 +256,32 @@ Default: ``null``
       my-box:
         hosts:
           - hostname_in_ssh_config
+
+.. _helm-values-apiService-sshKeySecret:
+
+``apiService.sshKeySecret``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optional secret that contains SSH identity files to the API server to use, all the entries in the secret will be mounted to ``~/.ssh/`` directory in the API server. Refer to :ref:`Deploy SkyPilot on existing machines <existing-machines>` for more details.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  apiService:
+    sshKeySecret: my-ssh-key-secret
+
+The content of the secret should be like:
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: my-ssh-key-secret
+  data:
+    id_rsa: <secret-content>
+
 
 .. _helm-values-apiService-skipResourceCheck:
 

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -46,6 +46,7 @@ Below is the available helm value keys and the default value of each key:
       # echo "Installing admin policy"
       # pip install git+https://github.com/michaelvll/admin-policy-examples
     :ref:`config <helm-values-apiService-config>`: null
+    :ref:`sshNodePools <helm-values-apiService-sshNodePools>`: null
     :ref:`skipResourceCheck <helm-values-apiService-skipResourceCheck>`: false
     :ref:`resources <helm-values-apiService-resources>`:
       requests:
@@ -232,6 +233,28 @@ Default: ``null``
       allowed_clouds:
         - aws
         - gcp
+
+.. _helm-values-apiService-sshNodePools:
+
+``apiService.sshNodePools``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Content of the ``~/.sky/ssh_node_pools.yaml`` to set on the API server. Set to ``null`` to use an empty ssh node pools. Refer to :ref:`Deploy SkyPilot on existing machines <existing-machines>` for more details.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  apiService:
+    sshNodePools: |-
+      my-cluster:
+        hosts:
+          - 1.2.3.4
+          - 1.2.3.5
+
+      my-box:
+        hosts:
+          - hostname_in_ssh_config
 
 .. _helm-values-apiService-skipResourceCheck:
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -149,7 +149,7 @@ Apply ``~/.sky/sky_node_pools.yaml`` to the API server by the following steps fo
    
    .. tab-item:: Helm Deployment
 
-      If you use a :ref:`Helm Deployment <sky-api-server-helm-deploy-command>`, apply the config to a ``ssh_node_pool.yaml`` file on your local machine and run:
+      If you use a :ref:`Helm Deployment <sky-api-server-helm-deploy-command>`, save the config to a ``ssh_node_pool.yaml`` file on your local machine and run:
 
       .. code-block:: bash
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -174,6 +174,10 @@ Apply ``~/.sky/sky_node_pools.yaml`` to the API server by the following steps fo
             --namespace $NAMESPACE \
             --reuse-values \
             --set apiService.sshKeySecret=$SECRET_NAME
+      
+      .. note::
+
+         SSH hosts configured on your local machine will not be available to the API server. It is recommended to set the SSH keys or password in the `ssh_node_pools.yaml` file for helm deployment.
    
    .. tab-item:: VM Deployment
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -33,7 +33,7 @@ launch clusters, jobs, or services, just like a regular cloud provider.
 Quickstart
 -------------
 
-Write to ``~/.sky/ssh_node_pools.yaml`` on the host of your API server (local or remote):
+Write to ``~/.sky/ssh_node_pools.yaml`` on the host of your API server (refer to :ref:`Defining SSH Node Pools <defining-ssh-node-pools>` if you are running a remote API server):
 
 .. code-block:: yaml
 
@@ -92,6 +92,8 @@ Equivalently, use ``resources.infra: ssh/<node_pool_name>`` in a task YAML:
 
 See more customization options and details about SSH Node Pools in the rest of this guide.
 
+.. _defining-ssh-node-pools:
+
 Defining SSH Node Pools
 -----------------------
 
@@ -137,10 +139,31 @@ Example:
           identity_file: bob-key
           password: bob-password
 
-The ``~/.sky/ssh_node_pools.yaml`` file is stored on the server side, not client side:
+Apply ``~/.sky/sky_node_pools.yaml`` to the API server by the following steps for different setup:
 
-- If you use a :ref:`local API server <sky-api-server-local>`, set ``~/.sky/ssh_node_pools.yaml`` on your local machine.
-- If you use a :ref:`remote API server <sky-api-server-remote>`, write the file on the remote API server host. This is most likely accessible by admins only.
+.. tab-set::
+
+   .. tab-item:: Local API server
+
+      If you did not start an API server instance or use a :ref:`local API server <sky-api-server-local>`, set ``~/.sky/ssh_node_pools.yaml`` on your local machine.
+   
+   .. tab-item:: Helm Deployment
+
+      If you use a :ref:`Helm Deployment <sky-api-server-helm-deploy-command>`, apply the config to a ``ssh_node_pool.yaml`` file on your local machine and run:
+
+      .. code-block:: bash
+
+         # RELEASE_NAME and NAMESPACE are the same as the ones used in the helm deployment
+         helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
+         --namespace $NAMESPACE \
+         --reuse-values \
+         --set-file apiService.sshNodePools=/your/path/to/ssh_node_pools.yaml
+   
+   .. tab-item:: VM Deployment
+
+      If you use a :ref:`VM Deployment <sky-api-server-cloud-deploy>`, set ``~/.sky/ssh_node_pools.yaml`` on the API server host.
+      This is usually only available to the administrator who deployed the API server.
+
 
 Observability of SSH Node Pools
 -------------------------------

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -158,11 +158,29 @@ Apply ``~/.sky/sky_node_pools.yaml`` to the API server by the following steps fo
          --namespace $NAMESPACE \
          --reuse-values \
          --set-file apiService.sshNodePools=/your/path/to/ssh_node_pools.yaml
+      
+      If your `ssh_node_pools.yaml` requires SSH keys, you can create a secret that contains the keys and set the :ref:`apiService.sshKeySecret <helm-values-apiService-sshKeySecret>` to the secret name:
+
+      .. code-block:: bash
+
+         SECRET_NAME=apiserver-ssh-key
+         # The NAMESPACE should be consistent with the API server deployment
+         kubectl create secret generic $SECRET_NAME \
+            --namespace $NAMESPACE \
+            --from-file=id_rsa=/path/to/id_rsa \
+            --from-file=other_id_rsa=/path/to/other_id_rsa
+
+         helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
+            --namespace $NAMESPACE \
+            --reuse-values \
+            --set apiService.sshKeySecret=$SECRET_NAME
    
    .. tab-item:: VM Deployment
 
       If you use a :ref:`VM Deployment <sky-api-server-cloud-deploy>`, set ``~/.sky/ssh_node_pools.yaml`` on the API server host.
       This is usually only available to the administrator who deployed the API server.
+
+      If any SSH key is needed, you should also set it on the API server host.
 
 
 Observability of SSH Node Pools


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually to set `~/.sky/ssh_node_pools` and `ssh_keys` on the API server
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
