### PR TITLE
[Test] fix test_config.py test_get_override_skypilot_config_from_client

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,7 @@ import sky.exceptions
 from sky.server.requests import payloads
 from sky.sky_logging import INFO
 from sky.skylet import constants
+from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import kubernetes_enums
@@ -524,6 +525,7 @@ def test_config_with_invalid_override(monkeypatch, tmp_path,
 @mock.patch('sky.skypilot_config.loaded_config_path',
             return_value='/path/to/config.yaml')
 @mock.patch('sky.sky_logging.logging_enabled', return_value=True)
+@annotations.client_api
 def test_get_override_skypilot_config_from_client(mock_to_dict, mock_logger,
                                                   mock_logging_enabled):
     with mock.patch('sky.skypilot_config.logger') as mock_logger:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes #5800 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
