### PR TITLE
Support restful admin policy

### DIFF
--- a/examples/admin_policy/example_server/README.md
+++ b/examples/admin_policy/example_server/README.md
@@ -1,0 +1,21 @@
+# Example RESTful Admin Policy Server
+
+This directory contains an example implementation of a RESTful admin policy server for SkyPilot using FastAPI.
+
+## Development
+
+First, refer to [SkyPilot Installation](https://docs.skypilot.co/en/latest/getting-started/installation.html) to install SkyPilot.
+
+Then start the server:
+
+```bash
+python policy_server.py --policy DoNothingPolicy
+```
+
+The server will apply the specified policy to the user request. Available policies can be found in the [example_policy module](../example_policy/example_policy).
+
+Finally, [set the admin policy at SkyPilot config](https://docs.skypilot.co/en/latest/cloud-setup/policy.html) to use the policy server:
+
+```yaml
+admin_policy: http://localhost:8080
+```

--- a/examples/admin_policy/example_server/policy_server.py
+++ b/examples/admin_policy/example_server/policy_server.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Example RESTful admin policy server for SkyPilot."""
+
+import argparse
+
+import example_policy
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi.responses import JSONResponse
+import uvicorn
+
+import sky
+
+app = FastAPI(
+    title="Example Admin Policy Server",
+    version="1.0.0"
+)
+
+@app.post('/')
+async def apply_policy(request: Request) -> JSONResponse:
+    """Apply admin policy to a user request"""
+    # Decode from request body
+    json_data = await request.json()
+    user_request = sky.UserRequest.decode(json_data)
+    
+    # Apply validation and mutation
+    mutated_request = request.app.state.policy_impl.apply(user_request)
+    
+    return JSONResponse(content=mutated_request.encode())
+
+@app.get('/')
+async def health_check():
+    return 'OK'
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--host', default='0.0.0.0', 
+                       help='Host to bind to (default: 0.0.0.0)')
+    parser.add_argument('--port', type=int, default=8080,
+                       help='Port to bind to (default: 8080)')
+    parser.add_argument('--policy', default='DoNothingPolicy',
+                       help='Policy to use (default: DoNothingPolicy)')
+    args = parser.parse_args()
+    policy_class = getattr(example_policy, args.policy)
+    assert issubclass(policy_class, sky.AdminPolicy), f'Policy {args.policy} is not a valid admin policy'
+    app.state.policy_impl = policy_class()
+    uvicorn.run(
+        app,
+        workers=1,
+        host=args.host,
+        port=args.port,
+        log_level="info"
+    )

--- a/examples/admin_policy/restful_policy.yaml
+++ b/examples/admin_policy/restful_policy.yaml
@@ -1,0 +1,1 @@
+admin_policy: http://localhost:8080

--- a/sky/admin_policy.py
+++ b/sky/admin_policy.py
@@ -2,14 +2,23 @@
 import abc
 import dataclasses
 import typing
-from typing import Optional
+from typing import Any, Dict, Optional
+
+import pydantic
+
+import sky
+from sky import exceptions
+from sky.adaptors import common as adaptors_common
+from sky.utils import config_utils
+from sky.utils import ux_utils
 
 if typing.TYPE_CHECKING:
-    import sky
+    import requests
+else:
+    requests = adaptors_common.LazyImport('requests')
 
 
-@dataclasses.dataclass
-class RequestOptions:
+class RequestOptions(pydantic.BaseModel):
     """Request options for admin policy.
 
     Args:
@@ -30,6 +39,14 @@ class RequestOptions:
     down: bool
     dryrun: bool
     is_client_side: bool = False
+
+
+class _UserRequestBody(pydantic.BaseModel):
+    """Auxiliary model to validate and serialize a user request."""
+    task: Dict[str, Any]
+    skypilot_config: Dict[str, Any]
+    request_options: Optional[RequestOptions] = None
+    at_client_side: bool = False
 
 
 @dataclasses.dataclass
@@ -58,15 +75,64 @@ class UserRequest:
     request_options: Optional['RequestOptions'] = None
     at_client_side: bool = False
 
+    def encode(self) -> str:
+        return _UserRequestBody(
+            task=self.task.to_yaml_config(),
+            skypilot_config=dict(self.skypilot_config),
+            request_options=self.request_options,
+            at_client_side=self.at_client_side).model_dump_json()
+
+    @classmethod
+    def decode(cls, body: str) -> 'UserRequest':
+        user_request_body = _UserRequestBody.model_validate_json(body)
+        return cls(task=sky.Task.from_yaml_config(user_request_body.task),
+                   skypilot_config=config_utils.Config.from_dict(
+                       user_request_body.skypilot_config),
+                   request_options=user_request_body.request_options,
+                   at_client_side=user_request_body.at_client_side)
+
+
+class _MutatedUserRequestBody(pydantic.BaseModel):
+    """Auxiliary model to validate and serialize a user request."""
+    task: Dict[str, Any]
+    skypilot_config: Dict[str, Any]
+
 
 @dataclasses.dataclass
 class MutatedUserRequest:
+    """Mutated user request."""
+
     task: 'sky.Task'
     skypilot_config: 'sky.Config'
 
+    def encode(self) -> str:
+        return _MutatedUserRequestBody(
+            task=self.task.to_yaml_config(),
+            skypilot_config=dict(self.skypilot_config)).model_dump_json()
+
+    @classmethod
+    def decode(cls, mutated_user_request_body: str) -> 'MutatedUserRequest':
+        mutated_user_request_body = _MutatedUserRequestBody.model_validate_json(
+            mutated_user_request_body)
+        return cls(task=sky.Task.from_yaml_config(
+            mutated_user_request_body.task),
+                   skypilot_config=config_utils.Config.from_dict(
+                       mutated_user_request_body.skypilot_config))
+
+
+class PolicyInterface:
+    """Interface for admin-defined policy for user requests."""
+
+    @abc.abstractmethod
+    def apply(self, user_request: UserRequest) -> MutatedUserRequest:
+        """Apply the admin policy to the user request."""
+    
+    def __str__(self):
+        return f'{self.__class__.__name__}'
+
 
 # pylint: disable=line-too-long
-class AdminPolicy:
+class AdminPolicy(PolicyInterface):
     """Abstract interface of an admin-defined policy for all user requests.
 
     Admins can implement a subclass of AdminPolicy with the following signature:
@@ -107,3 +173,64 @@ class AdminPolicy:
         """
         raise NotImplementedError(
             'Your policy must implement validate_and_mutate')
+
+    def apply(self, user_request: UserRequest) -> MutatedUserRequest:
+        return self.validate_and_mutate(user_request)
+
+
+class PolicyTemplate(PolicyInterface):
+    """Admin policy template that can be instantiated to create a policy."""
+
+    @abc.abstractmethod
+    def validate_and_mutate(self,
+                            user_request: UserRequest) -> MutatedUserRequest:
+        """Validates and mutates the user request and returns mutated request.
+
+        Args:
+            user_request: The user request to validate and mutate.
+                UserRequest contains (sky.Task, sky.Config)
+
+        Returns:
+            MutatedUserRequest: The mutated user request.
+
+        Raises:
+            Exception to throw if the user request failed the validation.
+        """
+        raise NotImplementedError(
+            'Your policy must implement validate_and_mutate')
+
+    def apply(self, user_request: UserRequest) -> MutatedUserRequest:
+        return self.validate_and_mutate(user_request)
+
+
+class RestfulAdminPolicy(PolicyTemplate):
+    """Admin policy that calls a RESTful API for validation."""
+
+    def __init__(self, policy_url: str):
+        super().__init__()
+        self.policy_url = policy_url
+
+    def validate_and_mutate(self,
+                            user_request: UserRequest) -> MutatedUserRequest:
+        try:
+            response = requests.post(
+                self.policy_url,
+                json=user_request.encode(),
+                headers={'Content-Type': 'application/json'},
+                # TODO(aylei): make this configurable
+                timeout=30)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.UserRequestRejectedByPolicy(
+                    f'Failed to validate request with admin policy URL '
+                    f'{self.policy_url}: {e}') from e
+
+        try:
+            mutated_user_request = MutatedUserRequest.decode(response.json())
+        except Exception as e:  # pylint: disable=broad-except
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.UserRequestRejectedByPolicy(
+                    f'Failed to decode response from admin policy URL '
+                    f'{self.policy_url}: {e}') from e
+        return mutated_user_request

--- a/sky/utils/admin_policy_utils.py
+++ b/sky/utils/admin_policy_utils.py
@@ -3,6 +3,7 @@ import contextlib
 import copy
 import importlib
 from typing import Iterator, Optional, Tuple, Union
+import urllib.parse
 
 import colorama
 
@@ -19,18 +20,34 @@ from sky.utils import ux_utils
 logger = sky_logging.init_logger(__name__)
 
 
-def _get_policy_cls(
-        policy: Optional[str]) -> Optional[admin_policy.AdminPolicy]:
-    """Gets admin-defined policy."""
-    if policy is None:
-        return None
+def _is_url(policy_string: str) -> bool:
+    """Check if the policy string is a URL."""
     try:
-        module_path, class_name = policy.rsplit('.', 1)
+        parsed = urllib.parse.urlparse(policy_string)
+        return parsed.scheme in ('http', 'https')
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _get_policy_impl(
+        policy_location: Optional[str]
+) -> Optional[admin_policy.PolicyInterface]:
+    """Gets admin-defined policy."""
+    if policy_location is None:
+        return None
+
+    if _is_url(policy_location):
+        # Use the built-in URL policy class when an URL is specified.
+        return admin_policy.RestfulAdminPolicy(policy_location)
+
+    # Handle module path format
+    try:
+        module_path, class_name = policy_location.rsplit('.', 1)
         module = importlib.import_module(module_path)
     except ImportError as e:
         with ux_utils.print_exception_no_traceback():
             raise ImportError(
-                f'Failed to import policy module: {policy}. '
+                f'Failed to import policy module: {policy_location}. '
                 'Please check if the module is installed in your Python '
                 'environment.') from e
 
@@ -42,13 +59,15 @@ def _get_policy_cls(
                 f'Could not find {class_name} class in module {module_path}. '
                 'Please check with your policy admin for details.') from e
 
-    # Check if the module implements the AdminPolicy interface.
+    # Currently we only allow users to define subclass of AdminPolicy
+    # instead of inheriting from PolicyInterface or PolicyTemplate.
     if not issubclass(policy_cls, admin_policy.AdminPolicy):
         with ux_utils.print_exception_no_traceback():
             raise ValueError(
-                f'Policy class {policy!r} does not implement the AdminPolicy '
-                'interface. Please check with your policy admin for details.')
-    return policy_cls
+                f'Policy class {policy_cls!r} does not implement the '
+                'AdminPolicy interface. Please check with your policy admin '
+                'for details.')
+    return policy_cls()
 
 
 @contextlib.contextmanager
@@ -102,9 +121,9 @@ def apply(
     else:
         dag = entrypoint
 
-    policy = skypilot_config.get_nested(('admin_policy',), None)
-    policy_cls = _get_policy_cls(policy)
-    if policy_cls is None:
+    policy_location = skypilot_config.get_nested(('admin_policy',), None)
+    policy = _get_policy_impl(policy_location)
+    if policy is None:
         return dag, skypilot_config.to_dict()
 
     if at_client_side:
@@ -120,7 +139,7 @@ def apply(
         user_request = admin_policy.UserRequest(task, config, request_options,
                                                 at_client_side)
         try:
-            mutated_user_request = policy_cls.validate_and_mutate(user_request)
+            mutated_user_request = policy.apply(user_request)
         except Exception as e:  # pylint: disable=broad-except
             with ux_utils.print_exception_no_traceback():
                 raise exceptions.UserRequestRejectedByPolicy(

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1149,9 +1149,17 @@ def get_config_schema():
 
     admin_policy_schema = {
         'type': 'string',
-        # Check regex to be a valid python module path
-        'pattern': (r'^[a-zA-Z_][a-zA-Z0-9_]*'
-                    r'(\.[a-zA-Z_][a-zA-Z0-9_]*)+$'),
+        'anyOf': [
+            {
+                # Check regex to be a valid python module path
+                'pattern': (r'^[a-zA-Z_][a-zA-Z0-9_]*'
+                            r'(\.[a-zA-Z_][a-zA-Z0-9_]*)+$'),
+            },
+            {
+                # Check for valid HTTP/HTTPS URL
+                'pattern': r'^https?://.*$',
+            }
+        ]
     }
 
     allowed_clouds = {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduce restful admin policy support.

UX:

1. Policy handler side: write a server like https://github.com/skypilot-org/skypilot/blob/e7b5068950cc553d24a6c999eedfcdcd78339f5e/examples/admin_policy/example_server/policy_server.py, and host the server through a centralised endpoint
2. SkyPilot side: specify the following config:

```yaml
admin_policy: http://{host}:{port}/{api_path}
```

Test:

- [x] Local manual test, passed
- [x] New unit test cases

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
