### PR TITLE
Correct the gif used in upgrade doc

### DIFF
--- a/docs/source/reference/api-server/api-server-upgrade.rst
+++ b/docs/source/reference/api-server/api-server-upgrade.rst
@@ -165,8 +165,8 @@ A server can be gracefully upgraded when the following conditions are met:
 
 Behavior when the API server is being upgraded:
 
-* For critical on-going requests (e.g. ``sky launch``), it waits them to finish with a timeout;
-* For non-critical on-going requests (e.g. ``sky logs``), it cancells them and return an error to ask client retry;
+* For critical on-going requests (e.g. launching a cluster), it waits them to finish with a timeout;
+* For non-critical on-going requests (e.g. log tailing), it cancels them and return an error to ask client retry;
 * For new requests, it returns an error to ask client retry;
 
 SkyPilot Python SDK and CLI will automatically retry until the new version of API server starts, and ongoing requests (e.g., tailing logs) will automatically resume:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The new gif: https://i.imgur.com/jUjXu0J.gif

Preview:

![](https://i.imgur.com/jUjXu0J.gif)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
