### PR TITLE
fix

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -49,12 +49,12 @@ jobs:
       - name: Determine installation method
         id: install_method
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "install_from_source=true" >> $GITHUB_OUTPUT
-            echo "Installing from source (manual trigger)"
-          else
+          if [ -n "${{ github.workflow_ref }}" ]; then
             echo "install_from_source=false" >> $GITHUB_OUTPUT
-            echo "Installing from wheel (pipeline trigger)"
+            echo "Installing from wheel (workflow call)"
+          else
+            echo "install_from_source=true" >> $GITHUB_OUTPUT
+            echo "Installing from source (direct trigger)"
           fi
 
       # For workflow trigger: download all artifacts
@@ -99,10 +99,10 @@ jobs:
             echo "latest_version=$VERSION" >> $GITHUB_OUTPUT
           fi
 
-          # Verify version is not exactly 1.0.0.dev
+          # Verify version is not exactly 1.0.0-dev0
           VERSION_TO_CHECK=$(cat $GITHUB_OUTPUT | grep "latest_version=" | cut -d"=" -f2)
-          if [[ "$VERSION_TO_CHECK" == "1.0.0.dev" ]]; then
-            echo "Error: Version cannot be exactly 1.0.0.dev"
+          if [[ "$VERSION_TO_CHECK" == "1.0.0-dev0" ]]; then
+            echo "Error: Version cannot be exactly 1.0.0-dev0"
             exit 1
           fi
           cat $GITHUB_OUTPUT


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Here's your refined message with corrected grammar and phrasing:

The build log shows [install from source](https://github.com/skypilot-org/skypilot/actions/runs/16003563218/job/45144786539), but we want it to install from whl.

I'm manually triggering the nightly build to fix it, so we can't determine based on event name since nightly builds can be triggered either automatically or manually.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
