### PR TITLE
[API server] Avoid overriding the config twice

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -232,7 +232,7 @@ Following tabs describe how to configure credentials for different clouds on the
               - context1
               - context2
 
-        Refer to :ref:`sky-api-server-config` for how to set the SkyPilot config in Helm chart values.
+        Refer to :ref:`config-yaml-kubernetes-allowed-contexts` for how to set the SkyPilot config in Helm chart values.
 
     .. tab-item:: AWS
         :sync: aws-creds-tab

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -80,6 +80,8 @@ After the API server is deployed, you can inspect the API server pod status with
 
 You should see the pod is initializing and finally becomes running and ready. If not, refer to :ref:`sky-api-server-troubleshooting-helm` to diagnose the issue.
 
+The API server above is deployed with a basic auth provided by Nginx. To use advanced OAuth2 authentication, refer to :ref:`Using an Auth Proxy with the SkyPilot API Server <api-server-auth-proxy>`.
+
 .. _sky-get-api-server-url:
 
 Step 2: Get the API server URL

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -200,9 +200,9 @@ Following tabs describe how to configure credentials for different clouds on the
 
         .. code-block:: bash
 
+            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
-              # keep the Helm chart values set in the previous step
               --reuse-values \
               --set kubernetesCredentials.useKubeconfig=true \
               --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
@@ -254,9 +254,9 @@ Following tabs describe how to configure credentials for different clouds on the
 
         .. code-block:: bash
 
+            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
                 --namespace $NAMESPACE \
-                # keep the Helm chart values set in the previous step
                 --reuse-values \
                 --set awsCredentials.enabled=true
 
@@ -292,9 +292,9 @@ Following tabs describe how to configure credentials for different clouds on the
 
         .. code-block:: bash
 
+            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
-              # keep the Helm chart values set in the previous step
               --reuse-values \
               --set gcpCredentials.enabled=true \
               --set gcpCredentials.projectId=YOUR_PROJECT_ID
@@ -357,9 +357,9 @@ Following tabs describe how to configure credentials for different clouds on the
 
         .. code-block:: bash
 
+            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
-              # keep the Helm chart values set in the previous step
               --reuse-values \
               --set lambdaCredentials.enabled=true
 
@@ -393,9 +393,9 @@ Following tabs describe how to configure credentials for different clouds on the
 
         .. code-block:: bash
 
+            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
-              # keep the Helm chart values set in the previous step
               --reuse-values \
               --set nebiusCredentials.enabled=true \
               --set nebiusCredentials.tenantId=YOUR_TENANT_ID
@@ -597,9 +597,9 @@ To set the config file, pass ``--set-file apiService.config=path/to/your/config.
     EOF
 
     # Install the API server with the config file
+    # --reuse-values keeps the Helm chart values set in the previous step
     helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
       --namespace $NAMESPACE \
-      # Reuse the values set in the previous steps, if any
       --reuse-values \
       --set-file apiService.config=config.yaml
 

--- a/sky/dashboard/src/pages/config.js
+++ b/sky/dashboard/src/pages/config.js
@@ -28,7 +28,11 @@ export default function ConfigPage() {
     setError(null);
     try {
       const config = await getConfig();
-      setEditableConfig(yaml.dump(config, { indent: 2 }));
+      if (Object.keys(config).length === 0) {
+        setEditableConfig('# Empty SkyPilot config. Enter config in YAML format\n');
+      } else {
+        setEditableConfig(yaml.dump(config, { indent: 2 }));
+      }
     } catch (error) {
       console.error('Error loading config:', error);
       setError(error);
@@ -101,7 +105,7 @@ export default function ConfigPage() {
         <Card className="w-full">
           <CardHeader>
             <CardTitle className="text-base font-normal flex items-center justify-between">
-              <span>Edit SkyPilot Configuration</span>
+              <span>Edit SkyPilot Configuration YAML</span>
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -72,6 +72,8 @@ def request_body_env_vars() -> dict:
 
 def get_override_skypilot_config_from_client() -> Dict[str, Any]:
     """Returns the override configs from the client."""
+    if annotations.is_on_api_server:
+        return {}
     config = skypilot_config.to_dict()
     # Remove the API server config, as we should not specify the SkyPilot
     # server endpoint on the server side. This avoids the warning at


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When a request creates a `RequestBody` on the API server side, it tries to fetch config from the serverside as the override, which will override the config twice. Please see the changes in `payloads.py`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
