### PR TITLE
Fix schedule input on nightly build pipeline

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -89,7 +89,7 @@ jobs:
 
   smoke-tests:
     needs: nightly-build-pypi
-    if: ${{ !inputs.skip_buildkite }}
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule' }}
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
@@ -103,12 +103,12 @@ jobs:
 
   publish-and-validate-both:
     needs: [nightly-build-pypi, smoke-tests]
-    if: ${{ inputs.skip_buildkite || (always() && needs.smoke-tests.result == 'success') }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.skip_buildkite) || (always() && needs.smoke-tests.result == 'success') }}
     uses: ./.github/workflows/publish-and-validate-both.yml
     with:
       package_name: skypilot-nightly
       expected_version: ${{ needs.nightly-build-pypi.outputs.version }}
-      skip_test_pypi: ${{ inputs.skip_test_pypi }}
+      skip_test_pypi: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_test_pypi || false }}
     secrets: inherit
 
   trigger-helm-release:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -113,6 +113,7 @@ jobs:
 
   trigger-helm-release:
     needs: [publish-and-validate-both]
+    if: ${{ needs.publish-and-validate-both.result == 'success' }}
     uses: ./.github/workflows/helm-docker-release.yaml
     with:
       package_name: skypilot-nightly


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The scheduled job failed because it had no input. See the [scheduled build](https://github.com/skypilot-org/skypilot/actions/runs/15488687390/job/43622658656).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
