### PR TITLE
[Dashboard] Fix infra page back and top-level buttons

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -600,53 +600,27 @@ export function GPUs() {
 
   // Check URL on component mount to set initial context
   useEffect(() => {
-    if (router.query.context) {
+    if (router.isReady && router.query.context) {
       const contextParam = Array.isArray(router.query.context)
         ? router.query.context[0]
         : router.query.context;
       setSelectedContext(decodeURIComponent(contextParam));
     }
-  }, [router.isReady, router.query]);
+  }, [router.isReady, router.query.context]);
 
   // Handler for clicking on a context
   const handleContextClick = (context) => {
     setSelectedContext(context);
-    // Use replace instead of push and set as to the same URL to ensure it's just a URL change
-    router.replace(
-      {
-        pathname: '/infra',
-        query: context ? { context } : undefined,
-      },
-      context ? `/infra/${encodeURIComponent(context)}` : '/infra',
-      { shallow: true }
-    );
+    // Use push instead of replace for proper browser history
+    router.push(`/infra/${encodeURIComponent(context)}`);
   };
 
   // Handler to go back to main view
   const handleBackClick = () => {
     setSelectedContext(null);
-    // Use replace and set as to the same URL
-    router.replace({ pathname: '/infra' }, '/infra', { shallow: true });
+    // Use push instead of replace for proper browser history
+    router.push('/infra');
   };
-
-  // Handle browser back/forward navigation
-  useEffect(() => {
-    const handleRouteChange = (url) => {
-      const contextMatch = url.match(/\/infra\/([^\/]+)$/);
-      if (contextMatch) {
-        const contextParam = decodeURIComponent(contextMatch[1]);
-        setSelectedContext(contextParam);
-      } else if (url === '/infra') {
-        setSelectedContext(null);
-      }
-    };
-
-    router.events.on('routeChangeComplete', handleRouteChange);
-
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
-    };
-  }, [router.events]);
 
   // Render context details
   const renderContextDetails = (contextName) => {
@@ -826,12 +800,6 @@ export function GPUs() {
           <Link
             href="/infra"
             className={`text-sky-blue hover:underline ${selectedContext ? '' : 'cursor-default'}`}
-            onClick={(e) => {
-              if (selectedContext) {
-                e.preventDefault();
-                handleBackClick();
-              }
-            }}
           >
             Infrastructure
           </Link>
@@ -839,25 +807,19 @@ export function GPUs() {
             <>
               <span className="mx-2 text-gray-500">›</span>
               {selectedContext.startsWith('ssh-') ? (
-                <span
+                <Link
+                  href="/infra"
                   className="text-sky-blue hover:underline cursor-pointer"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleBackClick();
-                  }}
                 >
                   SSH Node Pool
-                </span>
+                </Link>
               ) : (
-                <span
+                <Link
+                  href="/infra"
                   className="text-sky-blue hover:underline cursor-pointer"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleBackClick();
-                  }}
                 >
                   Kubernetes
-                </span>
+                </Link>
               )}
               <span className="mx-2 text-gray-500">›</span>
               <span className="text-sky-blue">

--- a/sky/dashboard/src/pages/infra/[context].js
+++ b/sky/dashboard/src/pages/infra/[context].js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { GPUs } from '@/components/infra';
+import Head from 'next/head';
+
+export default function InfraContextPage() {
+  return (
+    <>
+      <Head>
+        <title>Infra | SkyPilot Dashboard</title>
+      </Head>
+      <GPUs />
+    </>
+  );
+}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses a bug in the infra page which occurs when a user clicks into a cluster from the infra page and then tries to press the back button in their browser or click on the top-level infra page. While the url would change, the page would not update to the main infra page and would remain in the cluster-specific page. This PR resolves this issue.


<!-- Describe the tests ran -->
This PR was tested by clicking into a cluster from the infra page and pressing the back button and then clicking back into the cluster and clicking on the infra top-level button. Both of which now work as expected.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
