### PR TITLE
[Dashboard] Add API server version to dashboard

### DIFF
--- a/sky/dashboard/src/components/elements/version-display.jsx
+++ b/sky/dashboard/src/components/elements/version-display.jsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+import { ENDPOINT } from '@/data/connectors/constants';
+
+export function VersionDisplay() {
+  const [version, setVersion] = useState(null);
+
+  useEffect(() => {
+    fetch(`${ENDPOINT}/api/health`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.version) {
+          setVersion(data.version);
+        }
+      })
+      .catch((error) => {
+        console.error('Error fetching version:', error);
+      });
+  }, []);
+
+  if (!version) return null;
+
+  return <div className="text-sm text-gray-500">Version: {version}</div>;
+}

--- a/sky/dashboard/src/pages/config.js
+++ b/sky/dashboard/src/pages/config.js
@@ -10,6 +10,7 @@ import { ErrorDisplay } from '@/components/elements/ErrorDisplay';
 import { CircularProgress } from '@mui/material';
 import { SaveIcon, RotateCwIcon } from 'lucide-react';
 import yaml from 'js-yaml';
+import { VersionDisplay } from '@/components/elements/version-display';
 
 export default function ConfigPage() {
   const router = useRouter();
@@ -102,26 +103,18 @@ export default function ConfigPage() {
             <span className="text-sky-blue">SkyPilot Configuration</span>
           </div>
 
-          <div className="text-sm flex items-center">
-            {(loading || saving) && (
-              <div className="flex items-center mr-4">
-                <CircularProgress size={15} className="mt-0" />
-                <span className="ml-2 text-gray-500">
-                  {saving ? 'Applying...' : 'Loading...'}
-                </span>
-              </div>
-            )}
-
-            {/* <div className="flex items-center space-x-4">
-              <button
-                onClick={loadConfig}
-                disabled={loading || saving}
-                className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center"
-              >
-                <RotateCwIcon className="w-4 h-4 mr-1.5" />
-                Refresh
-              </button>
-            </div> */}
+          <div className="flex items-center space-x-4">
+            <VersionDisplay />
+            <div className="text-sm flex items-center">
+              {(loading || saving) && (
+                <div className="flex items-center mr-4">
+                  <CircularProgress size={15} className="mt-0" />
+                  <span className="ml-2 text-gray-500">
+                    {saving ? 'Applying...' : 'Loading...'}
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/sky/dashboard/src/pages/config.js
+++ b/sky/dashboard/src/pages/config.js
@@ -103,8 +103,7 @@ export default function ConfigPage() {
             <span className="text-sky-blue">SkyPilot Configuration</span>
           </div>
 
-          <div className="flex items-center space-x-4">
-            <VersionDisplay />
+          <div className="flex items-center">
             <div className="text-sm flex items-center">
               {(loading || saving) && (
                 <div className="flex items-center mr-4">
@@ -115,6 +114,7 @@ export default function ConfigPage() {
                 </div>
               )}
             </div>
+            <VersionDisplay />
           </div>
         </div>
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds the API server version to the "Configuration" page in the dashboard. 


<!-- Describe the tests ran -->
This was tested by reloading the dashboard and verifying that the correct version showed up. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
