### PR TITLE
[UI] Redact envs for cluster YAMLs

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -23,4 +23,5 @@ jobs:
         npm --prefix sky/dashboard install
         npm --prefix sky/dashboard run lint
         npm --prefix sky/dashboard run format:check
+        npm --prefix sky/dashboard run test
         npm --prefix sky/dashboard run build

--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -3197,7 +3197,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
         # Capture task YAML and command
         task_config = None
         if task is not None:
-            task_config = task.to_yaml_config()
+            task_config = task.to_yaml_config(redact_envs=True)
 
         with timeline.Event('backend.provision.post_process'):
             global_user_state.add_or_update_cluster(

--- a/sky/dashboard/src/lib/__tests__/yamlUtils.test.js
+++ b/sky/dashboard/src/lib/__tests__/yamlUtils.test.js
@@ -1,0 +1,309 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { formatYaml } from '../yamlUtils';
+
+describe('formatYaml function', () => {
+  describe('environment variable redaction', () => {
+    test('should redact all environment variables regardless of type', () => {
+      const yamlString = `
+name: test-task
+run: echo hello
+envs:
+  API_KEY: secret-api-key-123
+  DATABASE_URL: postgresql://user:password@host:5432/db
+  DEBUG: "true"
+  PORT: 8080
+resources:
+  cpus: 2
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // Check that ALL env vars are redacted (JavaScript version redacts everything)
+      expect(result).toContain('API_KEY: <redacted>');
+      expect(result).toContain('DATABASE_URL: <redacted>');
+      expect(result).toContain('DEBUG: <redacted>');
+      expect(result).toContain('PORT: <redacted>');
+      
+      // Check that sensitive values are not present
+      expect(result).not.toContain('secret-api-key-123');
+      expect(result).not.toContain('postgresql://user:password@host:5432/db');
+      expect(result).not.toContain('8080');
+      
+      // Check that other fields are preserved
+      expect(result).toContain('name: test-task');
+      expect(result).toContain('run: echo hello');
+      expect(result).toContain('cpus: 2');
+    });
+
+    test('should redact all environment variable types', () => {
+      const yamlString = `
+name: test-task
+envs:
+  STRING_VAR: "sensitive-value"
+  PORT: 8080
+  DEBUG_ENABLED: true
+  TIMEOUT: 30.5
+  EMPTY_VAR: ""
+  NULL_VAR: null
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // ALL env vars should be redacted in JavaScript version
+      expect(result).toContain('STRING_VAR: <redacted>');
+      expect(result).toContain('PORT: <redacted>');
+      expect(result).toContain('DEBUG_ENABLED: <redacted>');
+      expect(result).toContain('TIMEOUT: <redacted>');
+      expect(result).toContain('EMPTY_VAR: <redacted>');
+      expect(result).toContain('NULL_VAR: <redacted>');
+      
+      // No original values should be present
+      expect(result).not.toContain('sensitive-value');
+      expect(result).not.toContain('8080');
+      expect(result).not.toContain('true');
+      expect(result).not.toContain('30.5');
+    });
+
+    test('should not redact environment variables if envs is an array', () => {
+      const yamlString = `
+name: test-task
+envs:
+  - API_KEY=secret-value
+  - DEBUG=true
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // Should not redact array-style envs (this is intentional based on the condition)
+      expect(result).toContain('API_KEY=secret-value');
+      expect(result).toContain('DEBUG=true');
+    });
+
+    test('should handle missing envs field', () => {
+      const yamlString = `
+name: test-task
+run: echo hello
+resources:
+  cpus: 2
+`;
+
+      const result = formatYaml(yamlString);
+      
+      expect(result).toContain('name: test-task');
+      expect(result).toContain('run: echo hello');
+      expect(result).toContain('cpus: 2');
+      expect(result).not.toContain('envs:');
+    });
+
+    test('should handle null envs field', () => {
+      const yamlString = `
+name: test-task
+envs: null
+run: echo hello
+`;
+
+      const result = formatYaml(yamlString);
+      
+      expect(result).toContain('name: test-task');
+      expect(result).toContain('envs: null');
+      expect(result).toContain('run: echo hello');
+    });
+
+    test('should handle empty envs object', () => {
+      const yamlString = `
+name: test-task
+envs: {}
+run: echo hello
+`;
+
+      const result = formatYaml(yamlString);
+      
+      expect(result).toContain('name: test-task');
+      expect(result).toContain('run: echo hello');
+      // Empty object might be formatted differently by yaml.dump
+    });
+
+    test('should redact complex environment variables', () => {
+      const yamlString = `
+name: ml-training
+envs:
+  AWS_ACCESS_KEY_ID: AKIAIOSFODNN7EXAMPLE
+  AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  OPENAI_API_KEY: sk-proj-abcdef1234567890
+  DATABASE_PASSWORD: "MyVerySecretPassword123!"
+  JWT_SECRET: supersecretjwtkey
+  STRIPE_KEY: sk_live_51234567890
+  WORKER_COUNT: 4
+  ENABLE_LOGGING: true
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // ALL values should be redacted in JavaScript version
+      expect(result).toContain('AWS_ACCESS_KEY_ID: <redacted>');
+      expect(result).toContain('AWS_SECRET_ACCESS_KEY: <redacted>');
+      expect(result).toContain('OPENAI_API_KEY: <redacted>');
+      expect(result).toContain('DATABASE_PASSWORD: <redacted>');
+      expect(result).toContain('JWT_SECRET: <redacted>');
+      expect(result).toContain('STRIPE_KEY: <redacted>');
+      expect(result).toContain('WORKER_COUNT: <redacted>');
+      expect(result).toContain('ENABLE_LOGGING: <redacted>');
+      
+      // No sensitive data should be visible
+      expect(result).not.toContain('AKIAIOSFODNN7EXAMPLE');
+      expect(result).not.toContain('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+      expect(result).not.toContain('sk-proj-abcdef1234567890');
+      expect(result).not.toContain('MyVerySecretPassword123!');
+      expect(result).not.toContain('supersecretjwtkey');
+      expect(result).not.toContain('sk_live_51234567890');
+      expect(result).not.toContain('4');
+      expect(result).not.toContain('true');
+    });
+  });
+
+  describe('YAML formatting and structure', () => {
+    test('should handle null or empty input', () => {
+      expect(formatYaml(null)).toBe('No YAML available');
+      expect(formatYaml(undefined)).toBe('No YAML available');
+      expect(formatYaml('')).toBe('No YAML available');
+    });
+
+    test('should handle invalid YAML gracefully', () => {
+      const invalidYaml = `
+name: test
+envs:
+  API_KEY: secret
+  invalid: [unclosed
+`;
+
+      // Should return original string if parsing fails
+      const result = formatYaml(invalidYaml);
+      expect(result).toBe(invalidYaml);
+    });
+
+    test('should preserve task structure while redacting envs', () => {
+      const yamlString = `
+name: web-server
+setup: pip install requirements.txt
+run: python app.py
+envs:
+  SECRET_KEY: my-secret-key
+  PORT: 8080
+resources:
+  cpus: 2
+  memory: 4GB
+file_mounts:
+  /app: ./src
+workdir: /app
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // Check all non-env fields are preserved
+      expect(result).toContain('name: web-server');
+      expect(result).toContain('setup: pip install requirements.txt');
+      expect(result).toContain('run: python app.py');
+      expect(result).toContain('cpus: 2');
+      expect(result).toContain('memory: 4GB');
+      expect(result).toContain('/app: ./src');
+      expect(result).toContain('workdir: /app');
+      
+      // Check env redaction - ALL values are redacted in JavaScript
+      expect(result).toContain('SECRET_KEY: <redacted>');
+      expect(result).toContain('PORT: <redacted>');
+      expect(result).not.toContain('my-secret-key');
+      expect(result).not.toContain('8080');
+    });
+
+    test('should handle nested objects without affecting envs redaction', () => {
+      const yamlString = `
+name: complex-task
+envs:
+  SECRET: sensitive-data
+  COUNT: 5
+resources:
+  cloud: aws
+  instance_type: p3.2xlarge
+  accelerators:
+    V100: 1
+service:
+  readiness_probe:
+    path: /health
+    initial_delay_seconds: 30
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // Env redaction should work - ALL values redacted
+      expect(result).toContain('SECRET: <redacted>');
+      expect(result).toContain('COUNT: <redacted>');
+      expect(result).not.toContain('sensitive-data');
+      expect(result).not.toContain('5');
+      
+      // Nested structures should be preserved
+      expect(result).toContain('cloud: aws');
+      expect(result).toContain('instance_type: p3.2xlarge');
+      expect(result).toContain('V100: 1');
+      expect(result).toContain('path: /health');
+      expect(result).toContain('initial_delay_seconds: 30');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('should handle envs field that is not an object', () => {
+      const yamlString = `
+name: test-task
+envs: "not an object"
+run: echo hello
+`;
+
+      const result = formatYaml(yamlString);
+      
+      // Should not crash and should preserve the original value
+      expect(result).toContain('name: test-task');
+      expect(result).toContain('envs: not an object');
+      expect(result).toContain('run: echo hello');
+    });
+
+    test('should handle very large environment variable values', () => {
+      const longSecret = 'x'.repeat(1000);
+      const yamlString = `
+name: test-task
+envs:
+  LONG_SECRET: ${longSecret}
+  NORMAL_VAR: short
+run: echo hello
+`;
+
+      const result = formatYaml(yamlString);
+      
+      expect(result).toContain('LONG_SECRET: <redacted>');
+      expect(result).toContain('NORMAL_VAR: <redacted>');
+      expect(result).not.toContain(longSecret);
+    });
+
+    test('should handle environment variables with special characters in quoted strings', () => {
+      const yamlString = `
+name: test-task
+envs:
+  SPECIAL_CHARS: "hello-world"
+  UNICODE_VAR: "simple-text"
+  MULTILINE: "multi line text"
+`;
+
+      const result = formatYaml(yamlString);
+      
+      expect(result).toContain('SPECIAL_CHARS: <redacted>');
+      expect(result).toContain('UNICODE_VAR: <redacted>');
+      expect(result).toContain('MULTILINE: <redacted>');
+      
+      // Original values should not be present
+      expect(result).not.toContain('hello-world');
+      expect(result).not.toContain('simple-text');
+      expect(result).not.toContain('multi line text');
+    });
+  });
+}); 

--- a/sky/dashboard/src/lib/yamlUtils.js
+++ b/sky/dashboard/src/lib/yamlUtils.js
@@ -1,0 +1,200 @@
+import yaml from 'js-yaml';
+
+/**
+ * Formats YAML string with environment variable redaction for security
+ * @param {string} yamlString - The YAML string to format
+ * @returns {string} - Formatted YAML with redacted environment variables
+ */
+export const formatYaml = (yamlString) => {
+  if (!yamlString) return 'No YAML available';
+
+  try {
+    // Parse the YAML string into an object
+    const parsed = yaml.load(yamlString);
+
+    // Redact environment variable values at root level for security
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'envs' in parsed &&
+      typeof parsed.envs === 'object' &&
+      parsed.envs !== null &&
+      !Array.isArray(parsed.envs)
+    ) {
+      parsed.envs = Object.fromEntries(
+        Object.keys(parsed.envs).map((k) => [k, '<redacted>'])
+      );
+    }
+
+    // Re-serialize with pipe syntax for multiline strings
+    const formatted = yaml.dump(parsed, {
+      lineWidth: -1, // Disable line wrapping
+      styles: {
+        '!!str': 'literal', // Use pipe (|) syntax for multiline strings
+      },
+      quotingType: "'", // Use single quotes for strings that need quoting
+      forceQuotes: false, // Only quote when necessary
+      noRefs: true, // Disable YAML references
+      sortKeys: false, // Preserve original key order
+      condenseFlow: false, // Don't condense flow style
+      indent: 2, // Use 2 spaces for indentation
+    });
+
+    // Add blank lines between top-level sections for better readability
+    const lines = formatted.split('\n');
+    const result = [];
+    let prevIndent = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const currentIndent = line.search(/\S/); // Find first non-whitespace
+
+      // Add blank line before new top-level sections (indent = 0)
+      if (currentIndent === 0 && prevIndent >= 0 && i > 0) {
+        result.push('');
+      }
+
+      result.push(line);
+      prevIndent = currentIndent;
+    }
+
+    return result.join('\n').trim();
+  } catch (e) {
+    console.error('YAML formatting error:', e);
+    // If parsing fails, return the original string
+    return yamlString;
+  }
+};
+
+/**
+ * Helper function to get a preview of the YAML content for job documents
+ * @param {object} parsed - The parsed YAML object
+ * @returns {string} - A brief preview of the YAML content
+ */
+export const getYamlPreview = (parsed) => {
+  if (typeof parsed === 'string') {
+    return parsed.substring(0, 50) + '...';
+  }
+  if (parsed && parsed.name) {
+    return `name: ${parsed.name}`;
+  }
+  if (parsed && parsed.resources) {
+    return 'Task configuration';
+  }
+  return 'YAML document';
+};
+
+/**
+ * Formats a single YAML document with environment variable redaction
+ * @param {string} doc - The YAML document string to format
+ * @param {number} index - The index of the document
+ * @returns {object} - Formatted document object with content and preview
+ */
+export const formatSingleYamlDocument = (doc, index) => {
+  try {
+    // Parse the YAML string into an object
+    const parsed = yaml.load(doc);
+
+    // Redact environment variable values for security
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      'envs' in parsed &&
+      typeof parsed.envs === 'object' &&
+      parsed.envs !== null &&
+      !Array.isArray(parsed.envs)
+    ) {
+      parsed.envs = Object.fromEntries(
+        Object.keys(parsed.envs).map((k) => [k, '<redacted>'])
+      );
+    }
+
+    // Re-serialize with pipe syntax for multiline strings
+    const formatted = yaml.dump(parsed, {
+      lineWidth: -1, // Disable line wrapping
+      styles: {
+        '!!str': 'literal', // Use pipe (|) syntax for multiline strings
+      },
+      quotingType: "'", // Use single quotes for strings that need quoting
+      forceQuotes: false, // Only quote when necessary
+      noRefs: true, // Disable YAML references
+      sortKeys: false, // Preserve original key order
+      condenseFlow: false, // Don't condense flow style
+      indent: 2, // Use 2 spaces for indentation
+    });
+
+    // Add blank lines between top-level sections for better readability
+    const lines = formatted.split('\n');
+    const result = [];
+    let prevIndent = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const currentIndent = line.search(/\S/); // Find first non-whitespace
+
+      // Add blank line before new top-level sections (indent = 0)
+      if (currentIndent === 0 && prevIndent >= 0 && i > 0) {
+        result.push('');
+      }
+
+      result.push(line);
+      prevIndent = currentIndent;
+    }
+
+    return {
+      index: index,
+      content: result.join('\n').trim(),
+      preview: getYamlPreview(parsed),
+    };
+  } catch (e) {
+    console.error(`YAML formatting error for document ${index}:`, e);
+    // If parsing fails, return the original string
+    return {
+      index: index,
+      content: doc,
+      preview: 'Invalid YAML',
+    };
+  }
+};
+
+/**
+ * Formats YAML string for job display, handling multiple documents
+ * @param {string} yamlString - The YAML string to format
+ * @returns {Array} - Array of formatted document objects
+ */
+export const formatJobYaml = (yamlString) => {
+  if (!yamlString) return [];
+
+  try {
+    // Split the YAML into multiple documents
+    const documents = [];
+    const parts = yamlString.split(/^---$/m);
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i].trim();
+      if (part && part !== '') {
+        documents.push(part);
+      }
+    }
+
+    // Skip the first document (which is typically just the task name)
+    const docsToFormat = documents.length > 1 ? documents.slice(1) : documents;
+
+    // Format each document
+    const formattedDocs = docsToFormat.map((doc, index) => 
+      formatSingleYamlDocument(doc, index)
+    );
+
+    return formattedDocs;
+  } catch (e) {
+    console.error('YAML formatting error:', e);
+    // If parsing fails, return the original string as single document
+    return [
+      {
+        index: 0,
+        content: yamlString,
+        preview: 'Invalid YAML',
+      },
+    ];
+  }
+}; 

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -26,6 +26,7 @@ import {
 } from '@/components/elements/modals';
 import { useMobile } from '@/hooks/useMobile';
 import Head from 'next/head';
+import { formatYaml } from '@/lib/yamlUtils';
 
 // Helper function to format autostop information, similar to _get_autostop in CLI utils
 const formatAutostop = (autostop, toDown) => {
@@ -220,66 +221,7 @@ function ActiveTab({
     }
   };
 
-  const formatYaml = (yamlString) => {
-    if (!yamlString) return 'No YAML available';
 
-    try {
-      // Parse the YAML string into an object
-      const parsed = yaml.load(yamlString);
-
-      // Redact environment variable values at root level for security
-      if (
-        parsed &&
-        typeof parsed === 'object' &&
-        'envs' in parsed &&
-        typeof parsed.envs === 'object' &&
-        parsed.envs !== null &&
-        !Array.isArray(parsed.envs)
-      ) {
-        parsed.envs = Object.fromEntries(
-          Object.keys(parsed.envs).map((k) => [k, '<redacted>'])
-        );
-      }
-
-      // Re-serialize with pipe syntax for multiline strings
-      const formatted = yaml.dump(parsed, {
-        lineWidth: -1, // Disable line wrapping
-        styles: {
-          '!!str': 'literal', // Use pipe (|) syntax for multiline strings
-        },
-        quotingType: "'", // Use single quotes for strings that need quoting
-        forceQuotes: false, // Only quote when necessary
-        noRefs: true, // Disable YAML references
-        sortKeys: false, // Preserve original key order
-        condenseFlow: false, // Don't condense flow style
-        indent: 2, // Use 2 spaces for indentation
-      });
-
-      // Add blank lines between top-level sections for better readability
-      const lines = formatted.split('\n');
-      const result = [];
-      let prevIndent = -1;
-
-      for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
-        const currentIndent = line.search(/\S/); // Find first non-whitespace
-
-        // Add blank line before new top-level sections (indent = 0)
-        if (currentIndent === 0 && prevIndent >= 0 && i > 0) {
-          result.push('');
-        }
-
-        result.push(line);
-        prevIndent = currentIndent;
-      }
-
-      return result.join('\n').trim();
-    } catch (e) {
-      console.error('YAML formatting error:', e);
-      // If parsing fails, return the original string
-      return yamlString;
-    }
-  };
 
   const hasCreationArtifacts = clusterData?.command || clusterData?.task_yaml;
 

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -227,6 +227,20 @@ function ActiveTab({
       // Parse the YAML string into an object
       const parsed = yaml.load(yamlString);
 
+      // Redact environment variable values at root level for security
+      if (
+        parsed &&
+        typeof parsed === 'object' &&
+        'envs' in parsed &&
+        typeof parsed.envs === 'object' &&
+        parsed.envs !== null &&
+        !Array.isArray(parsed.envs)
+      ) {
+        parsed.envs = Object.fromEntries(
+          Object.keys(parsed.envs).map((k) => [k, '<redacted>'])
+        );
+      }
+
       // Re-serialize with pipe syntax for multiline strings
       const formatted = yaml.dump(parsed, {
         lineWidth: -1, // Disable line wrapping

--- a/sky/task.py
+++ b/sky/task.py
@@ -1266,7 +1266,7 @@ class Task:
                 d[k] = v
         return d
 
-    def to_yaml_config(self) -> Dict[str, Any]:
+    def to_yaml_config(self, redact_envs: bool = False) -> Dict[str, Any]:
         """Returns a yaml-style dict representation of the task.
 
         INTERNAL: this method is internal-facing.
@@ -1314,7 +1314,14 @@ class Task:
         add_if_not_none('workdir', self.workdir)
         add_if_not_none('event_callback', self.event_callback)
         add_if_not_none('run', self.run)
-        add_if_not_none('envs', self.envs, no_empty=True)
+        envs = self.envs
+        if envs:
+            if redact_envs:
+                envs = {
+                    k: '<redacted>' if isinstance(v, str) else v
+                    for k, v in envs.items()
+                }
+        add_if_not_none('envs', envs, no_empty=True)
 
         add_if_not_none('file_mounts', {})
 

--- a/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
+++ b/tests/unit_tests/test_sky/backends/test_cloud_vm_ray_backend.py
@@ -1,0 +1,141 @@
+"""Unit tests for CloudVmRayBackend task configuration redaction functionality."""
+
+from sky import task
+
+
+class TestCloudVmRayBackendTaskRedaction:
+    """Tests for CloudVmRayBackend usage of redacted task configs."""
+
+    def test_cloud_vm_ray_backend_redaction_usage_pattern(self):
+        """Test the exact usage pattern from the CloudVmRayBackend code."""
+        # Create a task with sensitive environment variables
+        test_task = task.Task(
+            run='echo hello',
+            envs={
+                'API_KEY': 'secret-api-key-123',
+                'DATABASE_PASSWORD': 'super-secret-password',
+                'DEBUG': 'true'
+            }
+        )
+        
+        # Test the exact pattern used in sky/backends/cloud_vm_ray_backend.py line 3199:
+        # task_config = task.to_yaml_config(redact_envs=True)
+        task_config = None
+        if test_task is not None:
+            task_config = test_task.to_yaml_config(redact_envs=True)
+        
+        # Verify the config was created and sensitive data is redacted
+        assert task_config is not None
+        assert 'envs' in task_config
+        assert task_config['envs']['API_KEY'] == '<redacted>'
+        assert task_config['envs']['DATABASE_PASSWORD'] == '<redacted>'
+        assert task_config['envs']['DEBUG'] == '<redacted>'
+        
+        # Verify the run command is preserved
+        assert task_config['run'] == 'echo hello'
+
+    def test_redacted_config_contains_no_sensitive_data(self):
+        """Test that redacted task config doesn't contain sensitive environment data."""
+        # Create a task with sensitive environment variables
+        test_task = task.Task(
+            run='echo hello',
+            envs={
+                'API_KEY': 'secret-api-key-123',
+                'DATABASE_PASSWORD': 'super-secret-password',
+                'AWS_SECRET_ACCESS_KEY': 'aws-secret-key',
+                'STRIPE_SECRET_KEY': 'sk_live_sensitive_key',
+                'JWT_SECRET': 'jwt-signing-secret',
+                'DEBUG': 'true',
+                'PORT': 8080
+            }
+        )
+        
+        # Get the redacted config as the backend would
+        redacted_config = test_task.to_yaml_config(redact_envs=True)
+        
+        # Verify sensitive string values are redacted
+        assert redacted_config['envs']['API_KEY'] == '<redacted>'
+        assert redacted_config['envs']['DATABASE_PASSWORD'] == '<redacted>'
+        assert redacted_config['envs']['AWS_SECRET_ACCESS_KEY'] == '<redacted>'
+        assert redacted_config['envs']['STRIPE_SECRET_KEY'] == '<redacted>'
+        assert redacted_config['envs']['JWT_SECRET'] == '<redacted>'
+        assert redacted_config['envs']['DEBUG'] == '<redacted>'
+        
+        # Non-string values should be preserved
+        assert redacted_config['envs']['PORT'] == 8080
+        
+        # Ensure no sensitive data appears anywhere in the config
+        config_str = str(redacted_config)
+        assert 'secret-api-key-123' not in config_str
+        assert 'super-secret-password' not in config_str
+        assert 'aws-secret-key' not in config_str
+        assert 'sk_live_sensitive_key' not in config_str
+        assert 'jwt-signing-secret' not in config_str
+
+    def test_non_redacted_config_contains_actual_values(self):
+        """Test that non-redacted config contains actual environment values."""
+        # Create a task with environment variables
+        test_task = task.Task(
+            run='echo hello',
+            envs={
+                'API_KEY': 'actual-api-key',
+                'DEBUG': 'true',
+                'PORT': 8080
+            }
+        )
+        
+        # Get the non-redacted config (default behavior)
+        non_redacted_config = test_task.to_yaml_config(redact_envs=False)
+        
+        # Verify actual values are present
+        assert non_redacted_config['envs']['API_KEY'] == 'actual-api-key'
+        assert non_redacted_config['envs']['DEBUG'] == 'true'
+        assert non_redacted_config['envs']['PORT'] == 8080
+        
+        # Also test default behavior (should be same as redact_envs=False)
+        default_config = test_task.to_yaml_config()
+        assert default_config == non_redacted_config
+
+    def test_backend_redaction_with_no_envs(self):
+        """Test backend behavior when task has no environment variables."""
+        # Create a task without environment variables
+        test_task = task.Task(run='echo hello')
+        
+        # Get redacted config
+        redacted_config = test_task.to_yaml_config(redact_envs=True)
+        
+        # Should not have envs key at all
+        assert 'envs' not in redacted_config
+        
+        # Should still have other task properties
+        assert redacted_config['run'] == 'echo hello'
+
+    def test_backend_redaction_preserves_task_structure(self):
+        """Test that redaction preserves all non-env task configuration."""
+        from sky import resources
+        
+        # Create a comprehensive task
+        test_task = task.Task(
+            run='python train.py',
+            envs={'SECRET': 'value', 'PORT': 8080},
+            workdir='/app',
+            name='training-task'
+        )
+        # Set resources using the proper method
+        test_task.set_resources(resources.Resources(cpus=4, memory=8))
+        
+        # Get both configs
+        original_config = test_task.to_yaml_config(redact_envs=False)
+        redacted_config = test_task.to_yaml_config(redact_envs=True)
+        
+        # All non-env fields should be identical
+        for key in original_config:
+            if key != 'envs':
+                assert original_config[key] == redacted_config[key]
+        
+        # Env handling should be different
+        assert original_config['envs']['SECRET'] == 'value'
+        assert redacted_config['envs']['SECRET'] == '<redacted>'
+        
+        # Non-string env values should be the same
+        assert original_config['envs']['PORT'] == redacted_config['envs']['PORT'] == 8080 

--- a/tests/unit_tests/test_sky/test_task.py
+++ b/tests/unit_tests/test_sky/test_task.py
@@ -78,3 +78,143 @@ def test_validate_file_mounts():
             '/remote2': 'gs://another-bucket/path'
         }
         task_obj.expand_and_validate_file_mounts()
+
+
+def test_to_yaml_config_without_envs():
+    """Test to_yaml_config() with no environment variables."""
+    task_obj = task.Task(run='echo hello')
+    
+    # Test default behavior (no redaction)
+    yaml_config = task_obj.to_yaml_config()
+    assert 'envs' not in yaml_config
+    
+    # Test with redact_envs=True (should have no effect when no envs)
+    yaml_config_redacted = task_obj.to_yaml_config(redact_envs=True)
+    assert 'envs' not in yaml_config_redacted
+    assert yaml_config == yaml_config_redacted
+
+
+def test_to_yaml_config_with_envs_no_redaction():
+    """Test to_yaml_config() with environment variables and no redaction."""
+    envs = {
+        'API_KEY': 'secret-api-key-123',
+        'DATABASE_URL': 'postgresql://user:password@host:5432/db',
+        'DEBUG': 'true',
+        'PORT': 8080,  # Non-string value
+        'EMPTY_VAR': ''
+    }
+    
+    task_obj = task.Task(run='echo hello', envs=envs)
+    
+    # Test default behavior (no redaction)
+    yaml_config = task_obj.to_yaml_config()
+    assert 'envs' in yaml_config
+    assert yaml_config['envs'] == envs
+    # Verify actual values are preserved
+    assert yaml_config['envs']['API_KEY'] == 'secret-api-key-123'
+    assert yaml_config['envs']['DATABASE_URL'] == 'postgresql://user:password@host:5432/db'
+    assert yaml_config['envs']['DEBUG'] == 'true'
+    assert yaml_config['envs']['PORT'] == 8080
+    assert yaml_config['envs']['EMPTY_VAR'] == ''
+
+
+def test_to_yaml_config_with_envs_redaction():
+    """Test to_yaml_config() with environment variables and redaction enabled."""
+    envs = {
+        'API_KEY': 'secret-api-key-123',
+        'DATABASE_URL': 'postgresql://user:password@host:5432/db',
+        'DEBUG': 'true',
+        'PORT': 8080,  # Non-string value should be preserved
+        'EMPTY_VAR': '',
+        'NONE_VAR': None  # Non-string value should be preserved
+    }
+    
+    task_obj = task.Task(run='echo hello', envs=envs)
+    
+    # Test with redaction enabled
+    yaml_config = task_obj.to_yaml_config(redact_envs=True)
+    assert 'envs' in yaml_config
+    
+    # String values should be redacted
+    assert yaml_config['envs']['API_KEY'] == '<redacted>'
+    assert yaml_config['envs']['DATABASE_URL'] == '<redacted>'
+    assert yaml_config['envs']['DEBUG'] == '<redacted>'
+    assert yaml_config['envs']['EMPTY_VAR'] == '<redacted>'
+    
+    # Non-string values should be preserved
+    assert yaml_config['envs']['PORT'] == 8080
+    assert yaml_config['envs']['NONE_VAR'] is None
+
+
+def test_to_yaml_config_redaction_flag_consistency():
+    """Test that redact_envs flag consistently affects only string env vars."""
+    envs = {
+        'STRING_VAR': 'sensitive-value',
+        'INT_VAR': 42,
+        'BOOL_VAR': True,
+        'FLOAT_VAR': 3.14,
+        'LIST_VAR': ['item1', 'item2'],
+        'DICT_VAR': {'key': 'value'}
+    }
+    
+    task_obj = task.Task(run='echo hello', envs=envs)
+    
+    # Get both configs
+    config_no_redact = task_obj.to_yaml_config(redact_envs=False)
+    config_redacted = task_obj.to_yaml_config(redact_envs=True)
+    
+    # Non-env fields should be identical
+    for key in config_no_redact:
+        if key != 'envs':
+            assert config_no_redact[key] == config_redacted[key]
+    
+    # Only string env vars should differ
+    assert config_no_redact['envs']['STRING_VAR'] == 'sensitive-value'
+    assert config_redacted['envs']['STRING_VAR'] == '<redacted>'
+    
+    # Non-string env vars should be identical
+    assert config_no_redact['envs']['INT_VAR'] == config_redacted['envs']['INT_VAR'] == 42
+    assert config_no_redact['envs']['BOOL_VAR'] == config_redacted['envs']['BOOL_VAR'] is True
+    assert config_no_redact['envs']['FLOAT_VAR'] == config_redacted['envs']['FLOAT_VAR'] == 3.14
+    assert config_no_redact['envs']['LIST_VAR'] == config_redacted['envs']['LIST_VAR']
+    assert config_no_redact['envs']['DICT_VAR'] == config_redacted['envs']['DICT_VAR']
+
+
+def test_to_yaml_config_empty_envs():
+    """Test to_yaml_config() with empty envs dict."""
+    task_obj = task.Task(run='echo hello', envs={})
+    
+    # Empty envs should not appear in config due to no_empty=True
+    config_no_redact = task_obj.to_yaml_config(redact_envs=False)
+    config_redacted = task_obj.to_yaml_config(redact_envs=True)
+    
+    assert 'envs' not in config_no_redact
+    assert 'envs' not in config_redacted
+
+
+def test_to_yaml_config_preserves_other_fields():
+    """Test that redaction doesn't affect other task fields."""
+    from sky import resources
+    
+    task_obj = task.Task(
+        run='echo hello',
+        envs={'SECRET': 'value'},
+        workdir='/tmp/workdir',
+        name='test-task'
+    )
+    # Set resources using the proper method
+    task_obj.set_resources(resources.Resources(memory=4))
+    
+    config_no_redact = task_obj.to_yaml_config(redact_envs=False)
+    config_redacted = task_obj.to_yaml_config(redact_envs=True)
+    
+    # All non-env fields should be identical
+    for key in config_no_redact:
+        if key != 'envs':
+            assert config_no_redact[key] == config_redacted[key]
+    
+    # Verify specific fields are preserved
+    assert config_redacted.get('run') == 'echo hello'
+    assert config_redacted.get('workdir') == '/tmp/workdir'
+    assert config_redacted.get('name') == 'test-task'
+    assert 'resources' in config_redacted


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The cluster YAMLs in the UI have `envs` in it, which may leak user's own secrets. For security reason, we now redact the values for envs for now as a first step.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
