### PR TITLE
[Test]extend `--base-branch` for backward compatiability test

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -115,9 +115,23 @@ jobs:
     secrets:
       BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
 
+  backward-compat-test:
+    needs: nightly-build-pypi
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.skip_buildkite || github.event_name == 'schedule' }}
+    uses: ./.github/workflows/buildkite-trigger-wait.yml
+    with:
+      commit: ${{ github.sha }}
+      branch: ${{ github.ref_name }}
+      message: "nightly-build-pypi backward compatibility test"
+      pipeline: "quicktest-core"
+      build_env_vars: '{"ARGS": "--base-branch pypi/skypilot-nightly"}'
+      timeout_minutes: 60
+    secrets:
+      BUILDKITE_TOKEN: ${{ secrets.BUILDKITE_TOKEN }}
+
   publish-and-validate-both:
-    needs: [nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes]
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.skip_buildkite) || (always() && needs.smoke-tests-aws.result == 'success' && needs.smoke-tests-kubernetes.result == 'success') }}
+    needs: [nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes, backward-compat-test]
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.skip_buildkite) || (always() && needs.smoke-tests-aws.result == 'success' && needs.smoke-tests-kubernetes.result == 'success' && needs.backward-compat-test.result == 'success') }}
     uses: ./.github/workflows/publish-and-validate-both.yml
     with:
       package_name: skypilot-nightly
@@ -135,7 +149,7 @@ jobs:
 
   notify-slack-failure:
     runs-on: ubuntu-latest
-    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes, publish-and-validate-both, trigger-helm-release]
+    needs: [check-date, nightly-build-pypi, smoke-tests-aws, smoke-tests-kubernetes, backward-compat-test, publish-and-validate-both, trigger-helm-release]
     if: failure() # Only run this job if any of the previous jobs failed
     steps:
       - name: Prepare failure message
@@ -145,7 +159,8 @@ jobs:
           COMMIT_SHA="${{ github.sha }}"
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${COMMIT_SHA}"
           SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
-          if [[ "${{ needs.smoke-tests-aws.result }}" == "failure" || "${{ needs.smoke-tests-kubernetes.result }}" == "failure" ]]; then
+          BUILDKITE_MSG=""
+          if [[ "${{ needs.smoke-tests-aws.result }}" == "failure" || "${{ needs.smoke-tests-kubernetes.result }}" == "failure" || "${{ needs.backward-compat-test.result }}" == "failure" ]]; then
             if [[ "${{ needs.smoke-tests-aws.result }}" == "failure" ]]; then
               BUILDKITE_MSG="<https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.smoke-tests-aws.outputs.build_number }}|Buildkite Log(--aws)>"
             fi
@@ -154,6 +169,12 @@ jobs:
                 BUILDKITE_MSG="${BUILDKITE_MSG} and"
               fi
               BUILDKITE_MSG="${BUILDKITE_MSG} <https://buildkite.com/skypilot-1/smoke-tests/builds/${{ needs.smoke-tests-kubernetes.outputs.build_number }}|Buildkite Log(--kubernetes)>"
+            fi
+            if [[ "${{ needs.backward-compat-test.result }}" == "failure" ]]; then
+              if [[ ! -z "$BUILDKITE_MSG" ]]; then
+                BUILDKITE_MSG="${BUILDKITE_MSG} and"
+              fi
+              BUILDKITE_MSG="${BUILDKITE_MSG} <https://buildkite.com/skypilot-1/quicktest-core/builds/${{ needs.backward-compat-test.outputs.build_number }}|Buildkite Log(backward-compat)>"
             fi
             MARKDOWN_TEXT="🚨 Workflow <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|*${{ github.workflow }}*> failed at Buildkite step for commit <${COMMIT_URL}|${SHORT_SHA}>. ${BUILDKITE_MSG}"
           else


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

`--base-branch` supports pypi package, and github commit sha.

Nightly build will trigger `--base-branch pypi/skypilot-nightly` and wait until it success.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Backward compatibility: `/quicktest-core --base-branch pypi/skypilot-nightly` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
