### PR TITLE
[Metrics] Grafana auto login using oauth proxy

### DIFF
--- a/charts/skypilot/templates/grafana-ingress.yaml
+++ b/charts/skypilot/templates/grafana-ingress.yaml
@@ -2,17 +2,21 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    # todo(rohan): add support for sso auth (use api server ingress.yaml as reference)
-    # Basic authentication
-    nginx.ingress.kubernetes.io/auth-type: basic
-    # Use the same realm as the API server
-    nginx.ingress.kubernetes.io/auth-realm: "SkyPilot API Server"
-    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-WEBAUTH-USER admin;
   name: {{ .Release.Name }}-grafana-authed
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- if index .Values.ingress "oauth2-proxy" "enabled" }}
+    # OAuth2 Proxy authentication for browser-based access
+    nginx.ingress.kubernetes.io/auth-signin: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/start?rd=$escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-url: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/auth
+    {{- else }}
+    # Basic authentication
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-realm: "SkyPilot API Server"
+    nginx.ingress.kubernetes.io/auth-secret: {{ .Values.ingress.authSecret | default (printf "%s-basic-auth" .Release.Name) }}
+    {{- end }}
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-WEBAUTH-USER admin;
 spec:
   ingressClassName: {{ .Values.grafana.ingress.ingressClassName }}
   rules:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR enables automatically logging into grafana once the user logs into the api server using an oauth proxy.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
