### PR TITLE
[Metrics] Add k8s node ip to infra dashboard page

### DIFF
--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -308,7 +308,8 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
   // Function to open Grafana
   const openGrafana = () => {
     // Use the configured Grafana URL if available, otherwise construct default
-    const grafanaUrl = window['SKYPILOT_GRAFANA_URL'] || `${window.location.origin}/grafana`;
+    const grafanaUrl =
+      window['SKYPILOT_GRAFANA_URL'] || `${window.location.origin}/grafana`;
     window.open(grafanaUrl, '_blank');
   };
 
@@ -400,6 +401,9 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                         Node
                       </th>
                       <th className="p-3 text-left font-medium text-gray-600">
+                        IP Address
+                      </th>
+                      <th className="p-3 text-left font-medium text-gray-600">
                         GPU
                       </th>
                       <th className="p-3 text-right font-medium text-gray-600">
@@ -415,6 +419,9 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                       >
                         <td className="p-3 whitespace-nowrap text-gray-700">
                           {node.node_name}
+                        </td>
+                        <td className="p-3 whitespace-nowrap text-gray-700">
+                          {node.ip_address || '-'}
                         </td>
                         <td className="p-3 whitespace-nowrap text-gray-700">
                           {node.gpu_name}

--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -464,6 +464,7 @@ async function getKubernetesGPUs(clustersAndJobsData) {
             gpu_name: acceleratorType,
             gpu_total: totalAccelerators,
             gpu_free: freeAccelerators,
+            ip_address: nodeData['ip_address'] || null,
             context: context,
           };
 

--- a/sky/models.py
+++ b/sky/models.py
@@ -29,6 +29,8 @@ class KubernetesNodeInfo:
     # Resources available on the node. E.g., {'nvidia.com/gpu': '2'}
     total: Dict[str, int]
     free: Dict[str, int]
+    # IP address of the node (external IP preferred, fallback to internal IP)
+    ip_address: Optional[str] = None
 
 
 @dataclasses.dataclass

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2680,6 +2680,21 @@ def get_kubernetes_node_info(
                     node.metadata.labels.get(label_key))
                 break
 
+        # Extract IP address from node addresses (prefer external, fallback to internal)
+        node_ip = None
+        if node.status.addresses:
+            # First try to find external IP
+            for address in node.status.addresses:
+                if address.type == 'ExternalIP':
+                    node_ip = address.address
+                    break
+            # If no external IP, try to find internal IP
+            if node_ip is None:
+                for address in node.status.addresses:
+                    if address.type == 'InternalIP':
+                        node_ip = address.address
+                        break
+
         allocated_qty = 0
         accelerator_count = get_node_accelerator_count(node.status.allocatable)
 
@@ -2711,7 +2726,8 @@ def get_kubernetes_node_info(
             name=node.metadata.name,
             accelerator_type=accelerator_name,
             total={'accelerator_count': int(accelerator_count)},
-            free={'accelerators_available': int(accelerators_available)})
+            free={'accelerators_available': int(accelerators_available)},
+            ip_address=node_ip)
     hint = ''
     if has_multi_host_tpu:
         hint = ('(Note: Multi-host TPUs are detected and excluded from the '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds the k8s node ip address to the infra dashboard page, so it can be used to identify instances in the dcgm exporter dashboard. 

The instances in the dcgm exporter dashboard were originally showing pod ips which differed from the node ips, but running the following command and then deleting the old dcgm exporter pods made the pods use the node ips:

```
kubectl patch daemonset nvidia-dcgm-exporter -n gpu-operator --type='merge' -p='
{
  "spec": {
    "template": {
      "spec": {
        "hostNetwork": true,
        "dnsPolicy": "ClusterFirstWithHostNet"
      }
    }
  }
}'
```


<!-- Describe the tests ran -->
Tested by verifying the IPs showing up in the infra dashboard and the updated node ips showing up in dcgm exporter dashboard in grafana. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
