### PR TITLE
[Serve] Catch more exceptions in syncing with controller

### DIFF
--- a/sky/serve/load_balancer.py
+++ b/sky/serve/load_balancer.py
@@ -2,7 +2,8 @@
 import asyncio
 import logging
 import threading
-from typing import Dict, Optional, Union
+import traceback
+from typing import Dict, List, Optional, Union
 
 import aiohttp
 import fastapi
@@ -69,6 +70,48 @@ class SkyServeLoadBalancer:
         # updating it from _sync_with_controller.
         self._client_pool_lock: threading.Lock = threading.Lock()
 
+    async def _sync_with_controller_once(self) -> List[asyncio.Task]:
+        close_client_tasks = []
+        async with aiohttp.ClientSession() as session:
+            try:
+                # Send request information
+                async with session.post(
+                        self._controller_url + '/controller/load_balancer_sync',
+                        json={
+                            'request_aggregator':
+                                self._request_aggregator.to_dict()
+                        },
+                        timeout=aiohttp.ClientTimeout(5),
+                ) as response:
+                    # Clean up after reporting request info to avoid OOM.
+                    self._request_aggregator.clear()
+                    response.raise_for_status()
+                    response_json = await response.json()
+                    ready_replica_urls = response_json.get(
+                        'ready_replica_urls', [])
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                logger.error(f'An error occurred when syncing with '
+                             f'the controller: {e}'
+                             f'\nTraceback: {traceback.format_exc()}')
+            else:
+                logger.info(f'Available Replica URLs: {ready_replica_urls}')
+                with self._client_pool_lock:
+                    self._load_balancing_policy.set_ready_replicas(
+                        ready_replica_urls)
+                    for replica_url in ready_replica_urls:
+                        if replica_url not in self._client_pool:
+                            self._client_pool[replica_url] = httpx.AsyncClient(
+                                base_url=replica_url)
+                    urls_to_close = set(
+                        self._client_pool.keys()) - set(ready_replica_urls)
+                    client_to_close = []
+                    for replica_url in urls_to_close:
+                        client_to_close.append(
+                            self._client_pool.pop(replica_url))
+                for client in client_to_close:
+                    close_client_tasks.append(client.aclose())
+        return close_client_tasks
+
     async def _sync_with_controller(self):
         """Sync with controller periodically.
 
@@ -82,49 +125,16 @@ class SkyServeLoadBalancer:
         await asyncio.sleep(5)
 
         while True:
-            close_client_tasks = []
-            async with aiohttp.ClientSession() as session:
-                try:
-                    # Send request information
-                    async with session.post(
-                            self._controller_url +
-                            '/controller/load_balancer_sync',
-                            json={
-                                'request_aggregator':
-                                    self._request_aggregator.to_dict()
-                            },
-                            timeout=aiohttp.ClientTimeout(5),
-                    ) as response:
-                        # Clean up after reporting request info to avoid OOM.
-                        self._request_aggregator.clear()
-                        response.raise_for_status()
-                        response_json = await response.json()
-                        ready_replica_urls = response_json.get(
-                            'ready_replica_urls', [])
-                except aiohttp.ClientError as e:
-                    logger.error('An error occurred when syncing with '
-                                 f'the controller: {e}')
-                else:
-                    logger.info(f'Available Replica URLs: {ready_replica_urls}')
-                    with self._client_pool_lock:
-                        self._load_balancing_policy.set_ready_replicas(
-                            ready_replica_urls)
-                        for replica_url in ready_replica_urls:
-                            if replica_url not in self._client_pool:
-                                self._client_pool[replica_url] = (
-                                    httpx.AsyncClient(base_url=replica_url))
-                        urls_to_close = set(
-                            self._client_pool.keys()) - set(ready_replica_urls)
-                        client_to_close = []
-                        for replica_url in urls_to_close:
-                            client_to_close.append(
-                                self._client_pool.pop(replica_url))
-                    for client in client_to_close:
-                        close_client_tasks.append(client.aclose())
-
-            await asyncio.sleep(constants.LB_CONTROLLER_SYNC_INTERVAL_SECONDS)
-            # Await those tasks after the interval to avoid blocking.
-            await asyncio.gather(*close_client_tasks)
+            try:
+                close_client_tasks = await self._sync_with_controller_once()
+                await asyncio.sleep(
+                    constants.LB_CONTROLLER_SYNC_INTERVAL_SECONDS)
+                # Await those tasks after the interval to avoid blocking.
+                await asyncio.gather(*close_client_tasks)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error(f'An error occurred when syncing with '
+                             f'the controller: {e}'
+                             f'\nTraceback: {traceback.format_exc()}')
 
     async def _proxy_request_to(
         self, url: str, request: fastapi.Request
@@ -168,7 +178,8 @@ class SkyServeLoadBalancer:
                 background=background.BackgroundTask(background_func))
         except (httpx.RequestError, httpx.HTTPStatusError) as e:
             logger.error(f'Error when proxy request to {url}: '
-                         f'{common_utils.format_exception(e)}')
+                         f'{common_utils.format_exception(e)}'
+                         f'\nTraceback: {traceback.format_exc()}')
             return e
 
     async def _proxy_with_retries(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

A user reports the error triggered by sync with controller is breaking the LB process and hence not responding to further requests. This PR catches more exception to prevent such behavior. We should investigate more for the root cause.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
