### PR TITLE
Support DB as a store for server-side config

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -498,13 +498,50 @@ In addition to basic HTTP authentication, SkyPilot also supports using an OAuth2
 
 Refer to :ref:`Using an Auth Proxy with the SkyPilot API Server <api-server-auth-proxy>` for detailed instructions on common OAuth2 providers, such as :ref:`Okta <oauth2-proxy-okta>` or Google Workspace.
 
+.. _api-server-persistence-db:
+
 Optional: Back the API server with a persistent database
 --------------------------------------------------------
 
-The API server can be backed with a persistent database to persist the user state and config.
+The API server can optionally be configured with a postgresSQL database to persist state.
 
-Refer to :ref:`Using a persistent database with the SkyPilot API Server <api-server-db>` for detailed instructions.
+If a persistent DB is not specified, API server uses a kubernetes persistent volume to persist state.
 
+.. note::
+
+  Database configuration must be set in the helm deployment.
+
+.. dropdown:: Set the config with helm deployment during the first deployment
+
+    To set the config file, pass ``--set-file apiService.config=path/to/your/config.yaml`` to the ``helm`` command:
+
+    .. code-block:: bash
+
+        # Create the config.yaml file
+        cat <<EOF > config.yaml
+        db: postgresql://<username>:<password>@<host>:<port>/<database>
+        EOF
+
+        # Install the API server with the config file
+        # --reuse-values keeps the Helm chart values set in the previous step
+        helm upgrade --install skypilot skypilot/skypilot-nightly --devel \
+        --namespace $NAMESPACE \
+        --reuse-values \
+        --set-file apiService.config=config.yaml
+
+    You can also directly set config values in the ``values.yaml`` file, e.g.:
+
+    .. code-block:: yaml
+
+        apiService:
+        config: |
+            db: postgresql://<username>:<password>@<host>:<port>/<database>
+
+    .. note::
+
+        If ``db`` is specified in the config, no other configuration parameter can be specified in the helm chart.
+
+        See ``Optional: Setting the SkyPilot config`` below for how to set other config values.
 
 Optional: Setting the SkyPilot config
 --------------------------------------

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -498,6 +498,14 @@ In addition to basic HTTP authentication, SkyPilot also supports using an OAuth2
 
 Refer to :ref:`Using an Auth Proxy with the SkyPilot API Server <api-server-auth-proxy>` for detailed instructions on common OAuth2 providers, such as :ref:`Okta <oauth2-proxy-okta>` or Google Workspace.
 
+Optional: Back the API server with a persistent database
+--------------------------------------------------------
+
+The API server can be backed with a persistent database to persist the user state and config.
+
+Refer to :ref:`Using a persistent database with the SkyPilot API Server <api-server-db>` for detailed instructions.
+
+
 Optional: Setting the SkyPilot config
 --------------------------------------
 

--- a/docs/source/reference/api-server/examples/api-server-persistence.rst
+++ b/docs/source/reference/api-server/examples/api-server-persistence.rst
@@ -17,6 +17,10 @@ to persistently back the SkyPilot state.
     While this document uses a GKE cluster with a GCP persistent disk as a backing volume,
     this guide is applicable to other managed k8s offerings that provide a CSI provider to a persistent storage device.
 
+.. note::
+
+    See :ref:`api-server-persistence-db` for an alternative way to persist the API server state using a postgresSQL database.
+
 TL;DR: Recover API server on another GKE cluster
 ------------------------------------------------
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1259,9 +1259,9 @@ Specify the database connection string to use for SkyPilot. If not specified, Sk
 If a postgres database URL is specified, SkyPilot will use the database to persist API server state.
 Currently, managed job controller state is not persisted in remote database even if `db` is specified.
 
-.. warning::
+.. note::
 
-  If `db` is specified in the config, no other configuration parameter can be specified in the config file.
+  If ``db`` is specified in the config, no other configuration parameter can be specified in the config file.
 
   Other configuration parameters can be set in the "Workspaces" tab of the web dashboard.
 

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1253,11 +1253,18 @@ Note: RBAC is only functional when :ref:`Auth Proxy <api-server-auth-proxy>` is 
 ``db``
 ~~~~~~
 
-Database configuration (optional).
+API Server Database configuration (optional).
 
 Specify the database connection string to use for SkyPilot. If not specified, SkyPilot will use a SQLite database initialized in ~/.sky directory.
 If a postgres database URL is specified, SkyPilot will use the database to persist API server state.
 Currently, managed job controller state is not persisted in remote database even if `db` is specified.
+
+.. warning::
+
+  If `db` is specified in the config, no other configuration parameter can be specified in the config file.
+
+  Other configuration parameters can be set in the "Workspaces" tab of the web dashboard.
+
 
 Example:
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -354,15 +354,14 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             file_config, saved_db_config)
         if overlaid_config != file_config:
-            # update the db here instead of having
-            # update_api_server_config_no_lock
-            # handle db update to avoid circular import
             skypilot_config.update_api_server_config_no_lock(overlaid_config,
                                                              update_db=False)
+        if overlaid_config != saved_db_config:
             set_config_yaml(API_SERVER_CONFIG_KEY, overlaid_config)
     else:
         # if no saved config exists, stash the current config to db
         # if one exists.
+        file_config.pop_nested(('db',), None)
         if file_config:
             set_config_yaml(API_SERVER_CONFIG_KEY, file_config)
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -44,6 +44,7 @@ if typing.TYPE_CHECKING:
 logger = sky_logging.init_logger(__name__)
 
 _ENABLED_CLOUDS_KEY_PREFIX = 'enabled_clouds_'
+API_SERVER_CONFIG_KEY = 'api_server_config'
 
 Base = declarative.declarative_base()
 
@@ -306,15 +307,16 @@ def create_table():
         session.commit()
 
 
-def get_config_yaml(key: str) -> Optional[str]:
+def get_config_yaml(key: str) -> Optional[config_utils.Config]:
     with orm.Session(SQLALCHEMY_ENGINE) as session:
         row = session.query(config_yaml_table).filter_by(key=key).first()
     if row:
-        return row.yaml
+        return config_utils.Config(yaml.safe_load(row.yaml))
     return None
 
 
-def set_config_yaml(key: str, yaml_str: str):
+def set_config_yaml(key: str, config: config_utils.Config):
+    config_str = common_utils.dump_yaml_str(dict(config))
     with orm.Session(SQLALCHEMY_ENGINE) as session:
         if (SQLALCHEMY_ENGINE.dialect.name ==
                 db_utils.SQLAlchemyDialect.SQLITE.value):
@@ -325,10 +327,10 @@ def set_config_yaml(key: str, yaml_str: str):
         else:
             raise ValueError('Unsupported database dialect')
         insert_stmnt = insert_func(config_yaml_table).values(key=key,
-                                                             yaml=yaml_str)
+                                                             yaml=config_str)
         do_update_stmt = insert_stmnt.on_conflict_do_update(
             index_elements=[config_yaml_table.c.key],
-            set_={config_yaml_table.c.yaml: yaml_str})
+            set_={config_yaml_table.c.yaml: config_str})
         session.execute(do_update_stmt)
         session.commit()
 
@@ -345,29 +347,29 @@ else:
     SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
 create_table()
 
-saved_db_config_str = None
+saved_db_config = None
 if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-    saved_db_config_str = get_config_yaml('api_server')
-    config = skypilot_config.get_server_config()
-    config.pop_nested(('db',), None)
-    if saved_db_config_str:
+    saved_db_config = get_config_yaml(API_SERVER_CONFIG_KEY)
+    file_config = skypilot_config.get_server_config()
+    file_config.pop_nested(('db',), None)
+    if saved_db_config:
         # if a saved config exists, merge config from db into skypilot_config
         # and use the merged config to update the db.
-        saved_db_config = config_utils.Config(
-            yaml.safe_load(saved_db_config_str))
         saved_db_config.pop_nested(('db',), None)
         overlaid_config = skypilot_config.overlay_skypilot_config(
-            config, saved_db_config)
-        if overlaid_config != config:
-            # update the db here instead of having update_config_no_lock
+            file_config, saved_db_config)
+        if overlaid_config != file_config:
+            # update the db here instead of having
+            # update_api_server_config_no_lock
             # handle db update to avoid circular import
-            skypilot_config.update_config_no_lock(overlaid_config,
-                                                  update_db=False)
-            set_config_yaml('api_server',
-                            common_utils.dump_yaml_str(dict(overlaid_config)))
+            skypilot_config.update_api_server_config_no_lock(overlaid_config,
+                                                             update_db=False)
+            set_config_yaml(API_SERVER_CONFIG_KEY, overlaid_config)
     else:
-        # if no saved config exists, stash the current config to db.
-        set_config_yaml('api_server', common_utils.dump_yaml_str(dict(config)))
+        # if no saved config exists, stash the current config to db
+        # if one exists.
+        if file_config:
+            set_config_yaml(API_SERVER_CONFIG_KEY, file_config)
 
 
 def add_or_update_user(user: models.User):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -305,21 +305,8 @@ def create_table():
         session.commit()
 
 
-conn_string = None
-if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-    conn_string = skypilot_config.get_nested(('db',), None)
-if conn_string:
-    logger.debug(f'using db URI from {conn_string}')
-    SQLALCHEMY_ENGINE = sqlalchemy.create_engine(conn_string)
-else:
-    _DB_PATH = os.path.expanduser('~/.sky/state.db')
-    pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
-    SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
-create_table()
-
-
 def get_config_yaml(key: str) -> Optional[str]:
-    with orm.Session(_SQLALCHEMY_ENGINE) as session:
+    with orm.Session(SQLALCHEMY_ENGINE) as session:
         row = session.query(config_yaml_table).filter_by(key=key).first()
     if row:
         return row.yaml
@@ -327,11 +314,11 @@ def get_config_yaml(key: str) -> Optional[str]:
 
 
 def set_config_yaml(key: str, yaml_str: str):
-    with orm.Session(_SQLALCHEMY_ENGINE) as session:
-        if (_SQLALCHEMY_ENGINE.dialect.name ==
+    with orm.Session(SQLALCHEMY_ENGINE) as session:
+        if (SQLALCHEMY_ENGINE.dialect.name ==
                 db_utils.SQLAlchemyDialect.SQLITE.value):
             insert_func = sqlite.insert
-        elif (_SQLALCHEMY_ENGINE.dialect.name ==
+        elif (SQLALCHEMY_ENGINE.dialect.name ==
               db_utils.SQLAlchemyDialect.POSTGRESQL.value):
             insert_func = postgresql.insert
         else:
@@ -345,16 +332,38 @@ def set_config_yaml(key: str, yaml_str: str):
         session.commit()
 
 
+conn_string = None
+if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+    conn_string = skypilot_config.get_nested(('db',), None)
+if conn_string:
+    logger.debug(f'using db URI from {conn_string}')
+    SQLALCHEMY_ENGINE = sqlalchemy.create_engine(conn_string)
+else:
+    _DB_PATH = os.path.expanduser('~/.sky/state.db')
+    pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
+    SQLALCHEMY_ENGINE = sqlalchemy.create_engine('sqlite:///' + _DB_PATH)
+create_table()
+
 saved_db_config_str = None
 if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-    # if a saved config exists, merge config from db into skypilot_config
     saved_db_config_str = get_config_yaml('api_server')
-
-if saved_db_config_str:
-    saved_db_config = yaml.safe_load(saved_db_config_str)
-    overlaid_config = skypilot_config.overlay_skypilot_config(
-        skypilot_config.get_server_config(), saved_db_config)
-    skypilot_config.update_config_no_lock(overlaid_config)
+    config = skypilot_config.get_server_config()
+    config.pop_nested(('db',), None)
+    if saved_db_config_str:
+        # if a saved config exists, merge config from db into skypilot_config
+        # and use the merged config to update the db.
+        saved_db_config = yaml.safe_load(saved_db_config_str)
+        overlaid_config = skypilot_config.overlay_skypilot_config(
+            config, saved_db_config)
+        if overlaid_config != config:
+            logger.info('updating config to db')
+            skypilot_config.update_config_no_lock(overlaid_config)
+        else:
+            logger.info('no config update needed')
+    else:
+        # if no saved config exists, stash the current config to db.
+        logger.info('stashing config to db')
+        skypilot_config.update_config_no_lock(config)
 
 
 def add_or_update_user(user: models.User):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -362,7 +362,7 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             skypilot_config.update_config_no_lock(overlaid_config)
     else:
         # if no saved config exists, stash the current config to db.
-        skypilot_config.update_config_no_lock(config)
+        set_config_yaml('api_server', common_utils.dump_yaml_str(dict(config)))
 
 
 def add_or_update_user(user: models.User):

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -359,13 +359,9 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:
-            logger.info('updating config to db')
             skypilot_config.update_config_no_lock(overlaid_config)
-        else:
-            logger.info('no config update needed')
     else:
         # if no saved config exists, stash the current config to db.
-        logger.info('stashing config to db')
         skypilot_config.update_config_no_lock(config)
 
 

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -29,6 +29,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.skylet import constants
 from sky.utils import common_utils
+from sky.utils import config_utils
 from sky.utils import context_utils
 from sky.utils import db_utils
 from sky.utils import registry
@@ -352,7 +353,9 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
     if saved_db_config_str:
         # if a saved config exists, merge config from db into skypilot_config
         # and use the merged config to update the db.
-        saved_db_config = yaml.safe_load(saved_db_config_str)
+        saved_db_config = config_utils.Config(
+            yaml.safe_load(saved_db_config_str))
+        saved_db_config.pop_nested(('db',), None)
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -359,7 +359,12 @@ if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         overlaid_config = skypilot_config.overlay_skypilot_config(
             config, saved_db_config)
         if overlaid_config != config:
-            skypilot_config.update_config_no_lock(overlaid_config)
+            # update the db here instead of having update_config_no_lock
+            # handle db update to avoid circular import
+            skypilot_config.update_config_no_lock(overlaid_config,
+                                                  update_db=False)
+            set_config_yaml('api_server',
+                            common_utils.dump_yaml_str(dict(overlaid_config)))
     else:
         # if no saved config exists, stash the current config to db.
         set_config_yaml('api_server', common_utils.dump_yaml_str(dict(config)))

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -304,11 +304,14 @@ def get_config_yaml(key: str) -> Optional[config_utils.Config]:
     with orm.Session(SQLALCHEMY_ENGINE) as session:
         row = session.query(config_table).filter_by(key=key).first()
     if row:
-        return config_utils.Config(yaml.safe_load(row.value))
+        db_config = config_utils.Config(yaml.safe_load(row.value))
+        db_config.pop_nested(('db',), None)
+        return db_config
     return None
 
 
 def set_config_yaml(key: str, config: config_utils.Config):
+    config.pop_nested(('db',), None)
     config_str = common_utils.dump_yaml_str(dict(config))
     with orm.Session(SQLALCHEMY_ENGINE) as session:
         if (SQLALCHEMY_ENGINE.dialect.name ==
@@ -344,11 +347,9 @@ saved_db_config = None
 if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
     saved_db_config = get_config_yaml(API_SERVER_CONFIG_KEY)
     file_config = skypilot_config.get_server_config()
-    file_config.pop_nested(('db',), None)
     if saved_db_config:
         # if a saved config exists, merge config from db into skypilot_config
         # and use the merged config to update the db.
-        saved_db_config.pop_nested(('db',), None)
         overlaid_config = skypilot_config.overlay_skypilot_config(
             file_config, saved_db_config)
         if overlaid_config != file_config:

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -759,8 +759,8 @@ def apply_cli_config(cli_config: Optional[List[str]]) -> Dict[str, Any]:
     return parsed_config
 
 
-def update_config_no_lock(config: config_utils.Config,
-                          update_db: bool = True) -> None:
+def update_api_server_config_no_lock(config: config_utils.Config,
+                                     update_db: bool = True) -> None:
     """Dumps the new config to a file and syncs to ConfigMap if in Kubernetes.
 
     Args:
@@ -793,5 +793,5 @@ def update_config_no_lock(config: config_utils.Config,
         if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             logger.debug('saving api_server config to db')
             global_user_state.set_config_yaml(
-                'api_server', common_utils.dump_yaml_str(dict(config)))
+                global_user_state.API_SERVER_CONFIG_KEY, config)
     _reload_config()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -774,10 +774,11 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
             constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
         raise ValueError('This function can only be called by the API Server.')
 
+    # import here to avoid circular import
+    from sky import global_user_state  # pylint: disable=import-outside-toplevel
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
         global_config_path = get_user_config_path()
-
     # Always save to the local file (PVC in Kubernetes, local file otherwise)
     common_utils.dump_yaml(global_config_path, dict(config))
 
@@ -786,5 +787,8 @@ def update_api_server_config_no_lock(config: config_utils.Config) -> None:
         # PVC file is the source of truth, ConfigMap is just a mirror for easy
         # access
         config_map_utils.patch_configmap_with_config(config, global_config_path)
-
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        logger.debug('saving api_server config to db')
+        global_user_state.set_config_yaml(
+            'api_server', common_utils.dump_yaml_str(dict(config)))
     _reload_config()

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -59,10 +59,9 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import filelock
 import sqlalchemy
-from sqlalchemy import db_utils
 from sqlalchemy import orm
-from sqlalchemy import postgresql
-from sqlalchemy import sqlite
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import sqlite
 from sqlalchemy.ext import declarative
 
 from sky import exceptions
@@ -72,6 +71,7 @@ from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import context
+from sky.utils import db_utils
 from sky.utils import schemas
 from sky.utils import ux_utils
 from sky.utils.kubernetes import config_map_utils
@@ -586,6 +586,9 @@ def _reload_config_as_server() -> None:
             create_table()
         db_config = get_config_yaml(API_SERVER_CONFIG_KEY)
         if db_config:
+            if sky_logging.logging_enabled(logger, sky_logging.DEBUG):
+                logger.debug(f'Config loaded from db:\n'
+                             f'{common_utils.dump_yaml_str(dict(db_config))}')
             server_config = overlay_skypilot_config(server_config, db_config)
 
     _set_loaded_config(server_config)

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -778,6 +778,7 @@ def update_api_server_config_no_lock(config: config_utils.Config,
     global_config_path = _resolve_server_config_path()
     if global_config_path is None:
         global_config_path = get_user_config_path()
+
     # Always save to the local file (PVC in Kubernetes, local file otherwise)
     common_utils.dump_yaml(global_config_path, dict(config))
 
@@ -787,11 +788,11 @@ def update_api_server_config_no_lock(config: config_utils.Config,
         # access
         config_map_utils.patch_configmap_with_config(config, global_config_path)
     if update_db:
-        # import here to avoid circular import
-        # pylint: disable=import-outside-toplevel
-        from sky import global_user_state
         if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
             logger.debug('saving api_server config to db')
+            # import here to avoid circular import
+            # pylint: disable=import-outside-toplevel
+            from sky import global_user_state
             global_user_state.set_config_yaml(
                 global_user_state.API_SERVER_CONFIG_KEY, config)
     _reload_config()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If `db` is specified in server config, the config file is not allowed to contain any other config. Additional config can be supplied to the API server by using the dashboard (or REST API directly), which is persisted in the remote db.

To avoid circular import dependency between this package and `global_user_state.py`, I've had to initialize a separate DB engine here.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Manual: `db` field cannot be specified with any other config.
- [x] Manual: `db` field is ignored in clients.
- [x] Manual: `db` field cannot be updated via the dashboard.
- [x] Manual: If `db` is specified, config loaded from DB is used.
- [x] Manual: When config is updated via the dashboard and `db` field is not set, config file is updated.
- [x] Manual: When config is updated via the dashboard and `db` field is set, DB config is updated.
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
