### PR TITLE
Robust test helm deploy on GKE

### DIFF
--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -98,10 +98,35 @@ ENDPOINT=http://${WEB_USERNAME}:${WEB_PASSWORD}@${HOST}
 
 echo "API server endpoint: $ENDPOINT"
 
-# Test the API server
+# Test the API server with retry logic
 echo "Testing API server health endpoint..."
-HEALTH_RESPONSE=$(curl -s ${ENDPOINT}/api/health)
-echo "Health response: $HEALTH_RESPONSE"
+echo "Endpoint: $ENDPOINT/api/health"
+MAX_RETRIES=10  # 5 minutes with 30 second intervals
+RETRY_INTERVAL=30
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    echo "Attempt $((RETRY_COUNT + 1))/$MAX_RETRIES: Testing health endpoint..."
+    HEALTH_RESPONSE=$(curl -s ${ENDPOINT}/api/health)
+    echo "Health response: $HEALTH_RESPONSE"
+
+    # Check if response is valid JSON (not HTML error page)
+    if echo "$HEALTH_RESPONSE" | jq . >/dev/null 2>&1; then
+        echo "API server is responding with valid JSON!"
+        break
+    else
+        echo "API server not ready yet (received HTML error page). Waiting ${RETRY_INTERVAL} seconds..."
+        if [ $RETRY_COUNT -lt $((MAX_RETRIES - 1)) ]; then
+            sleep $RETRY_INTERVAL
+        fi
+        RETRY_COUNT=$((RETRY_COUNT + 1))
+    fi
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "Error: API server failed to become ready after $((MAX_RETRIES * RETRY_INTERVAL)) seconds"
+    exit 1
+fi
 
 # Extract version from response and verify it matches
 RETURNED_VERSION=$(echo $HEALTH_RESPONSE | jq -r '.version')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

About the test failure [here](https://buildkite.com/skypilot-1/smoke-tests/builds/1367#01975a58-415a-4bc0-826e-99879c184a02):

The Sky server might not be ready, and Nginx returns HTTP 503.  
Add a retry loop to wait until it's ready.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/smoke-test --gcp --helm-package skypilot-nightly --helm-version 1.0.0.dev20250610 -k test_helm_deploy_gke` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
