### PR TITLE
[SSH] Enable `-f` in `sky ssh up`

### DIFF
--- a/sky/cli.py
+++ b/sky/cli.py
@@ -6274,13 +6274,18 @@ def ssh():
               is_flag=True,
               hidden=True,
               help='Run the command asynchronously.')
-def ssh_up(infra: Optional[str], async_call: bool):
-    """Set up a cluster using SSH targets from ~/.sky/ssh_node_pools.yaml.
+@click.option('--file',
+              '-f',
+              required=False,
+              help='The file containing the SSH targets.')
+def ssh_up(infra: Optional[str], async_call: bool, file: Optional[str]):
+    """Set up a cluster using SSH targets from a file. If not specified,
+    ~/.sky/ssh_node_pools.yaml will be used.
 
-    This command sets up a Kubernetes cluster on the machines specified in
-    ~/.sky/ssh_node_pools.yaml and configures SkyPilot to use it.
+    This command sets up a Kubernetes cluster on the machines specified in the
+    config file and configures SkyPilot to use it.
     """
-    request_id = sdk.ssh_up(infra=infra)
+    request_id = sdk.ssh_up(infra=infra, file=file)
     if async_call:
         print(f'Request submitted with ID: {request_id}')
     else:

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -524,6 +524,17 @@ class SSHUpBody(RequestBody):
     cleanup: bool = False
 
 
+class UpdateSSHNodePoolsBody(RequestBody):
+    """The request body for the update ssh node pools endpoint."""
+    pools_config: Dict[str, Any]
+
+
+class UploadSSHKeyBody(RequestBody):
+    """The request body for the upload ssh key endpoint."""
+    key_name: str
+    key_content: str
+
+
 class ServeTerminateReplicaBody(RequestBody):
     """The request body for the serve terminate replica endpoint."""
     service_name: str

--- a/sky/ssh_node_pools/core.py
+++ b/sky/ssh_node_pools/core.py
@@ -34,6 +34,13 @@ class SSHNodePoolManager:
         except Exception as e:
             raise RuntimeError(f"Failed to save SSH Node Pool config: {e}")
     
+
+    def update_pools(self, pools_config: Dict[str, Any]) -> None:
+        """Update SSH Node Pool configurations."""
+        all_pools = self.get_all_pools()
+        all_pools.update(pools_config)
+        self.save_all_pools(all_pools)
+    
     def add_or_update_pool(self, pool_name: str, pool_config: Dict[str, Any]) -> None:
         """Add or update a single SSH Node Pool configuration."""
         # Validate pool configuration
@@ -102,7 +109,7 @@ def get_all_pools() -> Dict[str, Any]:
 def update_pools(pools_config: Dict[str, Any]) -> None:
     """Update SSH Node Pool configurations."""
     manager = SSHNodePoolManager()
-    manager.save_all_pools(pools_config)
+    manager.update_pools(pools_config)
 
 
 def delete_pool(pool_name: str) -> bool:

--- a/sky/ssh_node_pools/server.py
+++ b/sky/ssh_node_pools/server.py
@@ -5,6 +5,9 @@ import fastapi
 
 from sky.ssh_node_pools import core
 from sky.utils import common_utils
+from sky.server.requests import payloads
+from sky.server.requests import executor
+from sky.server.requests import requests as requests_lib
 
 router = fastapi.APIRouter()
 
@@ -22,11 +25,17 @@ async def get_ssh_node_pools() -> Dict[str, Any]:
 
 
 @router.post('')
-async def update_ssh_node_pools(pools_config: Dict[str, Any]) -> Dict[str, str]:
+async def update_ssh_node_pools(request: fastapi.Request,
+                                update_ssh_node_pools_body: payloads.UpdateSSHNodePoolsBody) -> None:
     """Update SSH Node Pool configurations."""
     try:
-        core.update_pools(pools_config)
-        return {"status": "success"}
+        executor.schedule_request(
+            request_id=request.state.request_id,
+            request_name='update_ssh_node_pools',
+            request_body=update_ssh_node_pools_body,
+            func=core.update_pools,
+            schedule_type=requests_lib.ScheduleType.LONG,
+        )
     except Exception as e:
         raise fastapi.HTTPException(
             status_code=400,
@@ -55,7 +64,7 @@ async def delete_ssh_node_pool(pool_name: str) -> Dict[str, str]:
 
 
 @router.post('/keys')
-async def upload_ssh_key(request: fastapi.Request) -> Dict[str, str]:
+async def upload_ssh_key(request: fastapi.Request) -> None:
     """Upload SSH private key."""
     try:
         form = await request.form()
@@ -69,9 +78,16 @@ async def upload_ssh_key(request: fastapi.Request) -> Dict[str, str]:
             )
         
         key_content = await key_file.read()
-        key_path = core.upload_ssh_key(key_name, key_content.decode())
+        body = payloads.UploadSSHKeyBody(key_name=key_name, key_content=key_content.decode())
+        executor.schedule_request(
+            request_id=request.state.request_id,
+            request_name='upload_ssh_key',
+            request_body=body,
+            func=core.upload_ssh_key,
+            schedule_type=requests_lib.ScheduleType.LONG,
+        )
         
-        return {"status": "success", "key_path": key_path}
+        # return {"status": "success", "key_path": key_path}
     except fastapi.HTTPException:
         raise
     except Exception as e:

--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Set
 import yaml
 
 from sky.utils import ux_utils
+from sky.utils.kubernetes import ssh_utils
 
 # Colors for nicer UX
 RED = '\033[0;31m'
@@ -24,36 +25,12 @@ YELLOW = '\033[1;33m'
 WARNING_YELLOW = '\x1b[33m'
 NC = '\033[0m'  # No color
 
-DEFAULT_SSH_NODE_POOLS_PATH = os.path.expanduser('~/.sky/ssh_node_pools.yaml')
 DEFAULT_KUBECONFIG_PATH = os.path.expanduser('~/.kube/config')
 SSH_CONFIG_PATH = os.path.expanduser('~/.ssh/config')
 NODE_POOLS_INFO_DIR = os.path.expanduser('~/.sky/ssh_node_pools_info')
 
 # Get the directory of this script
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-class UniqueKeySafeLoader(yaml.SafeLoader):
-    """Custom YAML loader that raises an error if there are duplicate keys."""
-
-    def construct_mapping(self, node, deep=False):
-        mapping = {}
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            if key in mapping:
-                raise yaml.constructor.ConstructorError(
-                    note=(f'Duplicate cluster config for cluster {key!r}.\n'
-                          'Please remove one of them from: '
-                          f'{DEFAULT_SSH_NODE_POOLS_PATH}'))
-            value = self.construct_object(value_node, deep=deep)
-            mapping[key] = value
-        return mapping
-
-
-# Register the custom constructor inside the class
-UniqueKeySafeLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    UniqueKeySafeLoader.construct_mapping)
 
 
 def parse_args():
@@ -64,9 +41,9 @@ def parse_args():
     parser.add_argument(
         '--ssh-node-pools-file',
         dest='ssh_node_pools_file',
-        default=DEFAULT_SSH_NODE_POOLS_PATH,
+        default=ssh_utils.DEFAULT_SSH_NODE_POOLS_PATH,
         help=
-        f'Path to SSH node pools YAML file (default: {DEFAULT_SSH_NODE_POOLS_PATH})'
+        f'Path to SSH node pools YAML file (default: {ssh_utils.DEFAULT_SSH_NODE_POOLS_PATH})'
     )
     parser.add_argument(
         '--kubeconfig-path',
@@ -115,143 +92,6 @@ def parse_args():
     )
 
     return parser.parse_args()
-
-
-def load_ssh_targets(file_path: str) -> Dict[str, Any]:
-    """Load SSH targets from YAML file."""
-    if not os.path.exists(file_path):
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'SSH Node Pools file not found: {file_path}')
-
-    try:
-        with open(file_path, 'r', encoding='utf-8') as f:
-            targets = yaml.load(f, Loader=UniqueKeySafeLoader)
-        return targets
-    except yaml.constructor.ConstructorError as e:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(e.note) from e
-    except (yaml.YAMLError, IOError, OSError) as e:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(f'Error loading SSH Node Pools file: {e}') from e
-
-
-def check_host_in_ssh_config(hostname: str) -> bool:
-    """Return True iff *hostname* matches at least one `Host`/`Match` stanza
-    in the user's OpenSSH client configuration (including anything pulled in
-    via Include).
-
-    It calls:  ssh -vvG <hostname> -o ConnectTimeout=0
-    which:
-      • -G  expands the effective config without connecting
-      • -vv prints debug lines that show which stanzas are applied
-      • ConnectTimeout=0 avoids a DNS lookup if <hostname> is a FQDN/IP
-
-    No config files are opened or parsed manually.
-
-    Parameters
-    ----------
-    hostname : str
-        The alias/IP/FQDN you want to test.
-
-    Returns
-    -------
-    bool
-        True  – a specific stanza matched the host
-        False – nothing but the global defaults (`Host *`) applied
-    """
-    # We direct stderr→stdout because debug output goes to stderr.
-    proc = subprocess.run(
-        ['ssh', '-vvG', hostname, '-o', 'ConnectTimeout=0'],
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        check=False,  # we only want the text, not to raise
-    )
-
-    # Look for lines like:
-    #   debug1: ~/.ssh/config line 42: Applying options for <hostname>
-    # Anything other than "*"
-    pattern = re.compile(r'^debug\d+: .*Applying options for ([^*].*)$',
-                         re.MULTILINE)
-
-    return bool(pattern.search(proc.stdout))
-
-
-def get_cluster_config(targets: Dict[str, Any],
-                       cluster_name: Optional[str] = None,
-                       file_path: Optional[str] = None) -> Dict[str, Any]:
-    """Get configuration for specific clusters or all clusters."""
-    if not targets:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                f'No clusters defined in SSH Node Pools file {file_path}')
-
-    if cluster_name:
-        if cluster_name not in targets:
-            with ux_utils.print_exception_no_traceback():
-                raise ValueError(f'Cluster {cluster_name!r} not found in '
-                                 f'SSH Node Pools file {file_path}')
-        return {cluster_name: targets[cluster_name]}
-
-    # Return all clusters if no specific cluster is specified
-    return targets
-
-
-def prepare_hosts_info(cluster_name: str,
-                       cluster_config: Dict[str, Any]) -> List[Dict[str, str]]:
-    """Prepare list of hosts with resolved user, identity_file, and password."""
-    if 'hosts' not in cluster_config or not cluster_config['hosts']:
-        with ux_utils.print_exception_no_traceback():
-            raise ValueError(
-                f'No hosts defined in cluster {cluster_name} configuration')
-
-    # Get cluster-level defaults
-    cluster_user = cluster_config.get('user', '')
-    cluster_identity_file = cluster_config.get('identity_file', '')
-    cluster_password = cluster_config.get('password', '')
-
-    hosts_info = []
-    for host in cluster_config['hosts']:
-        # Host can be a string (IP or SSH config hostname) or a dict
-        if isinstance(host, str):
-            # Check if this is an SSH config hostname
-            is_ssh_config_host = check_host_in_ssh_config(host)
-
-            hosts_info.append({
-                'ip': host,
-                'user': '' if is_ssh_config_host else cluster_user,
-                'identity_file': '' if is_ssh_config_host else
-                                 cluster_identity_file,
-                'password': cluster_password,
-                'use_ssh_config': is_ssh_config_host
-            })
-        else:
-            # It's a dict with potential overrides
-            if 'ip' not in host:
-                print(
-                    f'{RED}Warning: Host missing \'ip\' field, skipping: {host}{NC}'
-                )
-                continue
-
-            # Check if this is an SSH config hostname
-            is_ssh_config_host = check_host_in_ssh_config(host['ip'])
-
-            # Use host-specific values or fall back to cluster defaults
-            host_user = '' if is_ssh_config_host else host.get(
-                'user', cluster_user)
-            host_identity_file = '' if is_ssh_config_host else host.get(
-                'identity_file', cluster_identity_file)
-            host_password = host.get('password', cluster_password)
-
-            hosts_info.append({
-                'ip': host['ip'],
-                'user': host_user,
-                'identity_file': host_identity_file,
-                'password': host_password,
-                'use_ssh_config': is_ssh_config_host
-            })
-
-    return hosts_info
 
 
 def run_command(cmd, shell=False):
@@ -660,10 +500,10 @@ def main():
         password = args.password
 
         # Check if hosts are in SSH config
-        head_use_ssh_config = global_use_ssh_config or check_host_in_ssh_config(
+        head_use_ssh_config = global_use_ssh_config or ssh_utils.check_host_in_ssh_config(
             head_node)
         worker_use_ssh_config = [
-            global_use_ssh_config or check_host_in_ssh_config(node)
+            global_use_ssh_config or ssh_utils.check_host_in_ssh_config(node)
             for node in worker_nodes
         ]
 
@@ -673,8 +513,8 @@ def main():
                        kubeconfig_path, args.cleanup)
     else:
         # Using YAML configuration
-        targets = load_ssh_targets(args.ssh_node_pools_file)
-        clusters_config = get_cluster_config(targets,
+        targets = ssh_utils.load_ssh_targets(args.ssh_node_pools_file)
+        clusters_config = ssh_utils.get_cluster_config(targets,
                                              args.infra,
                                              file_path=args.ssh_node_pools_file)
 
@@ -690,7 +530,7 @@ def main():
                 print(f'SKYPILOT_CURRENT_CLUSTER: {cluster_name}')
                 print(
                     f'{YELLOW}==== Deploying cluster: {cluster_name} ====${NC}')
-                hosts_info = prepare_hosts_info(cluster_name, cluster_config)
+                hosts_info = ssh_utils.prepare_hosts_info(cluster_name, cluster_config)
 
                 if not hosts_info:
                     print(
@@ -728,7 +568,7 @@ def main():
                                 f'Cluster configuration has changed for field {key!r}. '
                                 f'Previous value: {history.get(key)}, '
                                 f'Current value: {cluster_config.get(key)}')
-                    history_hosts_info = prepare_hosts_info(
+                    history_hosts_info = ssh_utils.prepare_hosts_info(
                         cluster_name, history)
                     if history_hosts_info[0] != hosts_info[0]:
                         raise ValueError(

--- a/sky/utils/kubernetes/ssh_utils.py
+++ b/sky/utils/kubernetes/ssh_utils.py
@@ -1,0 +1,193 @@
+import re
+import subprocess
+import os,uuid
+import yaml
+from typing import Dict, Any, Optional, List, Callable
+
+from sky.utils import ux_utils
+
+DEFAULT_SSH_NODE_POOLS_PATH = os.path.expanduser('~/.sky/ssh_node_pools.yaml')
+RED = '\033[0;31m'
+NC = '\033[0m'  # No color
+
+def check_host_in_ssh_config(hostname: str) -> bool:
+    """Return True iff *hostname* matches at least one `Host`/`Match` stanza
+    in the user's OpenSSH client configuration (including anything pulled in
+    via Include).
+
+    It calls:  ssh -vvG <hostname> -o ConnectTimeout=0
+    which:
+      • -G  expands the effective config without connecting
+      • -vv prints debug lines that show which stanzas are applied
+      • ConnectTimeout=0 avoids a DNS lookup if <hostname> is a FQDN/IP
+
+    No config files are opened or parsed manually.
+
+    Parameters
+    ----------
+    hostname : str
+        The alias/IP/FQDN you want to test.
+
+    Returns
+    -------
+    bool
+        True  – a specific stanza matched the host
+        False – nothing but the global defaults (`Host *`) applied
+    """
+    # We direct stderr→stdout because debug output goes to stderr.
+    proc = subprocess.run(
+        ['ssh', '-vvG', hostname, '-o', 'ConnectTimeout=0'],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,  # we only want the text, not to raise
+    )
+
+    # Look for lines like:
+    #   debug1: ~/.ssh/config line 42: Applying options for <hostname>
+    # Anything other than "*"
+    pattern = re.compile(r'^debug\d+: .*Applying options for ([^*].*)$',
+                         re.MULTILINE)
+
+    return bool(pattern.search(proc.stdout))
+
+
+class UniqueKeySafeLoader(yaml.SafeLoader):
+    """Custom YAML loader that raises an error if there are duplicate keys."""
+
+    def construct_mapping(self, node, deep=False):
+        mapping = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    note=(f'Duplicate cluster config for cluster {key!r}.\n'
+                          'Please remove one of them from: '
+                          f'{DEFAULT_SSH_NODE_POOLS_PATH}'))
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping
+
+
+# Register the custom constructor inside the class
+UniqueKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    UniqueKeySafeLoader.construct_mapping)
+
+
+def load_ssh_targets(file_path: str) -> Dict[str, Any]:
+    """Load SSH targets from YAML file."""
+    if not os.path.exists(file_path):
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'SSH Node Pools file not found: {file_path}')
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            targets = yaml.load(f, Loader=UniqueKeySafeLoader)
+        return targets
+    except yaml.constructor.ConstructorError as e:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(e.note) from e
+    except (yaml.YAMLError, IOError, OSError) as e:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(f'Error loading SSH Node Pools file: {e}') from e
+
+
+def get_cluster_config(targets: Dict[str, Any],
+                       cluster_name: Optional[str] = None,
+                       file_path: str = DEFAULT_SSH_NODE_POOLS_PATH) -> Dict[str, Any]:
+    """Get configuration for specific clusters or all clusters."""
+    if not targets:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'No clusters defined in SSH Node Pools file {file_path}')
+
+    if cluster_name:
+        if cluster_name not in targets:
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Cluster {cluster_name!r} not found in '
+                                 f'SSH Node Pools file {file_path}')
+        return {cluster_name: targets[cluster_name]}
+
+    # Return all clusters if no specific cluster is specified
+    return targets
+
+
+def prepare_hosts_info(cluster_name: str,
+                       cluster_config: Dict[str, Any],
+                       upload_ssh_key_func: Optional[Callable[[str, str], str]] = None) -> List[Dict[str, str]]:
+    """Prepare list of hosts with resolved user, identity_file, and password."""
+    if 'hosts' not in cluster_config or not cluster_config['hosts']:
+        with ux_utils.print_exception_no_traceback():
+            raise ValueError(
+                f'No hosts defined in cluster {cluster_name} configuration')
+
+    # Get cluster-level defaults
+    cluster_user = cluster_config.get('user', '')
+    cluster_identity_file = cluster_config.get('identity_file', '')
+    cluster_password = cluster_config.get('password', '')
+
+    use_cluster_config_msg = (f'Cluster {cluster_name} uses SSH config '
+                                     'for hostname {host}, which is not '
+                                     'supported by the -f flag. Please use a '
+                                     'dict with `ip` field instead.')
+
+    def _maybe_hardcode_identity_file(i: int, identity_file: str) -> str:
+        if upload_ssh_key_func is None:
+            return identity_file
+        if not os.path.exists(os.path.expanduser(identity_file)):
+            with ux_utils.print_exception_no_traceback():
+                raise ValueError(f'Identity file {identity_file} does not exist.')
+        key_name = f'{cluster_name}-{i}-{str(uuid.uuid4())[:4]}'
+        key_file_on_api_server = upload_ssh_key_func(key_name, identity_file)
+        print(f'Uploaded SSH key {key_name} -> {key_file_on_api_server}')
+        return key_file_on_api_server
+
+    hosts_info = []
+    for i,host in enumerate(cluster_config['hosts']):
+        # Host can be a string (IP or SSH config hostname) or a dict
+        if isinstance(host, str):
+            # Check if this is an SSH config hostname
+            is_ssh_config_host = check_host_in_ssh_config(host)
+            if upload_ssh_key_func is not None and is_ssh_config_host:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(use_cluster_config_msg.format(host=host))
+
+            hosts_info.append({
+                'ip': host,
+                'user': '' if is_ssh_config_host else cluster_user,
+                'identity_file': '' if is_ssh_config_host else
+                                 _maybe_hardcode_identity_file(i, cluster_identity_file),
+                'password': cluster_password,
+                'use_ssh_config': is_ssh_config_host
+            })
+        else:
+            # It's a dict with potential overrides
+            if 'ip' not in host:
+                print(
+                    f'{RED}Warning: Host missing \'ip\' field, skipping: {host}{NC}'
+                )
+                continue
+
+            # Check if this is an SSH config hostname
+            is_ssh_config_host = check_host_in_ssh_config(host['ip'])
+            if upload_ssh_key_func is not None and is_ssh_config_host:
+                with ux_utils.print_exception_no_traceback():
+                    raise ValueError(use_cluster_config_msg.format(host=host))
+
+            # Use host-specific values or fall back to cluster defaults
+            host_user = '' if is_ssh_config_host else host.get(
+                'user', cluster_user)
+            host_identity_file = '' if is_ssh_config_host else _maybe_hardcode_identity_file(i, host.get(
+                'identity_file', cluster_identity_file))
+            host_password = host.get('password', cluster_password)
+
+            hosts_info.append({
+                'ip': host['ip'],
+                'user': host_user,
+                'identity_file': host_identity_file,
+                'password': host_password,
+                'use_ssh_config': is_ssh_config_host
+            })
+
+    return hosts_info


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Tested with `sky ssh up --infra clsclient -f @temp/node_pool.yaml`

```yaml
# @temp/node_pool.yaml
cls:
  hosts:
    - dummy-host
clsclient:
  hosts:
    - ip: 3.230.128.92
      user: ubuntu
      identity_file: ~/.sky/generated/ssh-keys/sky-4cf4-tianxia.key

```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
