### PR TITLE
[Workspaces] Show reason for cloud disabled in sky check when clouds specified

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -257,7 +257,7 @@ def check_capabilities(
         # Check all workspaces
         workspaces_to_check = available_workspaces
 
-        hide_per_cloud_details_flag = (not verbose and
+        hide_per_cloud_details_flag = (not verbose and clouds is None and
                                        len(workspaces_to_check) > 1)
 
         for ws_name in workspaces_to_check:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Previously, when multiple workspaces existed, if a user ran sky check with a cloud or list of clouds specified (e.g. `sky check  gcp` or `sky check gcp azure aws`), the cli would not display the reason for a cloud being disabled. The only way to see the reason for a cloud being disabled when multiple workspaces exist was to use the `-v` flag or `-w {WORKSPACE_NAME}`. This PR makes it such that when a user expresses a specific intent (specifies a single cloud or list of clouds), that intent is respected and the reason for certain clouds being disabled will be displayed. 


<!-- Describe the tests ran -->
I created a test workspace in addition to the default workspace and then ran `sky check gcp` before and after this change to verify that it does indeed now show the reason for why gcp is disabled. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
