### PR TITLE
[Core] Fix multi nodes cluster issue with GKE DWS enabled

### DIFF
--- a/docs/source/reference/kubernetes/examples/kueue-example.rst
+++ b/docs/source/reference/kubernetes/examples/kueue-example.rst
@@ -196,7 +196,7 @@ Here, a cluster queue and a local queue are created.
     .. tab-item:: kueue.yaml with GKE DWS Enabled
         :sync: kueue-yaml-gke-dws-tab
 
-        When using :ref:`GKE DWS <dws-with-kueue>`, the ``kueue.yaml`` file should include the following:
+        When using :ref:`GKE DWS <dws-with-kueue>`, an ``AdmissionCheck`` and ``ProvisioningRequestConfig`` should be added to the ``kueue.yaml`` file to make sure that the head and worker PodSets in a multi-node cluster are merged into a single PodSet when creating ProvisioningRequest to trigger scale up in GKE.
 
         .. code-block:: yaml
 

--- a/docs/source/reference/kubernetes/examples/kueue-example.rst
+++ b/docs/source/reference/kubernetes/examples/kueue-example.rst
@@ -199,6 +199,7 @@ Here, a cluster queue and a local queue are created.
         When using :ref:`GKE DWS <dws-with-kueue>`, an ``AdmissionCheck`` and ``ProvisioningRequestConfig`` should be added to the ``kueue.yaml`` file to make sure that the head and worker PodSets in a multi-node cluster are merged into a single PodSet when creating ProvisioningRequest to trigger scale up in GKE.
 
         .. code-block:: yaml
+          :emphasize-lines: 1-20,41-42
 
           apiVersion: kueue.x-k8s.io/v1beta1
           kind: AdmissionCheck

--- a/docs/source/reservations/reservations.rst
+++ b/docs/source/reservations/reservations.rst
@@ -212,6 +212,7 @@ using DWS on GKE:
       dws:
         enabled: true
 
+.. _dws-with-kueue:
 
 Using DWS with Kueue
 ^^^^^^^^^^^^^^^^^^^^

--- a/sky/provision/kubernetes/instance.py
+++ b/sky/provision/kubernetes/instance.py
@@ -18,7 +18,6 @@ from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.provision.kubernetes import volume
 from sky.utils import command_runner
 from sky.utils import common_utils
-from sky.utils import config_utils
 from sky.utils import kubernetes_enums
 from sky.utils import status_lib
 from sky.utils import subprocess_utils
@@ -809,6 +808,21 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
 
     def _create_resource_thread(i: int):
         pod_spec_copy = copy.deepcopy(pod_spec)
+        # We need to keep the following fields in the pod spec to be same for
+        # head and worker pods.
+        # So that Kueue can merge them into a single PodSet when creating
+        # ProvisioningRequest to trigger scale up of the cluster autoscaler,
+        # this is especially required for DWS queued provisioning mode in GKE.
+        #  spec.containers[*].resources.requests
+        #  spec.initContainers[*].resources.requests
+        #  spec.resources
+        #  spec.nodeSelector
+        #  spec.tolerations
+        #  spec.affinity
+        #  resourceClaims
+        # Refer to the following links for more details:
+        # https://cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest#define_a_provisioningrequest_object # pylint: disable=line-too-long
+        # https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#podset-merge-policy # pylint: disable=line-too-long
         if head_pod_name is None and i == 0:
             # First pod should be head if no head exists
             pod_spec_copy['metadata']['labels'].update(constants.HEAD_NODE_TAGS)
@@ -825,37 +839,6 @@ def _create_pods(region: str, cluster_name_on_cloud: str,
                 return
             pod_spec_copy['metadata']['name'] = pod_name
             pod_spec_copy['metadata']['labels']['component'] = pod_name
-            # For multi-node support, we put a soft-constraint to schedule
-            # worker pods on different nodes than the head pod.
-            # This is not set as a hard constraint because if different nodes
-            # are not available, we still want to be able to schedule worker
-            # pods on larger nodes which may be able to fit multiple SkyPilot
-            # "nodes".
-            pod_spec_config = config_utils.Config(pod_spec_copy['spec'].get(
-                'affinity', {}))
-            existing_rules = pod_spec_config.get_nested(
-                ('podAntiAffinity',
-                 'preferredDuringSchedulingIgnoredDuringExecution'), [])
-            existing_rules.append({
-                # Max weight to avoid scheduling on the
-                # same physical node unless necessary.
-                'weight': 100,
-                'podAffinityTerm': {
-                    'labelSelector': {
-                        'matchExpressions': [{
-                            'key': k8s_constants.TAG_SKYPILOT_CLUSTER_NAME,
-                            'operator': 'In',
-                            'values': [cluster_name_on_cloud]
-                        }]
-                    },
-                    'topologyKey': 'kubernetes.io/hostname'
-                }
-            })
-            pod_spec_config.set_nested(
-                ('podAntiAffinity',
-                 'preferredDuringSchedulingIgnoredDuringExecution'),
-                existing_rules)
-            pod_spec_copy['spec']['affinity'] = pod_spec_config
 
         # TPU slice nodes are given a taint, google.com/tpu=present:NoSchedule.
         # This is to prevent from non-TPU workloads from being scheduled on TPU

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -485,6 +485,8 @@ class GKELabelFormatter(GPULabelFormatter):
                 # we map H100 ---> H100-80GB and keep H100-MEGA-80GB
                 # to distinguish between a3-high and a3-mega instances
                 return 'H100'
+            elif acc == 'H200-141GB':
+                return 'H200'
             return acc
         elif is_tpu_on_gke(value):
             return value

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -348,6 +348,23 @@ available_node_types:
                   operator: DoesNotExist
                 {% endfor %}
             {% endif %}
+          # For multi-node support, we put a soft-constraint to schedule
+          # worker pods on different nodes than the head pod.
+          # This is not set as a hard constraint because if different nodes
+          # are not available, we still want to be able to schedule worker
+          # pods on larger nodes which may be able to fit multiple SkyPilot
+          # "nodes".
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: skypilot-cluster-name
+                    operator: In
+                    values:
+                    - {{cluster_name_on_cloud}}
+                topologyKey: kubernetes.io/hostname
+              weight: 100
           {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -348,23 +348,6 @@ available_node_types:
                   operator: DoesNotExist
                 {% endfor %}
             {% endif %}
-          # For multi-node support, we put a soft-constraint to schedule
-          # worker pods on different nodes than the head pod.
-          # This is not set as a hard constraint because if different nodes
-          # are not available, we still want to be able to schedule worker
-          # pods on larger nodes which may be able to fit multiple SkyPilot
-          # "nodes".
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                  - key: skypilot-cluster-name
-                    operator: In
-                    values:
-                    - {{cluster_name_on_cloud}}
-                topologyKey: kubernetes.io/hostname
-              weight: 100
           {% if k8s_acc_label_key is not none and k8s_acc_label_values is not none %}
           podAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

- Fix multi nodes cluster issue with GKE DWS enabled
- Update doc for Kueue config with GKE DWS enabled
- Fix the issue when requesting H200 GPU

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - L4 GPU, flex start mode, 1 node
  - L4 GPU, flex start mode, 2 nodes
  - L4 GPU, flex start with queued provisioning mode, 1 node
  - L4 GPU, flex start with queued provisioning mode, 6 nodes
  - H100 GPU, flex start mode, 1 node
  - H100 GPU, flex start mode, 2 nodes
  - H100 GPU, flex start with queued provisioning mode, 1 node
  - H100 GPU, flex start with queued provisioning mode, 2 nodes
  - CPU, 1 node
  - CPU, 2 nodes
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
