### PR TITLE
Fix test_docker_storage_mounts

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -16,12 +16,12 @@ import colorama
 import pytest
 import requests
 from smoke_tests.docker import docker_utils
-import yaml
 
 import sky
 from sky import serve
 from sky import skypilot_config
 from sky.clouds import AWS
+from sky.clouds import gcp
 from sky.clouds import GCP
 from sky.server import common as server_common
 from sky.server.requests import payloads
@@ -87,6 +87,14 @@ JOB_WAIT_NOT_RUNNING = (
     'until ! echo "$s" | grep "{job_name}" | grep "RUNNING"; do '
     'sleep 10; s=$(sky jobs queue);'
     'echo "Waiting for job to stop RUNNING"; echo "$s"; done')
+
+ACTIVATE_SERVICE_ACCOUNT_AND_GSUTIL = (
+    'GOOGLE_APPLICATION_CREDENTIALS='
+    f'{gcp.DEFAULT_GCP_APPLICATION_CREDENTIAL_PATH}; '
+    'gcloud auth activate-service-account '
+    '--key-file=$GOOGLE_APPLICATION_CREDENTIALS '
+    '2> /dev/null || true; '
+    'gsutil')
 
 # Cluster functions
 _ALL_JOB_STATUSES = "|".join([status.value for status in sky.JobStatus])

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -19,15 +19,22 @@
 # Change cloud for generic tests to aws
 # > pytest tests/smoke_tests/test_region_and_zone.py --generic-cloud aws
 
+import pathlib
+import shlex
 import tempfile
 import textwrap
+import time
 
+import jinja2
 import pytest
 from smoke_tests import smoke_tests_utils
+from smoke_tests import test_mount_and_storage
 
 import sky
 from sky import skypilot_config
+from sky.data import storage as storage_lib
 from sky.skylet import constants
+from sky.utils import controller_utils
 
 
 # ---------- Test region ----------
@@ -214,3 +221,85 @@ def test_gcp_zone():
         f'sky down -y {name}',
     )
     smoke_tests_utils.run_one_test(test)
+
+
+# TODO (SKY-1119): These tests may fail as it can require access cloud
+# credentials for getting azure storage commands, even though the API server
+# is running remotely. We should fix this.
+@pytest.mark.no_vast  # Requires AWS
+@pytest.mark.no_hyperbolic  # Requires AWS
+@pytest.mark.parametrize(
+    'image_id',
+    [
+        'docker:nvidia/cuda:11.8.0-devel-ubuntu18.04',
+        'docker:ubuntu:18.04',
+        # Test image with python 3.11 installed by default.
+        'docker:continuumio/miniconda3:24.1.2-0',
+        # Test python>=3.12 where SkyPilot should automatically create a separate
+        # conda env for runtime with python 3.10.
+        'docker:continuumio/miniconda3:latest',
+    ])
+def test_docker_storage_mounts(generic_cloud: str, image_id: str):
+    # Tests bucket mounting on docker container
+    name = smoke_tests_utils.get_cluster_name()
+    timestamp = str(time.time()).replace('.', '')
+    storage_name = f'sky-test-{timestamp}'
+    template_str = pathlib.Path(
+        'tests/test_yamls/test_storage_mounting.yaml.j2').read_text()
+    template = jinja2.Template(template_str)
+    # ubuntu 18.04 does not support fuse3, and blobfuse2 depends on fuse3.
+    azure_mount_unsupported_ubuntu_version = '18.04'
+    # Commands to verify bucket upload. We need to check all three
+    # storage types because the optimizer may pick any of them.
+    s3_command = f'aws s3 ls {storage_name}/hello.txt'
+    gsutil_command = (
+        f'{{ {smoke_tests_utils.ACTIVATE_SERVICE_ACCOUNT_AND_GSUTIL} '
+        f'ls gs://{storage_name}/hello.txt; }}')
+    azure_blob_command = test_mount_and_storage.TestStorageWithCredentials.cli_ls_cmd(
+        storage_lib.StoreType.AZURE, storage_name, suffix='hello.txt')
+    # TODO(zpoint): this is a temporary fix. We should make it more robust.
+    # If azure is used, the azure blob storage checking assumes the bucket is
+    # created in the centralus region when getting the storage account. We
+    # should set the cluster to be launched in the same region.
+    region_str = f'/centralus' if generic_cloud == 'azure' else ''
+    if azure_mount_unsupported_ubuntu_version in image_id:
+        # The store for mount_private_mount is not specified in the template.
+        # If we're running on Azure, the private mount will be created on
+        # azure blob. Also, if we're running on Kubernetes, the private mount
+        # might be created on azure blob to avoid the issue of the fuse adapter
+        # not being able to access the mount point. That will not be supported on
+        # the ubuntu 18.04 image and thus fail. For other clouds, the private mount
+        # on other storage types (GCS/S3) should succeed.
+        include_private_mount = False if (
+            generic_cloud == 'azure' or generic_cloud == 'kubernetes') else True
+        content = template.render(storage_name=storage_name,
+                                  include_azure_mount=False,
+                                  include_private_mount=include_private_mount)
+    else:
+        content = template.render(storage_name=storage_name,)
+    cloud_dependencies_setup_cmd = ' && '.join(
+        controller_utils._get_cloud_dependencies_installation_commands(
+            controller_utils.Controllers.JOBS_CONTROLLER))
+    quoted_check = shlex.quote(
+        f'{constants.ACTIVATE_SKY_REMOTE_PYTHON_ENV} && '
+        f'{cloud_dependencies_setup_cmd}; {s3_command} || {gsutil_command} || '
+        f'{azure_blob_command}')
+    with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
+        f.write(content)
+        f.flush()
+        file_path = f.name
+        test_commands = [
+            *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
+            f'sky launch -y -c {name} --infra {generic_cloud}{region_str} {smoke_tests_utils.LOW_RESOURCE_ARG} --image-id {image_id} {file_path}',
+            f'sky logs {name} 1 --status',  # Ensure job succeeded.
+            # Check AWS, GCP, or Azure storage mount.
+            f'sky exec {name} {quoted_check}',
+            f'sky logs {name} 2 --status',  # Ensure the bucket check succeeded.
+        ]
+        test = smoke_tests_utils.Test(
+            'docker_storage_mounts',
+            test_commands,
+            f'sky down -y {name}; sky storage delete -y {storage_name}',
+            timeout=20 * 60,  # 20 mins
+        )
+        smoke_tests_utils.run_one_test(test)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Move the test to another file so that `generate_pipeline.py` won't skip schedule the test with different parameters to different Buildkite agents, avoiding excessive resource usage at once.

[Fail log
](https://buildkite.com/skypilot-1/smoke-tests/builds/1544#01979d10-8286-42d5-a15c-85f6012d30c8)


Before:

![image](https://github.com/user-attachments/assets/0c53dbad-7760-4551-9ff2-116d5039ffc5)

After:

![image](https://github.com/user-attachments/assets/d5900c3f-fb5b-427b-8a97-ae966cde7d84)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
