### PR TITLE
[Managed Jobs] speed up log loading time in dashboard and implement managed jobs log tailing

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3950,11 +3950,12 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                               job_id: Optional[int] = None,
                               job_name: Optional[str] = None,
                               controller: bool = False,
-                              follow: bool = True) -> int:
+                              follow: bool = True,
+                              tail: Optional[int] = None) -> int:
         # if job_name is not None, job_id should be None
         assert job_name is None or job_id is None, (job_name, job_id)
         code = managed_jobs.ManagedJobCodeGen.stream_logs(
-            job_name, job_id, follow, controller)
+            job_name, job_id, follow, controller, tail)
 
         # With the stdin=subprocess.DEVNULL, the ctrl-c will not directly
         # kill the process, so we need to handle it manually here.

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -336,7 +336,7 @@ export function LogFilter({ logs, controller = false }) {
       )}
       <div
         className="logs-container"
-        dangerouslySetInnerHTML={{ __html: formatLogs(filteredLogs) }}
+        dangerouslySetInnerHTML={{ __html: filteredLogs }}
       />
     </div>
   );

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -194,7 +194,7 @@ export async function streamManagedJobLogs({
   signal,
   onNewLog,
 }) {
-  // Use intelligent timeout based on activity, not arbitrary time limit
+  // Measure timeout from last received data, not from start of request.
   const inactivityTimeout = 30000; // 30 seconds of no data activity
   let lastActivity = Date.now();
   let timeoutId;

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -7,6 +7,9 @@ import {
   NOT_SUPPORTED_ERROR,
 } from '@/data/connectors/constants';
 
+// Configuration
+const DEFAULT_TAIL_LINES = 1000;
+
 export async function getManagedJobs({ allUsers = true } = {}) {
   try {
     const response = await fetch(`${ENDPOINT}/jobs/queue`, {
@@ -191,28 +194,50 @@ export async function streamManagedJobLogs({
   signal,
   onNewLog,
 }) {
-  const timeout = 10000; // Default timeout of 10 seconds
+  // Use intelligent timeout based on activity, not arbitrary time limit
+  const inactivityTimeout = 30000; // 30 seconds of no data activity
+  let lastActivity = Date.now();
+  let timeoutId;
 
-  // Create a timeout promise that resolves after the specified time
-  const timeoutPromise = new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ timeout: true });
-    }, timeout);
-  });
+  // Create an activity-based timeout promise
+  const createTimeoutPromise = () => {
+    return new Promise((resolve) => {
+      const checkActivity = () => {
+        const timeSinceLastActivity = Date.now() - lastActivity;
+
+        if (timeSinceLastActivity >= inactivityTimeout) {
+          resolve({ timeout: true });
+        } else {
+          // Check again after remaining time
+          timeoutId = setTimeout(
+            checkActivity,
+            inactivityTimeout - timeSinceLastActivity
+          );
+        }
+      };
+
+      timeoutId = setTimeout(checkActivity, inactivityTimeout);
+    });
+  };
+
+  const timeoutPromise = createTimeoutPromise();
 
   // Create the fetch promise
   const fetchPromise = (async () => {
     try {
+      const requestBody = {
+        controller: controller,
+        follow: false,
+        job_id: jobId,
+        tail: DEFAULT_TAIL_LINES,
+      };
+
       const response = await fetch(`${ENDPOINT}/jobs/logs`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({
-          controller: controller,
-          follow: false,
-          job_id: jobId,
-        }),
+        body: JSON.stringify(requestBody),
         // Only use the signal if it's provided
         ...(signal ? { signal } : {}),
       });
@@ -224,14 +249,27 @@ export async function streamManagedJobLogs({
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
+
+          // Update activity timestamp when we receive data
+          lastActivity = Date.now();
+
           const chunk = new TextDecoder().decode(value);
           onNewLog(chunk);
         }
       } finally {
         reader.cancel();
+        // Clear the timeout when streaming completes successfully
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
       }
       return { timeout: false };
     } catch (error) {
+      // Clear timeout on any error
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+
       // If this was an abort, just return silently
       if (error.name === 'AbortError') {
         return { timeout: false };
@@ -240,13 +278,19 @@ export async function streamManagedJobLogs({
     }
   })();
 
-  // Race the fetch against the timeout
+  // Race the fetch against the activity-based timeout
   const result = await Promise.race([fetchPromise, timeoutPromise]);
-  // If we timed out, just return silently without throwing an error
+
+  // Clear any remaining timeout
+  if (timeoutId) {
+    clearTimeout(timeoutId);
+  }
+
+  // If we timed out due to inactivity, show a more informative message
   if (result.timeout) {
     showToast(
-      `Log request for job ${jobId} timed out after ${timeout}ms`,
-      'error'
+      `Log request for job ${jobId} timed out after ${inactivityTimeout / 1000}s of inactivity`,
+      'warning'
     );
     return;
   }

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { CircularProgress } from '@mui/material';
 import { useRouter } from 'next/router';
 import { Layout } from '@/components/elements/layout';
@@ -27,8 +27,8 @@ function JobDetails() {
   const [scrollExecuted, setScrollExecuted] = useState(false);
   const [pageLoaded, setPageLoaded] = useState(false);
   const [domReady, setDomReady] = useState(false);
-  const [logsRefreshKey, setLogsRefreshKey] = useState(0);
-  const [controllerLogsRefreshKey, setControllerLogsRefreshKey] = useState(0);
+  const [refreshLogsFlag, setRefreshLogsFlag] = useState(0);
+  const [refreshControllerLogsFlag, setRefreshControllerLogsFlag] = useState(0);
   const isMobile = useMobile();
   // Update isInitialLoad when data is first loaded
   React.useEffect(() => {
@@ -109,9 +109,9 @@ function JobDetails() {
       // Trigger job data refresh
       setRefreshTrigger((prev) => prev + 1);
       // Trigger logs refresh
-      setLogsRefreshKey((prev) => prev + 1);
+      setRefreshLogsFlag((prev) => prev + 1);
       // Trigger controller logs refresh
-      setControllerLogsRefreshKey((prev) => prev + 1);
+      setRefreshControllerLogsFlag((prev) => prev + 1);
     } catch (error) {
       console.error('Error refreshing data:', error);
     } finally {
@@ -121,11 +121,11 @@ function JobDetails() {
 
   // Individual refresh handlers for logs
   const handleLogsRefresh = () => {
-    setLogsRefreshKey((prev) => prev + 1);
+    setRefreshLogsFlag((prev) => prev + 1);
   };
 
   const handleControllerLogsRefresh = () => {
-    setControllerLogsRefreshKey((prev) => prev + 1);
+    setRefreshControllerLogsFlag((prev) => prev + 1);
   };
 
   if (!router.isReady) {
@@ -204,6 +204,7 @@ function JobDetails() {
                     setIsLoadingControllerLogs={setIsLoadingControllerLogs}
                     isLoadingLogs={isLoadingLogs}
                     isLoadingControllerLogs={isLoadingControllerLogs}
+                    refreshFlag={0}
                   />
                 </div>
               </Card>
@@ -237,13 +238,13 @@ function JobDetails() {
                 </div>
                 <div className="p-4">
                   <JobDetailsContent
-                    key={logsRefreshKey}
                     jobData={detailJobData}
                     activeTab="logs"
                     setIsLoadingLogs={setIsLoadingLogs}
                     setIsLoadingControllerLogs={setIsLoadingControllerLogs}
                     isLoadingLogs={isLoadingLogs}
                     isLoadingControllerLogs={isLoadingControllerLogs}
+                    refreshFlag={refreshLogsFlag}
                   />
                 </div>
               </Card>
@@ -277,13 +278,13 @@ function JobDetails() {
                 </div>
                 <div className="p-4">
                   <JobDetailsContent
-                    key={controllerLogsRefreshKey}
                     jobData={detailJobData}
                     activeTab="controllerlogs"
                     setIsLoadingLogs={setIsLoadingLogs}
                     setIsLoadingControllerLogs={setIsLoadingControllerLogs}
                     isLoadingLogs={isLoadingLogs}
                     isLoadingControllerLogs={isLoadingControllerLogs}
+                    refreshFlag={refreshControllerLogsFlag}
                   />
                 </div>
               </Card>
@@ -306,11 +307,68 @@ function JobDetailsContent({
   setIsLoadingControllerLogs,
   isLoadingLogs,
   isLoadingControllerLogs,
+  refreshFlag,
 }) {
-  const [logs, setLogs] = useState([]);
-  const [controllerLogs, setControllerLogs] = useState([]);
+  // Change from array to string for better performance
+  const [logs, setLogs] = useState('');
+  const [controllerLogs, setControllerLogs] = useState('');
   const [isYamlExpanded, setIsYamlExpanded] = useState(false);
   const [expandedYamlDocs, setExpandedYamlDocs] = useState({});
+
+  // Add state for tracking incremental refresh
+  const [currentLogLength, setCurrentLogLength] = useState(0);
+  const [currentControllerLogLength, setCurrentControllerLogLength] =
+    useState(0);
+  const [isRefreshingLogs, setIsRefreshingLogs] = useState(false);
+  const [isRefreshingControllerLogs, setIsRefreshingControllerLogs] =
+    useState(false);
+
+  // Add state for streaming indicators
+  const [hasStartedLoading, setHasStartedLoading] = useState(false);
+  const [hasReceivedFirstChunk, setHasReceivedFirstChunk] = useState(false);
+
+  // Add refs to track active requests and prevent duplicates
+  const activeLogsRequest = useRef(null);
+  const activeControllerLogsRequest = useRef(null);
+
+  // Auto-scroll refs
+  const logsContainerRef = useRef(null);
+  const controllerLogsContainerRef = useRef(null);
+
+  // Performance optimization refs
+  const logsBatchRef = useRef('');
+  const controllerLogsBatchRef = useRef('');
+  const updateTimeoutRef = useRef(null);
+  const lastUpdateTimeRef = useRef(0);
+
+  // Configuration for performance
+  const BATCH_UPDATE_INTERVAL = 100; // Batch updates every 100ms
+  const THROTTLE_INTERVAL = 50; // Minimum time between updates
+
+  // Custom hook for auto-scrolling
+  const scrollToBottom = useCallback((logType) => {
+    const containerRef =
+      logType === 'logs' ? logsContainerRef : controllerLogsContainerRef;
+
+    if (!containerRef.current) return;
+
+    // Try multiple ways to find the scrollable container
+    const attempts = [
+      () => containerRef.current.querySelector('.logs-container'),
+      () => containerRef.current.querySelector('[class*="logs-container"]'),
+      () => containerRef.current.querySelector('div[style*="overflow"]'),
+      () => containerRef.current, // Fallback to the ref itself
+    ];
+
+    for (const attempt of attempts) {
+      const container = attempt();
+      if (container && container.scrollHeight > container.clientHeight) {
+        container.scrollTop = container.scrollHeight;
+        console.log(`Auto-scrolled ${logType} to bottom`); // Debug log
+        break;
+      }
+    }
+  }, []);
 
   const PENDING_STATUSES = ['PENDING', 'SUBMITTED', 'STARTING'];
   const PRE_START_STATUSES = ['PENDING', 'SUBMITTED'];
@@ -434,33 +492,66 @@ function JobDetailsContent({
 
   // Clear logs when activeTab changes or when jobData.id changes
   useEffect(() => {
-    setLogs([]);
+    setLogs('');
+    setCurrentLogLength(0);
+    setHasReceivedFirstChunk(false);
   }, [activeTab, jobData.id]);
 
   useEffect(() => {
-    setControllerLogs([]);
+    setControllerLogs('');
+    setCurrentControllerLogLength(0);
+    setHasReceivedFirstChunk(false);
   }, [activeTab, jobData.id]);
 
-  // Define a function to handle both log types
+  // Define a function to handle both log types with simplified logic
   const fetchLogs = useCallback(
-    (logType, jobId, setLogs, setIsLoading) => {
+    (logType, jobId, setLogs, setIsLoading, isRefreshing = false) => {
+      // Check if there's already an active request for this log type
+      const activeRequestRef =
+        logType === 'logs' ? activeLogsRequest : activeControllerLogsRequest;
+
+      if (activeRequestRef.current) {
+        console.log(`Request already active for ${logType}, skipping...`);
+        return () => {};
+      }
+
       let active = true;
       const controller = new AbortController();
 
       // Don't fetch logs if job is in pending state
       if (logType === 'logs' && (isPending || isRecovering)) {
         setIsLoading(false);
+        if (isRefreshing) {
+          setIsRefreshingLogs(false);
+        }
         return () => {};
       }
 
       // Don't fetch controller logs if job is in pre-start state
       if (logType === 'controllerlogs' && isPreStart) {
         setIsLoading(false);
+        if (isRefreshing) {
+          setIsRefreshingControllerLogs(false);
+        }
         return () => {};
       }
 
-      if (activeTab === logType && jobId) {
+      if (jobId) {
+        // Mark request as active
+        activeRequestRef.current = controller;
+
         setIsLoading(true);
+        setHasStartedLoading(true);
+
+        // If refreshing, clear and restart
+        if (isRefreshing) {
+          setLogs('');
+          if (logType === 'logs') {
+            setCurrentLogLength(0);
+          } else {
+            setCurrentControllerLogLength(0);
+          }
+        }
 
         streamManagedJobLogs({
           jobId: jobId,
@@ -469,13 +560,41 @@ function JobDetailsContent({
           onNewLog: (log) => {
             if (active) {
               const strippedLog = formatLogs(log);
-              setLogs((prevLogs) => [...prevLogs, strippedLog]);
+
+              // Set first chunk received flag for immediate display
+              if (!hasReceivedFirstChunk) {
+                setHasReceivedFirstChunk(true);
+              }
+
+              // Use batched updates for performance
+              updateLogsWithBatching(logType, strippedLog);
+
+              // Update length tracking
+              if (logType === 'logs') {
+                setCurrentLogLength((prev) => prev + strippedLog.length);
+              } else {
+                setCurrentControllerLogLength(
+                  (prev) => prev + strippedLog.length
+                );
+              }
             }
           },
         })
           .then(() => {
             if (active) {
               setIsLoading(false);
+              if (isRefreshing) {
+                if (logType === 'logs') {
+                  setIsRefreshingLogs(false);
+                } else {
+                  setIsRefreshingControllerLogs(false);
+                }
+              }
+
+              // Final scroll to bottom when loading completes
+              requestAnimationFrame(() => {
+                scrollToBottom(logType);
+              });
             }
           })
           .catch((error) => {
@@ -484,48 +603,266 @@ function JobDetailsContent({
               if (error.name !== 'AbortError') {
                 console.error(`Error streaming ${logType}:`, error);
                 if (error.message) {
-                  setLogs((prevLogs) => [
-                    ...prevLogs,
-                    `Error fetching logs: ${error.message}`,
-                  ]);
+                  setLogs(
+                    (prevLogs) =>
+                      prevLogs + `Error fetching logs: ${error.message}\n`
+                  );
                 }
               }
               setIsLoading(false);
+              if (isRefreshing) {
+                if (logType === 'logs') {
+                  setIsRefreshingLogs(false);
+                } else {
+                  setIsRefreshingControllerLogs(false);
+                }
+              }
+            }
+          })
+          .finally(() => {
+            console.log(`Cleaning up ${logType} request`);
+            active = false;
+
+            // Abort the controller if it matches the current one
+            if (activeRequestRef.current === controller) {
+              activeRequestRef.current.abort();
+              activeRequestRef.current = null;
+            }
+
+            // Clear any pending batch updates for this log type
+            if (logType === 'logs') {
+              logsBatchRef.current = '';
+            } else {
+              controllerLogsBatchRef.current = '';
+            }
+
+            // Clear update timeout
+            if (updateTimeoutRef.current) {
+              clearTimeout(updateTimeoutRef.current);
+              updateTimeoutRef.current = null;
             }
           });
 
         // Return cleanup function
         return () => {
+          console.log(`Cleaning up ${logType} request`);
           active = false;
+
+          // Abort the controller if it matches the current one
+          if (activeRequestRef.current === controller) {
+            activeRequestRef.current.abort();
+            activeRequestRef.current = null;
+          }
+
+          // Clear any pending batch updates for this log type
+          if (logType === 'logs') {
+            logsBatchRef.current = '';
+          } else {
+            controllerLogsBatchRef.current = '';
+          }
+
+          // Clear update timeout
+          if (updateTimeoutRef.current) {
+            clearTimeout(updateTimeoutRef.current);
+            updateTimeoutRef.current = null;
+          }
         };
       }
       return () => {
         active = false;
       };
     },
-    [activeTab, isPending, isPreStart, isRecovering]
+    [isPending, isPreStart, isRecovering, hasReceivedFirstChunk]
   );
 
-  // Only fetch logs when actually viewing the logs tab
+  // Fetch both logs and controller logs in parallel, regardless of activeTab
   useEffect(() => {
-    const cleanup = fetchLogs('logs', jobData.id, setLogs, setIsLoadingLogs);
-    return cleanup;
-  }, [activeTab, jobData.id, fetchLogs, setIsLoadingLogs]);
+    // Cancel any existing request
+    if (activeLogsRequest.current) {
+      activeLogsRequest.current.abort();
+      activeLogsRequest.current = null;
+    }
 
-  // Only fetch controller logs when actually viewing the controller logs tab
+    // Only fetch if not in pending/recovering state
+    if (!isPending && !isRecovering) {
+      const cleanup = fetchLogs('logs', jobData.id, setLogs, setIsLoadingLogs);
+      return cleanup;
+    }
+  }, [jobData.id, fetchLogs, setIsLoadingLogs, isPending, isRecovering]);
+
   useEffect(() => {
-    const cleanup = fetchLogs(
-      'controllerlogs',
-      jobData.id,
-      setControllerLogs,
-      setIsLoadingControllerLogs
-    );
-    return cleanup;
-  }, [activeTab, jobData.id, fetchLogs, setIsLoadingControllerLogs]);
+    // Cancel any existing request
+    if (activeControllerLogsRequest.current) {
+      activeControllerLogsRequest.current.abort();
+      activeControllerLogsRequest.current = null;
+    }
+
+    // Only fetch if not in pre-start state
+    if (!isPreStart) {
+      const cleanup = fetchLogs(
+        'controllerlogs',
+        jobData.id,
+        setControllerLogs,
+        setIsLoadingControllerLogs
+      );
+      return cleanup;
+    }
+  }, [jobData.id, fetchLogs, setIsLoadingControllerLogs, isPreStart]);
+
+  // Handle refresh for logs
+  useEffect(() => {
+    if (refreshFlag > 0 && activeTab === 'logs') {
+      // Cancel any existing request
+      if (activeLogsRequest.current) {
+        activeLogsRequest.current.abort();
+        activeLogsRequest.current = null;
+      }
+
+      setIsRefreshingLogs(true);
+      const cleanup = fetchLogs(
+        'logs',
+        jobData.id,
+        setLogs,
+        setIsLoadingLogs,
+        true // isRefreshing = true
+      );
+      return cleanup;
+    }
+  }, [refreshFlag, activeTab, jobData.id, fetchLogs, setIsLoadingLogs]);
+
+  // Handle refresh for controller logs
+  useEffect(() => {
+    if (refreshFlag > 0 && activeTab === 'controllerlogs') {
+      // Cancel any existing request
+      if (activeControllerLogsRequest.current) {
+        activeControllerLogsRequest.current.abort();
+        activeControllerLogsRequest.current = null;
+      }
+
+      setIsRefreshingControllerLogs(true);
+      const cleanup = fetchLogs(
+        'controllerlogs',
+        jobData.id,
+        setControllerLogs,
+        setIsLoadingControllerLogs,
+        true // isRefreshing = true
+      );
+      return cleanup;
+    }
+  }, [
+    refreshFlag,
+    activeTab,
+    jobData.id,
+    fetchLogs,
+    setIsLoadingControllerLogs,
+  ]);
+
+  // Comprehensive cleanup when component unmounts or user navigates away
+  useEffect(() => {
+    return () => {
+      console.log('Cleaning up managed job log requests...');
+
+      // Abort all active log requests
+      if (activeLogsRequest.current) {
+        activeLogsRequest.current.abort();
+        activeLogsRequest.current = null;
+      }
+
+      if (activeControllerLogsRequest.current) {
+        activeControllerLogsRequest.current.abort();
+        activeControllerLogsRequest.current = null;
+      }
+
+      // Clear all timeouts
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current);
+        updateTimeoutRef.current = null;
+      }
+
+      // Clear any pending batches
+      logsBatchRef.current = '';
+      controllerLogsBatchRef.current = '';
+
+      // Reset loading states to prevent any UI inconsistencies
+      setIsLoadingLogs(false);
+      setIsLoadingControllerLogs(false);
+      setIsRefreshingLogs(false);
+      setIsRefreshingControllerLogs(false);
+    };
+  }, []); // Empty dependency array means this runs only on unmount
+
+  // Handle page visibility changes to pause streaming when tab is not active
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        console.log('Page hidden - pausing log streaming for performance');
+
+        // Optionally abort active requests when page is hidden
+        // Uncomment if you want to completely stop streaming when tab is not visible
+        /*
+        if (activeLogsRequest.current) {
+          activeLogsRequest.current.abort();
+          activeLogsRequest.current = null;
+        }
+        if (activeControllerLogsRequest.current) {
+          activeControllerLogsRequest.current.abort();
+          activeControllerLogsRequest.current = null;
+        }
+        */
+
+        // Clear any pending batch updates to reduce background processing
+        if (updateTimeoutRef.current) {
+          clearTimeout(updateTimeoutRef.current);
+          updateTimeoutRef.current = null;
+        }
+      } else {
+        console.log('Page visible - resuming normal operation');
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  // Auto-scroll to bottom when logs change or tab changes
+  useEffect(() => {
+    const performScroll = () => {
+      if (
+        (activeTab === 'logs' && logs) ||
+        (activeTab === 'controllerlogs' && controllerLogs)
+      ) {
+        scrollToBottom(activeTab === 'logs' ? 'logs' : 'controllerlogs');
+      }
+    };
+
+    // Use requestAnimationFrame for better timing after DOM updates
+    requestAnimationFrame(() => {
+      requestAnimationFrame(performScroll); // Double RAF to ensure DOM is updated
+    });
+  }, [activeTab, logs, controllerLogs, scrollToBottom]);
+
+  // Performance-optimized log update function
+  const updateLogsWithBatching = useCallback(
+    (logType, newChunk) => {
+      const setLogsFunction = logType === 'logs' ? setLogs : setControllerLogs;
+
+      // Simple string append - no batching needed with backend tail
+      setLogsFunction((prevLogs) => prevLogs + newChunk);
+
+      // Auto-scroll after update
+      requestAnimationFrame(() => {
+        scrollToBottom(logType);
+      });
+    },
+    [scrollToBottom]
+  );
 
   if (activeTab === 'logs') {
     return (
-      <div className="max-h-96 overflow-y-auto">
+      <div className="max-h-96 overflow-y-auto" ref={logsContainerRef}>
         {isPending ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
             <span>
@@ -538,13 +875,15 @@ function JobDetailsContent({
               Waiting for the job to recover, please refresh after a while
             </span>
           </div>
+        ) : hasReceivedFirstChunk || logs ? (
+          <LogFilter logs={logs} />
         ) : isLoadingLogs ? (
           <div className="flex items-center justify-center py-4">
             <CircularProgress size={20} className="mr-2" />
-            <span>Loading...</span>
+            <span>Loading logs...</span>
           </div>
         ) : (
-          <LogFilter logs={logs.join('')} />
+          <LogFilter logs={logs} />
         )}
       </div>
     );
@@ -552,7 +891,10 @@ function JobDetailsContent({
 
   if (activeTab === 'controllerlogs') {
     return (
-      <div className="max-h-96 overflow-y-auto">
+      <div
+        className="max-h-96 overflow-y-auto"
+        ref={controllerLogsContainerRef}
+      >
         {isPreStart ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
             <span>
@@ -560,13 +902,15 @@ function JobDetailsContent({
               after a while
             </span>
           </div>
+        ) : hasReceivedFirstChunk || controllerLogs ? (
+          <LogFilter logs={controllerLogs} controller={true} />
         ) : isLoadingControllerLogs ? (
           <div className="flex items-center justify-center py-4">
             <CircularProgress size={20} className="mr-2" />
-            <span>Loading...</span>
+            <span>Loading logs...</span>
           </div>
         ) : (
-          <LogFilter logs={controllerLogs.join('')} controller={true} />
+          <LogFilter logs={controllerLogs} controller={true} />
         )}
       </div>
     );

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -192,6 +192,7 @@ def tail_logs(name: Optional[str] = None,
               follow: bool = True,
               controller: bool = False,
               refresh: bool = False,
+              tail: Optional[int] = None,
               output_stream: Optional['io.TextIOBase'] = None) -> int:
     """Tails logs of managed jobs.
 
@@ -204,6 +205,7 @@ def tail_logs(name: Optional[str] = None,
         follow: Whether to follow the logs.
         controller: Whether to tail logs from the jobs controller.
         refresh: Whether to restart the jobs controller if it is stopped.
+        tail: Number of lines to tail from the end of the log file.
         output_stream: The stream to write the logs to. If None, print to the
             console.
 
@@ -222,6 +224,7 @@ def tail_logs(name: Optional[str] = None,
         follow=follow,
         controller=controller,
         refresh=refresh,
+        tail=tail,
     )
     response = requests.post(
         f'{server_common.get_server_url()}/jobs/logs',

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -47,7 +47,7 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # The version of the lib files that jobs/utils use. Whenever there is an API
 # change for the jobs/utils, we need to bump this version and update
 # job.utils.ManagedJobCodeGen to handle the version update.
-MANAGED_JOBS_VERSION = 5
+MANAGED_JOBS_VERSION = 6
 
 # The command for setting up the jobs dashboard on the controller. It firstly
 # checks if the systemd services are available, and if not (e.g., Kubernetes

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -521,8 +521,12 @@ def cancel(name: Optional[str] = None,
 
 
 @usage_lib.entrypoint
-def tail_logs(name: Optional[str], job_id: Optional[int], follow: bool,
-              controller: bool, refresh: bool) -> int:
+def tail_logs(name: Optional[str],
+              job_id: Optional[int],
+              follow: bool,
+              controller: bool,
+              refresh: bool,
+              tail: Optional[int] = None) -> int:
     # NOTE(dev): Keep the docstring consistent between the Python API and CLI.
     """Tail logs of managed jobs.
 
@@ -565,7 +569,8 @@ def tail_logs(name: Optional[str], job_id: Optional[int], follow: bool,
                                          job_id=job_id,
                                          job_name=name,
                                          follow=follow,
-                                         controller=controller)
+                                         controller=controller,
+                                         tail=tail)
 
 
 def start_dashboard_forwarding(refresh: bool = False) -> Tuple[int, int]:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -865,16 +865,13 @@ def stream_logs(job_id: Optional[int],
         with open(controller_log_path, 'r', newline='', encoding='utf-8') as f:
             # Note: we do not need to care about start_stream_at here, since
             # that should be in the job log printed above.
+            read_from: Union[TextIO, Deque[str]] = f
             if tail is not None:
                 assert tail > 0
                 # Read only the last 'tail' lines efficiently using deque
-                lines = collections.deque(f, maxlen=tail)
-                for line in lines:
-                    print(line, end='')
-            else:
-                # Read all lines
-                for line in f:
-                    print(line, end='')
+                read_from = collections.deque(f, maxlen=tail)
+            for line in read_from:
+                print(line, end='')
             # Flush.
             print(end='', flush=True)
 
@@ -1391,7 +1388,7 @@ class ManagedJobCodeGen:
                     controller: bool = False,
                     tail: Optional[int] = None) -> str:
         code = textwrap.dedent(f"""\
-        if managed_job_version < 5:
+        if managed_job_version < 6:
             # Versions before 5 did not support tail parameter
             result = utils.stream_logs(job_id={job_id!r}, job_name={job_name!r},
                                     follow={follow}, controller={controller})

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -13,7 +13,7 @@ import textwrap
 import time
 import traceback
 import typing
-from typing import Any, Dict, List, Optional, Set, TextIO, Tuple, Union
+from typing import Any, Deque, Dict, List, Optional, Set, TextIO, Tuple, Union
 
 import colorama
 import filelock
@@ -585,7 +585,7 @@ def stream_logs_by_id(job_id: int,
                     # Stream the logs to the console without reading the whole
                     # file into memory.
                     start_streaming = False
-                    read_from: Union[TextIO, List[str]] = f
+                    read_from: Union[TextIO, Deque[str]] = f
                     if tail is not None:
                         assert tail > 0
                         # Read only the last 'tail' lines using deque

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -7,7 +7,7 @@ from sky.skylet import constants
 # API server version, whenever there is a change in API server that requires a
 # restart of the local API server or error out when the client does not match
 # the server version.
-API_VERSION = '6'
+API_VERSION = '7'
 
 # Prefix for API request names.
 REQUEST_NAME_PREFIX = 'sky.'

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -376,6 +376,7 @@ class JobsLogsBody(RequestBody):
     follow: bool = True
     controller: bool = False
     refresh: bool = False
+    tail: Optional[int] = None
 
 
 class RequestCancelBody(RequestBody):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR brings two main improvements:
1. Significantly improved log loading speed in the managed jobs dashboard. Logs were previously stored as an array in the frontend, but JavaScript is much faster at appending to a string than an array ([ref](https://stackoverflow.com/a/7299040)). Furthermore, the frontend was previously streaming the entire log from the backend before formatting and displaying it on the dashboard. This PR formats the logs as they come in and displays them in a streaming fashion which makes for a much faster UX. 
2. Implements log tailing for managed jobs. Even with the optimizations outlined above, once logs reach a certain length (> 100k lines) the dashboard loading speed becomes too long and can make the entire dashboard unresponsive. This change makes it such that only a configurable fixed-length (currently set to 1000 lines) of the most recent logs are shown on the dashboard. 

Jobs controllers older than v5 will still load the entire logs but the dashboard will use the optimizations listed in item 1 of the list above. Jobs controllers >= v5 will utilize those optimizations, but will also only load the tail of the logs. 

<!-- Describe the tests ran -->
This PR was tested by running a log-intensive managed job and verifying that in all cases, the dashboard loaded the logs much faster. Backwards compatibility was also verified by running a jobs controller on v4 vs v5 and seeing that all logs and tail of the logs were loaded for respective controller versions. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
