### PR TITLE
support `--postgres` on smoke test

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -116,6 +116,8 @@ def _parse_args(args: Optional[str] = None):
 
     parser.add_argument('--controller-cloud')
 
+    parser.add_argument('--postgres', action="store_true")
+
     parsed_args, _ = parser.parse_known_args(args_list)
 
     # Collect chosen clouds from the flags
@@ -146,6 +148,8 @@ def _parse_args(args: Optional[str] = None):
         extra_args.append(f'--base-branch {parsed_args.base_branch}')
     if parsed_args.controller_cloud:
         extra_args.append(f'--controller-cloud {parsed_args.controller_cloud}')
+    if parsed_args.postgres:
+        extra_args.append('--postgres')
 
     return default_clouds_to_run, parsed_args.k, extra_args
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,12 @@ def pytest_addoption(parser):
         default=None,
         help='Controller cloud to use for tests',
     )
+    parser.addoption(
+        '--postgres',
+        action='store_true',
+        default=False,
+        help='Run tests for Postgres Backend',
+    )
 
 
 def pytest_configure(config):
@@ -456,3 +462,13 @@ def setup_controller_cloud_env(request):
     controller_cloud = request.config.getoption('--controller-cloud')
     os.environ['PYTEST_SKYPILOT_CONTROLLER_CLOUD'] = controller_cloud
     yield controller_cloud
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_postgres_backend_env(request):
+    """Setup Postgres Backend environment variable if --postgres is specified."""
+    if not request.config.getoption('--postgres'):
+        yield
+        return
+    os.environ['PYTEST_SKYPILOT_POSTGRES_BACKEND'] = '1'
+    yield

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -360,6 +360,11 @@ def terminate_gcp_replica(name: str, zone: str, replica_id: int) -> str:
 def override_sky_config(
     test: Test, env_dict: Dict[str, str]
 ) -> Generator[Optional[tempfile.NamedTemporaryFile], None, None]:
+    if is_postgres_backend_test():
+        # Fail if postgresql is not installed.
+        subprocess.run(['sudo service postgresql start'], check=True)
+        env_dict['SKYPILOT_DB_URI'] = 'postgresql://postgres@localhost/skypilot'
+
     override_sky_config_dict = skypilot_config.config_utils.Config()
     if is_remote_server_test():
         endpoint = docker_utils.get_api_server_endpoint_inside_docker()
@@ -689,6 +694,10 @@ def is_remote_server_test() -> bool:
 
 def pytest_controller_cloud() -> Optional[str]:
     return os.environ.get('PYTEST_SKYPILOT_CONTROLLER_CLOUD', None)
+
+
+def is_postgres_backend_test() -> bool:
+    return os.environ.get('PYTEST_SKYPILOT_POSTGRES_BACKEND', None) is not None
 
 
 def override_env_config(config: Dict[str, str]):

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -361,8 +361,6 @@ def override_sky_config(
     test: Test, env_dict: Dict[str, str]
 ) -> Generator[Optional[tempfile.NamedTemporaryFile], None, None]:
     if is_postgres_backend_test():
-        # Fail if postgresql is not installed.
-        subprocess.run(['sudo service postgresql start'], check=True)
         env_dict['SKYPILOT_DB_URI'] = 'postgresql://postgres@localhost/skypilot'
 
     override_sky_config_dict = skypilot_config.config_utils.Config()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Related PR #5707

* Assume the system has `postgresql` installed.
* Test cases will set the `SKYPILOT_DB_URI` environment variable.(Assume `postgresql` already started before each test)
* If successful, it will proceed; if failed, it will exit immediately.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
