### PR TITLE
enforce auth for Bearer tokens that aren't skypilot SA tokens

### DIFF
--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -18,10 +18,12 @@ metadata:
     # Bearer token requests bypass OAuth2 proxy and go directly to the application
     nginx.ingress.kubernetes.io/auth-signin: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/start?rd=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/auth
-    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Email
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Email, X-Skypilot-Auth
     # Skip OAuth2 authentication for requests with Authorization header (Bearer tokens)
     nginx.ingress.kubernetes.io/auth-snippet: |
-      if ($http_authorization ~ "^Bearer .+") {
+      if ($http_authorization ~ "^Bearer sky_.+") {
+        # Set x_skypilot_auth_mode variable to make sure the request is validated on the API server side.
+        set $x_skypilot_auth_mode "token";
         return 200;
       }
     {{- else if and (not $enableBasicAuthInAPIServer) (or .Values.ingress.authSecret .Values.ingress.authCredentials) }}
@@ -37,22 +39,11 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     skypilot.co/ingress-path: {{ .Values.ingress.path }}
     {{- end }}
-    nginx.ingress.kubernetes.io/server-snippets: |
-      location / {
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_http_version 1.1;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header Connection "upgrade";
-        proxy_cache_bypass $http_upgrade;
-        {{- if index .Values.ingress "oauth2-proxy" "enabled" }}
-        # Pass through Authorization header for Bearer token authentication
-        proxy_set_header Authorization $http_authorization;
-        {{- end }}
-      }
-
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      {{- if index .Values.ingress "oauth2-proxy" "enabled" }}
+      # Set X-Skypilot-Auth-Mode header to the value from the auth request.
+      proxy_set_header X-Skypilot-Auth-Mode $x_skypilot_auth_mode;
+      {{- end }}
 
 spec:
   {{- if $useNewIngressClass }}

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -277,10 +277,9 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
     """Middleware to handle Bearer Token Auth (Service Accounts)."""
 
     async def dispatch(self, request: fastapi.Request, call_next):
-        """
-        Make sure correct bearer token auth is present.
+        """Make sure correct bearer token auth is present.
 
-        1. If the request has the X-Skypilot-Auth-Mode: token header, it must 
+        1. If the request has the X-Skypilot-Auth-Mode: token header, it must
            have a valid bearer token.
         2. For backwards compatibility, if the request has a Bearer token
            beginning with "sky_" (even if X-Skypilot-Auth-Mode is not present),
@@ -296,12 +295,12 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         has_skypilot_auth_header = (
             request.headers.get('X-Skypilot-Auth-Mode') == 'token')
         auth_header = request.headers.get('authorization')
-        has_bearer_token_starting_with_sky = (auth_header and 
-            auth_header.lower().startswith('bearer ') and
+        has_bearer_token_starting_with_sky = (
+            auth_header and auth_header.lower().startswith('bearer ') and
             auth_header.split(' ', 1)[1].startswith('sky_'))
 
-        if (not has_skypilot_auth_header and 
-            not has_bearer_token_starting_with_sky):
+        if (not has_skypilot_auth_header and
+                not has_bearer_token_starting_with_sky):
             # This is case #3 above. We do not need to validate the request.
             # No Bearer token, continue with normal processing (OAuth2 cookies,
             # etc.)
@@ -310,8 +309,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         if auth_header is None:
             return fastapi.responses.JSONResponse(
-                status_code=401,
-                content={'detail': 'Authentication required'})
+                status_code=401, content={'detail': 'Authentication required'})
 
         # Extract token
         split_header = auth_header.split(' ', 1)
@@ -322,8 +320,8 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         sa_token = split_header[1]
 
         # Handle SkyPilot service account tokens
-        return await self._handle_service_account_token(
-            request, sa_token, call_next)
+        return await self._handle_service_account_token(request, sa_token,
+                                                        call_next)
 
     async def _handle_service_account_token(self, request: fastapi.Request,
                                             sa_token: str, call_next):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -313,7 +313,7 @@ class BearerTokenMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         # Extract token
         split_header = auth_header.split(' ', 1)
-        if split_header[0] != 'Bearer':
+        if split_header[0].lower() != 'bearer':
             return fastapi.responses.JSONResponse(
                 status_code=401,
                 content={'detail': 'Invalid authentication method'})


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
