### PR TITLE
Support helm deploy test on GKE in smoke test and release pipeline

### DIFF
--- a/.buildkite/generate_pipeline.py
+++ b/.buildkite/generate_pipeline.py
@@ -109,14 +109,12 @@ def _parse_args(args: Optional[str] = None):
 
     # -k argument for a test selection pattern
     parser.add_argument("-k")
-
     parser.add_argument("--remote-server", action="store_true")
-
     parser.add_argument('--base-branch')
-
     parser.add_argument('--controller-cloud')
-
     parser.add_argument('--postgres', action="store_true")
+    parser.add_argument('--helm-version')
+    parser.add_argument('--helm-package')
 
     parsed_args, _ = parser.parse_known_args(args_list)
 
@@ -150,6 +148,10 @@ def _parse_args(args: Optional[str] = None):
         extra_args.append(f'--controller-cloud {parsed_args.controller_cloud}')
     if parsed_args.postgres:
         extra_args.append('--postgres')
+    if parsed_args.helm_version:
+        extra_args.append(f'--helm-version {parsed_args.helm_version}')
+    if parsed_args.helm_package:
+        extra_args.append(f'--helm-package {parsed_args.helm_package}')
 
     return default_clouds_to_run, parsed_args.k, extra_args
 

--- a/.github/workflows/helm-docker-release.yaml
+++ b/.github/workflows/helm-docker-release.yaml
@@ -69,7 +69,7 @@ jobs:
       branch: ${{ github.ref_name }}
       message: "helm-docker-release deploy tests ${{ needs.set-package.outputs.package_name }} ${{ needs.docker-build.outputs.version }}"
       pipeline: "smoke-tests"
-      build_env_vars: '{"ARGS": "--helm-package ${{ needs.set-package.outputs.package_name }} --helm-version ${{ needs.docker-build.outputs.version }} -k test_helm_deploy_gke"}'
+      build_env_vars: '{"ARGS": " --gcp --helm-package ${{ needs.set-package.outputs.package_name }} --helm-version ${{ needs.docker-build.outputs.version }} -k test_helm_deploy_gke"}'
       timeout_minutes: 120
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/helm-docker-release.yaml
+++ b/.github/workflows/helm-docker-release.yaml
@@ -69,7 +69,7 @@ jobs:
       branch: ${{ github.ref_name }}
       message: "helm-docker-release deploy tests ${{ needs.set-package.outputs.package_name }} ${{ needs.docker-build.outputs.version }}"
       pipeline: "smoke-tests"
-      build_env_vars: '{"ARGS": " --gcp --helm-package ${{ needs.set-package.outputs.package_name }} --helm-version ${{ needs.docker-build.outputs.version }} -k test_helm_deploy_gke"}'
-      timeout_minutes: 120
+      build_env_vars: '{"ARGS": "--gcp --helm-package ${{ needs.set-package.outputs.package_name }} --helm-version ${{ needs.docker-build.outputs.version }} -k test_helm_deploy_gke"}'
+      timeout_minutes: 30
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/helm-docker-release.yaml
+++ b/.github/workflows/helm-docker-release.yaml
@@ -60,3 +60,16 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       HELM_DEPLOY_KEY: ${{ secrets.HELM_DEPLOY_KEY }}
+
+  smoke-tests:
+    needs: [set-package, docker-build, publish-helm]
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
+    with:
+      commit: ${{ github.sha }}
+      branch: ${{ github.ref_name }}
+      message: "helm-docker-release deploy tests ${{ needs.set-package.outputs.package_name }} ${{ needs.docker-build.outputs.version }}"
+      pipeline: "smoke-tests"
+      build_env_vars: '{"ARGS": "--helm-package ${{ needs.set-package.outputs.package_name }} --helm-version ${{ needs.docker-build.outputs.version }} -k test_helm_deploy_gke"}'
+      timeout_minutes: 120
+    secrets:
+      BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -93,7 +93,7 @@ jobs:
     uses: ./.github/workflows/buildkite-trigger-wait.yml
     with:
       commit: ${{ github.sha }}
-      branch: master
+      branch: ${{ github.ref_name }}
       message: "nightly-build-pypi"
       pipeline: "smoke-tests"
       build_env_vars: '{"ARGS": "--aws"}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,6 +152,18 @@ def pytest_addoption(parser):
         default=False,
         help='Run tests for Postgres Backend',
     )
+    parser.addoption(
+        '--helm-version',
+        type=str,
+        default='',
+        help='Version of Helm to use for tests',
+    )
+    parser.addoption(
+        '--helm-package',
+        type=str,
+        default='skypilot-nightly',
+        help='Package name to use for Helm tests',
+    )
 
 
 def pytest_configure(config):

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -99,12 +99,6 @@ echo "API server endpoint: $ENDPOINT"
 
 # Test the API server
 echo "Testing API server health endpoint..."
-curl -s ${ENDPOINT}/health
+curl ${ENDPOINT}/health
 
 echo "Setup complete! You can now use the API server at: $ENDPOINT"
-
-# Keep the script running until user interrupts
-echo "Press Ctrl+C to exit and clean up the cluster..."
-while true; do
-    sleep 1
-done

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configuration
-CLUSTER_NAME="skypilot-helm-test-cluster"
+CLUSTER_NAME="skypilot-helm-test-cluster2"
 PROJECT_ID=$(gcloud config get-value project)
 ZONE="us-central1-a"  # Replace with your preferred zone
 NODE_COUNT=2
@@ -22,7 +22,7 @@ cleanup() {
 }
 
 # Set up trap
-trap cleanup EXIT
+# trap cleanup EXIT
 
 echo "Using GCP Project ID: $PROJECT_ID"
 echo "Installing SkyPilot Helm chart version: $HELM_VERSION"
@@ -99,6 +99,13 @@ echo "API server endpoint: $ENDPOINT"
 
 # Test the API server
 echo "Testing API server health endpoint..."
-curl ${ENDPOINT}/health
+HEALTH_RESPONSE=$(curl -s ${ENDPOINT}/api/health)
+echo "Health response: $HEALTH_RESPONSE"
 
-echo "Setup complete! You can now use the API server at: $ENDPOINT"
+# Extract version from response and verify it matches
+RETURNED_VERSION=$(echo $HEALTH_RESPONSE | jq -r '.version')
+if [ "$RETURNED_VERSION" != "$HELM_VERSION" ]; then
+    echo "Error: Version mismatch! Expected: $HELM_VERSION, Got: $RETURNED_VERSION"
+    exit 1
+fi
+echo "Version verification successful! Expected version $HELM_VERSION matches returned version $RETURNED_VERSION"

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configuration
-CLUSTER_NAME="skypilot-helm-test-cluster2"
+CLUSTER_NAME="skypilot-helm-test-cluster"
 PROJECT_ID=$(gcloud config get-value project)
 ZONE="us-central1-a"  # Replace with your preferred zone
 NODE_COUNT=2

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -22,7 +22,7 @@ cleanup() {
 }
 
 # Set up trap
-# trap cleanup EXIT
+trap cleanup EXIT
 
 echo "Using GCP Project ID: $PROJECT_ID"
 echo "Installing SkyPilot Helm chart version: $HELM_VERSION"
@@ -52,7 +52,8 @@ helm repo update
 NAMESPACE=skypilot
 RELEASE_NAME=skypilot
 WEB_USERNAME=skypilot
-WEB_PASSWORD=skypilot123  # Change this to a secure password
+# Generate a random 16-character password using /dev/urandom (macOS compatible)
+WEB_PASSWORD=$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 16)
 
 # Create auth string
 AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -6,7 +6,7 @@ CLUSTER_NAME="skypilot-helm-test-cluster"
 PROJECT_ID=$(gcloud config get-value project)
 ZONE="us-central1-a"  # Replace with your preferred zone
 NODE_COUNT=2
-MACHINE_TYPE="e2-standard-2"  # 2 vCPU, 8GB memory
+MACHINE_TYPE="e2-standard-8"  # 8 vCPU, 32GB memory
 PACKAGE_NAME=${1:-"skypilot-nightly"}  # Accept package name as first argument, default to skypilot-nightly
 HELM_VERSION=${2:-"latest"}  # Accept version as second argument, default to latest
 

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -83,7 +83,7 @@ kubectl get pods -n $NAMESPACE
 if ! kubectl wait --namespace $NAMESPACE \
     --for=condition=ready pod \
     --selector=app=${RELEASE_NAME}-api \
-    --timeout=1200s; then
+    --timeout=600s; then
     echo "Warning: Pod readiness check timed out. Checking pod status for debugging..."
     kubectl describe pods -n $NAMESPACE -l app=${RELEASE_NAME}-api
     kubectl logs -n $NAMESPACE -l app=${RELEASE_NAME}-api

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+set -e
+
+# Configuration
+CLUSTER_NAME="skypilot-helm-test-cluster"
+PROJECT_ID=$(gcloud config get-value project)
+ZONE="us-central1-a"  # Replace with your preferred zone
+NODE_COUNT=2
+MACHINE_TYPE="e2-standard-2"  # 2 vCPU, 8GB memory
+PACKAGE_NAME=${1:-"skypilot-nightly"}  # Accept package name as first argument, default to skypilot-nightly
+HELM_VERSION=${2:-"latest"}  # Accept version as second argument, default to latest
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    echo "Deleting GKE cluster: $CLUSTER_NAME"
+    gcloud container clusters delete $CLUSTER_NAME \
+        --project=$PROJECT_ID \
+        --zone=$ZONE \
+        --quiet || true
+    echo "Cleanup complete"
+}
+
+# Set up trap
+trap cleanup EXIT
+
+echo "Using GCP Project ID: $PROJECT_ID"
+echo "Installing SkyPilot Helm chart version: $HELM_VERSION"
+
+# Create GKE cluster
+echo "Creating GKE cluster..."
+gcloud container clusters create $CLUSTER_NAME \
+    --project=$PROJECT_ID \
+    --zone=$ZONE \
+    --num-nodes=$NODE_COUNT \
+    --machine-type=$MACHINE_TYPE \
+    --enable-ip-alias \
+    --enable-autoscaling \
+    --min-nodes=1 \
+    --max-nodes=3
+
+# Get credentials
+echo "Getting cluster credentials..."
+gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT_ID
+
+# Add SkyPilot Helm repository
+echo "Adding SkyPilot Helm repository..."
+helm repo add skypilot https://helm.skypilot.co
+helm repo update
+
+# Set up namespace and release name
+NAMESPACE=skypilot
+RELEASE_NAME=skypilot
+WEB_USERNAME=skypilot
+WEB_PASSWORD=skypilot123  # Change this to a secure password
+
+# Create auth string
+AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
+
+# Deploy SkyPilot API server
+echo "Deploying SkyPilot API server..."
+if [ "$HELM_VERSION" = "latest" ]; then
+    helm upgrade --install $RELEASE_NAME skypilot/$PACKAGE_NAME --devel \
+        --namespace $NAMESPACE \
+        --create-namespace \
+        --set ingress.authCredentials=$AUTH_STRING
+else
+    # Convert PEP440 version to SemVer if needed (e.g., 1.0.0.dev20250609 -> 1.0.0-dev.20250609)
+    SEMVER_VERSION=$(echo "$HELM_VERSION" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)\.dev([0-9]+)/\1-dev.\2/')
+    helm upgrade --install $RELEASE_NAME skypilot/$PACKAGE_NAME \
+        --namespace $NAMESPACE \
+        --create-namespace \
+        --version "$SEMVER_VERSION" \
+        --set ingress.authCredentials=$AUTH_STRING
+fi
+
+# Wait for pods to be ready
+echo "Waiting for pods to be ready..."
+echo "Checking pod status..."
+kubectl get pods -n $NAMESPACE
+
+# Wait for pods with increased timeout and better error handling
+if ! kubectl wait --namespace $NAMESPACE \
+    --for=condition=ready pod \
+    --selector=app=${RELEASE_NAME}-api \
+    --timeout=1200s; then
+    echo "Warning: Pod readiness check timed out. Checking pod status for debugging..."
+    kubectl describe pods -n $NAMESPACE -l app=${RELEASE_NAME}-api
+    kubectl logs -n $NAMESPACE -l app=${RELEASE_NAME}-api
+    exit 1
+fi
+
+# Get the API server URL
+echo "Getting API server URL..."
+HOST=$(kubectl get svc ${RELEASE_NAME}-ingress-nginx-controller --namespace $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+ENDPOINT=http://${WEB_USERNAME}:${WEB_PASSWORD}@${HOST}
+
+echo "API server endpoint: $ENDPOINT"
+
+# Test the API server
+echo "Testing API server health endpoint..."
+curl -s ${ENDPOINT}/health
+
+echo "Setup complete! You can now use the API server at: $ENDPOINT"
+
+# Keep the script running until user interrupts
+echo "Press Ctrl+C to exit and clean up the cluster..."
+while true; do
+    sleep 1
+done

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -127,6 +127,10 @@ RUN source ~/miniconda3/etc/profile.d/conda.sh && \
     export PATH="$PATH:$HOME/.local/bin" && \
     uv pip install pyOpenSSL==23.1.1
 
+
+# Install Helm
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
 # Copy the entrypoint script
 COPY tests/smoke_tests/docker/entrypoint.sh /home/${USERNAME}/entrypoint.sh
 COPY tests/smoke_tests/docker/stop_sky_resource.sh /home/${USERNAME}/stop_sky_resource.sh

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -44,7 +44,8 @@ RUN apt update -y && \
     uuid-runtime \
     docker.io \
     rsync \
-    jq
+    jq \
+    apache2-utils
 
 # Install kubectl
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/$(case "$(uname -m)" in \

--- a/tests/smoke_tests/test_images.py
+++ b/tests/smoke_tests/test_images.py
@@ -559,3 +559,13 @@ def test_kubernetes_docker_image_and_ssh():
         # Clean up temporary files
         os.unlink(docker_yaml_path)
         os.unlink(unprefixed_yaml_path)
+
+
+@pytest.mark.gcp
+def test_helm_deploy_gke(request):
+    helm_version = request.config.getoption('--helm-version')
+    package_name = request.config.getoption('--helm-package')
+    test = smoke_tests_utils.Test('helm_deploy_gke', [
+        f'bash tests/kubernetes/scripts/helm_gcp.sh {package_name} {helm_version}',
+    ])
+    smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* A bash script to launch GKE cluster and deploy helm with our specific skypilot version on it
* Verify the `${ENDPOINT}/api/health` work after deploy
* Trigger this test on release pipeline

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_helm_deploy_gke --gcp --helm-package skypilot-nightly --helm-version 1.0.0.dev20250607 -k test_helm_deploy_gke` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
