### PR TITLE
[UX] Improve error message when one node fails

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -703,7 +703,7 @@ class RayCodeGen:
                     # Find the first non-137 return code and its index
                     non_137 = next((i, r) for i, r in enumerate(returncodes) if r != 137)
                     # +1 because the worker rank is 0-based, but I think the worker number is 1-based
-                    reason = f'(Worker {{non_137[0] + 1}} failed with return code {{non_137[1]}}, SkyPilot cleaned the processes on other nodes with return code 137)'
+                    reason = f'(A Worker failed with return code {{non_137[1]}}, SkyPilot cleaned up the processes on other nodes with return code 137)'
                 print('ERROR: {colorama.Fore.RED}Job {self.job_id} failed with '
                       'return code list:{colorama.Style.RESET_ALL}',
                       returncodes,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -700,10 +700,9 @@ class RayCodeGen:
                 if any(r == 139 for r in returncodes):
                     reason = '(likely due to Segmentation Fault)'
                 if any(r == 137 for r in returncodes):
-                    # Find the first non-137 return code and its index
-                    non_137 = next((i, r) for i, r in enumerate(returncodes) if r != 137)
-                    # +1 because the worker rank is 0-based, but I think the worker number is 1-based
-                    reason = f'(A Worker failed with return code {{non_137[1]}}, SkyPilot cleaned up the processes on other nodes with return code 137)'
+                    # Find the first non-137 return code
+                    non_137 = next(r for r in returncodes if r != 137)
+                    reason = f'(A Worker failed with return code {{non_137}}, SkyPilot cleaned up the processes on other nodes with return code 137)'
                 print('ERROR: {colorama.Fore.RED}Job {self.job_id} failed with '
                       'return code list:{colorama.Style.RESET_ALL}',
                       returncodes,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -701,8 +701,9 @@ class RayCodeGen:
                     reason = '(likely due to Segmentation Fault)'
                 if any(r == 137 for r in returncodes):
                     # Find the first non-137 return code and its index
-                    non_137 = next(r for r in returncodes if r != 137)
-                    reason = f'(A worker failed with return code {{non_137}}, SkyPilot cleaned the processes on other nodes with returncode 137)'
+                    non_137 = next((i, r) for i, r in enumerate(returncodes) if r != 137)
+                    # +1 because the worker rank is 0-based, but I think the worker number is 1-based
+                    reason = f'(Worker {{non_137[0] + 1}} failed with return code {{non_137[1]}}, SkyPilot cleaned the processes on other nodes with return code 137)'
                 print('ERROR: {colorama.Fore.RED}Job {self.job_id} failed with '
                       'return code list:{colorama.Style.RESET_ALL}',
                       returncodes,

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -699,6 +699,10 @@ class RayCodeGen:
                 # 139 is the return code of SIGSEGV, i.e. Segmentation Fault.
                 if any(r == 139 for r in returncodes):
                     reason = '(likely due to Segmentation Fault)'
+                if any(r == 137 for r in returncodes):
+                    # Find the first non-137 return code and its index
+                    non_137 = next(r for r in returncodes if r != 137)
+                    reason = f'(A worker failed with return code {{non_137}}, SkyPilot cleaned the processes on other nodes with returncode 137)'
                 print('ERROR: {colorama.Fore.RED}Job {self.job_id} failed with '
                       'return code list:{colorama.Style.RESET_ALL}',
                       returncodes,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #4232. Prints:
> ERROR: Job X failed with return code list: [137, 1, 137 137] (A worker failed with return code 1, SkyPilot cleaned up the processes on other nodes with return code 137)

<!-- Describe the tests ran -->

Manually ran with a yaml file that runs `exit 1`
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
