### PR TITLE
Consistent name for `nightly-build` and fix bug

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,4 @@
-name: pypi-publish-nightly
+name: nightly-build
 on:
   schedule:
     - cron: '35 10 * * *' # 10:35am UTC, 2:35am PST, 5:35am EST

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -119,7 +119,7 @@ jobs:
     secrets: inherit
 
   publish-and-validate-pypi:
-    needs: [publish-and-validate-test-pypi]
+    needs: [nightly-build-pypi, publish-and-validate-test-pypi]
     uses: ./.github/workflows/publish-and-validate.yml
     with:
       package_name: skypilot-nightly

--- a/.github/workflows/publish-and-validate.yml
+++ b/.github/workflows/publish-and-validate.yml
@@ -50,6 +50,12 @@ jobs:
           MAX_ATTEMPTS=10
           ATTEMPT=1
 
+          # Validate expected version is not empty
+          if [ -z "${{ inputs.expected_version }}" ]; then
+            echo "Error: Expected version is empty"
+            exit 1
+          fi
+
           echo "Waiting for package ${{ inputs.package_name }} version ${{ inputs.expected_version }} to be available..."
 
           # Try installing the package up to MAX_ATTEMPTS times
@@ -81,7 +87,8 @@ jobs:
             # If this is the final attempt, don't sleep
             if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
               echo "Final attempt completed."
-              break
+              echo "Failed to install expected version after $MAX_ATTEMPTS attempts"
+              exit 1
             fi
 
             # Wait before next attempt


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

![image](https://github.com/user-attachments/assets/582194e6-ad51-4304-9568-3925df4434aa)

Minor change, rename to keep consistent


And we fail to pass the [expect version in today's build](https://github.com/skypilot-org/skypilot/actions/runs/15273151597/job/42963353202), fix the dependency bug.

![image](https://github.com/user-attachments/assets/7234482b-595d-4ad4-843e-a6aa7a69aef1)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
