### PR TITLE
[UX] Give suggestions for typos

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -24,6 +24,7 @@ listed in "sky --help".  Take care to put logically connected commands close to
 each other.
 """
 import collections
+import difflib
 import fnmatch
 import os
 import pathlib
@@ -40,7 +41,6 @@ import click
 import colorama
 import requests as requests_lib
 from rich import progress as rich_progress
-import difflib
 import yaml
 
 import sky
@@ -766,15 +766,15 @@ class _NaturalOrderGroup(click.Group):
 
         if cmd_name in self._common_mistakes:
             suggestion = self._common_mistakes[cmd_name]
-            ctx.fail(
-                f'No such command \'{cmd_name}\'.'
-                f'Did you mean: \'{suggestion}\'?'
-            )
+            ctx.fail(f'No such command \'{cmd_name}\'.'
+                     f'Did you mean: \'{suggestion}\'?')
 
-        matches = difflib.get_close_matches(
-            cmd_name, self.commands.keys(), n=2, cutoff=0.5)
+        matches = difflib.get_close_matches(cmd_name,
+                                            self.commands.keys(),
+                                            n=2,
+                                            cutoff=0.5)
         if matches:
-            suggestion = "', '".join(matches)
+            suggestion = '\', \''.join(matches)
             ctx.fail(f'No such command \'{cmd_name}\'.'
                      f'Did you mean: \'{suggestion}\'?')
         else:

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -766,7 +766,7 @@ class _NaturalOrderGroup(click.Group):
 
         if cmd_name in self._common_mistakes:
             suggestion = self._common_mistakes[cmd_name]
-            ctx.fail(f'No such command \'{cmd_name}\'.'
+            ctx.fail(f'No such command \'{cmd_name}\'. '
                      f'Did you mean: \'{suggestion}\'?')
 
         matches = difflib.get_close_matches(cmd_name,
@@ -775,7 +775,7 @@ class _NaturalOrderGroup(click.Group):
                                             cutoff=0.5)
         if matches:
             suggestion = '\', \''.join(matches)
-            ctx.fail(f'No such command \'{cmd_name}\'.'
+            ctx.fail(f'No such command \'{cmd_name}\'. '
                      f'Did you mean: \'{suggestion}\'?')
         else:
             ctx.fail(f'No such command \'{cmd_name}\'.')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Suggests possible commands the user meant if they make a typo or common mistake. I.e `sky jobs qeuee` will say 

```
Usage: sky jobs [OPTIONS] COMMAND [ARGS]...
Try 'sky jobs -h' for help.

Error: No such command 'qeuee'. Did you mean: 'queue'?
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
