### PR TITLE
[Core] Use current python path for daemon process

### DIFF
--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -17,7 +17,6 @@ import colorama
 from sky import exceptions
 from sky import sky_logging
 from sky.adaptors import common as adaptors_common
-from sky.skylet import constants
 from sky.skylet import log_lib
 from sky.utils import common_utils
 from sky.utils import timeline

--- a/sky/utils/subprocess_utils.py
+++ b/sky/utils/subprocess_utils.py
@@ -6,6 +6,7 @@ import random
 import resource
 import shlex
 import subprocess
+import sys
 import threading
 import time
 import typing
@@ -322,12 +323,8 @@ def kill_process_daemon(process_pid: int) -> None:
     daemon_script = os.path.join(
         os.path.dirname(os.path.abspath(log_lib.__file__)),
         'subprocess_daemon.py')
-    python_path = subprocess.check_output(constants.SKY_GET_PYTHON_PATH_CMD,
-                                          shell=True,
-                                          stderr=subprocess.DEVNULL,
-                                          encoding='utf-8').strip()
     daemon_cmd = [
-        python_path,
+        sys.executable,
         daemon_script,
         '--parent-pid',
         str(parent_pid),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The previous way to get the python executable is not robust in the local env. To reproduce:
1. `sky launch -c dev`
2. `ssh dev`
3. `git clone skypilot-repo` and install from source in a different env and start an API server with the code
4. `rm ~/skypilot-runtime -r` and run `sky launch -c test`
Error occurs:
```
E 06-27 18:32:16 sdk.py:1730]   File "/home/ubuntu/skypilot-dev/sky/utils/subprocess_utils.py", line 347, in kill_process_daemon
E 06-27 18:32:16 sdk.py:1730]     subprocess.Popen(
E 06-27 18:32:16 sdk.py:1730]   File "/home/ubuntu/miniconda3/lib/python3.10/subprocess.py", line 971, in __init__
E 06-27 18:32:16 sdk.py:1730]     self._execute_child(args, executable, preexec_fn, close_fds,
E 06-27 18:32:16 sdk.py:1730]   File "/home/ubuntu/miniconda3/lib/python3.10/subprocess.py", line 1863, in _execute_child
E 06-27 18:32:16 sdk.py:1730]     raise child_exception_type(errno_num, err_msg, err_filename)
E 06-27 18:32:16 sdk.py:1730] FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/skypilot-runtime/bin/python'
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
