### PR TITLE
[Core][Jobs] filemounts upload for job consolidation

### DIFF
--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -57,8 +57,9 @@ def _upload_files_to_controller(dag: 'sky.Dag') -> Dict[str, str]:
 
     # For consolidation mode, we don't need to use cloud storage,
     # as uploading to the controller is only a local copy.
-    if (not managed_job_utils.is_consolidation_mode() and
-            storage_lib.get_cached_enabled_storage_cloud_names_or_refresh()):
+    storage_clouds = (
+        storage_lib.get_cached_enabled_storage_cloud_names_or_refresh())
+    if not managed_job_utils.is_consolidation_mode() and storage_clouds:
         for task_ in dag.tasks:
             controller_utils.maybe_translate_local_file_mounts_and_sync_up(
                 task_, task_type='jobs')
@@ -69,7 +70,7 @@ def _upload_files_to_controller(dag: 'sky.Dag') -> Dict[str, str]:
         # directly to the controller, because the controller may not
         # even be up yet.
         for task_ in dag.tasks:
-            if task_.storage_mounts:
+            if task_.storage_mounts and not storage_clouds:
                 # Technically, we could convert COPY storage_mounts that
                 # have a local source and do not specify `store`, but we
                 # will not do that for now. Only plain file_mounts are


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We still need to upload files in consolidation mode, for each job to have a separate environment.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
