### PR TITLE
[UX] Add backward compat for old API server with workspaces

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -1999,8 +1999,9 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
             # Backward compatibility for API server before #5660.
             # TODO(zhwu): remove this after 0.12.0.
             logger.warning(f'{colorama.Style.DIM}SkyPilot API server is '
-                           'in an old version, and may miss some features. '
-                           'Update with: sky api stop; sky api start'
+                           'in an old version, and may miss feature: '
+                           'workspaces. Update with: sky api stop; '
+                           'sky api start'
                            f'{colorama.Style.RESET_ALL}')
             workspace_request_id = None
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #5731 

<img width="815" alt="Screenshot 2025-05-25 at 10 51 16 AM" src="https://github.com/user-attachments/assets/c22b8fa7-04ab-43b4-a753-4f6512483687" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
