### PR TITLE
Update text capitalization in users.jsx

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -387,7 +387,7 @@ export function Clusters() {
                 />
               </div>
               <span className="ml-2 text-sm text-gray-700">
-                Show History (last 30 days)
+                Show history (Last 30 days)
               </span>
             </label>
           </div>


### PR DESCRIPTION
A text string was updated in `sky/dashboard/src/components/clusters.jsx`.

Initially, the change was requested for `users.jsx`, but a codebase search revealed the target string "Show History (last 30 days)" was located in `clusters.jsx`.

The string was modified to "Show history (Last 30 days)", specifically:
*   "History" was changed to "history" (lowercase 'h').
*   "last" was changed to "Last" (uppercase 'L').

This adjustment ensures consistent casing for the display text.