### PR TITLE
lazy initialization of permissions service

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -3,6 +3,7 @@ import contextlib
 import hashlib
 import logging
 import os
+import threading
 from typing import Generator, List
 
 import casbin
@@ -34,22 +35,29 @@ class PermissionService:
     """Permission service for SkyPilot API Server."""
 
     def __init__(self):
-        with _policy_lock():
-            global _enforcer_instance
-            if _enforcer_instance is None:
-                _enforcer_instance = self
-                engine = global_user_state.initialize_and_get_db()
-                db_utils.add_tables_to_db_sqlalchemy(
-                    sqlalchemy_adapter.Base.metadata, engine)
-                adapter = sqlalchemy_adapter.Adapter(engine)
-                model_path = os.path.join(os.path.dirname(__file__),
-                                          'model.conf')
-                enforcer = casbin.Enforcer(model_path, adapter)
-                self.enforcer = enforcer
-                self._maybe_initialize_policies()
-                self._maybe_initialize_basic_auth_user()
-            else:
-                self.enforcer = _enforcer_instance.enforcer
+        self.enforcer = None
+        self.init_lock = threading.Lock()
+
+    def _lazy_initialize(self):
+        if self.enforcer is not None:
+            return
+        with self.init_lock:
+            with _policy_lock():
+                global _enforcer_instance
+                if _enforcer_instance is None:
+                    _enforcer_instance = self
+                    engine = global_user_state.initialize_and_get_db()
+                    db_utils.add_tables_to_db_sqlalchemy(
+                        sqlalchemy_adapter.Base.metadata, engine)
+                    adapter = sqlalchemy_adapter.Adapter(engine)
+                    model_path = os.path.join(os.path.dirname(__file__),
+                                              'model.conf')
+                    enforcer = casbin.Enforcer(model_path, adapter)
+                    self.enforcer = enforcer
+                    self._maybe_initialize_policies()
+                    self._maybe_initialize_basic_auth_user()
+                else:
+                    self.enforcer = _enforcer_instance.enforcer
 
     def _maybe_initialize_basic_auth_user(self) -> None:
         """Initialize basic auth user if it is enabled."""
@@ -73,7 +81,6 @@ class PermissionService:
 
     def _maybe_initialize_policies(self) -> None:
         """Initialize policies if they don't already exist."""
-        # TODO(zhwu): we should avoid running this on client side.
         logger.debug(f'Initializing policies in process: {os.getpid()}')
         self._load_policy_no_lock()
 
@@ -152,6 +159,7 @@ class PermissionService:
 
     def add_user_if_not_exists(self, user_id: str) -> None:
         """Add user role relationship."""
+        self._lazy_initialize()
         with _policy_lock():
             self._add_user_if_not_exists_no_lock(user_id)
 
@@ -171,6 +179,7 @@ class PermissionService:
 
     def delete_user(self, user_id: str) -> None:
         """Delete user role relationship."""
+        self._lazy_initialize()
         with _policy_lock():
             # Get current roles
             self._load_policy_no_lock()
@@ -184,6 +193,7 @@ class PermissionService:
 
     def update_role(self, user_id: str, new_role: str) -> None:
         """Update user role relationship."""
+        self._lazy_initialize()
         with _policy_lock():
             # Get current roles
             self._load_policy_no_lock()
@@ -216,6 +226,7 @@ class PermissionService:
         Returns:
             A list of role names that the user has.
         """
+        self._lazy_initialize()
         self._load_policy_no_lock()
         return self.enforcer.get_roles_for_user(user_id)
 
@@ -228,6 +239,7 @@ class PermissionService:
         # it is a hot path in every request. It is ok to have a stale policy,
         # as long as it is eventually consistent.
         # self._load_policy_no_lock()
+        self._lazy_initialize()
         return self.enforcer.enforce(user_id, path, method)
 
     def _load_policy_no_lock(self):
@@ -236,6 +248,7 @@ class PermissionService:
 
     def load_policy(self):
         """Load policy from storage with lock."""
+        self._lazy_initialize()
         with _policy_lock():
             self._load_policy_no_lock()
 
@@ -251,6 +264,7 @@ class PermissionService:
         For public workspaces, the permission is granted via a wildcard policy
         ('*').
         """
+        self._lazy_initialize()
         if os.getenv(constants.ENV_VAR_IS_SKYPILOT_SERVER) is None:
             # When it is not on API server, we allow all users to access all
             # workspaces, as the workspace check has been done on API server.
@@ -307,6 +321,7 @@ class PermissionService:
                    For public workspaces, this should be ['*'].
                    For private workspaces, this should be specific user IDs.
         """
+        self._lazy_initialize()
         with _policy_lock():
             for user in users:
                 logger.debug(f'Adding workspace policy: user={user}, '
@@ -324,6 +339,7 @@ class PermissionService:
                    For public workspaces, this should be ['*'].
                    For private workspaces, this should be specific user IDs.
         """
+        self._lazy_initialize()
         with _policy_lock():
             self._load_policy_no_lock()
             # Remove all existing policies for this workspace
@@ -337,6 +353,7 @@ class PermissionService:
 
     def remove_workspace_policy(self, workspace_name: str) -> None:
         """Remove workspace policy."""
+        self._lazy_initialize()
         with _policy_lock():
             self.enforcer.remove_filtered_policy(1, workspace_name)
             self.enforcer.save_policy()

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -36,7 +36,6 @@ class PermissionService:
 
     def __init__(self):
         self.enforcer = None
-        self.init_lock = threading.Lock()
 
     def _lazy_initialize(self):
         if self.enforcer is not None:

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -3,7 +3,6 @@ import contextlib
 import hashlib
 import logging
 import os
-import threading
 from typing import Generator, List
 
 import casbin
@@ -49,7 +48,7 @@ class PermissionService:
                     sqlalchemy_adapter.Base.metadata, engine)
                 adapter = sqlalchemy_adapter.Adapter(engine)
                 model_path = os.path.join(os.path.dirname(__file__),
-                                            'model.conf')
+                                          'model.conf')
                 enforcer = casbin.Enforcer(model_path, adapter)
                 self.enforcer = enforcer
                 self._maybe_initialize_policies()

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -41,23 +41,22 @@ class PermissionService:
     def _lazy_initialize(self):
         if self.enforcer is not None:
             return
-        with self.init_lock:
-            with _policy_lock():
-                global _enforcer_instance
-                if _enforcer_instance is None:
-                    _enforcer_instance = self
-                    engine = global_user_state.initialize_and_get_db()
-                    db_utils.add_tables_to_db_sqlalchemy(
-                        sqlalchemy_adapter.Base.metadata, engine)
-                    adapter = sqlalchemy_adapter.Adapter(engine)
-                    model_path = os.path.join(os.path.dirname(__file__),
-                                              'model.conf')
-                    enforcer = casbin.Enforcer(model_path, adapter)
-                    self.enforcer = enforcer
-                    self._maybe_initialize_policies()
-                    self._maybe_initialize_basic_auth_user()
-                else:
-                    self.enforcer = _enforcer_instance.enforcer
+        with _policy_lock():
+            global _enforcer_instance
+            if _enforcer_instance is None:
+                _enforcer_instance = self
+                engine = global_user_state.initialize_and_get_db()
+                db_utils.add_tables_to_db_sqlalchemy(
+                    sqlalchemy_adapter.Base.metadata, engine)
+                adapter = sqlalchemy_adapter.Adapter(engine)
+                model_path = os.path.join(os.path.dirname(__file__),
+                                            'model.conf')
+                enforcer = casbin.Enforcer(model_path, adapter)
+                self.enforcer = enforcer
+                self._maybe_initialize_policies()
+                self._maybe_initialize_basic_auth_user()
+            else:
+                self.enforcer = _enforcer_instance.enforcer
 
     def _maybe_initialize_basic_auth_user(self) -> None:
         """Initialize basic auth user if it is enabled."""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Re-application of https://github.com/skypilot-org/skypilot/pull/5942.

https://github.com/skypilot-org/skypilot/pull/5942 was reverted in https://github.com/skypilot-org/skypilot/pull/6013 because the PR resulted in DB initialization conflicts. Now that those conflicts are solved with https://github.com/skypilot-org/skypilot/pull/6216 and https://github.com/skypilot-org/skypilot/pull/6212, we can reintroduce this commit.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
