### PR TITLE
print exception stacktrace when SKYPILOT_DEBUG=1

### DIFF
--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -13,6 +13,7 @@ from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils import rich_console_utils
+from sky.utils import env_options
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -57,10 +58,15 @@ def print_exception_no_traceback():
             if error():
                 raise ValueError('...')
     """
-    original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
-    sys.tracebacklimit = 0
-    yield
-    sys.tracebacklimit = original_tracelimit
+    if env_options.Options.SHOW_DEBUG_INFO.get():
+        # When SKYPILOT_DEBUG is set, show the full traceback
+        yield
+    else:
+        original_tracelimit = getattr(sys, 'tracebacklimit', 1000)
+        sys.tracebacklimit = 0
+        yield
+        sys.tracebacklimit = original_tracelimit
+
 
 
 @contextlib.contextmanager

--- a/sky/utils/ux_utils.py
+++ b/sky/utils/ux_utils.py
@@ -12,8 +12,8 @@ import colorama
 from sky import sky_logging
 from sky.skylet import constants
 from sky.utils import common_utils
-from sky.utils import rich_console_utils
 from sky.utils import env_options
+from sky.utils import rich_console_utils
 
 if typing.TYPE_CHECKING:
     import pathlib
@@ -66,7 +66,6 @@ def print_exception_no_traceback():
         sys.tracebacklimit = 0
         yield
         sys.tracebacklimit = original_tracelimit
-
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This seems to have inadvertently regressed in #4660.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
