### PR TITLE
[api] catch UnicodeDecodeError during /upload

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -206,9 +206,14 @@ def _upload_chunk_with_retry(params: UploadChunkParams) -> None:
                     f'Retrying... ({attempt + 1} / {max_attempts})')
                 time.sleep(1)
             else:
+                try:
+                    response_details = response.json().get('detail')
+                except Exception:  # pylint: disable=broad-except
+                    response_details = response.content
                 error_msg = (
                     f'Failed to upload chunk: {params.chunk_index + 1} / '
-                    f'{params.total_chunks}: {response.json().get("detail")}')
+                    f'{params.total_chunks}: {response_details} '
+                    f'(Status code: {response.status_code})')
                 upload_logger.error(error_msg)
                 with ux_utils.print_exception_no_traceback():
                     raise RuntimeError(

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -128,7 +128,7 @@ async def _override_user_info_in_request_body(request: fastapi.Request,
     if body:
         try:
             original_json = await request.json()
-        except json.JSONDecodeError as e:
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
             logger.error(f'Error parsing request JSON: {e}')
         else:
             logger.debug(f'Overriding user for {request.state.request_id}: '


### PR DESCRIPTION
If there are non-UTF8 chars in the request body, calling request.json() can result in a UnicodeDecodeError. We should handle this the same as a JSONDecodeError. This can happen during file upload on an API server using auth proxy.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
