### PR TITLE
fix permission service init race condition

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -51,6 +51,8 @@ class PermissionService:
                                                   'model.conf')
                         enforcer = casbin.Enforcer(model_path, adapter)
                         self.enforcer = enforcer
+                    else:
+                        self.enforcer = _enforcer_instance.enforcer
             else:
                 self.enforcer = _enforcer_instance.enforcer
             with _policy_lock():


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
I noticed a CI test failure on my other PR (which was resolved with a rerun) - inspection of the [test failure](https://github.com/skypilot-org/skypilot/actions/runs/15581703816/job/43878303202?pr=5964) revealed very interesting traceback.

```
E 06-11 09:52:43 sdk.py:1667] Traceback (most recent call last):
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/server/requests/executor.py", line 345, in _request_execution_wrapper
E 06-11 09:52:43 sdk.py:1667]     with override_request_env_and_config(request_body):
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/.local/share/uv/python/cpython-3.8.20-linux-x86_64-gnu/lib/python3.8/contextlib.py", line 113, in __enter__
E 06-11 09:52:43 sdk.py:1667]     return next(self.gen)
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/server/requests/executor.py", line 271, in override_request_env_and_config
E 06-11 09:52:43 sdk.py:1667]     workspaces_core.reject_request_for_unauthorized_workspace(user)
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/workspaces/core.py", line 485, in reject_request_for_unauthorized_workspace
E 06-11 09:52:43 sdk.py:1667]     if not permission.permission_service.check_workspace_permission(
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/users/permission.py", line 230, in check_workspace_permission
E 06-11 09:52:43 sdk.py:1667]     self._lazy_initialize()
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/users/permission.py", line 57, in _lazy_initialize
E 06-11 09:52:43 sdk.py:1667]     self._maybe_initialize_policies()
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/users/permission.py", line 62, in _maybe_initialize_policies
E 06-11 09:52:43 sdk.py:1667]     self._load_policy_no_lock()
E 06-11 09:52:43 sdk.py:1667]   File "/home/runner/work/skypilot/skypilot/sky/users/permission.py", line 210, in _load_policy_no_lock
E 06-11 09:52:43 sdk.py:1667]     self.enforcer.load_policy()
E 06-11 09:52:43 sdk.py:1667] AttributeError: 'NoneType' object has no attribute 'load_policy'
```

The traceback suggests that `self.enforcer` is set to `None`. Since I just touched this module (see https://github.com/skypilot-org/skypilot/pull/5942/files) I investigated to see if the mentioned PR had anything to do with it.

Based on my investigation, this is the only branch where the `self.enforcer` can be left as `None` before `_maybe_initialize_policies` is called. This bug existed before lazy initialization, but it is possible the lazy initialization made the bug more likely to hit. In any case, this PR should fix the bug.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
