### PR TITLE
[Metrics] make metrics table only show up if grafana returns code 200

### DIFF
--- a/sky/dashboard/src/utils/grafana.js
+++ b/sky/dashboard/src/utils/grafana.js
@@ -34,11 +34,8 @@ export const checkGrafanaAvailability = async () => {
         signal: AbortSignal.timeout(5000),
       });
 
-      // Consider Grafana available if we get any response from the Grafana API
-      // This includes 200 (OK), 401 (Unauthorized), 403 (Forbidden), etc.
-      // A 401/403 means Grafana is running but requires authentication
-      grafanaAvailabilityCache =
-        response.status >= 200 && response.status < 500;
+      // Consider Grafana available if we get any 200 response from the Grafana API
+      const grafanaAvailabilityCache = response.status == 200;
       return grafanaAvailabilityCache;
     } catch (error) {
       console.debug('Grafana availability check failed:', error);


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
