### PR TITLE
feat. ssh prefix configuration

### DIFF
--- a/sky/adaptors/kubernetes.py
+++ b/sky/adaptors/kubernetes.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional, Set
 
 from sky import sky_logging
 from sky.adaptors import common
+from sky.skylet import constants
 from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import ux_utils
@@ -92,14 +93,15 @@ def _load_config(context: Optional[str] = None):
             suffix = common_utils.format_exception(e, use_bracket=True)
             context_name = '(current-context)' if context is None else context
             is_ssh_node_pool = False
-            if context_name.startswith('ssh-'):
-                context_name = common_utils.removeprefix(context_name, 'ssh-')
+            if context_name.startswith(constants.SSH_CLUSTER_PREFIX):
+                context_name = common_utils.removeprefix(
+                    context_name, constants.SSH_CLUSTER_PREFIX)
                 is_ssh_node_pool = True
             # Check if exception was due to no current-context
             if 'Expected key current-context' in str(e):
                 if is_ssh_node_pool:
                     context_name = common_utils.removeprefix(
-                        context_name, 'ssh-')
+                        context_name, constants.SSH_CLUSTER_PREFIX)
                     err_str = ('Failed to load SSH Node Pool configuration for '
                                f'{context_name!r}.\n'
                                '    Run `sky ssh up --infra {context_name}` to '

--- a/sky/cli.py
+++ b/sky/cli.py
@@ -3596,7 +3596,7 @@ def show_gpus(
         # display an aggregated table for all contexts
         # if there are more than one contexts with GPUs.
         def _filter_ctx(ctx: str) -> bool:
-            ctx_is_ssh = ctx and ctx.startswith('ssh-')
+            ctx_is_ssh = ctx and ctx.startswith(constants.SSH_CLUSTER_PREFIX)
             return ctx_is_ssh is is_ssh
 
         num_filtered_contexts = 0
@@ -3613,7 +3613,8 @@ def show_gpus(
                 if not _filter_ctx(ctx):
                     continue
                 if is_ssh:
-                    display_ctx = common_utils.removeprefix(ctx, 'ssh-')
+                    display_ctx = common_utils.removeprefix(
+                        ctx, constants.SSH_CLUSTER_PREFIX)
                 else:
                     display_ctx = ctx
                 num_filtered_contexts += 1

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -173,15 +173,17 @@ class Kubernetes(clouds.Cloud):
         # Exclude contexts starting with `ssh-`
         # TODO(romilb): Remove when SSH Node Pools use a separate kubeconfig.
         all_contexts = [
-            ctx for ctx in all_contexts if not ctx.startswith('ssh-')
+            ctx for ctx in all_contexts
+            if not ctx.startswith(constants.SSH_CLUSTER_PREFIX)
         ]
 
         if allowed_contexts is None:
             # Try kubeconfig if present
             current_context = (
                 kubernetes_utils.get_current_kube_config_context_name())
-            if ((current_context is None or current_context.startswith('ssh-'))
-                    and kubernetes_utils.is_incluster_config_available()):
+            if ((current_context is None or
+                 current_context.startswith(constants.SSH_CLUSTER_PREFIX)) and
+                    kubernetes_utils.is_incluster_config_available()):
                 # If no kubeconfig contexts found, use in-cluster if available
                 current_context = kubernetes.in_cluster_context_name()
             allowed_contexts = []
@@ -195,7 +197,7 @@ class Kubernetes(clouds.Cloud):
                 existing_contexts.append(context)
             else:
                 # Skip SSH Node Pool contexts
-                if context.startswith('ssh-'):
+                if context.startswith(constants.SSH_CLUSTER_PREFIX):
                     continue
                 skipped_contexts.append(context)
         if not silent:

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -479,8 +479,10 @@ class Resources:
         region_str = ''
         if self.region is not None:
             region_name = self.region
-            if self.region.startswith('ssh-'):
-                region_name = common_utils.removeprefix(self.region, 'ssh-')
+            if self.region.startswith(constants.SSH_CLUSTER_PREFIX):
+                region_name = common_utils.removeprefix(
+                    self.region, constants.SSH_CLUSTER_PREFIX)
+                return f'SSH Node Pool {region_name}'
             region_str = f', region={region_name}'
         zone_str = ''
         if self.zone is not None:

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -298,6 +298,11 @@ SET_SSH_MAX_SESSIONS_CONFIG_CMD = (
     '(systemctl reload sshd || service ssh reload); '
     '\'')
 
+# SSH cluster context prefix - used to identify SSH-based contexts
+# This prefix is prepended to cluster names for SSH-based deployments
+# Consider changing to 'skyssh-' for better identification as a SkyPilot cluster
+SSH_CLUSTER_PREFIX = 'ssh-'
+
 # Internal: Env var indicating the system is running with a remote API server.
 # It is used for internal purposes, including the jobs controller to mark
 # clusters as launched with a remote API server.

--- a/sky/utils/infra_utils.py
+++ b/sky/utils/infra_utils.py
@@ -2,6 +2,7 @@
 import dataclasses
 from typing import Optional
 
+from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import ux_utils
 
@@ -94,7 +95,7 @@ class InfraInfo:
             # kubeconfig to store the ssh contexts.
             region = '/'.join(parts[1:]) if len(parts) >= 2 else None
             if region:
-                region = f'ssh-{region}'
+                region = f'{constants.SSH_CLUSTER_PREFIX}{region}'
             zone = None
         else:
             # For non-Kubernetes clouds, continue with regular parsing
@@ -146,8 +147,9 @@ class InfraInfo:
         # If the cloud is ssh, we remove the ssh- prefix from the region
         # TODO(romilb): This is a workaround while we use the global
         # kubeconfig to store the ssh contexts.
-        if region and region.startswith('ssh-'):
-            region = region[4:]
+        if region and region.startswith(constants.SSH_CLUSTER_PREFIX):
+            region = common_utils.removeprefix(region,
+                                               constants.SSH_CLUSTER_PREFIX)
 
         # Build the parts list and filter out trailing wildcards
         parts = [cloud.lower(), region, zone]
@@ -180,7 +182,8 @@ class InfraInfo:
             # Node Pools.
             # TODO(romilb): This is a workaround while we use the global
             # kubeconfig to store the ssh contexts.
-            region_or_zone = common_utils.removeprefix(self.region, 'ssh-')
+            region_or_zone = common_utils.removeprefix(
+                self.region, constants.SSH_CLUSTER_PREFIX)
 
         if region_or_zone is not None and truncate:
             region_or_zone = common_utils.truncate_long_string(

--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Set
 
 import yaml
 
+from sky.skylet import constants
 from sky.utils import ux_utils
 
 # Colors for nicer UX
@@ -701,7 +702,7 @@ def main():
                 # Generate a unique context name for each cluster
                 context_name = args.context_name
                 if context_name == 'default':
-                    context_name = 'ssh-' + cluster_name
+                    context_name = f'{constants.SSH_CLUSTER_PREFIX}{cluster_name}'
 
                 # Check cluster history
                 os.makedirs(NODE_POOLS_INFO_DIR, exist_ok=True)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Related to #5987 

Added a ssh constant that can be configured and used instead of ssh


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
