### PR TITLE
[Core] Do not check PVC for HA job controller

### DIFF
--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -853,10 +853,6 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 existing_rules)
             pod_spec_copy['spec']['affinity'] = pod_spec_config
 
-        # Check if any PVCs with access mode ReadWriteOnce or ReadWriteOncePod
-        # is used by any pod in the namespace.
-        volume.check_pvc_usage_for_pod(context, namespace, pod_spec_copy)
-
         # TPU slice nodes are given a taint, google.com/tpu=present:NoSchedule.
         # This is to prevent from non-TPU workloads from being scheduled on TPU
         # slice nodes. We need this toleration to allow the pod to be scheduled
@@ -899,6 +895,10 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
             except Exception as e:
                 print('Deployment failed', e)
                 raise e
+
+        # Check if any PVCs with access mode ReadWriteOnce or ReadWriteOncePod
+        # is used by any pod in the namespace.
+        volume.check_pvc_usage_for_pod(context, namespace, pod_spec_copy)
 
         return _create_namespaced_pod_with_retries(namespace, pod_spec_copy,
                                                    context)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Do not check PVC for HA job controller

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - HA job controller works 
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
