### PR TITLE
strategic init of permission srv

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -79,6 +79,7 @@ else:
 
 P = ParamSpec('P')
 
+permission.initialize_permission_service()
 
 def _add_timestamp_prefix_for_server_logs() -> None:
     server_logger = sky_logging.init_logger('sky.server')

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -79,7 +79,6 @@ else:
 
 P = ParamSpec('P')
 
-permission.initialize_permission_service()
 
 def _add_timestamp_prefix_for_server_logs() -> None:
     server_logger = sky_logging.init_logger('sky.server')
@@ -197,6 +196,8 @@ class RBACMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         if auth_user is None:
             return await call_next(request)
 
+        permission.initialize_permission_service()
+        assert permission.permission_service is not None
         permission_service = permission.permission_service
         # Check the role permission
         if permission_service.check_endpoint_permission(auth_user.id,
@@ -438,6 +439,8 @@ class AuthProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
         if auth_user is not None:
             newly_added = global_user_state.add_or_update_user(auth_user)
             if newly_added:
+                permission.initialize_permission_service()
+                assert permission.permission_service is not None
                 permission.permission_service.add_user_if_not_exists(
                     auth_user.id)
 

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -353,6 +353,11 @@ def _policy_lock() -> Generator[None, None, None]:
                            'Please try again or manually remove the lock '
                            f'file if you believe it is stale.') from e
 
-
 # Singleton instance of PermissionService for other modules to use.
-permission_service = PermissionService()
+permission_service = None
+
+def initialize_permission_service():
+    """Initialize permission service."""
+    global permission_service
+    if permission_service is None:
+        permission_service = PermissionService()

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 from typing import Generator, List
+import threading
 
 import casbin
 import filelock
@@ -354,10 +355,13 @@ def _policy_lock() -> Generator[None, None, None]:
                            f'file if you believe it is stale.') from e
 
 # Singleton instance of PermissionService for other modules to use.
+_PERMISSION_SERVICE_INIT_LOCK = threading.Lock()
 permission_service = None
 
 def initialize_permission_service():
     """Initialize permission service."""
     global permission_service
     if permission_service is None:
-        permission_service = PermissionService()
+        with _PERMISSION_SERVICE_INIT_LOCK:
+            if permission_service is None:
+                permission_service = PermissionService()

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -3,8 +3,8 @@ import contextlib
 import hashlib
 import logging
 import os
-from typing import Generator, List
 import threading
+from typing import Generator, List
 
 import casbin
 import filelock
@@ -354,9 +354,11 @@ def _policy_lock() -> Generator[None, None, None]:
                            'Please try again or manually remove the lock '
                            f'file if you believe it is stale.') from e
 
+
 # Singleton instance of PermissionService for other modules to use.
 _PERMISSION_SERVICE_INIT_LOCK = threading.Lock()
 permission_service = None
+
 
 def initialize_permission_service():
     """Initialize permission service."""

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -543,6 +543,7 @@ async def delete_service_account_token(
         raise fastapi.HTTPException(status_code=404, detail='Token not found')
 
     # Check permissions using Casbin policy system
+    permission.initialize_permission_service()
     assert permission.permission_service is not None
     if not permission.permission_service.check_service_account_token_permission(
             auth_user.id, token_info['creator_user_hash'], 'delete'):

--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -30,6 +30,7 @@ logger = sky_logging.init_logger(__name__)
 USER_LOCK_PATH = os.path.expanduser('~/.sky/.{user_id}.lock')
 USER_LOCK_TIMEOUT_SECONDS = 20
 
+permission.initialize_permission_service()
 router = fastapi.APIRouter()
 
 

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -126,6 +126,7 @@ def update_workspace(workspace_name: str, config: Dict[str,
         workspaces[workspace_name] = config
         users = workspaces_utils.get_workspace_users(config)
         permission.initialize_permission_service()
+        assert permission.permission_service is not None
         permission_service = permission.permission_service
         permission_service.update_workspace_policy(workspace_name, users)
 
@@ -175,6 +176,7 @@ def create_workspace(workspace_name: str, config: Dict[str,
         # Add policy for the workspace and allowed users
         users = workspaces_utils.get_workspace_users(config)
         permission.initialize_permission_service()
+        assert permission.permission_service is not None
         permission_service = permission.permission_service
         permission_service.add_workspace_policy(workspace_name, users)
 
@@ -228,6 +230,7 @@ def delete_workspace(workspace_name: str) -> Dict[str, Any]:
             raise ValueError(f'Workspace {workspace_name!r} does not exist.')
         del workspaces[workspace_name]
         permission.initialize_permission_service()
+        assert permission.permission_service is not None
         permission_service = permission.permission_service
         permission_service.remove_workspace_policy(workspace_name)
 
@@ -336,6 +339,7 @@ def update_config(config: Dict[str, Any]) -> Dict[str, Any]:
             config_obj = config_utils.Config.from_dict(config)
             skypilot_config.update_api_server_config_no_lock(config_obj)
             permission.initialize_permission_service()
+            assert permission.permission_service is not None
             permission_service = permission.permission_service
             for operation, workspaces in workspaces_to_check_policy.items():
                 for workspace_name, users in workspaces.items():
@@ -379,6 +383,7 @@ def reject_request_for_unauthorized_workspace(user: models.User) -> None:
     """
     active_workspace = skypilot_config.get_active_workspace()
     permission.initialize_permission_service()
+    assert permission.permission_service is not None
     if not permission.permission_service.check_workspace_permission(
             user.id, active_workspace):
         raise exceptions.PermissionDeniedError(
@@ -414,6 +419,7 @@ def workspaces_for_user(user_id: str) -> Dict[str, Any]:
     user_workspaces = {}
 
     permission.initialize_permission_service()
+    assert permission.permission_service is not None
     for workspace_name, workspace_config in workspaces.items():
         if permission.permission_service.check_workspace_permission(
                 user_id, workspace_name):

--- a/sky/workspaces/core.py
+++ b/sky/workspaces/core.py
@@ -20,6 +20,7 @@ from sky.utils import schemas
 from sky.workspaces import utils as workspaces_utils
 
 logger = sky_logging.init_logger(__name__)
+permission.initialize_permission_service()
 
 # Lock for workspace configuration updates to prevent race conditions
 _WORKSPACE_CONFIG_LOCK_TIMEOUT_SECONDS = 60


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The idea here is to only initialize the permission service when permission service is actually needed, as opposed to import time initialization of permission service.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
