### PR TITLE
Fix failuer of `test_skyserve_new_autoscaler_update`

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -897,6 +897,9 @@ def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
                        (1, False, 'SHUTTING_DOWN'), (1, False, 'READY')]) +
             _check_service_version(name, "1,2"),
         ]
+        # The two non-spot instances will be in READY or SHUTTING_DOWN status
+        # after autoscale.
+        TWO_NON_SPOT_INSTANCES_STATUS_AFTER_AUTOSCALE = r'READY\|SHUTTING_DOWN'
     else:
         # Check blue green update, it will keep both old on-demand instances
         # running, once there are 4 spot instance ready.
@@ -906,6 +909,8 @@ def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
                        (2, False, 'READY')]) +
             _check_service_version(name, "1"),
         ]
+        # The two non-spot instances will be in READY status after autoscale.
+        TWO_NON_SPOT_INSTANCES_STATUS_AFTER_AUTOSCALE = 'READY'
     test = smoke_tests_utils.Test(
         f'test-skyserve-new-autoscaler-update-{mode}',
         [
@@ -918,10 +923,11 @@ def test_skyserve_new_autoscaler_update(mode: str, generic_cloud: str):
             # Wait for update to be registered
             'sleep 90',
             wait_until_no_pending,
-            _check_replica_in_status(
-                name, [(4, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                       (1, False, _SERVICE_LAUNCHING_STATUS_REGEX),
-                       (2, False, 'READY')]),
+            _check_replica_in_status(name, [
+                (4, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX),
+                (2, False, TWO_NON_SPOT_INSTANCES_STATUS_AFTER_AUTOSCALE)
+            ]),
             *update_check,
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=5),
             f'{_SERVE_ENDPOINT_WAIT.format(name=name)}; '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Matching `SHUTTING_DOWN` and `READY` at the same time  

Failure [log](https://buildkite.com/skypilot-1/smoke-tests/builds/1041#_)  

The issue is we expect 2 non-spot instances in `READY` after `wait_until_no_pending`, but the comment says:  

```bash
# Check rolling update: it will terminate one of the old on-demand  
# instances once there are 4 spot instances ready.  
```  

We expect the `terminate one of the old on-demand` step to happen *after* the 2 non-spot instances are `READY`, but the timing isn't guaranteed—it could happen earlier or later.  

In today's test, everything happened earlier than the check, causing all retry tests to fail. I've now updated the test to match both `SHUTTING_DOWN` and `READY` simultaneously for better fault tolerance.  

```bash

[test-skyserve-new-autoscaler-update-rolling] + s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling); echo "$s"; until ! echo "$s" \| grep PENDING; do   echo "Waiting for replica to be out of pending...";  sleep 5; s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling);   echo "$s"; done
--
  | [test-skyserve-new-autoscaler-update-rolling]
  | D 05-25 21:57:17 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:17 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:57:17 skypilot_config.py:419] jobs:
  | D 05-25 21:57:17 skypilot_config.py:419]   controller:
  | D 05-25 21:57:17 skypilot_config.py:419]     resources:
  | D 05-25 21:57:17 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:17 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:17 skypilot_config.py:419]
  | D 05-25 21:57:17 skypilot_config.py:419] serve:
  | D 05-25 21:57:17 skypilot_config.py:419]   controller:
  | D 05-25 21:57:17 skypilot_config.py:419]     resources:
  | D 05-25 21:57:17 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:17 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:17 skypilot_config.py:419]
  | D 05-25 21:57:18 skypilot_config.py:426] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:18 common.py:206] Health check status: 200
  | D 05-25 21:57:18 common.py:206] Health check status: 200
  | Services
  | NAME                                 VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1        2m 46s  READY   2/7       http://44.195.89.213:30001
  |  
  | Service Replicas
  | SERVICE_NAME                         ID  VERSION  ENDPOINT                    LAUNCHED        INFRA             RESOURCES                                STATUS
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1   1        http://98.80.136.214:8081   2 mins ago      AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  2   1        http://3.237.92.157:8081    2 mins ago      AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  3   2        http://44.220.50.41:8081    12 secs ago     AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  4   2        http://44.222.102.132:8081  a few secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  5   2        http://13.217.168.171:8081  a few secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  6   2        http://44.221.90.209:8081   a few secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           -               -                 -                                        PENDING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           -               -                 -                                        PENDING
  | Waiting for replica to be out of pending...
  | D 05-25 21:57:37 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:37 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:57:37 skypilot_config.py:419] jobs:
  | D 05-25 21:57:37 skypilot_config.py:419]   controller:
  | D 05-25 21:57:37 skypilot_config.py:419]     resources:
  | D 05-25 21:57:37 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:37 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:37 skypilot_config.py:419]
  | D 05-25 21:57:37 skypilot_config.py:419] serve:
  | D 05-25 21:57:37 skypilot_config.py:419]   controller:
  | D 05-25 21:57:37 skypilot_config.py:419]     resources:
  | D 05-25 21:57:37 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:37 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:37 skypilot_config.py:419]
  | D 05-25 21:57:37 skypilot_config.py:426] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:38 common.py:206] Health check status: 200
  | D 05-25 21:57:38 common.py:206] Health check status: 200
  | Services
  | NAME                                 VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1        3m      READY   2/7       http://44.195.89.213:30001
  |  
  | Service Replicas
  | SERVICE_NAME                         ID  VERSION  ENDPOINT                    LAUNCHED     INFRA             RESOURCES                                STATUS
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1   1        http://98.80.136.214:8081   3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  2   1        http://3.237.92.157:8081    3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  3   2        http://44.220.50.41:8081    26 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  4   2        http://44.222.102.132:8081  23 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  5   2        http://13.217.168.171:8081  20 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  6   2        http://44.221.90.209:8081   24 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  PROVISIONING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           -            -                 -                                        PENDING
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           -            -                 -                                        PENDING
  | Waiting for replica to be out of pending...
  | D 05-25 21:57:51 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:51 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:57:51 skypilot_config.py:419] jobs:
  | D 05-25 21:57:51 skypilot_config.py:419]   controller:
  | D 05-25 21:57:51 skypilot_config.py:419]     resources:
  | D 05-25 21:57:51 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:51 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:51 skypilot_config.py:419]
  | D 05-25 21:57:51 skypilot_config.py:419] serve:
  | D 05-25 21:57:51 skypilot_config.py:419]   controller:
  | D 05-25 21:57:51 skypilot_config.py:419]     resources:
  | D 05-25 21:57:51 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:57:51 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:57:51 skypilot_config.py:419]
  | D 05-25 21:57:51 skypilot_config.py:426] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:57:52 common.py:206] Health check status: 200
  | D 05-25 21:57:52 common.py:206] Health check status: 200
  | Services
  | NAME                                 VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1,2      3m 16s  READY   5/7       http://44.195.89.213:30001
  |  
  | Service Replicas
  | SERVICE_NAME                         ID  VERSION  ENDPOINT                    LAUNCHED     INFRA             RESOURCES                                STATUS
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1   1        http://98.80.136.214:8081   3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  2   1        http://3.237.92.157:8081    3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        SHUTTING_DOWN
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  3   2        http://44.220.50.41:8081    42 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  4   2        http://44.222.102.132:8081  39 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  5   2        http://13.217.168.171:8081  36 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  6   2        http://44.221.90.209:8081   40 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           12 secs ago  AWS (us-east-1)   1x(cpus=2, mem=4, c6i.large, ...)        PROVISIONING
  | [test-skyserve-new-autoscaler-update-rolling] + s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling); until ! echo "$s" \| grep "Controller is initializing."; do     echo "Waiting for serve status to be ready...";     sleep 5;     s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling); done; echo "$s"; num_provisioning=$(echo "$s" \| grep "PROVISIONING" \| wc -l); num_vcpu_in_provision=$(echo "$s" \| grep "PROVISIONING" \| grep "x(cpus=2, " \| wc -l); until [ "$num_provisioning" -eq "$num_vcpu_in_provision" ]; do     echo "Waiting for provisioning resource repr ready...";     echo "PROVISIONING: $num_provisioning, vCPU: $num_vcpu_in_provision";     sleep 2;     s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling);     num_provisioning=$(echo "$s" \| grep "PROVISIONING" \| wc -l);     num_vcpu_in_provision=$(echo "$s" \| grep "PROVISIONING" \| grep "x(cpus=2, " \| wc -l); done; echo "Provisioning complete. PROVISIONING: $num_provisioning, cpus=2: $num_cpus_in_provision"; start_time=$(date +%s); timeout=300; while true; do     not_ready_count=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling \|         awk '/t-ss-new-aut-6c-9c3e77a5-02-rolling/ && $10 == "NOT_READY" {print}' \|         wc -l);     [ "$not_ready_count" -eq 0 ] && break;     current_time=$(date +%s);     elapsed=$((current_time - start_time));     if [ "$elapsed" -ge "$timeout" ]; then         echo "Timeout: $not_ready_count service/replica(s) stuck in NOT_READY";         exit 1;     fi;     echo "Waiting for $not_ready_count NOT_READY service/replicas...";     sleep 10; done; echo "$s"; echo "$s" \| grep "x\[spot\](cpus=2, " \| grep "PROVISIONING\\|STARTING\\|READY" \| wc -l \| grep 4 \|\| exit 1; echo "$s" \| grep "x(cpus=2, " \| grep "PROVISIONING\\|STARTING" \| wc -l \| grep 1 \|\| exit 1; echo "$s" \| grep "x(cpus=2, " \| grep "READY" \| wc -l \| grep 2 \|\| exit 1;
  | [test-skyserve-new-autoscaler-update-rolling]
  | D 05-25 21:58:01 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:58:01 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:58:01 skypilot_config.py:419] jobs:
  | D 05-25 21:58:01 skypilot_config.py:419]   controller:
  | D 05-25 21:58:01 skypilot_config.py:419]     resources:
  | D 05-25 21:58:01 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:58:01 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:58:01 skypilot_config.py:419]
  | D 05-25 21:58:01 skypilot_config.py:419] serve:
  | D 05-25 21:58:01 skypilot_config.py:419]   controller:
  | D 05-25 21:58:01 skypilot_config.py:419]     resources:
  | D 05-25 21:58:01 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:58:01 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:58:01 skypilot_config.py:419]
  | D 05-25 21:58:02 skypilot_config.py:426] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:58:02 common.py:206] Health check status: 200
  | D 05-25 21:58:02 common.py:206] Health check status: 200
  | Services
  | NAME                                 VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1,2      3m 25s  READY   5/7       http://44.195.89.213:30001
  |  
  | Service Replicas
  | SERVICE_NAME                         ID  VERSION  ENDPOINT                    LAUNCHED     INFRA             RESOURCES                                STATUS
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1   1        http://98.80.136.214:8081   3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  2   1        http://3.237.92.157:8081    3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        SHUTTING_DOWN
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  3   2        http://44.220.50.41:8081    51 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  4   2        http://44.222.102.132:8081  48 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  5   2        http://13.217.168.171:8081  45 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  6   2        http://44.221.90.209:8081   49 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           21 secs ago  AWS (us-east-1)   1x(cpus=2, mem=4, c6i.large, ...)        PROVISIONING
  | Provisioning complete. PROVISIONING: 1, cpus=2:
  | D 05-25 21:58:01 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:58:01 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:58:01 skypilot_config.py:419] jobs:
  | D 05-25 21:58:01 skypilot_config.py:419]   controller:
  | D 05-25 21:58:01 skypilot_config.py:419]     resources:
  | D 05-25 21:58:01 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:58:01 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:58:01 skypilot_config.py:419]
  | D 05-25 21:58:01 skypilot_config.py:419] serve:
  | D 05-25 21:58:01 skypilot_config.py:419]   controller:
  | D 05-25 21:58:01 skypilot_config.py:419]     resources:
  | D 05-25 21:58:01 skypilot_config.py:419]       cpus: 2+
  | D 05-25 21:58:01 skypilot_config.py:419]       memory: 4+
  | D 05-25 21:58:01 skypilot_config.py:419]
  | D 05-25 21:58:02 skypilot_config.py:426] Config syntax check passed for path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:58:02 common.py:206] Health check status: 200
  | D 05-25 21:58:02 common.py:206] Health check status: 200
  | Services
  | NAME                                 VERSION  UPTIME  STATUS  REPLICAS  ENDPOINT
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1,2      3m 25s  READY   5/7       http://44.195.89.213:30001
  |  
  | Service Replicas
  | SERVICE_NAME                         ID  VERSION  ENDPOINT                    LAUNCHED     INFRA             RESOURCES                                STATUS
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  1   1        http://98.80.136.214:8081   3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  2   1        http://3.237.92.157:8081    3 mins ago   AWS (us-east-1a)  1x(cpus=2, mem=4, c6i.large, ...)        SHUTTING_DOWN
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  3   2        http://44.220.50.41:8081    51 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  4   2        http://44.222.102.132:8081  48 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  5   2        http://13.217.168.171:8081  45 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  6   2        http://44.221.90.209:8081   49 secs ago  AWS (us-east-1f)  1x[spot](cpus=2, mem=4, c6i.large, ...)  READY
  | t-ss-new-aut-6c-9c3e77a5-02-rolling  7   2        -                           21 secs ago  AWS (us-east-1)   1x(cpus=2, mem=4, c6i.large, ...)        PROVISIONING
  | 4
  | 1
  | [test-skyserve-new-autoscaler-update-rolling] Failed (returned 1).
  | [test-skyserve-new-autoscaler-update-rolling] Reason: s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling); until ! echo "$s" \| grep "Controller is initializing."; do     echo "Waiting for serve status to be ready...";     sleep 5;     s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling); done; echo "$s"; num_provisioning=$(echo "$s" \| grep "PROVISIONING" \| wc -l); num_vcpu_in_provision=$(echo "$s" \| grep "PROVISIONING" \| grep "x(cpus=2, " \| wc -l); until [ "$num_provisioning" -eq "$num_vcpu_in_provision" ]; do     echo "Waiting for provisioning resource repr ready...";     echo "PROVISIONING: $num_provisioning, vCPU: $num_vcpu_in_provision";     sleep 2;     s=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling);     num_provisioning=$(echo "$s" \| grep "PROVISIONING" \| wc -l);     num_vcpu_in_provision=$(echo "$s" \| grep "PROVISIONING" \| grep "x(cpus=2, " \| wc -l); done; echo "Provisioning complete. PROVISIONING: $num_provisioning, cpus=2: $num_cpus_in_provision"; start_time=$(date +%s); timeout=300; while true; do     not_ready_count=$(sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling \|         awk '/t-ss-new-aut-6c-9c3e77a5-02-rolling/ && $10 == "NOT_READY" {print}' \|         wc -l);     [ "$not_ready_count" -eq 0 ] && break;     current_time=$(date +%s);     elapsed=$((current_time - start_time));     if [ "$elapsed" -ge "$timeout" ]; then         echo "Timeout: $not_ready_count service/replica(s) stuck in NOT_READY";         exit 1;     fi;     echo "Waiting for $not_ready_count NOT_READY service/replicas...";     sleep 10; done; echo "$s"; echo "$s" \| grep "x\[spot\](cpus=2, " \| grep "PROVISIONING\\|STARTING\\|READY" \| wc -l \| grep 4 \|\| exit 1; echo "$s" \| grep "x(cpus=2, " \| grep "PROVISIONING\\|STARTING" \| wc -l \| grep 1 \|\| exit 1; echo "$s" \| grep "x(cpus=2, " \| grep "READY" \| wc -l \| grep 2 \|\| exit 1;
  | + sky serve status t-ss-new-aut-6c-9c3e77a5-02-rolling
  | D 05-25 21:58:20 skypilot_config.py:468] Using config path: tests/test_yamls/low_resource_sky_config.yaml
  | D 05-25 21:58:20 skypilot_config.py:419] Config loaded from tests/test_yamls/low_resource_sky_config.yaml:
  | D 05-25 21:58:20 skypilot_config.py:419] jobs:
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_new_autoscaler_update --aws`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
