### PR TITLE
[UX] update infra cli help text with k8s shorthand and ssh node pools

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -353,12 +353,12 @@ _TASK_OPTIONS = [
         type=str,
         help='Infrastructure to use. '
         'Format: cloud, cloud/region, cloud/region/zone, '
-        'or kubernetes/context-name. '
+        'k8s/context-name, or ssh/node-pool-name. '
         'Examples: aws, aws/us-east-1, aws/us-east-1/us-east-1a, '
         # TODO(zhwu): we have to use `\*` to make sure the docs build
         # not complaining about the `*`, but this will cause `--help`
         # to show `\*` instead of `*`.
-        'aws/\\*/us-east-1a, kubernetes/my-cluster-context.'),
+        'aws/\\*/us-east-1a, k8s/my-context, ssh/my-nodes.'),
     click.option(
         '--cloud',
         required=False,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR modifies the cli help text for `--infra` to reference the `k8s` shorthand for kubernetes and ssh node pools.

<!-- Describe the tests ran -->

```
sky launch -h
...
  --infra TEXT                    Infrastructure to use. Format: cloud,
                                  cloud/region, cloud/region/zone,
                                  k8s/context-name, or ssh/node-pool-name.
                                  Examples: aws, aws/us-east-1, aws/us-
                                  east-1/us-east-1a, aws/\*/us-east-1a,
                                  k8s/my-context, ssh/my-nodes.
...
```
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
