### PR TITLE
Remove concrrency for limit dep tests to fix flaky CI tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -108,11 +108,7 @@ jobs:
           TEST_PATH: ${{ matrix.test-path }}
         run: |
           source ~/test-env/bin/activate
-          if [[ "$TEST_PATH" == "tests/test_no_parellel.py" ]]; then
-            SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 eval "pytest -n 0 --dist no $TEST_PATH"
-          else
-            SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 eval "pytest -n 4 --dist worksteal $TEST_PATH"
-          fi
+          SKYPILOT_DISABLE_USAGE_COLLECTION=1 SKYPILOT_SKIP_CLOUD_IDENTITY_CHECK=1 eval "pytest -n 0 --dist no $TEST_PATH"
 
   failover-test:
     # Test failover functionality


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We have a race condition in SQLAlchemy table creation (see [link](https://github.com/skypilot-org/skypilot/actions/runs/16163739158/job/45620601765?pr=6200)). Since the limit dependencies tests aren't our main time consuming tests, we'll remove concurrency to eliminate the flakiness for now.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
