### PR TITLE
[API server] Adopt oauth2 flow if browser is avaiable

### DIFF
--- a/sky/client/oauth.py
+++ b/sky/client/oauth.py
@@ -1,0 +1,149 @@
+"""Client-side OAuth module."""
+from http.server import BaseHTTPRequestHandler
+from http.server import HTTPServer
+import threading
+import time
+from typing import Dict, Optional
+from urllib import parse as urlparse
+
+AUTH_TIMEOUT = 300  # 5 minutes
+
+
+class _AuthCallbackHandler(BaseHTTPRequestHandler):
+    """HTTP request handler for OAuth callback."""
+
+    def __init__(self, token_container: Dict[str, Optional[str]], *args,
+                 **kwargs):
+        self.token_container = token_container
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        """Handle GET request for OAuth callback."""
+        parsed_url = urlparse.urlparse(self.path)
+        query_params = urlparse.parse_qs(parsed_url.query)
+
+        if 'token' in query_params:
+            token = query_params['token'][0]
+            self.token_container['token'] = token
+
+            # Send success response
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+
+            success_html = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>SkyPilot Authentication</title>
+                <style>
+                    body { 
+                        font-family: Arial, sans-serif; 
+                        text-align: center; 
+                        padding: 50px; 
+                        background-color: #f5f5f5; 
+                    }
+                    .container { 
+                        background: white; 
+                        padding: 30px; 
+                        border-radius: 10px; 
+                        box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
+                        max-width: 500px; 
+                        margin: 0 auto; 
+                    }
+                    .success { color: #28a745; }
+                    .logo { font-size: 24px; margin-bottom: 20px; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <div class="logo">🚀 SkyPilot</div>
+                    <h2 class="success">Authentication Successful!</h2>
+                    <p>You have successfully authenticated with SkyPilot.</p>
+                    <p>You can now close this window and return to your 
+                       terminal.</p>
+                </div>
+            </body>
+            </html>
+            """
+            self.wfile.write(success_html.encode('utf-8'))
+        else:
+            # Send error response
+            self.send_response(400)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+
+            error_html = """
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <title>SkyPilot Authentication Error</title>
+                <style>
+                    body { 
+                        font-family: Arial, sans-serif; 
+                        text-align: center; 
+                        padding: 50px; 
+                        background-color: #f5f5f5; 
+                    }
+                    .container { 
+                        background: white; 
+                        padding: 30px; 
+                        border-radius: 10px; 
+                        box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
+                        max-width: 500px; 
+                        margin: 0 auto; 
+                    }
+                    .error { color: #dc3545; }
+                    .logo { font-size: 24px; margin-bottom: 20px; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <div class="logo">🚀 SkyPilot</div>
+                    <h2 class="error">Authentication Failed</h2>
+                    <p>No authentication token was received.</p>
+                    <p>Please try again or contact support if the problem 
+                       persists.</p>
+                </div>
+            </body>
+            </html>
+            """
+            self.wfile.write(error_html.encode('utf-8'))
+
+    def log_message(self, *args):  # pylint: disable=unused-argument
+        """Suppress default HTTP server logging."""
+        pass
+
+
+def start_local_auth_server(port: int,
+                            token_store: Dict[str, Optional[str]],
+                            timeout: int = AUTH_TIMEOUT) -> HTTPServer:
+    """Start a local HTTP server to handle OAuth callback.
+
+    Args:
+        port: Port to bind the server to.
+        token_container: Dict to store the received token.
+        timeout: Timeout in seconds to wait for the callback.
+
+    Returns:
+        The HTTP server instance.
+    """
+
+    def handler_factory(*args, **kwargs):
+        return _AuthCallbackHandler(token_store, *args, **kwargs)
+
+    server = HTTPServer(('localhost', port), handler_factory)
+    server.timeout = timeout
+
+    def serve_until_token():
+        """Serve requests until token is received or timeout."""
+        start_time = time.time()
+        while (token_store['token'] is None and
+               time.time() - start_time < timeout):
+            server.handle_request()
+
+    # Start server in a separate thread
+    server_thread = threading.Thread(target=serve_until_token, daemon=True)
+    server_thread.start()
+
+    return server

--- a/sky/client/oauth.py
+++ b/sky/client/oauth.py
@@ -4,7 +4,6 @@ from http.server import HTTPServer
 import threading
 import time
 from typing import Dict, Optional
-from urllib import parse as urlparse
 
 AUTH_TIMEOUT = 300  # 5 minutes
 
@@ -12,99 +11,33 @@ AUTH_TIMEOUT = 300  # 5 minutes
 class _AuthCallbackHandler(BaseHTTPRequestHandler):
     """HTTP request handler for OAuth callback."""
 
-    def __init__(self, token_container: Dict[str, Optional[str]], *args,
-                 **kwargs):
+    def __init__(self, token_container: Dict[str, Optional[str]],
+                 remote_endpoint: str, *args, **kwargs):
         self.token_container = token_container
+        self.remote_endpoint = remote_endpoint
         super().__init__(*args, **kwargs)
 
-    def do_GET(self):  # pylint: disable=invalid-name
-        """Handle GET request for OAuth callback."""
-        parsed_url = urlparse.urlparse(self.path)
-        query_params = urlparse.parse_qs(parsed_url.query)
+    def do_POST(self):  # pylint: disable=invalid-name
+        """Handle POST request for OAuth callback."""
+        data = self.rfile.read(int(self.headers['Content-Length']))
 
-        if 'token' in query_params:
-            token = query_params['token'][0]
+        if data:
+            token = data.decode('utf-8')
             self.token_container['token'] = token
 
             # Send success response
             self.send_response(200)
             self.send_header('Content-type', 'text/html')
+            self.send_header('Access-Control-Allow-Origin',
+                             self.remote_endpoint)
             self.end_headers()
-
-            success_html = """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <title>SkyPilot Authentication</title>
-                <style>
-                    body { 
-                        font-family: Arial, sans-serif; 
-                        text-align: center; 
-                        padding: 50px; 
-                        background-color: #f5f5f5; 
-                    }
-                    .container { 
-                        background: white; 
-                        padding: 30px; 
-                        border-radius: 10px; 
-                        box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
-                        max-width: 500px; 
-                        margin: 0 auto; 
-                    }
-                    .success { color: #28a745; }
-                    .logo { font-size: 24px; margin-bottom: 20px; }
-                </style>
-            </head>
-            <body>
-                <div class="container">
-                    <h2 class="success">Authentication Successful!</h2>
-                    <p>You have successfully authenticated with SkyPilot.</p>
-                    <p>You can now close this window and return to your 
-                       terminal.</p>
-                </div>
-            </body>
-            </html>
-            """
-            self.wfile.write(success_html.encode('utf-8'))
         else:
             # Send error response
             self.send_response(400)
             self.send_header('Content-type', 'text/html')
+            self.send_header('Access-Control-Allow-Origin',
+                             self.remote_endpoint)
             self.end_headers()
-
-            error_html = """
-            <!DOCTYPE html>
-            <html>
-            <head>
-                <title>SkyPilot Authentication Error</title>
-                <style>
-                    body { 
-                        font-family: Arial, sans-serif; 
-                        text-align: center; 
-                        padding: 50px; 
-                        background-color: #f5f5f5; 
-                    }
-                    .container { 
-                        background: white; 
-                        padding: 30px; 
-                        border-radius: 10px; 
-                        box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
-                        max-width: 500px; 
-                        margin: 0 auto; 
-                    }
-                    .error { color: #dc3545; }
-                    .logo { font-size: 24px; margin-bottom: 20px; }
-                </style>
-            </head>
-            <body>
-                <div class="container">
-                    <h2 class="error">Authentication Failed</h2>
-                    <p>No authentication token was received.</p>
-                </div>
-            </body>
-            </html>
-            """
-            self.wfile.write(error_html.encode('utf-8'))
 
     def log_message(self, *args):  # pylint: disable=unused-argument
         """Suppress default HTTP server logging."""
@@ -113,12 +46,15 @@ class _AuthCallbackHandler(BaseHTTPRequestHandler):
 
 def start_local_auth_server(port: int,
                             token_store: Dict[str, Optional[str]],
+                            remote_endpoint: str,
                             timeout: int = AUTH_TIMEOUT) -> HTTPServer:
     """Start a local HTTP server to handle OAuth callback.
 
     Args:
         port: Port to bind the server to.
         token_container: Dict to store the received token.
+        remote_endpoint: The endpoint of the SkyPilot API server that will send
+          the token, needed for CORS.
         timeout: Timeout in seconds to wait for the callback.
 
     Returns:
@@ -126,7 +62,8 @@ def start_local_auth_server(port: int,
     """
 
     def handler_factory(*args, **kwargs):
-        return _AuthCallbackHandler(token_store, *args, **kwargs)
+        return _AuthCallbackHandler(token_store, remote_endpoint, *args,
+                                    **kwargs)
 
     server = HTTPServer(('localhost', port), handler_factory)
     server.timeout = timeout

--- a/sky/client/oauth.py
+++ b/sky/client/oauth.py
@@ -98,11 +98,8 @@ class _AuthCallbackHandler(BaseHTTPRequestHandler):
             </head>
             <body>
                 <div class="container">
-                    <div class="logo">🚀 SkyPilot</div>
                     <h2 class="error">Authentication Failed</h2>
                     <p>No authentication token was received.</p>
-                    <p>Please try again or contact support if the problem 
-                       persists.</p>
                 </div>
             </body>
             </html>

--- a/sky/client/oauth.py
+++ b/sky/client/oauth.py
@@ -57,7 +57,6 @@ class _AuthCallbackHandler(BaseHTTPRequestHandler):
             </head>
             <body>
                 <div class="container">
-                    <div class="logo">🚀 SkyPilot</div>
                     <h2 class="success">Authentication Successful!</h2>
                     <p>You have successfully authenticated with SkyPilot.</p>
                     <p>You can now close this window and return to your 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1979,7 +1979,8 @@ def api_login(endpoint: Optional[str] = None, get_token: bool = False) -> None:
                 except Exception:  # pylint: disable=broad-except
                     pass
             if not token:
-                raise ValueError('Authentication failed.')
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError('Authentication failed.')
 
         # Parse the token.
         # b64decode will ignore invalid characters, but does some length and

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1941,12 +1941,9 @@ def api_login(endpoint: Optional[str] = None, get_token: bool = False) -> None:
 
             token_url = (f'{endpoint}/token?redirect_uri='
                          f'{urlparse.quote(callback_url)}')
-
-            # Try to open browser
-            browser_opened = webbrowser.open(token_url)
-            if browser_opened:
+            if webbrowser.open(token_url):
                 click.echo(f'{colorama.Fore.GREEN}A web browser has been '
-                           'opened at {token_url}. Please continue the login '
+                           f'opened at {token_url}. Please continue the login '
                            f'in the web browser.{colorama.Style.RESET_ALL}')
             else:
                 raise ValueError('Failed to open browser.')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -36,6 +36,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.client import common as client_common
+from sky.client import oauth as oauth_lib
 from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
@@ -1908,6 +1909,7 @@ def api_login(endpoint: Optional[str] = None, get_token: bool = False) -> None:
     Args:
         endpoint: The endpoint of the SkyPilot API server, e.g.,
             http://1.2.3.4:46580 or https://skypilot.mydomain.com.
+        get_token: Whether to force getting a new token even if not needed.
 
     Returns:
         None
@@ -1926,14 +1928,58 @@ def api_login(endpoint: Optional[str] = None, get_token: bool = False) -> None:
     server_status = server_common.check_server_healthy(endpoint)
     if server_status == server_common.ApiServerStatus.NEEDS_AUTH or get_token:
         # We detected an auth proxy, so go through the auth proxy cookie flow.
-        parsed_url = urlparse.urlparse(endpoint)
-        token_url = f'{endpoint}/token'
-        click.echo('Authentication is needed. Please visit this URL setup up '
-                   f'the token:{colorama.Style.BRIGHT}\n\n{token_url}'
-                   f'\n{colorama.Style.RESET_ALL}')
-        if webbrowser.open(token_url):
-            click.echo('Opening browser...')
-        token: str = click.prompt('Paste the token')
+        token: Optional[str] = None
+        server: Optional[oauth_lib.HTTPServer] = None
+        try:
+            callback_port = common_utils.find_free_port(8000)
+            callback_url = f'http://localhost:{callback_port}'
+
+            token_container: Dict[str, Optional[str]] = {'token': None}
+            logger.debug('Starting local authentication server...')
+            server = oauth_lib.start_local_auth_server(callback_port,
+                                                       token_container)
+
+            token_url = (f'{endpoint}/token?redirect_uri='
+                         f'{urlparse.quote(callback_url)}')
+
+            # Try to open browser
+            browser_opened = webbrowser.open(token_url)
+            if browser_opened:
+                click.echo(f'{colorama.Fore.GREEN}A web browser has been '
+                           'opened at {token_url}. Please continue the login '
+                           f'in the web browser.{colorama.Style.RESET_ALL}')
+            else:
+                raise ValueError('Failed to open browser.')
+
+            start_time = time.time()
+
+            while (token_container['token'] is None and
+                   time.time() - start_time < oauth_lib.AUTH_TIMEOUT):
+                time.sleep(1)
+
+            if token_container['token'] is None:
+                click.echo(f'{colorama.Fore.YELLOW}Authentication timed out '
+                           f'after {oauth_lib.AUTH_TIMEOUT} seconds.')
+            else:
+                token = token_container['token']
+
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug(f'Automatic authentication failed: {e}, '
+                         'falling back to manual token entry.')
+            # Fall back to manual token entry
+            token_url = f'{endpoint}/token'
+            click.echo('Authentication is needed. Please visit this URL '
+                       f'to set up the token:{colorama.Style.BRIGHT}\n\n'
+                       f'{token_url}\n{colorama.Style.RESET_ALL}')
+            token = click.prompt('Paste the token')
+        finally:
+            if server is not None:
+                try:
+                    server.server_close()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            if not token:
+                raise ValueError('Authentication failed.')
 
         # Parse the token.
         # b64decode will ignore invalid characters, but does some length and
@@ -1959,6 +2005,7 @@ def api_login(endpoint: Optional[str] = None, get_token: bool = False) -> None:
         else:
             raise ValueError(f'Unsupported token version: {json_data.get("v")}')
 
+        parsed_url = urlparse.urlparse(endpoint)
         cookie_jar = cookiejar.MozillaCookieJar()
         for (name, value) in cookie_dict.items():
             # dict keys in JSON must be strings

--- a/sky/server/html/token_page.html
+++ b/sky/server/html/token_page.html
@@ -117,7 +117,8 @@
                 <path d="M16.632 21.3918L15.2651 27.6605L21.3357 25.6091L30.3276 16.6172L16.632 21.3918Z" fill="#39A4DD"/>
             </svg>
         </div>
-        <h1>Sign in to SkyPilot CLI</h1>
+        <h1 class="no-local-port">Sign in to SkyPilot CLI</h1>
+        <h1 class="local-port-info">Successfully signed into SkyPilot CLI</h1>
         <p class="user-identifier">USER_PLACEHOLDER</p>
         <!-- display token info by default -->
         <p class="no-local-port">You are seeing this page because a SkyPilot command requires authentication.</p>
@@ -127,8 +128,7 @@
         <p class="footer-text no-local-port">You can close this tab after copying the token.</p>
 
         <!-- don't display local port info unless successful -->
-        <p class="local-port-info">Successfully authenticated to the SkyPilot CLI.</p>
-        <p class="footer-text local-port-info">You can now close this tab.</p>
+        <p class="local-port-info">You can now close this tab.</p>
     </div>
 
     <script>

--- a/sky/server/html/token_page.html
+++ b/sky/server/html/token_page.html
@@ -100,6 +100,9 @@
             color: #5f6368;
             margin-top: 30px;
         }
+        .local-port-info {
+            display: none;
+        }
     </style>
 </head>
 <body>
@@ -116,12 +119,16 @@
         </div>
         <h1>Sign in to SkyPilot CLI</h1>
         <p class="user-identifier">USER_PLACEHOLDER</p>
-        <p>You are seeing this page because a SkyPilot command requires authentication.</p>
-        <p>Please copy the following token and paste it into your SkyPilot CLI prompt:</p>
-        <div id="token-box" class="code-block">SKYPILOT_API_SERVER_USER_TOKEN_PLACEHOLDER</div>
-        <button id="copy-btn" class="copy-button">Copy Token</button>
+        <!-- display token info by default -->
+        <p class="no-local-port">You are seeing this page because a SkyPilot command requires authentication.</p>
+        <p class="no-local-port">Please copy the following token and paste it into your SkyPilot CLI prompt:</p>
+        <div id="token-box" class="code-block no-local-port">SKYPILOT_API_SERVER_USER_TOKEN_PLACEHOLDER</div>
+        <button id="copy-btn" class="copy-button no-local-port">Copy Token</button>
+        <p class="footer-text no-local-port">You can close this tab after copying the token.</p>
 
-        <p class="footer-text">You can close this tab after copying the token.</p>
+        <!-- don't display local port info unless successful -->
+        <p class="local-port-info">Successfully authenticated to the SkyPilot CLI.</p>
+        <p class="footer-text local-port-info">You can now close this tab.</p>
     </div>
 
     <script>
@@ -154,6 +161,25 @@
                 copyBtn.textContent = 'Copy Token';
             }, 2000);
         });
+
+        function hideTokenInfo() {
+            const noLocalPortElems = document.querySelectorAll('.no-local-port');
+            noLocalPortElems.forEach(elem => {
+                elem.style.display = 'none';
+            });
+            const localPortInfoElems = document.querySelectorAll('.local-port-info');
+            localPortInfoElems.forEach(elem => {
+                elem.classList.remove('local-port-info');
+            });
+        }
+
+        if (window.location.search.includes('local_port=')) {
+            const uri = `http://localhost:${window.location.search.split('local_port=')[1]}`;
+            fetch(uri, {
+                method: 'POST',
+                body: 'SKYPILOT_API_SERVER_USER_TOKEN_PLACEHOLDER'
+            }).then(hideTokenInfo)
+        }
     </script>
 </body>
 </html>

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import sys
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple
+import urllib.parse
 import uuid
 import zipfile
 
@@ -272,7 +273,9 @@ app.include_router(workspaces_rest.router,
 
 
 @app.get('/token')
-async def token(request: fastapi.Request) -> fastapi.responses.HTMLResponse:
+async def token(
+        request: fastapi.Request,
+        redirect_uri: Optional[str] = None) -> fastapi.responses.Response:
     user = _get_auth_user_header(request)
 
     token_data = {
@@ -284,6 +287,22 @@ async def token(request: fastapi.Request) -> fastapi.responses.HTMLResponse:
     json_bytes = json.dumps(token_data).encode('utf-8')
     base64_str = base64.b64encode(json_bytes).decode('utf-8')
 
+    # If redirect_uri is provided, redirect with token as query parameter
+    if redirect_uri is not None:
+        # Parse the redirect URI to add the token parameter
+        parsed_url = urllib.parse.urlparse(redirect_uri)
+        query_params = urllib.parse.parse_qs(parsed_url.query)
+        query_params['token'] = [base64_str]
+
+        # Reconstruct the URL with the token parameter
+        new_query = urllib.parse.urlencode(query_params, doseq=True)
+        redirect_url = urllib.parse.urlunparse(
+            (parsed_url.scheme, parsed_url.netloc, parsed_url.path,
+             parsed_url.params, new_query, parsed_url.fragment))
+
+        return fastapi.responses.RedirectResponse(url=redirect_url)
+
+    # Original HTML response when no redirect_uri is provided
     html_dir = pathlib.Path(__file__).parent / 'html'
     token_page_path = html_dir / 'token_page.html'
     try:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Use oauth2 flow when browser is available, so that user don't have to copy-paste the token string.

UI:

![image](https://github.com/user-attachments/assets/831569d4-4ae5-4adc-9f4c-90ea98cd9f6d)

Try it out:

```bash
$ git checkout oauth2-flow
$ sky api login -e http://dogfood.skypilot.co
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Tested manually
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
