### PR TITLE
[UX] Faster jobs launch with no enabled clouds

### DIFF
--- a/sky/check.py
+++ b/sky/check.py
@@ -16,8 +16,8 @@ from sky import skypilot_config
 from sky.adaptors import cloudflare
 from sky.clouds import cloud as sky_cloud
 from sky.skylet import constants
-from sky.utils import common_utils
 from sky.utils import annotations
+from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import rich_utils
 from sky.utils import subprocess_utils


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Adds an per request `lru_cache` to `get_cached_enabled_clouds_or_refresh` to make all subsequent calls during `jobs launch` faster. Time for jobs launch goes from ~37s to ~30s.

Closes #5913.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
