### PR TITLE
Reset global state between test

### DIFF
--- a/tests/common_test_fixtures.py
+++ b/tests/common_test_fixtures.py
@@ -28,6 +28,7 @@ from sky.server.requests import executor
 from sky.server.requests import requests as api_requests
 from sky.server.server import app
 from sky.skylet import constants
+from sky.utils import annotations
 from sky.utils import controller_utils
 from sky.utils import message_utils
 from sky.utils import registry
@@ -569,3 +570,10 @@ def skyignore_dir():
             f.write(skyignore_content)
 
         yield temp_dir
+
+
+@pytest.fixture(autouse=True)
+def reset_global_state():
+    """Reset global state before each test."""
+    annotations.is_on_api_server = True
+    yield


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Follow up on https://github.com/skypilot-org/skypilot/pull/5801#discussion_r2136831871

The test passes when we run the whole file:

`SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no tests/test_config.py`

But fails when we run a single test:

`SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 pytest -n 0 --dist no tests/test_config.py::test_specific_test`

The problem happens because the global variable is_on_api_server in sky/utils/annotations.py gets changed by test cases but isn't reset between tests. This occurs since pytest runs tests in the same Python process by default, which means tests share global states.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
