### PR TITLE
Support skip steps in nightly build

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -3,6 +3,17 @@ on:
   schedule:
     - cron: '35 10 * * *' # 10:35am UTC, 2:35am PST, 5:35am EST
   workflow_dispatch:
+    inputs:
+      skip_buildkite:
+        description: 'Skip Buildkite tests (smoke, backward-compat, etc.)'
+        required: false
+        default: false
+        type: boolean
+      skip_test_pypi:
+        description: 'Skip publishing to Test PyPI'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # nightly release check from https://stackoverflow.com/a/67527144
@@ -99,6 +110,7 @@ jobs:
 
   wait-for-buildkite:
     needs: extract-build-number
+    if: ${{ !inputs.skip_buildkite }}
     uses: ./.github/workflows/wait-for-buildkite.yml
     with:
       organization: "skypilot-1"
@@ -110,7 +122,7 @@ jobs:
 
   publish-and-validate-test-pypi:
     needs: [nightly-build-pypi, wait-for-buildkite]
-    if: needs.wait-for-buildkite.outputs.build_status == 'success'
+    if: ${{ !inputs.skip_test_pypi && (inputs.skip_buildkite || needs.wait-for-buildkite.outputs.build_status == 'success') }}
     uses: ./.github/workflows/publish-and-validate.yml
     with:
       package_name: skypilot-nightly


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This to skip steps if the previous workflow failed and we don't want to or cannot retry some steps.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
