### PR TITLE
[Dashboard] Fix jobs table context truncation

### DIFF
--- a/sky/dashboard/src/data/connectors/jobs.jsx
+++ b/sky/dashboard/src/data/connectors/jobs.jsx
@@ -112,7 +112,11 @@ export async function getManagedJobs({ allUsers = true } = {}) {
 
       const full_region_or_zone = region_or_zone;
       if (region_or_zone && region_or_zone.length > 15) {
-        region_or_zone = region_or_zone.substring(0, 15) + '...';
+        // Use head-and-tail truncation like the cluster page
+        const truncateLength = 15;
+        const startLength = Math.floor((truncateLength - 3) / 2);
+        const endLength = Math.ceil((truncateLength - 3) / 2);
+        region_or_zone = `${region_or_zone.substring(0, startLength)}...${region_or_zone.substring(region_or_zone.length - endLength)}`;
       }
 
       let infra = cloud + ' (' + region_or_zone + ')';


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Now the truncation will keep both head and tail of the string.

Before:

<img width="262" alt="image" src="https://github.com/user-attachments/assets/112b2c81-3699-43ed-b254-8249c6ae991a" />


After:

<img width="240" alt="image" src="https://github.com/user-attachments/assets/527dbbce-7266-4d27-9e85-ec9a3e212271" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
