### PR TITLE
[helm] Allow config to be set as a secret

### DIFF
--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -43,6 +43,21 @@ WARNING: apiService.config is set during an upgrade operation, which will be IGN
 To update your SkyPilot config, follow the instructions in the upgrade guide:
 https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#setting-the-skypilot-config
 {{- end -}}
+{{- if and .Release.IsUpgrade .Values.apiService.configSecretName -}}
+WARNING: apiService.configSecretName is set during an upgrade operation, which will be IGNORED.
+
+To update your SkyPilot config, follow the instructions in the upgrade guide:
+https://docs.skypilot.co/en/latest/reference/api-server/api-server-admin-deploy.html#setting-the-skypilot-config
+{{- end -}}
+{{- end -}}
+
+{{/*
+Check if both apiService.config and apiService.configSecretName is set and display warning
+*/}}
+{{- define "skypilot.checkDuplicateConfigSource" -}}
+{{- if and .Values.apiService.config .Values.apiService.configSecretName -}}
+WARNING: both apiService.config and apiService.configSecretName are set during an upgrade operation. apiService.config will be IGNORED.
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -163,8 +163,15 @@ spec:
           mountPath: /root/.ssh # To preserve the SSH keys for the user when using the API server
           subPath: .ssh
         {{- end }}
+        # mount the config from the secret if it is set
+        {{- if .Values.apiService.configSecretName }}
+        - name: skypilot-config-secret
+          mountPath: /var/skypilot/config
+        # mount the config from the configmap if the secret is not set
+        {{- else }}
         - name: skypilot-config
           mountPath: /var/skypilot/config
+        {{- end }}
         {{- if .Values.apiService.sshNodePools }}
         - name: skypilot-ssh-node-pools
           mountPath: /var/skypilot/ssh_node_pool
@@ -375,6 +382,11 @@ spec:
       - name: skypilot-config
         configMap:
           name: {{ .Release.Name }}-config
+      {{- if .Values.apiService.configSecretName }}
+      - name: skypilot-config-secret
+        secret:
+          secretName: {{ .Values.apiService.configSecretName }}
+      {{- end }}
       {{- if .Values.apiService.sshNodePools }}
       - name: skypilot-ssh-node-pools
         secret:

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -49,6 +49,10 @@ apiService:
   #     - aws
   #     - kubernetes
 
+  # Set ~/.sky/config.yaml content on the API server from a secret
+  # if configSecretName is set, config is ignored
+  configSecretName: null
+
   # Set ~/.sky/ssh_node_pools.yaml content on the API server
   # Updating this value will not restart the API server but it will take tens of seconds to take effect on the API server.
   # You can verify config updates on the server by exec-ing into the pod and running `cat ~/.sky/ssh_node_pools.yaml`


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
