### PR TITLE
Fix the container image in resources.py

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -119,11 +119,6 @@ _DEFAULT_GPU_K80_IMAGE_ID = 'skypilot:k80-debian-10'
 # Refer to https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/machine-learning/a3-highgpu-8g/README.md#before-starting
 _DEFAULT_GPU_DIRECT_IMAGE_ID = 'skypilot:gpu-direct-cos'
 
-# From https://cloud.google.com/compute/docs/gpus/gpudirect
-# A specific image is used to ensure that the the GPU is configured with TCPX support.
-_NETWORK_GCP_IMAGE_ID = ('docker:us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/'
-                         'nccl-plugin-gpudirecttcpx')
-
 
 def _run_output(cmd):
     proc = subprocess.run(cmd,
@@ -547,7 +542,7 @@ class GCP(clouds.Cloud):
                         acc.lower())
                 resources_vars['gpu_count'] = acc_count
                 if enable_gpu_direct or network_tier == resources_utils.NetworkTier.BEST:
-                    image_id = _NETWORK_GCP_IMAGE_ID
+                    image_id = _DEFAULT_GPU_DIRECT_IMAGE_ID
                 else:
                     if acc == 'K80':
                         # Though the image is called cu113, it actually has later

--- a/sky/clouds/utils/gcp_utils.py
+++ b/sky/clouds/utils/gcp_utils.py
@@ -190,3 +190,7 @@ def get_minimal_storage_permissions() -> List[str]:
     permissions += constants.GCP_MINIMAL_PERMISSIONS
 
     return permissions
+
+
+def get_gcp_gpu_direct_image_id() -> str:
+    return constants.GCP_GPU_DIRECT_IMAGE_ID

--- a/sky/provision/gcp/constants.py
+++ b/sky/provision/gcp/constants.py
@@ -54,6 +54,10 @@ CLUSTER_PREFIX_LENGTH = 10
 
 COMPACT_GROUP_PLACEMENT_POLICY = 'compact'
 COLLOCATED_COLLOCATION = 'COLLOCATED'
+
+# From https://cloud.google.com/compute/docs/gpus/gpudirect
+# A specific image is used to ensure that the the GPU is configured with TCPX support.
+GCP_GPU_DIRECT_IMAGE_ID = 'docker:us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx'
 GPU_DIRECT_TCPX_USER_DATA = textwrap.dedent("""
     # Install GPU Direct TCPX
     cos-extensions install gpu -- --version=latest;

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -14,6 +14,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.clouds import cloud as sky_cloud
 from sky.clouds import service_catalog
+from sky.clouds.utils import gcp_utils
 from sky.provision import docker_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.skylet import constants
@@ -325,6 +326,16 @@ class Resources:
                         f'{", ".join(supported_tiers)}.')
             network_tier = resources_utils.NetworkTier(network_tier_str)
         self._network_tier = network_tier
+
+        # TODO(maknee):
+        # This is a hack to set the image id for the best network tier.
+        # We should find a better way to do this.
+        # Perhaps by injecting into resources while provisioning.
+        if isinstance(self._cloud, clouds.GCP):
+            if self._network_tier == resources_utils.NetworkTier.BEST:
+                self._image_id = {
+                    self._region: gcp_utils.get_gcp_gpu_direct_image_id()
+                }
 
         if ports is not None:
             if isinstance(ports, tuple):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

There'an error in the image id, which requires it to be placed in resources.py for now. W

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
