### PR TITLE
[CLI] Fix cost report for controller names

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1843,7 +1843,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     status_utils.show_cost_report_table(normal_cluster_records, all)
     for controller_name, cluster_record in controllers.items():
         status_utils.show_cost_report_table(
-            [cluster_record], all, controller_name=controller_name)
+            [cluster_record], all, controller_name=controller_name.capitalize())
         total_cost += cluster_record['total_cost']
 
     click.echo(f'\n{colorama.Style.BRIGHT}'

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1829,7 +1829,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         cluster_name = cluster_record['name']
         controller = controller_utils.Controllers.from_name(cluster_name)
         if controller is not None:
-            controller_name = controller.value.name
+            controller_name = controller.value.cluster_name
             # to display most recent entry for each controller cluster
             # TODO(sgurram): fix assumption of sorted order of clusters
             if controller_name not in controllers:
@@ -1843,7 +1843,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
     status_utils.show_cost_report_table(normal_cluster_records, all)
     for controller_name, cluster_record in controllers.items():
         status_utils.show_cost_report_table(
-            [cluster_record], all, controller_name=controller_name.capitalize())
+            [cluster_record], all, controller_name=controller_name)
         total_cost += cluster_record['total_cost']
 
     click.echo(f'\n{colorama.Style.BRIGHT}'

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1829,7 +1829,7 @@ def cost_report(all: bool):  # pylint: disable=redefined-builtin
         cluster_name = cluster_record['name']
         controller = controller_utils.Controllers.from_name(cluster_name)
         if controller is not None:
-            controller_name = controller.value.cluster_name
+            controller_name = controller.value.name
             # to display most recent entry for each controller cluster
             # TODO(sgurram): fix assumption of sorted order of clusters
             if controller_name not in controllers:

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -201,9 +201,6 @@ def show_cost_report_table(cluster_records: List[_ClusterCostReportRecord],
 
     if cluster_records:
         if controller_name is not None:
-            controller = controller_utils.Controllers.from_name(controller_name)
-            if controller is None:
-                raise ValueError(f'Controller {controller_name} not found.')
             controller_handle: backends.CloudVmRayResourceHandle = (
                 cluster_records[0]['handle'])
             autostop_config = (

--- a/sky/utils/cli_utils/status_utils.py
+++ b/sky/utils/cli_utils/status_utils.py
@@ -7,7 +7,6 @@ import colorama
 
 from sky import backends
 from sky.utils import common_utils
-from sky.utils import controller_utils
 from sky.utils import log_utils
 from sky.utils import resources_utils
 from sky.utils import status_lib


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Previously when we do `sky cost-report`, we are using the `controller.value.name` (`'managed jobs controller'`) but not the `controller.value.cluster_name` to query the status.

```bash
Traceback (most recent call last):
  File "/opt/miniconda3/envs/sky/bin/sky", line 8, in <module>
    sys.exit(cli())
  File "/Users/tianxia/Desktop/skypilot/sky/cli.py", line 9, in cli
    command.cli()
  File "/opt/miniconda3/envs/sky/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/opt/miniconda3/envs/sky/lib/python3.10/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/tianxia/Desktop/skypilot/sky/utils/common_utils.py", line 531, in _record
    return f(*args, **kwargs)
  File "/Users/tianxia/Desktop/skypilot/sky/client/cli/command.py", line 734, in invoke
    return super().invoke(ctx)
  File "/opt/miniconda3/envs/sky/lib/python3.10/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/miniconda3/envs/sky/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/miniconda3/envs/sky/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/tianxia/Desktop/skypilot/sky/utils/common_utils.py", line 551, in _record
    return f(*args, **kwargs)
  File "/Users/tianxia/Desktop/skypilot/sky/client/cli/command.py", line 1844, in cost_report
    status_utils.show_cost_report_table(
  File "/Users/tianxia/Desktop/skypilot/sky/utils/cli_utils/status_utils.py", line 206, in show_cost_report_table
    raise ValueError(f'Controller {controller_name} not found.')
ValueError: Controller Managed jobs controller not found.
```

However, this status query is not needed because it is already done in the caller function.

https://github.com/skypilot-org/skypilot/blob/c869a03590603040df8af4ed3f64596f5bb22ec7/sky/client/cli/command.py#L1826-L1847

This PR remove this check.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
