### PR TITLE
Refactor nightly build logic

### DIFF
--- a/.github/workflows/helm-docker-release.yaml
+++ b/.github/workflows/helm-docker-release.yaml
@@ -2,9 +2,19 @@ name: Build and Publish Helm Charts
 description: Build and publish docker image and Helm charts for SkyPilot.
 
 on:
-  schedule:
-    # Set the time to be 1 hour after the pypi nightly build
-    - cron: '35 11 * * *' # 11:35am UTC, 3:35am PST, 6:35am EST
+  workflow_call:
+    inputs:
+      package_name:
+        description: 'SkyPilot PyPI package name'
+        required: true
+        type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      HELM_DEPLOY_KEY:
+        required: true
   workflow_dispatch:
     inputs:
       package_name:
@@ -20,9 +30,16 @@ jobs:
   set-package:
     runs-on: ubuntu-latest
     outputs:
-      package_name: ${{ github.event_name == 'workflow_dispatch' && inputs.package_name || 'skypilot-nightly' }}
+      package_name: ${{ inputs.package_name }}
     steps:
-      - run: echo "Using package ${{ github.event_name == 'workflow_dispatch' && inputs.package_name || 'skypilot-nightly' }}"
+      - name: Validate package name
+        run: |
+          if [[ "${{ inputs.package_name }}" != "skypilot-nightly" && "${{ inputs.package_name }}" != "skypilot" ]]; then
+            echo "Error: package_name must be either 'skypilot-nightly' or 'skypilot'"
+            exit 1
+          fi
+      - name: Echo package name
+        run: echo "Using package ${{ inputs.package_name }}"
 
   docker-build:
     needs: set-package

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -127,9 +127,16 @@ jobs:
       repository_type: 'pypi'
     secrets: inherit
 
+  trigger-helm-release:
+    needs: [publish-and-validate-pypi]
+    uses: ./.github/workflows/helm-docker-release.yaml
+    with:
+      package_name: skypilot-nightly
+    secrets: inherit
+
   notify-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-date, nightly-build-pypi, extract-build-number, wait-for-buildkite, publish-and-validate-test-pypi, publish-and-validate-pypi]
+    needs: [check-date, nightly-build-pypi, extract-build-number, wait-for-buildkite, publish-and-validate-test-pypi, publish-and-validate-pypi, trigger-helm-release]
     if: failure() # Only run this job if any of the previous jobs failed
     steps:
       - name: Prepare failure message


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Disable the scheduled run for `helm-docker` nightly and make `pypi-nightly-build` trigger `helm-docker` instead.  

This ensures `helm-docker` runs only after `pypi` updates (event-based instead of time-based).  

Since we now control everything in `pypi-nightly-build`, rename it to `nightly-build` for better clarity.  

Resolve #5712

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
