### PR TITLE
[Dashboard] Display sky commit sha on dashboard

### DIFF
--- a/sky/dashboard/src/components/elements/version-display.jsx
+++ b/sky/dashboard/src/components/elements/version-display.jsx
@@ -10,19 +10,18 @@ export function VersionDisplay() {
     fetch(`${ENDPOINT}/api/health`)
       .then((res) => res.json())
       .then((data) => {
-        console.log('Health API response:', data); // Debug logging
         if (data.version) {
           setVersion(data.version);
         }
         if (data.commit) {
           setCommit(data.commit);
-          console.log('Commit found:', data.commit); // Debug logging
-        } else {
-          console.log('No commit found in response'); // Debug logging
         }
       })
       .catch((error) => {
-        console.error('Error fetching version:', error);
+        console.error(
+          'Error fetching API server version and commit hash:',
+          error
+        );
       });
   }, []);
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes it such that when you hover over the api server version in the configuration page of the dashboard, the commit sha is shown.

<!-- Describe the tests ran -->
Built the dashboard and verified that the commit sha showed up when hovering over the sky api version in the configuration page. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
