### PR TITLE
[config] return empty list when no config is loaded

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -167,7 +167,10 @@ def _get_loaded_config_path() -> List[Optional[str]]:
     serialized = _get_config_context().config_path
     if not serialized:
         return []
-    return json.loads(serialized)
+    config_paths = json.loads(serialized)
+    if config_paths is None:
+        return []
+    return config_paths
 
 
 def _set_loaded_config_path(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

To repro
1. On a brand new machine with no config yaml, but a `.sky.yaml` in the cwd
2. `sky check`
```
E 06-04 20:43:10 sdk.py:1601]   File "/home/ubuntu/sky_workdir/sky/server/requests/executor.py", line 244, in override_request_env_and_config
E 06-04 20:43:10 sdk.py:1601]     with skypilot_config.override_skypilot_config(
E 06-04 20:43:10 sdk.py:1601]   File "/home/ubuntu/miniconda3/lib/python3.10/contextlib.py", line 135, in __enter__
E 06-04 20:43:10 sdk.py:1601]     return next(self.gen)
E 06-04 20:43:10 sdk.py:1601]   File "/home/ubuntu/sky_workdir/sky/skypilot_config.py", line 650, in override_skypilot_config
E 06-04 20:43:10 sdk.py:1601]     assert _get_loaded_config_path() is not None
E 06-04 20:43:10 sdk.py:1601] TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'
E 06-04 20:43:10 sdk.py:1601] 
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
