### PR TITLE
Fix kubernetes quicktest core

### DIFF
--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -279,10 +279,12 @@ class TestBackwardCompatibility:
                 job_status=status,
                 timeout=600 if generic_cloud == 'kubernetes' else 300)
 
+        blocking_seconds_for_cancel_job = 2000 if generic_cloud == 'kubernetes' else 1000
         commands = [
             *self._switch_to_base(
                 # Cover jobs launched in the old version and ran to terminal states
-                launch_job(f'{managed_job_name}-old-0', 'echo hi; sleep 1000'),
+                launch_job(f'{managed_job_name}-old-0',
+                           f'echo hi; sleep {blocking_seconds_for_cancel_job}'),
                 launch_job(f'{managed_job_name}-old-1', 'echo hi'),
                 wait_for_status(f'{managed_job_name}-old-1',
                                 [sky.ManagedJobStatus.SUCCEEDED]),
@@ -294,7 +296,8 @@ class TestBackwardCompatibility:
                     sky.ManagedJobStatus.CANCELLING
                 ]),
                 # Cover jobs launched in the new version and still running after upgrade
-                launch_job(f'{managed_job_name}-0', 'echo hi; sleep 1000'),
+                launch_job(f'{managed_job_name}-0',
+                           f'echo hi; sleep {blocking_seconds_for_cancel_job}'),
                 launch_job(f'{managed_job_name}-1', 'echo hi; sleep 400'),
                 wait_for_status(f'{managed_job_name}-0',
                                 [sky.ManagedJobStatus.RUNNING]),
@@ -306,7 +309,8 @@ class TestBackwardCompatibility:
                 f'result="$(sky jobs logs --no-follow -n {managed_job_name}-1)"; echo "$result"; echo "$result" | grep hi',
                 launch_job(f'{managed_job_name}-2', 'echo hi; sleep 400'),
                 # Cover cancelling jobs launched in the new version
-                launch_job(f'{managed_job_name}-3', 'echo hi; sleep 1000'),
+                launch_job(f'{managed_job_name}-3',
+                           f'echo hi; sleep {blocking_seconds_for_cancel_job}'),
                 f'result="$(sky jobs logs --no-follow -n {managed_job_name}-2)"; echo "$result"; echo "$result" | grep hi',
                 f'sky jobs cancel -y -n {managed_job_name}-0',
                 f'sky jobs cancel -y -n {managed_job_name}-3',

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -277,7 +277,7 @@ class TestBackwardCompatibility:
             return smoke_tests_utils.get_cmd_wait_until_managed_job_status_contains_matching_job_name(
                 job_name=job_name,
                 job_status=status,
-                timeout=120 if generic_cloud == 'kubernetes' else 300)
+                timeout=600 if generic_cloud == 'kubernetes' else 300)
 
         commands = [
             *self._switch_to_base(

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -176,6 +176,7 @@ class TestBackwardCompatibility:
         teardown = f'{self.ACTIVATE_CURRENT} && sky down {cluster_name}* -y'
         self.run_compatibility_test(cluster_name, commands, teardown)
 
+    @pytest.mark.no_kubernetes
     def test_autostop_functionality(self, generic_cloud: str):
         """Test autostop functionality across versions"""
         cluster_name = smoke_tests_utils.get_cluster_name()
@@ -274,7 +275,9 @@ class TestBackwardCompatibility:
         def wait_for_status(job_name: str,
                             status: Sequence[sky.ManagedJobStatus]):
             return smoke_tests_utils.get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                job_name=job_name, job_status=status, timeout=300)
+                job_name=job_name,
+                job_status=status,
+                timeout=120 if generic_cloud == 'kubernetes' else 300)
 
         commands = [
             *self._switch_to_base(

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -275,7 +275,9 @@ class TestBackwardCompatibility:
         def wait_for_status(job_name: str,
                             status: Sequence[sky.ManagedJobStatus]):
             return smoke_tests_utils.get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                job_name=job_name, job_status=status, timeout=300)
+                job_name=job_name,
+                job_status=status,
+                timeout=600 if generic_cloud == 'kubernetes' else 300)
 
         commands = [
             *self._switch_to_base(

--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -275,9 +275,7 @@ class TestBackwardCompatibility:
         def wait_for_status(job_name: str,
                             status: Sequence[sky.ManagedJobStatus]):
             return smoke_tests_utils.get_cmd_wait_until_managed_job_status_contains_matching_job_name(
-                job_name=job_name,
-                job_status=status,
-                timeout=600 if generic_cloud == 'kubernetes' else 300)
+                job_name=job_name, job_status=status, timeout=300)
 
         commands = [
             *self._switch_to_base(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Skip autostop
* Upgrade the BuildKite VM from `r5a.2xlarge` to `m6a.4xlarge` (from 8 CPU/64GB to 16 CPU/64GB). -- Manual deploy, no code change needed

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] All smoke tests: `/quicktest-core --kubernetes` (CI) or `pytest tests/test_smoke.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
