### PR TITLE
Include metrics in whl during build

### DIFF
--- a/sky/setup_files/MANIFEST.in
+++ b/sky/setup_files/MANIFEST.in
@@ -17,3 +17,4 @@ include sky/utils/kubernetes/*
 include sky/server/html/*
 recursive-include sky/dashboard/out *
 include sky/users/*.conf
+include sky/metrics/*


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Found the [bug](https://github.com/zpoint/skypilot/actions/runs/16020643114/job/45196710063) during release tests:

We import the directory but its not included in our MANIFEST

```bash
#18 DONE 42.8s
#19 [11/12] RUN sky -v && sky api info || {         echo "=== SkyPilot API server failed to start. Checking logs... ===";         if [ -f ~/.sky/api_server/server.log ]; then             cat ~/.sky/api_server/server.log;         else             echo "No server log file found at ~/.sky/api_server/server.log";         fi;         exit 1;     }
#19 3.385 skypilot, version 1.0.0.dev20250702
#19 4.246 Failed to connect to SkyPilot API server at http://127.0.0.1:46580./ Starting a local server.
#19 5.827 sky.exceptions.ApiServerConnectionError: Could not connect to SkyPilot API server at http://127.0.0.1:46580./ Please ensure that the server is running. Try: curl http://127.0.0.1:46580/api/health
#19 5.827 
#19 5.827 During handling of the above exception, another exception occurred:
#19 5.827 
#19 5.827 RuntimeError: SkyPilot API server process exited unexpectedly.
#19 5.827 View logs at: ~/.sky/api_server/server.log
#19 5.945 === SkyPilot API server failed to start. Checking logs... ===
#19 5.946 Traceback (most recent call last):
#19 5.946   File "/opt/conda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
#19 5.946     return _run_code(code, main_globals, None,
#19 5.946   File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code
#19 5.946     exec(code, run_globals)
#19 5.946   File "/opt/conda/lib/python3.10/site-packages/sky/server/server.py", line 42, in <module>
#19 5.946     from sky.metrics import utils as metrics_utils
#19 5.946 ModuleNotFoundError: No module named 'sky.metrics'
#19 ERROR: process "/bin/sh -c sky -v && sky api info || {         echo \"=== SkyPilot API server failed to start. Checking logs... ===\";         if [ -f ~/.sky/api_server/server.log ]; then             cat ~/.sky/api_server/server.log;         else             echo \"No server log file found at ~/.sky/api_server/server.log\";         fi;         exit 1;     }" did not complete successfully: exit code: 1
------
 > [11/12] RUN sky -v && sky api info || {         echo "=== SkyPilot API server failed to start. Checking logs... ===";         if [ -f ~/.sky/api_server/server.log ]; then             cat ~/.sky/api_server/server.log;         else             echo "No server log file found at ~/.sky/api_server/server.log";         fi;         exit 1;     }:
5.827 View logs at: ~/.sky/api_server/server.log
5.945 === SkyPilot API server failed to start. Checking logs... ===
5.946 Traceback (most recent call last):
5.946   File "/opt/conda/lib/python3.10/runpy.py", line 196, in _run_module_as_main
5.946     return _run_code(code, main_globals, None,
5.946   File "/opt/conda/lib/python3.10/runpy.py", line 86, in _run_code
5.946     exec(code, run_globals)
5.946   File "/opt/conda/lib/python3.10/site-packages/sky/server/server.py", line 42, in <module>
5.946     from sky.metrics import utils as metrics_utils
5.946 ModuleNotFoundError: No module named 'sky.metrics'
------
Dockerfile:75
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

`