### PR TITLE
Skip test_cancel_launch_and_exec_async for kubernetes tests

### DIFF
--- a/tests/smoke_tests/test_basic.py
+++ b/tests/smoke_tests/test_basic.py
@@ -825,6 +825,7 @@ def test_launch_and_exec_async(generic_cloud: str):
 
 
 @pytest.mark.no_hyperbolic  # Hyperbolic fails to provision resources
+@pytest.mark.no_kubernetes  # Kubernetes runs to UP state too fast
 def test_cancel_launch_and_exec_async(generic_cloud: str):
     """Test if async launch and exec commands work correctly when cluster is shutdown"""
     name = smoke_tests_utils.get_cluster_name()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

I think we can skip this for Kubernetes tests. Since I increased the VM instance size for the k8s kind cluster recently, we reach the `UP` state too quickly, but this test case expects the `INIT` state

Fail [log](https://buildkite.com/skypilot-1/smoke-tests/builds/1487#_) on nightly-build

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
