### PR TITLE
[SSH Node Pools] Allow `sky ssh down` to pass on host config change

### DIFF
--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -723,14 +723,16 @@ def main():
                 # Do not support changing anything besides hosts for now
                 if history is not None:
                     for key in ['user', 'identity_file', 'password']:
-                        if history.get(key) != cluster_config.get(key):
+                        if not args.cleanup and history.get(
+                                key) != cluster_config.get(key):
                             raise ValueError(
                                 f'Cluster configuration has changed for field {key!r}. '
                                 f'Previous value: {history.get(key)}, '
                                 f'Current value: {cluster_config.get(key)}')
                     history_hosts_info = prepare_hosts_info(
                         cluster_name, history)
-                    if history_hosts_info[0] != hosts_info[0]:
+                    if not args.cleanup and history_hosts_info[0] != hosts_info[
+                            0]:
                         raise ValueError(
                             f'Cluster configuration has changed for master node. '
                             f'Previous value: {history_hosts_info[0]}, '
@@ -860,7 +862,7 @@ def deploy_cluster(head_node,
         use_ssh_config=head_use_ssh_config,
         # For SkySSHUpLineProcessor
         print_output=True)
-    if result is None:
+    if not cleanup and result is None:
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError(
                 f'Failed to SSH to head node ({head_node}). '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
