### PR TITLE
[WIP] Multi-k8s handling in config

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -535,7 +535,6 @@ def get_expirable_clouds(
                 remote_identities = schemas.get_default_remote_identity(
                     str(cloud).lower())
 
-
         local_credential_expiring = cloud.can_credential_expire()
         if isinstance(remote_identities, str):
             if remote_identities == local_credentials_value and local_credential_expiring:

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3534,7 +3534,8 @@ def show_gpus(
         cloud_obj, clouds.Kubernetes) and not isinstance(cloud_obj, clouds.SSH)
     cloud_is_ssh = isinstance(cloud_obj, clouds.SSH)
     # TODO(romilb): We should move this to the backend.
-    kubernetes_autoscaling = kubernetes_utils.get_autoscaler_type() is not None
+    kubernetes_autoscaling = kubernetes_utils.get_config_property_value(
+        ('autoscaler',), context=region) is not None
     kubernetes_is_enabled = clouds.Kubernetes.canonical_name() in enabled_clouds
     ssh_is_enabled = clouds.SSH.canonical_name() in enabled_clouds
     query_k8s_realtime_gpu = (kubernetes_is_enabled and

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2516,6 +2516,26 @@ def get_autoscaler_type(
     return autoscaler_type
 
 
+def get_config_property_value(keys: Tuple[str, ...],
+                              context: Optional[str] = None,
+                              default_value: Optional[Any] = None) -> Any:
+    """Returns the nested key value by reading from config
+    Order to get the property_name value:
+    1. if context is specified, will try to get the value from kubernetes/contexts/context/keys
+    2. if no context or no override, try to get it at the k8s level kubernetes/keys
+    3. if not found at k8s level, return either default_value if specified or None
+    """
+    property_value = None
+    if context is not None:
+        property_value = skypilot_config.get_nested(
+            ('kubernetes', 'contexts', context) + keys, None)
+    # if no override found for specified context
+    if property_value is None:
+        property_value = skypilot_config.get_nested(
+            ('kubernetes',) + keys, default_value if default_value else None)
+    return property_value
+
+
 # Mapping of known spot label keys and values for different cluster types
 # Add new cluster types here if they support spot instances along with the
 # corresponding spot label key and value.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1143,7 +1143,8 @@ def get_accelerator_label_key_values(
     context_display_name = context.lstrip('ssh-') if (
         context and is_ssh_node_pool) else context
 
-    autoscaler_type = get_autoscaler_type()
+    autoscaler_type = get_config_property_value(('autoscaler',),
+                                                context=context)
     if autoscaler_type is not None:
         # If autoscaler is set in config.yaml, override the label key and value
         # to the autoscaler's format and bypass the GPU checks.
@@ -2505,17 +2506,6 @@ def get_head_pod_name(cluster_name_on_cloud: str):
     return f'{cluster_name_on_cloud}-head'
 
 
-def get_autoscaler_type(
-) -> Optional[kubernetes_enums.KubernetesAutoscalerType]:
-    """Returns the autoscaler type by reading from config"""
-    autoscaler_type = skypilot_config.get_nested(('kubernetes', 'autoscaler'),
-                                                 None)
-    if autoscaler_type is not None:
-        autoscaler_type = kubernetes_enums.KubernetesAutoscalerType(
-            autoscaler_type)
-    return autoscaler_type
-
-
 def get_config_property_value(keys: Tuple[str, ...],
                               context: Optional[str] = None,
                               default_value: Optional[Any] = None) -> Any:
@@ -2568,7 +2558,8 @@ def get_spot_label(
 
     # Check if autoscaler is configured. Allow spot instances if autoscaler type
     # is known to support spot instances.
-    autoscaler_type = get_autoscaler_type()
+    autoscaler_type = get_config_property_value(('autoscaler',),
+                                                context=context)
     if autoscaler_type == kubernetes_enums.KubernetesAutoscalerType.GKE:
         return SPOT_LABEL_MAP[autoscaler_type.value]
 

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2506,6 +2506,12 @@ def get_head_pod_name(cluster_name_on_cloud: str):
     return f'{cluster_name_on_cloud}-head'
 
 
+def get_custom_k8s_contexts_names() -> List[str]:
+    """Returns the list of context names from the config"""
+    contexts = skypilot_config.get_nested(('kubernetes', 'contexts'), {})
+    return [*contexts] or []
+
+
 def get_config_property_value(keys: Tuple[str, ...],
                               context: Optional[str] = None,
                               default_value: Optional[Any] = None) -> Any:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -7,6 +7,7 @@ import enum
 from typing import Any, Dict, List, Tuple
 
 from sky.skylet import constants
+from sky.utils import kubernetes_enums
 
 
 def _check_not_both_fields_present(field1: str, field2: str):
@@ -853,11 +854,64 @@ _REMOTE_IDENTITY_SCHEMA_KUBERNETES = {
     },
 }
 
+_CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
+    'networking': {
+        'type': 'string',
+        'case_insensitive_enum': [
+            type.value for type in kubernetes_enums.KubernetesNetworkingMode
+        ],
+    },
+    'ports': {
+        'type': 'string',
+        'case_insensitive_enum': [
+            type.value for type in kubernetes_enums.KubernetesPortMode
+        ],
+    },
+    'pod_config': {
+        'type': 'object',
+        'required': [],
+        # Allow arbitrary keys since validating pod spec is hard
+        'additionalProperties': True,
+    },
+    'custom_metadata': {
+        'type': 'object',
+        'required': [],
+        # Allow arbitrary keys since validating metadata is hard
+        'additionalProperties': True,
+        # Disallow 'name' and 'namespace' keys in this dict
+        'not': {
+            'anyOf': [{
+                'required': ['name']
+            }, {
+                'required': ['namespace']
+            }]
+        },
+    },
+    'provision_timeout': {
+        'type': 'integer',
+    },
+    'autoscaler': {
+        'type': 'string',
+        'case_insensitive_enum': [
+            type.value for type in kubernetes_enums.KubernetesAutoscalerType
+        ],
+    },
+    'high_availability': {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'storage_class_name': {
+                'type': 'string',
+            }
+        },
+    },
+}
+
 
 def get_config_schema():
     # pylint: disable=import-outside-toplevel
     from sky.clouds import service_catalog
-    from sky.utils import kubernetes_enums
 
     resources_schema = {
         k: v
@@ -1003,60 +1057,21 @@ def get_config_schema():
                         'type': 'string',
                     },
                 },
-                'networking': {
-                    'type': 'string',
-                    'case_insensitive_enum': [
-                        type.value
-                        for type in kubernetes_enums.KubernetesNetworkingMode
-                    ]
-                },
-                'ports': {
-                    'type': 'string',
-                    'case_insensitive_enum': [
-                        type.value
-                        for type in kubernetes_enums.KubernetesPortMode
-                    ]
-                },
-                'pod_config': {
+                'contexts': {
                     'type': 'object',
                     'required': [],
-                    # Allow arbitrary keys since validating pod spec is hard
-                    'additionalProperties': True,
+                    'properties': {},
+                    # Properties are kubernetes context names.
+                    'additionalProperties': {
+                        'type': 'object',
+                        'required': [],
+                        'additionalProperties': False,
+                        'properties': {
+                            **_CONTEXT_CONFIG_SCHEMA_KUBERNETES,
+                        },
+                    },
                 },
-                'custom_metadata': {
-                    'type': 'object',
-                    'required': [],
-                    # Allow arbitrary keys since validating metadata is hard
-                    'additionalProperties': True,
-                    # Disallow 'name' and 'namespace' keys in this dict
-                    'not': {
-                        'anyOf': [{
-                            'required': ['name']
-                        }, {
-                            'required': ['namespace']
-                        }]
-                    }
-                },
-                'provision_timeout': {
-                    'type': 'integer',
-                },
-                'autoscaler': {
-                    'type': 'string',
-                    'case_insensitive_enum': [
-                        type.value
-                        for type in kubernetes_enums.KubernetesAutoscalerType
-                    ]
-                },
-                'high_availability': {
-                    'type': 'object',
-                    'required': [],
-                    'additionalProperties': False,
-                    'properties': {
-                        'storage_class_name': {
-                            'type': 'string',
-                        }
-                    }
-                },
+                **_CONTEXT_CONFIG_SCHEMA_KUBERNETES,
             }
         },
         'ssh': {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -918,3 +918,8 @@ def test_kubernetes_context_config(monkeypatch, tmp_path) -> None:
     context_b_provision_timeout = kubernetes_utils.get_config_property_value(
         ('provision_timeout',), context='contextB')
     assert context_b_provision_timeout == 60
+
+    contexts = kubernetes_utils.get_custom_k8s_contexts_names()
+    assert len(contexts) == 2
+    assert contexts[0] == 'contextA'
+    assert contexts[1] == 'contextB'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -884,3 +884,37 @@ def test_hierarchical_server_config(monkeypatch, tmp_path):
         ('gcp', 'labels', 'env-user-config'), None) is None
     assert skypilot_config.get_nested(
         ('gcp', 'labels', 'env-project-config'), None) is None
+
+
+def test_kubernetes_context_config(monkeypatch, tmp_path) -> None:
+    """Test that the nested config works."""
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    with open(tmp_path / 'context_config.yaml', 'w', encoding='utf-8') as f:
+        f.write(f"""\
+        kubernetes:
+            contexts:
+                contextA:
+                    autoscaler: gke
+                contextB:
+                    provision_timeout: 60
+            autoscaler: generic
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'context_config.yaml')
+    skypilot_config._reload_config()
+
+    # test autoscaler property
+    context_a_autoscaler = kubernetes_utils.get_config_property_value(
+        ('autoscaler',), context='contextA')
+    assert context_a_autoscaler == 'gke'
+    context_b_autoscaler = kubernetes_utils.get_config_property_value(
+        ('autoscaler',), context='contextB')
+    assert context_b_autoscaler == 'generic'
+
+    # test provision_timeout property
+    context_a_provision_timeout = kubernetes_utils.get_config_property_value(
+        ('provision_timeout',), context='contextA', default_value=10)
+    assert context_a_provision_timeout == 10
+    context_b_provision_timeout = kubernetes_utils.get_config_property_value(
+        ('provision_timeout',), context='contextB')
+    assert context_b_provision_timeout == 60


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR is a first draft of the changes discussed in #5353.
Goal is to be able to customize each k8s context properties in the `config.yaml` file.

The code in this PR is far from being completed.
It's more of a PoC to further discuss design as I feel the updates here might introduce breaking changes.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR `tests/test_config.py`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
