### PR TITLE
[Core] Client side should not rely on global_user_state

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -212,6 +212,7 @@ def _get_glob_storages(storages: List[str]) -> List[str]:
     """Returns a list of storages that match the glob pattern."""
     glob_storages = []
     for storage_object in storages:
+        # TODO(zhwu): client side should not rely on global_user_state.
         glob_storage = global_user_state.get_glob_storage_name(storage_object)
         if not glob_storage:
             click.echo(f'Storage {storage_object} not found.')
@@ -1784,8 +1785,7 @@ def _show_enabled_infra():
     """Show the enabled infrastructure."""
     title = (f'{colorama.Fore.CYAN}{colorama.Style.BRIGHT}Enabled Infra:'
              f'{colorama.Style.RESET_ALL} ')
-    enabled_clouds = global_user_state.get_cached_enabled_clouds(
-        clouds.CloudCapability.COMPUTE)
+    enabled_clouds = sdk.get(sdk.enabled_clouds())
     enabled_ssh_infras = []
     enabled_k8s_infras = []
     enabled_cloud_infras = []


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
