### PR TITLE
Use selected branch to trigger buildkite test in github action

### DIFF
--- a/.github/workflows/smoke-tests-trigger.yaml
+++ b/.github/workflows/smoke-tests-trigger.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
           pipeline: "skypilot-1/smoke-tests"
-          branch: "master"
+          branch: ${{ github.ref_name }}
           commit: "HEAD"
           message: "Manual Smoke Tests: ${{ github.event.inputs.param }}"
           ignore_pipeline_branch_filter: true


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Currently hardcode master, change to selected github ref

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
