### PR TITLE
[API server] Use uvloop by default

### DIFF
--- a/sky/server/uvicorn.py
+++ b/sky/server/uvicorn.py
@@ -159,6 +159,8 @@ class Server(uvicorn.Server):
     def run(self, *args, **kwargs):
         """Run the server process."""
         context_utils.hijack_sys_attrs()
+        # Use default loop policy of uvicorn (use uvloop if available).
+        self.config.setup_event_loop()
         with self.capture_signals():
             asyncio.run(self.serve(*args, **kwargs))
 

--- a/tests/load_tests/test_load_on_server.py
+++ b/tests/load_tests/test_load_on_server.py
@@ -233,8 +233,13 @@ def test_validate_api(num_requests):
     run_concurrent_api_requests(num_requests, validate, 'API /validate')
 
 
+def test_api_status(num_requests):
+    print(f"Testing {num_requests} API status requests")
+    run_concurrent_api_requests(num_requests, sdk.api_status, 'API /status')
+
+
 all_requests = ['launch', 'status', 'logs', 'jobs', 'serve']
-all_apis = ['status', 'cli_status', 'tail_logs', 'validate']
+all_apis = ['status', 'cli_status', 'tail_logs', 'validate', 'api_status']
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -318,6 +323,9 @@ if __name__ == '__main__':
                                           args=(args.n, cloud))
             elif api == 'validate':
                 thread = threading.Thread(target=test_validate_api,
+                                          args=(args.n,))
+            elif api == 'api_status':
+                thread = threading.Thread(target=test_api_status,
                                           args=(args.n,))
             if thread:
                 test_threads.append(thread)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes a bug introduced by https://github.com/skypilot-org/skypilot/pull/6048 which breaks the behavior event loop selecting. Now uvicorn will use uvloop by default if available.

Benchmark:

uvloop:

```bash
$ python tests/load_tests/test_load_on_server.py -n 100 --apis api_status
Latency Statistics:
----------------------------------------------------------------------------------------------------
Kind                 Count    Total(s)   Avg(s)     Min(s)     Max(s)     P95(s)     P99(s)
----------------------------------------------------------------------------------------------------
API /status          100      14.50      0.14       0.04       0.18       0.18       0.18
```

default loop:

```bash
$ python tests/load_tests/test_load_on_server.py -n 100 --apis api_status
Latency Statistics:
----------------------------------------------------------------------------------------------------
Kind                 Count    Total(s)   Avg(s)     Min(s)     Max(s)     P95(s)     P99(s)
----------------------------------------------------------------------------------------------------
API /status          100      17.38      0.17       0.03       0.20       0.20       0.20
```

A unit test is also added to avoid regression

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
