### PR TITLE
Test case for k8s cli `show-gpus` without kubernetes dependency installed

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,16 +54,14 @@ jobs:
           source ~/test-env/bin/activate
           SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
 
-  limited-deps-test:
-    # Test with limited dependencies to ensure cloud module imports don't break
-    # basic functionality (e.g., importing IBM shouldn't break AWS support)
+  no-k8s-deps-test:
+    # Test to ensure cli show-gpus command works without k8s installed.
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.8"]
         test-path:
-          - tests/test_cli.py
-          - tests/test_jobs_and_serve.py
+          - tests/test_cli.py::TestNoK8sInstalled
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -78,12 +76,43 @@ jobs:
           source ~/test-env/bin/activate
           uv pip install --prerelease=allow "azure-cli>=2.65.0"
           # Install limited dependencies only
-          uv pip install -e ".[kubernetes,aws,gcp,azure]"
+          uv pip install -e ".[aws]"
           uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0
       - name: Run tests with pytest
         run: |
           source ~/test-env/bin/activate
           SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
+
+  limited-deps-test:
+      # Test with limited dependencies to ensure cloud module imports don't break
+      # basic functionality (e.g., importing IBM shouldn't break AWS support)
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-version: ["3.8"]
+          test-path:
+            - tests/test_cli.py
+            - tests/test_jobs_and_serve.py
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v3
+        - name: Install the latest version of uv
+          uses: astral-sh/setup-uv@v4
+          with:
+            version: "latest"
+            python-version: ${{ matrix.python-version }}
+        - name: Install limited dependencies
+          run: |
+            uv venv --seed ~/test-env
+            source ~/test-env/bin/activate
+            uv pip install --prerelease=allow "azure-cli>=2.65.0"
+            # Install limited dependencies only
+            uv pip install -e ".[kubernetes,aws,gcp,azure]"
+            uv pip install pytest pytest-xdist pytest-env>=0.6 pytest-asyncio memory-profiler==0.61.0
+        - name: Run tests with pytest
+          run: |
+            source ~/test-env/bin/activate
+            SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no ${{ matrix.test-path }}
 
   failover-test:
     # Test failover functionality


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Cover the test case from #5245.

This case is when the server has Kubernetes enabled but the client doesn't. It should work rather than raise an exception.

We test this case in pytest by mocking some functions:

* Make `show-gpus` think `kubernetes` is enabled and GPUs are available in `sdk.realtime_kubernetes_gpu_availability`
* Then show-gpus calls `get_kubernetes_node_info`, which raises `KubeAPIUnreachableError` in our test case
* The test should pass

We should avoid raising other exceptions like `ImportError`, which would cause the test to fail.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
