### PR TITLE
show version info for db changes in docs

### DIFF
--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -545,6 +545,8 @@ If a persistent DB is not specified, the API server uses a Kubernetes persistent
 
     **Option 2: Set the DB connection URI via Kubernetes secret**
 
+    (available on nightly version 20250626 and later)
+    
     Create a Kubernetes secret that contains the DB connection URI:
 
     .. code-block:: bash

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -1288,7 +1288,9 @@ even if ``db`` is specified.
 
 .. note::
 
-  The ``db`` configuration can also be set using the ``SKYPILOT_DB_CONNECTION_URI`` environment variable.
+  (available on nightly version 20250626 and later)
+
+  ``db`` configuration can also be set using the ``SKYPILOT_DB_CONNECTION_URI`` environment variable.
 
 .. note::
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
We should get into the habit of including which version a change is made available - this PR does it for the recently introduced environment variable specification of DB backend.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
