### PR TITLE
[SSH] Volume mounting for SSH Node Pools

### DIFF
--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -262,6 +262,8 @@ Volume mounting can be done directly in the task YAML on a per-task basis, or gl
     .. tab-item:: Nebius shared filesystem
       :name: ssh-volumes-nebius-shared-filesystem
 
+      SSH Node Pools running on Nebius VMs can access Nebius shared filesystems.
+
       When creating a VM on the Nebius console, attach your desired shared file system to the VM (``Create virtual machine`` -> ``Attach shared filesystem``):
 
       * Ensure ``Auto mount`` is enabled.

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -203,6 +203,118 @@ SkyPilot automatically select one with available resources.
     # Let SkyPilot automatically select the cluster with available resources.
     sky launch --infra ssh -- echo "Running on SkyPilot selected cluster"
 
+Attaching NFS and other volumes
+-------------------------------
+
+SkyPilot jobs can access NFS, shared disks or local high-performance storage like NVMe drives available on your host machines in a SSH Node Pool.
+
+Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/config.yaml`.
+
+.. tab-set::
+
+    .. tab-item:: Attaching a path on the host
+      :name: ssh-volumes-hostpath-nfs
+
+      Any path available on the host can be directly mounted to SkyPilot jobs. For example, to mount a NFS share available on the hosts:
+
+      **Per-task configuration:**
+
+      .. code-block:: yaml
+
+           # task.yaml
+           run: |
+             echo "Hello, world!" > /mnt/nfs/hello.txt
+             ls -la /mnt/nfs
+
+           config:
+             ssh:
+               pod_config:
+                 spec:
+                   containers:
+                     - volumeMounts:
+                         - mountPath: /mnt/nfs
+                           name: my-host-nfs
+                   volumes:
+                     - name: my-host-nfs
+                       hostPath:
+                         path: /path/on/host/nfs
+                         type: Directory
+
+      **Global configuration:**
+
+      .. code-block:: yaml
+
+           # ~/.sky/config.yaml
+           ssh:
+             pod_config:
+               spec:
+                 containers:
+                   - volumeMounts:
+                       - mountPath: /mnt/nfs
+                         name: my-host-nfs
+                 volumes:
+                   - name: my-host-nfs
+                     hostPath:
+                       path: /path/on/host/nfs
+                       type: Directory
+
+
+    .. tab-item:: Nebius shared filesystem
+      :name: ssh-volumes-nebius-shared-filesystem
+
+      When creating a VM on the Nebius console, attach your desired shared file system to the VM (``Create virtual machine`` -> ``Attach shared filesystem``):
+
+      * Ensure ``Auto mount`` is enabled.
+      * Note the ``Mount tag`` (e.g. ``filesystem-d0``).
+
+      .. image:: ../images/screenshots/nebius/nebius-k8s-attach-fs.png
+        :width: 50%
+        :align: center
+
+      Nebius will automatically mount the shared filesystem to all hosts. You can then attach the volume to your SkyPilot jobs:
+
+      **Per-task configuration:**
+
+      .. code-block:: yaml
+
+           # task.yaml
+           run: |
+             echo "Hello, world!" > /mnt/nfs/hello.txt
+             ls -la /mnt/nfs
+
+           config:
+             ssh:
+               pod_config:
+                 spec:
+                   containers:
+                     - volumeMounts:
+                         - mountPath: /mnt/nfs
+                           name: nebius-sharedfs
+                   volumes:
+                     - name: nebius-sharedfs
+                       hostPath:
+                         path: /mnt/<mount_tag> # e.g. /mnt/filesystem-d0
+                         type: Directory
+
+      **Global configuration:**
+
+      .. code-block:: yaml
+
+           # ~/.sky/config.yaml
+           ssh:
+             pod_config:
+               spec:
+                 containers:
+                   - volumeMounts:
+                       - mountPath: /mnt/nfs
+                         name: nebius-sharedfs
+                 volumes:
+                   - name: nebius-sharedfs
+                     hostPath:
+                       path: /mnt/<mount_tag> # e.g. /mnt/filesystem-d0
+                       type: Directory
+
+
 Cleanup
 -------
 

--- a/docs/source/reservations/existing-machines.rst
+++ b/docs/source/reservations/existing-machines.rst
@@ -206,13 +206,13 @@ SkyPilot automatically select one with available resources.
 Attaching NFS and other volumes
 -------------------------------
 
-SkyPilot jobs can access NFS, shared disks or local high-performance storage like NVMe drives available on your host machines in a SSH Node Pool.
+SkyPilot jobs can access NFS, shared disks, or local high-performance storage like NVMe drives available on your host machines in a SSH Node Pool.
 
 Volume mounting can be done directly in the task YAML on a per-task basis, or globally for all tasks in :code:`~/.sky/config.yaml`.
 
 .. tab-set::
 
-    .. tab-item:: Attaching a path on the host
+    .. tab-item:: Mounting a path on the host (NFS)
       :name: ssh-volumes-hostpath-nfs
 
       Any path available on the host can be directly mounted to SkyPilot jobs. For example, to mount a NFS share available on the hosts:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -815,7 +815,9 @@ def write_cluster_config(
     if isinstance(cloud, clouds.Kubernetes):
         cluster_config_overrides = to_provision.cluster_config_overrides
         kubernetes_utils.combine_pod_config_fields(
-            tmp_yaml_path, cluster_config_overrides=cluster_config_overrides)
+            tmp_yaml_path,
+            cluster_config_overrides=cluster_config_overrides,
+            cloud=cloud)
         kubernetes_utils.combine_metadata_fields(tmp_yaml_path)
         yaml_obj = common_utils.read_yaml(tmp_yaml_path)
         pod_config: Dict[str, Any] = yaml_obj['available_node_types'][

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2342,7 +2342,7 @@ def get_endpoint_debug_message() -> str:
 def combine_pod_config_fields(
     cluster_yaml_path: str,
     cluster_config_overrides: Dict[str, Any],
-    cloud: clouds.Cloud,
+    cloud: Optional[clouds.Cloud] = None,
 ) -> None:
     """Adds or updates fields in the YAML with fields from the
     ~/.sky/config.yaml's kubernetes.pod_spec dict.

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -367,6 +367,7 @@ RCLONE_CACHE_REFRESH_INTERVAL = 10
 OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('docker', 'run_options'),
     ('nvidia_gpus', 'disable_ecc'),
+    ('ssh', 'pod_config'),
     ('kubernetes', 'pod_config'),
     ('kubernetes', 'provision_timeout'),
     ('gcp', 'managed_instance_group'),


### PR DESCRIPTION
Adds docs and plumbing for mounting host paths into SkyPilot jobs running on SSH node pools.

Future TODO: support this through a more native file_mounts? This is a very common JTBD for fixed clusters.