### PR TITLE
[UI] Timestamp tweaks

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -696,7 +696,9 @@ export function ClusterTable({
                         <span>{item.resources_str}</span>
                       </NonCapitalizedTooltip>
                     </TableCell>
-                    <TableCell><TimestampWithTooltip date={item.time} /></TableCell>
+                    <TableCell>
+                      <TimestampWithTooltip date={item.time} />
+                    </TableCell>
                     <TableCell>
                       {formatAutostop(item.autostop, item.to_down)}
                     </TableCell>

--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -18,6 +18,7 @@ import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
   REFRESH_INTERVAL,
+  TimestampWithTooltip,
 } from '@/components/utils';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -695,7 +696,7 @@ export function ClusterTable({
                         <span>{item.resources_str}</span>
                       </NonCapitalizedTooltip>
                     </TableCell>
-                    <TableCell>{relativeTime(item.time)}</TableCell>
+                    <TableCell><TimestampWithTooltip date={item.time} /></TableCell>
                     <TableCell>
                       {formatAutostop(item.autostop, item.to_down)}
                     </TableCell>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -28,6 +28,7 @@ import {
   NonCapitalizedTooltip,
   relativeTime,
   formatDateTime,
+  TimestampWithTooltip,
 } from '@/components/utils';
 import {
   FileSearchIcon,
@@ -141,7 +142,7 @@ const formatUserDisplay = (username, userId) => {
   return usernameBase;
 };
 
-// Helper function to format submitted time with abbreviated units
+// Helper function to format submitted time with abbreviated units (now uses TimestampWithTooltip)
 const formatSubmittedTime = (timestamp) => {
   if (!timestamp) return '-';
 
@@ -149,59 +150,7 @@ const formatSubmittedTime = (timestamp) => {
   const date =
     timestamp instanceof Date ? timestamp : new Date(timestamp * 1000);
 
-  // Get the original timeString from relativeTime
-  let timeString = relativeTime(date);
-
-  // If relativeTime returns a React element, extract the string from its props
-  if (
-    React.isValidElement(timeString) &&
-    timeString.props &&
-    timeString.props.children
-  ) {
-    // The actual string is nested within the Tooltip
-    if (
-      React.isValidElement(timeString.props.children) &&
-      timeString.props.children.props &&
-      timeString.props.children.props.children
-    ) {
-      timeString = timeString.props.children.props.children;
-    } else {
-      timeString = timeString.props.children;
-    }
-  }
-
-  // Ensure we have a string before proceeding
-  if (typeof timeString !== 'string') {
-    return timeString; // Return as is if not a string after extraction
-  }
-
-  // Apply the same shortening logic
-  const shortenedTime = shortenTimeForJobs(timeString);
-
-  // Return with tooltip functionality like relativeTime does
-  const now = new Date();
-  const differenceInDays =
-    (now.getTime() - date.getTime()) / (1000 * 3600 * 24);
-
-  if (Math.abs(differenceInDays) < 7) {
-    return (
-      <Tooltip
-        content={formatDateTime(date)}
-        className="capitalize text-sm text-muted-foreground"
-      >
-        {shortenedTime}
-      </Tooltip>
-    );
-  } else {
-    return (
-      <Tooltip
-        content={formatDateTime(date)}
-        className="text-sm text-muted-foreground"
-      >
-        {shortenedTime}
-      </Tooltip>
-    );
-  }
+  return <TimestampWithTooltip date={date} />;
 };
 
 // Helper function to shorten time strings for jobs
@@ -217,7 +166,7 @@ function shortenTimeForJobs(timeString) {
 
   // Handle "less than a minute ago" case
   if (timeString.toLowerCase() === 'less than a minute ago') {
-    return 'Less than a minute ago';
+    return 'Less than 1m ago';
   }
 
   // Handle "about X unit(s) ago" e.g. "about 1 hour ago" -> "1h ago"

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -453,15 +453,9 @@ export function TimestampWithTooltip({ date }) {
   const fullLocalTimestamp = dateStr + ', ' + timeStr;
 
   let displayText;
-
-  // For timestamps >= 1 day ago, show the date in yyyy-mm-dd format
-  // For timestamps < 1 day ago, show relative time
-  if (differenceInDays >= 1) {
-    displayText = dateStr;
-  } else {
-    const originalTimeString = formatDistance(date, now, { addSuffix: true });
-    displayText = shortenTimeString(originalTimeString);
-  }
+  // Always show relative time with shortened format
+  const originalTimeString = formatDistance(date, now, { addSuffix: true });
+  displayText = shortenTimeString(originalTimeString);
 
   return (
     <CustomTooltip

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -453,9 +453,15 @@ export function TimestampWithTooltip({ date }) {
   const fullLocalTimestamp = dateStr + ', ' + timeStr;
 
   let displayText;
-  // Always show relative time with shortened format
-  const originalTimeString = formatDistance(date, now, { addSuffix: true });
-  displayText = shortenTimeString(originalTimeString);
+
+  // For timestamps >= 1 day ago, show the date in yyyy-mm-dd format
+  // For timestamps < 1 day ago, show relative time
+  if (differenceInDays >= 1) {
+    displayText = dateStr;
+  } else {
+    const originalTimeString = formatDistance(date, now, { addSuffix: true });
+    displayText = shortenTimeString(originalTimeString);
+  }
 
   return (
     <CustomTooltip

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -439,16 +439,19 @@ export function TimestampWithTooltip({ date }) {
   const now = new Date();
   const differenceInDays = (now - date) / (1000 * 3600 * 24);
 
-    // Format the full timestamp in '2025-06-13, 03:53:33 PM PDT' format
-  const dateStr = date.getFullYear() + '-' +
-    String(date.getMonth() + 1).padStart(2, '0') + '-' +
+  // Format the full timestamp in '2025-06-13, 03:53:33 PM PDT' format
+  const dateStr =
+    date.getFullYear() +
+    '-' +
+    String(date.getMonth() + 1).padStart(2, '0') +
+    '-' +
     String(date.getDate()).padStart(2, '0');
   const timeStr = date.toLocaleString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
-    timeZoneName: 'short'
+    timeZoneName: 'short',
   });
   const fullLocalTimestamp = dateStr + ', ' + timeStr;
 
@@ -475,15 +478,18 @@ export function formatFullTimestamp(date) {
     return 'N/A';
   }
 
-  const dateStr = date.getFullYear() + '-' +
-    String(date.getMonth() + 1).padStart(2, '0') + '-' +
+  const dateStr =
+    date.getFullYear() +
+    '-' +
+    String(date.getMonth() + 1).padStart(2, '0') +
+    '-' +
     String(date.getDate()).padStart(2, '0');
   const timeStr = date.toLocaleString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
     hour12: true,
-    timeZoneName: 'short'
+    timeZoneName: 'short',
   });
   return dateStr + ', ' + timeStr;
 }

--- a/sky/dashboard/src/components/utils.jsx
+++ b/sky/dashboard/src/components/utils.jsx
@@ -59,6 +59,11 @@ function shortenTimeString(timeString) {
     return 'now';
   }
 
+  // Handle "less than a minute ago" case
+  if (timeString.toLowerCase() === 'less than a minute ago') {
+    return 'Less than 1m ago';
+  }
+
   // Handle "about X unit(s) ago" e.g. "about 1 hour ago" -> "1h ago"
   const aboutMatch = timeString.match(/^about\s+(\d+)\s+(\w+)\s+ago$/i);
   if (aboutMatch) {
@@ -133,7 +138,7 @@ export function formatDateTime(date) {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-    hour: '2-digit',
+    hour: 'numeric',
     minute: '2-digit',
     second: '2-digit',
     hour12: false, // Use 24-hour format
@@ -423,4 +428,62 @@ export function LogFilter({ logs, controller = false }) {
       />
     </div>
   );
+}
+
+// New component for timestamps with dotted underlines and local timezone tooltips
+export function TimestampWithTooltip({ date }) {
+  if (!date) {
+    return 'N/A';
+  }
+
+  const now = new Date();
+  const differenceInDays = (now - date) / (1000 * 3600 * 24);
+
+    // Format the full timestamp in '2025-06-13, 03:53:33 PM PDT' format
+  const dateStr = date.getFullYear() + '-' +
+    String(date.getMonth() + 1).padStart(2, '0') + '-' +
+    String(date.getDate()).padStart(2, '0');
+  const timeStr = date.toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+    timeZoneName: 'short'
+  });
+  const fullLocalTimestamp = dateStr + ', ' + timeStr;
+
+  let displayText;
+  // Always show relative time with shortened format
+  const originalTimeString = formatDistance(date, now, { addSuffix: true });
+  displayText = shortenTimeString(originalTimeString);
+
+  return (
+    <CustomTooltip
+      content={fullLocalTimestamp}
+      className="text-sm text-muted-foreground"
+    >
+      <span className="border-b border-dotted border-gray-400 cursor-help">
+        {displayText}
+      </span>
+    </CustomTooltip>
+  );
+}
+
+// Helper function to format timestamp in full format without underline (for detail pages)
+export function formatFullTimestamp(date) {
+  if (!date) {
+    return 'N/A';
+  }
+
+  const dateStr = date.getFullYear() + '-' +
+    String(date.getMonth() + 1).padStart(2, '0') + '-' +
+    String(date.getDate()).padStart(2, '0');
+  const timeStr = date.toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+    timeZoneName: 'short'
+  });
+  return dateStr + ', ' + timeStr;
 }

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -19,6 +19,7 @@ import yaml from 'js-yaml';
 import {
   CustomTooltip as Tooltip,
   NonCapitalizedTooltip,
+  formatFullTimestamp,
 } from '@/components/utils';
 import {
   SSHInstructionsModal,
@@ -298,7 +299,7 @@ function ActiveTab({
                 </div>
                 <div className="text-base mt-1">
                   {clusterData.time
-                    ? new Date(clusterData.time).toLocaleString()
+                    ? formatFullTimestamp(new Date(clusterData.time))
                     : 'N/A'}
                 </div>
               </div>

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -4,7 +4,7 @@ import { Card } from '@/components/ui/card';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useClusterDetails } from '@/data/connectors/clusters';
-import { CustomTooltip as Tooltip } from '@/components/utils';
+import { CustomTooltip as Tooltip, formatFullTimestamp } from '@/components/utils';
 import { RotateCwIcon } from 'lucide-react';
 import { CircularProgress } from '@mui/material';
 import { streamClusterJobLogs } from '@/data/connectors/clusters';
@@ -236,6 +236,14 @@ export function JobDetailPage() {
                       </div>
                       <div className="text-base mt-1">{jobData.user}</div>
                     </div>
+                    <div>
+                      <div className="text-gray-600 font-medium text-base">
+                        Submitted
+                      </div>
+                      <div className="text-base mt-1">
+                        {jobData.submitted_at ? formatFullTimestamp(jobData.submitted_at) : 'N/A'}
+                      </div>
+                    </div>
                     {jobData.resources && (
                       <div>
                         <div className="text-gray-600 font-medium text-base">
@@ -296,8 +304,7 @@ export function JobDetailPage() {
                   {isPending ? (
                     <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
                       <span>
-                        Waiting for the job to start, please refresh after a
-                        while
+                        Waiting for the job to start; refresh in a few moments.
                       </span>
                     </div>
                   ) : isLoadingLogs ? (

--- a/sky/dashboard/src/pages/clusters/[cluster]/[job].js
+++ b/sky/dashboard/src/pages/clusters/[cluster]/[job].js
@@ -4,7 +4,10 @@ import { Card } from '@/components/ui/card';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useClusterDetails } from '@/data/connectors/clusters';
-import { CustomTooltip as Tooltip, formatFullTimestamp } from '@/components/utils';
+import {
+  CustomTooltip as Tooltip,
+  formatFullTimestamp,
+} from '@/components/utils';
 import { RotateCwIcon } from 'lucide-react';
 import { CircularProgress } from '@mui/material';
 import { streamClusterJobLogs } from '@/data/connectors/clusters';
@@ -241,7 +244,9 @@ export function JobDetailPage() {
                         Submitted
                       </div>
                       <div className="text-base mt-1">
-                        {jobData.submitted_at ? formatFullTimestamp(jobData.submitted_at) : 'N/A'}
+                        {jobData.submitted_at
+                          ? formatFullTimestamp(jobData.submitted_at)
+                          : 'N/A'}
                       </div>
                     </div>
                     {jobData.resources && (

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -12,7 +12,10 @@ import {
   CopyIcon,
   CheckIcon,
 } from 'lucide-react';
-import { CustomTooltip as Tooltip, formatFullTimestamp } from '@/components/utils';
+import {
+  CustomTooltip as Tooltip,
+  formatFullTimestamp,
+} from '@/components/utils';
 import { LogFilter, formatLogs } from '@/components/utils';
 import { streamManagedJobLogs } from '@/data/connectors/jobs';
 import { StatusBadge } from '@/components/elements/StatusBadge';
@@ -886,9 +889,7 @@ function JobDetailsContent({
       <div className="max-h-96 overflow-y-auto" ref={logsContainerRef}>
         {isPending ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
-            <span>
-              Waiting for the job to start; refresh in a few moments.
-            </span>
+            <span>Waiting for the job to start; refresh in a few moments.</span>
           </div>
         ) : isRecovering ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
@@ -962,7 +963,9 @@ function JobDetailsContent({
       <div>
         <div className="text-gray-600 font-medium text-base">Submitted</div>
         <div className="text-base mt-1">
-          {jobData.submitted_at ? formatFullTimestamp(jobData.submitted_at) : 'N/A'}
+          {jobData.submitted_at
+            ? formatFullTimestamp(jobData.submitted_at)
+            : 'N/A'}
         </div>
       </div>
       <div>

--- a/sky/dashboard/src/pages/jobs/[job].js
+++ b/sky/dashboard/src/pages/jobs/[job].js
@@ -12,7 +12,7 @@ import {
   CopyIcon,
   CheckIcon,
 } from 'lucide-react';
-import { CustomTooltip as Tooltip } from '@/components/utils';
+import { CustomTooltip as Tooltip, formatFullTimestamp } from '@/components/utils';
 import { LogFilter, formatLogs } from '@/components/utils';
 import { streamManagedJobLogs } from '@/data/connectors/jobs';
 import { StatusBadge } from '@/components/elements/StatusBadge';
@@ -887,13 +887,13 @@ function JobDetailsContent({
         {isPending ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
             <span>
-              Waiting for the job to start, please refresh after a while
+              Waiting for the job to start; refresh in a few moments.
             </span>
           </div>
         ) : isRecovering ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
             <span>
-              Waiting for the job to recover, please refresh after a while
+              Waiting for the job to recover; refresh in a few moments.
             </span>
           </div>
         ) : hasReceivedFirstChunk || logs ? (
@@ -919,8 +919,8 @@ function JobDetailsContent({
         {isPreStart ? (
           <div className="bg-[#f7f7f7] flex items-center justify-center py-4 text-gray-500">
             <span>
-              Waiting for the job controller process to start, please refresh
-              after a while
+              Waiting for the job controller process to start; refresh in a few
+              moments.
             </span>
           </div>
         ) : hasReceivedFirstChunk || controllerLogs ? (
@@ -950,7 +950,7 @@ function JobDetailsContent({
         <div className="text-gray-600 font-medium text-base">Status</div>
         <div className="text-base mt-1 flex items-center">
           <StatusBadge status={jobData.status} />
-          {jobData.priority && (
+          {jobData.priority !== undefined && jobData.priority !== null && (
             <span className="ml-2"> (Priority: {jobData.priority})</span>
           )}
         </div>
@@ -958,6 +958,12 @@ function JobDetailsContent({
       <div>
         <div className="text-gray-600 font-medium text-base">User</div>
         <div className="text-base mt-1">{jobData.user}</div>
+      </div>
+      <div>
+        <div className="text-gray-600 font-medium text-base">Submitted</div>
+        <div className="text-base mt-1">
+          {jobData.submitted_at ? formatFullTimestamp(jobData.submitted_at) : 'N/A'}
+        </div>
       </div>
       <div>
         <div className="text-gray-600 font-medium text-base">


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Changes
- Display short timestamps in a dotted underline 
- Consistent timestamps across clusters + jobs
- more than 1d old gets the YYYY-mm-dd format instead of "3d ago" or "1mo ago"

Now
<img width="1487" alt="Screenshot 2025-06-23 at 13 41 06" src="https://github.com/user-attachments/assets/2926ce19-ef57-40e6-9e20-ee49da7b95a8" />
<img width="706" alt="Screenshot 2025-06-23 at 13 25 23" src="https://github.com/user-attachments/assets/9d8abea1-cd70-482a-a85f-cb569ca660b2" />
<img width="993" alt="Screenshot 2025-06-23 at 13 36 02" src="https://github.com/user-attachments/assets/658a027a-5c59-4890-89e1-a02b776a6c1b" />



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
