### PR TITLE
fix `kubernetes.context_configs` config schema to allow setting `remote_identity`

### DIFF
--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1106,6 +1106,9 @@ _CONTEXT_CONFIG_SCHEMA_KUBERNETES = {
             },
         },
     },
+    'remote_identity': {
+        'type': 'string',
+    }
 }
 
 

--- a/tests/unit_tests/test_sky/utils/test_schemas.py
+++ b/tests/unit_tests/test_sky/utils/test_schemas.py
@@ -423,5 +423,24 @@ class TestWorkspaceSchema(unittest.TestCase):
                                     schema=self.workspaces_schema)
 
 
+class TestKubernetesSchema(unittest.TestCase):
+    """Tests for the kubernetes schema in schemas.py."""
+
+    def setUp(self):
+        self.config_schema = schemas.get_config_schema()
+        self.k8s_schema = self.config_schema['properties']['kubernetes']
+
+    def test_context_configs_allows_remote_identity(self):
+        """Test that context_configs allows remote_identity."""
+        valid_config = {
+            'context_configs': {
+                'my-context': {
+                    'remote_identity': 'my-service-account'
+                }
+            }
+        }
+        jsonschema.validate(instance=valid_config, schema=self.k8s_schema)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #6210 

There was a bug in our config schema which caused `remote_identity` to not be a valid property in `kubernetes.context_configs`.

This PR fixes the schema to allow it.

I also verified that the field does get read properly. I tested by setting it to a service account that doesn't exist on my kubernetes cluster.

```yaml
# ~/.sky/config.yaml
kubernetes:
  allowed_contexts:
  - cluster1
  - cluster2
  context_configs:
    cluster2:
      remote_identity: nonexistent-sa
```

and seeing it fail with:

```bash
W 07-10 17:22:58 instance.py:1007] run_instances: Error occurred when creating pods: 
kubernetes.client.exceptions.ApiException: (403) Reason: Forbidden HTTP response body: 
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"mycluster3-def-head\" is forbidden: 
error looking up service account default/nonexistent-sa: serviceaccount \"nonexistent-sa\" not 
found","reason":"Forbidden","details":{"name":"mycluster3-def-head","kind":"pods"},"code":403}
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
