### PR TITLE
Fix Cudo Integration

### DIFF
--- a/sky/catalog/data_fetchers/fetch_cudo.py
+++ b/sky/catalog/data_fetchers/fetch_cudo.py
@@ -14,13 +14,6 @@ import sky.provision.cudo.cudo_utils as utils
 VMS_CSV = 'cudo/vms.csv'
 
 
-def cudo_api():
-    configuration = cudo_compute.Configuration()
-    configuration.host = 'https://rest.compute.cudo.org'
-    client = cudo_compute.ApiClient(configuration)
-    return cudo_compute.VirtualMachinesApi(client)
-
-
 def get_gpu_info(count, model):
     mem = utils.cudo_gpu_mem[model]
     # pylint: disable=line-too-long
@@ -45,39 +38,46 @@ def get_instance_type(machine_type, vcpu, mem, gpu):
         mem) + 'gb'
 
 
-def machine_types(gpu_model, mem_gib, vcpu_count, gpu_count):
-    try:
-        api = cudo_api()
-        types = api.list_vm_machine_types(mem_gib,
-                                          vcpu_count,
-                                          gpu=gpu_count,
-                                          gpu_model=gpu_model)
-        return types.to_dict()
-    except cudo_compute.rest.ApiException as e:
-        raise e
-
-
 def update_prices():
     rows = []
+
+    api = cudo_compute.cudo_api.virtual_machines()
+    all_types = api.list_vm_machine_types2()
+    all_machine_types = all_types.to_dict()['machine_types']
+
     for spec in utils.machine_specs:
-        mts = machine_types('', spec['mem'], spec['vcpu'], spec['gpu'])
-        for hc in mts['host_configs']:
-            if not utils.gpu_exists(hc['gpu_model']):
-                continue
-            accelerator_name = utils.cudo_gpu_to_skypilot_gpu(hc['gpu_model'])
-            row = {
-                'instance_type': get_instance_type(hc['machine_type'],
-                                                   spec['vcpu'], spec['mem'],
-                                                   spec['gpu']),
-                'accelerator_name': accelerator_name,
-                'accelerator_count': str(spec['gpu']) + '.0',
-                'vcpus': str(spec['vcpu']),
-                'memory_gib': str(spec['mem']),
-                'price': hc['total_price_hr']['value'],
-                'region': hc['data_center_id'],
-                'gpu_info': get_gpu_info(spec['gpu'], accelerator_name),
-            }
-            rows.append(row)
+        for machine_type in all_machine_types:
+            if (machine_type['min_vcpu'] <= spec['vcpu'] and
+                    machine_type['min_memory_gib'] <= spec['mem'] and
+                    utils.gpu_exists(machine_type['gpu_model'])):
+
+                accelerator_name = utils.cudo_gpu_to_skypilot_gpu(
+                    machine_type['gpu_model'])
+
+                # Calculate total price per hour based on the given spec
+                vcpu_price = float(
+                    machine_type['vcpu_price_hr']['value']) * spec['vcpu']
+                memory_price = float(
+                    machine_type['memory_gib_price_hr']['value']) * spec['mem']
+                gpu_price = float(
+                    machine_type['gpu_price_hr']['value']) * spec['gpu']
+                # Note: Not including storage and IPv4 prices
+                # for now as they may be optional
+                total_price = vcpu_price + memory_price + gpu_price
+
+                row = {
+                    'instance_type': get_instance_type(
+                        machine_type['machine_type'], spec['vcpu'], spec['mem'],
+                        spec['gpu']),
+                    'accelerator_name': accelerator_name,
+                    'accelerator_count': str(spec['gpu']) + '.0',
+                    'vcpus': str(spec['vcpu']),
+                    'memory_gib': str(spec['mem']),
+                    'price': str(total_price),
+                    'region': machine_type['data_center_id'],
+                    'gpu_info': get_gpu_info(spec['gpu'], accelerator_name),
+                }
+                rows.append(row)
     path = VMS_CSV
     with open(path, 'w', encoding='utf-8') as file:
         file.write(

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -298,7 +298,7 @@ class Cudo(clouds.Cloud):
         from cudo_compute import cudo_api
         from cudo_compute.rest import ApiException
         try:
-            _, error = cudo_api.client()
+            _, error = cudo_api.make_client()
         except FileNotFoundError as e:
             return False, (
                 'Cudo credentials are not set. '

--- a/sky/provision/cudo/cudo_utils.py
+++ b/sky/provision/cudo/cudo_utils.py
@@ -1,22 +1,28 @@
 """Cudo catalog helper."""
 
 cudo_gpu_model = {
-    'NVIDIA V100': 'V100',
-    'NVIDIA A40': 'A40',
-    'RTX 3080': 'RTX3080',
-    'RTX A4000': 'RTXA4000',
-    'RTX A4500': 'RTXA4500',
+    'H100 NVL': 'H100',
+    'H100 SXM': 'H100-SXM',
+    'L40S (compute mode)': 'L40S',
+    'L40S (graphics mode)': 'L40S',
+    'A40 (compute mode)': 'A40',
+    'A40 (graphics mode)': 'A40',
     'RTX A5000': 'RTXA5000',
     'RTX A6000': 'RTXA6000',
+    'A100 80GB PCIe': 'A100',
+    'A800 PCIe': 'A800',
+    'V100': 'V100',
 }
 
 cudo_gpu_mem = {
-    'RTX3080': 12,
+    'H100': 94,
+    'H100-SXM': 80,
+    'L40S': 48,
     'A40': 48,
-    'RTXA4000': 16,
-    'RTXA4500': 20,
     'RTXA5000': 24,
     'RTXA6000': 48,
+    'A100': 80,
+    'A800': 80,
     'V100': 16,
 }
 

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -28,12 +28,10 @@ def launch(name: str, data_center_id: str, ssh_key: str, machine_type: str,
                                  size_gib=disk_size),
         metadata=tags)
 
-    try:
-        api = cudo.cudo.cudo_api.virtual_machines()
-        vm = api.create_vm(cudo.cudo.cudo_api.project_id_throwable(), request)
-        return vm.to_dict()['id']
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    api = cudo.cudo.cudo_api.virtual_machines()
+    vm = api.create_vm(cudo.cudo.cudo_api.project_id_throwable(), request)
+
+    return vm.to_dict()['id']
 
 
 def remove(instance_id: str):
@@ -54,11 +52,8 @@ def remove(instance_id: str):
     state = 'unknown'
     project_id = cudo.cudo.cudo_api.project_id_throwable()
     while retry_count < max_retries:
-        try:
-            vm = api.get_vm(project_id, instance_id)
-            state = vm.to_dict()['vm']['short_state']
-        except cudo.cudo.rest.ApiException as e:
-            raise e
+        vm = api.get_vm(project_id, instance_id)
+        state = vm.to_dict()['vm']['short_state']
 
         if state in terminate_ok:
             break
@@ -69,76 +64,81 @@ def remove(instance_id: str):
             'Timeout error, could not terminate due to VM state: {}'.format(
                 state))
 
-    try:
-        api.terminate_vm(project_id, instance_id)
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    api.terminate_vm(project_id, instance_id)
 
 
 def set_tags(instance_id: str, tags: Dict):
     """Sets the tags for the given instance."""
-    try:
-        api = cudo.cudo.cudo_api.virtual_machines()
-        api.update_vm_metadata(
-            cudo.cudo.cudo_api.project_id(), instance_id,
-            cudo.cudo.UpdateVMMetadataBody(
-                metadata=tags,
-                merge=True))  # TODO (skypilot team) merge or overwrite?
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    api = cudo.cudo.cudo_api.virtual_machines()
+    api.update_vm_metadata(
+        cudo.cudo.cudo_api.project_id(), instance_id,
+        cudo.cudo.UpdateVMMetadataBody(
+            metadata=tags,
+            merge=True))  # TODO (skypilot team) merge or overwrite?
 
 
 def get_instance(vm_id):
-    try:
-        api = cudo.cudo.cudo_api.virtual_machines()
-        vm = api.get_vm(cudo.cudo.cudo_api.project_id_throwable(), vm_id)
-        vm_dict = vm.to_dict()
-        return vm_dict
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    api = cudo.cudo.cudo_api.virtual_machines()
+    vm = api.get_vm(cudo.cudo.cudo_api.project_id_throwable(), vm_id)
+    vm_dict = vm.to_dict()
+    return vm_dict
 
 
 def list_instances():
-    try:
-        api = cudo.cudo.cudo_api.virtual_machines()
-        vms = api.list_vms(cudo.cudo.cudo_api.project_id_throwable())
-        instances = {}
-        for vm in vms.to_dict()['vms']:
-            ex_ip = vm['external_ip_address']
-            in_ip = vm['internal_ip_address']
-            if not in_ip:
-                in_ip = ex_ip
-            instance = {
-                # active_state, init_state, lcm_state, short_state
-                'status': vm['short_state'],
-                'tags': vm['metadata'],
-                'name': vm['id'],
-                'ip': ex_ip,
-                'external_ip': ex_ip,
-                'internal_ip': in_ip
-            }
-            instances[vm['id']] = instance
-        return instances
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    api = cudo.cudo.cudo_api.virtual_machines()
+    vms = api.list_vms(cudo.cudo.cudo_api.project_id_throwable())
+    instances = {}
+    for vm in vms.to_dict()['vms']:
+        ex_ip = vm['external_ip_address']
+        in_ip = vm['internal_ip_address']
+        if not in_ip:
+            in_ip = ex_ip
+        instance = {
+            # active_state, init_state, lcm_state, short_state
+            'status': vm['short_state'],
+            'tags': vm['metadata'],
+            'name': vm['id'],
+            'ip': ex_ip,
+            'external_ip': ex_ip,
+            'internal_ip': in_ip
+        }
+        instances[vm['id']] = instance
+    return instances
 
 
 def vm_available(to_start_count, gpu_count, gpu_model, data_center_id, mem,
                  cpus):
-    try:
-        gpu_model = utils.skypilot_gpu_to_cudo_gpu(gpu_model)
-        api = cudo.cudo.cudo_api.virtual_machines()
-        types = api.list_vm_machine_types(mem,
-                                          cpus,
-                                          gpu=gpu_count,
-                                          gpu_model=gpu_model,
-                                          data_center_id=data_center_id)
-        types_dict = types.to_dict()
-        hc = types_dict['host_configs']
-        total_count = sum(item['count_vm_available'] for item in hc)
-        if total_count < to_start_count:
-            raise Exception(
-                'Too many VMs requested, try another gpu type or region')
-        return total_count
-    except cudo.cudo.rest.ApiException as e:
-        raise e
+    gpu_model = utils.skypilot_gpu_to_cudo_gpu(gpu_model)
+    api = cudo.cudo.cudo_api.virtual_machines()
+    types = api.list_vm_machine_types2()
+    types_dict = types.to_dict()
+
+    # Filter machine types based on requirements
+    matching_types = []
+    for machine_type in types_dict:
+        # Check if this machine type matches our requirements
+        if (machine_type['data_center_id'] == data_center_id and
+                machine_type['gpu_model'] == gpu_model and
+                machine_type['min_vcpu'] <= cpus <= machine_type.get(
+                    'max_vcpu_free', float('inf')) and
+                machine_type['min_memory_gib'] <= mem <= machine_type.get(
+                    'max_memory_gib_free', float('inf'))):
+
+            # Calculate available VMs based on resource constraints
+            max_vms_by_vcpu = machine_type[
+                'total_vcpu_free'] // cpus if cpus > 0 else float('inf')
+            max_vms_by_memory = machine_type[
+                'total_memory_gib_free'] // mem if mem > 0 else float('inf')
+            max_vms_by_gpu = machine_type[
+                'total_gpu_free'] // gpu_count if gpu_count > 0 else float(
+                    'inf')
+
+            available_vms = min(max_vms_by_vcpu, max_vms_by_memory,
+                                max_vms_by_gpu)
+            matching_types.append(available_vms)
+
+    total_count = sum(matching_types)
+    if total_count < to_start_count:
+        raise Exception(
+            'Too many VMs requested, try another gpu type or region')
+    return total_count

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -111,11 +111,12 @@ def vm_available(to_start_count, gpu_count, gpu_model, data_center_id, mem,
     gpu_model = utils.skypilot_gpu_to_cudo_gpu(gpu_model)
     api = cudo.cudo.cudo_api.virtual_machines()
     types = api.list_vm_machine_types2()
-    types_dict = types.to_dict()['machine_types']
+    types_dict = types.to_dict()
+    machine_types = types_dict['machine_types']
 
     # Filter machine types based on requirements
     matching_types = []
-    for machine_type in types_dict:
+    for machine_type in machine_types:
         # Check if this machine type matches our requirements
         if (machine_type['data_center_id'] == data_center_id and
                 machine_type['gpu_model'] == gpu_model and

--- a/sky/provision/cudo/cudo_wrapper.py
+++ b/sky/provision/cudo/cudo_wrapper.py
@@ -111,7 +111,7 @@ def vm_available(to_start_count, gpu_count, gpu_model, data_center_id, mem,
     gpu_model = utils.skypilot_gpu_to_cudo_gpu(gpu_model)
     api = cudo.cudo.cudo_api.virtual_machines()
     types = api.list_vm_machine_types2()
-    types_dict = types.to_dict()
+    types_dict = types.to_dict()['machine_types']
 
     # Filter machine types based on requirements
     matching_types = []


### PR DESCRIPTION
Fixes https://github.com/skypilot-org/skypilot/issues/5208
Fixes https://github.com/skypilot-org/skypilot/issues/3829

**Changes:**

- Replaced all `list_vm_machine_types` calls with `list_vm_machine_types2`. `list_vm_machine_types2` has a different call signature, wherein it doesn't accept any argument, and just returns a list of instances coupled with availability info.
- Updated Cudo catalog to include all GPUs.
- Fixed `sky check` command for Cudo cloud.
- Here's the `skypilot-catalog` PR: https://github.com/skypilot-org/skypilot-catalog/pull/136

**Open Questions:**

1. Cudo offers two variants of A40 and L40S: "graphics mode" and "compute mode". Should the catalog include both and choose the lower cost of the two? Or should it just include "compute mode"?
2. Cudo doesn't offer H100 PCIe; it has H100 SXM and H100 NVL. Should one of these be designated as "H100"? If yes, which one? Currently, I've labelled H100 SXM as H100.


**Tested (run the relevant ones):**

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Launched a VM on Cudo and terminated it.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
