### PR TITLE
fix SSH detection

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1727,12 +1727,12 @@ class RetryingVmProvisioner(object):
                 f'{requested_resources}. ')
         elif to_provision.region is not None:
             # For public clouds, provision.region is always set.
-            if to_provision.cloud.is_same_cloud(clouds.SSH()):
+            if clouds.SSH().is_same_cloud(to_provision.cloud):
                 message = ('Failed to acquire resources in SSH Node Pool '
                            f'({to_provision.region.lstrip("ssh-")}) for '
                            f'{requested_resources}. The SSH Node Pool may not '
                            'have enough resources.')
-            elif to_provision.cloud.is_same_cloud(clouds.Kubernetes()):
+            elif clouds.Kubernetes().is_same_cloud(to_provision.cloud):
                 message = ('Failed to acquire resources in context '
                            f'{to_provision.region} for {requested_resources}. ')
             else:


### PR DESCRIPTION
`a.is_same_cloud(b)` is just `isinstance(b, a)`. So the old code would think that a k8s cluster is an SSH nodepool, since `isinstance(SSH, k8s)` is true.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
