### PR TITLE
remove job.priority from docs

### DIFF
--- a/docs/source/examples/managed-jobs.rst
+++ b/docs/source/examples/managed-jobs.rst
@@ -196,39 +196,6 @@ The SkyPilot dashboard, ``sky dashboard`` has a **Jobs** page that shows all man
 The UI shows the same information as the CLI ``sky jobs queue -au``.
 
 
-.. _job-priority:
-
-Job queueing and priority
--------------------------
-
-Job queueing and priority are supported by managed jobs.
-
-
-Specify job priority by setting the ``job.priority`` field in the :ref:`SkyPilot YAML <yaml-spec-job-priority>`.
-
-.. code-block:: yaml
-
-  job:
-    # Priority of the job, between -1000 and 1000 (default: 0).
-    #
-    # A higher value means that the job is higher priority. High priority jobs
-    # are scheduled sooner and will block lower priority jobs from starting
-    # until the high priority jobs have started.
-    priority: 0
-
-
-All jobs are submitted to a queue. When the scheduler is selecting the next job
-to schedule, it will select the highest priority job.
-
-If a high priority job is still launching, lower priority jobs will not be
-scheduled (i.e., stay in pending).
-
-.. image:: https://i.imgur.com/8H8ictY.png
-  :width: 800
-  :alt: Job queueing and priority
-
-
-
 .. _spot-jobs:
 
 Running on spot instances

--- a/docs/source/reference/yaml-spec.rst
+++ b/docs/source/reference/yaml-spec.rst
@@ -1308,35 +1308,3 @@ Port to run your service on each replica.
 
   resources:
     ports: 8080
-
-Managed jobs
-============
-
-When creating a managed job, you can add an optional ``job`` section to your SkyPilot YAML for additional configuration.
-
-Syntax
-
-.. parsed-literal::
-
-  job:
-    :ref:`priority <yaml-spec-job-priority>`: 200
-
-
-Fields
-----------
-
-.. _yaml-spec-job-priority:
-
-``job.priority``
-~~~~~~~~~~~~~~~~
-
-Priority of the job, between -1000 and 1000 (default: 0).
-
-Set the queuing priority of the job. A higher value means that the job is higher
-priority. High priority jobs are scheduled sooner and will block lower priority
-jobs from starting until the high priority jobs have started.
-
-.. code-block:: yaml
-
-  job:
-    priority: 200


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Code deprecation of `job.priority` will follow, but first we should remove mentions of it in docs.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
