### PR TITLE
Fix kubeconfig override

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -65,13 +65,20 @@ def _api_logging_decorator(logger_src: str, level: int):
 
     return decorated_api
 
+def _get_config_file() -> str:
+    # Kubernetes load the kubeconfig from the KUBECONFIG env var on
+    # package initialization. So we have to reload the KUBECOFNIG env var
+    # everytime in case the KUBECONFIG env var is changed.
+    return os.environ.get('KUBECONFIG', '~/.kube/config')
+
 
 def _load_config(context: Optional[str] = None):
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def _load_config_from_kubeconfig(context: Optional[str] = None):
         try:
-            kubernetes.config.load_kube_config(context=context)
+            kubernetes.config.load_kube_config(config_file=_get_config_file(),
+                                               context=context)
         except kubernetes.config.config_exception.ConfigException as e:
             suffix = common_utils.format_exception(e, use_bracket=True)
             context_name = '(current-context)' if context is None else context
@@ -137,6 +144,9 @@ def _load_config(context: Optional[str] = None):
             _load_config_from_kubeconfig()
     else:
         _load_config_from_kubeconfig(context)
+
+def list_kube_config_contexts():
+    return kubernetes.config.list_kube_config_contexts(_get_config_file())
 
 
 @_api_logging_decorator('urllib3', logging.ERROR)

--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -65,6 +65,7 @@ def _api_logging_decorator(logger_src: str, level: int):
 
     return decorated_api
 
+
 def _get_config_file() -> str:
     # Kubernetes load the kubeconfig from the KUBECONFIG env var on
     # package initialization. So we have to reload the KUBECOFNIG env var
@@ -144,6 +145,7 @@ def _load_config(context: Optional[str] = None):
             _load_config_from_kubeconfig()
     else:
         _load_config_from_kubeconfig(context)
+
 
 def list_kube_config_contexts():
     return kubernetes.config.list_kube_config_contexts(_get_config_file())

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -848,11 +848,11 @@ class Kubernetes(clouds.Cloud):
 
     @classmethod
     def get_user_identities(cls) -> Optional[List[List[str]]]:
-        k8s = kubernetes.kubernetes
         identities = []
+        k8s = kubernetes.kubernetes
         try:
             all_contexts, current_context = (
-                k8s.config.list_kube_config_contexts())
+                kubernetes.list_kube_config_contexts())
         except k8s.config.config_exception.ConfigException:
             return None
         # Add current context at the head of the list

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1525,7 +1525,7 @@ def is_kubeconfig_exec_auth(
         return False, None
 
     # Get active context and user from kubeconfig using k8s api
-    all_contexts, current_context = k8s.config.list_kube_config_contexts()
+    all_contexts, current_context = kubernetes.list_kube_config_contexts()
     context_obj = current_context
     if context is not None:
         for c in all_contexts:
@@ -1581,7 +1581,7 @@ def get_current_kube_config_context_name() -> Optional[str]:
     """
     k8s = kubernetes.kubernetes
     try:
-        _, current_context = k8s.config.list_kube_config_contexts()
+        _, current_context = kubernetes.list_kube_config_contexts()
         return current_context['name']
     except k8s.config.config_exception.ConfigException:
         return None
@@ -1617,7 +1617,7 @@ def get_all_kube_context_names() -> List[str]:
     k8s = kubernetes.kubernetes
     context_names = []
     try:
-        all_contexts, _ = k8s.config.list_kube_config_contexts()
+        all_contexts, _ = kubernetes.list_kube_config_contexts()
         # all_contexts will always have at least one context. If kubeconfig
         # does not have any contexts defined, it will raise ConfigException.
         context_names = [context['name'] for context in all_contexts]
@@ -1660,7 +1660,7 @@ def get_kube_config_context_namespace(
                 return f.read().strip()
     # If not in-cluster, get the namespace from kubeconfig
     try:
-        contexts, current_context = k8s.config.list_kube_config_contexts()
+        contexts, current_context = kubernetes.list_kube_config_contexts()
         if context_name is None:
             context = current_context
         else:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -405,7 +405,9 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     # pairs.
     logger.debug(f'Validating tasks: {validate_body.dag}')
 
-    context.initialize()
+    ctx = context.initialize()
+    # TODO(aylei): generalize this to all requests without a db record.
+    ctx.override_envs(validate_body.env_vars)
 
     def validate_dag(dag: dag_utils.dag_lib.Dag):
         # TODO: Admin policy may contain arbitrary code, which may be expensive

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -405,7 +405,9 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
     # pairs.
     logger.debug(f'Validating tasks: {validate_body.dag}')
 
-    ctx = context.initialize()
+    context.initialize()
+    ctx = context.get()
+    assert ctx is not None
     # TODO(aylei): generalize this to all requests without a db record.
     ctx.override_envs(validate_body.env_vars)
 

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -256,9 +256,10 @@ class Popen(subprocess.Popen):
         super().__init__(*args, env=env, **kwargs)
 
 
-def initialize():
+def initialize() -> Context:
     """Initialize the current SkyPilot context."""
     _CONTEXT.set(Context())
+    return _CONTEXT.get()
 
 
 class _ContextualStream:

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -256,10 +256,9 @@ class Popen(subprocess.Popen):
         super().__init__(*args, env=env, **kwargs)
 
 
-def initialize() -> Context:
+def initialize():
     """Initialize the current SkyPilot context."""
     _CONTEXT.set(Context())
-    return _CONTEXT.get()
 
 
 class _ContextualStream:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5725

Two issues are addressed:

1. Add env var override to `/validate` handler;
2. Fix KUBECONFIG reload issue of kubernetes lib;

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually tested changing KUBECONFIG locally:

```
(sky) ➜  skypilot git:(master) ✗ export KUBECONFIG=~/.kube/config
(sky) ➜  skypilot git:(master) ✗ sky launch --cpus 2 "echo hello" --cloud kubernetes --region gke_sky-dev-465_us-central1-c_skypilotalpha -c aylei2
The --cloud, --region, and --zone options are deprecated. Use --infra instead.
Command to run: echo hello
ValueError: Context gke_sky-dev-465_us-central1-c_skypilotalpha not found in kubeconfig. Kubernetes only supports context names as regions. Available contexts: ['kind-kind']
(sky) ➜  skypilot git:(master) ✗ export KUBECONFIG=~/.kube/gke
(sky) ➜  skypilot git:(master) ✗ sky launch --cpus 2 "echo hello" --cloud kubernetes --region gke_sky-dev-465_us-central1-c_skypilotalpha -c aylei2
The --cloud, --region, and --zone options are deprecated. Use --infra instead.
Command to run: echo hello
Considered resources (1 node):
--------------------------------------------------------------------------------------------------
 INFRA                                    INSTANCE   vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN
--------------------------------------------------------------------------------------------------
 Kubernetes (gke_sky-dev...ypilotalpha)   -          2       2         -      0.00          ✔
--------------------------------------------------------------------------------------------------
Launching a new cluster 'aylei2'. Proceed? [Y/n]: ^CAborted!
```

- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
