### PR TITLE
[API server] persistent kubeconfig

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -97,6 +97,11 @@ spec:
             fi
           done
           {{- end }}
+          {{- if and .Values.kubernetesCredentials.useKubeconfig .Values.apiService.sshNodePools }}
+          mkdir -p /root/.kube
+          # Merge the kubeconfig from secret and PVC
+          KUBECONFIG=/var/skypilot/kubeconfig/config:/root/.kube/config kubectl config view --flatten > /root/.kube/config
+          {{- end }}
 
           if sky api start -h | grep -q -- "--foreground"; then
             exec sky api start --deploy --foreground
@@ -153,8 +158,18 @@ spec:
           subPath: gcp-cred.json
         {{- end }}
         {{- if .Values.kubernetesCredentials.useKubeconfig }}
+        {{- if .Values.apiService.sshNodePools }}
         - name: kube-config
+          mountPath: /var/skypilot/kubeconfig
+        {{- else }}
+        - name: kube-config
+          mountPath: /root/.kube/config
+        {{- end }}
+        {{- end }}
+        {{- if .Values.apiService.sshNodePools }}
+        - name: state-volume
           mountPath: /root/.kube
+          subPath: .kube
         {{- end }}
         {{- if .Values.runpodCredentials.enabled }}
         - name: runpod-config

--- a/charts/skypilot/templates/api-secrets.yaml
+++ b/charts/skypilot/templates/api-secrets.yaml
@@ -1,4 +1,4 @@
-{{- /* Use serect since sshNodePools config may contain credentials */ -}}
+{{- /* Use secrect since sshNodePools config may contain credentials */ -}}
 {{- if .Values.apiService.sshNodePools}}
 apiVersion: v1
 kind: Secret

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -205,6 +205,10 @@ Following tabs describe how to configure credentials for different clouds on the
               --set kubernetesCredentials.useKubeconfig=true \
               --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
 
+        .. note::
+
+            Changes to the kubeconfig secret will be automatically reflected in the API server if :ref:`apiService.sshNodePools <helm-values-apiService-sshNodePools>` is not set. Otherwise, you will need to recreate the API server Pod to apply the changes.
+
         .. tip::
 
             If you are using a kubeconfig file that contains `exec-based authentication <https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuration>`_ (e.g., GKE's default ``gke-gcloud-auth-plugin`` based authentication), you will need to strip the path information from the ``command`` field in the exec configuration.

--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -7,6 +7,7 @@ import os
 import random
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -1356,7 +1357,7 @@ def deploy_cluster(head_node,
                 merged_file.write(result)
 
         # Replace the kubeconfig with the merged config
-        os.replace(merged_config, kubeconfig_path)
+        shutil.move(merged_config, kubeconfig_path)
 
         # Set the new context as the current context
         run_command(['kubectl', 'config', 'use-context', context_name],


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When `sshNodePool` is enabled, enable persistent kubeconfig to make sure the kubeconfig of ssh cluster does not get lost.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manually tested on GKE cluster
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
