### PR TITLE
[Docs] Update nebius to use `network_tier` instead of suggesting to set env

### DIFF
--- a/examples/api-deploy-gke-nebius-okta/README.md
+++ b/examples/api-deploy-gke-nebius-okta/README.md
@@ -271,7 +271,7 @@ Some commands to try:
 
 To configure SkyPilot to use infiniband on Nebius:
 
-1. Set `network_tier: best` in your SkyPilot task YAML resources to enable InfiniBand:
+Set `network_tier: best` in your SkyPilot task YAML resources to enable InfiniBand:
 
     ```yaml
     resources:

--- a/examples/api-deploy-gke-nebius-okta/README.md
+++ b/examples/api-deploy-gke-nebius-okta/README.md
@@ -271,28 +271,13 @@ Some commands to try:
 
 To configure SkyPilot to use infiniband on Nebius:
 
-1. Set the following config in your SkyPilot task YAML to enable InfiniBand:
+1. Set `network_tier: best` in your SkyPilot task YAML resources to enable InfiniBand:
 
     ```yaml
-    config:
-      kubernetes:
-        pod_config:
-          spec:
-            containers:
-            - securityContext:
-                capabilities:
-                  add:
-                  - IPC_LOCK
+    resources:
+      network_tier: best
     ```
 
-2. Configure the environment variables in your SkyPilot task:
-
-    ```yaml
-    run: |
-      export NCCL_IB_HCA=mlx5
-      export UCX_NET_DEVICES=mlx5_0:1,mlx5_1:1,mlx5_2:1,mlx5_3:1,mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1
-      ... your own run script ...
-    ```
 
 > **💡 Tip:** Add the above config to the SkyPilot config (`~/.sky/config.yaml` [global config](https://docs.skypilot.co/en/latest/reference/config.html#config-yaml) or `.sky.yaml` [project config](https://docs.skypilot.co/en/latest/reference/config-sources.html#config-client-project-config)) to have Infiniband configured automatically for all your jobs.
 

--- a/examples/api-deploy-gke-nebius-okta/README.md
+++ b/examples/api-deploy-gke-nebius-okta/README.md
@@ -278,9 +278,6 @@ Set `network_tier: best` in your SkyPilot task YAML resources to enable InfiniBa
       network_tier: best
     ```
 
-
-> **💡 Tip:** Add the above config to the SkyPilot config (`~/.sky/config.yaml` [global config](https://docs.skypilot.co/en/latest/reference/config.html#config-yaml) or `.sky.yaml` [project config](https://docs.skypilot.co/en/latest/reference/config-sources.html#config-client-project-config)) to have Infiniband configured automatically for all your jobs.
-
 Refer to [Using InfiniBand in Nebius with SkyPilot](https://docs.skypilot.co/en/latest/examples/performance/nebius_infiniband.html)  and [NCCL test example](https://github.com/skypilot-org/skypilot/blob/master/examples/nebius_infiniband/nccl.yaml) for more details.
 
 ### Shared storage with Nebius shared filesystem


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Update to use network tier 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
