### PR TITLE
stash config to db

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -358,13 +358,9 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:
-            logger.info('updating config to db')
             skypilot_config.update_config_no_lock(overlaid_config)
-        else:
-            logger.info('no config update needed')
     else:
         # if no saved config exists, stash the current config to db.
-        logger.info('stashing config to db')
         skypilot_config.update_config_no_lock(config)
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -361,7 +361,7 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             skypilot_config.update_config_no_lock(overlaid_config)
     else:
         # if no saved config exists, stash the current config to db.
-        skypilot_config.update_config_no_lock(config)
+        set_config_yaml('api_server', common_utils.dump_yaml_str(dict(config)))
 
 
 def add_or_update_user(user: models.User):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -353,15 +353,14 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             file_config, saved_db_config)
         if overlaid_config != file_config:
-            # update the db here instead of having
-            # update_api_server_config_no_lock
-            # handle db update to avoid circular import
             skypilot_config.update_api_server_config_no_lock(overlaid_config,
                                                              update_db=False)
+        if overlaid_config != saved_db_config:
             set_config_yaml(API_SERVER_CONFIG_KEY, overlaid_config)
     else:
         # if no saved config exists, stash the current config to db
         # if one exists.
+        file_config.pop_nested(('db',), None)
         if file_config:
             set_config_yaml(API_SERVER_CONFIG_KEY, file_config)
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -358,7 +358,12 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:
-            skypilot_config.update_config_no_lock(overlaid_config)
+            # update the db here instead of having update_config_no_lock
+            # handle db update to avoid circular import
+            skypilot_config.update_config_no_lock(overlaid_config,
+                                                  update_db=False)
+            set_config_yaml('api_server',
+                            common_utils.dump_yaml_str(dict(overlaid_config)))
     else:
         # if no saved config exists, stash the current config to db.
         set_config_yaml('api_server', common_utils.dump_yaml_str(dict(config)))

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -299,6 +299,19 @@ def create_table():
         session.commit()
 
 
+conn_string = None
+if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+    conn_string = skypilot_config.get_nested(('db',), None)
+if conn_string:
+    logger.debug(f'using db URI from {conn_string}')
+    SQLALCHEMY_ENGINE = sqlalchemy.create_engine(conn_string)
+else:
+    _DB_PATH = os.path.expanduser('~/.sky/state.db')
+    pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
+    SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
+create_table()
+
+
 def get_config_yaml(key: str) -> Optional[config_utils.Config]:
     with orm.Session(SQLALCHEMY_ENGINE) as session:
         row = session.query(config_table).filter_by(key=key).first()
@@ -330,18 +343,6 @@ def set_config_yaml(key: str, config: config_utils.Config):
         session.commit()
 
 
-conn_string = None
-if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-    conn_string = skypilot_config.get_nested(('db',), None)
-if conn_string:
-    logger.debug(f'using db URI from {conn_string}')
-    SQLALCHEMY_ENGINE = sqlalchemy.create_engine(conn_string)
-else:
-    _DB_PATH = os.path.expanduser('~/.sky/state.db')
-    pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
-    SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
-create_table()
-
 saved_db_config = None
 if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
     saved_db_config = get_config_yaml(API_SERVER_CONFIG_KEY)
@@ -365,7 +366,7 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             set_config_yaml(API_SERVER_CONFIG_KEY, file_config)
 
 
-def add_or_update_user(user: models.User):
+def add_or_update_user(user: models.User) -> bool:
     """Store the mapping from user hash to user name for display purposes.
 
     Returns:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -144,6 +144,13 @@ cluster_yaml_table = sqlalchemy.Table(
     sqlalchemy.Column('yaml', sqlalchemy.Text),
 )
 
+config_yaml_table = sqlalchemy.Table(
+    'config_yaml',
+    Base.metadata,
+    sqlalchemy.Column('key', sqlalchemy.Text, primary_key=True),
+    sqlalchemy.Column('yaml', sqlalchemy.Text),
+)
+
 
 def _glob_to_similar(glob_pattern):
     """Converts a glob pattern to a PostgreSQL LIKE pattern."""
@@ -310,7 +317,46 @@ else:
 create_table()
 
 
-def add_or_update_user(user: models.User) -> bool:
+def get_config_yaml(key: str) -> Optional[str]:
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        row = session.query(config_yaml_table).filter_by(key=key).first()
+    if row:
+        return row.yaml
+    return None
+
+
+def set_config_yaml(key: str, yaml_str: str):
+    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+        if (_SQLALCHEMY_ENGINE.dialect.name ==
+                db_utils.SQLAlchemyDialect.SQLITE.value):
+            insert_func = sqlite.insert
+        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+              db_utils.SQLAlchemyDialect.POSTGRESQL.value):
+            insert_func = postgresql.insert
+        else:
+            raise ValueError('Unsupported database dialect')
+        insert_stmnt = insert_func(config_yaml_table).values(key=key,
+                                                             yaml=yaml_str)
+        do_update_stmt = insert_stmnt.on_conflict_do_update(
+            index_elements=[config_yaml_table.c.key],
+            set_={config_yaml_table.c.yaml: yaml_str})
+        session.execute(do_update_stmt)
+        session.commit()
+
+
+saved_db_config_str = None
+if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+    # if a saved config exists, merge config from db into skypilot_config
+    saved_db_config_str = get_config_yaml('api_server')
+
+if saved_db_config_str:
+    saved_db_config = yaml.safe_load(saved_db_config_str)
+    overlaid_config = skypilot_config.overlay_skypilot_config(
+        skypilot_config.get_server_config(), saved_db_config)
+    skypilot_config.update_config_no_lock(overlaid_config)
+
+
+def add_or_update_user(user: models.User):
     """Store the mapping from user hash to user name for display purposes.
 
     Returns:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -146,13 +146,6 @@ cluster_yaml_table = sqlalchemy.Table(
     sqlalchemy.Column('yaml', sqlalchemy.Text),
 )
 
-config_yaml_table = sqlalchemy.Table(
-    'config_yaml',
-    Base.metadata,
-    sqlalchemy.Column('key', sqlalchemy.Text, primary_key=True),
-    sqlalchemy.Column('yaml', sqlalchemy.Text),
-)
-
 
 def _glob_to_similar(glob_pattern):
     """Converts a glob pattern to a PostgreSQL LIKE pattern."""
@@ -308,9 +301,9 @@ def create_table():
 
 def get_config_yaml(key: str) -> Optional[config_utils.Config]:
     with orm.Session(SQLALCHEMY_ENGINE) as session:
-        row = session.query(config_yaml_table).filter_by(key=key).first()
+        row = session.query(config_table).filter_by(key=key).first()
     if row:
-        return config_utils.Config(yaml.safe_load(row.yaml))
+        return config_utils.Config(yaml.safe_load(row.value))
     return None
 
 
@@ -325,11 +318,11 @@ def set_config_yaml(key: str, config: config_utils.Config):
             insert_func = postgresql.insert
         else:
             raise ValueError('Unsupported database dialect')
-        insert_stmnt = insert_func(config_yaml_table).values(key=key,
-                                                             yaml=config_str)
+        insert_stmnt = insert_func(config_table).values(key=key,
+                                                        value=config_str)
         do_update_stmt = insert_stmnt.on_conflict_do_update(
-            index_elements=[config_yaml_table.c.key],
-            set_={config_yaml_table.c.yaml: config_str})
+            index_elements=[config_table.c.key],
+            set_={config_table.c.value: config_str})
         session.execute(do_update_stmt)
         session.commit()
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -29,6 +29,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import context_utils
 from sky.utils import db_utils
 from sky.utils import registry
@@ -351,7 +352,9 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
     if saved_db_config_str:
         # if a saved config exists, merge config from db into skypilot_config
         # and use the merged config to update the db.
-        saved_db_config = yaml.safe_load(saved_db_config_str)
+        saved_db_config = config_utils.Config(
+            yaml.safe_load(saved_db_config_str))
+        saved_db_config.pop_nested(('db',), None)
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -756,8 +756,8 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     return parsed_config
 
 
-def update_config_no_lock(config: config_utils.Config,
-                          update_db: bool = True) -> None:
+def update_api_server_config_no_lock(config: config_utils.Config,
+                                     update_db: bool = True) -> None:
     """Dumps the new config to a file and syncs to ConfigMap if in Kubernetes.
 
     Args:
@@ -781,5 +781,5 @@ def update_config_no_lock(config: config_utils.Config,
         if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             logger.debug('saving api_server config to db')
             global_user_state.set_config_yaml(
-                'api_server', common_utils.dump_yaml_str(dict(config)))
+                global_user_state.API_SERVER_CONFIG_KEY, config)
     _reload_config()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -762,10 +762,11 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
     Args:
         config: The config to save and sync.
     """
+    # import here to avoid circular import
+    from sky import global_user_state  # pylint: disable=import-outside-toplevel
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
         global_config_path = get_user_config_path()
-
     # Always save to the local file (PVC in Kubernetes, local file otherwise)
     common_utils.dump_yaml(global_config_path, dict(config))
 
@@ -774,5 +775,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         # PVC file is the source of truth, ConfigMap is just a mirror for easy
         # access
         config_map_utils.patch_configmap_with_config(config, global_config_path)
-
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        logger.debug('saving api_server config to db')
+        global_user_state.set_config_yaml(
+            'api_server', common_utils.dump_yaml_str(dict(config)))
     _reload_config()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -766,6 +766,7 @@ def update_api_server_config_no_lock(config: config_utils.Config,
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
         global_config_path = get_user_config_path()
+
     # Always save to the local file (PVC in Kubernetes, local file otherwise)
     common_utils.dump_yaml(global_config_path, dict(config))
 
@@ -775,11 +776,11 @@ def update_api_server_config_no_lock(config: config_utils.Config,
         # access
         config_map_utils.patch_configmap_with_config(config, global_config_path)
     if update_db:
-        # import here to avoid circular import
-        # pylint: disable=import-outside-toplevel
-        from sky import global_user_state
         if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             logger.debug('saving api_server config to db')
+            # import here to avoid circular import
+            # pylint: disable=import-outside-toplevel
+            from sky import global_user_state
             global_user_state.set_config_yaml(
                 global_user_state.API_SERVER_CONFIG_KEY, config)
     _reload_config()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -756,14 +756,13 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     return parsed_config
 
 
-def update_api_server_config_no_lock(config: config_utils.Config) -> None:
+def update_config_no_lock(config: config_utils.Config,
+                          update_db: bool = True) -> None:
     """Dumps the new config to a file and syncs to ConfigMap if in Kubernetes.
 
     Args:
         config: The config to save and sync.
     """
-    # import here to avoid circular import
-    from sky import global_user_state  # pylint: disable=import-outside-toplevel
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
         global_config_path = get_user_config_path()
@@ -775,8 +774,12 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         # PVC file is the source of truth, ConfigMap is just a mirror for easy
         # access
         config_map_utils.patch_configmap_with_config(config, global_config_path)
-    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-        logger.debug('saving api_server config to db')
-        global_user_state.set_config_yaml(
-            'api_server', common_utils.dump_yaml_str(dict(config)))
+    if update_db:
+        # import here to avoid circular import
+        # pylint: disable=import-outside-toplevel
+        from sky import global_user_state
+        if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+            logger.debug('saving api_server config to db')
+            global_user_state.set_config_yaml(
+                'api_server', common_utils.dump_yaml_str(dict(config)))
     _reload_config()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Configuration file is stashed to DB.

If a config file exists and DB record both exist, DB record is overlaid on top of config file and this config is both committed to db and to the file.

To change the DB record, one can use the dashboard's config edit feature.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual: config is committed to DB and is used if config file is deleted.
- [x] Manual: DB config is overlaid on top of config file if both sources exist.
- [x] Manual: empty config is not committed to db.
- [x] Manual: `db:` field is ignored in the config stashing logic.
- [x] Manual: Editing config via dashboard results in both the config file and DB config being updated.
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
