### PR TITLE
[Jobs] Fix return type docstr

### DIFF
--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -122,11 +122,13 @@ def queue(refresh: bool,
                 'resources': (str) resources of the job,
                 'submitted_at': (float) timestamp of submission,
                 'end_at': (float) timestamp of end,
-                'duration': (float) duration in seconds,
+                'job_duration': (float) duration in seconds,
                 'recovery_count': (int) Number of retries,
                 'status': (sky.jobs.ManagedJobStatus) of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
+                'task_id': (int), id of the task in the job. Set to 0, except in pipelines.
+                'task_name': (str), name of the task in the job. Same as job_name, except in pipelines.
               }
             ]
 

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -127,8 +127,8 @@ def queue(refresh: bool,
                 'status': (sky.jobs.ManagedJobStatus) of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
-                'task_id': (int), id of the task in the job. Set to 0, except in pipelines.
-                'task_name': (str), name of the task in the job. Same as job_name, except in pipelines.
+                'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+                'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
               }
             ]
 

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -494,13 +494,15 @@ def queue(refresh: bool,
                 'resources': str,
                 'submitted_at': (float) timestamp of submission,
                 'end_at': (float) timestamp of end,
-                'duration': (float) duration in seconds,
+                'job_duration': (float) duration in seconds,
                 'recovery_count': (int) Number of retries,
                 'status': (sky.jobs.ManagedJobStatus) of the job,
                 'cluster_resources': (str) resources of the cluster,
                 'region': (str) region of the cluster,
                 'user_name': (Optional[str]) job creator's user name,
                 'user_hash': (str) job creator's user hash,
+                'task_id': (int), id of the task in the job. Set to 0, except in pipelines.
+                'task_name': (str), name of the task in the job. Same as job_name, except in pipelines.
             }
         ]
     Raises:

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -501,8 +501,8 @@ def queue(refresh: bool,
                 'region': (str) region of the cluster,
                 'user_name': (Optional[str]) job creator's user name,
                 'user_hash': (str) job creator's user hash,
-                'task_id': (int), id of the task in the job. Set to 0, except in pipelines.
-                'task_name': (str), name of the task in the job. Same as job_name, except in pipelines.
+                'task_id': (int), set to 0 (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
+                'task_name': (str), same as job_name (except in pipelines, which may have multiple tasks), # pylint: disable=line-too-long
             }
         ]
     Raises:


### PR DESCRIPTION
Some additional fields critical to CLI/dashboard were missing from docstr. Also ~`duration`~ -> `job_duration`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
