### PR TITLE
[jobs] invert priority value

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -211,7 +211,7 @@ Specify job priority by setting the ``job.priority`` field in the :ref:`SkyPilot
   job:
     # Priority of the job, between 0 and 1000 (default: 500).
     #
-    # A lower value means that the job is higher priority. High priority jobs
+    # A higher value means that the job is higher priority. High priority jobs
     # are scheduled sooner and will block lower priority jobs from starting
     # until the high priority jobs have started.
     priority: 500

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -1301,7 +1301,7 @@ Fields
 
 Priority of the job, between 0 and 1000 (default: 500).
 
-Set the queuing priority of the job. A lower value means that the job is higher
+Set the queuing priority of the job. A higher value means that the job is higher
 priority. High priority jobs are scheduled sooner and will block lower priority
 jobs from starting until the high priority jobs have started.
 

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -4199,7 +4199,7 @@ def jobs():
               type=click.IntRange(0, 1000),
               default=None,
               show_default=True,
-              help=('Job priority from 0 to 1000. A lower number is higher '
+              help=('Job priority from 0 to 1000. A higher number is higher '
                     'priority. Default is 500.'))
 @click.option(
     '--detach-run',

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -323,11 +323,10 @@ if __name__ == '__main__':
     parser.add_argument('--env-file',
                         type=str,
                         help='The path to the controller env file.')
-    parser.add_argument(
-        '--priority',
-        type=int,
-        default=500,
-        help='Job priority (0-1000). Default: 500.')
+    parser.add_argument('--priority',
+                        type=int,
+                        default=500,
+                        help='Job priority (0-1000). Default: 500.')
     args = parser.parse_args()
     submit_job(args.job_id, args.dag_yaml, args.user_yaml_path, args.env_file,
                args.priority)

--- a/sky/jobs/scheduler.py
+++ b/sky/jobs/scheduler.py
@@ -327,7 +327,7 @@ if __name__ == '__main__':
         '--priority',
         type=int,
         default=500,
-        help='Job priority (0-1000, lower is higher). Default: 500.')
+        help='Job priority (0-1000). Default: 500.')
     args = parser.parse_args()
     submit_job(args.job_id, args.dag_yaml, args.user_yaml_path, args.env_file,
                args.priority)

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -999,8 +999,7 @@ def dump_managed_job_queue() -> str:
             state_details = 'In backoff, waiting for resources'
         elif job['schedule_state'] in ('WAITING', 'ALIVE_WAITING'):
             priority = job.get('priority')
-            if (priority is not None and
-                    priority < highest_blocking_priority):
+            if (priority is not None and priority < highest_blocking_priority):
                 # Job is lower priority than some other blocking job.
                 state_details = 'Waiting for higher priority jobs to launch'
             else:

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -934,7 +934,7 @@ def dump_managed_job_queue() -> str:
     # Figure out what the highest priority blocking job is. We need to know in
     # order to determine if other jobs are blocked by a higher priority job, or
     # just by the limited controller resources.
-    lowest_blocking_priority_value = 1000
+    highest_blocking_priority = 0
     for job in jobs:
         if job['schedule_state'] not in (
                 # LAUNCHING and ALIVE_BACKOFF jobs will block other jobs with
@@ -950,8 +950,8 @@ def dump_managed_job_queue() -> str:
             continue
 
         priority = job.get('priority')
-        if priority is not None and priority < lowest_blocking_priority_value:
-            lowest_blocking_priority_value = priority
+        if priority is not None and priority > highest_blocking_priority:
+            highest_blocking_priority = priority
 
     for job in jobs:
         end_at = job['end_at']
@@ -1000,7 +1000,7 @@ def dump_managed_job_queue() -> str:
         elif job['schedule_state'] in ('WAITING', 'ALIVE_WAITING'):
             priority = job.get('priority')
             if (priority is not None and
-                    priority > lowest_blocking_priority_value):
+                    priority < highest_blocking_priority):
                 # Job is lower priority than some other blocking job.
                 state_details = 'Waiting for higher priority jobs to launch'
             else:


### PR DESCRIPTION
Now, a higher priority value indicates that the job is higher priority.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
