### PR TITLE
[Perf] Sky status `aws configure list`

### DIFF
--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -734,7 +734,7 @@ class AWS(clouds.Cloud):
                               shell=True,
                               check=False,
                               stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+                              stderr=subprocess.DEVNULL)
         if proc.returncode != 0:
             return None
         return proc.stdout


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

AWS configure list is a bit slow on MAC (~3s)

This is coming from the client -- the main bottleneck is `aws configure list`. Reduced 6s -> 3s.

<img width="1239" alt="2" src="https://github.com/user-attachments/assets/b90845a6-0c24-4873-9c1d-986788be3139" />

<img width="1246" alt="1" src="https://github.com/user-attachments/assets/6cc43cdc-d365-43a0-8c9b-52c00fd2ae09" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
