### PR TITLE
Make jq a prerequisite for ssh cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     apt-get update -y && \
     apt-get install --no-install-recommends -y \
         git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse socat netcat-openbsd curl rsync vim tini autossh && \
+        pciutils nano fuse socat netcat-openbsd curl rsync vim tini autossh jq && \
     rm -rf /var/lib/apt/lists/* && \
     # Install kubectl based on architecture
     ARCH=${TARGETARCH:-$(case "$(uname -m)" in \

--- a/Dockerfile_k8s
+++ b/Dockerfile_k8s
@@ -9,7 +9,7 @@ ARG TARGETARCH
 
 # Initialize conda for root user, install ssh and other local dependencies
 RUN apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl autossh -y && \
+    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse socat netcat-openbsd curl autossh jq -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt remove -y python3 && \
     conda init

--- a/Dockerfile_k8s_gpu
+++ b/Dockerfile_k8s_gpu
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # We remove cuda lists to avoid conflicts with the cuda version installed by ray
 RUN rm -rf /etc/apt/sources.list.d/cuda* && \
     apt update -y && \
-    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl -y && \
+    apt install git gcc rsync sudo patch openssh-server pciutils nano fuse unzip socat netcat-openbsd curl jq -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Setup SSH and generate hostkeys

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -25,6 +25,7 @@ logger = sky_logging.init_logger(__name__)
 # Default path for Kubernetes configuration file
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 
+
 def check_ssh_cluster_dependencies(
         raise_error: bool = True) -> Optional[List[str]]:
     """Checks if the dependencies for ssh cluster are installed.
@@ -46,9 +47,9 @@ def check_ssh_cluster_dependencies(
     # Ensure jq is installed
     try:
         subprocess.run(['jq', '--version'],
-                      stdout=subprocess.DEVNULL,
-                      stderr=subprocess.DEVNULL,
-                      check=True)
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL,
+                       check=True)
     except (FileNotFoundError, subprocess.CalledProcessError):
         required_binaries.append('jq')
         reasons.append(jq_message)

--- a/sky/utils/kubernetes/kubernetes_deploy_utils.py
+++ b/sky/utils/kubernetes/kubernetes_deploy_utils.py
@@ -25,6 +25,47 @@ logger = sky_logging.init_logger(__name__)
 # Default path for Kubernetes configuration file
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 
+def check_ssh_cluster_dependencies(
+        raise_error: bool = True) -> Optional[List[str]]:
+    """Checks if the dependencies for ssh cluster are installed.
+
+    Args:
+        raise_error: set to true when the dependency needs to be present.
+            set to false for `sky check`, where reason strings are compiled
+            at the end.
+
+    Returns: the reasons list if there are missing dependencies.
+    """
+    # error message
+    jq_message = ('`jq` is required to setup ssh cluster.')
+
+    # save
+    reasons = []
+    required_binaries = []
+
+    # Ensure jq is installed
+    try:
+        subprocess.run(['jq', '--version'],
+                      stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL,
+                      check=True)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        required_binaries.append('jq')
+        reasons.append(jq_message)
+
+    if required_binaries:
+        reasons.extend([
+            'On Debian/Ubuntu, install the missing dependenc(ies) with:',
+            f'  $ sudo apt install {" ".join(required_binaries)}',
+            'On MacOS, install with: ',
+            f'  $ brew install {" ".join(required_binaries)}',
+        ])
+        if raise_error:
+            with ux_utils.print_exception_no_traceback():
+                raise RuntimeError('\n'.join(reasons))
+        return reasons
+    return None
+
 
 def deploy_ssh_cluster(cleanup: bool = False,
                        infra: Optional[str] = None,
@@ -41,6 +82,8 @@ def deploy_ssh_cluster(cleanup: bool = False,
         kubeconfig_path: Path to save the Kubernetes configuration file.
             If None, the default ~/.kube/config will be used.
     """
+    check_ssh_cluster_dependencies()
+
     # Prepare command to call deploy_remote_cluster.py script
     # TODO(romilb): We should move this to a native python method/class call
     #  instead of invoking a script with subprocess.

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -43,7 +43,8 @@ RUN apt update -y && \
     socat \
     uuid-runtime \
     docker.io \
-    rsync
+    rsync \
+    jq
 
 # Install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(case "$(uname -m)" in \


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Tested manually:

When jq is installed:

```bash
$ sky check ssh
Checking credentials to enable infra for SkyPilot.
  SSH: enabled [compute]
    SSH Node Pools:
    └── my-cluster: enabled. Note: Could not detect GPUs in SSH Node Pool 'my-cluster'. If this cluster contains GPUs, please ensure GPU drivers are installed on the node and re-run `sky ssh up --infra my-cluster`.

🎉 Enabled infra 🎉
  SSH [compute]
    SSH Node Pools:
    └── my-cluster
```

When jq is not installed:

```bash
$ sky ssh up
RuntimeError: `jq` is required to setup ssh cluster.
On Debian/Ubuntu, install the missing dependenc(ies) with:
  $ sudo apt install jq
On MacOS, install with:
  $ brew install jq
```

When jq is previously available and `sky ssh up` success, but get purged later:

```
$ sky check ssh
sky check ssh
Checking credentials to enable infra for SkyPilot.
ERROR:root:exec: process returned 1. jq is not installed. Please install jq to use this script.
  SSH: disabled
```

**NOTE**:

The latest nightly docker image has been built with the new dockerfile, i.e. has jq installed.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manul test above 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
