### PR TITLE
Store cluster task YAML and command

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -1520,6 +1520,7 @@ class RetryingVmProvisioner(object):
                 cluster_handle=handle,
                 requested_resources=requested_resources,
                 ready=False,
+                task_yaml=handle.cluster_yaml,
             )
 
             global_user_state.set_owner_identity_for_cluster(
@@ -3185,6 +3186,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
                 set(task.resources),
                 ready=True,
                 config_hash=config_hash,
+                task_yaml=handle.cluster_yaml,
             )
             usage_lib.messages.usage.update_final_cluster_status(
                 status_lib.ClusterStatus.UP)

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -80,6 +80,8 @@ export async function getClusters({ clusterNames = null } = {}) {
         status: clusterStatusMap[cluster.status],
         cluster: cluster.name,
         user: cluster.user_name,
+        command: cluster.last_use,
+        task_yaml: cluster.task_yaml,
         user_hash: cluster.user_hash,
         cloud: cluster.cloud,
         region: cluster.region,

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -229,6 +229,18 @@ function ActiveTab({ clusterData, clusterJobData, loading }) {
                     : 'N/A'}
                 </div>
               </div>
+              <div>
+                <div className="text-gray-600 font-medium text-base">Command</div>
+                <div className="text-base mt-1 break-all">
+                  {clusterData.command || 'N/A'}
+                </div>
+              </div>
+              <div>
+                <div className="text-gray-600 font-medium text-base">Task YAML</div>
+                <div className="text-base mt-1 break-all">
+                  {clusterData.task_yaml || 'N/A'}
+                </div>
+              </div>
             </div>
           </div>
         </Card>

--- a/tests/test_jobs_and_serve.py
+++ b/tests/test_jobs_and_serve.py
@@ -83,7 +83,8 @@ def _mock_cluster_state(_mock_db_conn, tmp_path):
         'test-cluster1',
         handle,
         requested_resources={handle.launched_resources},
-        ready=True)
+        ready=True,
+        task_yaml=handle.cluster_yaml)
     handle = backends.CloudVmRayResourceHandle(
         cluster_name='test-cluster2',
         cluster_name_on_cloud='test-cluster2',
@@ -97,7 +98,8 @@ def _mock_cluster_state(_mock_db_conn, tmp_path):
         'test-cluster2',
         handle,
         requested_resources={handle.launched_resources},
-        ready=True)
+        ready=True,
+        task_yaml=handle.cluster_yaml)
     handle = backends.CloudVmRayResourceHandle(
         cluster_name='test-cluster3',
         cluster_name_on_cloud='test-cluster3',
@@ -110,7 +112,8 @@ def _mock_cluster_state(_mock_db_conn, tmp_path):
         'test-cluster3',
         handle,
         requested_resources={handle.launched_resources},
-        ready=False)
+        ready=False,
+        task_yaml=handle.cluster_yaml)
 
 
 @pytest.fixture
@@ -127,7 +130,8 @@ def _mock_jobs_controller(_mock_db_conn, tmp_path):
         common.JOB_CONTROLLER_NAME,
         handle,
         requested_resources={handle.launched_resources},
-        ready=True)
+        ready=True,
+        task_yaml=handle.cluster_yaml)
 
 
 @pytest.fixture
@@ -147,7 +151,8 @@ def _mock_serve_controller(_mock_db_conn, tmp_path):
         common.SKY_SERVE_CONTROLLER_NAME,
         handle,
         requested_resources={handle.launched_resources},
-        ready=True)
+        ready=True,
+        task_yaml=handle.cluster_yaml)
 
 
 class TestWithEmptyDBSetup:


### PR DESCRIPTION
## Summary
- rename DB column `cluster_yaml` to `task_yaml`
- propagate the `task_yaml` path when registering clusters
- expose the path through cluster APIs and dashboard
- update tests

## Testing
- `bash format.sh`
- `pytest tests/unit_tests/test_sky/test_task.py::test_validate_workdir -q`