### PR TITLE
Fix `test_skyserve_dynamic_ondemand_fallback`

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -427,10 +427,10 @@ def test_skyserve_dynamic_ondemand_fallback():
             'echo "$s" | grep -q "0/4" || exit 1',
             # Wait for the provisioning starts
             'sleep 40',
-            _check_replica_in_status(name, [
-                (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                (2, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|SHUTTING_DOWN')
-            ]),
+            _check_replica_in_status(
+                name, [(2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                       (2, False, _SERVICE_LAUNCHING_STATUS_REGEX +
+                        '\|SHUTTING_DOWN\|READY')]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -445,7 +445,7 @@ def test_skyserve_dynamic_ondemand_fallback():
             _check_replica_in_status(name, [
                 (1, True, 'READY'),
                 (1, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX) + '\|READY'
+                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY')
             ]),
 
             # Wait until 2 spot instances are ready.

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -427,10 +427,15 @@ def test_skyserve_dynamic_ondemand_fallback():
             'echo "$s" | grep -q "0/4" || exit 1',
             # Wait for the provisioning starts
             'sleep 40',
-            _check_replica_in_status(name, [
-                (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                (2, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|SHUTTING_DOWN')
-            ]),
+            _check_replica_in_status(
+                name,
+                [
+                    (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                    # The instance may still be in READY state when we check the status,
+                    # before transitioning to SHUTTING_DOWN.
+                    (2, False,
+                     _SERVICE_LAUNCHING_STATUS_REGEX + '\|SHUTTING_DOWN\|READY')
+                ]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -431,9 +431,13 @@ def test_skyserve_dynamic_ondemand_fallback():
                 name,
                 [
                     (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                    # The instance may still be in READY state when we check the status,
-                    # before transitioning to SHUTTING_DOWN.
-                    (2, False,
+                    # The instance may still be in READY state when we check the
+                    # status, before transitioning to SHUTTING_DOWN.
+                    # When in SHUTTING_DOWN state, instances may actually shut
+                    # down and disappear from the status. Therefore, we check
+                    # for 1 instance instead of 2, as the count can be either
+                    # 1 or 2.
+                    (1, False,
                      _SERVICE_LAUNCHING_STATUS_REGEX + '\|SHUTTING_DOWN\|READY')
                 ]),
 

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -442,10 +442,11 @@ def test_skyserve_dynamic_ondemand_fallback():
             # 1 on-demand (provisioning) + 1 Spot (ready) + 1 spot (provisioning).
             f'{_SERVE_STATUS_WAIT.format(name=name)}; '
             'echo "$s" | grep -q "1/3"',
-            _check_replica_in_status(
-                name, [(1, True, 'READY'),
-                       (1, True, _SERVICE_LAUNCHING_STATUS_REGEX),
-                       (1, False, _SERVICE_LAUNCHING_STATUS_REGEX)]),
+            _check_replica_in_status(name, [
+                (1, True, 'READY'),
+                (1, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY')
+            ]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -427,10 +427,10 @@ def test_skyserve_dynamic_ondemand_fallback():
             'echo "$s" | grep -q "0/4" || exit 1',
             # Wait for the provisioning starts
             'sleep 40',
-            _check_replica_in_status(
-                name, [(2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                       (2, False, _SERVICE_LAUNCHING_STATUS_REGEX +
-                        '\|SHUTTING_DOWN\|READY')]),
+            _check_replica_in_status(name, [
+                (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                (2, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|SHUTTING_DOWN')
+            ]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),
@@ -442,19 +442,18 @@ def test_skyserve_dynamic_ondemand_fallback():
             # 1 on-demand (provisioning) + 1 Spot (ready) + 1 spot (provisioning).
             f'{_SERVE_STATUS_WAIT.format(name=name)}; '
             'echo "$s" | grep -q "1/3"',
-            _check_replica_in_status(name, [
-                (1, True, 'READY'),
-                (1, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY')
-            ]),
+            _check_replica_in_status(
+                name, [(1, True, 'READY'),
+                       (1, True, _SERVICE_LAUNCHING_STATUS_REGEX),
+                       (1, False, _SERVICE_LAUNCHING_STATUS_REGEX)]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),
             _check_replica_in_status(name, [(2, True, 'READY'),
                                             (0, False, '')]),
         ],
-        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
-        f'{_TEARDOWN_SERVICE.format(name=name)}',
+        #f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
+        #f'{_TEARDOWN_SERVICE.format(name=name)}',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
         timeout=20 * 60,
     )

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -442,11 +442,15 @@ def test_skyserve_dynamic_ondemand_fallback():
             # 1 on-demand (provisioning) + 1 Spot (ready) + 1 spot (provisioning).
             f'{_SERVE_STATUS_WAIT.format(name=name)}; '
             'echo "$s" | grep -q "1/3"',
-            _check_replica_in_status(name, [
-                (1, True, 'READY'),
-                (1, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
-                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY')
-            ]),
+            _check_replica_in_status(
+                name,
+                [
+                    # The newly launched instance may transition to READY status
+                    # quickly, so when checking status it could be either READY or
+                    # LAUNCHING.
+                    (2, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                    (1, False, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY')
+                ]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -442,18 +442,19 @@ def test_skyserve_dynamic_ondemand_fallback():
             # 1 on-demand (provisioning) + 1 Spot (ready) + 1 spot (provisioning).
             f'{_SERVE_STATUS_WAIT.format(name=name)}; '
             'echo "$s" | grep -q "1/3"',
-            _check_replica_in_status(
-                name, [(1, True, 'READY'),
-                       (1, True, _SERVICE_LAUNCHING_STATUS_REGEX),
-                       (1, False, _SERVICE_LAUNCHING_STATUS_REGEX)]),
+            _check_replica_in_status(name, [
+                (1, True, 'READY'),
+                (1, True, _SERVICE_LAUNCHING_STATUS_REGEX + '\|READY'),
+                (1, False, _SERVICE_LAUNCHING_STATUS_REGEX) + '\|READY'
+            ]),
 
             # Wait until 2 spot instances are ready.
             _SERVE_WAIT_UNTIL_READY.format(name=name, replica_num=2),
             _check_replica_in_status(name, [(2, True, 'READY'),
                                             (0, False, '')]),
         ],
-        #f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
-        #f'{_TEARDOWN_SERVICE.format(name=name)}',
+        f'{smoke_tests_utils.down_cluster_for_cloud_cmd(name)}; '
+        f'{_TEARDOWN_SERVICE.format(name=name)}',
         env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
         timeout=20 * 60,
     )


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

[Failure logs](https://buildkite.com/skypilot-1/full-smoke-tests-run/builds/40#_) in release 0.10.0

It seems GCP provisioning speed has improved. The `sky serve` status shows replicas are sometimes in `READY` state instead of the `PROVISIONING` state we used to see.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
