### PR TITLE
[Helm] Fix Nebius credentials for API server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN conda install -c conda-forge google-cloud-sdk && \
     curl -LO "https://dl.k8s.io/release/v1.31.6/bin/linux/$ARCH/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
     rm kubectl && \
+    curl -sSL https://storage.eu-north1.nebius.cloud/cli/install.sh | NEBIUS_INSTALL_FOLDER=/usr/local/bin bash && \
     # Install uv and skypilot
     curl -LsSf https://astral.sh/uv/install.sh | sh && \
     ~/.local/bin/uv pip install --prerelease allow azure-cli --system && \

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -87,6 +87,17 @@ spec:
           # The configmap serves as the ground truth for the ssh_node_pools.yaml file, read-only
           ln -sf /var/skypilot/ssh_node_pool/ssh_node_pools.yaml /root/.sky/ssh_node_pools.yaml
           {{- end }}
+          # Nebius credentials mounting
+          # Since the ~/.nebius directory is also used by the Nebius CLI, we mount the credentials to /root/.nebius_credentials
+          # and create a symlink to /root/.nebius. This cannot be done in the init container because the Nebius CLI needs read-write access to ~/.nebius.
+          {{- if .Values.nebiusCredentials.enabled }}
+          echo "Setting up Nebius credentials..."
+          mkdir -p /root/.nebius
+          ln -sf /root/.nebius_credentials/credentials.json /root/.nebius/credentials.json
+          echo "{{ .Values.nebiusCredentials.tenantId }}" >> /root/.nebius/NEBIUS_TENANT_ID.txt
+          # Create a Nebius profile for the nebius CLI to use as default
+          nebius profile create --profile sky --endpoint api.nebius.cloud --service-account-file /root/.nebius/credentials.json || echo "Unable to create Nebius profile."
+          {{- end }}
           {{- if .Values.apiService.sshKeySecret }}
           mkdir -p /root/.ssh
           echo "Linking ssh keys to /root/.ssh"
@@ -167,9 +178,9 @@ spec:
           readOnly: true
         {{- end }}
         {{- if .Values.nebiusCredentials.enabled }}
-        - name: nebius-config
-          mountPath: /root/.nebius
-          readOnly: true
+        - name: nebius-credentials
+          mountPath: /root/.nebius_credentials/credentials.json
+          subPath: credentials.json
         {{- end }}
       initContainers:
       {{- if .Values.awsCredentials.enabled }}
@@ -288,27 +299,6 @@ spec:
         - name: lambda-config
           mountPath: /root/.lambda_cloud
       {{- end }}
-      {{- if .Values.nebiusCredentials.enabled }}
-      - name: create-nebius-credentials
-        {{- with .Values.securityContext }}
-        securityContext:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
-        image: {{ .Values.apiService.image }}
-        command: ["/bin/sh", "-c"]
-        args:
-        - |
-          echo "Setting up Nebius credentials..."
-          mkdir -p /root/.nebius
-          cp /root/.nebius_cloud/credentials.json /root/.nebius/credentials.json
-          echo "{{ .Values.nebiusCredentials.tenantId }}" >> /root/.nebius/NEBIUS_TENANT_ID.txt
-        volumeMounts:
-        - name: nebius-config
-          mountPath: /root/.nebius
-        - name: nebius-credentials
-          mountPath: /root/.nebius_cloud/credentials.json
-          subPath: credentials.json
-      {{- end }}
       volumes:
       {{- if .Values.storage.enabled }}
       - name: state-volume
@@ -338,8 +328,6 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if .Values.nebiusCredentials.enabled }}
-      - name: nebius-config
-        emptyDir: {}
       - name: nebius-credentials
         secret:
           secretName: {{ .Values.nebiusCredentials.nebiusSecretName }}

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -479,7 +479,7 @@ Refer to :ref:`sky-api-server-upgrade` for how to upgrade the API server.
 .. _update-sky-config:
 
 Optional: Update SkyPilot configuration
-----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``apiService.config`` will be IGNORED during an upgrade. To update your SkyPilot config:
 

--- a/sky/utils/kubernetes/exec_kubeconfig_converter.py
+++ b/sky/utils/kubernetes/exec_kubeconfig_converter.py
@@ -5,6 +5,9 @@ the 'command' field in the exec configuration, leaving only the executable name.
 This is useful when moving between different environments where auth plugin
 executables might be installed in different locations.
 
+For Nebius kubeconfigs, it also changes the --profile argument to 'sky' to
+ensure compatibility with SkyPilot's expected profile configuration.
+
 It assumes the target environment has the auth executable available in PATH.
 If not, you'll need to update your environment container to include the auth
 executable in PATH.
@@ -20,6 +23,8 @@ import yaml
 
 def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
     """Strip path information from exec plugin commands in a kubeconfig file.
+    
+    For Nebius kubeconfigs, also changes the --profile argument to 'sky'.
 
     Args:
         kubeconfig_path (str): Path to the input kubeconfig file
@@ -39,6 +44,20 @@ def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
             if executable != current_command:
                 exec_info['command'] = executable
                 updated = True
+            
+            # Handle Nebius kubeconfigs: change --profile to 'sky'
+            if executable == 'nebius' or current_command == 'nebius':
+                args = exec_info.get('args', [])
+                if args and '--profile' in args:
+                    try:
+                        profile_index = args.index('--profile')
+                        if profile_index + 1 < len(args):
+                            old_profile = args[profile_index + 1]
+                            if old_profile != 'sky':
+                                args[profile_index + 1] = 'sky'
+                                updated = True
+                    except ValueError:
+                        pass  # --profile not found in args
 
     if updated:
         with open(output_path, 'w', encoding='utf-8') as file:

--- a/sky/utils/kubernetes/exec_kubeconfig_converter.py
+++ b/sky/utils/kubernetes/exec_kubeconfig_converter.py
@@ -44,7 +44,7 @@ def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
             if executable != current_command:
                 exec_info['command'] = executable
                 updated = True
-            
+
             # Handle Nebius kubeconfigs: change --profile to 'sky'
             if executable == 'nebius' or current_command == 'nebius':
                 args = exec_info.get('args', [])

--- a/sky/utils/kubernetes/exec_kubeconfig_converter.py
+++ b/sky/utils/kubernetes/exec_kubeconfig_converter.py
@@ -23,7 +23,7 @@ import yaml
 
 def strip_auth_plugin_paths(kubeconfig_path: str, output_path: str):
     """Strip path information from exec plugin commands in a kubeconfig file.
-    
+
     For Nebius kubeconfigs, also changes the --profile argument to 'sky'.
 
     Args:


### PR DESCRIPTION
Adds support for exec-based auth on managed k8s clusters on nebius.

Required the installation of Nebius CLI and updating our exec auth convertor to use a standard `sky` profile.

Because the CLI needs write access to `~/.nebius`, needed to change the credential init pattern from using an initContainer to mounting credentials directly and symlinking specific files. 