### PR TITLE
[Bug] Fixed kubeconfig mounting in helm deployment

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -1,0 +1,38 @@
+name: Helm Unit Tests
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'charts/**'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'charts/**'
+  workflow_dispatch:
+
+jobs:
+  helm-unittest:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: '3.14.0'
+        
+    - name: Install helm unittest plugin
+      run: |
+        helm plugin install https://github.com/helm-unittest/helm-unittest.git
+        
+    - name: Update chart dependencies
+      run: |
+        cd charts/skypilot
+        helm dependency update
+        
+    - name: Run helm unit tests
+      run: |
+        helm unittest -f charts/skypilot/unittests/*.yaml charts/skypilot

--- a/charts/skypilot/.helmignore
+++ b/charts/skypilot/.helmignore
@@ -1,0 +1,1 @@
+unittests

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -184,7 +184,7 @@ spec:
           mountPath: /var/skypilot/kubeconfig
         {{- else }}
         - name: kube-config
-          mountPath: /root/.kube/config
+          mountPath: /root/.kube
         {{- end }}
         {{- end }}
         {{- if .Values.apiService.sshNodePools }}

--- a/charts/skypilot/unittests/deployment_test.yaml
+++ b/charts/skypilot/unittests/deployment_test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: server_deployment_test
+templates:
+  - templates/api-deployment.yaml
+tests:
+  - it: should mount kubeconfig correctly when useKubeconfig is enabled
+    set:
+      kubernetesCredentials.useKubeconfig: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kube-config
+            mountPath: /root/.kube
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: kube-config
+            secret:
+              secretName: kubeconfig-secret
+
+  - it: should persist .kube directory when sshNodePool is enabled
+    set:
+      sshNodePool.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: state-volume
+            mountPath: /root/.kube
+
+  - it: should merge kubeconfig from .kube and configmap when useKubeconfig and sshNodePool are both enabled
+    set:
+      kubernetesCredentials.useKubeconfig: true
+      sshNodePool.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: kube-config
+            mountPath: /var/skypilot/kubeconfig
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: state-volume
+            mountPath: /root/.kube
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBECONFIG
+            value: /root/.kube/config:/var/skypilot/kubeconfig/config

--- a/charts/skypilot/unittests/deployment_test.yaml
+++ b/charts/skypilot/unittests/deployment_test.yaml
@@ -17,22 +17,23 @@ tests:
           content:
             name: kube-config
             secret:
-              secretName: kubeconfig-secret
+              secretName: kube-credentials
 
   - it: should persist .kube directory when sshNodePool is enabled
     set:
-      sshNodePool.enabled: true
+      apiService.sshNodePools: test
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: state-volume
             mountPath: /root/.kube
+            subPath: .kube
 
   - it: should merge kubeconfig from .kube and configmap when useKubeconfig and sshNodePool are both enabled
     set:
       kubernetesCredentials.useKubeconfig: true
-      sshNodePool.enabled: true
+      apiService.sshNodePools: test
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -44,6 +45,7 @@ tests:
           content:
             name: state-volume
             mountPath: /root/.kube
+            subPath: .kube
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/5972

This is introduced by https://github.com/skypilot-org/skypilot/pull/5742, only `sshNodePools` enabled and both `kubeconfig` and `sshNodePools` enabled are tested in that PR. So unit test cased are added to avoid regression.

Also tested manually on real kubernetes cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
