### PR TITLE
[API server] Add automatic restart of daemon and traceback

### DIFF
--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -38,4 +38,4 @@ DASHBOARD_DIR = os.path.join(os.path.dirname(__file__), '..', 'dashboard',
                              'out')
 
 # The interval (seconds) for the event to be restarted in the background.
-EVENT_RESTART_INTERVAL_SECONDS = 20
+DAEMON_RESTART_INTERVAL_SECONDS = 20

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -36,3 +36,6 @@ API_COOKIE_FILE_DEFAULT_LOCATION = '~/.sky/cookies.txt'
 # The path to the dashboard build output
 DASHBOARD_DIR = os.path.join(os.path.dirname(__file__), '..', 'dashboard',
                              'out')
+
+# The interval (seconds) for the event to be restarted in the background.
+EVENT_RESTART_INTERVAL_SECONDS = 20

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -394,9 +394,9 @@ class InternalRequestDaemon:
                     logger.exception(
                         f'Error running {self.name} event. '
                         f'Restarting in '
-                        f'{server_constants.EVENT_RESTART_INTERVAL_SECONDS} '
+                        f'{server_constants.DAEMON_RESTART_INTERVAL_SECONDS} '
                         'seconds...')
-                    time.sleep(server_constants.EVENT_RESTART_INTERVAL_SECONDS)
+                    time.sleep(server_constants.DAEMON_RESTART_INTERVAL_SECONDS)
 
 
 # Register the events to run in the background.

--- a/sky/server/requests/requests.py
+++ b/sky/server/requests/requests.py
@@ -375,9 +375,28 @@ def managed_job_status_refresh_event():
 
 @dataclasses.dataclass
 class InternalRequestDaemon:
+    """Internal daemon that runs an event in the background."""
+
     id: str
     name: str
     event_fn: Callable[[], None]
+
+    def run_event(self):
+        """Run the event."""
+        while True:
+            with ux_utils.enable_traceback():
+                try:
+                    self.event_fn()
+                    break
+                except Exception:  # pylint: disable=broad-except
+                    # It is OK to fail to run the event, as the event is not
+                    # critical, but we should log the error.
+                    logger.exception(
+                        f'Error running {self.name} event. '
+                        f'Restarting in '
+                        f'{server_constants.EVENT_RESTART_INTERVAL_SECONDS} '
+                        'seconds...')
+                    time.sleep(server_constants.EVENT_RESTART_INTERVAL_SECONDS)
 
 
 # Register the events to run in the background.

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -330,7 +330,7 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
                 request_id=event.id,
                 request_name=event.name,
                 request_body=payloads.RequestBody(),
-                func=event.event_fn,
+                func=event.run_event,
                 schedule_type=requests_lib.ScheduleType.SHORT,
                 is_skypilot_system=True,
             )


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
