### PR TITLE
move catalog constants to skylet constants

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -4,8 +4,8 @@ import importlib
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from sky.catalog import constants as service_catalog_constants
 from sky.catalog.config import fallback_to_default_catalog
+from sky.skylet import constants
 from sky.utils import resources_utils
 from sky.utils import subprocess_utils
 
@@ -18,7 +18,7 @@ CloudFilter = Optional[Union[List[str], str]]
 
 def _map_clouds_catalog(clouds: CloudFilter, method_name: str, *args, **kwargs):
     if clouds is None:
-        clouds = list(service_catalog_constants.ALL_CLOUDS)
+        clouds = list(constants.ALL_CLOUDS)
 
         # TODO(hemil): Remove this once the common service catalog
         # functions are refactored from clouds/kubernetes.py to

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -11,8 +11,8 @@ import filelock
 
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
-from sky.catalog import constants as service_catalog_constants
 from sky.clouds import cloud as cloud_lib
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import rich_utils
@@ -28,8 +28,7 @@ else:
 logger = sky_logging.init_logger(__name__)
 
 _ABSOLUTE_VERSIONED_CATALOG_DIR = os.path.join(
-    os.path.expanduser(service_catalog_constants.CATALOG_DIR),
-    service_catalog_constants.CATALOG_SCHEMA_VERSION)
+    os.path.expanduser(constants.CATALOG_DIR), constants.CATALOG_SCHEMA_VERSION)
 os.makedirs(_ABSOLUTE_VERSIONED_CATALOG_DIR, exist_ok=True)
 
 
@@ -96,7 +95,7 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
     def _get_modified_catalogs() -> List[str]:
         """Returns a list of modified catalogs relative to the catalog dir."""
         modified_catalogs = []
-        for cloud_name in service_catalog_constants.ALL_CLOUDS:
+        for cloud_name in constants.ALL_CLOUDS:
             cloud_catalog_dir = os.path.join(_ABSOLUTE_VERSIONED_CATALOG_DIR,
                                              cloud_name)
             if not os.path.exists(cloud_catalog_dir):
@@ -114,9 +113,8 @@ def get_modified_catalog_file_mounts() -> Dict[str, str]:
     modified_catalog_path_map = {}  # Map of remote: local catalog paths
     for catalog in modified_catalog_list:
         # Use relative paths for remote to handle varying usernames on the cloud
-        remote_path = os.path.join(
-            service_catalog_constants.CATALOG_DIR,
-            service_catalog_constants.CATALOG_SCHEMA_VERSION, catalog)
+        remote_path = os.path.join(constants.CATALOG_DIR,
+                                   constants.CATALOG_SCHEMA_VERSION, catalog)
         local_path = os.path.expanduser(remote_path)
         modified_catalog_path_map[remote_path] = local_path
     return modified_catalog_path_map
@@ -198,8 +196,8 @@ def read_catalog(filename: str,
         # Atomic check, to avoid conflicts with other processes.
         with filelock.FileLock(meta_path + '.lock'):
             if _need_update():
-                url = f'{service_catalog_constants.HOSTED_CATALOG_DIR_URL}/{service_catalog_constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
-                url_fallback = f'{service_catalog_constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{service_catalog_constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
+                url = f'{constants.HOSTED_CATALOG_DIR_URL}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
+                url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
                 headers = {'User-Agent': 'SkyPilot/0.7'}
                 update_frequency_str = ''
                 if pull_frequency_hours is not None:

--- a/sky/catalog/constants.py
+++ b/sky/catalog/constants.py
@@ -1,8 +1,0 @@
-"""Constants used for service catalog."""
-HOSTED_CATALOG_DIR_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/catalogs'  # pylint: disable=line-too-long
-HOSTED_CATALOG_DIR_URL_S3_MIRROR = 'https://skypilot-catalog.s3.us-east-1.amazonaws.com/catalogs'  # pylint: disable=line-too-long
-CATALOG_SCHEMA_VERSION = 'v7'
-CATALOG_DIR = '~/.sky/catalogs'
-ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci',
-              'kubernetes', 'runpod', 'vast', 'vsphere', 'cudo', 'fluidstack',
-              'paperspace', 'do', 'nebius', 'ssh')

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -61,7 +61,6 @@ from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.benchmark import benchmark_state
 from sky.benchmark import benchmark_utils
-from sky.catalog import constants as service_catalog_constants
 from sky.client import sdk
 from sky.data import storage_utils
 from sky.provision.kubernetes import constants as kubernetes_constants
@@ -3836,7 +3835,7 @@ def show_gpus(
         clouds_to_list: Union[Optional[str], List[str]] = cloud_name
         if cloud_name is None:
             clouds_to_list = [
-                c for c in service_catalog_constants.ALL_CLOUDS
+                c for c in constants.ALL_CLOUDS
                 if c != 'kubernetes' and c != 'ssh'
             ]
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -412,3 +412,13 @@ SKYPILOT_DEFAULT_WORKSPACE = 'default'
 # Experimental - may be deprecated in the future without notice.
 SKYPILOT_API_SERVER_DB_URL_ENV_VAR: str = (
     f'{SKYPILOT_ENV_VAR_PREFIX}API_SERVER_DB_URL')
+
+# BEGIN constants used for service catalog.
+HOSTED_CATALOG_DIR_URL = 'https://raw.githubusercontent.com/skypilot-org/skypilot-catalog/master/catalogs'  # pylint: disable=line-too-long
+HOSTED_CATALOG_DIR_URL_S3_MIRROR = 'https://skypilot-catalog.s3.us-east-1.amazonaws.com/catalogs'  # pylint: disable=line-too-long
+CATALOG_SCHEMA_VERSION = 'v7'
+CATALOG_DIR = '~/.sky/catalogs'
+ALL_CLOUDS = ('aws', 'azure', 'gcp', 'ibm', 'lambda', 'scp', 'oci',
+              'kubernetes', 'runpod', 'vast', 'vsphere', 'cudo', 'fluidstack',
+              'paperspace', 'do', 'nebius', 'ssh')
+# END constants used for service catalog.

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -6,7 +6,6 @@ https://json-schema.org/
 import enum
 from typing import Any, Dict, List, Tuple
 
-from sky.catalog import constants as service_catalog_constants
 from sky.skylet import constants
 
 
@@ -70,7 +69,7 @@ def _get_single_resources_schema():
     # Building the regex pattern for the infra field
     # Format: cloud[/region[/zone]] or wildcards or kubernetes context
     # Match any cloud name (case insensitive)
-    all_clouds = list(service_catalog_constants.ALL_CLOUDS)
+    all_clouds = list(constants.ALL_CLOUDS)
     all_clouds.remove('kubernetes')
     cloud_pattern = f'(?i:({"|".join(all_clouds)}))'
 
@@ -107,8 +106,7 @@ def _get_single_resources_schema():
         'properties': {
             'cloud': {
                 'type': 'string',
-                'case_insensitive_enum': list(
-                    service_catalog_constants.ALL_CLOUDS)
+                'case_insensitive_enum': list(constants.ALL_CLOUDS)
             },
             'region': {
                 'type': 'string',
@@ -1162,7 +1160,7 @@ def get_config_schema():
         'items': {
             'type': 'string',
             'case_insensitive_enum':
-                (list(service_catalog_constants.ALL_CLOUDS) + ['cloudflare'])
+                (list(constants.ALL_CLOUDS) + ['cloudflare'])
         }
     }
 
@@ -1209,8 +1207,7 @@ def get_config_schema():
 
     workspace_schema = {'type': 'string'}
 
-    allowed_workspace_cloud_names = list(
-        service_catalog_constants.ALL_CLOUDS) + ['cloudflare']
+    allowed_workspace_cloud_names = list(constants.ALL_CLOUDS) + ['cloudflare']
     # Create pattern for not supported clouds, i.e.
     # all clouds except gcp, kubernetes, ssh
     not_supported_clouds = [


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The catalog package has a non-empty `__init__.py` - so any package that needs catalog constants have `__init__.py` run, which causes unnecessary circular imports. This change moves the constants to skylet, which has an empty `__init__.py`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
