### PR TITLE
[UX] Change rsync filters to custom filters.

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -337,8 +337,8 @@ def path_size_megabytes(path: str) -> int:
             git_exclude_filter = command_runner.RSYNC_EXCLUDE_OPTION.format(
                 shlex.quote(str(resolved_path / command_runner.GIT_EXCLUDE)))
     rsync_command = (f'rsync {command_runner.RSYNC_DISPLAY_OPTION} '
-                     f'{rsync_filter} '
-                     f'{git_exclude_filter} --dry-run {path!r}')
+                    f'--exclude-from={shlex.quote(str(resolved_path / constants.GIT_IGNORE_FILE))} '
+                    f'{git_exclude_filter} --dry-run {path!r}')
     rsync_output = ''
     try:
         rsync_output = str(subprocess.check_output(rsync_command, shell=True))

--- a/sky/utils/command_runner.pyi
+++ b/sky/utils/command_runner.pyi
@@ -14,10 +14,7 @@ from sky import sky_logging as sky_logging
 from sky.skylet import log_lib as log_lib
 from sky.utils import subprocess_utils as subprocess_utils
 
-GIT_EXCLUDE: str
 RSYNC_DISPLAY_OPTION: str
-RSYNC_FILTER_GITIGNORE: str
-RSYNC_FILTER_SKYIGNORE: str
 RSYNC_EXCLUDE_OPTION: str
 ALIAS_SUDO_TO_EMPTY_FOR_ROOT_CMD: str
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Use the same filters as `storage_utils.py` for uploading to a bucket for `rsync`.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
