### PR TITLE
[Core] Support mounting volumes for clusters in Kubernetes

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -650,6 +650,7 @@ class Kubernetes(clouds.Cloud):
                 (k8s_ha_storage_class_name),
             'avoid_label_keys': avoid_label_keys,
             'k8s_ipc_lock_capability': k8s_ipc_lock_capability,
+            'pvcs': resources.volumes,
         }
 
         # Add kubecontext if it is set. It may be None if SkyPilot is running

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -244,6 +244,28 @@ provider:
             selector:
                 component: {{cluster_name_on_cloud}}-head
 
+    {%- if pvcs %}
+    pvcs:
+    {%- for pvc in pvcs %}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: {{pvc.name}}
+        namespace: {{k8s_namespace}}
+      spec:
+        accessModes:
+          - {{pvc.access_mode}}
+        {%- if pvc.storage_class_name %}
+        storageClassName: {{pvc.storage_class_name}}
+        {%- endif %}
+        resources:
+          requests:
+            storage: {{pvc.disk_size}}Gi
+      autoDelete: {{pvc.auto_delete}}
+      path: {{pvc.path}}
+    {%- endfor %}
+    {%- endif %}
+
 # Specify the pod type for the ray head node (as configured below).
 head_node_type: ray_head_default
 # Specify the allowed pod types for this ray cluster and the resources they provide.

--- a/sky/utils/resources_utils.py
+++ b/sky/utils/resources_utils.py
@@ -92,6 +92,13 @@ class DiskAttachMode(enum.Enum):
     READ_WRITE = 'read_write'
 
 
+class DiskAccessMode(enum.Enum):
+    """Disk access mode."""
+    READ_WRITE_ONCE = 'ReadWriteOnce'
+    READ_WRITE_MANY = 'ReadWriteMany'
+    READ_ONLY_MANY = 'ReadOnlyMany'
+
+
 @dataclasses.dataclass
 class ClusterName:
     display_name: str

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -66,6 +66,9 @@ _AUTOSTOP_SCHEMA = {
 
 def _get_single_resources_schema():
     """Schema for a single resource in a resources list."""
+    # pylint: disable=import-outside-toplevel
+    from sky.utils import resources_utils
+
     # Building the regex pattern for the infra field
     # Format: cloud[/region[/zone]] or wildcards or kubernetes context
     # Match any cloud name (case insensitive)
@@ -203,11 +206,29 @@ def _get_single_resources_schema():
                         },
                         'storage_type': {
                             'type': 'string',
+                            'case_insensitive_enum': [
+                                storage_type.value
+                                for storage_type in resources_utils.StorageType
+                            ]
                         },
                         'name': {
                             'type': 'string',
                         },
                         'attach_mode': {
+                            'type': 'string',
+                            'case_insensitive_enum': [
+                                attach_mode.value for attach_mode in
+                                resources_utils.DiskAttachMode
+                            ]
+                        },
+                        'access_mode': {
+                            'type': 'string',
+                            'case_insensitive_enum': [
+                                access_mode.value for access_mode in
+                                resources_utils.DiskAccessMode
+                            ]
+                        },
+                        'storage_class_name': {
                             'type': 'string',
                         },
                     },
@@ -365,6 +386,7 @@ def get_resources_schema():
 def get_storage_schema():
     # pylint: disable=import-outside-toplevel
     from sky.data import storage
+    from sky.utils import resources_utils
     return {
         '$schema': 'https://json-schema.org/draft/2020-12/schema',
         'type': 'object',
@@ -411,8 +433,26 @@ def get_storage_schema():
                     },
                     'storage_type': {
                         'type': 'string',
+                        'case_insensitive_enum': [
+                            storage_type.value
+                            for storage_type in resources_utils.StorageType
+                        ]
                     },
                     'attach_mode': {
+                        'type': 'string',
+                        'case_insensitive_enum': [
+                            attach_mode.value
+                            for attach_mode in resources_utils.DiskAttachMode
+                        ]
+                    },
+                    'access_mode': {
+                        'type': 'string',
+                        'case_insensitive_enum': [
+                            access_mode.value
+                            for access_mode in resources_utils.DiskAccessMode
+                        ]
+                    },
+                    'storage_class_name': {
                         'type': 'string',
                     },
                 },


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Support mounting volumes for clusters in Kubernetes

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Launch&down cluster without volumes in Kubernetes
  - Launch&down cluster with non-persistent volumes in Kubernetes
```
num_nodes: 2

file_mounts:
  /mnt/ab:
    name: shared
    store: volume
    config:
      disk_size: 10
      storage_class_name: csi-mounted-fs-path-sc
      access_mode: ReadWriteMany
  /mnt/ef:
    name: dedicated
    store: volume
    config:
      disk_size: 10
```
  - Launch&down cluster with persistent volumes in Kubernetes
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
