### PR TITLE
[jobs] add manual preemption to dashboard/sdk

### DIFF
--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -32,6 +32,7 @@ import {
   RotateCwIcon,
   MonitorPlay,
   RefreshCcw,
+  StopCircle,
 } from 'lucide-react';
 import { handleJobAction } from '@/data/connectors/jobs';
 import { ConfirmationModal } from '@/components/elements/modals';
@@ -1034,6 +1035,16 @@ export function Status2Actions({
     });
   };
 
+  const handlePreemptClick = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      await handleJobAction('preempt', jobId);
+    } catch (error) {
+      console.error('Error preempting job:', error);
+    }
+  };
+
   return (
     <div className="flex items-center space-x-4">
       <Tooltip
@@ -1050,19 +1061,34 @@ export function Status2Actions({
         </button>
       </Tooltip>
       {managed && (
-        <Tooltip
-          key="controllerlogs"
-          content="View Controller Logs"
-          className="capitalize text-sm text-muted-foreground"
-        >
-          <button
-            onClick={(e) => handleLogsClick(e, 'controllerlogs')}
-            className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
+        <>
+          <Tooltip
+            key="controllerlogs"
+            content="View Controller Logs"
+            className="capitalize text-sm text-muted-foreground"
           >
-            <MonitorPlay className="w-4 h-4" />
-            {withLabel && <span className="ml-2">Controller Logs</span>}
-          </button>
-        </Tooltip>
+            <button
+              onClick={(e) => handleLogsClick(e, 'controllerlogs')}
+              className="text-sky-blue hover:text-sky-blue-bright font-medium inline-flex items-center h-8"
+            >
+              <MonitorPlay className="w-4 h-4" />
+              {withLabel && <span className="ml-2">Controller Logs</span>}
+            </button>
+          </Tooltip>
+          <Tooltip
+            key="preempt"
+            content="Preempt Job"
+            className="capitalize text-sm text-muted-foreground"
+          >
+            <button
+              onClick={handlePreemptClick}
+              className="text-red-600 hover:text-red-700 font-medium inline-flex items-center h-8"
+            >
+              <StopCircle className="w-4 h-4" />
+              {withLabel && <span className="ml-1.5">Preempt</span>}
+            </button>
+          </Tooltip>
+        </>
       )}
     </div>
   );

--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -363,6 +363,12 @@ export async function handleJobAction(action, jobId, cluster) {
       requestBody = { all_users: true, refresh: true };
       jobId = 'controller';
       break;
+    case 'preempt':
+      logStarter = 'Preempting';
+      logMiddle = 'preempted';
+      apiPath = 'jobs/preempt';
+      requestBody = { job_ids: [jobId] };
+      break;
     default:
       throw new Error(`Invalid action: ${action}`);
   }

--- a/sky/jobs/__init__.py
+++ b/sky/jobs/__init__.py
@@ -5,6 +5,7 @@ from sky.jobs.client.sdk import cancel
 from sky.jobs.client.sdk import dashboard
 from sky.jobs.client.sdk import download_logs
 from sky.jobs.client.sdk import launch
+from sky.jobs.client.sdk import preempt
 from sky.jobs.client.sdk import queue
 from sky.jobs.client.sdk import tail_logs
 from sky.jobs.constants import JOBS_CLUSTER_NAME_PREFIX_LENGTH
@@ -32,6 +33,7 @@ __all__ = [
     # Core
     'cancel',
     'launch',
+    'preempt',
     'queue',
     'tail_logs',
     'dashboard',

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -190,6 +190,20 @@ def cancel(
 
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
+def preempt(job_ids: List[int]) -> server_common.RequestId:
+    """Preempt managed jobs."""
+    body = payloads.JobsPreemptBody(job_ids=job_ids)
+    response = requests.post(
+        f'{server_common.get_server_url()}/jobs/preempt',
+        json=json.loads(body.model_dump_json()),
+        timeout=(5, None),
+        cookies=server_common.get_api_cookie_jar(),
+    )
+    return server_common.get_request_id(response=response)
+
+
+@usage_lib.entrypoint
+@server_common.check_server_healthy_or_start
 def tail_logs(name: Optional[str] = None,
               job_id: Optional[int] = None,
               follow: bool = True,

--- a/sky/jobs/constants.py
+++ b/sky/jobs/constants.py
@@ -47,7 +47,7 @@ JOBS_CLUSTER_NAME_PREFIX_LENGTH = 25
 # The version of the lib files that jobs/utils use. Whenever there is an API
 # change for the jobs/utils, we need to bump this version and update
 # job.utils.ManagedJobCodeGen to handle the version update.
-MANAGED_JOBS_VERSION = 6
+MANAGED_JOBS_VERSION = 7
 
 # The command for setting up the jobs dashboard on the controller. It firstly
 # checks if the systemd services are available, and if not (e.g., Kubernetes

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -525,6 +525,25 @@ def cancel(name: Optional[str] = None,
 
 
 @usage_lib.entrypoint
+def preempt(job_ids: Optional[List[int]] = None) -> None:
+    """Preempt managed jobs."""
+    handle = backend_utils.is_controller_accessible(
+        controller=controller_utils.Controllers.JOBS_CONTROLLER,
+        stopped_message='No jobs are running.')
+    code = managed_job_utils.ManagedJobCodeGen.preempt_jobs_by_id(job_ids)
+    backend = backend_utils.get_backend_from_handle(handle)
+    assert isinstance(backend, backends.CloudVmRayBackend), backend
+    returncode, stdout, stderr = backend.run_on_head(handle,
+                                                     code,
+                                                     require_outputs=True,
+                                                     stream_logs=False)
+    subprocess_utils.handle_returncode(returncode, code,
+                                       'Failed to preempt managed job',
+                                       stdout + stderr)
+    logger.info(stdout)
+
+
+@usage_lib.entrypoint
 def tail_logs(name: Optional[str],
               job_id: Optional[int],
               follow: bool,

--- a/sky/jobs/server/server.py
+++ b/sky/jobs/server/server.py
@@ -61,6 +61,19 @@ async def cancel(request: fastapi.Request,
     )
 
 
+@router.post('/preempt')
+async def preempt(request: fastapi.Request,
+                  jobs_preempt_body: payloads.JobsPreemptBody) -> None:
+    executor.schedule_request(
+        request_id=request.state.request_id,
+        request_name='jobs.preempt',
+        request_body=jobs_preempt_body,
+        func=core.preempt,
+        schedule_type=api_requests.ScheduleType.SHORT,
+        request_cluster_name=common.JOB_CONTROLLER_NAME,
+    )
+
+
 @router.post('/logs')
 async def logs(
     request: fastapi.Request, jobs_logs_body: payloads.JobsLogsBody,

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -394,6 +394,11 @@ class JobsCancelBody(RequestBody):
     all_users: bool = False
 
 
+class JobsPreemptBody(RequestBody):
+    """The request body for the jobs preempt endpoint."""
+    job_ids: List[int]
+
+
 class JobsLogsBody(RequestBody):
     """The request body for the jobs logs endpoint."""
     name: Optional[str] = None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add a way to "preempt" a running managed job. It will delete the corresponding cluster, allowing the job to recover once there is another launch slot available with the right priority.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
