### PR TITLE
[Fix] clean temp files after launch

### DIFF
--- a/sky/execution.py
+++ b/sky/execution.py
@@ -23,6 +23,7 @@ from sky.utils import dag_utils
 from sky.utils import resources_utils
 from sky.utils import rich_utils
 from sky.utils import status_lib
+from sky.utils import tempstore
 from sky.utils import timeline
 from sky.utils import ux_utils
 
@@ -476,6 +477,9 @@ def _execute_dag(
 
 @timeline.event
 @usage_lib.entrypoint
+# A launch routine will share tempfiles between steps, so we init a tempdir
+# for the launch routine and gc the entire dir after launch.
+@tempstore.with_tempdir
 def launch(
     task: Union['sky.Task', 'sky.Dag'],
     cluster_name: Optional[str] = None,

--- a/sky/utils/tempstore.py
+++ b/sky/utils/tempstore.py
@@ -2,9 +2,11 @@
 
 import contextlib
 import contextvars
+import functools
 import os
 import tempfile
-from typing import Iterator, Optional
+import typing
+from typing import Any, Callable, Iterator, Optional, TypeVar
 
 _TEMP_DIR: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     'temp_store_dir', default=None)
@@ -49,3 +51,20 @@ def mkdtemp(suffix: Optional[str] = None,
         os.makedirs(dir, exist_ok=True)
 
     return tempfile.mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+
+def with_tempdir(func: F) -> F:
+    """Decorator that wraps a function call with tempdir() context manager.
+
+    Refer to `tempdir` for more details.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with tempdir():
+            return func(*args, **kwargs)
+
+    return typing.cast(F, wrapper)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Follow up: https://github.com/skypilot-org/skypilot/pull/6173

#6173 only init the tempdir context for launch initiated by API server. This PR init it for every launch in favor of cleaning temp files after launch, especially for job controller.

Tested manually, the at least 1.5MB temp store of each launch consumes if now eliminated.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
