### PR TITLE
Fix publish to pypi pipeline logic

### DIFF
--- a/.github/workflows/publish-and-validate-both.yml
+++ b/.github/workflows/publish-and-validate-both.yml
@@ -36,7 +36,7 @@ jobs:
 
   publish-and-validate-pypi:
     needs: [publish-and-validate-test-pypi]
-    if: always()
+    if: always() && (needs.publish-and-validate-test-pypi.result == 'success' || inputs.skip_test_pypi)
     uses: ./.github/workflows/publish-and-validate.yml
     with:
       package_name: ${{ inputs.package_name }}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See https://github.com/skypilot-org/skypilot/actions/runs/15632646911

If test pypi fail, we should not trigger the real pypi publish.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
