### PR TITLE
[Docs][k8s/ssh] Update k8s troubleshooting for SSH Node Pools

### DIFF
--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -66,6 +66,7 @@ Run :code:`sky check` to verify that SkyPilot can access your cluster.
     # Should show `Kubernetes: Enabled`
 
 If you see an error, ensure that your kubeconfig file at :code:`~/.kube/config` is correctly set up.
+Also, make sure that the cluster context name doesn't start with the prefix :code:`ssh-`. This prefix is reserved by SkyPilot internal use.
 
 
 Step A3 - Do your nodes have enough disk space?

--- a/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
+++ b/docs/source/reference/kubernetes/kubernetes-troubleshooting.rst
@@ -66,7 +66,7 @@ Run :code:`sky check` to verify that SkyPilot can access your cluster.
     # Should show `Kubernetes: Enabled`
 
 If you see an error, ensure that your kubeconfig file at :code:`~/.kube/config` is correctly set up.
-Also, make sure that the cluster context name doesn't start with the prefix :code:`ssh-`. This prefix is reserved by SkyPilot internal use.
+Also, make sure that the cluster context name doesn't start with the prefix :code:`ssh-`. This prefix is reserved for SkyPilot internal use.
 
 
 Step A3 - Do your nodes have enough disk space?


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Internally, SSH Node Pools are k3s clusters with context name prefixes of `ssh-`. This information was added to the kubernetes troubleshooting docs. 


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
