### PR TITLE
[Metrics] Remote multi k8s cluster metrics

### DIFF
--- a/charts/external-metrics/.gitignore
+++ b/charts/external-metrics/.gitignore
@@ -1,0 +1,2 @@
+Chart.lock
+charts/

--- a/charts/external-metrics/Chart.yaml
+++ b/charts/external-metrics/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: skypilot
+description: A Helm chart for deploying Prometheus Server
+type: application
+version: 0.0.0
+appVersion: "0.0"
+dependencies:
+  - name: prometheus
+    version: 27.20.0
+    repository: https://prometheus-community.github.io/helm-charts
+    condition: prometheus.enabled

--- a/charts/external-metrics/values.yaml
+++ b/charts/external-metrics/values.yaml
@@ -1,0 +1,21 @@
+# Set configuration for Prometheus helm chart
+prometheus:
+  enabled: true
+  # Refer to https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml for available values.
+  # Keep the installation minimal by default. If you want to monitor more resources other than the API server,
+  # it is recommended to install and manage prometheus separately.
+  # SkyPilot API server will be automatically discovered by the prometheus if it runs with the default kubernetes discovery configuration.
+  server:
+    persistentVolume:
+      enabled: true
+      size: 10Gi
+  kube-state-metrics:
+    enabled: true
+    metricLabelsAllowlist:
+      - pods=[skypilot-cluster]
+  prometheus-node-exporter:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  alertmanager:
+    enabled: false

--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -85,7 +85,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(DCGM_FI_DEV_GPU_TEMP{Hostname=~\"$host\", gpu=~\"$gpu\"})",
+          "expr": "avg(DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -157,7 +157,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(DCGM_FI_DEV_POWER_USAGE{Hostname=~\"$host\", gpu=~\"$gpu\"})",
+          "expr": "sum(DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "instant": true,
           "interval": "",
           "legendFormat": "",
@@ -258,7 +258,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{Hostname=~\"$host\", gpu=~\"$gpu\"}[1h]) / 3600000)",
+          "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}[1h]) / 3600000)",
           "instant": false,
           "interval": "",
           "legendFormat": "Last 1h",
@@ -271,7 +271,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{Hostname=~\"$host\", gpu=~\"$gpu\"}[24h]) / 3600000)",
+          "expr": "sum(increase(DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}[24h]) / 3600000)",
           "hide": false,
           "instant": false,
           "legendFormat": "Last 24h",
@@ -376,9 +376,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_POWER_USAGE{Hostname=~\"$host\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
           "interval": "",
-          "legendFormat": "{{Hostname}} - {{modelName}} GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -480,9 +480,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_FB_USED{Hostname=~\"$host\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
           "interval": "",
-          "legendFormat": "{{Hostname}} - {{modelName}} GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -586,9 +586,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_FB_USED{Hostname=~\"$host\", gpu=~\"$gpu\"} / (DCGM_FI_DEV_FB_USED{Hostname=~\"$host\", gpu=~\"$gpu\"} + DCGM_FI_DEV_FB_FREE{Hostname=~\"$host\", gpu=~\"$gpu\"})",
+          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} / (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} + DCGM_FI_DEV_FB_FREE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
-          "legendFormat": "{{Hostname}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -692,9 +692,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_UTIL{Hostname=~\"$host\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_DEV_GPU_UTIL{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
           "interval": "",
-          "legendFormat": "{{Hostname}} - {{modelName}} GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -798,9 +798,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{Hostname=~\"$host\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
           "interval": "",
-          "legendFormat": "{{Hostname}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -902,10 +902,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_TEMP{Hostname=~\"$host\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
           "instant": false,
           "interval": "",
-          "legendFormat": "{{Hostname}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -1006,11 +1006,11 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_SM_CLOCK{Hostname=~\"$host\", gpu=~\"$gpu\"} * 1000000",
+          "expr": "DCGM_FI_DEV_SM_CLOCK{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} * 1000000",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{Hostname}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -1048,7 +1048,7 @@
             "$__all"
           ]
         },
-        "definition": "label_values(DCGM_FI_DEV_GPU_TEMP,Hostname)",
+        "definition": "label_values(DCGM_FI_DEV_GPU_TEMP,node)",
         "includeAll": true,
         "label": "Host",
         "multi": true,
@@ -1056,7 +1056,7 @@
         "options": [],
         "query": {
           "qryType": 1,
-          "query": "label_values(DCGM_FI_DEV_GPU_TEMP,Hostname)",
+          "query": "label_values(DCGM_FI_DEV_GPU_TEMP,node)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
@@ -1087,6 +1087,29 @@
         "regex": "",
         "sort": 3,
         "type": "query"
+      },
+      {
+        "current": {
+          "text": ".*",
+          "value": ".*"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "",
+        "multi": false,
+        "name": "cluster",
+        "options": [
+          {
+            "selected": true,
+            "text": ".*",
+            "value": ".*"
+          }
+        ],
+                  "query": ".*",
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "textbox"
       }
     ]
   },

--- a/charts/skypilot/manifests/dcgm-cluster-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-dashboard.json
@@ -376,9 +376,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_POWER_USAGE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
-          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
+          "legendFormat": "{{node}} - GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -480,14 +480,14 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "GPU Memory Used",
+      "title": "GPU Memory Utilization",
       "type": "timeseries"
     },
     {
@@ -586,9 +586,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} / (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} + DCGM_FI_DEV_FB_FREE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) / (avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_USED{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) + avg by (node, gpu, cluster) (DCGM_FI_DEV_FB_FREE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}))",
           "interval": "",
-          "legendFormat": "{{node}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -639,8 +639,8 @@
               "mode": "off"
             }
           },
-          "decimals": 2,
           "mappings": [],
+          "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -692,7 +692,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_UTIL{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_UTIL{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
           "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
@@ -798,9 +798,9 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "interval": "",
-          "legendFormat": "{{node}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }
@@ -902,10 +902,10 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_GPU_TEMP{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"})",
           "instant": false,
           "interval": "",
-          "legendFormat": "{{node}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -1006,11 +1006,11 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "DCGM_FI_DEV_SM_CLOCK{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"} * 1000000",
+          "expr": "avg by (node, gpu, cluster) (DCGM_FI_DEV_SM_CLOCK{node=~\"$host\", gpu=~\"$gpu\", cluster=~\"$cluster\"}) * 1000000",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{node}} - GPU {{gpu}}",
+          "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
           "range": true,
           "refId": "A"
         }

--- a/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
+++ b/charts/skypilot/manifests/dcgm-cluster-filter-dashboard.json
@@ -114,10 +114,10 @@
               "uid": "prometheus"
             },
             "editorMode": "code",
-            "expr": "label_replace(DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}, \"InstanceClean\", \"$1\", \"instance\", \"([^:]+):?.*\")",
+            "expr": "DCGM_FI_DEV_GPU_UTIL{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
             "hide": false,
             "instant": false,
-            "legendFormat": "{{InstanceClean}} - {{modelName}} GPU {{gpu}}",
+            "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
           }
@@ -181,7 +181,7 @@
                 }
               ]
             },
-            "unit": "bytes"
+            "unit": "decmbytes"
           },
           "overrides": []
         },
@@ -217,10 +217,10 @@
               "uid": "prometheus"
             },
             "editorMode": "code",
-            "expr": "label_replace(DCGM_FI_DEV_FB_USED{instance=~\"$instance\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}, \"InstanceClean\", \"$1\", \"instance\", \"([^:]+):?.*\")",
+            "expr": "DCGM_FI_DEV_FB_USED{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
             "hide": false,
             "instant": false,
-            "legendFormat": "{{InstanceClean}} - {{modelName}} GPU {{gpu}}",
+            "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
           }
@@ -320,10 +320,10 @@
               "uid": "prometheus"
             },
             "editorMode": "code",
-            "expr": "label_replace(DCGM_FI_DEV_GPU_TEMP{instance=~\"$instance\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}, \"InstanceClean\", \"$1\", \"instance\", \"([^:]+):?.*\")",
+            "expr": "DCGM_FI_DEV_GPU_TEMP{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
             "hide": false,
             "instant": false,
-            "legendFormat": "{{InstanceClean}} - {{modelName}} GPU {{gpu}}",
+            "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
           }
@@ -423,10 +423,10 @@
               "uid": "prometheus"
             },
             "editorMode": "code",
-            "expr": "label_replace(DCGM_FI_DEV_POWER_USAGE{instance=~\"$instance\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}, \"InstanceClean\", \"$1\", \"instance\", \"([^:]+):?.*\")",
+            "expr": "DCGM_FI_DEV_POWER_USAGE{node=~\"$node\", gpu=~\"$gpu\"} * on(pod, namespace) group_left(label_skypilot_cluster) kube_pod_labels{label_skypilot_cluster=~\"$cluster\"}",
             "hide": false,
             "instant": false,
-            "legendFormat": "{{InstanceClean}} - {{modelName}} GPU {{gpu}}",
+            "legendFormat": "{{node}} - {{modelName}} GPU {{gpu}}",
             "range": true,
             "refId": "A"
           }
@@ -475,12 +475,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, instance)",
+          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
           "includeAll": true,
           "multi": true,
-          "name": "instance",
+          "name": "node",
           "options": [],
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, instance)",
+          "query": "label_values(DCGM_FI_DEV_GPU_UTIL, node)",
           "refresh": 1,
           "regex": "",
           "type": "query"
@@ -495,12 +495,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\"}, gpu)",
+          "definition": "label_values(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, gpu)",
           "includeAll": true,
           "multi": true,
           "name": "gpu",
           "options": [],
-          "query": "label_values(DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\"}, gpu)",
+          "query": "label_values(DCGM_FI_DEV_GPU_UTIL{node=~\"$node\"}, gpu)",
           "refresh": 1,
           "regex": "",
           "sort": 1,
@@ -516,5 +516,5 @@
     "timezone": "browser",
     "title": "SkyPilot DCGM GPU Metrics",
     "uid": "skypilot-dcgm-gpu",
-    "version": 2
+    "version": 3
   } 

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -351,6 +351,17 @@ prometheus:
     persistentVolume:
       enabled: true
       size: 10Gi
+  # Configure additional scrape configs using extraScrapeConfigs
+  extraScrapeConfigs: |
+    # Static scrape target for SkyPilot API server GPU metrics
+    - job_name: 'skypilot-api-server-gpu-metrics'
+      static_configs:
+        # Use the API service created by this Helm chart
+        - targets: ['{{ .Release.Name }}-api-service.{{ .Release.Namespace }}.svc.cluster.local:80']
+      metrics_path: '/gpu-metrics'
+      scrape_interval: 15s
+      scrape_timeout: 10s
+      # Add labels to identify these metrics
   kube-state-metrics:
     enabled: true
     metricLabelsAllowlist:

--- a/sky/dashboard/src/components/infra.jsx
+++ b/sky/dashboard/src/components/infra.jsx
@@ -376,10 +376,14 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
     setIsLoadingHosts(true);
     try {
       const grafanaUrl = getGrafanaUrl();
-      const clusterParam = contextName === "in-cluster" ? '^$' : contextName;
-      
+      const clusterParam = contextName === 'in-cluster' ? '^$' : contextName;
+
       // Build query to get nodes for specific cluster
-      const query = 'query=' + encodeURIComponent(`group by (node) (DCGM_FI_DEV_GPU_TEMP{cluster=~"${clusterParam}"})`);
+      const query =
+        'query=' +
+        encodeURIComponent(
+          `group by (node) (DCGM_FI_DEV_GPU_TEMP{cluster=~"${clusterParam}"})`
+        );
 
       const endpoint = `/api/datasources/proxy/1/api/v1/query?${query}`;
 
@@ -395,15 +399,23 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
         if (response.ok) {
           const data = await response.json();
           if (data.data && data.data.result && data.data.result.length > 0) {
-            const nodes = data.data.result.map(result => result.metric.node).filter(Boolean).sort();
+            const nodes = data.data.result
+              .map((result) => result.metric.node)
+              .filter(Boolean)
+              .sort();
             setAvailableHosts(nodes);
-            console.log(`Successfully fetched hosts for cluster ${clusterParam || 'in-cluster'}:`, nodes);
+            console.log(
+              `Successfully fetched hosts for cluster ${clusterParam || 'in-cluster'}:`,
+              nodes
+            );
           } else {
             console.log('No nodes found for this cluster');
             setAvailableHosts([]);
           }
         } else {
-          console.log(`HTTP ${response.status} from ${endpoint}: ${response.statusText}`);
+          console.log(
+            `HTTP ${response.status} from ${endpoint}: ${response.statusText}`
+          );
           setAvailableHosts([]);
         }
       } catch (error) {
@@ -428,12 +440,13 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
   // Function to build Grafana panel URL with filters
   const buildGrafanaUrlForContext = (panelId) => {
     const grafanaUrl = getGrafanaUrl();
-    const hostParam = selectedHosts === '$__all' ? '$__all' : selectedHosts;
-    
+    // When "All Nodes" is selected (.*), pass .* directly to match all nodes
+    const hostParam = selectedHosts;
+
     // Cluster parameter logic for k8s contexts only
     // For in-cluster: regex to match only missing/empty cluster labels
-    // For external clusters: exact cluster name  
-    const clusterParam = contextName === "in-cluster" ? '^$' : contextName;
+    // For external clusters: exact cluster name
+    const clusterParam = contextName === 'in-cluster' ? '^$' : contextName;
 
     return `${grafanaUrl}/d-solo/skypilot-dcgm-cluster-dashboard/skypilot-dcgm-kubernetes-cluster-dashboard?orgId=1&timezone=browser&var-datasource=prometheus&var-host=${encodeURIComponent(hostParam)}&var-gpu=$__all&var-cluster=${encodeURIComponent(clusterParam)}&refresh=5s&theme=light&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}&panelId=${panelId}&__feature.dashboardSceneSolo`;
   };
@@ -559,7 +572,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
           {/* GPU Metrics Section - only show for k8s contexts, not SSH node pools */}
           {isGrafanaAvailable &&
             gpusInContext &&
-            gpusInContext.length > 0 && 
+            gpusInContext.length > 0 &&
             !isSSHContext && (
               <>
                 <h4 className="text-lg font-semibold mb-4 mt-6">GPU Metrics</h4>
@@ -633,17 +646,25 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                     {nodesInContext && nodesInContext.length > 0 ? (
                       <>
                         Showing:{' '}
-                        {selectedHosts === '$__all' ? 'All nodes' : selectedHosts} •
-                        Time: {timeRange.from} to {timeRange.to}
+                        {selectedHosts === '$__all'
+                          ? 'All nodes'
+                          : selectedHosts}{' '}
+                        • Time: {timeRange.from} to {timeRange.to}
                         {availableHosts.length > 0 && (
-                          <span> • {availableHosts.length} nodes available</span>
+                          <span>
+                            {' '}
+                            • {availableHosts.length} nodes available
+                          </span>
                         )}
                       </>
                     ) : (
                       <>
-                        Cluster: {isSSHContext ? contextName.replace(/^ssh-/, '') : contextName} •
-                        Time: {timeRange.from} to {timeRange.to} •
-                        Showing metrics for all nodes in cluster
+                        Cluster:{' '}
+                        {isSSHContext
+                          ? contextName.replace(/^ssh-/, '')
+                          : contextName}{' '}
+                        • Time: {timeRange.from} to {timeRange.to} • Showing
+                        metrics for all nodes in cluster
                       </>
                     )}
                   </div>
@@ -651,7 +672,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
 
                 <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
                   {/* GPU Utilization */}
-                  <div className="bg-white rounded-md">
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
                     <div className="p-2">
                       <iframe
                         src={buildGrafanaUrlForContext('6')}
@@ -666,7 +687,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                   </div>
 
                   {/* GPU Memory */}
-                  <div className="bg-white rounded-md">
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
                     <div className="p-2">
                       <iframe
                         src={buildGrafanaUrlForContext('18')}
@@ -681,7 +702,7 @@ export function ContextDetails({ contextName, gpusInContext, nodesInContext }) {
                   </div>
 
                   {/* GPU Power Consumption */}
-                  <div className="bg-white rounded-md">
+                  <div className="bg-white rounded-md border border-gray-200 shadow-sm">
                     <div className="p-2">
                       <iframe
                         src={buildGrafanaUrlForContext('10')}

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -149,7 +149,7 @@ function ClusterDetails() {
     // Use the matched cluster name if available, otherwise fall back to the display name
     const clusterParam = matchedClusterName || clusterData?.cluster || '$__all';
 
-    return `${grafanaUrl}/d-solo/skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics?orgId=1&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}&timezone=browser&var-cluster=${encodeURIComponent(clusterParam)}&var-instance=$__all&var-gpu=$__all&theme=light&panelId=${panelId}&__feature.dashboardSceneSolo`;
+    return `${grafanaUrl}/d-solo/skypilot-dcgm-gpu/skypilot-dcgm-gpu-metrics?orgId=1&from=${encodeURIComponent(timeRange.from)}&to=${encodeURIComponent(timeRange.to)}&timezone=browser&var-cluster=${encodeURIComponent(clusterParam)}&var-node=$__all&var-gpu=$__all&theme=light&panelId=${panelId}&__feature.dashboardSceneSolo`;
   };
 
   // Update isInitialLoad when cluster details are first loaded (not waiting for jobs)

--- a/sky/dashboard/src/pages/clusters/[cluster].js
+++ b/sky/dashboard/src/pages/clusters/[cluster].js
@@ -666,9 +666,12 @@ function ActiveTab({
         </div>
       </div>
 
-      {/* GPU Metrics Section - Only show for Kubernetes in-cluster */}
+      {/* GPU Metrics Section - Show for all Kubernetes clusters (in-cluster and external), but not SSH node pools */}
       {clusterData &&
-        clusterData.full_infra === 'Kubernetes (in-cluster)' &&
+        clusterData.full_infra &&
+        clusterData.full_infra.includes('Kubernetes') &&
+        !clusterData.full_infra.includes('SSH') &&
+        !clusterData.full_infra.includes('ssh') &&
         isGrafanaAvailable && (
           <div className="mb-6">
             <div className="rounded-lg border bg-card text-card-foreground shadow-sm">

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1,71 +1,69 @@
-import asyncio
+"""Utilities for processing GPU metrics from Kubernetes clusters."""
 import os
 import re
 import subprocess
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import httpx
 
 
-def start_svc_port_forward(context: str, namespace: str, service: str, service_port: int) -> Tuple[subprocess.Popen, int]:
+def start_svc_port_forward(context: str, namespace: str, service: str,
+                           service_port: int) -> Tuple[subprocess.Popen, int]:
     """Starts a port forward to a service in a Kubernetes cluster.
-    
     Args:
         context: Kubernetes context name
         namespace: Namespace where the service is located
         service: Service name to port forward to
         service_port: Port on the service to forward to
-    
     Returns:
         Tuple of (subprocess.Popen process, local_port assigned)
-        
     Raises:
         RuntimeError: If port forward fails to start
     """
-    # Use ":service_port" to let kubectl choose the local port
+    # Use ':service_port' to let kubectl choose the local port
     cmd = [
-        "kubectl", "--context", context, "-n", namespace, 
-        "port-forward", f"service/{service}", f":{service_port}"
+        'kubectl', '--context', context, '-n', namespace, 'port-forward',
+        f'service/{service}', f':{service_port}'
     ]
-    
+
     env = os.environ.copy()
     if 'KUBECONFIG' not in env:
         env['KUBECONFIG'] = os.path.expanduser('~/.kube/config')
-    
+
     # start the port forward process
-    port_forward_process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env
-    )
-    
+    port_forward_process = subprocess.Popen(cmd,
+                                            stdout=subprocess.PIPE,
+                                            stderr=subprocess.STDOUT,
+                                            text=True,
+                                            env=env)
+
     local_port = None
     start_time = time.time()
     timeout = 10  # 10 second timeout
-    
-    # wait for the port forward to start (for up to {timeout} seconds) and extract the local port
+
+    # wait for the port forward to start and extract the local port
     while time.time() - start_time < timeout:
         if port_forward_process.poll() is not None:
             # port forward process has terminated
             if port_forward_process.returncode != 0:
-                raise RuntimeError(f"Port forward failed for service {service} in namespace {namespace} on context {context}")
+                raise RuntimeError(
+                    f'Port forward failed for service {service} in namespace '
+                    f'{namespace} on context {context}')
             break
-            
+
         # read output line by line to find the local port
         if port_forward_process.stdout:
             line = port_forward_process.stdout.readline()
             if line:
-                # look for "Forwarding from 127.0.0.1:XXXXX -> service_port"
+                # look for 'Forwarding from 127.0.0.1:XXXXX -> service_port'
                 match = re.search(r'Forwarding from 127\.0\.0\.1:(\d+)', line)
                 if match:
                     local_port = int(match.group(1))
                     break
-        
+
         time.sleep(0.1)
-    
+
     if local_port is None:
         try:
             port_forward_process.terminate()
@@ -74,14 +72,15 @@ def start_svc_port_forward(context: str, namespace: str, service: str, service_p
             port_forward_process.kill()
             port_forward_process.wait()
         finally:
-            raise RuntimeError(f"Failed to extract local port for service {service} in namespace {namespace} on context {context}")
-    
+            raise RuntimeError(
+                f'Failed to extract local port for service {service} in '
+                f'namespace {namespace} on context {context}')
+
     return port_forward_process, local_port
 
 
 def stop_svc_port_forward(port_forward_process: subprocess.Popen) -> None:
     """Stops a port forward to a service in a Kubernetes cluster.
-    
     Args:
         port_forward_process: The subprocess.Popen process to terminate
     """
@@ -94,28 +93,26 @@ def stop_svc_port_forward(port_forward_process: subprocess.Popen) -> None:
 
 
 async def send_metrics_request_with_port_forward(
-    context: str, 
-    namespace: str, 
-    service: str, 
-    service_port: int,
-    endpoint_path: str = "/federate",
-    match_patterns: Optional[List[str]] = None, 
-    timeout: float = 30.0
-) -> str:
+        context: str,
+        namespace: str,
+        service: str,
+        service_port: int,
+        endpoint_path: str = '/federate',
+        match_patterns: Optional[List[str]] = None,
+        timeout: float = 30.0) -> str:
     """Sends a metrics request to a Prometheus endpoint via port forwarding.
-    
     Args:
         context: Kubernetes context name
         namespace: Namespace where the service is located
         service: Service name to port forward to
         service_port: Port on the service to forward to
-        endpoint_path: Path to append to the localhost endpoint (e.g., "/federate")
-        match_patterns: List of metric patterns to match (for federate endpoint)
+        endpoint_path: Path to append to the localhost endpoint (e.g.,
+            '/federate')
+        match_patterns: List of metric patterns to match (for federate
+            endpoint)
         timeout: Request timeout in seconds
-        
     Returns:
         Response text containing the metrics
-        
     Raises:
         RuntimeError: If port forward or HTTP request fails
     """
@@ -123,39 +120,38 @@ async def send_metrics_request_with_port_forward(
     try:
         # Start port forward
         port_forward_process, local_port = start_svc_port_forward(
-            context, namespace, service, service_port
-        )
-        
+            context, namespace, service, service_port)
+
         # Build endpoint URL
-        endpoint = f"http://localhost:{local_port}{endpoint_path}"
-        
+        endpoint = f'http://localhost:{local_port}{endpoint_path}'
+
         # Make HTTP request
         async with httpx.AsyncClient(timeout=timeout) as client:
             if match_patterns:
                 # For federate endpoint, add match[] parameters
-                params = [("match[]", pattern) for pattern in match_patterns]
+                params = [('match[]', pattern) for pattern in match_patterns]
                 response = await client.get(endpoint, params=params)
             else:
                 response = await client.get(endpoint)
-            
+
             response.raise_for_status()
             return response.text
-            
+
     finally:
         # Always clean up port forward
         if port_forward_process:
             stop_svc_port_forward(port_forward_process)
 
+
 async def add_cluster_name_label(metrics_text: str, context: str) -> str:
     """Adds a cluster_name label to each metric line.
-    
     Args:
         metrics_text: The text containing the metrics
         context: The cluster name
     """
     lines = metrics_text.strip().split('\n')
     modified_lines = []
-    
+
     for line in lines:
         # keep comment lines and empty lines as-is
         if line.startswith('#') or not line.strip():
@@ -166,48 +162,42 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
         brace_end = line.find('}')
         if brace_start != -1 and brace_end != -1:
             metric_name = line[:brace_start]
-            existing_labels = line[brace_start+1:brace_end]
-            rest_of_line = line[brace_end+1:]
-            
+            existing_labels = line[brace_start + 1:brace_end]
+            rest_of_line = line[brace_end + 1:]
+
             if existing_labels:
                 new_labels = f'cluster="{context}",{existing_labels}'
             else:
                 new_labels = f'cluster="{context}"'
-            
+
             modified_line = f'{metric_name}{{{new_labels}}}{rest_of_line}'
             modified_lines.append(modified_line)
         else:
             # keep other lines as-is
             modified_lines.append(line)
-    
+
     return '\n'.join(modified_lines)
+
 
 async def get_metrics_for_context(context: str) -> str:
     """Get GPU metrics for a single Kubernetes context.
-    
     Args:
         context: Kubernetes context name
-        
     Returns:
         metrics_text: String containing the metrics
-        
     Raises:
         Exception: If metrics collection fails for any reason
     """
     # Query both DCGM metrics and kube_pod_labels metrics
     # This ensures the dashboard can perform joins to filter by skypilot cluster
-    match_patterns = [
-        '{__name__=~"DCGM_.*"}',
-        'kube_pod_labels'
-    ]
+    match_patterns = ['{__name__=~"DCGM_.*"}', 'kube_pod_labels']
     metrics_text = await send_metrics_request_with_port_forward(
         context=context,
-        namespace='skypilot', 
+        namespace='skypilot',
         service='skypilot-prometheus-server',
         service_port=80,
-        endpoint_path="/federate",
-        match_patterns=match_patterns
-    )
+        endpoint_path='/federate',
+        match_patterns=match_patterns)
 
     # add cluster name as a label to each metric line
     metrics_text = await add_cluster_name_label(metrics_text, context)

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -1,0 +1,211 @@
+import asyncio
+import os
+import re
+import subprocess
+import time
+from typing import Dict, List, Optional, Tuple
+
+import httpx
+
+
+def start_svc_port_forward(context: str, namespace: str, service: str, service_port: int) -> Tuple[subprocess.Popen, int]:
+    """Starts a port forward to a service in a Kubernetes cluster.
+    
+    Args:
+        context: Kubernetes context name
+        namespace: Namespace where the service is located
+        service: Service name to port forward to
+        service_port: Port on the service to forward to
+    
+    Returns:
+        Tuple of (subprocess.Popen process, local_port assigned)
+        
+    Raises:
+        RuntimeError: If port forward fails to start
+    """
+    # Use ":service_port" to let kubectl choose the local port
+    cmd = [
+        "kubectl", "--context", context, "-n", namespace, 
+        "port-forward", f"service/{service}", f":{service_port}"
+    ]
+    
+    env = os.environ.copy()
+    if 'KUBECONFIG' not in env:
+        env['KUBECONFIG'] = os.path.expanduser('~/.kube/config')
+    
+    # start the port forward process
+    port_forward_process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env
+    )
+    
+    local_port = None
+    start_time = time.time()
+    timeout = 10  # 10 second timeout
+    
+    # wait for the port forward to start (for up to {timeout} seconds) and extract the local port
+    while time.time() - start_time < timeout:
+        if port_forward_process.poll() is not None:
+            # port forward process has terminated
+            if port_forward_process.returncode != 0:
+                raise RuntimeError(f"Port forward failed for service {service} in namespace {namespace} on context {context}")
+            break
+            
+        # read output line by line to find the local port
+        if port_forward_process.stdout:
+            line = port_forward_process.stdout.readline()
+            if line:
+                # look for "Forwarding from 127.0.0.1:XXXXX -> service_port"
+                match = re.search(r'Forwarding from 127\.0\.0\.1:(\d+)', line)
+                if match:
+                    local_port = int(match.group(1))
+                    break
+        
+        time.sleep(0.1)
+    
+    if local_port is None:
+        try:
+            port_forward_process.terminate()
+            port_forward_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            port_forward_process.kill()
+            port_forward_process.wait()
+        finally:
+            raise RuntimeError(f"Failed to extract local port for service {service} in namespace {namespace} on context {context}")
+    
+    return port_forward_process, local_port
+
+
+def stop_svc_port_forward(port_forward_process: subprocess.Popen) -> None:
+    """Stops a port forward to a service in a Kubernetes cluster.
+    
+    Args:
+        port_forward_process: The subprocess.Popen process to terminate
+    """
+    try:
+        port_forward_process.terminate()
+        port_forward_process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        port_forward_process.kill()
+        port_forward_process.wait()
+
+
+async def send_metrics_request_with_port_forward(
+    context: str, 
+    namespace: str, 
+    service: str, 
+    service_port: int,
+    endpoint_path: str = "/federate",
+    match_patterns: Optional[List[str]] = None, 
+    timeout: float = 30.0
+) -> str:
+    """Sends a metrics request to a Prometheus endpoint via port forwarding.
+    
+    Args:
+        context: Kubernetes context name
+        namespace: Namespace where the service is located
+        service: Service name to port forward to
+        service_port: Port on the service to forward to
+        endpoint_path: Path to append to the localhost endpoint (e.g., "/federate")
+        match_patterns: List of metric patterns to match (for federate endpoint)
+        timeout: Request timeout in seconds
+        
+    Returns:
+        Response text containing the metrics
+        
+    Raises:
+        RuntimeError: If port forward or HTTP request fails
+    """
+    port_forward_process = None
+    try:
+        # Start port forward
+        port_forward_process, local_port = start_svc_port_forward(
+            context, namespace, service, service_port
+        )
+        
+        # Build endpoint URL
+        endpoint = f"http://localhost:{local_port}{endpoint_path}"
+        
+        # Make HTTP request
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if match_patterns:
+                # For federate endpoint, add match[] parameters
+                params = [("match[]", pattern) for pattern in match_patterns]
+                response = await client.get(endpoint, params=params)
+            else:
+                response = await client.get(endpoint)
+            
+            response.raise_for_status()
+            return response.text
+            
+    finally:
+        # Always clean up port forward
+        if port_forward_process:
+            stop_svc_port_forward(port_forward_process)
+
+async def add_cluster_name_label(metrics_text: str, context: str) -> str:
+    """Adds a cluster_name label to each metric line.
+    
+    Args:
+        metrics_text: The text containing the metrics
+        context: The cluster name
+    """
+    lines = metrics_text.strip().split('\n')
+    modified_lines = []
+    
+    for line in lines:
+        # keep comment lines and empty lines as-is
+        if line.startswith('#') or not line.strip():
+            modified_lines.append(line)
+            continue
+        # if line is a metric line with labels, add cluster label
+        brace_start = line.find('{')
+        brace_end = line.find('}')
+        if brace_start != -1 and brace_end != -1:
+            metric_name = line[:brace_start]
+            existing_labels = line[brace_start+1:brace_end]
+            rest_of_line = line[brace_end+1:]
+            
+            if existing_labels:
+                new_labels = f'cluster="{context}",{existing_labels}'
+            else:
+                new_labels = f'cluster="{context}"'
+            
+            modified_line = f'{metric_name}{{{new_labels}}}{rest_of_line}'
+            modified_lines.append(modified_line)
+        else:
+            # keep other lines as-is
+            modified_lines.append(line)
+    
+    return '\n'.join(modified_lines)
+
+async def get_metrics_for_context(context: str) -> Tuple[str, str]:
+    """Get GPU metrics for a single Kubernetes context.
+    
+    Args:
+        context: Kubernetes context name
+        
+    Returns:
+        Tuple of (context, metrics_text)
+        
+    Raises:
+        Exception: If metrics collection fails for any reason
+    """
+    # query GPU utilization metrics
+    match_patterns = ['{__name__="DCGM_FI_DEV_GPU_UTIL"}']
+    metrics_text = await send_metrics_request_with_port_forward(
+        context=context,
+        namespace='skypilot', 
+        service='skypilot-prometheus-server',
+        service_port=80,
+        endpoint_path="/federate",
+        match_patterns=match_patterns
+    )
+
+    # add cluster name as a label to each metric line
+    metrics_text = await add_cluster_name_label(metrics_text, context)
+
+    return metrics_text

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -195,7 +195,7 @@ async def get_metrics_for_context(context: str) -> Tuple[str, str]:
         Exception: If metrics collection fails for any reason
     """
     # query GPU utilization metrics
-    match_patterns = ['{__name__="DCGM_FI_DEV_GPU_UTIL"}']
+    match_patterns = ['{__name__=~"DCGM_.*"}']
     metrics_text = await send_metrics_request_with_port_forward(
         context=context,
         namespace='skypilot', 

--- a/sky/metrics/utils.py
+++ b/sky/metrics/utils.py
@@ -182,20 +182,24 @@ async def add_cluster_name_label(metrics_text: str, context: str) -> str:
     
     return '\n'.join(modified_lines)
 
-async def get_metrics_for_context(context: str) -> Tuple[str, str]:
+async def get_metrics_for_context(context: str) -> str:
     """Get GPU metrics for a single Kubernetes context.
     
     Args:
         context: Kubernetes context name
         
     Returns:
-        Tuple of (context, metrics_text)
+        metrics_text: String containing the metrics
         
     Raises:
         Exception: If metrics collection fails for any reason
     """
-    # query GPU utilization metrics
-    match_patterns = ['{__name__=~"DCGM_.*"}']
+    # Query both DCGM metrics and kube_pod_labels metrics
+    # This ensures the dashboard can perform joins to filter by skypilot cluster
+    match_patterns = [
+        '{__name__=~"DCGM_.*"}',
+        'kube_pod_labels'
+    ]
     metrics_text = await send_metrics_request_with_port_forward(
         context=context,
         namespace='skypilot', 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1554,7 +1554,7 @@ async def all_contexts(request: fastapi.Request) -> None:
     )
 
 @app.get('/gpu-metrics')
-async def gpu_metrics(request: fastapi.Request) -> None:
+async def gpu_metrics(request: fastapi.Request) -> fastapi.Response:
     """Gets the GPU metrics from multiple external k8s clusters"""
     from sky.metrics import utils as metrics_utils
 
@@ -1565,7 +1565,8 @@ async def gpu_metrics(request: fastapi.Request) -> None:
 
     tasks = [
         asyncio.create_task(metrics_utils.get_metrics_for_context(context))
-        for context in contexts
+        for context in contexts 
+        if context != 'in-cluster'
     ]
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -1578,18 +1579,13 @@ async def gpu_metrics(request: fastapi.Request) -> None:
             all_metrics.append(metrics_text)
             successful_contexts += 1
 
-    # For now, just print all metrics
-    # TODO(rohan): return structured response
-    # TODO(rohan): add cluster name as metrics label
     combined_metrics = "\n\n".join(all_metrics)
-    print(combined_metrics)
-
-    return {
-        "status": "success",
-        "contexts_processed": successful_contexts,
-        "total_contexts": len(contexts),
-        "failed_contexts": len(contexts) - successful_contexts
-    }
+    
+    # Return as plain text for Prometheus compatibility
+    return fastapi.Response(
+        content=combined_metrics,
+        media_type="text/plain; version=0.0.4; charset=utf-8"
+    )
 
 # === Internal APIs ===
 @app.get('/api/completion/cluster_name')

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -39,6 +39,7 @@ from sky import models
 from sky import sky_logging
 from sky.data import storage_utils
 from sky.jobs.server import server as jobs_rest
+from sky.metrics import utils as metrics_utils
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.serve.server import server as serve_rest
 from sky.server import common
@@ -1553,19 +1554,17 @@ async def all_contexts(request: fastapi.Request) -> None:
         schedule_type=requests_lib.ScheduleType.SHORT,
     )
 
+
 @app.get('/gpu-metrics')
-async def gpu_metrics(request: fastapi.Request) -> fastapi.Response:
+async def gpu_metrics() -> fastapi.Response:
     """Gets the GPU metrics from multiple external k8s clusters"""
-    from sky.metrics import utils as metrics_utils
-
     contexts = core.get_all_contexts()
-
     all_metrics = []
     successful_contexts = 0
 
     tasks = [
         asyncio.create_task(metrics_utils.get_metrics_for_context(context))
-        for context in contexts 
+        for context in contexts
         if context != 'in-cluster'
     ]
 
@@ -1573,19 +1572,20 @@ async def gpu_metrics(request: fastapi.Request) -> fastapi.Response:
 
     for i, result in enumerate(results):
         if isinstance(result, Exception):
-            logger.error(f'Failed to get metrics for context {contexts[i]}: {result}')
+            logger.error(
+                f'Failed to get metrics for context {contexts[i]}: {result}')
         else:
             metrics_text = result
             all_metrics.append(metrics_text)
             successful_contexts += 1
 
-    combined_metrics = "\n\n".join(all_metrics)
-    
+    combined_metrics = '\n\n'.join(all_metrics)
+
     # Return as plain text for Prometheus compatibility
     return fastapi.Response(
         content=combined_metrics,
-        media_type="text/plain; version=0.0.4; charset=utf-8"
-    )
+        media_type='text/plain; version=0.0.4; charset=utf-8')
+
 
 # === Internal APIs ===
 @app.get('/api/completion/cluster_name')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR adds support for remote k8s cluster GPU metrics, building off of the recently merged in-cluster metrics. There is a new `/gpu-metrics` endpoint in the API server which a centralized prometheus server can scrape for metrics across all remote kubernetes clusters in the sky allowed contexts. 

The endpoint works by looking up the allowed k8s contexts, starting up a port forward session to prometheus server in each one, scraping the GPU metrics, proxying the metrics to the central, and then tearing down the port forwards.

It modifies the existing api server deployment helm chart such that the prometheus server that gets deployed is set to scrape the `/gpu-metrics` endpoint on the api server. It also creates a new helm chart which can be used to deploy a prometheus server in the remote k8s clusters to be monitored. 

todo:
- [] make grafana auto-login work with oauth (currently only configured to work with basic auth)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
