### PR TITLE
[auth] read client id/secret from k8s secret

### DIFF
--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -3,15 +3,13 @@
 {{- if not (index $oauth2 "oidc-issuer-url") -}}
 {{- fail "ingress.oauth2-proxy.oidc-issuer-url is required when OAuth2 proxy is enabled" -}}
 {{- end -}}
-{{- if and (not (index $oauth2 "client-details-from-secret" "enabled")) (eq (index $oauth2 "client-id") "") -}}
-{{- fail "ingress.oauth2-proxy.client-id is required when OAuth2 proxy is enabled and client-details-from-secret is not enabled" -}}
+{{- if and (not (index $oauth2 "client-details-from-secret")) (eq (index $oauth2 "client-id") "") -}}
+{{- fail "ingress.oauth2-proxy.client-id is required when OAuth2 proxy is enabled and client-details-from-secret is not set" -}}
 {{- end -}}
-{{- if and (not (index $oauth2 "client-details-from-secret" "enabled")) (eq (index $oauth2 "client-secret") "") -}}
-{{- fail "ingress.oauth2-proxy.client-secret is required when OAuth2 proxy is enabled and client-details-from-secret is not enabled" -}}
+{{- if and (not (index $oauth2 "client-details-from-secret")) (eq (index $oauth2 "client-secret") "") -}}
+{{- fail "ingress.oauth2-proxy.client-secret is required when OAuth2 proxy is enabled and client-details-from-secret is not set" -}}
 {{- end -}}
-{{- if and (index $oauth2 "client-details-from-secret" "enabled") (eq (index $oauth2 "client-details-from-secret" "secret-name") "") -}}
-{{- fail "ingress.oauth2-proxy.client-details-from-secret.secret-name is required when client-details-from-secret is enabled" -}}
-{{- end -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,20 +61,20 @@ spec:
         {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
-          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret" "enabled") }}
+          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
           valueFrom:
             secretKeyRef:
-              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "secret-name" }}
-              key: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "client-id-key" | default "client-id" }}
+              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
+              key: client-id
           {{- else }}
           value: {{ index .Values.ingress "oauth2-proxy" "client-id" | quote }}
           {{- end }}
         - name: OAUTH2_PROXY_CLIENT_SECRET
-          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret" "enabled") }}
+          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
           valueFrom:
             secretKeyRef:
-              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "secret-name" }}
-              key: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "client-secret-key" | default "client-secret" }}
+              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
+              key: client-secret
           {{- else }}
           value: {{ index .Values.ingress "oauth2-proxy" "client-secret" | quote }}
           {{- end }}

--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -3,11 +3,14 @@
 {{- if not (index $oauth2 "oidc-issuer-url") -}}
 {{- fail "ingress.oauth2-proxy.oidc-issuer-url is required when OAuth2 proxy is enabled" -}}
 {{- end -}}
-{{- if eq (index $oauth2 "client-id") "" -}}
-{{- fail "ingress.oauth2-proxy.client-id is required when OAuth2 proxy is enabled" -}}
+{{- if and (not (index $oauth2 "client-details-from-secret" "enabled")) (eq (index $oauth2 "client-id") "") -}}
+{{- fail "ingress.oauth2-proxy.client-id is required when OAuth2 proxy is enabled and client-details-from-secret is not enabled" -}}
 {{- end -}}
-{{- if eq (index $oauth2 "client-secret") "" -}}
-{{- fail "ingress.oauth2-proxy.client-secret is required when OAuth2 proxy is enabled" -}}
+{{- if and (not (index $oauth2 "client-details-from-secret" "enabled")) (eq (index $oauth2 "client-secret") "") -}}
+{{- fail "ingress.oauth2-proxy.client-secret is required when OAuth2 proxy is enabled and client-details-from-secret is not enabled" -}}
+{{- end -}}
+{{- if and (index $oauth2 "client-details-from-secret" "enabled") (eq (index $oauth2 "client-details-from-secret" "secret-name") "") -}}
+{{- fail "ingress.oauth2-proxy.client-details-from-secret.secret-name is required when client-details-from-secret is enabled" -}}
 {{- end -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -60,9 +63,23 @@ spec:
         {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
+          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret" "enabled") }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "secret-name" }}
+              key: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "client-id-key" | default "client-id" }}
+          {{- else }}
           value: {{ index .Values.ingress "oauth2-proxy" "client-id" | quote }}
+          {{- end }}
         - name: OAUTH2_PROXY_CLIENT_SECRET
+          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret" "enabled") }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "secret-name" }}
+              key: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" "client-secret-key" | default "client-secret" }}
+          {{- else }}
           value: {{ index .Values.ingress "oauth2-proxy" "client-secret" | quote }}
+          {{- end }}
         - name: SERVICE_NAME
           value: {{ .Release.Name }}
         - name: OAUTH2_PROXY_COOKIE_SECRET

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -143,16 +143,10 @@ ingress:
     # Client Secret from OIDC provider (Okta) (required when enabled=true)
     client-secret: ""
     # Alternative: Get both client ID and client secret from a Kubernetes secret
-    # If client-details-from-secret.enabled is true, both client-id and client-secret values above are ignored
-    client-details-from-secret:
-      # Set to true to enable getting both client credentials from a K8s secret
-      enabled: false
-      # Name of the secret containing both client ID and client secret
-      secret-name: ""
-      # Key within the secret that contains the client ID value
-      client-id-key: "client-id"
-      # Key within the secret that contains the client secret value
-      client-secret-key: "client-secret"
+    # If set to a secret name, both client-id and client-secret values above are ignored
+    # The secret must contain keys named "client-id" and "client-secret"
+    # If empty/null, the above client-id and client-secret values are used instead
+    client-details-from-secret: ""
     # Use HTTPS (set to true for production environments)
     use-https: false
     # Email domains to allow (use "*" for all domains)

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -146,6 +146,7 @@ ingress:
     # If set to a secret name, both client-id and client-secret values above are ignored
     # The secret must contain keys named "client-id" and "client-secret"
     # If empty/null, the above client-id and client-secret values are used instead
+    # See https://docs.skypilot.co/en/latest/reference/api-server/examples/api-server-auth-proxy.html#auth-proxy-client-secret
     client-details-from-secret: ""
     # Use HTTPS (set to true for production environments)
     use-https: false

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -142,6 +142,17 @@ ingress:
     client-id: ""
     # Client Secret from OIDC provider (Okta) (required when enabled=true)
     client-secret: ""
+    # Alternative: Get both client ID and client secret from a Kubernetes secret
+    # If client-details-from-secret.enabled is true, both client-id and client-secret values above are ignored
+    client-details-from-secret:
+      # Set to true to enable getting both client credentials from a K8s secret
+      enabled: false
+      # Name of the secret containing both client ID and client secret
+      secret-name: ""
+      # Key within the secret that contains the client ID value
+      client-id-key: "client-id"
+      # Key within the secret that contains the client secret value
+      client-secret-key: "client-secret"
     # Use HTTPS (set to true for production environments)
     use-https: false
     # Email domains to allow (use "*" for all domains)

--- a/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
+++ b/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
@@ -120,7 +120,7 @@ Use ``helm upgrade`` to redeploy the API server helm chart with the ``skypilot-o
 
 .. _auth-proxy-client-secret:
 
-For better security, you can also store the client credentials in a Kubernetes secret instead of passing them as Helm values:
+For better security, you can also store the client details in a Kubernetes secret instead of passing them as Helm values:
 
 .. code-block:: console
 

--- a/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
+++ b/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
@@ -118,6 +118,21 @@ Use ``helm upgrade`` to redeploy the API server helm chart with the ``skypilot-o
       --set ingress.oauth2-proxy.client-id=<CLIENT ID> \
       --set ingress.oauth2-proxy.client-secret=<CLIENT SECRET>
 
+For better security, you can also store the client credentials in a Kubernetes secret instead of passing them as Helm values:
+
+.. code-block:: console
+
+    $ # Create a secret with your Okta credentials
+    $ kubectl create secret generic oauth2-proxy-credentials -n $NAMESPACE \
+      --from-literal=client-id=<CLIENT ID> \
+      --from-literal=client-secret=<CLIENT SECRET>
+
+    $ # Deploy using the secret
+    $ helm upgrade -n $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel --reuse-values \
+      --set ingress.oauth2-proxy.enabled=true \
+      --set ingress.oauth2-proxy.oidc-issuer-url=https://<OKTA URL>.okta.com \
+      --set ingress.oauth2-proxy.client-details-from-secret=oauth2-proxy-credentials
+
 To make sure it's working, visit your endpoint URL in a browser. You should be redirected to Okta to sign in.
 
 Now, you can use ``sky api login -e <ENDPOINT>`` to go though the login flow for the CLI.

--- a/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
+++ b/docs/source/reference/api-server/examples/api-server-auth-proxy.rst
@@ -118,6 +118,8 @@ Use ``helm upgrade`` to redeploy the API server helm chart with the ``skypilot-o
       --set ingress.oauth2-proxy.client-id=<CLIENT ID> \
       --set ingress.oauth2-proxy.client-secret=<CLIENT SECRET>
 
+.. _auth-proxy-client-secret:
+
 For better security, you can also store the client credentials in a Kubernetes secret instead of passing them as Helm values:
 
 .. code-block:: console


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add a config option so that the OAuth Client ID/Client Secret used the oauth2-proxy can be specified in a kubernetes secret rather than in the helm values.
If using this feature, the secret should be defined as follows:
```
apiVersion: v1
kind: Secret
metadata:
  name: oauth2-proxy-credentials
  namespace: skypilot
data:
  client-id: XXXXXXX
  client-secret: XXXXXX
```
Where the namespace and name match those specified in helm

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
