### PR TITLE
raise exception when running locally with consolidation mode enabled

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2541,7 +2541,8 @@ def is_controller_accessible(
     """
     if (managed_job_utils.is_consolidation_mode() and
             controller == controller_utils.Controllers.JOBS_CONTROLLER):
-        if server_common.is_api_server_local():
+        if not env_options.Options.IS_DEVELOPER.get(
+        ) and server_common.is_api_server_local():
             raise exceptions.NotSupportedError(
                 'Consolidation mode is not supported when running locally.')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -36,6 +36,7 @@ from sky.adaptors import common as adaptors_common
 from sky.jobs import utils as managed_job_utils
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.server import common as server_common
 from sky.skylet import constants
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
@@ -2535,9 +2536,15 @@ def is_controller_accessible(
           identity.
         exceptions.ClusterNotUpError: if the controller is not accessible, or
           failed to be connected.
+        exceptions.NotSupportedError: if the controller is not supported to run
+          on the current mode.
     """
     if (managed_job_utils.is_consolidation_mode() and
             controller == controller_utils.Controllers.JOBS_CONTROLLER):
+        if server_common.is_api_server_local():
+            raise exceptions.NotSupportedError(
+                'Consolidation mode is not supported when running locally.')
+
         cn = 'local-controller-consolidation'
         return backends.LocalResourcesHandle(
             cluster_name=cn,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -36,7 +36,6 @@ from sky.adaptors import common as adaptors_common
 from sky.jobs import utils as managed_job_utils
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
-from sky.server import common as server_common
 from sky.skylet import constants
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
@@ -2536,16 +2535,9 @@ def is_controller_accessible(
           identity.
         exceptions.ClusterNotUpError: if the controller is not accessible, or
           failed to be connected.
-        exceptions.NotSupportedError: if the controller is not supported to run
-          on the current mode.
     """
     if (managed_job_utils.is_consolidation_mode() and
             controller == controller_utils.Controllers.JOBS_CONTROLLER):
-        if not env_options.Options.IS_DEVELOPER.get(
-        ) and server_common.is_api_server_local():
-            raise exceptions.NotSupportedError(
-                'Consolidation mode is not supported when running locally.')
-
         cn = 'local-controller-consolidation'
         return backends.LocalResourcesHandle(
             cluster_name=cn,

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -136,8 +136,9 @@ def _validate_consolidation_mode_config(
     if (current_is_consolidation_mode and
             not env_options.Options.IS_DEVELOPER.get() and
             server_common.is_api_server_local()):
-        raise exceptions.NotSupportedError(
-            'Consolidation mode is not supported when running locally.')
+        with ux_utils.print_exception_no_traceback():
+            raise exceptions.NotSupportedError(
+                'Consolidation mode is not supported when running locally.')
     # Check whether the consolidation mode config is changed.
     if current_is_consolidation_mode:
         controller_cn = (

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -130,15 +130,15 @@ def terminate_cluster(cluster_name: str, max_retry: int = 6) -> None:
             time.sleep(backoff.current_backoff())
 
 
-def _check_consolidation_mode_consistency(
+def _validate_consolidation_mode_config(
         current_is_consolidation_mode: bool) -> None:
-    """Check the consistency of the consolidation mode."""
-    # Check whether the consolidation mode config is changed.
+    """Validate the consolidation mode config."""
     if (current_is_consolidation_mode and
             not env_options.Options.IS_DEVELOPER.get() and
             server_common.is_api_server_local()):
         raise exceptions.NotSupportedError(
             'Consolidation mode is not supported when running locally.')
+    # Check whether the consolidation mode config is changed.
     if current_is_consolidation_mode:
         controller_cn = (
             controller_utils.Controllers.JOBS_CONTROLLER.value.cluster_name)
@@ -183,7 +183,7 @@ def _check_consolidation_mode_consistency(
 def is_consolidation_mode() -> bool:
     consolidation_mode = skypilot_config.get_nested(
         ('jobs', 'controller', 'consolidation_mode'), default_value=False)
-    _check_consolidation_mode_consistency(consolidation_mode)
+    _validate_consolidation_mode_config(consolidation_mode)
     return consolidation_mode
 
 

--- a/sky/jobs/utils.py
+++ b/sky/jobs/utils.py
@@ -30,6 +30,7 @@ from sky.backends import backend_utils
 from sky.jobs import constants as managed_job_constants
 from sky.jobs import scheduler
 from sky.jobs import state as managed_job_state
+from sky.server import common as server_common
 from sky.skylet import constants
 from sky.skylet import job_lib
 from sky.skylet import log_lib
@@ -38,6 +39,7 @@ from sky.utils import annotations
 from sky.utils import command_runner
 from sky.utils import common_utils
 from sky.utils import controller_utils
+from sky.utils import env_options
 from sky.utils import infra_utils
 from sky.utils import log_utils
 from sky.utils import message_utils
@@ -132,6 +134,11 @@ def _check_consolidation_mode_consistency(
         current_is_consolidation_mode: bool) -> None:
     """Check the consistency of the consolidation mode."""
     # Check whether the consolidation mode config is changed.
+    if (current_is_consolidation_mode and
+            not env_options.Options.IS_DEVELOPER.get() and
+            server_common.is_api_server_local()):
+        raise exceptions.NotSupportedError(
+            'Consolidation mode is not supported when running locally.')
     if current_is_consolidation_mode:
         controller_cn = (
             controller_utils.Controllers.JOBS_CONTROLLER.value.cluster_name)


### PR DESCRIPTION
This PR disables the use of consolidation mode (`jobs.controller.consolidation_mode`) when running the API server locally. This is done by raising a `NotSupportedError` exception when a user tries to enable it locally.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

Tested manually by doing `sky jobs launch "echo hello"` against a local API server, and verifying that the exception is raised if `SKYPILOT_DEV` is false/unset.

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
