### PR TITLE
Move  `test_optimizer_random_dag` out of group

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,8 +23,9 @@ jobs:
           - tests/test_cli.py
           - "tests/test_optimizer_dryruns.py -k \"partial\""
           - "tests/test_optimizer_dryruns.py -k \"not partial\""
-          - tests/test_jobs_and_serve.py tests/test_yaml_parser.py tests/test_global_user_state.py tests/test_config.py tests/test_jobs.py tests/test_list_accelerators.py tests/test_wheels.py tests/test_api.py tests/test_optimizer_random_dag.py tests/test_storage.py tests/test_api_compatibility.py
+          - tests/test_jobs_and_serve.py tests/test_yaml_parser.py tests/test_global_user_state.py tests/test_config.py tests/test_jobs.py tests/test_list_accelerators.py tests/test_wheels.py tests/test_api.py tests/test_storage.py tests/test_api_compatibility.py
           - tests/test_no_parellel.py
+          - tests/test_optimizer_random_dag.py
         include:
           - test-path: tests/unit_tests
             test-name: "Unit Tests"
@@ -34,10 +35,14 @@ jobs:
             test-name: "Optimizer Dryruns Part 1"
           - test-path: "tests/test_optimizer_dryruns.py -k \"not partial\""
             test-name: "Optimizer Dryruns Part 2"
-          - test-path: tests/test_jobs_and_serve.py tests/test_yaml_parser.py tests/test_global_user_state.py tests/test_config.py tests/test_jobs.py tests/test_list_accelerators.py tests/test_wheels.py tests/test_api.py tests/test_optimizer_random_dag.py tests/test_storage.py tests/test_api_compatibility.py
+          - test-path: tests/test_jobs_and_serve.py tests/test_yaml_parser.py tests/test_global_user_state.py tests/test_config.py tests/test_jobs.py tests/test_list_accelerators.py tests/test_wheels.py tests/test_api.py tests/test_storage.py tests/test_api_compatibility.py
             test-name: "Jobs, Serve, Wheels, API, Config, Optimizer & Storage Tests"
           - test-path: tests/test_no_parellel.py
             test-name: "No Parallel Tests"
+          # We separate out the random DAG tests because its flaky due to catalog updates.
+          # TODO(zeping): Move back to the main test group once we fixed the flakiness.
+          - test-path: tests/test_optimizer_random_dag.py
+            test-name: "Optimizer Random DAG Tests"
     runs-on: ubuntu-latest
     name: "Python Tests - ${{ matrix.test-name }}"
     steps:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This is flaky because the catalog changes. Our catalog updates every 6 hours. I’m not sure if the catalog is broken or our test code is broken.
Last time I tried debugging and found it was caused by changes in either AWS, vSphere, or Hyperbolic. But when I tried to investigate further, the 6-hour update happened, the catalog refreshed, and the problem resolved itself automatically, so the issue remains unresolved.

Remove it from `required` tests to unblock PR merge.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
