### PR TITLE
[Core] Support setting private workspace and adding users to it

### DIFF
--- a/sky/dashboard/src/components/workspace-editor.jsx
+++ b/sky/dashboard/src/components/workspace-editor.jsx
@@ -660,6 +660,10 @@ export function WorkspaceEditor({ workspaceName, isNewWorkspace = false }) {
                           <div className="p-3 bg-gray-50 border rounded-lg">
                             <pre className="text-xs font-mono text-gray-600 whitespace-pre-wrap">
                               {`${workspaceName || 'my-workspace'}:
+  private: true
+  allowed_users:
+    - user1
+    - user2
   gcp:
     project_id: xxx
     disabled: false

--- a/sky/users/model.conf
+++ b/sky/users/model.conf
@@ -12,4 +12,4 @@ g = _, _
 e = some(where (p.eft == allow))
 
 [matchers]
-m = g(r.sub, p.sub) && r.obj == p.obj && r.act == p.act
+m = (g(r.sub, p.sub)|| p.sub == '*') && r.obj == p.obj && r.act == p.act

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -20,6 +20,7 @@ import uuid
 import jsonschema
 
 from sky import exceptions
+from sky import models
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.skylet import constants
@@ -999,3 +1000,20 @@ def _get_cgroup_memory_limit() -> Optional[int]:
 def _is_cgroup_v2() -> bool:
     """Return True if the environment is running cgroup v2."""
     return os.path.isfile('/sys/fs/cgroup/cgroup.controllers')
+
+
+def get_workspace_users(workspace_config: Dict[str, Any],
+                        all_users: List[models.User]) -> List[str]:
+    """Get the private users for a workspace."""
+    if 'private' in workspace_config and workspace_config['private']:
+        user_ids = []
+        user_names = workspace_config['allowed_users']
+        all_users_map = {user.name: user.id for user in all_users}
+        for user_name in user_names:
+            if user_name not in all_users_map:
+                logger.warning(f'User {user_name} not found in all users')
+                continue
+            user_ids.append(all_users_map[user_name])
+        return user_ids
+    else:
+        return ['*']

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1249,6 +1249,15 @@ def get_config_schema():
             'properties': {
                 # Explicit definition for GCP allows both project_id and
                 # disabled
+                'private': {
+                    'type': 'boolean',
+                },
+                'allowed_users': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'string',
+                    },
+                },
                 'gcp': {
                     'type': 'object',
                     'properties': {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support setting a private workspace and adding users to it.
Configurations:
```
 <workspace>:
    private: true
    allowed_users:
    - user1
```
- The public workspaces can be accessed by all users
- The private workspace can be accessed by users with the `User` role in the `allowed_users` and users with the `Admin` role.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  See separate comment below. 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

TODO:
- [ ] Figure out how to get the active workspace in server side
- [ ] Show private workspace and allowed users in dashboard
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
