### PR TITLE
[k8s] Fix GPU isolation when no GPUs are requested

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -471,6 +471,12 @@ class Kubernetes(clouds.Cloud):
         ssh_jump_image = service_catalog.get_image_id_from_tag(
             self.IMAGE_CPU, clouds='kubernetes')
 
+        # Set environment variables for the pod. Note that SkyPilot env vars
+        # are set separately when the task is run. These env vars are
+        # independent of the SkyPilot task to be run.
+        k8s_env_vars = {kubernetes.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context}
+
+        # Setup GPU/TPU labels and resource keys.
         k8s_acc_label_key = None
         k8s_acc_label_values = None
         k8s_topology_label_key = None
@@ -492,6 +498,17 @@ class Kubernetes(clouds.Cloud):
             else:
                 k8s_resource_key = kubernetes_utils.get_gpu_resource_key()
         else:
+            # If no GPUs are requested, we set NVIDIA_VISIBLE_DEVICES=none to
+            # maintain GPU isolation. This is to override the default behavior
+            # of Nvidia device plugin which would expose all GPUs to the pod
+            # when no GPUs are requested.
+            # Note that NVIDIA_VISIBLE_DEVICES is different from
+            # CUDA_VISIBLE_DEVICES - the latter is used to control which GPUs
+            # are visible to the application and is set inside the pod, while
+            # the former is used to control which GPUs are visible to the pod
+            # through the nvidia runtime.
+            # See: https://github.com/NVIDIA/k8s-device-plugin/issues/61
+            k8s_env_vars['NVIDIA_VISIBLE_DEVICES'] = 'none'
             avoid_label_keys = kubernetes_utils.get_accelerator_label_keys(
                 context)
             if len(avoid_label_keys) == 0:
@@ -551,11 +568,6 @@ class Kubernetes(clouds.Cloud):
             ('kubernetes', 'provision_timeout'),
             timeout,
             override_configs=resources.cluster_config_overrides)
-
-        # Set environment variables for the pod. Note that SkyPilot env vars
-        # are set separately when the task is run. These env vars are
-        # independent of the SkyPilot task to be run.
-        k8s_env_vars = {kubernetes.IN_CLUSTER_CONTEXT_NAME_ENV_VAR: context}
 
         # We specify object-store-memory to be 500MB to avoid taking up too
         # much memory on the head node. 'num-cpus' should be set to limit


### PR DESCRIPTION
Nvidia device plugin has a known issue where if no GPUs are requested, it exposes all GPUs to the pod: https://github.com/NVIDIA/k8s-device-plugin/issues/61

As a result, `sky launch -c cpus --infra kubernetes --image-id us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest -- nvidia-smi` would show all GPUs, even though not GPUs were requested.

The "right" way to fix it is to have the cluster admin install the gpu-operator such that it does not mount the GPU devices when no GPUs are requested by setting this in their [gpu operator helm chart](https://github.com/NVIDIA/k8s-device-plugin/issues/61#issuecomment-2401284348):
```
toolkit:
  env:
    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_ENVVAR_WHEN_UNPRIVILEGED
      value: "false"
    - name: ACCEPT_NVIDIA_VISIBLE_DEVICES_AS_VOLUME_MOUNTS
      value: "true"
devicePlugin:
  env:
    - name: DEVICE_LIST_STRATEGY
      value: volume-mounts
``` 

In this PR, we implement a simpler workaround by manually setting `NVIDIA_VISIBLE_DEVICES=none` when no GPUs are requested. This signals the underlying nvidia device plugin to not mount any GPUs to the pod.

Tested:
- [x] `sky launch -c cpus --infra kubernetes --image-id us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest -- nvidia-smi`, launched on a GPU only cluster, shows:
```
(sky-cmd, pid=2387) No devices were found
```
- [x] `sky launch -c gpus --infra kubernetes --image-id us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot-gpu:latest --gpus H100:4 -- nvidia-smi` works as expected, shows 4 GPUs of 8.

