### PR TITLE
[Test] Read constant from package rather than source code file

### DIFF
--- a/tests/smoke_tests/backward_compat/test_backward_compat.py
+++ b/tests/smoke_tests/backward_compat/test_backward_compat.py
@@ -84,7 +84,7 @@ class TestBackwardCompatibility:
                              f'stderr: {base_skylet_version.stderr}, '
                              f'stdout: {base_skylet_version.stdout}')
 
-        version = base_skylet_version.stdout.strip()
+        version = base_skylet_version.stdout.strip().split('\n')[-1]
         if not version:
             raise ValueError('SKYLET_VERSION is empty')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix the failure happened [here](https://buildkite.com/skypilot-1/quicktest-core/builds/628#0197f3e2-c0a7-436d-86cd-3f2318bde7d9)

The test reads the constant from the file, but if we're comparing with the previous PyPI package rather than source code, we don't have the constant.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
