### PR TITLE
change priority logic to disable head of line blocking

### DIFF
--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -1483,11 +1483,10 @@ def get_waiting_job() -> Optional[Dict[str, Any]]:
                 job_info_table.c.schedule_state.in_([
                     ManagedJobScheduleState.WAITING.value,
                     ManagedJobScheduleState.ALIVE_WAITING.value,
-                ]),
-            )).order_by(
-                job_info_table.c.priority.desc(),
-                job_info_table.c.spot_job_id.asc(),
-            ).limit(1)
+                ]),)).order_by(
+                    job_info_table.c.priority.desc(),
+                    job_info_table.c.spot_job_id.asc(),
+                ).limit(1)
         waiting_job_row = session.execute(query).fetchone()
         if waiting_job_row is None:
             return None


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When different `kueue.local_queue_name` is specified across different workspaces, different jobs may be destined towards independent queues that don't interact with each other. In such cases, the head-of-line blocking behavior of global skypilot queue can cause jobs that shouldn't be blocked to be blocked.

For now, remove this head-of-line blocking behavior from skypilot queue.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
