### PR TITLE
Fix artifact name

### DIFF
--- a/.github/workflows/publish-and-validate.yml
+++ b/.github/workflows/publish-and-validate.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
+          name: skypilot-artifacts-${{ inputs.package_name }}
           path: dist/
 
       - name: Publish distribution to repository


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Failed [log](https://github.com/skypilot-org/skypilot/actions/runs/15997044835/job/45143103622)

Because the artifact name became inconsistent after the previous refactor.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
