### PR TITLE
[CLI] Fix `sky api logs --server-log`

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -85,7 +85,8 @@ def stream_response(request_id: Optional[str],
         for line in rich_utils.decode_rich_status(response):
             if line is not None:
                 print(line, flush=True, end='', file=output_stream)
-        return get(request_id)
+        if request_id is not None:
+            return get(request_id)
     except Exception:  # pylint: disable=broad-except
         logger.debug(f'To stream request logs: sky api logs {request_id}')
         raise


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

When deploy on helm, we call `stream_and_get` without a request id (`id=None`):

https://github.com/skypilot-org/skypilot/blob/27c65168accef13707ed99a43544b9b59a90a188/sky/client/sdk.py#L1915

which will produce the following error:

<img width="739" alt="image" src="https://github.com/user-attachments/assets/e7b8631e-480c-4d9d-9728-15ef4421b54d" />

This PR fixes the problem.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
