### PR TITLE
[Dashboard] Make non-important links gray

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -780,12 +780,13 @@ export function ClusterTable({
                         <UserDisplay
                           username={item.user}
                           userHash={item.user_hash}
+                          linkClassName="text-gray-600 hover:text-gray-800"
                         />
                       </TableCell>
                       <TableCell className="hidden md:table-cell">
                         <Link
                           href="/workspaces"
-                          className="text-blue-600 hover:underline"
+                          className="text-gray-600 hover:text-gray-800"
                         >
                           {item.workspace || 'default'}
                         </Link>
@@ -798,7 +799,7 @@ export function ClusterTable({
                           <span>
                             <Link
                               href="/infra"
-                              className="text-blue-600 hover:underline"
+                              className="text-gray-600 hover:text-gray-800"
                             >
                               {item.cloud}
                             </Link>

--- a/sky/dashboard/src/components/jobs.jsx
+++ b/sky/dashboard/src/components/jobs.jsx
@@ -1037,12 +1037,13 @@ export function ManagedJobsTable({
                         <UserDisplay
                           username={item.user}
                           userHash={item.user_hash}
+                          linkClassName="text-gray-600 hover:text-gray-800"
                         />
                       </TableCell>
                       <TableCell>
                         <Link
                           href="/workspaces"
-                          className="text-blue-600 hover:underline"
+                          className="text-gray-600 hover:text-gray-800"
                         >
                           {item.workspace || 'default'}
                         </Link>
@@ -1064,7 +1065,7 @@ export function ManagedJobsTable({
                             <span>
                               <Link
                                 href="/infra"
-                                className="text-blue-600 hover:underline"
+                                className="text-gray-600 hover:text-gray-800"
                               >
                                 {item.cloud || item.infra.split('(')[0].trim()}
                               </Link>
@@ -1560,12 +1561,13 @@ export function ClusterJobs({
                       <UserDisplay
                         username={item.user}
                         userHash={item.user_hash}
+                        linkClassName="text-gray-600 hover:text-gray-800"
                       />
                     </TableCell>
                     <TableCell>
                       <Link
                         href="/workspaces"
-                        className="text-blue-600 hover:underline"
+                        className="text-gray-600 hover:text-gray-800"
                       >
                         {item.workspace || 'default'}
                       </Link>


### PR DESCRIPTION
Improving readability and highlighting important links by reducing the prominence of non-important links (user, workspace, infra). Baby steps towards making the dashboard UI nicer. 

## Before
<img width="2013" height="453" alt="image" src="https://github.com/user-attachments/assets/8fca6cfc-51f4-42eb-b9fb-ad6fcc19d970" />


## After

<img width="1982" height="511" alt="image" src="https://github.com/user-attachments/assets/faf941f1-0530-4b01-b42a-c48f1121db2b" />

