### PR TITLE
[GKE] Fix GKE label formatter for H200

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -435,9 +435,9 @@ class Kubernetes(clouds.Cloud):
         max_timeout = 60  # Cap at 1 minute
         if enable_flex_start:
             # Flex start takes longer to provision.
-            base_timeout = 600
+            base_timeout = 1200
             per_node_timeout = 10
-            max_timeout = 900
+            max_timeout = 2400
         elif volume_mounts is not None:
             for volume_mount in volume_mounts:
                 if (volume_mount.volume_config.type ==

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -313,6 +313,9 @@ def get_gke_accelerator_name(accelerator: str) -> str:
         # A100-80GB, L4, H100-80GB and H100-MEGA-80GB
         # have a different name pattern.
         return 'nvidia-{}'.format(accelerator.lower())
+    elif accelerator == 'H200':
+        # H200s on GCP use this label format
+        return 'nvidia-h200-141gb'
     elif accelerator.startswith('tpu-'):
         return accelerator
     else:


### PR DESCRIPTION
Previously our label formatter returned `nvidia-tesla-h200`. Now it returns the correct GKE label `nvidia-h200-141gb`.

Also updates timeouts for DWS flex start. 