### PR TITLE
[Dashboard] Cluster-Specific and Managed Job-Specific Page Caching

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -524,9 +524,6 @@ export function GPUs() {
     // This calls the fetchData version defined when isInitialLoad is true.
     // That fetchData will then set isInitialLoad to false within its finally block.
     const initializeData = async () => {
-      // Enable cache debug mode temporarily
-      dashboardCache.setDebugMode(true);
-
       // Trigger cache preloading for infra page and background preload other pages
       await cachePreloader.preloadForPage('infra');
 
@@ -565,11 +562,10 @@ export function GPUs() {
   }, []);
 
   const handleRefresh = () => {
-    // Only invalidate cache entry specific to the infra page
+    // Invalidate cache to ensure fresh data is fetched
+    dashboardCache.invalidate(getClusters);
+    dashboardCache.invalidate(getManagedJobs, [{ allUsers: true }]);
     dashboardCache.invalidate(getInfraData);
-    // Don't invalidate shared cache entries that other pages depend on
-    // dashboardCache.invalidate(getClusters);
-    // dashboardCache.invalidate(getManagedJobs);
 
     if (refreshDataRef.current) {
       refreshDataRef.current({ showLoadingIndicators: true });

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -219,9 +219,7 @@ export function ManagedJobs() {
         const configuredWorkspaceNames = Object.keys(fetchedWorkspacesConfig);
 
         // Fetch all jobs to see if 'default' workspace is implicitly used
-        const jobsResponse = await dashboardCache.get(getManagedJobs, [
-          { allUsers: true },
-        ]);
+        const jobsResponse = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
         const allJobs = jobsResponse.jobs || [];
         const uniqueJobWorkspaces = [
           ...new Set(
@@ -243,10 +241,8 @@ export function ManagedJobs() {
   }, []);
 
   const handleRefresh = () => {
-    // Only invalidate cache entries specific to the jobs page
+    // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getManagedJobs, [{ allUsers: true }]);
-    // Don't invalidate getClusters as it's shared with other pages
-    // dashboardCache.invalidate(getClusters);
     dashboardCache.invalidate(getWorkspaces);
 
     if (refreshDataRef.current) {
@@ -430,9 +426,6 @@ export function ManagedJobsTable({
   useEffect(() => {
     setData([]);
     let isCurrent = true;
-
-    // Enable cache debug mode temporarily
-    dashboardCache.setDebugMode(true);
 
     fetchData();
 

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1153,12 +1153,6 @@ export function ClusterJobs({ clusterName, clusterJobData, loading, refreshClust
         <div className="flex items-center justify-between p-4">
           <h3 className="text-lg font-semibold">Cluster Jobs</h3>
           <div className="flex items-center">
-            {loading && (
-              <div className="flex items-center mr-2">
-                <CircularProgress size={15} className="mt-0" />
-                <span className="ml-2 text-gray-500 text-sm">Loading jobs...</span>
-              </div>
-            )}
             {refreshClusterJobsOnly && (
               <button
                 onClick={refreshClusterJobsOnly}
@@ -1226,7 +1220,19 @@ export function ClusterJobs({ clusterName, clusterJobData, loading, refreshClust
             </TableRow>
           </TableHeader>
           <TableBody>
-            {paginatedData.length > 0 ? (
+            {loading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={9}
+                  className="text-center py-12 text-gray-500"
+                >
+                  <div className="flex justify-center items-center">
+                    <CircularProgress size={24} className="mr-2" />
+                    <span>Loading cluster jobs...</span>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : paginatedData.length > 0 ? (
               paginatedData.map((item) => (
                 <React.Fragment key={item.id}>
                   <TableRow

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1058,7 +1058,7 @@ export function Status2Actions({
   );
 }
 
-export function ClusterJobs({ clusterName, clusterJobData, loading }) {
+export function ClusterJobs({ clusterName, clusterJobData, loading, refreshClusterJobsOnly }) {
   const [expandedRowId, setExpandedRowId] = useState(null);
   const [sortConfig, setSortConfig] = useState({
     key: null,
@@ -1152,12 +1152,24 @@ export function ClusterJobs({ clusterName, clusterJobData, loading }) {
       <Card>
         <div className="flex items-center justify-between p-4">
           <h3 className="text-lg font-semibold">Cluster Jobs</h3>
-          {loading && (
-            <div className="flex items-center mr-2">
-              <CircularProgress size={15} className="mt-0" />
-              <span className="ml-2 text-gray-500 text-sm">Loading...</span>
-            </div>
-          )}
+          <div className="flex items-center">
+            {loading && (
+              <div className="flex items-center mr-2">
+                <CircularProgress size={15} className="mt-0" />
+                <span className="ml-2 text-gray-500 text-sm">Loading jobs...</span>
+              </div>
+            )}
+            {refreshClusterJobsOnly && (
+              <button
+                onClick={refreshClusterJobsOnly}
+                disabled={loading}
+                className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center text-sm ml-2"
+              >
+                <RotateCwIcon className="w-4 h-4 mr-1" />
+                Refresh Jobs
+              </button>
+            )}
+          </div>
         </div>
         <Table>
           <TableHeader>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -219,7 +219,9 @@ export function ManagedJobs() {
         const configuredWorkspaceNames = Object.keys(fetchedWorkspacesConfig);
 
         // Fetch all jobs to see if 'default' workspace is implicitly used
-        const jobsResponse = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
+        const jobsResponse = await dashboardCache.get(getManagedJobs, [
+          { allUsers: true },
+        ]);
         const allJobs = jobsResponse.jobs || [];
         const uniqueJobWorkspaces = [
           ...new Set(

--- a/sky/dashboard/src/components/workspaces.jsx
+++ b/sky/dashboard/src/components/workspaces.jsx
@@ -314,7 +314,7 @@ export function Workspaces() {
         await Promise.all([
           dashboardCache.get(getWorkspaces),
           dashboardCache.get(getClusters),
-          dashboardCache.get(getManagedJobs),
+          dashboardCache.get(getManagedJobs, [{ allUsers: true }]),
         ]);
 
       setRawWorkspacesData(fetchedWorkspacesConfig);
@@ -478,7 +478,7 @@ export function Workspaces() {
     // Invalidate cache to ensure fresh data is fetched
     dashboardCache.invalidate(getWorkspaces);
     dashboardCache.invalidate(getClusters);
-    dashboardCache.invalidate(getManagedJobs);
+    dashboardCache.invalidate(getManagedJobs, [{ allUsers: true }]);
     dashboardCache.invalidateFunction(getEnabledClouds); // This function has arguments
 
     fetchData(true); // Show loading on manual refresh

--- a/sky/dashboard/src/data/connectors/clusters.jsx
+++ b/sky/dashboard/src/data/connectors/clusters.jsx
@@ -229,7 +229,9 @@ export function useClusterDetails({ cluster, job = null }) {
       try {
         setLoadingClusterData(true);
         // Use dashboard cache for cluster data
-        const data = await dashboardCache.get(getClusters, [{ clusterNames: [cluster] }]);
+        const data = await dashboardCache.get(getClusters, [
+          { clusterNames: [cluster] },
+        ]);
         setClusterData(data[0]); // Assuming getClusters returns an array
         return data[0]; // Return the data for use in fetchClusterJobData
       } catch (error) {
@@ -248,10 +250,12 @@ export function useClusterDetails({ cluster, job = null }) {
         try {
           setLoadingClusterJobData(true);
           // Use dashboard cache for cluster jobs
-          const data = await dashboardCache.get(getClusterJobs, [{
-            clusterName: cluster,
-            workspace: workspace || 'default',
-          }]);
+          const data = await dashboardCache.get(getClusterJobs, [
+            {
+              clusterName: cluster,
+              workspace: workspace || 'default',
+            },
+          ]);
           setClusterJobData(data);
         } catch (error) {
           console.error('Error fetching cluster job data:', error);
@@ -266,14 +270,16 @@ export function useClusterDetails({ cluster, job = null }) {
   const refreshData = useCallback(async () => {
     // Invalidate cache for fresh data
     dashboardCache.invalidate(getClusters, [{ clusterNames: [cluster] }]);
-    
+
     const clusterInfo = await fetchClusterData();
     if (clusterInfo) {
       // Invalidate cluster jobs cache for fresh data
-      dashboardCache.invalidate(getClusterJobs, [{
-        clusterName: cluster,
-        workspace: clusterInfo.workspace || 'default',
-      }]);
+      dashboardCache.invalidate(getClusterJobs, [
+        {
+          clusterName: cluster,
+          workspace: clusterInfo.workspace || 'default',
+        },
+      ]);
       await fetchClusterJobData(clusterInfo.workspace);
     }
   }, [fetchClusterData, fetchClusterJobData, cluster]);
@@ -281,10 +287,12 @@ export function useClusterDetails({ cluster, job = null }) {
   const refreshClusterJobsOnly = useCallback(async () => {
     if (clusterData) {
       // Invalidate only cluster jobs cache for fresh data
-      dashboardCache.invalidate(getClusterJobs, [{
-        clusterName: cluster,
-        workspace: clusterData.workspace || 'default',
-      }]);
+      dashboardCache.invalidate(getClusterJobs, [
+        {
+          clusterName: cluster,
+          workspace: clusterData.workspace || 'default',
+        },
+      ]);
       await fetchClusterJobData(clusterData.workspace);
     }
   }, [fetchClusterJobData, clusterData, cluster]);
@@ -300,13 +308,13 @@ export function useClusterDetails({ cluster, job = null }) {
     initializeData();
   }, [cluster, job, fetchClusterData, fetchClusterJobData]);
 
-  return { 
-    clusterData, 
-    clusterJobData, 
+  return {
+    clusterData,
+    clusterJobData,
     loading: clusterDetailsLoading, // Only cluster details loading for initial page render
     clusterDetailsLoading,
     clusterJobsLoading,
     refreshData,
-    refreshClusterJobsOnly
+    refreshClusterJobsOnly,
   };
 }

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -102,16 +102,19 @@ export async function getCloudInfrastructure(clusters, jobs) {
 }
 
 /**
- * Shared function to get all infra data (GPU + Cloud) - used by both cache preloader and infra page
+ * Main function to get all infrastructure data.
+ * Uses cached data from clusters and jobs to avoid redundant API calls.
  */
 export async function getInfraData() {
   // Import here to avoid circular dependencies
   const { getClusters } = await import('@/data/connectors/clusters');
   const { getManagedJobs } = await import('@/data/connectors/jobs');
+  const dashboardCache = (await import('@/lib/cache')).default;
 
+  // Use cache to get data instead of calling functions directly
   const [clustersData, jobsData] = await Promise.all([
-    getClusters(),
-    getManagedJobs(),
+    dashboardCache.get(getClusters),
+    dashboardCache.get(getManagedJobs, [{ allUsers: true }]),
   ]);
 
   const clusters = clustersData || [];

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -175,7 +175,9 @@ export function useManagedJobDetails(refreshTrigger = 0) {
     async function fetchJobData() {
       try {
         setLoadingJobData(true);
-        const data = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
+        const data = await dashboardCache.get(getManagedJobs, [
+          { allUsers: true },
+        ]);
         setJobData(data);
       } catch (error) {
         console.error('Error fetching managed job data:', error);
@@ -205,7 +207,9 @@ export function useSingleManagedJob(jobId, refreshTrigger = 0) {
         setLoadingJobData(true);
 
         // Always get all jobs data (cache handles freshness automatically)
-        const allJobsData = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
+        const allJobsData = await dashboardCache.get(getManagedJobs, [
+          { allUsers: true },
+        ]);
 
         // Filter for the specific job client-side
         const job = allJobsData?.jobs?.find(

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -175,8 +175,7 @@ export function useManagedJobDetails(refreshTrigger = 0) {
     async function fetchJobData() {
       try {
         setLoadingJobData(true);
-        // Revert to non-cached version for Solution 1 comparison
-        const data = await getManagedJobs({ allUsers: true });
+        const data = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
         setJobData(data);
       } catch (error) {
         console.error('Error fetching managed job data:', error);
@@ -206,9 +205,7 @@ export function useSingleManagedJob(jobId, refreshTrigger = 0) {
         setLoadingJobData(true);
 
         // Always get all jobs data (cache handles freshness automatically)
-        const allJobsData = await dashboardCache.get(getManagedJobs, [
-          { allUsers: true },
-        ]);
+        const allJobsData = await dashboardCache.get(getManagedJobs, [{ allUsers: true }]);
 
         // Filter for the specific job client-side
         const job = allJobsData?.jobs?.find(

--- a/sky/dashboard/src/lib/README.md
+++ b/sky/dashboard/src/lib/README.md
@@ -213,7 +213,7 @@ For refresh buttons that should pull completely fresh data:
 const handleRefresh = () => {
   // Functions without arguments - use invalidate()
   dashboardCache.invalidate(getClusters);
-  dashboardCache.invalidate(getManagedJobs);
+  dashboardCache.invalidate(getManagedJobs, [{ allUsers: true }]);
   dashboardCache.invalidate(getWorkspaces);
 
   // Functions with arguments - use invalidateFunction()

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -99,10 +99,7 @@ class CachePreloader {
         if (force) {
           dashboardCache.invalidate(fn, args);
         }
-        // Use isBackgroundRequest: true for preloader to prevent interference
-        promises.push(
-          dashboardCache.get(fn, args, { isBackgroundRequest: true })
-        );
+        promises.push(dashboardCache.get(fn, args));
       } else if (functionName === 'getEnabledClouds') {
         // Dynamic function that requires workspace data
         promises.push(this._loadEnabledCloudsForAllWorkspaces(force));
@@ -123,9 +120,7 @@ class CachePreloader {
       if (force) {
         dashboardCache.invalidate(getWorkspaces);
       }
-      const workspacesData = await dashboardCache.get(getWorkspaces, [], {
-        isBackgroundRequest: true,
-      });
+      const workspacesData = await dashboardCache.get(getWorkspaces, []);
       const workspaceNames = Object.keys(workspacesData || {});
 
       // Then load enabled clouds for each workspace
@@ -133,9 +128,7 @@ class CachePreloader {
         if (force) {
           dashboardCache.invalidate(getEnabledClouds, [wsName]);
         }
-        return dashboardCache.get(getEnabledClouds, [wsName], {
-          isBackgroundRequest: true,
-        });
+        return dashboardCache.get(getEnabledClouds, [wsName]);
       });
 
       await Promise.allSettled(promises);
@@ -195,11 +188,9 @@ class CachePreloader {
         if (force) {
           dashboardCache.invalidate(fn, args);
         }
-        return dashboardCache
-          .get(fn, args, { isBackgroundRequest: true })
-          .catch((error) => {
-            console.error(`[CachePreloader] Failed to preload ${name}:`, error);
-          });
+        return dashboardCache.get(fn, args).catch((error) => {
+          console.error(`[CachePreloader] Failed to preload ${name}:`, error);
+        });
       }
     );
 
@@ -214,7 +205,6 @@ class CachePreloader {
     return {
       ...dashboardCache.getStats(),
       isPreloading: this.isPreloading,
-      preloadPromises: this.preloadPromises.size,
     };
   }
 

--- a/sky/dashboard/src/lib/cache-preloader.js
+++ b/sky/dashboard/src/lib/cache-preloader.js
@@ -120,7 +120,7 @@ class CachePreloader {
       if (force) {
         dashboardCache.invalidate(getWorkspaces);
       }
-      const workspacesData = await dashboardCache.get(getWorkspaces, []);
+      const workspacesData = await dashboardCache.get(getWorkspaces);
       const workspaceNames = Object.keys(workspacesData || {});
 
       // Then load enabled clouds for each workspace

--- a/sky/dashboard/src/lib/cache.js
+++ b/sky/dashboard/src/lib/cache.js
@@ -10,8 +10,7 @@ const DEFAULT_CACHE_TTL = CACHE_CONFIG.DEFAULT_TTL;
 class DashboardCache {
   constructor() {
     this.cache = new Map();
-    this.backgroundJobs = new Map(); // Track ongoing background refresh jobs
-    this.debugMode = false; // Added for debug mode
+    this.debugMode = false;
   }
 
   /**
@@ -20,14 +19,10 @@ class DashboardCache {
    * @param {Array} [args=[]] - Arguments to pass to the fetch function
    * @param {Object} [options={}] - Cache options
    * @param {number} [options.ttl] - Time to live in milliseconds
-   * @param {boolean} [options.refreshOnAccess] - Whether to refresh TTL on cache access (default: true)
-   * @param {boolean} [options.isBackgroundRequest] - Whether this is a background request (default: false)
    * @returns {Promise} - The cached or fresh data
    */
   async get(fetchFunction, args = [], options = {}) {
     const ttl = options.ttl || DEFAULT_CACHE_TTL;
-    const refreshOnAccess = options.refreshOnAccess === true; // Change default to false
-    const isBackgroundRequest = options.isBackgroundRequest === true; // New option to identify background requests
     const key = this._generateKey(fetchFunction, args);
     const functionName = fetchFunction.name || 'anonymous';
 
@@ -38,51 +33,14 @@ class DashboardCache {
     if (cachedItem && now - cachedItem.lastUpdated < ttl) {
       const age = Math.round((now - cachedItem.lastUpdated) / 1000);
       this._debug(
-        `Cache HIT for ${functionName} (age: ${age}s, TTL: ${Math.round(ttl / 1000)}s)${isBackgroundRequest ? ' [BACKGROUND]' : ''}`
-      );
-
-      // Update the lastUpdated timestamp to extend the cache life on access
-      if (refreshOnAccess && !isBackgroundRequest) {
-        this.cache.set(key, {
-          data: cachedItem.data,
-          lastUpdated: now,
-        });
-        this._debug(`Cache TTL refreshed for ${functionName}`);
-      }
-
-      // Only trigger background refresh for foreground requests, not background ones
-      // This prevents background jobs from triggering more background jobs
-      if (!isBackgroundRequest) {
-        // Launch background refresh only if cache is older than half TTL
-        // This prevents too frequent background refreshes
-        const halfTTL = ttl / 2;
-        if (
-          now - cachedItem.lastUpdated > halfTTL &&
-          !this.backgroundJobs.has(key)
-        ) {
-          this._debug(
-            `Triggering background refresh for ${functionName} (age > half TTL)`
-          );
-          this._refreshInBackground(fetchFunction, args, key);
-        }
-      }
-
-      return cachedItem.data;
-    }
-
-    // If data is stale or doesn't exist, fetch fresh data
-    // But if this is a background request and we have stale data, return stale data instead of fetching
-    if (isBackgroundRequest && cachedItem) {
-      this._debug(
-        `Background request returning stale data for ${functionName}`
+        `Cache HIT for ${functionName} (age: ${age}s, TTL: ${Math.round(ttl / 1000)}s)`
       );
       return cachedItem.data;
     }
 
+    // Data is stale or doesn't exist, fetch fresh data
     try {
-      this._debug(
-        `Cache MISS for ${functionName} - fetching fresh data${isBackgroundRequest ? ' [BACKGROUND]' : ''}`
-      );
+      this._debug(`Cache MISS for ${functionName} - fetching fresh data`);
       const freshData = await fetchFunction(...args);
 
       // Update cache with fresh data
@@ -91,9 +49,7 @@ class DashboardCache {
         lastUpdated: now,
       });
 
-      this._debug(
-        `Cache updated for ${functionName}${isBackgroundRequest ? ' [BACKGROUND]' : ''}`
-      );
+      this._debug(`Cache updated for ${functionName}`);
       return freshData;
     } catch (error) {
       // If fetch fails and we have stale data, return stale data
@@ -118,8 +74,7 @@ class DashboardCache {
   invalidate(fetchFunction, args = []) {
     const key = this._generateKey(fetchFunction, args);
     this.cache.delete(key);
-    // Also cancel any ongoing background job for this key
-    this.backgroundJobs.delete(key);
+    this._debug(`Cache invalidated for ${key}`);
   }
 
   /**
@@ -140,8 +95,11 @@ class DashboardCache {
     // Delete all matching entries
     keysToDelete.forEach((key) => {
       this.cache.delete(key);
-      this.backgroundJobs.delete(key);
     });
+
+    this._debug(
+      `Cache invalidated for all ${functionName} entries (${keysToDelete.length} entries)`
+    );
   }
 
   /**
@@ -149,7 +107,7 @@ class DashboardCache {
    */
   clear() {
     this.cache.clear();
-    this.backgroundJobs.clear();
+    this._debug('All cache entries cleared');
   }
 
   /**
@@ -158,7 +116,6 @@ class DashboardCache {
   getStats() {
     return {
       cacheSize: this.cache.size,
-      backgroundJobs: this.backgroundJobs.size,
       keys: Array.from(this.cache.keys()),
     };
   }
@@ -176,13 +133,11 @@ class DashboardCache {
         key,
         age: Math.round(age / 1000), // Age in seconds
         lastUpdated: new Date(item.lastUpdated).toISOString(),
-        hasBackgroundJob: this.backgroundJobs.has(key),
       });
     }
 
     return {
       cacheSize: this.cache.size,
-      backgroundJobs: this.backgroundJobs.size,
       entries: entries.sort((a, b) => a.age - b.age),
     };
   }
@@ -202,39 +157,6 @@ class DashboardCache {
     if (this.debugMode) {
       console.log(`[DashboardCache] ${message}`, ...args);
     }
-  }
-
-  /**
-   * Refresh data in the background without blocking the current request
-   * @private
-   */
-  _refreshInBackground(fetchFunction, args, key) {
-    // Check if we already have a background job running for this key
-    if (this.backgroundJobs.has(key)) {
-      this._debug(`Background job already running for ${key}, skipping`);
-      return; // Don't start another background job if one is already running
-    }
-
-    // Mark that we have a background job running for this key
-    this.backgroundJobs.set(key, true);
-    this._debug(`Starting background refresh for ${key}`);
-
-    // Add a small delay to let any ongoing foreground requests complete
-    setTimeout(() => {
-      // Execute the refresh asynchronously with background request flag
-      this.get(fetchFunction, args, { isBackgroundRequest: true })
-        .then((freshData) => {
-          this._debug(`Background refresh completed for ${key}`);
-        })
-        .catch((error) => {
-          console.warn(`Background refresh failed for ${key}:`, error);
-        })
-        .finally(() => {
-          // Remove the background job marker
-          this.backgroundJobs.delete(key);
-          this._debug(`Background job finished for ${key}`);
-        });
-    }, 100); // 100ms delay to avoid immediate conflicts
   }
 
   /**

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -381,14 +381,12 @@ function ActiveTab({ clusterData, clusterJobData, clusterJobsLoading, refreshClu
 
       {/* Jobs Table */}
       <div className="mb-8">
-        {clusterJobData && (
-          <ClusterJobs
-            clusterName={clusterData.cluster}
-            clusterJobData={clusterJobData}
-            loading={clusterJobsLoading}
-            refreshClusterJobsOnly={refreshClusterJobsOnly}
-          />
-        )}
+        <ClusterJobs
+          clusterName={clusterData.cluster}
+          clusterJobData={clusterJobData}
+          loading={clusterJobsLoading}
+          refreshClusterJobsOnly={refreshClusterJobsOnly}
+        />
       </div>
     </div>
   );

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -51,14 +51,14 @@ function ClusterDetails() {
   const [isSSHModalOpen, setIsSSHModalOpen] = useState(false);
   const [isVSCodeModalOpen, setIsVSCodeModalOpen] = useState(false);
   const isMobile = useMobile();
-  const { 
-    clusterData, 
-    clusterJobData, 
-    loading, 
+  const {
+    clusterData,
+    clusterJobData,
+    loading,
     clusterDetailsLoading,
     clusterJobsLoading,
     refreshData,
-    refreshClusterJobsOnly
+    refreshClusterJobsOnly,
   } = useClusterDetails({ cluster });
 
   // Update isInitialLoad when cluster details are first loaded (not waiting for jobs)
@@ -179,7 +179,12 @@ function ClusterDetails() {
   );
 }
 
-function ActiveTab({ clusterData, clusterJobData, clusterJobsLoading, refreshClusterJobsOnly }) {
+function ActiveTab({
+  clusterData,
+  clusterJobData,
+  clusterJobsLoading,
+  refreshClusterJobsOnly,
+}) {
   const [isYamlExpanded, setIsYamlExpanded] = useState(false);
 
   const toggleYamlExpanded = () => {

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -51,15 +51,22 @@ function ClusterDetails() {
   const [isSSHModalOpen, setIsSSHModalOpen] = useState(false);
   const [isVSCodeModalOpen, setIsVSCodeModalOpen] = useState(false);
   const isMobile = useMobile();
-  const { clusterData, clusterJobData, loading, refreshData } =
-    useClusterDetails({ cluster });
+  const { 
+    clusterData, 
+    clusterJobData, 
+    loading, 
+    clusterDetailsLoading,
+    clusterJobsLoading,
+    refreshData,
+    refreshClusterJobsOnly
+  } = useClusterDetails({ cluster });
 
-  // Update isInitialLoad when data is first loaded
+  // Update isInitialLoad when cluster details are first loaded (not waiting for jobs)
   React.useEffect(() => {
-    if (!loading && isInitialLoad) {
+    if (!clusterDetailsLoading && isInitialLoad) {
       setIsInitialLoad(false);
     }
-  }, [loading, isInitialLoad]);
+  }, [clusterDetailsLoading, isInitialLoad]);
 
   const handleManualRefresh = async () => {
     setIsRefreshing(true);
@@ -106,7 +113,7 @@ function ClusterDetails() {
 
           <div className="text-sm flex items-center">
             <div className="text-sm flex items-center">
-              {(loading || isRefreshing) && (
+              {(clusterDetailsLoading || isRefreshing) && (
                 <div className="flex items-center mr-4">
                   <CircularProgress size={15} className="mt-0" />
                   <span className="ml-2 text-gray-500">Loading...</span>
@@ -120,7 +127,7 @@ function ClusterDetails() {
                   >
                     <button
                       onClick={handleManualRefresh}
-                      disabled={loading || isRefreshing}
+                      disabled={clusterDetailsLoading || isRefreshing}
                       className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center"
                     >
                       <RotateCwIcon className="w-4 h-4 mr-1.5" />
@@ -140,16 +147,17 @@ function ClusterDetails() {
           </div>
         </div>
 
-        {loading && isInitialLoad ? (
+        {clusterDetailsLoading && isInitialLoad ? (
           <div className="flex justify-center items-center py-12">
             <CircularProgress size={24} className="mr-2" />
-            <span className="text-gray-500">Loading...</span>
+            <span className="text-gray-500">Loading cluster details...</span>
           </div>
         ) : clusterData ? (
           <ActiveTab
             clusterData={clusterData}
             clusterJobData={clusterJobData}
-            loading={loading || isRefreshing}
+            clusterJobsLoading={clusterJobsLoading}
+            refreshClusterJobsOnly={refreshClusterJobsOnly}
           />
         ) : null}
 
@@ -171,7 +179,7 @@ function ClusterDetails() {
   );
 }
 
-function ActiveTab({ clusterData, clusterJobData, loading }) {
+function ActiveTab({ clusterData, clusterJobData, clusterJobsLoading, refreshClusterJobsOnly }) {
   const [isYamlExpanded, setIsYamlExpanded] = useState(false);
 
   const toggleYamlExpanded = () => {
@@ -377,7 +385,8 @@ function ActiveTab({ clusterData, clusterJobData, loading }) {
           <ClusterJobs
             clusterName={clusterData.cluster}
             clusterJobData={clusterJobData}
-            loading={loading}
+            loading={clusterJobsLoading}
+            refreshClusterJobsOnly={refreshClusterJobsOnly}
           />
         )}
       </div>

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -3,7 +3,7 @@ import { CircularProgress } from '@mui/material';
 import { useRouter } from 'next/router';
 import { Layout } from '@/components/elements/layout';
 import { Card } from '@/components/ui/card';
-import { useManagedJobDetails } from '@/data/connectors/jobs';
+import { useSingleManagedJob } from '@/data/connectors/jobs';
 import Link from 'next/link';
 import { RotateCwIcon, ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import { CustomTooltip as Tooltip } from '@/components/utils';
@@ -19,7 +19,7 @@ function JobDetails() {
   const router = useRouter();
   const { job: jobId, tab } = router.query;
   const [refreshTrigger, setRefreshTrigger] = useState(0);
-  const { jobData, loading } = useManagedJobDetails(refreshTrigger);
+  const { jobData, loading } = useSingleManagedJob(jobId, refreshTrigger);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [isLoadingLogs, setIsLoadingLogs] = useState(false);


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR implements caching of specific cluster and managed jobs pages in the dashboard. 

<!-- Describe the tests ran -->
This PR was tested by rapidly switching between the top level pages and specific cluster and managed jobs pages and verifying that the loading speed was reduced when visiting pages repeatedly. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
