### PR TITLE
[API server] add extraInitContainers field to helm deployment

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -323,6 +323,10 @@ spec:
         - name: lambda-config
           mountPath: /root/.lambda_cloud
       {{- end }}
+      {{- if .Values.extraInitContainers }}
+      {{- toYaml .Values.extraInitContainers | nindent 6 }}
+      {{- end }}
+
       volumes:
       {{- if .Values.storage.enabled }}
       - name: state-volume

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -281,6 +281,9 @@ nebiusCredentials:
   # Name of the secret containing the Nebius credentials. Only used if enabled is true.
   nebiusSecretName: nebius-credentials
 
+# Extra init containers to run before the api container
+extraInitContainers:
+
 # Set securityContext for the api pod
 podSecurityContext: {}
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Allowing user-specified init containers to be deployed alongside the API server container in a sidecar pattern can be helpful. One example is running Cloud SQL Auth Proxy as a sidecar to facilitate GKE pod access to GCP Cloud SQL server.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
