### PR TITLE
[Core] Enable workspace context when fetching enabled clouds

### DIFF
--- a/sky/core.py
+++ b/sky/core.py
@@ -1016,22 +1016,23 @@ def enabled_clouds(workspace: Optional[str] = None,
         workspace = skypilot_config.get_active_workspace()
     cached_clouds = global_user_state.get_cached_enabled_clouds(
         sky_cloud.CloudCapability.COMPUTE, workspace=workspace)
-    if not expand:
-        return [cloud.canonical_name() for cloud in cached_clouds]
-    enabled_ssh_infras = []
-    enabled_k8s_infras = []
-    enabled_cloud_infras = []
-    for cloud in cached_clouds:
-        cloud_infra = cloud.expand_infras()
-        if isinstance(cloud, clouds.SSH):
-            enabled_ssh_infras.extend(cloud_infra)
-        elif isinstance(cloud, clouds.Kubernetes):
-            enabled_k8s_infras.extend(cloud_infra)
-        else:
-            enabled_cloud_infras.extend(cloud_infra)
-    all_infras = sorted(enabled_ssh_infras) + sorted(
-        enabled_k8s_infras) + sorted(enabled_cloud_infras)
-    return all_infras
+    with skypilot_config.local_active_workspace_ctx(workspace):
+        if not expand:
+            return [cloud.canonical_name() for cloud in cached_clouds]
+        enabled_ssh_infras = []
+        enabled_k8s_infras = []
+        enabled_cloud_infras = []
+        for cloud in cached_clouds:
+            cloud_infra = cloud.expand_infras()
+            if isinstance(cloud, clouds.SSH):
+                enabled_ssh_infras.extend(cloud_infra)
+            elif isinstance(cloud, clouds.Kubernetes):
+                enabled_k8s_infras.extend(cloud_infra)
+            else:
+                enabled_cloud_infras.extend(cloud_infra)
+        all_infras = sorted(enabled_ssh_infras) + sorted(
+            enabled_k8s_infras) + sorted(enabled_cloud_infras)
+        return all_infras
 
 
 @usage_lib.entrypoint


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
