### PR TITLE
standardize db initialization

### DIFF
--- a/sky/benchmark/benchmark_state.py
+++ b/sky/benchmark/benchmark_state.py
@@ -17,7 +17,6 @@ _BENCHMARK_BUCKET_NAME_KEY = 'bucket_name'
 _BENCHMARK_BUCKET_TYPE_KEY = 'bucket_type'
 
 _BENCHMARK_DB_PATH = os.path.expanduser('~/.sky/benchmark.db')
-os.makedirs(pathlib.Path(_BENCHMARK_DB_PATH).parents[0], exist_ok=True)
 
 
 class _BenchmarkSQLiteConn(threading.local):
@@ -80,6 +79,8 @@ def _init_db(func):
             return func(*args, **kwargs)
         with _benchmark_db_init_lock:
             if not _BENCHMARK_DB:
+                os.makedirs(pathlib.Path(_BENCHMARK_DB_PATH).parents[0],
+                            exist_ok=True)
                 _BENCHMARK_DB = _BenchmarkSQLiteConn()
         return func(*args, **kwargs)
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -161,8 +161,8 @@ def create_table(cursor, conn):
     conn.commit()
 
 
-# Module-level connection/cursor; thread-safe as the module is only imported
-# once.
+# Module-level connection/cursor; thread-safe as the db is initialized once
+# across all threads.
 def _get_db_path() -> str:
     """Workaround to collapse multi-step Path ops for type checker.
     Ensures _DB_PATH is str, avoiding Union[Path, str] inference.
@@ -173,8 +173,7 @@ def _get_db_path() -> str:
     return str(path)
 
 
-_DB_PATH = _get_db_path()
-_db_initialized = False
+_DB_PATH = None
 _db_init_lock = threading.Lock()
 
 
@@ -183,13 +182,13 @@ def _init_db(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        global _db_initialized
-        if _db_initialized:
+        global _DB_PATH
+        if _DB_PATH is not None:
             return func(*args, **kwargs)
         with _db_init_lock:
-            if not _db_initialized:
+            if _DB_PATH is None:
+                _DB_PATH = _get_db_path()
                 db_utils.SQLiteConn(_DB_PATH, create_table)
-                _db_initialized = True
         return func(*args, **kwargs)
 
     return wrapper
@@ -442,7 +441,7 @@ class ManagedJobScheduleState(enum.Enum):
 # === Status transition functions ===
 @_init_db
 def set_job_info(job_id: int, name: str, workspace: str, entrypoint: str):
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\
@@ -456,7 +455,7 @@ def set_job_info(job_id: int, name: str, workspace: str, entrypoint: str):
 @_init_db
 def set_pending(job_id: int, task_id: int, task_name: str, resources_str: str):
     """Set the task to pending state."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\
@@ -484,7 +483,7 @@ def set_starting(job_id: int, task_id: int, run_timestamp: str,
         specs: The specs of the managed task.
         callback_func: The callback function.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     # Use the timestamp in the `run_timestamp` ('sky-2022-10...'), to make
     # the log directory and submission time align with each other, so as to
     # make it easier to find them based on one of the values.
@@ -524,7 +523,7 @@ def set_backoff_pending(job_id: int, task_id: int):
     This should only be used to transition from STARTING or RECOVERING back to
     PENDING.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\
@@ -552,7 +551,7 @@ def set_restarting(job_id: int, task_id: int, recovering: bool):
     after using set_backoff_pending to transition back to PENDING during
     launch retry backoff.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     target_status = ManagedJobStatus.STARTING.value
     if recovering:
         target_status = ManagedJobStatus.RECOVERING.value
@@ -578,7 +577,7 @@ def set_restarting(job_id: int, task_id: int, recovering: bool):
 def set_started(job_id: int, task_id: int, start_time: float,
                 callback_func: CallbackType):
     """Set the task to started state."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     logger.info('Job started.')
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
@@ -610,7 +609,7 @@ def set_started(job_id: int, task_id: int, start_time: float,
 @_init_db
 def set_recovering(job_id: int, task_id: int, callback_func: CallbackType):
     """Set the task to recovering state, and update the job duration."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     logger.info('=== Recovering... ===')
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
@@ -634,7 +633,7 @@ def set_recovering(job_id: int, task_id: int, callback_func: CallbackType):
 def set_recovered(job_id: int, task_id: int, recovered_time: float,
                   callback_func: CallbackType):
     """Set the task to recovered."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\
@@ -658,7 +657,7 @@ def set_recovered(job_id: int, task_id: int, recovered_time: float,
 def set_succeeded(job_id: int, task_id: int, end_time: float,
                   callback_func: CallbackType):
     """Set the task to succeeded, if it is in a non-terminal state."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\
@@ -703,7 +702,7 @@ def set_failed(
         override_terminal: If True, override the current status even if end_at
             is already set.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     assert failure_type.is_failed(), failure_type
     end_time = time.time() if end_time is None else end_time
 
@@ -761,7 +760,7 @@ def set_cancelling(job_id: int, callback_func: CallbackType):
     task_id is not needed, because we expect the job should be cancelled
     as a whole, and we should not cancel a single task.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute(
             """\
@@ -783,7 +782,7 @@ def set_cancelled(job_id: int, callback_func: CallbackType):
 
     The set_cancelling should be called before this function.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute(
             """\
@@ -804,7 +803,7 @@ def set_cancelled(job_id: int, callback_func: CallbackType):
 def set_local_log_file(job_id: int, task_id: Optional[int],
                        local_log_file: str):
     """Set the local log file for a job."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     filter_str = 'spot_job_id=(?)'
     filter_args = [local_log_file, job_id]
 
@@ -822,7 +821,7 @@ def set_local_log_file(job_id: int, task_id: Optional[int],
 def get_nonterminal_job_ids_by_name(name: Optional[str],
                                     all_users: bool = False) -> List[int]:
     """Get non-terminal job ids by name."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     statuses = ', '.join(['?'] * len(ManagedJobStatus.terminal_statuses()))
     field_values = [
         status.value for status in ManagedJobStatus.terminal_statuses()
@@ -866,7 +865,7 @@ def get_schedule_live_jobs(job_id: Optional[int]) -> List[Dict[str, Any]]:
     exception: the job may have just transitioned from WAITING to LAUNCHING, but
     the controller process has not yet started.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     job_filter = '' if job_id is None else 'AND spot_job_id=(?)'
     job_value = (job_id,) if job_id is not None else ()
 
@@ -909,7 +908,7 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
     - Jobs have schedule_state DONE but are in a non-terminal status
     - Legacy jobs (that is, no schedule state) that are in non-terminal status
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     job_filter = '' if job_id is None else 'AND spot.spot_job_id=(?)'
     job_value = () if job_id is None else (job_id,)
 
@@ -958,7 +957,7 @@ def get_jobs_to_check_status(job_id: Optional[int] = None) -> List[int]:
 @_init_db
 def get_all_job_ids_by_name(name: Optional[str]) -> List[int]:
     """Get all job ids by name."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     name_filter = ''
     field_values = []
     if name is not None:
@@ -987,7 +986,7 @@ def get_all_job_ids_by_name(name: Optional[str]) -> List[int]:
 @_init_db
 def _get_all_task_ids_statuses(
         job_id: int) -> List[Tuple[int, ManagedJobStatus]]:
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         id_statuses = cursor.execute(
             """\
@@ -1035,7 +1034,7 @@ def get_failure_reason(job_id: int) -> Optional[str]:
 
     If the job has multiple tasks, we return the first failure reason.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         reason = cursor.execute(
             """\
@@ -1051,7 +1050,7 @@ def get_failure_reason(job_id: int) -> Optional[str]:
 @_init_db
 def get_managed_jobs(job_id: Optional[int] = None) -> List[Dict[str, Any]]:
     """Get managed jobs from the database."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     job_filter = '' if job_id is None else f'WHERE spot.spot_job_id={job_id}'
 
     # Join spot and job_info tables to get the job name for each task.
@@ -1097,7 +1096,7 @@ def get_managed_jobs(job_id: Optional[int] = None) -> List[Dict[str, Any]]:
 @_init_db
 def get_task_name(job_id: int, task_id: int) -> str:
     """Get the task name of a job."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         task_name = cursor.execute(
             """\
@@ -1110,7 +1109,7 @@ def get_task_name(job_id: int, task_id: int) -> str:
 @_init_db
 def get_latest_job_id() -> Optional[int]:
     """Get the latest job id."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute("""\
             SELECT spot_job_id FROM spot
@@ -1123,7 +1122,7 @@ def get_latest_job_id() -> Optional[int]:
 
 @_init_db
 def get_task_specs(job_id: int, task_id: int) -> Dict[str, Any]:
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         task_specs = cursor.execute(
             """\
@@ -1136,7 +1135,7 @@ def get_task_specs(job_id: int, task_id: int) -> Dict[str, Any]:
 @_init_db
 def get_local_log_file(job_id: int, task_id: Optional[int]) -> Optional[str]:
     """Get the local log directory for a job."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     filter_str = 'spot_job_id=(?)'
     filter_args = [job_id]
     if task_id is not None:
@@ -1159,7 +1158,7 @@ def scheduler_set_waiting(job_id: int, dag_yaml_path: str,
                           original_user_yaml_path: str, env_file_path: str,
                           user_hash: str, priority: int) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1177,7 +1176,7 @@ def scheduler_set_waiting(job_id: int, dag_yaml_path: str,
 def scheduler_set_launching(job_id: int,
                             current_state: ManagedJobScheduleState) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1191,7 +1190,7 @@ def scheduler_set_launching(job_id: int,
 @_init_db
 def scheduler_set_alive(job_id: int) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1205,7 +1204,7 @@ def scheduler_set_alive(job_id: int) -> None:
 @_init_db
 def scheduler_set_alive_backoff(job_id: int) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1219,7 +1218,7 @@ def scheduler_set_alive_backoff(job_id: int) -> None:
 @_init_db
 def scheduler_set_alive_waiting(job_id: int) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1234,7 +1233,7 @@ def scheduler_set_alive_waiting(job_id: int) -> None:
 @_init_db
 def scheduler_set_done(job_id: int, idempotent: bool = False) -> None:
     """Do not call without holding the scheduler lock."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1248,7 +1247,7 @@ def scheduler_set_done(job_id: int, idempotent: bool = False) -> None:
 
 @_init_db
 def set_job_controller_pid(job_id: int, pid: int):
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         updated_count = cursor.execute(
             'UPDATE job_info SET '
@@ -1259,7 +1258,7 @@ def set_job_controller_pid(job_id: int, pid: int):
 
 @_init_db
 def get_job_schedule_state(job_id: int) -> ManagedJobScheduleState:
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         state = cursor.execute(
             'SELECT schedule_state FROM job_info WHERE spot_job_id = (?)',
@@ -1269,7 +1268,7 @@ def get_job_schedule_state(job_id: int) -> ManagedJobScheduleState:
 
 @_init_db
 def get_num_launching_jobs() -> int:
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         return cursor.execute(
             'SELECT COUNT(*) '
@@ -1280,7 +1279,7 @@ def get_num_launching_jobs() -> int:
 
 @_init_db
 def get_num_alive_jobs() -> int:
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         return cursor.execute(
             'SELECT COUNT(*) '
@@ -1303,7 +1302,7 @@ def get_waiting_job() -> Optional[Dict[str, Any]]:
     Backwards compatibility note: jobs submitted before #4485 will have no
     schedule_state and will be ignored by this SQL query.
     """
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         # Get the highest-priority WAITING or ALIVE_WAITING job whose priority
         # is greater than or equal to the highest priority LAUNCHING or
@@ -1338,7 +1337,7 @@ def get_waiting_job() -> Optional[Dict[str, Any]]:
 @_init_db
 def get_workspace(job_id: int) -> str:
     """Get the workspace of a job."""
-    assert _db_initialized
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         workspace = cursor.execute(
             'SELECT workspace FROM job_info WHERE spot_job_id = (?)',

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -9,6 +9,7 @@ import pathlib
 import shutil
 import signal
 import sqlite3
+import threading
 import time
 import traceback
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple
@@ -392,10 +393,6 @@ def kill_requests(request_ids: Optional[List[str]] = None,
     return cancelled_request_ids
 
 
-_DB_PATH = os.path.expanduser(server_constants.API_SERVER_REQUEST_DB_PATH)
-pathlib.Path(_DB_PATH).parents[0].mkdir(parents=True, exist_ok=True)
-
-
 def create_table(cursor, conn):
     # Enable WAL mode to avoid locking issues.
     # See: issue #1441 and PR #1509
@@ -433,6 +430,7 @@ def create_table(cursor, conn):
 
 
 _DB = None
+_init_db_lock = threading.Lock()
 
 
 def init_db(func):
@@ -441,8 +439,15 @@ def init_db(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         global _DB
-        if _DB is None:
-            _DB = db_utils.SQLiteConn(_DB_PATH, create_table)
+        if _DB is not None:
+            return func(*args, **kwargs)
+        with _init_db_lock:
+            if _DB is None:
+                db_path = os.path.expanduser(
+                    server_constants.API_SERVER_REQUEST_DB_PATH)
+                pathlib.Path(db_path).parents[0].mkdir(parents=True,
+                                                       exist_ok=True)
+                _DB = db_utils.SQLiteConn(db_path, create_table)
         return func(*args, **kwargs)
 
     return wrapper

--- a/sky/skylet/configs.py
+++ b/sky/skylet/configs.py
@@ -2,17 +2,16 @@
 import functools
 import os
 import pathlib
+import threading
 from typing import Callable, Optional, Union
 
 from sky.utils import db_utils
 
-_DB_PATH = os.path.expanduser('~/.sky/skylet_config.db')
-os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
-
-_table_created = False
+_DB_PATH = None
+_db_init_lock = threading.Lock()
 
 
-def ensure_table(func: Callable):
+def init_db(func: Callable):
     """Ensure the table exists before calling the function.
 
     Since this module will be imported whenever `sky` is imported (due to
@@ -24,25 +23,32 @@ def ensure_table(func: Callable):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        global _table_created
-        if not _table_created:
-            with db_utils.safe_cursor(
-                    _DB_PATH) as c:  # Call it 'c' to avoid pylint complaining.
-                # Use WAL mode to avoid locking problem in #1507.
-                # Reference: https://stackoverflow.com/a/39265148
-                c.execute('PRAGMA journal_mode=WAL')
-                c.execute("""\
-                    CREATE TABLE IF NOT EXISTS config (
-                        key TEXT PRIMARY KEY,
-                        value TEXT)""")
-        _table_created = True
+        global _DB_PATH
+        if _DB_PATH is not None:
+            return func(*args, **kwargs)
+
+        with _db_init_lock:
+            if _DB_PATH is None:
+                _DB_PATH = os.path.expanduser('~/.sky/skylet_config.db')
+                os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
+                with db_utils.safe_cursor(
+                        _DB_PATH
+                ) as c:  # Call it 'c' to avoid pylint complaining.
+                    # Use WAL mode to avoid locking problem in #1507.
+                    # Reference: https://stackoverflow.com/a/39265148
+                    c.execute('PRAGMA journal_mode=WAL')
+                    c.execute("""\
+                        CREATE TABLE IF NOT EXISTS config (
+                            key TEXT PRIMARY KEY,
+                            value TEXT)""")
         return func(*args, **kwargs)
 
     return wrapper
 
 
-@ensure_table
+@init_db
 def get_config(key: str) -> Optional[bytes]:
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         rows = cursor.execute('SELECT value FROM config WHERE key = ?', (key,))
         for (value,) in rows:
@@ -50,8 +56,9 @@ def get_config(key: str) -> Optional[bytes]:
         return None
 
 
-@ensure_table
+@init_db
 def set_config(key: str, value: Union[bytes, str]) -> None:
+    assert _DB_PATH is not None
     with db_utils.safe_cursor(_DB_PATH) as cursor:
         cursor.execute(
             """\

--- a/sky/skylet/job_lib.py
+++ b/sky/skylet/job_lib.py
@@ -64,10 +64,6 @@ class JobInfoLoc(enum.IntEnum):
     PID = 9
 
 
-_DB_PATH = os.path.expanduser('~/.sky/jobs.db')
-os.makedirs(pathlib.Path(_DB_PATH).parents[0], exist_ok=True)
-
-
 def create_table(cursor, conn):
     # Enable WAL mode to avoid locking issues.
     # See: issue #3863, #1441 and PR #1509
@@ -136,7 +132,9 @@ def init_db(func):
 
         with _db_init_lock:
             if _DB is None:
-                _DB = db_utils.SQLiteConn(_DB_PATH, create_table)
+                db_path = os.path.expanduser('~/.sky/jobs.db')
+                os.makedirs(pathlib.Path(db_path).parents[0], exist_ok=True)
+                _DB = db_utils.SQLiteConn(db_path, create_table)
         return func(*args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
1. add locks to lazily initialized DBs that don't have locking
2. do not initialize directory until the DB is initialized
3. do not use `_db_initialized` boolean if another variable is available to determine if a DB has been initialized or not.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
