### PR TITLE
[SSO] Cleanly error out if user is not authenticated to API server

### DIFF
--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -488,6 +488,16 @@ class ApiServerConnectionError(RuntimeError):
             f'Try: curl {server_url}/api/health')
 
 
+class ApiServerAuthenticationError(RuntimeError):
+    """Raised when authentication is required for the API server."""
+
+    def __init__(self, server_url: str):
+        super().__init__(
+            f'Authentication required for SkyPilot API server at {server_url}. '
+            f'Please run:\n'
+            f'  sky api login -e {server_url}')
+
+
 class APIVersionMismatchError(RuntimeError):
     """Raised when the API version mismatch."""
     pass

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -533,10 +533,13 @@ def check_server_healthy_or_start_fn(deploy: bool = False,
     api_server_status = None
     try:
         api_server_status = check_server_healthy()
+        if api_server_status == ApiServerStatus.NEEDS_AUTH:
+            endpoint = get_server_url()
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.ApiServerAuthenticationError(endpoint)
     except exceptions.ApiServerConnectionError as exc:
         endpoint = get_server_url()
-        if (not is_api_server_local() or
-                api_server_status == ApiServerStatus.NEEDS_AUTH):
+        if not is_api_server_local():
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.ApiServerConnectionError(endpoint) from exc
         # Lock to prevent multiple processes from starting the server at the


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Prior to this PR, when a user was not authenticated via SSO and tried to run a command such as `sky status`, there would be an extremely verbose and completely unhelpful error message essentially printing the entire html for the sso page (okta, google, etc.). 

This was because the client code was not properly handling the NEEDS_AUTH server response. This PR fixes the client-side NEEDS_AUTH handling and returns a simple error message to the user indicating that they need to authenticate and what command to run to do so. 

<!-- Describe the tests ran -->
I tried running `sky status` on a remote API server where I was not authenticated and saw the following response:
```
❯ sky status
sky.exceptions.ApiServerAuthenticationError: Authentication required for SkyPilot API server at http://dogfood.skypilot.co. Please run:
  sky api login -e http://dogfood.skypilot.co
```

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
