### PR TITLE
also pin upper version of pyopenssl

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -58,9 +58,6 @@ install_requires = [
     'setproctitle',
     'sqlalchemy',
     'psycopg2-binary',
-    # see https://github.com/conda/conda/issues/13619
-    # see https://github.com/googleapis/google-api-python-client/issues/2554
-    'pyopenssl >= 23.2.0, <24.3.0',
 ]
 
 local_ray = [
@@ -121,7 +118,13 @@ extras_require: Dict[str, List[str]] = {
     # We need google-api-python-client>=2.69.0 to enable 'discardLocalSsd'
     # parameter for stopping instances. Reference:
     # https://github.com/googleapis/google-api-python-client/commit/f6e9d3869ed605b06f7cbf2e8cf2db25108506e6
-    'gcp': ['google-api-python-client>=2.69.0', 'google-cloud-storage'],
+    'gcp': [
+        'google-api-python-client>=2.69.0',
+        'google-cloud-storage',
+        # see https://github.com/conda/conda/issues/13619
+        # see https://github.com/googleapis/google-api-python-client/issues/2554
+        'pyopenssl >= 23.2.0, <24.3.0',
+    ],
     'ibm': [
         'ibm-cloud-sdk-core',
         'ibm-vpc',

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -59,7 +59,8 @@ install_requires = [
     'sqlalchemy',
     'psycopg2-binary',
     # see https://github.com/conda/conda/issues/13619
-    'pyopenssl >= 23.2.0',
+    # see https://github.com/googleapis/google-api-python-client/issues/2554
+    'pyopenssl >= 23.2.0, <24.3.0',
 ]
 
 local_ray = [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
smoke test failure https://buildkite.com/skypilot-1/smoke-tests/builds/1126#01971865-48aa-402b-af4d-76b6dcec62d3
due to 
```
module 'OpenSSL.crypto' has no attribute 'sign'
```

caused by https://github.com/googleapis/google-api-python-client/issues/2554

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
