### PR TITLE
gcp catalog: use n1-standard hosts for V100, halve vCPU-per-GPU & lower RAM ratio  ➜ fixes #2239

### DIFF
--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -61,7 +61,7 @@ _DEFAULT_HOST_VM_FAMILY = (
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4
 
-_DEFAULT_GPU_MEMORY_CPU_RATIO = 4
+_DEFAULT_GPU_MEMORY_CPU_RATIO = 3.75
 
 # TODO(zongheng): fix A100 info directly in catalog.
 # https://cloud.google.com/blog/products/compute/a2-vms-with-nvidia-a100-gpus-are-ga
@@ -137,10 +137,10 @@ _NUM_ACC_TO_NUM_CPU = {
     },
     # Based on p3 on AWS.
     'V100': {
-        1: 8,
-        2: 16,
-        4: 32,
-        8: 64
+        1: 4,
+        2: 8,
+        4: 16,
+        8: 32,
     },
     # Based on g4dn on AWS.
     'T4': {

--- a/tests/unit_tests/test_gcp_instance_type_selection.py
+++ b/tests/unit_tests/test_gcp_instance_type_selection.py
@@ -1,0 +1,17 @@
+import sky
+
+
+def test_v100_two_gpu_gets_n1_standard_8():
+    """Ensure SkyPilot picks n1-standard-8 as the host VM for 2×V100 on GCP."""
+    instance_types, fuzzy = sky.catalog.get_instance_type_for_accelerator(
+        'V100', 2, clouds='gcp'
+    )
+
+    # The primary recommendation should be n1-standard-8.
+    assert instance_types, 'No instance type returned for V100:2 on GCP.'
+    assert 'n1-standard-8' in instance_types, (
+        f"Expected 'n1-standard-8' in recommendations, got {instance_types}"
+    )
+
+    # Fuzzy list should be empty since we expect an exact match.
+    assert not fuzzy, f'Unexpected fuzzy candidates returned: {fuzzy}' 


### PR DESCRIPTION
### What & Why

Users requesting `V100:2` on GCP were routed to `n1-highmem-16`; that VM
family has scarce quota and often fails to schedule, while Vertex AI uses
`n1-standard-8` for the same workload (see issue #2239).

This PR aligns SkyPilot’s heuristic with GCP reality:

1. **Halve the vCPU mapping for V100**  
   `_NUM_ACC_TO_NUM_CPU['V100']` → 4 vCPU / GPU (was 8).

2. **Lower the default RAM-per-vCPU for GPU hosts**  
   `_DEFAULT_GPU_MEMORY_CPU_RATIO` → 3.75 GiB (matches the `n1-standard`
   family).

3. **Regression test**  
   `tests/unit_tests/test_gcp_instance_type_selection.py` asserts that
   `catalog.get_instance_type_for_accelerator('V100', 2, clouds='gcp')`
   now returns `n1-standard-8` with no fuzzy fallback.

### Tests run

- [x] New unit test (`pytest tests/unit_tests/test_gcp_instance_type_selection.py`)
- [x] All existing unit tests (`pytest -q`)  
- [ ] Smoke tests (maintainer will trigger `/smoke-test`)
- [ ] Quick core compatibility (maintainer will trigger `/quicktest-core`)

### Impact

Requests like

```yaml
resources:
  accelerators: V100:2
```

will provision `n1-standard-8` + 2 × V100 instead of `n1-highmem-16`,
greatly improving quota availability and reducing cost.

Closes #2239.