### PR TITLE
Fix flaky test: test_dynamic_kubernetes_contexts_policy

### DIFF
--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -194,26 +194,29 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
                                     idle_minutes_to_autostop=None)
 
 
-@mock.patch('sky.provision.kubernetes.utils.get_all_kube_context_names',
-            return_value=['kind-skypilot', 'kind-skypilot2', 'kind-skypilot3'])
 def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):
-    dag, config = _load_task_and_apply_policy(
-        task,
-        os.path.join(POLICY_PATH, 'dynamic_kubernetes_contexts_update.yaml'))
+    with mock.patch(
+            'sky.provision.kubernetes.utils.get_all_kube_context_names',
+            return_value=['kind-skypilot', 'kind-skypilot2', 'kind-skypilot3']):
+        dag, config = _load_task_and_apply_policy(
+            task,
+            os.path.join(POLICY_PATH,
+                         'dynamic_kubernetes_contexts_update.yaml'))
 
-    assert config.get_nested(
-        ('kubernetes', 'allowed_contexts'),
-        None) == ['kind-skypilot', 'kind-skypilot2'
-                 ], 'Kubernetes allowed contexts should be updated'
-
-    with admin_policy_utils.apply_and_use_config_in_current_request(dag):
-        assert skypilot_config.get_nested(
+        assert config.get_nested(
             ('kubernetes', 'allowed_contexts'),
             None) == ['kind-skypilot', 'kind-skypilot2'
-                     ], 'Global skypilot config should be updated'
-    assert skypilot_config.get_nested(
-        ('kubernetes', 'allowed_contexts'),
-        None) is None, 'Global skypilot config should be restored after request'
+                     ], 'Kubernetes allowed contexts should be updated'
+
+        with admin_policy_utils.apply_and_use_config_in_current_request(dag):
+            assert skypilot_config.get_nested(
+                ('kubernetes', 'allowed_contexts'),
+                None) == ['kind-skypilot', 'kind-skypilot2'
+                         ], 'Global skypilot config should be updated'
+        assert skypilot_config.get_nested(
+            ('kubernetes', 'allowed_contexts'),
+            None) is None, ('Global skypilot config should be restored '
+                            'after request')
 
 
 def test_set_max_autostop_idle_minutes_policy(add_example_policy_paths, task):


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/6084

Reason: 
1. The test case has a bug that did not accept the result of `mock.patch` as the first argument, so the module path fixture is not applied to this case;
2. The fixture has a bug that it modifies the global `sys.path`
3. Thus, if another case with this fixture runs before `test_dynamic_kubernetes_contexts_policy`, then this case will succeed, otherwise an import error raised like https://github.com/skypilot-org/skypilot/actions/runs/15851130500/job/44684610494?pr=6046

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
