### PR TITLE
Refactor release pipeline -- fix the skip options in nightly build

### DIFF
--- a/.github/workflows/buildkite-trigger-wait.yml
+++ b/.github/workflows/buildkite-trigger-wait.yml
@@ -1,0 +1,91 @@
+name: Buildkite Trigger and Wait
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        required: true
+        type: string
+        description: "Commit SHA to trigger build for"
+      branch:
+        required: false
+        type: string
+        default: "master"
+        description: "Branch to trigger build for"
+      message:
+        required: true
+        type: string
+        description: "Message for the build"
+      pipeline:
+        required: true
+        type: string
+        description: "Buildkite pipeline name (e.g., skypilot-1/smoke-tests)"
+      build_env_vars:
+        required: false
+        type: string
+        default: '{}'
+        description: "JSON string of environment variables to pass to the build"
+      timeout_minutes:
+        required: false
+        type: number
+        default: 120
+        description: "Timeout in minutes for waiting"
+      wait:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to wait for the build to complete"
+      fail_on_buildkite_failure:
+        required: false
+        type: boolean
+        default: true
+        description: "Whether to fail the job if the Buildkite build fails"
+    secrets:
+      BUILDKITE_TOKEN:
+        required: true
+        description: "Buildkite API token with read access"
+    outputs:
+      build_number:
+        description: "Buildkite build number"
+        value: ${{ jobs.extract-buildkite.outputs.build_number }}
+      build_status:
+        description: "Final status of the build (success, failure, timeout)"
+        value: ${{ jobs.wait-for-buildkite.outputs.build_status }}
+
+jobs:
+  trigger-buildkite:
+    runs-on: ubuntu-latest
+    outputs:
+      json: ${{ steps.trigger_buildkite.outputs.json }}
+    steps:
+      # Trigger Buildkite smoke tests
+      - name: Trigger Buildkite Smoke Tests
+        id: trigger_buildkite
+        uses: buildkite/trigger-pipeline-action@v2.3.0
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: ${{ inputs.pipeline }}
+          branch: ${{ inputs.branch }}
+          commit: ${{ inputs.commit }}
+          message: ${{ inputs.message }}
+          ignore_pipeline_branch_filter: true
+          build_env_vars: ${{ inputs.build_env_vars }}
+
+  extract-buildkite:
+    needs: trigger-buildkite
+    uses: ./.github/workflows/extract-buildkite.yml
+    with:
+      json_data: ${{ needs.trigger-buildkite.outputs.json }}
+
+  wait-for-buildkite:
+    needs: extract-buildkite
+    if: ${{ inputs.wait }}
+    uses: ./.github/workflows/wait-for-buildkite.yml
+    with:
+      organization: "skypilot-1"
+      pipeline: ${{ inputs.pipeline }}
+      build_number: ${{ needs.extract-buildkite.outputs.build_number }}
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+      fail_on_buildkite_failure: ${{ inputs.fail_on_buildkite_failure }}
+    secrets:
+      BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/buildkite-trigger-wait.yml
+++ b/.github/workflows/buildkite-trigger-wait.yml
@@ -19,7 +19,7 @@ on:
       pipeline:
         required: true
         type: string
-        description: "Buildkite pipeline name (e.g., skypilot-1/smoke-tests)"
+        description: "Buildkite pipeline name (e.g., smoke-tests)"
       build_env_vars:
         required: false
         type: string

--- a/.github/workflows/buildkite-trigger-wait.yml
+++ b/.github/workflows/buildkite-trigger-wait.yml
@@ -64,7 +64,7 @@ jobs:
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: ${{ inputs.pipeline }}
+          pipeline: skypilot-1/${{ inputs.pipeline }}
           branch: ${{ inputs.branch }}
           commit: ${{ inputs.commit }}
           message: ${{ inputs.message }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,7 +16,6 @@ on:
         type: boolean
 
 jobs:
-  # nightly release check from https://stackoverflow.com/a/67527144
   check-date:
     runs-on: ubuntu-latest
     outputs:
@@ -36,7 +35,6 @@ jobs:
     needs: check-date
     if: ${{ needs.check-date.outputs.should_run != 'false' }}
     outputs:
-      buildkite_json: ${{ steps.trigger_buildkite.outputs.json }}
       version: ${{ steps.set-release-version.outputs.version }}
     steps:
       - name: Clone repository
@@ -59,7 +57,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: 'pip' # caching pip dependencies
+          cache: 'pip'
       - name: Install pypa/build
         run: >-
           python -m
@@ -89,62 +87,32 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-      # Trigger Buildkite smoke tests
-      - name: Trigger Buildkite Smoke Tests
-        if: ${{ !inputs.skip_buildkite }}
-        id: trigger_buildkite
-        uses: buildkite/trigger-pipeline-action@v2.3.0
-        with:
-          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "skypilot-1/smoke-tests"
-          branch: "master"
-          commit: "${{ github.sha }}"
-          message: "nightly-build-pypi"
-          ignore_pipeline_branch_filter: true
-          build_env_vars: '{"ARGS": "--aws"}'
-
-  extract-build-number:
+  smoke-tests:
     needs: nightly-build-pypi
-    uses: ./.github/workflows/extract-buildkite.yml
-    with:
-      json_data: ${{ needs.nightly-build-pypi.outputs.buildkite_json }}
-
-  wait-for-buildkite:
-    needs: extract-build-number
     if: ${{ !inputs.skip_buildkite }}
-    uses: ./.github/workflows/wait-for-buildkite.yml
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
-      organization: "skypilot-1"
-      pipeline: "smoke-tests"
-      build_number: ${{ needs.extract-build-number.outputs.build_number }}
+      commit: ${{ github.sha }}
+      branch: master
+      message: "nightly-build-pypi"
+      pipeline: "skypilot-1/smoke-tests"
+      build_env_vars: '{"ARGS": "--aws"}'
       timeout_minutes: 120
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
-  publish-and-validate-test-pypi:
-    needs: [nightly-build-pypi, wait-for-buildkite]
-    # Use `always()` to ensure this job runs even if the previous job are skipped.
-    if: ${{ !inputs.skip_test_pypi && (inputs.skip_buildkite || (always() && needs.wait-for-buildkite.result == 'success')) }}
-    uses: ./.github/workflows/publish-and-validate.yml
+  publish-and-validate-both:
+    needs: [nightly-build-pypi, smoke-tests]
+    if: ${{ inputs.skip_buildkite || (always() && needs.smoke-tests.result == 'success') }}
+    uses: ./.github/workflows/publish-and-validate-both.yml
     with:
       package_name: skypilot-nightly
       expected_version: ${{ needs.nightly-build-pypi.outputs.version }}
-      repository_type: 'test-pypi'
-    secrets: inherit
-
-  publish-and-validate-pypi:
-    needs: [nightly-build-pypi, publish-and-validate-test-pypi]
-    # Use `always()` to ensure this job runs even if the previous job are skipped.
-    if: ${{ inputs.skip_test_pypi || (always() && needs.publish-and-validate-test-pypi.result == 'success') }}
-    uses: ./.github/workflows/publish-and-validate.yml
-    with:
-      package_name: skypilot-nightly
-      expected_version: ${{ needs.nightly-build-pypi.outputs.version }}
-      repository_type: 'pypi'
+      skip_test_pypi: ${{ inputs.skip_test_pypi }}
     secrets: inherit
 
   trigger-helm-release:
-    needs: [publish-and-validate-pypi]
+    needs: [publish-and-validate-both]
     uses: ./.github/workflows/helm-docker-release.yaml
     with:
       package_name: skypilot-nightly
@@ -152,7 +120,7 @@ jobs:
 
   notify-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-date, nightly-build-pypi, extract-build-number, wait-for-buildkite, publish-and-validate-test-pypi, publish-and-validate-pypi, trigger-helm-release]
+    needs: [check-date, nightly-build-pypi, smoke-tests, publish-and-validate-both, trigger-helm-release]
     if: failure() # Only run this job if any of the previous jobs failed
     steps:
       - name: Prepare failure message
@@ -162,8 +130,8 @@ jobs:
           COMMIT_SHA="${{ github.sha }}"
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
           SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
-          if [[ "${{ needs.wait-for-buildkite.result }}" == "failure" ]]; then
-            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed at Buildkite step for commit <${COMMIT_URL}|${SHORT_SHA}>. <https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.extract-build-number.outputs.build_number }}|Buildkite Log>"
+          if [[ "${{ needs.smoke-tests.result }}" == "failure" ]]; then
+            MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed at Buildkite step for commit <${COMMIT_URL}|${SHORT_SHA}>. <https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.smoke-tests.outputs.build_number }}|Buildkite Log>"
             echo "message_text=${TITLE_TEXT}" >> $GITHUB_OUTPUT
             echo "message_block=${MARKDOWN_TEXT}" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -95,7 +95,7 @@ jobs:
       commit: ${{ github.sha }}
       branch: master
       message: "nightly-build-pypi"
-      pipeline: "skypilot-1/smoke-tests"
+      pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--aws"}'
       timeout_minutes: 120
     secrets:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: 'pip'
+          cache: 'pip' # caching pip dependencies
       - name: Install pypa/build
         run: >-
           python -m

--- a/.github/workflows/publish-and-validate-both.yml
+++ b/.github/workflows/publish-and-validate-both.yml
@@ -1,0 +1,45 @@
+name: Publish and Validate Package to Both Repositories
+
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        description: 'Name of the package to validate (skypilot or skypilot-nightly)'
+        required: true
+        type: string
+      expected_version:
+        description: 'Expected version of the package'
+        required: true
+        type: string
+      skip_test_pypi:
+        description: 'Skip publishing to Test PyPI'
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      TEST_PYPI_API_TOKEN:
+        description: 'API token for Test PyPI'
+        required: true
+      PYPI_API_TOKEN:
+        description: 'API token for PyPI'
+        required: true
+
+jobs:
+  publish-and-validate-test-pypi:
+    if: ${{ !inputs.skip_test_pypi }}
+    uses: ./.github/workflows/publish-and-validate.yml
+    with:
+      package_name: ${{ inputs.package_name }}
+      expected_version: ${{ inputs.expected_version }}
+      repository_type: 'test-pypi'
+    secrets: inherit
+
+  publish-and-validate-pypi:
+    needs: [publish-and-validate-test-pypi]
+    if: always()
+    uses: ./.github/workflows/publish-and-validate.yml
+    with:
+      package_name: ${{ inputs.package_name }}
+      expected_version: ${{ inputs.expected_version }}
+      repository_type: 'pypi'
+    secrets: inherit

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       test_branch: ${{ steps.create_test_branch.outputs.test_branch }}
-      smoke_tests_json: ${{ steps.trigger_smoke_tests.outputs.json }}
-      quicktest_json: ${{ steps.trigger_quicktest_core.outputs.json }}
-      release_test_json: ${{ steps.trigger_release_tests.outputs.json }}
       release_branch: ${{ steps.create_release_branch.outputs.release_branch }}
       release_version: ${{ steps.determine_version.outputs.release_version }}
+      new_commit_sha: ${{ steps.create_test_branch.outputs.new_commit_sha }}
+      previous_release_branch: ${{ steps.find_previous_release_branch.outputs.previous_release_branch }}
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -273,88 +273,50 @@ jobs:
           git push -f origin ${TEST_BRANCH}
           echo "test_branch=${TEST_BRANCH}" >> $GITHUB_OUTPUT
 
-      # Trigger Buildkite smoke tests
-      - name: Trigger Full Smoke Tests
-        id: trigger_smoke_tests
-        uses: buildkite/trigger-pipeline-action@v2.3.0
-        with:
-          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "skypilot-1/full-smoke-tests-run"
-          branch: "${{ steps.create_test_branch.outputs.test_branch }}"
-          commit: "${{ steps.create_test_branch.outputs.new_commit_sha }}"
-          message: "Release ${{ steps.determine_version.outputs.release_version }}"
-          ignore_pipeline_branch_filter: true
-
-      # Trigger Buildkite quicktest-core
-      - name: Trigger Quicktest Core
-        id: trigger_quicktest_core
-        uses: buildkite/trigger-pipeline-action@v2.3.0
-        with:
-          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "skypilot-1/quicktest-core"
-          branch: "${{ steps.create_test_branch.outputs.test_branch }}"
-          commit: "${{ steps.create_test_branch.outputs.new_commit_sha }}"
-          message: "Release ${{ steps.determine_version.outputs.release_version }}"
-          ignore_pipeline_branch_filter: true
-          build_env_vars: '{"ARGS": "--base-branch ${{ steps.find_previous_release_branch.outputs.previous_release_branch }}"}'
-
-      # Trigger Buildkite release tests
-      - name: Trigger Release Tests
-        id: trigger_release_tests
-        uses: buildkite/trigger-pipeline-action@v2.3.0
-        with:
-          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "skypilot-1/release"
-          branch: "${{ steps.create_test_branch.outputs.test_branch }}"
-          commit: "${{ steps.create_test_branch.outputs.new_commit_sha }}"
-          message: "Release ${{ steps.determine_version.outputs.release_version }}"
-          ignore_pipeline_branch_filter: true
-
-  # Call extract-buildkite workflow for each job
-  extract-smoke-tests:
+  smoke-tests:
     needs: release-build
-    uses: ./.github/workflows/extract-buildkite.yml
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
-      json_data: ${{ needs.release-build.outputs.smoke_tests_json }}
-
-  extract-quicktest:
-    needs: release-build
-    uses: ./.github/workflows/extract-buildkite.yml
-    with:
-      json_data: ${{ needs.release-build.outputs.quicktest_json }}
-
-  extract-release-test:
-    needs: release-build
-    uses: ./.github/workflows/extract-buildkite.yml
-    with:
-      json_data: ${{ needs.release-build.outputs.release_test_json }}
-
-  wait-for-smoke-tests:
-    needs: [release-build, extract-smoke-tests]
-    uses: ./.github/workflows/wait-for-buildkite.yml
-    with:
-      organization: "skypilot-1"
-      pipeline: "full-smoke-tests-run"
-      build_number: ${{ needs.extract-smoke-tests.outputs.build_number }}
+      commit: ${{ needs.release-build.outputs.new_commit_sha }}
+      branch: ${{ needs.release-build.outputs.test_branch }}
+      message: "Release ${{ needs.release-build.outputs.release_version }}"
+      pipeline: "skypilot-1/full-smoke-tests-run"
       timeout_minutes: 240
-      fail_on_buildkite_failure: false
+      wait: true
+      fail_on_buildkite_failure: true
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
-  wait-for-quicktest-core:
-    needs: [release-build, extract-quicktest]
-    uses: ./.github/workflows/wait-for-buildkite.yml
+  quicktest-core:
+    needs: release-build
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
-      organization: "skypilot-1"
-      pipeline: "quicktest-core"
-      build_number: ${{ needs.extract-quicktest.outputs.build_number }}
+      commit: ${{ needs.release-build.outputs.new_commit_sha }}
+      branch: ${{ needs.release-build.outputs.test_branch }}
+      message: "Release ${{ needs.release-build.outputs.release_version }}"
+      pipeline: "skypilot-1/quicktest-core"
+      build_env_vars: '{"ARGS": "--base-branch ${{ needs.release-build.outputs.previous_release_branch }}"}'
       timeout_minutes: 180
+      wait: true
+      fail_on_buildkite_failure: true
+    secrets:
+      BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+
+  release-tests:
+    needs: release-build
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
+    with:
+      commit: ${{ needs.release-build.outputs.new_commit_sha }}
+      branch: ${{ needs.release-build.outputs.test_branch }}
+      message: "Release ${{ needs.release-build.outputs.release_version }}"
+      pipeline: "skypilot-1/release"
+      wait: false
       fail_on_buildkite_failure: false
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
   create-pr:
-    needs: [release-build, wait-for-smoke-tests, wait-for-quicktest-core, extract-release-test, extract-smoke-tests, extract-quicktest]
+    needs: [release-build, smoke-tests, quicktest-core, release-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -368,11 +330,10 @@ jobs:
           TEST_BRANCH: ${{ needs.release-build.outputs.test_branch }}
           RELEASE_BRANCH: ${{ needs.release-build.outputs.release_branch }}
           RELEASE_VERSION: ${{ needs.release-build.outputs.release_version }}
-          SMOKE_TEST_BUILD: ${{ needs.extract-smoke-tests.outputs.build_number }}
-          QUICKTEST_BUILD: ${{ needs.extract-quicktest.outputs.build_number }}
-          RELEASE_TEST_BUILD: ${{ needs.extract-release-test.outputs.build_number }}
+          SMOKE_TEST_BUILD: ${{ needs.smoke-tests.outputs.build_number }}
+          QUICKTEST_BUILD: ${{ needs.quicktest-core.outputs.build_number }}
+          RELEASE_TEST_BUILD: ${{ needs.release-tests.outputs.build_number }}
         run: |
-
           # Configure git
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -381,8 +342,8 @@ jobs:
           PR_BODY="Release ${RELEASE_VERSION}
 
           Buildkite Test Links:
-          - [Full Smoke Tests](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/${SMOKE_TEST_BUILD}) - $([ "${{ needs.wait-for-smoke-tests.outputs.build_status }}" == "success" ] && echo "✅ Success" || echo "❌ Failed")
-          - [Quicktest Core](https://buildkite.com/skypilot-1/quicktest-core/builds/${QUICKTEST_BUILD}) - $([ "${{ needs.wait-for-quicktest-core.outputs.build_status }}" == "success" ] && echo "✅ Success" || echo "❌ Failed")
+          - [Full Smoke Tests](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/${SMOKE_TEST_BUILD}) - $([ "${{ needs.smoke-tests.outputs.build_status }}" == "success" ] && echo "✅ Success" || echo "❌ Failed")
+          - [Quicktest Core](https://buildkite.com/skypilot-1/quicktest-core/builds/${QUICKTEST_BUILD}) - $([ "${{ needs.quicktest-core.outputs.build_status }}" == "success" ] && echo "✅ Success" || echo "❌ Failed")
           - [Release Tests](https://buildkite.com/skypilot-1/release/builds/${RELEASE_TEST_BUILD}) - ⏳ (not waiting for completion)
 
           *Release Tests may take up to 24 hours to complete and might fail due to resource constraints.*"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -280,7 +280,7 @@ jobs:
       commit: ${{ needs.release-build.outputs.new_commit_sha }}
       branch: ${{ needs.release-build.outputs.test_branch }}
       message: "Release ${{ needs.release-build.outputs.release_version }}"
-      pipeline: "skypilot-1/full-smoke-tests-run"
+      pipeline: "full-smoke-tests-run"
       timeout_minutes: 240
       wait: true
       fail_on_buildkite_failure: true
@@ -294,7 +294,7 @@ jobs:
       commit: ${{ needs.release-build.outputs.new_commit_sha }}
       branch: ${{ needs.release-build.outputs.test_branch }}
       message: "Release ${{ needs.release-build.outputs.release_version }}"
-      pipeline: "skypilot-1/quicktest-core"
+      pipeline: "quicktest-core"
       build_env_vars: '{"ARGS": "--base-branch ${{ needs.release-build.outputs.previous_release_branch }}"}'
       timeout_minutes: 180
       wait: true
@@ -309,7 +309,7 @@ jobs:
       commit: ${{ needs.release-build.outputs.new_commit_sha }}
       branch: ${{ needs.release-build.outputs.test_branch }}
       message: "Release ${{ needs.release-build.outputs.release_version }}"
-      pipeline: "skypilot-1/release"
+      pipeline: "release"
       wait: false
       fail_on_buildkite_failure: false
     secrets:

--- a/.github/workflows/smoke-tests-trigger.yaml
+++ b/.github/workflows/smoke-tests-trigger.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "skypilot-1/smoke-tests"
+          pipeline: "smoke-tests"
           branch: "master"
           commit: "HEAD"
           message: "Manual Smoke Tests: ${{ github.event.inputs.param }}"

--- a/.github/workflows/smoke-tests-trigger.yaml
+++ b/.github/workflows/smoke-tests-trigger.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: buildkite/trigger-pipeline-action@v2.3.0
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
-          pipeline: "smoke-tests"
+          pipeline: "skypilot-1/smoke-tests"
           branch: "master"
           commit: "HEAD"
           message: "Manual Smoke Tests: ${{ github.event.inputs.param }}"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Follow up on #5889  

The helm-release wasn't triggered when the PyPI test was skipped.  

Simplify the logic by creating two more YAML files:  

1. Trigger and wait for Buildkite  
2. Publish and validate PyPI (both test PyPI and PyPI)  

Then in the nightly workflow, we can call these two files. This way, we only need one `if` condition in one step, instead of having `if` conditions in every step and using `always()` everywhere to make GitHub Actions work. The current approach is harder to read and understand.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
