### PR TITLE
lazy initialization of benchmark db

### DIFF
--- a/sky/benchmark/benchmark_state.py
+++ b/sky/benchmark/benchmark_state.py
@@ -1,5 +1,6 @@
 """Sky benchmark database, backed by sqlite."""
 import enum
+import functools
 import os
 import pathlib
 import pickle
@@ -65,7 +66,24 @@ class _BenchmarkSQLiteConn(threading.local):
         self.conn.commit()
 
 
-_BENCHMARK_DB = _BenchmarkSQLiteConn()
+_BENCHMARK_DB = None
+_benchmark_db_init_lock = threading.Lock()
+
+
+def _init_db(func):
+    """Initialize the database."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        global _BENCHMARK_DB
+        if _BENCHMARK_DB:
+            return func(*args, **kwargs)
+        with _benchmark_db_init_lock:
+            if not _BENCHMARK_DB:
+                _BENCHMARK_DB = _BenchmarkSQLiteConn()
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 class BenchmarkStatus(enum.Enum):
@@ -121,9 +139,11 @@ class BenchmarkRecord(NamedTuple):
     estimated_total_seconds: Optional[float] = None
 
 
+@_init_db
 def add_benchmark(benchmark_name: str, task_name: Optional[str],
                   bucket_name: str) -> None:
     """Add a new benchmark."""
+    assert _BENCHMARK_DB is not None
     launched_at = int(time.time())
     _BENCHMARK_DB.cursor.execute(
         'INSERT INTO benchmark'
@@ -133,8 +153,10 @@ def add_benchmark(benchmark_name: str, task_name: Optional[str],
     _BENCHMARK_DB.conn.commit()
 
 
+@_init_db
 def add_benchmark_result(benchmark_name: str,
                          cluster_handle: 'backend_lib.ResourceHandle') -> None:
+    assert _BENCHMARK_DB is not None
     name = cluster_handle.cluster_name
     num_nodes = cluster_handle.launched_nodes
     resources = pickle.dumps(cluster_handle.launched_resources)
@@ -146,10 +168,12 @@ def add_benchmark_result(benchmark_name: str,
     _BENCHMARK_DB.conn.commit()
 
 
+@_init_db
 def update_benchmark_result(
         benchmark_name: str, cluster_name: str,
         benchmark_status: BenchmarkStatus,
         benchmark_record: Optional[BenchmarkRecord]) -> None:
+    assert _BENCHMARK_DB is not None
     _BENCHMARK_DB.cursor.execute(
         'UPDATE benchmark_results SET '
         'status=(?), record=(?) WHERE benchmark=(?) AND cluster=(?)',
@@ -158,8 +182,10 @@ def update_benchmark_result(
     _BENCHMARK_DB.conn.commit()
 
 
+@_init_db
 def delete_benchmark(benchmark_name: str) -> None:
     """Delete a benchmark result."""
+    assert _BENCHMARK_DB is not None
     _BENCHMARK_DB.cursor.execute(
         'DELETE FROM benchmark_results WHERE benchmark=(?)', (benchmark_name,))
     _BENCHMARK_DB.cursor.execute('DELETE FROM benchmark WHERE name=(?)',
@@ -167,8 +193,10 @@ def delete_benchmark(benchmark_name: str) -> None:
     _BENCHMARK_DB.conn.commit()
 
 
+@_init_db
 def get_benchmark_from_name(benchmark_name: str) -> Optional[Dict[str, Any]]:
     """Get a benchmark from its name."""
+    assert _BENCHMARK_DB is not None
     rows = _BENCHMARK_DB.cursor.execute(
         'SELECT * FROM benchmark WHERE name=(?)', (benchmark_name,))
     for name, task, bucket, launched_at in rows:
@@ -181,8 +209,10 @@ def get_benchmark_from_name(benchmark_name: str) -> Optional[Dict[str, Any]]:
         return record
 
 
+@_init_db
 def get_benchmarks() -> List[Dict[str, Any]]:
     """Get all benchmarks."""
+    assert _BENCHMARK_DB is not None
     rows = _BENCHMARK_DB.cursor.execute('SELECT * FROM benchmark')
     records = []
     for name, task, bucket, launched_at in rows:
@@ -196,8 +226,10 @@ def get_benchmarks() -> List[Dict[str, Any]]:
     return records
 
 
+@_init_db
 def set_benchmark_bucket(bucket_name: str, bucket_type: str) -> None:
     """Save the benchmark bucket name and type."""
+    assert _BENCHMARK_DB is not None
     _BENCHMARK_DB.cursor.execute(
         'REPLACE INTO benchmark_config (key, value) VALUES (?, ?)',
         (_BENCHMARK_BUCKET_NAME_KEY, bucket_name))
@@ -207,8 +239,10 @@ def set_benchmark_bucket(bucket_name: str, bucket_type: str) -> None:
     _BENCHMARK_DB.conn.commit()
 
 
+@_init_db
 def get_benchmark_bucket() -> Tuple[Optional[str], Optional[str]]:
     """Get the benchmark bucket name and type."""
+    assert _BENCHMARK_DB is not None
     rows = _BENCHMARK_DB.cursor.execute(
         'SELECT value FROM benchmark_config WHERE key=(?)',
         (_BENCHMARK_BUCKET_NAME_KEY,))
@@ -227,15 +261,19 @@ def get_benchmark_bucket() -> Tuple[Optional[str], Optional[str]]:
     return bucket_name, bucket_type
 
 
+@_init_db
 def get_benchmark_clusters(benchmark_name: str) -> List[str]:
     """Get all clusters for a benchmark."""
+    assert _BENCHMARK_DB is not None
     rows = _BENCHMARK_DB.cursor.execute(
         'SELECT cluster FROM benchmark_results WHERE benchmark=(?)',
         (benchmark_name,))
     return [row[0] for row in rows]
 
 
+@_init_db
 def get_benchmark_results(benchmark_name: str) -> List[Dict[str, Any]]:
+    assert _BENCHMARK_DB is not None
     rows = _BENCHMARK_DB.cursor.execute(
         'SELECT * FROM benchmark_results WHERE benchmark=(?)',
         (benchmark_name,))


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Lazily initialize ~/.sky/benchmark.db on first query. This has the effect of avoiding DB initialization on client side.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
