### PR TITLE
[K8s] update ray node imagePullPolicy to Always from IfNotPresent

### DIFF
--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -392,7 +392,7 @@ available_node_types:
         {% endfor %}
         containers:
         - name: ray-node
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           image: {{image_id}}
           env:
             - name: SKYPILOT_POD_NODE_TYPE


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR changes the imagePullPolicy for ray-node to Always instead of IfNotPresent. This resolves an issue where nodes can get into inconsistent state in the case where a cluster is sky launched on a single node (pulls image v1) and then the cluster is torn down and another cluster is sky launched on the same node and others and the other nodes pull image v2. 

This value was initially set to IfNotPresent to reduce the amount of time pulling images if they have already been pulled, but the following benchmarking results for Always seem reasonable and will fix the bug described above:

IfNotPresent:
1st sky launch: ~30s spent pulling image
2nd sky launch: 0s spent pulling image ("already present on machine")

Always:
3rd sky launch: ~1s spent pulling image

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
