### PR TITLE
Azure dependency fix

### DIFF
--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -129,6 +129,7 @@ extras_require: Dict[str, List[str]] = {
         'azure-mgmt-compute>=33.0.0',
         'azure-storage-blob>=12.23.1',
         'msgraph-sdk',
+        'msrestazure',
     ] + local_ray,
     # We need google-api-python-client>=2.69.0 to enable 'discardLocalSsd'
     # parameter for stopping instances. Reference:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6226

Test in Ubuntu


# Before this PR (master)

```
uv venv --seed ~/test-env
source ~/test-env/bin/activate
uv pip install --prerelease=allow "azure-cli>=2.65.0"
uv pip install -e ".[azure]"
sky check azure
```

```bash
(test-env) zpoint:~/codes/skypilot (master)$ sky check azure
Checking credentials to enable infra for SkyPilot.
  Azure: disabled 
    Reason [compute]: Getting user's Azure identity failed. Run the following commands:
      $ az login
      $ az account set -s <subscription_id>
    For more info: https://docs.microsoft.com/en-us/cli/azure/get-started-with-azure-cli
    Details: sky.exceptions.CloudUserIdentityError: Failed to get Azure user identity with unknown exception.
  Reason: [ImportError] You need to install 'msrestazure' to use this feature
    Reason [storage]: Getting user's Azure identity failed. Run the following commands:
      $ az login
      $ az account set -s <subscription_id>
    For more info: https://docs.microsoft.com/en-us/cli/azure/get-started-with-azure-cli
    Details: sky.exceptions.CloudUserIdentityError: Failed to get Azure user identity with unknown exception.
  Reason: [ImportError] cannot import name 'credentials' from 'azure.common' (/home/zpoint/test-env/lib/python3.11/site-packages/azure/common/__init__.py)

🎉 Enabled infra 🎉
  No infra to check/enabled.

To enable a cloud, follow the hints above and rerun: sky check
If any problems remain, refer to detailed docs at: https://docs.skypilot.co/en/latest/getting-started/installation.html

Using SkyPilot API server: http://127.0.0.1:46580
(test-env) zpoint:~/codes/skypilot (master)$ 
```

# This PR

```
uv venv --seed ~/test-env
source ~/test-env/bin/activate
uv pip install --prerelease=allow "azure-cli>=2.65.0"
uv pip install -e ".[azure]"
sky check azure
```

```bash
(test-env) zpoint:~/codes/skypilot (dev/zeping/azure_dependency)$ sky check azure
Checking credentials to enable infra for SkyPilot.
  Azure: enabled [compute, storage]

🎉 Enabled infra 🎉
  Azure [compute, storage]

To enable a cloud, follow the hints above and rerun: sky check
If any problems remain, refer to detailed docs at: https://docs.skypilot.co/en/latest/getting-started/installation.html

Using SkyPilot API server: http://127.0.0.1:46580
(test-env) zpoint:~/codes/skypilot (dev/zeping/azure_dependency)$ 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
