### PR TITLE
Disabled auto tier best

### DIFF
--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -731,12 +731,7 @@ class Cloud:
         Raises:
             exceptions.NotSupportedError: If the network tier is not supported.
         """
-        del instance_type  # unused by default, but can be overridden
-
-        # BEST tier is always allowed - clouds will map it to their best
-        # available
-        if network_tier == resources_utils.NetworkTier.BEST:
-            return
+        del instance_type  # unused
 
         # For other tiers, check if supported
         if network_tier not in cls._SUPPORTED_NETWORK_TIERS:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Change to remove network tier best automatically.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
