### PR TITLE
[Core] Fix users to be `None` in kubeconfig

### DIFF
--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -3138,7 +3138,7 @@ def get_kubeconfig_paths() -> List[str]:
     return expanded
 
 
-def format_kubeconfig_exec_auth(config: Any,
+def format_kubeconfig_exec_auth(config: Dict[str, Any],
                                 output_path: str,
                                 inject_wrapper: bool = True) -> bool:
     """Reformat the kubeconfig so that exec-based authentication can be used
@@ -3165,7 +3165,10 @@ def format_kubeconfig_exec_auth(config: Any,
     Returns: whether config was updated, for logging purposes
     """
     updated = False
-    for user in config.get('users', []):
+    users = config.get('users', [])
+    if users is None:
+        users = []
+    for user in users:
         exec_info = user.get('user', {}).get('exec', {})
         current_command = exec_info.get('command', '')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes the issue when `users` in kubeconfig is null.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
