### PR TITLE
[db] lazy db init for global_user_state

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -302,17 +302,16 @@ def create_table():
         session.commit()
 
 
-# if _SQLALCHEMY_ENGINE is None:
-#     if os.environ.get(constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR):
-#         # If SKYPILOT_API_SERVER_DB_URL_ENV_VAR is set,
-#         # use it as the database URI.
-#         logger.debug('using db URI from '
-#                      f'{constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR}')
-#         _SQLALCHEMY_ENGINE = sqlalchemy.create_engine(
-#             os.environ.get(constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR))
-#     else:
-#         _SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
-#     create_table()
+if _SQLALCHEMY_ENGINE is None:
+    if os.environ.get(constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR):
+        # If SKYPILOT_API_SERVER_DB_URL_ENV_VAR is set,
+        # use it as the database URI.
+        logger.debug('using db URI from '
+                     f'{constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR}')
+        _SQLALCHEMY_ENGINE = sqlalchemy.create_engine(
+            os.environ.get(constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR))
+    else:
+        _SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
 
 
 def _init_db(func):
@@ -320,20 +319,8 @@ def _init_db(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        global _SQLALCHEMY_ENGINE
-        if _SQLALCHEMY_ENGINE is None:
-            if os.environ.get(constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR):
-                # If SKYPILOT_API_SERVER_DB_URL_ENV_VAR is set,
-                # use it as the database URI.
-                logger.debug('using db URI from '
-                             f'{constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR}')
-                _SQLALCHEMY_ENGINE = sqlalchemy.create_engine(
-                    os.environ.get(
-                        constants.SKYPILOT_API_SERVER_DB_URL_ENV_VAR))
-            else:
-                _SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' +
-                                                              _DB_PATH)
-            create_table()
+        create_table()
+
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
