### PR TITLE
[ssh] better error for missing identity file

### DIFF
--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -1091,7 +1091,7 @@ def deploy_cluster(head_node,
                     f'Skipping...{NC}')
                 return node, True, False
             worker_user = worker_hosts[i]['user']
-            worker_key = worker_hosts[i]['identity_file']
+            worker_key = os.path.expanduser(worker_hosts[i]['identity_file'])
             worker_password = worker_hosts[i]['password']
             worker_askpass = create_askpass_script(worker_password)
             worker_config = worker_use_ssh_config[i]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #6002

Additional fixes:
- fix issue of worker ips not expanding path.

Note: `setup_kubectl_ssh_tunnel` doesn't need to be checked in current workflow because 1) its a shell script which will fail if file doesn't exist anyways and throw a similar error 2) ssh identity file will error out before that code path is reached. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
