### PR TITLE
[Core] Support client-side admin policy

### DIFF
--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -19,7 +19,7 @@ Example usage:
 Overview
 --------
 
-Admin policies are :ref:`implemented in Python packages <implement-admin-policy>` first, then get distributed and applied at the :ref:`server-side <server-side-admin-policy>` and/or the :ref:`client-side <client-side-admin-policy>`.
+Admin policies are :ref:`implemented in Python packages <implement-admin-policy>` first, then get distributed and applied at the :ref:`server-side <server-side-admin-policy>` and/or the :ref:`client-side <client-side-admin-policy>`. If both are set, the policy at client-side will be applied first, the mutated tasks and SkyPilot config will then be processed by the policy at server-side.
 
 .. _client-side-admin-policy:
 

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -253,4 +253,4 @@ Use local GCP credentials for all tasks
 
 .. note::
 
-    This policy only makes sense when applied at :ref:`client-side <client-side-admin-policy>`. Use this policy at the :ref:`server-side <server-side-admin-policy>` is a no-op since the task launched by API server inherits the credentials from the API server by default.
+    This policy only take effects when applied at :ref:`client-side <client-side-admin-policy>`. Use this policy at the :ref:`server-side <server-side-admin-policy>` will be a no-op.

--- a/docs/source/cloud-setup/policy.rst
+++ b/docs/source/cloud-setup/policy.rst
@@ -14,31 +14,37 @@ Example usage:
 - :ref:`use-spot-for-gpu-policy`
 - :ref:`enforce-autostop-policy`
 - :ref:`dynamic-kubernetes-contexts-update-policy`
-
-
-To implement and use an admin policy:
-
-- Admins writes a simple Python package with a policy class that implements SkyPilot's ``sky.AdminPolicy`` interface;
-- Admins distributes this package to users;
-- Users simply set the ``admin_policy`` field in the SkyPilot config file ``~/.sky/config.yaml`` for the policy to go into effect.
-
+- :ref:`use-local-gcp-credentials-policy`
 
 Overview
 --------
 
+Admin policies are :ref:`implemented in Python packages <implement-admin-policy>` first, then get distributed and applied at the :ref:`server-side <server-side-admin-policy>` and/or the :ref:`client-side <client-side-admin-policy>`.
 
+.. _client-side-admin-policy:
 
-User-Side
-~~~~~~~~~~
+Client-side
+~~~~~~~~~~~
 
-To apply the policy, a user needs to set the ``admin_policy`` field in the SkyPilot config
-``~/.sky/config.yaml`` to the path of the Python package that implements the policy.
-For example:
+If you want the policy get applied only on your local machine or you don't have a :ref:`centralized API server <sky-api-server>` deployed, you can apply the policy at the client-side.
+
+First, install the Python package that implements the policy:
+
+.. code-block:: bash
+
+    pip install mypackage.subpackage
+
+Then, set the :ref:`admin_policy <config-yaml-admin-policy>` field in :ref:`the SkyPilot config <config-yaml>` to the path of the Python package that implements the policy.
 
 .. code-block:: yaml
 
     admin_policy: mypackage.subpackage.MyPolicy
 
+Optionally, you can also apply different policies in different projects by leveraging the :ref:`layered config <config-sources-and-overrides>`, e.g. set a different policy in ``$pwd/.sky.yaml`` for the current project:
+
+.. code-block:: yaml
+
+    admin_policy: mypackage.subpackage.AnotherPolicy
 
 .. hint::
 
@@ -49,12 +55,33 @@ For example:
 
         python -c "from mypackage.subpackage import MyPolicy"
 
+.. _server-side-admin-policy:
 
-Admin-Side
-~~~~~~~~~~
+Server-side
+~~~~~~~~~~~
 
-An admin can distribute the Python package to users with a pre-defined policy. The
-policy should implement the ``sky.AdminPolicy`` `interface <https://github.com/skypilot-org/skypilot/blob/master/sky/admin_policy.py>`_:
+If you have a :ref:`centralized API server <sky-api-server>` deployed, you can enforce a policy for all users by setting it at the server-side.
+
+First, install the Python package that implements the policy on the API server host:
+
+.. code-block:: bash
+
+    pip install mypackage.subpackage
+
+For helm deployment, refer to :ref:`sky-api-server-admin-policy` to install the policy package.
+
+Then, open the server's dashboard, go to :ref:`the server's SkyPilot config <sky-api-server-config>` and set the :ref:`admin_policy <config-yaml-admin-policy>` field to the path of the Python package that implements the policy.
+
+.. code-block:: yaml
+
+    admin_policy: mypackage.subpackage.MyPolicy
+
+.. _implement-admin-policy:
+
+Implement an admin policy
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Admin policies are implemented by extending the ``sky.AdminPolicy`` `interface <https://github.com/skypilot-org/skypilot/blob/master/sky/admin_policy.py>`_:
 
 
 .. literalinclude:: ../../../sky/admin_policy.py
@@ -93,7 +120,7 @@ Your custom admin policy should look like this:
 
 
 In other words, an ``AdminPolicy`` can mutate any fields of a user request, including
-the :ref:`task <yaml-spec>` and the :ref:`global skypilot config <config-yaml>`,
+the :ref:`task <yaml-spec>` and the :ref:`skypilot config <config-yaml>` for that specific user request,
 giving admins a lot of flexibility to control user's SkyPilot usage.
 
 An ``AdminPolicy`` can be used to both validate and mutate user requests. If
@@ -113,9 +140,6 @@ The ``sky.Config`` and ``sky.RequestOptions`` classes are defined as follows:
     :pyobject: RequestOptions
     :caption: `RequestOptions Class <https://github.com/skypilot-org/skypilot/blob/master/sky/admin_policy.py>`_
 
-.. note::
-
-    The ``sky.AdminPolicy`` should be idempotent. In other words, it should be safe to apply the policy multiple times to the same user request.
 
 Example policies
 ----------------
@@ -212,3 +236,21 @@ Dynamically update Kubernetes contexts to use
 .. literalinclude:: ../../../examples/admin_policy/dynamic_kubernetes_contexts_update.yaml
     :language: yaml
     :caption: `Config YAML for using DynamicKubernetesContextsUpdatePolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/dynamic_kubernetes_contexts_update.yaml>`_
+
+.. _use-local-gcp-credentials-policy:
+
+Use local GCP credentials for all tasks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../examples/admin_policy/example_policy/example_policy/client_policy.py
+    :language: python
+    :pyobject: UseLocalGcpCredentialsPolicy
+    :caption: `UseLocalGcpCredentialsPolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/example_policy/example_policy/client_policy.py>`_
+
+.. literalinclude:: ../../../examples/admin_policy/use_local_gcp_credentials.yaml
+    :language: yaml
+    :caption: `Config YAML for using UseLocalGcpCredentialsPolicy <https://github.com/skypilot-org/skypilot/blob/master/examples/admin_policy/use_local_gcp_credentials.yaml>`_
+
+.. note::
+
+    This policy only makes sense when applied at :ref:`client-side <client-side-admin-policy>`. Use this policy at the :ref:`server-side <server-side-admin-policy>` is a no-op since the task launched by API server inherits the credentials from the API server by default.

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -498,6 +498,8 @@ In addition to basic HTTP authentication, SkyPilot also supports using an OAuth2
 
 Refer to :ref:`Using an Auth Proxy with the SkyPilot API Server <api-server-auth-proxy>` for detailed instructions on common OAuth2 providers, such as :ref:`Okta <oauth2-proxy-okta>` or Google Workspace.
 
+.. _sky-api-server-config:
+
 Optional: Setting the SkyPilot config
 --------------------------------------
 
@@ -640,11 +642,7 @@ The steps below are based on the `official documentation <https://docs.aws.amazo
 
 Once the EBS CSI driver is installed, the default ``gp2`` storage class will be backed by EBS volumes.
 
-.. _sky-api-server-config:
-
-
-
-
+.. _sky-api-server-admin-policy:
 
 Setting an admin policy
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/admin_policy/example_policy/example_policy/__init__.py
+++ b/examples/admin_policy/example_policy/example_policy/__init__.py
@@ -1,4 +1,5 @@
 """Example admin policy module and prebuilt policies."""
+from example_policy.client_policy import UseLocalGCPCredentialsPolicy
 from example_policy.skypilot_policy import AddLabelsPolicy
 from example_policy.skypilot_policy import DisablePublicIpPolicy
 from example_policy.skypilot_policy import DynamicKubernetesContextsUpdatePolicy

--- a/examples/admin_policy/example_policy/example_policy/__init__.py
+++ b/examples/admin_policy/example_policy/example_policy/__init__.py
@@ -1,5 +1,5 @@
 """Example admin policy module and prebuilt policies."""
-from example_policy.client_policy import UseLocalGCPCredentialsPolicy
+from example_policy.client_policy import UseLocalGcpCredentialsPolicy
 from example_policy.skypilot_policy import AddLabelsPolicy
 from example_policy.skypilot_policy import DisablePublicIpPolicy
 from example_policy.skypilot_policy import DynamicKubernetesContextsUpdatePolicy

--- a/examples/admin_policy/example_policy/example_policy/client_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/client_policy.py
@@ -13,7 +13,7 @@ _GOOGLE_APPLICATION_CREDENTIALS_PATH = (
     '~/.config/gcloud/application_default_credentials.json')
 
 
-class UseLocalGCPCredentialsPolicy(sky.AdminPolicy):
+class UseLocalGcpCredentialsPolicy(sky.AdminPolicy):
     """Example policy: use local GCP credentials in the task."""
 
     @classmethod

--- a/examples/admin_policy/example_policy/example_policy/client_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/client_policy.py
@@ -1,0 +1,45 @@
+"""Example prebuilt admin policies for client usage specifically."""
+import os
+
+import sky
+from sky import sky_logging
+
+logger = sky_logging.init_logger(__name__)
+
+# Ref:
+# https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key
+_GOOGLE_APPLICATION_CREDENTIALS_ENV = 'GOOGLE_APPLICATION_CREDENTIALS'
+_GOOGLE_APPLICATION_CREDENTIALS_PATH = (
+    '~/.config/gcloud/application_default_credentials.json')
+
+
+class UseLocalGCPCredentialsPolicy(sky.AdminPolicy):
+    """Example policy: use local GCP credentials in the task."""
+
+    @classmethod
+    def validate_and_mutate(
+            cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
+        task = user_request.task
+        if task.file_mounts is None:
+            task.file_mounts = {}
+        # Use the env var to detect whether an explicit credential path is
+        # specified.
+        cred_path = os.environ.get(_GOOGLE_APPLICATION_CREDENTIALS_ENV)
+        logger.info(f'get task: {task}')
+        if cred_path is not None:
+            task.file_mounts[_GOOGLE_APPLICATION_CREDENTIALS_PATH] = cred_path
+            activate_cmd = (f'gcloud auth activate-service-account --key-file '
+                            f'{_GOOGLE_APPLICATION_CREDENTIALS_PATH}')
+            if task.run is None:
+                task.run = activate_cmd
+            elif isinstance(task.run, str):
+                task.run = f'{activate_cmd} && {task.run}'
+            else:
+                # Impossible according to current code base, but just in case.
+                logger.warning('The task run command is not a string, '
+                               f'so the local {cred_path} will not be used.')
+        else:
+            # Otherwise upload the entire default credential directory to get
+            # consistent identity in the task and the local environment.
+            task.file_mounts['~/.config/gcloud'] = '~/.config/gcloud'
+        return sky.MutatedUserRequest(task, user_request.skypilot_config)

--- a/examples/admin_policy/example_policy/example_policy/client_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/client_policy.py
@@ -19,13 +19,18 @@ class UseLocalGcpCredentialsPolicy(sky.AdminPolicy):
     @classmethod
     def validate_and_mutate(
             cls, user_request: sky.UserRequest) -> sky.MutatedUserRequest:
+        # Only apply the policy at client-side.
+        if not user_request.at_client_side:
+            return sky.MutatedUserRequest(user_request.task,
+                                          user_request.skypilot_config)
+
         task = user_request.task
         if task.file_mounts is None:
             task.file_mounts = {}
         # Use the env var to detect whether an explicit credential path is
         # specified.
         cred_path = os.environ.get(_GOOGLE_APPLICATION_CREDENTIALS_ENV)
-        logger.info(f'get task: {task}')
+
         if cred_path is not None:
             task.file_mounts[_GOOGLE_APPLICATION_CREDENTIALS_PATH] = cred_path
             activate_cmd = (f'gcloud auth activate-service-account --key-file '

--- a/examples/admin_policy/use_local_gcp_credentials.yaml
+++ b/examples/admin_policy/use_local_gcp_credentials.yaml
@@ -1,0 +1,1 @@
+admin_policy: example_policy.UseLocalGCPCredentialsPolicy

--- a/examples/admin_policy/use_local_gcp_credentials.yaml
+++ b/examples/admin_policy/use_local_gcp_credentials.yaml
@@ -1,1 +1,1 @@
-admin_policy: example_policy.UseLocalGCPCredentialsPolicy
+admin_policy: example_policy.UseLocalGcpCredentialsPolicy

--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -29,6 +29,7 @@ class RequestOptions:
     idle_minutes_to_autostop: Optional[int]
     down: bool
     dryrun: bool
+    is_client_side: bool = False
 
 
 @dataclasses.dataclass
@@ -50,10 +51,12 @@ class UserRequest:
         task: User specified task.
         skypilot_config: Global skypilot config to be used in this request.
         request_options: Request options. It is None for jobs and services.
+        at_client_side: Is the request intercepted by the policy at client-side?
     """
     task: 'sky.Task'
     skypilot_config: 'sky.Config'
     request_options: Optional['RequestOptions'] = None
+    at_client_side: bool = False
 
 
 @dataclasses.dataclass

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -494,7 +494,7 @@ def launch(
         down=down,
         dryrun=dryrun)
     with admin_policy_utils.apply_and_use_config_in_current_request(
-            dag, request_options=request_options) as dag:
+            dag, request_options=request_options, at_client_side=True) as dag:
         return _launch(
             dag,
             cluster_name,

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -68,7 +68,8 @@ def launch(
     """
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+    with admin_policy_utils.apply_and_use_config_in_current_request(
+            dag, at_client_side=True) as dag:
         sdk.validate(dag)
         if _need_confirmation:
             request_id = sdk.optimize(dag)

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -14,7 +14,9 @@ from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.skylet import constants
 from sky.usage import usage_lib
+from sky.utils import admin_policy_utils
 from sky.utils import common_utils
+from sky.utils import context
 from sky.utils import dag_utils
 
 if typing.TYPE_CHECKING:
@@ -29,6 +31,7 @@ else:
 logger = sky_logging.init_logger(__name__)
 
 
+@context.contextual
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 def launch(
@@ -65,27 +68,31 @@ def launch(
     """
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    sdk.validate(dag)
-    if _need_confirmation:
-        request_id = sdk.optimize(dag)
-        sdk.stream_and_get(request_id)
-        prompt = f'Launching a managed job {dag.name!r}. Proceed?'
-        if prompt is not None:
-            click.confirm(prompt, default=True, abort=True, show_default=True)
+    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+        sdk.validate(dag)
+        if _need_confirmation:
+            request_id = sdk.optimize(dag)
+            sdk.stream_and_get(request_id)
+            prompt = f'Launching a managed job {dag.name!r}. Proceed?'
+            if prompt is not None:
+                click.confirm(prompt,
+                              default=True,
+                              abort=True,
+                              show_default=True)
 
-    dag = client_common.upload_mounts_to_api_server(dag)
-    dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
-    body = payloads.JobsLaunchBody(
-        task=dag_str,
-        name=name,
-    )
-    response = requests.post(
-        f'{server_common.get_server_url()}/jobs/launch',
-        json=json.loads(body.model_dump_json()),
-        timeout=(5, None),
-        cookies=server_common.get_api_cookie_jar(),
-    )
-    return server_common.get_request_id(response)
+        dag = client_common.upload_mounts_to_api_server(dag)
+        dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
+        body = payloads.JobsLaunchBody(
+            task=dag_str,
+            name=name,
+        )
+        response = requests.post(
+            f'{server_common.get_server_url()}/jobs/launch',
+            json=json.loads(body.model_dump_json()),
+            timeout=(5, None),
+            cookies=server_common.get_api_cookie_jar(),
+        )
+        return server_common.get_request_id(response)
 
 
 @usage_lib.entrypoint

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -10,6 +10,8 @@ from sky.client import common as client_common
 from sky.server import common as server_common
 from sky.server.requests import payloads
 from sky.usage import usage_lib
+from sky.utils import admin_policy_utils
+from sky.utils import context
 from sky.utils import dag_utils
 
 if typing.TYPE_CHECKING:
@@ -23,6 +25,7 @@ else:
     requests = adaptors_common.LazyImport('requests')
 
 
+@context.contextual
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 def up(
@@ -55,30 +58,35 @@ def up(
     from sky.client import sdk  # pylint: disable=import-outside-toplevel
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    sdk.validate(dag)
-    request_id = sdk.optimize(dag)
-    sdk.stream_and_get(request_id)
-    if _need_confirmation:
-        prompt = f'Launching a new service {service_name!r}. Proceed?'
-        if prompt is not None:
-            click.confirm(prompt, default=True, abort=True, show_default=True)
+    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+        sdk.validate(dag)
+        request_id = sdk.optimize(dag)
+        sdk.stream_and_get(request_id)
+        if _need_confirmation:
+            prompt = f'Launching a new service {service_name!r}. Proceed?'
+            if prompt is not None:
+                click.confirm(prompt,
+                              default=True,
+                              abort=True,
+                              show_default=True)
 
-    dag = client_common.upload_mounts_to_api_server(dag)
-    dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
+        dag = client_common.upload_mounts_to_api_server(dag)
+        dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
 
-    body = payloads.ServeUpBody(
-        task=dag_str,
-        service_name=service_name,
-    )
-    response = requests.post(
-        f'{server_common.get_server_url()}/serve/up',
-        json=json.loads(body.model_dump_json()),
-        timeout=(5, None),
-        cookies=server_common.get_api_cookie_jar(),
-    )
-    return server_common.get_request_id(response)
+        body = payloads.ServeUpBody(
+            task=dag_str,
+            service_name=service_name,
+        )
+        response = requests.post(
+            f'{server_common.get_server_url()}/serve/up',
+            json=json.loads(body.model_dump_json()),
+            timeout=(5, None),
+            cookies=server_common.get_api_cookie_jar(),
+        )
+        return server_common.get_request_id(response)
 
 
+@context.contextual
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 def update(
@@ -112,30 +120,31 @@ def update(
     from sky.client import sdk  # pylint: disable=import-outside-toplevel
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    sdk.validate(dag)
-    request_id = sdk.optimize(dag)
-    sdk.stream_and_get(request_id)
-    if _need_confirmation:
-        click.confirm(f'Updating service {service_name!r}. Proceed?',
-                      default=True,
-                      abort=True,
-                      show_default=True)
+    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+        sdk.validate(dag)
+        request_id = sdk.optimize(dag)
+        sdk.stream_and_get(request_id)
+        if _need_confirmation:
+            click.confirm(f'Updating service {service_name!r}. Proceed?',
+                          default=True,
+                          abort=True,
+                          show_default=True)
 
-    dag = client_common.upload_mounts_to_api_server(dag)
-    dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
-    body = payloads.ServeUpdateBody(
-        task=dag_str,
-        service_name=service_name,
-        mode=mode,
-    )
+        dag = client_common.upload_mounts_to_api_server(dag)
+        dag_str = dag_utils.dump_chain_dag_to_yaml_str(dag)
+        body = payloads.ServeUpdateBody(
+            task=dag_str,
+            service_name=service_name,
+            mode=mode,
+        )
 
-    response = requests.post(
-        f'{server_common.get_server_url()}/serve/update',
-        json=json.loads(body.model_dump_json()),
-        timeout=(5, None),
-        cookies=server_common.get_api_cookie_jar(),
-    )
-    return server_common.get_request_id(response)
+        response = requests.post(
+            f'{server_common.get_server_url()}/serve/update',
+            json=json.loads(body.model_dump_json()),
+            timeout=(5, None),
+            cookies=server_common.get_api_cookie_jar(),
+        )
+        return server_common.get_request_id(response)
 
 
 @usage_lib.entrypoint

--- a/sky/serve/client/sdk.py
+++ b/sky/serve/client/sdk.py
@@ -58,7 +58,8 @@ def up(
     from sky.client import sdk  # pylint: disable=import-outside-toplevel
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+    with admin_policy_utils.apply_and_use_config_in_current_request(
+            dag, at_client_side=True) as dag:
         sdk.validate(dag)
         request_id = sdk.optimize(dag)
         sdk.stream_and_get(request_id)
@@ -120,7 +121,8 @@ def update(
     from sky.client import sdk  # pylint: disable=import-outside-toplevel
 
     dag = dag_utils.convert_entrypoint_to_dag(task)
-    with admin_policy_utils.apply_and_use_config_in_current_request(dag) as dag:
+    with admin_policy_utils.apply_and_use_config_in_current_request(
+            dag, at_client_side=True) as dag:
         sdk.validate(dag)
         request_id = sdk.optimize(dag)
         sdk.stream_and_get(request_id)

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -79,6 +79,9 @@ def get_override_skypilot_config_from_client() -> Dict[str, Any]:
     # server endpoint on the server side. This avoids the warning at
     # server-side.
     config.pop_nested(('api_server',), default_value=None)
+    # Remove the admin policy, as the policy has been applied on the client
+    # side.
+    config.pop_nested(('admin_policy',), default_value=None)
     return config
 
 

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -377,8 +377,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
 ]
 # When overriding the SkyPilot configs on the API server with the client one,
 # we skip the following keys because they are meant to be client-side configs.
-SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [('admin_policy',),
-                                                       ('api_server',),
+SKIPPED_CLIENT_OVERRIDE_KEYS: List[Tuple[str, ...]] = [('api_server',),
                                                        ('allowed_clouds',),
                                                        ('workspaces',), ('db',)]
 

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -2,6 +2,7 @@
 import contextlib
 import copy
 import importlib
+import os
 from typing import Iterator, Optional, Tuple, Union
 
 import colorama
@@ -12,6 +13,7 @@ from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
 from sky import task as task_lib
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import config_utils
 from sky.utils import ux_utils
@@ -105,7 +107,10 @@ def apply(
     if policy_cls is None:
         return dag, skypilot_config.to_dict()
 
-    logger.info(f'Applying policy: {policy}')
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        logger.info(f'Applying server admin policy: {policy}')
+    else:
+        logger.info(f'Applying client admin policy: {policy}')
     config = copy.deepcopy(skypilot_config.to_dict())
     mutated_dag = dag_lib.Dag()
     mutated_dag.name = dag.name

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -342,7 +342,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             with mock.patch(
                     'example_policy.client_policy.logger') as mock_logger:
                 mutated_request = (UseLocalGcpCredentialsPolicy.
-                                  cpalidate_and_mutate(user_request))
+                                   cpalidate_and_mutate(user_request))
 
                 # Check that warning was logged
                 mock_logger.warning.assert_called_once()

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -342,7 +342,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             with mock.patch(
                     'example_policy.client_policy.logger') as mock_logger:
                 mutated_request = (UseLocalGcpCredentialsPolicy.
-                                   cpalidate_and_mutate(user_request))
+                                   validate_and_mutate(user_request))
 
                 # Check that warning was logged
                 mock_logger.warning.assert_called_once()

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -232,3 +232,127 @@ def test_set_max_autostop_idle_minutes_policy(add_example_policy_paths, task):
     assert resources[0].autostop_config.enabled is True
     assert resources[0].autostop_config.idle_minutes == 10
     assert resources[0].autostop_config.down is True  # default
+
+
+def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
+    """Test UseLocalGCPCredentialsPolicy for various scenarios."""
+    from example_policy.client_policy import UseLocalGCPCredentialsPolicy
+
+    # Mock any potential gcloud calls that might happen during testing
+    with mock.patch('subprocess.run'), \
+         mock.patch('subprocess.call'), \
+         mock.patch('subprocess.check_output'), \
+         mock.patch('subprocess.Popen'):
+
+        test_creds_path = '/path/to/service-account.json'
+        with mock.patch.dict(
+                os.environ,
+            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+            fresh_task = sky.Task.from_yaml(
+                os.path.join(POLICY_PATH, 'task.yaml'))
+            fresh_task.run = None
+            user_request = sky.UserRequest(task=fresh_task,
+                                           skypilot_config=None)
+            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+                user_request)
+
+            # Check that the credentials file is mounted
+            expected_mount_path = ('~/.config/gcloud/'
+                                   'application_default_credentials.json')
+            assert expected_mount_path in mutated_request.task.file_mounts
+            assert (mutated_request.task.file_mounts[expected_mount_path] ==
+                    test_creds_path)
+
+            # Check that the gcloud auth command is set as the run command
+            expected_auth_cmd = ('gcloud auth activate-service-account '
+                                 '--key-file ~/.config/gcloud/'
+                                 'application_default_credentials.json')
+            assert mutated_request.task.run == expected_auth_cmd
+
+        # task.run has existing command
+        with mock.patch.dict(
+                os.environ,
+            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+            fresh_task = sky.Task.from_yaml(
+                os.path.join(POLICY_PATH, 'task.yaml'))
+            original_run_cmd = 'echo "hello world"'
+            fresh_task.run = original_run_cmd
+            user_request = sky.UserRequest(task=fresh_task,
+                                           skypilot_config=None)
+            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+                user_request)
+
+            # Check that the gcloud auth command is prepended
+            expected_auth_cmd = ('gcloud auth activate-service-account '
+                                 '--key-file ~/.config/gcloud/'
+                                 'application_default_credentials.json')
+            expected_full_cmd = f'{expected_auth_cmd} && {original_run_cmd}'
+            assert mutated_request.task.run == expected_full_cmd
+
+        env_without_creds = {
+            k: v
+            for k, v in os.environ.items()
+            if k != 'GOOGLE_APPLICATION_CREDENTIALS'
+        }
+        with mock.patch.dict(os.environ, env_without_creds, clear=True):
+            fresh_task = sky.Task.from_yaml(
+                os.path.join(POLICY_PATH, 'task.yaml'))
+            original_run_cmd = fresh_task.run
+            user_request = sky.UserRequest(task=fresh_task,
+                                           skypilot_config=None)
+            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+                user_request)
+
+            # Check that the entire gcloud directory is mounted
+            assert '~/.config/gcloud' in mutated_request.task.file_mounts
+            assert (mutated_request.task.file_mounts['~/.config/gcloud'] ==
+                    '~/.config/gcloud')
+
+            # Check that the run command is unchanged
+            assert mutated_request.task.run == original_run_cmd
+
+        with mock.patch.dict(
+                os.environ,
+            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+            fresh_task = sky.Task.from_yaml(
+                os.path.join(POLICY_PATH, 'task.yaml'))
+            fresh_task.file_mounts = {'/existing/mount': '/local/path'}
+            user_request = sky.UserRequest(task=fresh_task,
+                                           skypilot_config=None)
+            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+                user_request)
+
+            # Check that both existing and new mounts are present
+            assert '/existing/mount' in mutated_request.task.file_mounts
+            expected_mount_path = ('~/.config/gcloud/'
+                                   'application_default_credentials.json')
+            assert expected_mount_path in mutated_request.task.file_mounts
+            assert len(mutated_request.task.file_mounts) == 2
+
+        with mock.patch.dict(
+                os.environ,
+            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+            fresh_task = sky.Task.from_yaml(
+                os.path.join(POLICY_PATH, 'task.yaml'))
+            fresh_task.run = ['echo', 'hello']  # List instead of string
+            user_request = sky.UserRequest(task=fresh_task,
+                                           skypilot_config=None)
+
+            # Mock the logger to capture the warning
+            with mock.patch(
+                    'example_policy.client_policy.logger') as mock_logger:
+                mutated_request = (UseLocalGCPCredentialsPolicy.
+                                   validate_and_mutate(user_request))
+
+                # Check that warning was logged
+                mock_logger.warning.assert_called_once()
+                warning_msg = mock_logger.warning.call_args[0][0]
+                assert 'will not be used' in warning_msg
+
+                # Check that file mount still happens
+                expected_mount_path = ('~/.config/gcloud/'
+                                       'application_default_credentials.json')
+                assert expected_mount_path in mutated_request.task.file_mounts
+
+                # Check that run command is unchanged
+                assert mutated_request.task.run == ['echo', 'hello']

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -238,121 +238,95 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
     """Test UseLocalGcpCredentialsPolicy for various scenarios."""
     from example_policy.client_policy import UseLocalGcpCredentialsPolicy
 
-    # Mock any potential gcloud calls that might happen during testing
-    with mock.patch('subprocess.run'), \
-         mock.patch('subprocess.call'), \
-         mock.patch('subprocess.check_output'), \
-         mock.patch('subprocess.Popen'):
+    test_creds_path = '/path/to/service-account.json'
+    with mock.patch.dict(os.environ,
+                         {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+        fresh_task = sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
+        fresh_task.run = None
+        user_request = sky.UserRequest(task=fresh_task,
+                                       skypilot_config=None,
+                                       at_client_side=True)
+        mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
+            user_request)
 
-        test_creds_path = '/path/to/service-account.json'
-        with mock.patch.dict(
-                os.environ,
-            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
-            fresh_task = sky.Task.from_yaml(
-                os.path.join(POLICY_PATH, 'task.yaml'))
-            fresh_task.run = None
-            user_request = sky.UserRequest(task=fresh_task,
-                                           skypilot_config=None)
-            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
-                user_request)
+        # Check that the credentials file is mounted
+        expected_mount_path = ('~/.config/gcloud/'
+                               'application_default_credentials.json')
+        assert expected_mount_path in mutated_request.task.file_mounts
+        assert (mutated_request.task.file_mounts[expected_mount_path] ==
+                test_creds_path)
 
-            # Check that the credentials file is mounted
-            expected_mount_path = ('~/.config/gcloud/'
-                                   'application_default_credentials.json')
-            assert expected_mount_path in mutated_request.task.file_mounts
-            assert (mutated_request.task.file_mounts[expected_mount_path] ==
-                    test_creds_path)
+        # Check that the gcloud auth command is set as the run command
+        expected_auth_cmd = ('gcloud auth activate-service-account '
+                             '--key-file ~/.config/gcloud/'
+                             'application_default_credentials.json')
+        assert mutated_request.task.run == expected_auth_cmd
 
-            # Check that the gcloud auth command is set as the run command
-            expected_auth_cmd = ('gcloud auth activate-service-account '
-                                 '--key-file ~/.config/gcloud/'
-                                 'application_default_credentials.json')
-            assert mutated_request.task.run == expected_auth_cmd
+    # task.run has existing command
+    with mock.patch.dict(os.environ,
+                         {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+        fresh_task = sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
+        original_run_cmd = 'echo "hello world"'
+        fresh_task.run = original_run_cmd
+        user_request = sky.UserRequest(task=fresh_task,
+                                       skypilot_config=None,
+                                       at_client_side=True)
+        mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
+            user_request)
 
-        # task.run has existing command
-        with mock.patch.dict(
-                os.environ,
-            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
-            fresh_task = sky.Task.from_yaml(
-                os.path.join(POLICY_PATH, 'task.yaml'))
-            original_run_cmd = 'echo "hello world"'
-            fresh_task.run = original_run_cmd
-            user_request = sky.UserRequest(task=fresh_task,
-                                           skypilot_config=None)
-            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
-                user_request)
+        # Check that the gcloud auth command is prepended
+        expected_auth_cmd = ('gcloud auth activate-service-account '
+                             '--key-file ~/.config/gcloud/'
+                             'application_default_credentials.json')
+        expected_full_cmd = f'{expected_auth_cmd} && {original_run_cmd}'
+        assert mutated_request.task.run == expected_full_cmd
 
-            # Check that the gcloud auth command is prepended
-            expected_auth_cmd = ('gcloud auth activate-service-account '
-                                 '--key-file ~/.config/gcloud/'
-                                 'application_default_credentials.json')
-            expected_full_cmd = f'{expected_auth_cmd} && {original_run_cmd}'
-            assert mutated_request.task.run == expected_full_cmd
+    env_without_creds = {
+        k: v
+        for k, v in os.environ.items()
+        if k != 'GOOGLE_APPLICATION_CREDENTIALS'
+    }
+    with mock.patch.dict(os.environ, env_without_creds, clear=True):
+        fresh_task = sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
+        original_run_cmd = fresh_task.run
+        user_request = sky.UserRequest(task=fresh_task,
+                                       skypilot_config=None,
+                                       at_client_side=True)
+        mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
+            user_request)
 
-        env_without_creds = {
-            k: v
-            for k, v in os.environ.items()
-            if k != 'GOOGLE_APPLICATION_CREDENTIALS'
-        }
-        with mock.patch.dict(os.environ, env_without_creds, clear=True):
-            fresh_task = sky.Task.from_yaml(
-                os.path.join(POLICY_PATH, 'task.yaml'))
-            original_run_cmd = fresh_task.run
-            user_request = sky.UserRequest(task=fresh_task,
-                                           skypilot_config=None)
-            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
-                user_request)
+        # Check that the entire gcloud directory is mounted
+        assert '~/.config/gcloud' in mutated_request.task.file_mounts
+        assert (mutated_request.task.file_mounts['~/.config/gcloud'] ==
+                '~/.config/gcloud')
 
-            # Check that the entire gcloud directory is mounted
-            assert '~/.config/gcloud' in mutated_request.task.file_mounts
-            assert (mutated_request.task.file_mounts['~/.config/gcloud'] ==
-                    '~/.config/gcloud')
+        # Check that the run command is unchanged
+        assert mutated_request.task.run == original_run_cmd
 
-            # Check that the run command is unchanged
-            assert mutated_request.task.run == original_run_cmd
+    with mock.patch.dict(os.environ,
+                         {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+        fresh_task = sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
+        fresh_task.file_mounts = {'/existing/mount': '/local/path'}
+        user_request = sky.UserRequest(task=fresh_task,
+                                       skypilot_config=None,
+                                       at_client_side=True)
+        mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
+            user_request)
 
-        with mock.patch.dict(
-                os.environ,
-            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
-            fresh_task = sky.Task.from_yaml(
-                os.path.join(POLICY_PATH, 'task.yaml'))
-            fresh_task.file_mounts = {'/existing/mount': '/local/path'}
-            user_request = sky.UserRequest(task=fresh_task,
-                                           skypilot_config=None)
-            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
-                user_request)
+        # Check that both existing and new mounts are present
+        assert '/existing/mount' in mutated_request.task.file_mounts
+        expected_mount_path = ('~/.config/gcloud/'
+                               'application_default_credentials.json')
+        assert expected_mount_path in mutated_request.task.file_mounts
+        assert len(mutated_request.task.file_mounts) == 2
 
-            # Check that both existing and new mounts are present
-            assert '/existing/mount' in mutated_request.task.file_mounts
-            expected_mount_path = ('~/.config/gcloud/'
-                                   'application_default_credentials.json')
-            assert expected_mount_path in mutated_request.task.file_mounts
-            assert len(mutated_request.task.file_mounts) == 2
-
-        with mock.patch.dict(
-                os.environ,
-            {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
-            fresh_task = sky.Task.from_yaml(
-                os.path.join(POLICY_PATH, 'task.yaml'))
-            fresh_task.run = ['echo', 'hello']  # List instead of string
-            user_request = sky.UserRequest(task=fresh_task,
-                                           skypilot_config=None)
-
-            # Mock the logger to capture the warning
-            with mock.patch(
-                    'example_policy.client_policy.logger') as mock_logger:
-                mutated_request = (UseLocalGcpCredentialsPolicy.
-                                   validate_and_mutate(user_request))
-
-                # Check that warning was logged
-                mock_logger.warning.assert_called_once()
-                warning_msg = mock_logger.warning.call_args[0][0]
-                assert 'will not be used' in warning_msg
-
-                # Check that file mount still happens
-                expected_mount_path = ('~/.config/gcloud/'
-                                       'application_default_credentials.json')
-                assert expected_mount_path in mutated_request.task.file_mounts
-
-                # Check that run command is unchanged
-                assert mutated_request.task.run == ['echo', 'hello']
+    with mock.patch.dict(os.environ,
+                         {'GOOGLE_APPLICATION_CREDENTIALS': test_creds_path}):
+        fresh_task = sky.Task.from_yaml(os.path.join(POLICY_PATH, 'task.yaml'))
+        user_request = sky.UserRequest(task=fresh_task,
+                                       skypilot_config=None,
+                                       at_client_side=False)
+        mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
+            user_request)
+        # Should skip the policy at client-side
+        assert mutated_request.task.file_mounts is None

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -235,8 +235,8 @@ def test_set_max_autostop_idle_minutes_policy(add_example_policy_paths, task):
 
 
 def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
-    """Test UseLocalGCPCredentialsPolicy for various scenarios."""
-    from example_policy.client_policy import UseLocalGCPCredentialsPolicy
+    """Test UseLocalGcpCredentialsPolicy for various scenarios."""
+    from example_policy.client_policy import UseLocalGcpCredentialsPolicy
 
     # Mock any potential gcloud calls that might happen during testing
     with mock.patch('subprocess.run'), \
@@ -253,7 +253,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             fresh_task.run = None
             user_request = sky.UserRequest(task=fresh_task,
                                            skypilot_config=None)
-            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
                 user_request)
 
             # Check that the credentials file is mounted
@@ -279,7 +279,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             fresh_task.run = original_run_cmd
             user_request = sky.UserRequest(task=fresh_task,
                                            skypilot_config=None)
-            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
                 user_request)
 
             # Check that the gcloud auth command is prepended
@@ -300,7 +300,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             original_run_cmd = fresh_task.run
             user_request = sky.UserRequest(task=fresh_task,
                                            skypilot_config=None)
-            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
                 user_request)
 
             # Check that the entire gcloud directory is mounted
@@ -319,7 +319,7 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             fresh_task.file_mounts = {'/existing/mount': '/local/path'}
             user_request = sky.UserRequest(task=fresh_task,
                                            skypilot_config=None)
-            mutated_request = UseLocalGCPCredentialsPolicy.validate_and_mutate(
+            mutated_request = UseLocalGcpCredentialsPolicy.validate_and_mutate(
                 user_request)
 
             # Check that both existing and new mounts are present
@@ -341,8 +341,8 @@ def test_use_local_gcp_credentials_policy(add_example_policy_paths, task):
             # Mock the logger to capture the warning
             with mock.patch(
                     'example_policy.client_policy.logger') as mock_logger:
-                mutated_request = (UseLocalGCPCredentialsPolicy.
-                                   validate_and_mutate(user_request))
+                mutated_request = (UseLocalGcpCredentialsPolicy.
+                                  cpalidate_and_mutate(user_request))
 
                 # Check that warning was logged
                 mock_logger.warning.assert_called_once()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduce client-side admin policy support and update the doc of admin policy to reflect our client-server architecture.

Also, an example policy is added to illustrate the usage of client-side admin policy, which always override the GCP credentials at the task to the local GCP credentials instead of the API server's.

Test:

- [x] `sky launch` with the `UseLocalGcpCredentialsPolicy`, default identity.
- [x] `sky launch` with the `UseLocalGcpCredentialsPolicy`, with an service account key specified by `GOOGLE_APPLICATION_CREDENTIALS` env var.
- [x] `sky jobs launch` with `UseLocalGcpCredentialsPolicy`, default identity.
- [x] `sky jobs launch` with `UseLocalGcpCredentialsPolicy`, with an service account key specified by `GOOGLE_APPLICATION_CREDENTIALS` env var.

A relevant unit test case is also added.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
