### PR TITLE
[k8s] Wait for apt installation to complete before proceeding with setup

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -398,7 +398,7 @@ available_node_types:
                 # For backwards compatibility, we put a marker file in the pod
                 # to indicate that the apt ssh setup step will write a completion
                 # marker file (/tmp/apt_ssh_setup_complete) to the pod.
-                # TODO: Remove this marker file and it's usage in setup_commands
+                # TODO: Remove this marker file and its usage in setup_commands
                 # after v0.11.0 release.
                 touch /tmp/apt_ssh_setup_started
 


### PR DESCRIPTION
As a part of nimbus (https://github.com/skypilot-org/skypilot/pull/4393) we parallelized dependency setup in the k8s pods. However, we did not add a wait for SSH setup to complete. Waiting for SSH is critical for rsync operations to succeed.

A recent archive.ubuntu.com outage caused delayed SSH installs, resulting in #5794 and #5792.

This PR fixes it by waiting for SSH install to complete. 

Note: we are not updating APT mirrors in this PR to avoid hardcoding mirrors. 

Closes #5794 and #5792.

Tested: 
 - [x] `sky launch -c test --infra kubernetes --image-id docker:nvcr.io/nvidia/pytorch:24.05-py3`
 - [x] `sky launch -c test --infra kubernetes --image-id docker:ubuntu:latest`
 - [x] Back compat -  `sky launch` with master, then `sky launch` again with this branch
Note: we are not updating the mirror 