### PR TITLE
Add Sagemaker support for Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install "skypilot-nightly[kubernetes,aws,gcp,azure,oci,lambda,runpod,fluidst
   <img src="docs/source/_static/intro.gif" alt="SkyPilot">
 </p>
 
-Current supported infra: Kubernetes, AWS, GCP, Azure, OCI, Lambda Cloud, Fluidstack,
+Current supported infra: Kubernetes, AWS, AWS SageMaker, GCP, Azure, OCI, Lambda Cloud, Fluidstack,
 RunPod, Cudo, Digital Ocean, Paperspace, Cloudflare, Samsung, IBM, Vast.ai,
 VMware vSphere, Nebius.
 <p align="center">

--- a/docs/source/docs/index.rst
+++ b/docs/source/docs/index.rst
@@ -180,7 +180,7 @@ SkyPilot supports your existing GPU, TPU, and CPU workloads, with no code change
 
 
 
-Current supported infra: Kubernetes, AWS, GCP, Azure, OCI, Lambda Cloud, Fluidstack,
+Current supported infra: Kubernetes, AWS, AWS SageMaker, GCP, Azure, OCI, Lambda Cloud, Fluidstack,
 RunPod, Cudo, Digital Ocean, Paperspace, Cloudflare, Samsung, IBM, Vast.ai,
 VMware vSphere, Nebius.
 

--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -176,6 +176,7 @@ This will produce a summary like:
 
   Checking credentials to enable clouds for SkyPilot.
     AWS: enabled
+    SageMaker: enabled
     GCP: enabled
     Azure: enabled
     OCI: enabled
@@ -338,6 +339,14 @@ Lambda Cloud
 
   mkdir -p ~/.lambda_cloud
   echo "api_key = <your_api_key_here>" > ~/.lambda_cloud/lambda_keys
+
+SageMaker
+~~~~~~~~~~~~~~~~~~
+
+`Amazon SageMaker <https://aws.amazon.com/sagemaker/>`_ is a fully managed
+service for training machine learning models. SkyPilot uses your existing
+AWS credentials. Ensure an IAM role with SageMaker permissions is available
+and specify it when launching jobs.
 
 Paperspace
 ~~~~~~~~~~~~~~~~~~

--- a/sky/adaptors/sagemaker.py
+++ b/sky/adaptors/sagemaker.py
@@ -1,0 +1,7 @@
+"""AWS SageMaker adaptor using lazy imports."""
+from sky.adaptors import common
+
+boto3 = common.LazyImport(
+    'boto3',
+    import_error_message='Failed to import dependencies for SageMaker. '
+    'Try running: pip install "skypilot[aws]"')

--- a/sky/utils/aws/__init__.py
+++ b/sky/utils/aws/__init__.py
@@ -1,0 +1,3 @@
+from . import sagemaker_utils
+
+__all__ = ['sagemaker_utils']

--- a/sky/utils/aws/sagemaker_utils.py
+++ b/sky/utils/aws/sagemaker_utils.py
@@ -1,0 +1,45 @@
+"""Utility functions for AWS SageMaker jobs."""
+from typing import Dict, Optional
+
+from sky.adaptors import sagemaker as sagemaker_adaptor
+
+
+def launch_training_job(job_name: str,
+                        image_uri: str,
+                        role: str,
+                        *,
+                        instance_type: str = 'ml.m5.large',
+                        instance_count: int = 1,
+                        volume_size_gb: int = 50,
+                        max_runtime: int = 3600,
+                        hyperparameters: Optional[Dict[str, str]] = None,
+                        output_path: Optional[str] = None) -> None:
+    """Launch a SageMaker training job.
+
+    This is a thin wrapper around ``boto3.client('sagemaker').create_training_job``.
+    """
+    sm_client = sagemaker_adaptor.boto3.client('sagemaker')
+
+    config = {
+        'TrainingJobName': job_name,
+        'AlgorithmSpecification': {
+            'TrainingImage': image_uri,
+            'TrainingInputMode': 'File',
+        },
+        'RoleArn': role,
+        'ResourceConfig': {
+            'InstanceType': instance_type,
+            'InstanceCount': instance_count,
+            'VolumeSizeInGB': volume_size_gb,
+        },
+        'StoppingCondition': {'MaxRuntimeInSeconds': max_runtime},
+    }
+    if output_path is not None:
+        config['OutputDataConfig'] = {'S3OutputPath': output_path}
+    if hyperparameters:
+        # Convert hyperparameter values to strings as required by SageMaker
+        config['HyperParameters'] = {
+            key: str(value) for key, value in hyperparameters.items()
+        }
+
+    sm_client.create_training_job(**config)

--- a/tests/unit_tests/test_sagemaker_utils.py
+++ b/tests/unit_tests/test_sagemaker_utils.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+from sky.utils.aws import sagemaker_utils
+
+
+def test_launch_training_job(monkeypatch):
+    fake_client = mock.MagicMock()
+    monkeypatch.setattr(sagemaker_utils.sagemaker_adaptor.boto3, 'client',
+                        lambda name: fake_client)
+    sagemaker_utils.launch_training_job(
+        job_name='test-job',
+        image_uri='123.dkr.ecr.us-west-2.amazonaws.com/myimage:latest',
+        role='arn:aws:iam::123:role/test')
+    fake_client.create_training_job.assert_called_once()


### PR DESCRIPTION
## Summary
- add SageMaker adaptor and utility helper
- mention SageMaker in supported infra docs
- unit test for launching SageMaker training jobs
- ensure hyperparameter values are stringified

## Testing
- `pip install -r requirements-dev.txt`
- `bash format.sh` *(fails: `fatal: Not a valid object name origin/master` but formatting succeeded)*
- `pytest tests/unit_tests/test_sagemaker_utils.py::test_launch_training_job -n 1 -q`
