### PR TITLE
Safely precreate casbin tables before creating adapter

### DIFF
--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -12,6 +12,7 @@ import sqlalchemy_adapter
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
+from sky.utils import db_utils
 from sky.skylet import constants
 from sky.users import rbac
 from sky.utils import common_utils
@@ -38,6 +39,8 @@ class PermissionService:
             if _enforcer_instance is None:
                 _enforcer_instance = self
                 engine = global_user_state.initialize_and_get_db()
+                db_utils.add_tables_to_db_sqlalchemy(
+                    sqlalchemy_adapter.Base.metadata, engine)
                 adapter = sqlalchemy_adapter.Adapter(engine)
                 model_path = os.path.join(os.path.dirname(__file__),
                                           'model.conf')

--- a/sky/users/permission.py
+++ b/sky/users/permission.py
@@ -12,10 +12,10 @@ import sqlalchemy_adapter
 from sky import global_user_state
 from sky import models
 from sky import sky_logging
-from sky.utils import db_utils
 from sky.skylet import constants
 from sky.users import rbac
 from sky.utils import common_utils
+from sky.utils import db_utils
 
 logging.getLogger('casbin.policy').setLevel(sky_logging.ERROR)
 logging.getLogger('casbin.role').setLevel(sky_logging.ERROR)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This function
```
adapter = sqlalchemy_adapter.Adapter(engine)
```

calls `Base.metadata.create_all`, as shown in the code snippet for the adapter code

```
class CasbinRule(Base):
    __tablename__ = "casbin_rule"

    id = Column(Integer, primary_key=True)
    ptype = Column(String(255))
    v0 = Column(String(255))
    v1 = Column(String(255))
    v2 = Column(String(255))
    v3 = Column(String(255))
    v4 = Column(String(255))
    v5 = Column(String(255))

    def __str__(self):
        arr = [self.ptype]
        for v in (self.v0, self.v1, self.v2, self.v3, self.v4, self.v5):
            if v is None:
                break
            arr.append(v)
        return ", ".join(arr)

    def __repr__(self):
        return '<CasbinRule {}: "{}">'.format(self.id, str(self))


class Filter:
    ptype = []
    v0 = []
    v1 = []
    v2 = []
    v3 = []
    v4 = []
    v5 = []


class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
    """the interface for Casbin adapters."""

    def __init__(self, engine, db_class=None, filtered=False):
        if isinstance(engine, str):
            self._engine = create_engine(engine)
        else:
            self._engine = engine

        if db_class is None:
            db_class = CasbinRule
        else:
            for attr in (
                "id",
                "ptype",
                "v0",
                "v1",
                "v2",
                "v3",
                "v4",
                "v5",
            ):  # id attr was used by filter
                if not hasattr(db_class, attr):
                    raise Exception(f"{attr} not found in custom DatabaseClass.")
            Base.metadata = db_class.metadata

        self._db_class = db_class
        self.session_local = sessionmaker(bind=self._engine)

        Base.metadata.create_all(self._engine)
        self._filtered = filtered
```

As described in https://github.com/skypilot-org/skypilot/pull/6212, `Base.metadata.create_all` is a thread-unsafe function because the mechanism it uses to check if table exists is prone to TOCTTOU bug. This PR safely creates the database table before calling the adapter initialization, therefore guaranteeing the table exists by the time adapter is initialized.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
