### PR TITLE
[UX] Units for disk, memory, autostop 

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1935,7 +1935,21 @@ class Resources:
         resources_fields['network_tier'] = config.pop('network_tier', None)
         resources_fields['ports'] = config.pop('ports', None)
         resources_fields['labels'] = config.pop('labels', None)
-        resources_fields['autostop'] = config.pop('autostop', None)
+        autostop = config.pop('autostop', None)
+        if isinstance(autostop, str):
+            if autostop.endswith('min') or autostop.endswith('m'):
+                autostop = float(''.join(filter(str.isdigit, autostop)))
+            elif autostop.endswith('h') or autostop.endswith('hr'):
+                autostop = float(''.join(filter(str.isdigit, autostop))) * 60
+            elif autostop.endswith('d') or autostop.endswith('day'):
+                autostop = float(''.join(filter(str.isdigit, autostop))) * 60 * 24
+            elif autostop.endswith('w') or autostop.endswith('week'):
+                autostop = float(''.join(filter(str.isdigit, autostop))) * 60 * 24 * 7
+            elif autostop.endswith('s') or autostop.endswith('sec'):
+                autostop = float(''.join(filter(str.isdigit, autostop))) / 60
+            else:
+                autostop = float(autostop)
+        resources_fields['autostop'] = str(autostop)
         resources_fields['volumes'] = config.pop('volumes', None)
         resources_fields['_docker_login_config'] = config.pop(
             '_docker_login_config', None)

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1964,12 +1964,18 @@ class Resources:
         if resources_fields['cpus'] is not None:
             resources_fields['cpus'] = str(resources_fields['cpus'])
         if resources_fields['memory'] is not None:
-            resources_fields['memory'] = str(resources_fields['memory'])
+            memory = resources_fields['memory']
+            if len(list(filter(str.isdigit, memory))) != 0:
+                memory = str(_convert_to_gb(memory))
+            resources_fields['memory'] = memory
         if resources_fields['accelerator_args'] is not None:
             resources_fields['accelerator_args'] = dict(
                 resources_fields['accelerator_args'])
         if resources_fields['disk_size'] is not None:
-            resources_fields['disk_size'] = int(resources_fields['disk_size'])
+            disk_size = resources_fields['disk_size']
+            if len(list(filter(str.isdigit, disk_size))) != 0:
+                disk_size = _convert_to_gb(disk_size)
+            resources_fields['disk_size'] = int(disk_size)
 
         assert not config, f'Invalid resource args: {config.keys()}'
         return Resources(**resources_fields)
@@ -2233,3 +2239,21 @@ def _maybe_add_docker_prefix_to_image_id(
     for k, v in image_id_dict.items():
         if not v.startswith('docker:'):
             image_id_dict[k] = f'docker:{v}'
+
+
+def _convert_to_gb(memory: str) -> float:
+    memory = memory.upper()
+    if memory.endswith('GB'):
+        return float(memory[:-2])
+    elif memory.endswith('MB'):
+        return float(memory[:-2]) / 1024
+    elif memory.endswith('TB'):
+        return float(memory[:-2]) * 1024
+    elif memory.endswith('KB'):
+        return float(memory[:-2]) / 1024 / 1024
+    elif memory.endswith('B'):
+        return float(memory[:-1]) / 1024 / 1024 / 1024
+    elif memory.endswith('PB'):
+        return float(memory[:-2]) * 1024 * 1024
+    else:
+        raise ValueError(f"Invalid memory format: {memory}")

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1940,20 +1940,24 @@ class Resources:
         resources_fields['ports'] = config.pop('ports', None)
         resources_fields['labels'] = config.pop('labels', None)
         autostop = config.pop('autostop', None)
-        if isinstance(autostop, str):
+        if autostop is not None:
             if autostop.endswith('min') or autostop.endswith('m'):
-                autostop = float(''.join(filter(str.isdigit, autostop)))
+                autostop = str(float(''.join(filter(str.isdigit, autostop))))
             elif autostop.endswith('h') or autostop.endswith('hr'):
-                autostop = float(''.join(filter(str.isdigit, autostop))) * 60
+                autostop = str(
+                    float(''.join(filter(str.isdigit, autostop))) * 60)
             elif autostop.endswith('d') or autostop.endswith('day'):
-                autostop = float(''.join(filter(str.isdigit, autostop))) * 60 * 24
+                autostop = str(
+                    float(''.join(filter(str.isdigit, autostop))) * 60 * 24)
             elif autostop.endswith('w') or autostop.endswith('week'):
-                autostop = float(''.join(filter(str.isdigit, autostop))) * 60 * 24 * 7
+                autostop = str(
+                    float(''.join(filter(str.isdigit, autostop))) * 60 * 24 * 7)
             elif autostop.endswith('s') or autostop.endswith('sec'):
-                autostop = float(''.join(filter(str.isdigit, autostop))) / 60
+                autostop = str(
+                    float(''.join(filter(str.isdigit, autostop))) / 60)
             else:
-                autostop = float(autostop)
-        resources_fields['autostop'] = str(autostop)
+                autostop = str(float(autostop))
+        resources_fields['autostop'] = autostop
         resources_fields['volumes'] = config.pop('volumes', None)
         resources_fields['_docker_login_config'] = config.pop(
             '_docker_login_config', None)
@@ -2246,22 +2250,20 @@ def _convert_to_gb(memory: str) -> str:
 
     memory = memory.upper()
     if memory.endswith('GB'):
-        memory = int(memory[:-2])
+        memory = str(int(memory[:-2]))
     elif memory.endswith('MB'):
-        memory = int(memory[:-2]) // 1024
+        memory = str(int(memory[:-2]) // 1024)
     elif memory.endswith('TB'):
-        memory = int(memory[:-2]) * 1024
+        memory = str(int(memory[:-2]) * 1024)
     elif memory.endswith('KB'):
-        memory = int(memory[:-2]) // 1024 // 1024
+        memory = str(int(memory[:-2]) // 1024 // 1024)
     elif memory.endswith('B'):
-        memory = int(memory[:-1]) // 1024 // 1024 // 1024
+        memory = str(int(memory[:-1]) // 1024 // 1024 // 1024)
     elif memory.endswith('PB'):
-        memory = int(memory[:-2]) * 1024 * 1024
-    elif memory.isdigit():
-        memory = int(memory)
-    else:
-        raise ValueError(f"Invalid memory format: {memory}")
+        memory = str(int(memory[:-2]) * 1024 * 1024)
+    elif not memory.isdigit():
+        raise ValueError(f'Invalid memory format: {memory}')
 
     if plus:
-        memory = f"{memory}+"
-    return str(memory)
+        memory = f'{memory}+'
+    return memory

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -33,6 +33,8 @@ def _check_not_both_fields_present(field1: str, field2: str):
     }
 
 
+time_pattern = '^[0-9]+([m]|[h]|[d]|[w]|[s]|[min]|[hr]|[day]|[week]|[sec])?$'
+
 _AUTOSTOP_SCHEMA = {
     'anyOf': [
         {
@@ -43,7 +45,8 @@ _AUTOSTOP_SCHEMA = {
         {
             # Shorthand to set idle_minutes by directly specifying, e.g.
             #   autostop: 5
-            'type': 'integer',
+            'type': 'string',
+            'pattern': time_pattern,
             'minimum': 0,
         },
         {
@@ -97,6 +100,8 @@ def _get_single_resources_schema():
     infra_pattern = (f'^(?:{cloud_pattern}{region_zone_pattern}|'
                      f'{wildcard_cloud}{wildcard_with_region}|'
                      f'{kubernetes_pattern})$')
+    
+    memory_pattern = '^[0-9]+([GgMmTt][Bb])$'
 
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
@@ -190,7 +195,12 @@ def _get_single_resources_schema():
                     'type': 'object',
                     'properties': {
                         'disk_size': {
-                            'type': 'integer',
+                            'anyOf': [{
+                                'type': 'string',
+                                'pattern': memory_pattern,
+                            }, {
+                                'type': 'integer',
+                            }],
                         },
                         'disk_tier': {
                             'type': 'string',
@@ -214,7 +224,12 @@ def _get_single_resources_schema():
                 },
             },
             'disk_size': {
-                'type': 'integer',
+                'anyOf': [{
+                    'type': 'string',
+                    'pattern': memory_pattern,
+                }, {
+                    'type': 'integer',
+                }],
             },
             'disk_tier': {
                 'type': 'string',
@@ -365,6 +380,9 @@ def get_resources_schema():
 def get_storage_schema():
     # pylint: disable=import-outside-toplevel
     from sky.data import storage
+
+    memory_pattern = '^[0-9]+([GgMmTt][Bb])$'
+    
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'type': 'object',
@@ -404,7 +422,12 @@ def get_storage_schema():
                 'type': 'object',
                 'properties': {
                     'disk_size': {
-                        'type': 'integer',
+                        'anyOf': [{
+                            'type': 'string',
+                            'pattern': memory_pattern,
+                        }, {
+                            'type': 'integer',
+                        }],
                     },
                     'disk_tier': {
                         'type': 'string',

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -100,7 +100,7 @@ def _get_single_resources_schema():
     infra_pattern = (f'^(?:{cloud_pattern}{region_zone_pattern}|'
                      f'{wildcard_cloud}{wildcard_with_region}|'
                      f'{kubernetes_pattern})$')
-    
+
     memory_pattern = '^[0-9]+([GgMmTt][Bb])$'
 
     return {
@@ -382,7 +382,7 @@ def get_storage_schema():
     from sky.data import storage
 
     memory_pattern = '^[0-9]+([GgMmTt][Bb])$'
-    
+
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'type': 'object',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adds units for disk memory and autostop. The units added are minutes, seconds, hours, days for autostop, and b, kb, mb, gb, tb, pb for disk and memory.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
