### PR TITLE
Fix Typos in Comments and Docstrings

### DIFF
--- a/sky/utils/command_runner.py
+++ b/sky/utils/command_runner.py
@@ -561,7 +561,7 @@ class SSHCommandRunner(CommandRunner):
         if self.ssh_control_name is not None:
             control_path = _ssh_control_path(self.ssh_control_name)
             if control_path is not None:
-                # Suppress the `Exit request sent.` output for this comamnd
+                # Suppress the `Exit request sent.` output for this command
                 # which would interrupt the CLI spinner.
                 cmd = (f'ssh -O exit -S {control_path}/%C '
                        f'{self.ssh_user}@{self.ip} > /dev/null 2>&1')

--- a/sky/utils/context.py
+++ b/sky/utils/context.py
@@ -262,7 +262,7 @@ F = TypeVar('F', bound=Callable[..., Any])
 
 
 def contextual(func: F) -> F:
-    """Decorator to intiailize a context before executing the function.
+    """Decorator to initialize a context before executing the function.
 
     If a context is already initialized, this decorator will reset the context,
     i.e. all contextual variables set previously will be cleared.


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in the codebase:
- In `sky/utils/command_runner.py`, the word "comamnd" in a comment was corrected to "command".
- In `sky/utils/context.py`, the word "intialize" in a docstring was corrected to "initialize".

These changes improve code readability and maintain documentation accuracy. No functional code was modified.