### PR TITLE
[Core] make autostop in task the source of truth

### DIFF
--- a/examples/admin_policy/example_policy/example_policy/__init__.py
+++ b/examples/admin_policy/example_policy/example_policy/__init__.py
@@ -5,3 +5,4 @@ from example_policy.skypilot_policy import DynamicKubernetesContextsUpdatePolicy
 from example_policy.skypilot_policy import EnforceAutostopPolicy
 from example_policy.skypilot_policy import RejectAllPolicy
 from example_policy.skypilot_policy import UseSpotForGpuPolicy
+from example_policy.skypilot_policy import SetMaxAutostopIdleMinutesPolicy

--- a/examples/admin_policy/example_policy/example_policy/__init__.py
+++ b/examples/admin_policy/example_policy/example_policy/__init__.py
@@ -4,5 +4,5 @@ from example_policy.skypilot_policy import DisablePublicIpPolicy
 from example_policy.skypilot_policy import DynamicKubernetesContextsUpdatePolicy
 from example_policy.skypilot_policy import EnforceAutostopPolicy
 from example_policy.skypilot_policy import RejectAllPolicy
-from example_policy.skypilot_policy import UseSpotForGpuPolicy
 from example_policy.skypilot_policy import SetMaxAutostopIdleMinutesPolicy
+from example_policy.skypilot_policy import UseSpotForGpuPolicy

--- a/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
@@ -136,6 +136,27 @@ class EnforceAutostopPolicy(sky.AdminPolicy):
             skypilot_config=user_request.skypilot_config)
 
 
+class SetMaxAutostopIdleMinutesPolicy(sky.AdminPolicy):
+    """Example policy: set max autostop idle minutes for all tasks."""
+
+    @classmethod
+    def validate_and_mutate(
+            cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
+        """Sets max autostop idle minutes for all tasks."""
+        max_idle_minutes = 10
+        task = user_request.task
+        for r in task.resources:
+            disabled = (r.autostop_config is None or
+                        not r.autostop_config.enabled)
+            too_long = (not disabled and
+                        r.autostop_config.idle_minutes is not None and
+                        r.autostop_config.idle_minutes > max_idle_minutes)
+            if disabled or too_long:
+                r.override_autostop_config(idle_minutes=max_idle_minutes)
+
+        return sky.MutatedUserRequest(
+            task=task, skypilot_config=user_request.skypilot_config)
+
 def update_current_kubernetes_clusters_from_registry():
     """Mock implementation of updating kubernetes clusters from registry."""
     # All cluster names can be fetched from an organization's internal API.

--- a/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
@@ -157,6 +157,7 @@ class SetMaxAutostopIdleMinutesPolicy(sky.AdminPolicy):
         return sky.MutatedUserRequest(
             task=task, skypilot_config=user_request.skypilot_config)
 
+
 def update_current_kubernetes_clusters_from_registry():
     """Mock implementation of updating kubernetes clusters from registry."""
     # All cluster names can be fetched from an organization's internal API.

--- a/examples/admin_policy/set_max_autostop_idle_minutes.yaml
+++ b/examples/admin_policy/set_max_autostop_idle_minutes.yaml
@@ -1,0 +1,1 @@
+admin_policy: example_policy.SetMaxAutostopIdleMinutesPolicy

--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -21,6 +21,11 @@ class RequestOptions:
         dryrun: Is the request a dryrun?
     """
     cluster_name: Optional[str]
+    # Keep these two fields for backward compatibility. The values are copied
+    # from task.resources.autostop_config, so that legacy admin policy plugins
+    # can still read the correct autostop config from request options before
+    # we drop the compatibility.
+    # TODO(aylei): remove these fields after 0.12.0
     idle_minutes_to_autostop: Optional[int]
     down: bool
     dryrun: bool

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -400,18 +400,22 @@ def launch(
         retry_until_up: whether to retry launching the cluster until it is
           up.
         idle_minutes_to_autostop: automatically stop the cluster after this
-          many minute of idleness, i.e., no running or pending jobs in the
-          cluster's job queue. Idleness gets reset whenever setting-up/
-          running/pending jobs are found in the job queue. Setting this
-          flag is equivalent to running ``sky.launch()`` and then
-          ``sky.autostop(idle_minutes=<minutes>)``. If not set, the cluster
-          will not be autostopped.
+            many minute of idleness, i.e., no running or pending jobs in the
+            cluster's job queue. Idleness gets reset whenever setting-up/
+            running/pending jobs are found in the job queue. Setting this
+            flag is equivalent to running
+            ``sky.launch(...)`` and then
+            ``sky.autostop(idle_minutes=<minutes>)``. If set, the autostop
+            config specified in the task' resources will be overridden by
+            this parameter.
         dryrun: if True, do not actually launch the cluster.
         down: Tear down the cluster after all jobs finish (successfully or
-          abnormally). If --idle-minutes-to-autostop is also set, the
-          cluster will be torn down after the specified idle time.
-          Note that if errors occur during provisioning/data syncing/setting
-          up, the cluster will not be torn down for debugging purposes.
+            abnormally). If --idle-minutes-to-autostop is also set, the
+            cluster will be torn down after the specified idle time.
+            Note that if errors occur during provisioning/data syncing/setting
+            up, the cluster will not be torn down for debugging purposes. If
+            set, the autostop config specified in the task' resources will be
+            overridden by this parameter.
         backend: backend to use.  If None, use the default backend
           (CloudVMRayBackend).
         optimize_target: target to optimize for. Choices: OptimizeTarget.COST,
@@ -468,12 +472,28 @@ def launch(
                                       'Please contact the SkyPilot team if you '
                                       'need this feature at slack.skypilot.co.')
     dag = dag_utils.convert_entrypoint_to_dag(task)
+    # Override the autostop config from command line flags to task YAML.
+    for task in dag.tasks:
+        for resource in task.resources:
+            resource.override_autostop_config(
+                down=down, idle_minutes=idle_minutes_to_autostop)
+            if resource.autostop_config is not None:
+                # For backward-compatbility, get the final autostop config for
+                # admin policy.
+                # TODO(aylei): remove this after 0.12.0
+                down = resource.autostop_config.down
+                idle_minutes_to_autostop = resource.autostop_config.idle_minutes
+
     request_options = admin_policy.RequestOptions(
         cluster_name=cluster_name,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
         down=down,
         dryrun=dryrun)
     validate(dag, admin_policy_request_options=request_options)
+    # The flags have been applied to the task YAML and the backward
+    # compatibility of admin policy has been handled. We should no longer use
+    # these flags.
+    del down, idle_minutes_to_autostop
 
     confirm_shown = False
     if _need_confirmation:
@@ -537,9 +557,7 @@ def launch(
         task=dag_str,
         cluster_name=cluster_name,
         retry_until_up=retry_until_up,
-        idle_minutes_to_autostop=idle_minutes_to_autostop,
         dryrun=dryrun,
-        down=down,
         backend=backend.NAME if backend else None,
         optimize_target=optimize_target,
         no_setup=no_setup,

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -176,6 +176,15 @@ def _execute(
             for storage in task.storage_mounts.values():
                 # Ensure the storage is constructed.
                 storage.construct()
+        for resource in task.resources:
+            # For backward compatibility, we need to override the autostop
+            # config at server-side for legacy clients.
+            # TODO(aylei): remove this after we bump the API version.
+            resource.override_autostop_config(
+                down=down, idle_minutes=idle_minutes_to_autostop)
+            if resource.autostop_config is not None:
+                down = resource.autostop_config.down
+                idle_minutes_to_autostop = resource.autostop_config.idle_minutes
     with admin_policy_utils.apply_and_use_config_in_current_request(
             dag,
             request_options=admin_policy.RequestOptions(
@@ -187,7 +196,6 @@ def _execute(
         return _execute_dag(
             dag,
             dryrun=dryrun,
-            down=down,
             stream_logs=stream_logs,
             handle=handle,
             backend=backend,
@@ -197,7 +205,6 @@ def _execute(
             cluster_name=cluster_name,
             detach_setup=detach_setup,
             detach_run=detach_run,
-            idle_minutes_to_autostop=idle_minutes_to_autostop,
             no_setup=no_setup,
             clone_disk_from=clone_disk_from,
             skip_unnecessary_provisioning=skip_unnecessary_provisioning,
@@ -210,7 +217,6 @@ def _execute(
 def _execute_dag(
     dag: 'sky.Dag',
     dryrun: bool,
-    down: bool,
     stream_logs: bool,
     handle: Optional[backends.ResourceHandle],
     backend: Optional[backends.Backend],
@@ -220,7 +226,6 @@ def _execute_dag(
     cluster_name: Optional[str],
     detach_setup: bool,
     detach_run: bool,
-    idle_minutes_to_autostop: Optional[int],
     no_setup: bool,
     clone_disk_from: Optional[str],
     skip_unnecessary_provisioning: bool,
@@ -280,38 +285,33 @@ def _execute_dag(
     # we aren't sure which resources will be launched, and different
     # resources may have different autostop configs.
     if isinstance(backend, backends.CloudVmRayBackend):
-        if down and idle_minutes_to_autostop is None:
-            # Use auto{stop,down} to terminate the cluster after the task is
-            # done.
-            idle_minutes_to_autostop = 0
-        elif not down and idle_minutes_to_autostop is None:
-            # No autostop config specified on command line, use the
-            # config from resources.
-            # TODO(cooperc): This should be done after provisioning, in order to
-            # support different autostop configs for different resources.
-            # Blockers:
-            # - Need autostop config to set requested_features before
-            #   provisioning.
-            # - Need to send info message about idle_minutes_to_autostop==0 here
-            # - Need to check if autostop is supported by the backend.
-            resources = list(task.resources)
-            for resource in resources:
-                if resource.autostop_config != resources[0].autostop_config:
-                    raise ValueError(
-                        'All resources must have the same autostop config.')
-            resource_autostop_config = resources[0].autostop_config
+        # No autostop config specified on command line, use the
+        # config from resources.
+        # TODO(cooperc): This should be done after provisioning, in order to
+        # support different autostop configs for different resources.
+        # Blockers:
+        # - Need autostop config to set requested_features before
+        #   provisioning.
+        # - Need to send info message about idle_minutes_to_autostop==0 here
+        # - Need to check if autostop is supported by the backend.
+        resources = list(task.resources)
+        for resource in resources:
+            if resource.autostop_config != resources[0].autostop_config:
+                raise ValueError(
+                    'All resources must have the same autostop config.')
+        resource_autostop_config = resources[0].autostop_config
 
-            if resource_autostop_config is not None:
-                if resource_autostop_config.enabled:
-                    idle_minutes_to_autostop = (
-                        resource_autostop_config.idle_minutes)
-                    down = resource_autostop_config.down
-                else:
-                    # Autostop is explicitly disabled, so cancel it if it's
-                    # already set.
-                    assert not resource_autostop_config.enabled
-                    idle_minutes_to_autostop = -1
-                    down = False
+        if resource_autostop_config is not None:
+            if resource_autostop_config.enabled:
+                idle_minutes_to_autostop = (
+                    resource_autostop_config.idle_minutes)
+                down = resource_autostop_config.down
+            else:
+                # Autostop is explicitly disabled, so cancel it if it's
+                # already set.
+                assert not resource_autostop_config.enabled
+                idle_minutes_to_autostop = -1
+                down = False
         if idle_minutes_to_autostop is not None:
             if idle_minutes_to_autostop == 0:
                 # idle_minutes_to_autostop=0 can cause the following problem:
@@ -337,13 +337,6 @@ def _execute_dag(
         # NOTE: in general we may not have sufficiently specified info
         # (cloud/resource) to check STOP_SPOT_INSTANCE here. This is checked in
         # the backend.
-
-    elif idle_minutes_to_autostop is not None:
-        # TODO(zhwu): Autostop is not supported for non-CloudVmRayBackend.
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                f'Backend {backend.NAME} does not support autostop, please try'
-                f' {backends.CloudVmRayBackend.NAME}')
 
     if Stage.CLONE_DISK in stages:
         task = _maybe_clone_disk_from_cluster(clone_disk_from, cluster_name,
@@ -529,13 +522,16 @@ def launch(
             running/pending jobs are found in the job queue. Setting this
             flag is equivalent to running
             ``sky.launch(...)`` and then
-            ``sky.autostop(idle_minutes=<minutes>)``. If not set, the cluster
-            will not be autostopped.
+            ``sky.autostop(idle_minutes=<minutes>)``. If set, the autostop
+            config specified in the task' resources will be overridden by
+            this parameter.
         down: Tear down the cluster after all jobs finish (successfully or
             abnormally). If --idle-minutes-to-autostop is also set, the
             cluster will be torn down after the specified idle time.
             Note that if errors occur during provisioning/data syncing/setting
-            up, the cluster will not be torn down for debugging purposes.
+            up, the cluster will not be torn down for debugging purposes. If
+            set, the autostop config specified in the task' resources will be
+            overridden by this parameter.
         dryrun: if True, do not actually launch the cluster.
         stream_logs: if True, show the logs in the terminal.
         backend: backend to use.  If None, use the default backend

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -301,6 +301,8 @@ def _execute_dag(
                     'All resources must have the same autostop config.')
         resource_autostop_config = resources[0].autostop_config
 
+        idle_minutes_to_autostop: Optional[int] = None
+        down = False
         if resource_autostop_config is not None:
             if resource_autostop_config.enabled:
                 idle_minutes_to_autostop = (

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -883,6 +883,25 @@ class Resources:
             valid_volumes.append(volume)
         self._volumes = valid_volumes
 
+    def override_autostop_config(self,
+                                 down: bool = False,
+                                 idle_minutes: Optional[int] = None) -> None:
+        """Override autostop config to the resource.
+
+        Args:
+            down: If true, override the autostop config to use autodown.
+            idle_minutes: If not None, override the idle minutes to autostop or
+                autodown.
+        """
+        if not down and idle_minutes is None:
+            return
+        if self._autostop_config is None:
+            self._autostop_config = AutostopConfig(enabled=True,)
+        if down:
+            self._autostop_config.down = down
+        if idle_minutes is not None:
+            self._autostop_config.idle_minutes = idle_minutes
+
     def is_launchable(self) -> bool:
         """Returns whether the resource is launchable."""
         return self.cloud is not None and self._instance_type is not None

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -196,8 +196,10 @@ class LaunchBody(RequestBody):
     task: str
     cluster_name: str
     retry_until_up: bool = False
+    # TODO(aylei): remove this field in v0.12.0
     idle_minutes_to_autostop: Optional[int] = None
     dryrun: bool = False
+    # TODO(aylei): remove this field in v0.12.0
     down: bool = False
     backend: Optional[str] = None
     optimize_target: common_lib.OptimizeTarget = common_lib.OptimizeTarget.COST

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -181,7 +181,7 @@ class TestBackwardCompatibility:
         cluster_name = smoke_tests_utils.get_cluster_name()
         task_yaml = textwrap.dedent("""\
             resources:
-            autostop:
+              autostop:
                 idle_minutes: 5
             """)
 

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -179,7 +179,10 @@ class TestBackwardCompatibility:
         cluster_name = smoke_tests_utils.get_cluster_name()
         commands = [
             f'{self.ACTIVATE_BASE} && {self.SKY_API_RESTART} && '
-            f'sky launch --cloud {generic_cloud} -y {smoke_tests_utils.LOW_RESOURCE_ARG} --num-nodes 2 -c {cluster_name} examples/minimal.yaml',
+            # Set intiial autostop in base
+            f'sky launch --cloud {generic_cloud} -y {smoke_tests_utils.LOW_RESOURCE_ARG} --num-nodes 2 -c {cluster_name} tests/test_yamls/autostop.yaml',
+            f'sky status | grep {cluster_name} | grep "5m"',
+            # Change the autostop time in current
             f'{self.ACTIVATE_CURRENT} && {self.SKY_API_RESTART} && sky autostop -y -i0 {cluster_name}',
             f"""
             {self.ACTIVATE_CURRENT} && {smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -1,6 +1,8 @@
 import os
 import pathlib
 import subprocess
+import tempfile
+import textwrap
 from typing import Sequence
 
 import pytest
@@ -177,10 +179,21 @@ class TestBackwardCompatibility:
     def test_autostop_functionality(self, generic_cloud: str):
         """Test autostop functionality across versions"""
         cluster_name = smoke_tests_utils.get_cluster_name()
+        task_yaml = textwrap.dedent("""\
+            resources:
+            autostop:
+                idle_minutes: 5
+            """)
+
+        with tempfile.NamedTemporaryFile(prefix='autostop_',
+                                         delete=False,
+                                         mode='w') as f:
+            f.write(task_yaml)
+            yaml_path = f.name
         commands = [
             f'{self.ACTIVATE_BASE} && {self.SKY_API_RESTART} && '
             # Set intiial autostop in base
-            f'sky launch --cloud {generic_cloud} -y {smoke_tests_utils.LOW_RESOURCE_ARG} --num-nodes 2 -c {cluster_name} tests/test_yamls/autostop.yaml',
+            f'sky launch --cloud {generic_cloud} -y {smoke_tests_utils.LOW_RESOURCE_ARG} --num-nodes 2 -c {cluster_name} {yaml_path}',
             f'sky status | grep {cluster_name} | grep "5m"',
             # Change the autostop time in current
             f'{self.ACTIVATE_CURRENT} && {self.SKY_API_RESTART} && sky autostop -y -i0 {cluster_name}',

--- a/tests/test_yamls/autostop.yaml
+++ b/tests/test_yamls/autostop.yaml
@@ -1,0 +1,3 @@
+resources:
+  autostop:
+    idle_minutes: 5

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -217,12 +217,15 @@ def test_set_max_autostop_idle_minutes_policy(add_example_policy_paths, task):
     # Test with resources having different autostop configurations
     task.set_resources([
         # Resource with autostop over limit (should be capped at 10 minutes)
-        sky.Resources(cpus='16+', autostop={'idle_minutes': 20, 'down': True}),
+        sky.Resources(cpus='16+', autostop={
+            'idle_minutes': 20,
+            'down': True
+        }),
     ])
-    
+
     dag, _ = _load_task_and_apply_policy(
         task, os.path.join(POLICY_PATH, 'set_max_autostop_idle_minutes.yaml'))
-    
+
     resources = dag.tasks[0].resources
 
     assert resources[0].autostop_config is not None

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -203,3 +203,29 @@ def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):
     assert skypilot_config.get_nested(
         ('kubernetes', 'allowed_contexts'),
         None) is None, 'Global skypilot config should be restored after request'
+
+
+def test_set_max_autostop_idle_minutes_policy(add_example_policy_paths, task):
+    # Test with task that has no specific autostop configuration
+    dag, _ = _load_task_and_apply_policy(
+        task, os.path.join(POLICY_PATH, 'set_max_autostop_idle_minutes.yaml'))
+    for resource in dag.tasks[0].resources:
+        assert resource.autostop_config is not None
+        assert resource.autostop_config.enabled is True
+        assert resource.autostop_config.idle_minutes == 10
+
+    # Test with resources having different autostop configurations
+    task.set_resources([
+        # Resource with autostop over limit (should be capped at 10 minutes)
+        sky.Resources(cpus='16+', autostop={'idle_minutes': 20, 'down': True}),
+    ])
+    
+    dag, _ = _load_task_and_apply_policy(
+        task, os.path.join(POLICY_PATH, 'set_max_autostop_idle_minutes.yaml'))
+    
+    resources = dag.tasks[0].resources
+
+    assert resources[0].autostop_config is not None
+    assert resources[0].autostop_config.enabled is True
+    assert resources[0].autostop_config.idle_minutes == 10
+    assert resources[0].autostop_config.down is True  # default

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -665,6 +665,7 @@ def test_network_tier_repr():
     repr_str = str(r)
     assert 'network_tier=standard' in repr_str
 
+
 def test_autostop_config():
     """Test autostop config override functionality."""
     # Override with down=True when no existing autostop config
@@ -762,4 +763,3 @@ def test_autostop_config():
     assert r.autostop_config.enabled is False  # should remain disabled
     assert r.autostop_config.down is True
     assert r.autostop_config.idle_minutes == 55
-

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -664,3 +664,102 @@ def test_network_tier_repr():
     r = Resources(network_tier='standard')
     repr_str = str(r)
     assert 'network_tier=standard' in repr_str
+
+def test_autostop_config():
+    """Test autostop config override functionality."""
+    # Override with down=True when no existing autostop config
+    r = Resources()
+    assert r.autostop_config is None
+
+    r.override_autostop_config(down=True)
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is True
+    assert r.autostop_config.idle_minutes == 5  # default value
+
+    # Override with idle_minutes when no existing autostop config
+    r = Resources()
+    assert r.autostop_config is None
+
+    r.override_autostop_config(idle_minutes=10)
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is False  # default value
+    assert r.autostop_config.idle_minutes == 10
+
+    # Override with both down and idle_minutes when no existing config
+    r = Resources()
+    assert r.autostop_config is None
+
+    r.override_autostop_config(down=True, idle_minutes=15)
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is True
+    assert r.autostop_config.idle_minutes == 15
+
+    # Override when there's an existing autostop config
+    r = Resources(autostop={'idle_minutes': 20, 'down': False})
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is False
+    assert r.autostop_config.idle_minutes == 20
+
+    # Override only down flag
+    r.override_autostop_config(down=True)
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is True
+    assert r.autostop_config.idle_minutes == 20  # unchanged
+
+    # Override existing config with new idle_minutes
+    r = Resources(autostop={'idle_minutes': 25, 'down': True})
+    assert r.autostop_config.idle_minutes == 25
+    assert r.autostop_config.down is True
+
+    r.override_autostop_config(idle_minutes=30)
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is True  # unchanged
+    assert r.autostop_config.idle_minutes == 30
+
+    # Override existing config with both parameters
+    r = Resources(autostop={'idle_minutes': 35, 'down': False})
+    r.override_autostop_config(down=True, idle_minutes=40)
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is True
+    assert r.autostop_config.idle_minutes == 40
+
+    # Call override with default parameters (should do nothing)
+    r = Resources()
+    assert r.autostop_config is None
+
+    r.override_autostop_config()  # both parameters are default (False, None)
+    assert r.autostop_config is None  # should remain None
+
+    # Call override with default parameters on existing config
+    r = Resources(autostop={'idle_minutes': 45, 'down': True})
+    original_config = r.autostop_config
+
+    r.override_autostop_config()  # should do nothing
+    assert r.autostop_config is original_config  # same object
+    assert r.autostop_config.idle_minutes == 45  # unchanged
+    assert r.autostop_config.down is True  # unchanged
+
+    # Override with down=False (should still create config if none exists)
+    r = Resources()
+    assert r.autostop_config is None
+
+    r.override_autostop_config(down=False, idle_minutes=50)
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is True
+    assert r.autostop_config.down is False
+    assert r.autostop_config.idle_minutes == 50
+
+    # Test with disabled autostop config
+    r = Resources(autostop=False)
+    assert r.autostop_config is not None
+    assert r.autostop_config.enabled is False
+
+    r.override_autostop_config(down=True, idle_minutes=55)
+    assert r.autostop_config.enabled is False  # should remain disabled
+    assert r.autostop_config.down is True
+    assert r.autostop_config.idle_minutes == 55
+


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5642

Manual test:

**Task YAML**

```bash
$ cat task.yaml
resources:
  cloud: kubernetes
  autostop:
    idle_minutes: 5
```

**Enable the new policy**

```bash
$ cat ~/.sky/config.yaml
admin_policy: example_policy.SetMaxAutostopIdleMinutesPolicy
```

**sky launch failed since Kubernetes does not support autostop**

```bash
$ sky launch task.yaml
⨯ Failed to provision resources. View logs: sky api logs -l sky-2025-06-05-13-26-34-315923/provision.log
sky.exceptions.ResourcesUnavailableError: Failed to provision all possible launchable resources. Relax the task's resource requirements: 1x Kubernetes(cpus=1+)
...
```

**Override with autodown, succeed**

```bash
$ sky launch task.yaml --down
✓ Cluster launched: sky-b461-aylei
$ sky status
NAME            INFRA                                   RESOURCES               STATUS  AUTOSTOP    LAUNCHED
sky-b461-aylei  Kubernetes (gke_sky-dev...ypilotalpha)  1x(cpus=1, mem=1, ...)  UP      5m (down)   2 mins ago
```


**Override idle minutes to 15, should be capped by the admin policy**

```bash
$ sky launch task.yaml --down -i 15
✓ Cluster launched: sky-b245-aylei
$ sky status
NAME            INFRA                                   RESOURCES               STATUS  AUTOSTOP    LAUNCHED
sky-b245-aylei  Kubernetes (gke_sky-dev...ypilotalpha)  1x(cpus=1, mem=1, ...)  UP      10m (down)  42 secs ago
```

**Switch to master, test compatibility, Note that server still runs in the PR version**

```bash
$ git checkout master
$ sky launch task.yaml --down -i 15
✓ Cluster launched: sky-55b7-aylei.
$ sky status
NAME            INFRA                                   RESOURCES               STATUS  AUTOSTOP    LAUNCHED
sky-55b7-aylei  Kubernetes (gke_sky-dev...ypilotalpha)  1x(cpus=1, mem=1, ...)  UP      10m (down)  3 mins ago
```



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (see above)
- [x] Unit tests 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
