### PR TITLE
Add sshKeys helm value

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -98,7 +98,7 @@ spec:
           # Create a Nebius profile for the nebius CLI to use as default
           nebius profile create --profile sky --endpoint api.nebius.cloud --service-account-file /root/.nebius/credentials.json || echo "Unable to create Nebius profile."
           {{- end }}
-          {{- if .Values.apiService.sshKeySecret }}
+          {{- if or .Values.apiService.sshKeySecret .Values.apiService.sshKeys }}
           mkdir -p /root/.ssh
           echo "Linking ssh keys to /root/.ssh"
           for file in /var/skypilot/ssh_keys/*; do
@@ -147,7 +147,7 @@ spec:
         - name: skypilot-ssh-node-pools
           mountPath: /var/skypilot/ssh_node_pool
         {{- end }}
-        {{- if .Values.apiService.sshKeySecret }}
+        {{- if or .Values.apiService.sshKeySecret .Values.apiService.sshKeys }}
         - name: skypilot-ssh-identity
           mountPath: /var/skypilot/ssh_keys
         {{- end }}
@@ -345,9 +345,9 @@ spec:
         secret:
           secretName: {{ .Release.Name }}-ssh-node-pools
       {{- end }}
-      {{- if .Values.apiService.sshKeySecret }}
+      {{- if or .Values.apiService.sshKeySecret .Values.apiService.sshKeys }}
       - name: skypilot-ssh-identity
         secret:
-          secretName: {{ .Values.apiService.sshKeySecret }}
-          defaultMode: 0600 
+          secretName: {{ default (printf "%s-ssh-keys" .Release.Name) .Values.apiService.sshKeySecret }}
+          defaultMode: 0600
       {{- end }}

--- a/charts/skypilot/templates/api-secrets.yaml
+++ b/charts/skypilot/templates/api-secrets.yaml
@@ -7,5 +7,96 @@ metadata:
   namespace: {{ .Release.Namespace }}
 stringData:
   ssh_node_pools.yaml: |
-{{ .Values.apiService.sshNodePools | indent 4 }} 
+{{ .Values.apiService.sshNodePools | indent 4 }}
+{{- end }}
+
+{{- /* Create SSH key secret if keys are provided */ -}}
+{{- if .Values.apiService.sshKeys }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-ssh-keys" .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+{{- range $name, $content := .Values.apiService.sshKeys }}
+  {{ $name }}: |
+{{ $content | indent 4 }}
+{{- end }}
+{{- end }}
+
+{{- /* Create kubeconfig secret if provided */ -}}
+{{- if and .Values.kubernetesCredentials.useKubeconfig .Values.kubernetesCredentials.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.kubernetesCredentials.kubeconfigSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  kubeconfig: |
+{{ .Values.kubernetesCredentials.kubeconfig | indent 4 }}
+{{- end }}
+
+{{- /* Create AWS credentials secret if access keys are provided */ -}}
+{{- if and .Values.awsCredentials.enabled .Values.awsCredentials.accessKeyId .Values.awsCredentials.secretAccessKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.awsCredentials.awsSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{ .Values.awsCredentials.accessKeyIdKeyName }}: {{ .Values.awsCredentials.accessKeyId | quote }}
+  {{ .Values.awsCredentials.secretAccessKeyKeyName }}: {{ .Values.awsCredentials.secretAccessKey | quote }}
+{{- end }}
+
+{{- /* Create GCP credentials secret if provided */ -}}
+{{- if and .Values.gcpCredentials.enabled .Values.gcpCredentials.credentialsJson }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.gcpCredentials.gcpSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  gcp-cred.json: |
+{{ .Values.gcpCredentials.credentialsJson | indent 4 }}
+{{- end }}
+
+{{- /* Create RunPod credentials secret if API key is provided */ -}}
+{{- if and .Values.runpodCredentials.enabled .Values.runpodCredentials.apiKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.runpodCredentials.runpodSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  api_key: {{ .Values.runpodCredentials.apiKey | quote }}
+{{- end }}
+
+{{- /* Create Lambda credentials secret if API key is provided */ -}}
+{{- if and .Values.lambdaCredentials.enabled .Values.lambdaCredentials.apiKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.lambdaCredentials.lambdaSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  api_key: {{ .Values.lambdaCredentials.apiKey | quote }}
+{{- end }}
+
+{{- /* Create Nebius credentials secret if JSON credentials provided */ -}}
+{{- if and .Values.nebiusCredentials.enabled .Values.nebiusCredentials.credentialsJson }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.nebiusCredentials.nebiusSecretName }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  credentials.json: |
+{{ .Values.nebiusCredentials.credentialsJson | indent 4 }}
 {{- end }}

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -47,8 +47,18 @@ apiService:
   #  my-box:
   #    hosts:
   #      - hostname_in_ssh_config
-  # Optional secret that contains SSH keys for the API server to use, all the entries in the secret will be mounted to ~/.ssh/ directory in the API server.
-  sshKeySecret: null
+# Optional secret that contains SSH keys for the API server to use, all the entries
+# in the secret will be mounted to ~/.ssh/ directory in the API server.
+sshKeySecret: null
+# Map of SSH key file names to their contents. If set, the chart will create a
+# secret automatically and mount the keys to ~/.ssh/.
+sshKeys: {}
+# sshKeys:
+#   id_rsa: |-
+#     -----BEGIN RSA PRIVATE KEY-----
+#     ...
+#   id_rsa.pub: |
+#     ssh-rsa AAAA...
   
 
   # Skip resource check for the API server, not recommended for production deployment
@@ -236,6 +246,9 @@ kubernetesCredentials:
   useKubeconfig: false
   # Name of the secret containing the kubeconfig file. Only used if useKubeconfig is true.
   kubeconfigSecretName: kube-credentials
+  # Content of the kubeconfig file. If set, the chart will create a secret using
+  # this value and reference it via `kubeconfigSecretName`.
+  kubeconfig: null
   # Namespace to use for in-cluster resources
   inclusterNamespace: null
 
@@ -247,6 +260,10 @@ awsCredentials:
   accessKeyIdKeyName: aws_access_key_id
   # Key name used to set AWS_SECRET_ACCESS_KEY.
   secretAccessKeyKeyName: aws_secret_access_key
+  # Optional AWS credentials. When provided, a secret will be automatically
+  # created with these values and referenced by `awsSecretName`.
+  accessKeyId: null
+  secretAccessKey: null
 
 gcpCredentials:
   enabled: false
@@ -254,18 +271,27 @@ gcpCredentials:
   projectId: null
   # Name of the secret containing the gcp credentials. Only used if enabled is true.
   gcpSecretName: gcp-credentials
+  # Content of the service account JSON key. When set, a secret will be created
+  # with this content and referenced by `gcpSecretName`.
+  credentialsJson: null
 
 # Populate RunPod credentials from the secret with key `api_key`
 runpodCredentials:
   enabled: false
   # Name of the secret containing the RunPod credentials. Only used if enabled is true.
   runpodSecretName: runpod-credentials
+  # API key for RunPod. If provided, the chart will create a secret with key
+  # `api_key` and reference it via `runpodSecretName`.
+  apiKey: null
 
 # Populate Lambda credentials from the secret with key `api_key`
 lambdaCredentials:
   enabled: false
   # Name of the secret containing the Lambda credentials. Only used if enabled is true.
   lambdaSecretName: lambda-credentials
+  # API key for Lambda. If provided, the chart will create a secret with key
+  # `api_key` and reference it via `lambdaSecretName`.
+  apiKey: null
 
 # Populate Nebius credentials from the secret with nebius credentials.
 nebiusCredentials:
@@ -273,6 +299,9 @@ nebiusCredentials:
   tenantId: null
   # Name of the secret containing the Nebius credentials. Only used if enabled is true.
   nebiusSecretName: nebius-credentials
+  # Content of the Nebius credentials JSON. If provided, a secret will be created
+  # and referenced by `nebiusSecretName`.
+  credentialsJson: null
 
 # Set securityContext for the api pod
 podSecurityContext: {}

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -187,25 +187,17 @@ Following tabs describe how to configure credentials for different clouds on the
 
             The default permissions granted to the API server works out of box. For further hardening, you can refer to :ref:`Setting minimum permissions in helm deployment <minimum-permissions-in-helm>` to understand the permissions and how to customize them.
 
-        To authenticate to other clusters, first create a Kubernetes secret with the kubeconfig file with :ref:`necessary permissions <cloud-permissions-kubernetes>`:
+        To authenticate to other clusters, pass the kubeconfig file directly during installation:
 
         .. code-block:: bash
 
-            kubectl create secret generic kube-credentials \
-              --namespace $NAMESPACE \
-              --from-file=config=$HOME/.kube/config
-
-
-        Once the secret is created, set ``kubernetesCredentials.useKubeconfig=true`` and ``kubernetesCredentials.kubeconfigSecretName`` in the Helm chart values to use the kubeconfig for authentication:
-
-        .. code-block:: bash
-
-            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
               --reuse-values \
               --set kubernetesCredentials.useKubeconfig=true \
-              --set kubernetesCredentials.kubeconfigSecretName=kube-credentials
+              --set-file kubernetesCredentials.kubeconfig=$HOME/.kube/config
+
+        The chart will create a secret named ``kube-credentials`` automatically.
 
         .. tip::
 
@@ -237,20 +229,7 @@ Following tabs describe how to configure credentials for different clouds on the
     .. tab-item:: AWS
         :sync: aws-creds-tab
 
-        Make sure you have the access key id and secret access key.
-
-        Create a Kubernetes secret with your AWS credentials:
-
-        .. code-block:: bash
-
-            kubectl create secret generic aws-credentials \
-              --namespace $NAMESPACE \
-              --from-literal=aws_access_key_id=YOUR_ACCESS_KEY_ID \
-              --from-literal=aws_secret_access_key=YOUR_SECRET_ACCESS_KEY
-
-        Replace ``YOUR_ACCESS_KEY_ID`` and ``YOUR_SECRET_ACCESS_KEY`` with your actual AWS credentials.
-
-        Enable AWS credentials by setting ``awsCredentials.enabled=true`` and ``awsCredentials.awsSecretName=aws-credentials`` in the Helm values file.
+        Provide your AWS credentials directly when installing the chart:
 
         .. code-block:: bash
 
@@ -258,7 +237,11 @@ Following tabs describe how to configure credentials for different clouds on the
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
                 --namespace $NAMESPACE \
                 --reuse-values \
-                --set awsCredentials.enabled=true
+                --set awsCredentials.enabled=true \
+                --set awsCredentials.accessKeyId=YOUR_ACCESS_KEY_ID \
+                --set awsCredentials.secretAccessKey=YOUR_SECRET_ACCESS_KEY
+
+        The chart will create a secret named ``aws-credentials`` automatically.
 
         .. dropdown:: Use existing AWS credentials
 
@@ -280,15 +263,7 @@ Following tabs describe how to configure credentials for different clouds on the
 
         We use service accounts to authenticate with GCP. Refer to :ref:`GCP service account <gcp-service-account>` guide on how to set up a service account.
 
-        Once you have the JSON key for your service account, create a Kubernetes secret to store it:
-
-        .. code-block:: bash
-
-            kubectl create secret generic gcp-credentials \
-              --namespace $NAMESPACE \
-              --from-file=gcp-cred.json=YOUR_SERVICE_ACCOUNT_JSON_KEY.json
-
-        When installing or upgrading the Helm chart, enable GCP credentials by setting ``gcpCredentials.enabled=true`` and ``gcpCredentials.projectId`` to your project ID:
+        Provide the service account JSON key when installing the chart:
 
         .. code-block:: bash
 
@@ -297,7 +272,10 @@ Following tabs describe how to configure credentials for different clouds on the
               --namespace $NAMESPACE \
               --reuse-values \
               --set gcpCredentials.enabled=true \
-              --set gcpCredentials.projectId=YOUR_PROJECT_ID
+              --set gcpCredentials.projectId=YOUR_PROJECT_ID \
+              --set-file gcpCredentials.credentialsJson=YOUR_SERVICE_ACCOUNT_JSON_KEY.json
+
+        The chart will create a secret named ``gcp-credentials`` automatically.
 
         .. dropdown:: Use existing GCP credentials
 
@@ -315,17 +293,17 @@ Following tabs describe how to configure credentials for different clouds on the
     .. tab-item:: RunPod
         :sync: runpod-creds-tab
 
-        SkyPilot API server use **API key** to authenticate with RunPod. To configure RunPod access, go to the `Settings <https://www.runpod.io/console/user/settings>`_ page on your RunPod console and generate an **API key**.
-
-        Once the key is generated, create a Kubernetes secret to store it:
+        SkyPilot API server uses an **API key** to authenticate with RunPod. Generate an API key from the `Settings <https://www.runpod.io/console/user/settings>`_ page and pass it to the chart directly:
 
         .. code-block:: bash
 
-            kubectl create secret generic runpod-credentials \
+            helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
-              --from-literal api_key=YOUR_API_KEY
+              --reuse-values \
+              --set runpodCredentials.enabled=true \
+              --set runpodCredentials.apiKey=YOUR_API_KEY
 
-        When installing or upgrading the Helm chart, enable RunPod credentials by setting ``runpodCredentials.enabled=true``
+        The chart will create a secret named ``runpod-credentials`` automatically.
 
         .. dropdown:: Use existing RunPod credentials
 
@@ -343,25 +321,17 @@ Following tabs describe how to configure credentials for different clouds on the
     .. tab-item:: Lambda
         :sync: lambda-creds-tab
 
-        SkyPilot API server uses an **API key** to authenticate with Lambda. To configure Lambda access, go to the `API Keys <https://cloud.lambda.ai/api-keys/cloud-api>`_ page on your Lambda Cloud console and generate an **API key**.
-
-        Once the key is generated, create a Kubernetes secret to store it:
+        SkyPilot API server uses an **API key** to authenticate with Lambda. Generate an API key from the `API Keys <https://cloud.lambda.ai/api-keys/cloud-api>`_ page and pass it directly to the chart:
 
         .. code-block:: bash
 
-            kubectl create secret generic lambda-credentials \
-              --namespace $NAMESPACE \
-              --from-literal api_key=YOUR_API_KEY
-
-        When installing or upgrading the Helm chart, enable Lambda credentials by setting ``lambdaCredentials.enabled=true``
-
-        .. code-block:: bash
-
-            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
               --reuse-values \
-              --set lambdaCredentials.enabled=true
+              --set lambdaCredentials.enabled=true \
+              --set lambdaCredentials.apiKey=YOUR_API_KEY
+
+        The chart will create a secret named ``lambda-credentials`` automatically.
 
         .. dropdown:: Use existing Lambda credentials
 
@@ -381,24 +351,18 @@ Following tabs describe how to configure credentials for different clouds on the
 
         We use service accounts to authenticate with Nebius. Refer to :ref:`Nebius service account <nebius-service-account>` guide on how to set up a service account.
 
-        Once you have the JSON credentials for your service account, create a Kubernetes secret to store it:
+        Provide the service account credentials JSON when installing the chart:
 
         .. code-block:: bash
 
-            kubectl create secret generic nebius-credentials \
-              --namespace $NAMESPACE \
-              --from-file=credentials.json=$HOME/.nebius/credentials.json
-
-        When installing or upgrading the Helm chart, enable Nebius credentials by setting ``nebiusCredentials.enabled=true`` and ``nebiusCredentials.tenantId`` to your tenant ID:
-
-        .. code-block:: bash
-
-            # --reuse-values keeps the Helm chart values set in the previous step
             helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
               --reuse-values \
               --set nebiusCredentials.enabled=true \
-              --set nebiusCredentials.tenantId=YOUR_TENANT_ID
+              --set nebiusCredentials.tenantId=YOUR_TENANT_ID \
+              --set-file nebiusCredentials.credentialsJson=$HOME/.nebius/credentials.json
+
+        The chart will create a secret named ``nebius-credentials`` automatically.
 
         .. dropdown:: Use existing Nebius credentials
 
@@ -428,24 +392,29 @@ Following tabs describe how to configure credentials for different clouds on the
               --reuse-values \
               --set-file apiService.sshNodePools=/your/path/to/ssh_node_pools.yaml
 
-        If your ``ssh_node_pools.yaml`` requires SSH keys, create a secret that contains the keys and set the :ref:`apiService.sshKeySecret <helm-values-apiService-sshKeySecret>` to the secret name:
+        If your ``ssh_node_pools.yaml`` requires SSH keys, pass them directly to the chart:
 
         .. code-block:: bash
 
-            SECRET_NAME=apiserver-ssh-key
-
-            # Create a secret that contains the SSH keys
-            # The NAMESPACE should be consistent with the API server deployment
-            kubectl create secret generic $SECRET_NAME \
-              --namespace $NAMESPACE \
-              --from-file=id_rsa=/path/to/id_rsa \
-              --from-file=other_id_rsa=/path/to/other_id_rsa
-
-            # Keys will be mounted to ~/.ssh/ (e.g., ~/.ssh/id_rsa, ~/.ssh/other_id_rsa)
             helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
               --namespace $NAMESPACE \
               --reuse-values \
-              --set apiService.sshKeySecret=$SECRET_NAME
+              --set-file apiService.sshKeys.id_rsa=/path/to/id_rsa \
+              --set-file apiService.sshKeys.other_id_rsa=/path/to/other_id_rsa
+
+        The chart will create a secret named ``$RELEASE_NAME-ssh-keys`` automatically.
+
+        .. dropdown:: Use existing SSH key secret
+
+            You can also set the following value to use a secret that already contains your SSH keys:
+
+            .. code-block:: bash
+
+                # TODO: replace with your secret name
+                helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
+                    --namespace $NAMESPACE \
+                    --reuse-values \
+                    --set apiService.sshKeySecret=your_secret_name
 
         After the API server is deployed, use the ``sky ssh up`` command to set up the SSH Node Pools. Refer to :ref:`existing-machines` for more details.
 

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -48,6 +48,7 @@ Below is the available helm value keys and the default value of each key:
     :ref:`config <helm-values-apiService-config>`: null
     :ref:`sshNodePools <helm-values-apiService-sshNodePools>`: null
     :ref:`sshKeySecret <helm-values-apiService-sshKeySecret>`: null
+    :ref:`sshKeys <helm-values-apiService-sshKeys>`: {}
     :ref:`skipResourceCheck <helm-values-apiService-skipResourceCheck>`: false
     :ref:`resources <helm-values-apiService-resources>`:
       requests:
@@ -142,6 +143,7 @@ Below is the available helm value keys and the default value of each key:
     :ref:`useApiServerCluster <helm-values-kubernetesCredentials-useApiServerCluster>`: true
     :ref:`useKubeconfig <helm-values-kubernetesCredentials-useKubeconfig>`: false
     :ref:`kubeconfigSecretName <helm-values-kubernetesCredentials-kubeconfigSecretName>`: kube-credentials
+    :ref:`kubeconfig <helm-values-kubernetesCredentials-kubeconfig>`: null
     :ref:`inclusterNamespace <helm-values-kubernetesCredentials-inclusterNamespace>`: null
 
   :ref:`awsCredentials <helm-values-awsCredentials>`:
@@ -149,11 +151,14 @@ Below is the available helm value keys and the default value of each key:
     :ref:`awsSecretName <helm-values-awsCredentials-awsSecretName>`: aws-credentials
     :ref:`accessKeyIdKeyName <helm-values-awsCredentials-accessKeyIdKeyName>`: aws_access_key_id
     :ref:`secretAccessKeyKeyName <helm-values-awsCredentials-secretAccessKeyKeyName>`: aws_secret_access_key
+    :ref:`accessKeyId <helm-values-awsCredentials-accessKeyId>`: null
+    :ref:`secretAccessKey <helm-values-awsCredentials-secretAccessKey>`: null
 
   :ref:`gcpCredentials <helm-values-gcpCredentials>`:
     :ref:`enabled <helm-values-gcpCredentials-enabled>`: false
     :ref:`projectId <helm-values-gcpCredentials-projectId>`: null
     :ref:`gcpSecretName <helm-values-gcpCredentials-gcpSecretName>`: gcp-credentials
+    :ref:`credentialsJson <helm-values-gcpCredentials-credentialsJson>`: null
 
   :ref:`podSecurityContext <helm-values-podSecurityContext>`: {}
 
@@ -281,6 +286,26 @@ The content of the secret should be like:
     name: my-ssh-key-secret
   data:
     id_rsa: <secret-content>
+
+.. _helm-values-apiService-sshKeys:
+
+``apiService.sshKeys``
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Map of SSH key file names to their contents. When set, the chart will create a secret
+named ``<release-name>-ssh-keys`` and mount the keys to ``~/.ssh/`` in the API server.
+
+Default: ``{}``
+
+.. code-block:: yaml
+
+  apiService:
+    sshKeys:
+      id_rsa: |-
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+      id_rsa.pub: |
+        ssh-rsa AAAA...
 
 
 .. _helm-values-apiService-skipResourceCheck:
@@ -899,6 +924,22 @@ Default: ``kube-credentials``
   kubernetesCredentials:
     kubeconfigSecretName: kube-credentials
 
+.. _helm-values-kubernetesCredentials-kubeconfig:
+
+``kubernetesCredentials.kubeconfig``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Content of the kubeconfig file. If set, a secret will be created automatically and referenced by ``kubeconfigSecretName``.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  kubernetesCredentials:
+    kubeconfig: |
+      apiVersion: v1
+      clusters: []
+
 .. _helm-values-kubernetesCredentials-inclusterNamespace:
 
 ``kubernetesCredentials.inclusterNamespace``
@@ -974,6 +1015,34 @@ Default: ``aws_secret_access_key``
   awsCredentials:
     secretAccessKeyKeyName: aws_secret_access_key
 
+.. _helm-values-awsCredentials-accessKeyId:
+
+``awsCredentials.accessKeyId``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+AWS access key ID. If provided, the chart will create a secret automatically.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  awsCredentials:
+    accessKeyId: YOUR_ACCESS_KEY_ID
+
+.. _helm-values-awsCredentials-secretAccessKey:
+
+``awsCredentials.secretAccessKey``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+AWS secret access key. If provided, the chart will create a secret automatically.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  awsCredentials:
+    secretAccessKey: YOUR_SECRET_ACCESS_KEY
+
 .. _helm-values-gcpCredentials:
 
 ``gcpCredentials``
@@ -1020,6 +1089,23 @@ Default: ``gcp-credentials``
 
   gcpCredentials:
     gcpSecretName: gcp-credentials
+
+.. _helm-values-gcpCredentials-credentialsJson:
+
+``gcpCredentials.credentialsJson``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Content of the service account JSON key. If provided, the chart will create a secret automatically and reference it via ``gcpSecretName``.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  gcpCredentials:
+    credentialsJson: |
+      {
+        "type": "service_account"
+      }
 
 .. _helm-values-podSecurityContext:
 


### PR DESCRIPTION
## Summary
- make skypilot helm chart accept SSH keys directly via `apiService.sshKeys`
- create secret and mount automatically when `sshKeys` are provided
- update admin docs for one-step SSH node pool setup
- document new helm value

## Testing
- `bash format.sh`
- `pytest -k nothing -q` *(fails: KeyboardInterrupt due to network restrictions)*