### PR TITLE
Fix `check_file_age` on docs build

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -3,8 +3,10 @@
 # Function to check if file exists and is less than 24 hours old
 check_file_age() {
     if [ -f "$1" ] && [ $(( $(date +%s) - $(stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null) )) -lt 86400 ]; then
+        echo "File $1 exists and is recent"
         return 0  # File exists and is recent
     fi
+    echo "File $1 does not exist or is old"
     return 1  # File doesn't exist or is old
 }
 

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -21,6 +21,7 @@ check_file_age() {
     fi
 
     if [ $(( current_time - mtime )) -lt 86400 ]; then
+        echo "File $1 is recent (less than 24 hours old)"
         return 0  # File exists and is recent
     fi
     return 1  # File is old

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -2,12 +2,28 @@
 
 # Function to check if file exists and is less than 24 hours old
 check_file_age() {
-    if [ -f "$1" ] && [ $(( $(date +%s) - $(stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null) )) -lt 86400 ]; then
-        echo "File $1 exists and is recent"
+    if [ ! -f "$1" ]; then
+        echo "File $1 does not exist" >&2
+        return 1  # File doesn't exist
+    fi
+
+    current_time=$(date +%s)
+
+    # Try MacOS stat format first
+    mtime=$(stat -f %m "$1" 2>/dev/null)
+    if [ $? -ne 0 ]; then
+        # If MacOS format fails, try Linux format
+        mtime=$(stat -c %Y "$1" 2>/dev/null)
+        if [ $? -ne 0 ]; then
+            echo "Failed to get modification time for $1" >&2
+            return 1  # Could not get modification time
+        fi
+    fi
+
+    if [ $(( current_time - mtime )) -lt 86400 ]; then
         return 0  # File exists and is recent
     fi
-    echo "File $1 does not exist or is old"
-    return 1  # File doesn't exist or is old
+    return 1  # File is old
 }
 
 # Only run sky show-gpus commands if output files don't exist or are old


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This works on Mac, but doesn't work on Linux. 

The key insight is that when the first stat fail, `2>/dev/null` only redirects stderr, but the filesystem information was being output to stdout, which then prevented the `||` from working as intended. The command `failed` but still produced output that was used instead of running the second command.

```bash
stat -f %m logs/aws_cleanup_docker.log
stat: cannot read file system information for '%m': No such file or directory
  File: "logs/aws_cleanup_docker.log"
    ID: 26a8068dfa30fea6 Namelen: 255     Type: ext2/ext3
Block size: 4096       Fundamental block size: 4096
Blocks: Total: 64991724   Free: 57549761   Available: 57545665
Inodes: Total: 33030144   Free: 31932102
```


[Current build](https://github.com/skypilot-org/skypilot/actions/runs/15321174299/job/43105082379?pr=5806):

![image](https://github.com/user-attachments/assets/c0f07068-3772-4a10-9f49-88e983a5536c)

[Previous build](https://github.com/skypilot-org/skypilot/actions/runs/15321031373/job/43104638063?pr=5806):

![image](https://github.com/user-attachments/assets/2581ba5a-5bc6-43d5-bfa8-bf0c95872f1a)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
