### PR TITLE
[core] support HA job controller

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -196,6 +196,13 @@ rbac:
     - apiGroups: [ "" ]
       resources: [ "configmaps" ]
       verbs: [ "get", "patch" ]
+    # Required for high-availability controller
+    - apiGroups: ["apps"]
+      resources: ["deployments", "deployments/status"]
+      verbs: ["*"]
+    - apiGroups: [""]
+      resources: ["persistentvolumeclaims"]
+      verbs: ["*"]
   # Cluster-scoped rules for API server.
   clusterRules:
     # Required for getting node resources.

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -263,8 +263,7 @@ def _execute_dag(
     if controller is not None:
         requested_features.add(
             clouds.CloudImplementationFeatures.HOST_CONTROLLERS)
-        if controller_utils.high_availability_specified(cluster_name,
-                                                        skip_warning=False):
+        if controller_utils.high_availability_specified(cluster_name):
             requested_features.add(clouds.CloudImplementationFeatures.
                                    HIGH_AVAILABILITY_CONTROLLERS)
             # If we provision a cluster that supports high availability

--- a/sky/utils/controller_utils.py
+++ b/sky/utils/controller_utils.py
@@ -206,8 +206,7 @@ class Controllers(enum.Enum):
         return None
 
 
-def high_availability_specified(cluster_name: Optional[str],
-                                skip_warning: bool = True) -> bool:
+def high_availability_specified(cluster_name: Optional[str]) -> bool:
     """Check if the controller high availability is specified in user config.
     """
     controller = Controllers.from_name(cluster_name)
@@ -215,18 +214,9 @@ def high_availability_specified(cluster_name: Optional[str],
         return False
 
     if skypilot_config.loaded():
-        high_availability = skypilot_config.get_nested(
-            (controller.value.controller_type, 'controller',
-             'high_availability'), False)
-        if high_availability:
-            if controller.value.controller_type != 'serve':
-                if not skip_warning:
-                    print(f'{colorama.Fore.RED}High availability controller is'
-                          'only supported for SkyServe controller. It cannot'
-                          f'be enabled for {controller.value.name}.'
-                          f'Skipping this flag.{colorama.Style.RESET_ALL}')
-            else:
-                return True
+        return skypilot_config.get_nested((controller.value.controller_type,
+                                           'controller', 'high_availability'),
+                                          False)
     return False
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The code of HA serve controller seems fine when used in HA jobs controller. Did some manual test:

1. Enable HA job controller:

Add the following configuration to skypilot.yaml

```yaml
jobs:
  controller:
    resources:
      cloud: kubernetes
    high_availability: true
```

2. Test launch:

```bash
$ sky jobs launch -n j1 --cpus 1+ "echo hi; sleep 5; echo done;"
....
✓ Managed job finished: 1 (status: SUCCEEDED).
```

3. Test the state is persistent:

```bash
$ kubectl get po
NAME                                                              READY   STATUS    RESTARTS   AGE
sky-jobs-controller-a246a9e3-a246a9e3-deployment-6f5775557bh4h5   1/1     Running   0          10m

# Manually trigger a failover
$ kubectl delete po sky-jobs-controller-a246a9e3-a246a9e3-deployment-6f5775557bh4h5
pod "sky-jobs-controller-a246a9e3-a246a9e3-deployment-6f5775557bh4h5" deleted
$ kubectl get po
NAME                                                              READY   STATUS    RESTARTS   AGE
sky-jobs-controller-a246a9e3-a246a9e3-deployment-6f57755572zpfc   1/1     Running   0          11s
$ sky jobs queue
Fetching managed job statuses...
Managed jobs
No in-progress managed jobs.
ID  TASK  NAME  PRIORITY  REQUESTED   SUBMITTED   TOT. DURATION  JOB DURATION  #RECOVERIES  STATUS
1   -     j1    500       1x[CPU:1+]  7 mins ago  3m 25s         11s           0            SUCCEEDED
```

4. Terminate job controller

```
$ sky down sky-jobs-controller-a246a9e3 -y
WARNING: Tearing down the managed jobs controller. Please be aware of the following:
 * All logs and status information of the managed jobs (output of `sky jobs queue`) will be lost.
 * No in-progress managed jobs found. It should be safe to terminate (see caveats above).
To proceed, please type 'delete': delete
Terminating cluster sky-jobs-controller-a246a9e3...done.
Terminating 1 cluster ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
