### PR TITLE
Fix `release-publish` pipeline failure

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -115,7 +115,7 @@ jobs:
     secrets: inherit
 
   create-release:
-    needs: [extract-version, publish-to-pypi]
+    needs: [extract-version, publish-and-validate-pypi]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously, when we closed the release [PR](https://github.com/skypilot-org/skypilot/pull/5828), it triggered this build error:  

https://github.com/skypilot-org/skypilot/actions/runs/15604281205  


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
