### PR TITLE
change privacy policy filename to be a dotfile

### DIFF
--- a/sky/usage/constants.py
+++ b/sky/usage/constants.py
@@ -3,7 +3,7 @@
 LOG_URL = 'http://usage.skypilot.co:9090/loki/api/v1/push'  # pylint: disable=line-too-long
 
 USAGE_MESSAGE_SCHEMA_VERSION = 1
-PRIVACY_POLICY_PATH = '~/.sky/privacy_policy'
+PRIVACY_POLICY_SHOWN_PATH = '~/.sky/.privacy_policy_shown'
 
 USAGE_POLICY_MESSAGE = (
     'SkyPilot collects usage data to improve its services. '

--- a/sky/usage/usage_lib.py
+++ b/sky/usage/usage_lib.py
@@ -474,7 +474,8 @@ def maybe_show_privacy_policy():
     """Show the privacy policy if it is not already shown."""
     # Show the policy message only when the entrypoint is used.
     # An indicator for PRIVACY_POLICY has already been shown.
-    privacy_policy_indicator = os.path.expanduser(constants.PRIVACY_POLICY_PATH)
+    privacy_policy_indicator = os.path.expanduser(
+        constants.PRIVACY_POLICY_SHOWN_PATH)
     if not env_options.Options.DISABLE_LOGGING.get():
         os.makedirs(os.path.dirname(privacy_policy_indicator), exist_ok=True)
         try:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Mini-proposal: As part of the effort to declutter the `~/.sky` directory, we should change the `privacy_policy` to a dotfile. This file really serves as an internal flag with no real meaning/infromation to users, so it should be hidden.

This does mean a user who was on a previous version of `sky` will see the privacy policy show up once again, but I can't imagine any other side effects.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
