### PR TITLE
Fix latest version mismatch on helm_gcp deployment tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--helm-package',
         type=str,
-        default='skypilot-nightly',
+        default='',
         help='Package name to use for Helm tests',
     )
 

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -130,6 +130,13 @@ fi
 
 # Extract version from response and verify it matches (only if not using 'latest')
 RETURNED_VERSION=$(echo $HEALTH_RESPONSE | jq -r '.version')
+
+# Verify that we got a valid version string
+if [ -z "$RETURNED_VERSION" ] || [ ${#RETURNED_VERSION} -le 1 ]; then
+    echo "Error: Invalid version returned from API. Got: '$RETURNED_VERSION'"
+    exit 1
+fi
+
 if [ "$HELM_VERSION" != "latest" ]; then
     if [ "$RETURNED_VERSION" != "$HELM_VERSION" ]; then
         echo "Error: Version mismatch! Expected: $HELM_VERSION, Got: $RETURNED_VERSION"

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -128,10 +128,14 @@ if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
     exit 1
 fi
 
-# Extract version from response and verify it matches
+# Extract version from response and verify it matches (only if not using 'latest')
 RETURNED_VERSION=$(echo $HEALTH_RESPONSE | jq -r '.version')
-if [ "$RETURNED_VERSION" != "$HELM_VERSION" ]; then
-    echo "Error: Version mismatch! Expected: $HELM_VERSION, Got: $RETURNED_VERSION"
-    exit 1
+if [ "$HELM_VERSION" != "latest" ]; then
+    if [ "$RETURNED_VERSION" != "$HELM_VERSION" ]; then
+        echo "Error: Version mismatch! Expected: $HELM_VERSION, Got: $RETURNED_VERSION"
+        exit 1
+    fi
+    echo "Version verification successful! Expected version $HELM_VERSION matches returned version $RETURNED_VERSION"
+else
+    echo "Using latest version. Skipping version verification. Deployed version: $RETURNED_VERSION"
 fi
-echo "Version verification successful! Expected version $HELM_VERSION matches returned version $RETURNED_VERSION"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

See failure [logs](https://buildkite.com/organizations/skypilot-1/pipelines/full-smoke-tests-run/builds/40/jobs/01977708-50e0-4556-9366-dea1e2ffccf2/log) in release

If we are using the latest version, it could be the previously published version at any time - we don't verify in this case.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_helm_deploy_gke --gcp` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
