### PR TITLE
better import management of sdk package

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -28,8 +28,6 @@ import click
 import colorama
 import filelock
 
-from sky import admin_policy
-from sky import backends
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
@@ -42,7 +40,6 @@ from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
 from sky.usage import usage_lib
-from sky.utils import admin_policy_utils
 from sky.utils import annotations
 from sky.utils import cluster_utils
 from sky.utils import common
@@ -64,6 +61,8 @@ if typing.TYPE_CHECKING:
     import requests
 
     import sky
+    from sky import admin_policy
+    from sky import backends
 else:
     psutil = adaptors_common.LazyImport('psutil')
 
@@ -273,7 +272,7 @@ def list_accelerator_counts(
 def optimize(
     dag: 'sky.Dag',
     minimize: common.OptimizeTarget = common.OptimizeTarget.COST,
-    admin_policy_request_options: Optional[admin_policy.RequestOptions] = None
+    admin_policy_request_options: Optional['admin_policy.RequestOptions'] = None
 ) -> server_common.RequestId:
     """Finds the best execution plan for the given DAG.
 
@@ -317,7 +316,7 @@ def workspaces() -> server_common.RequestId:
 def validate(
     dag: 'sky.Dag',
     workdir_only: bool = False,
-    admin_policy_request_options: Optional[admin_policy.RequestOptions] = None
+    admin_policy_request_options: Optional['admin_policy.RequestOptions'] = None
 ) -> None:
     """Validates the tasks.
 
@@ -372,7 +371,7 @@ def launch(
     idle_minutes_to_autostop: Optional[int] = None,
     dryrun: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
-    backend: Optional[backends.Backend] = None,
+    backend: Optional['backends.Backend'] = None,
     optimize_target: common.OptimizeTarget = common.OptimizeTarget.COST,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
@@ -495,6 +494,11 @@ def launch(
                 down = resource.autostop_config.down
                 idle_minutes_to_autostop = resource.autostop_config.idle_minutes
 
+    # Keep the import of admin policy local to avoid expensive
+    # imports when not needed.
+    # pylint: disable=import-outside-toplevel
+    from sky import admin_policy
+    from sky.utils import admin_policy_utils
     request_options = admin_policy.RequestOptions(
         cluster_name=cluster_name,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
@@ -525,12 +529,12 @@ def launch(
 def _launch(
     dag: 'sky.Dag',
     cluster_name: str,
-    request_options: admin_policy.RequestOptions,
+    request_options: 'admin_policy.RequestOptions',
     retry_until_up: bool = False,
     idle_minutes_to_autostop: Optional[int] = None,
     dryrun: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
-    backend: Optional[backends.Backend] = None,
+    backend: Optional['backends.Backend'] = None,
     optimize_target: common.OptimizeTarget = common.OptimizeTarget.COST,
     no_setup: bool = False,
     clone_disk_from: Optional[str] = None,
@@ -639,7 +643,7 @@ def exec(  # pylint: disable=redefined-builtin
     cluster_name: Optional[str] = None,
     dryrun: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
-    backend: Optional[backends.Backend] = None,
+    backend: Optional['backends.Backend'] = None,
 ) -> server_common.RequestId:
     """Executes a task on an existing cluster.
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -46,13 +46,7 @@ from sky.utils import common
 from sky.utils import common_utils
 from sky.utils import context as sky_context
 from sky.utils import dag_utils
-from sky.utils import env_options
-from sky.utils import infra_utils
-from sky.utils import rich_utils
-from sky.utils import status_lib
-from sky.utils import subprocess_utils
 from sky.utils import ux_utils
-from sky.utils.kubernetes import ssh_utils
 
 if typing.TYPE_CHECKING:
     import io
@@ -92,6 +86,9 @@ def stream_response(request_id: Optional[str],
         retry_context = rest.get_retry_context()
     try:
         line_count = 0
+        # We import rich_utils here to avoid expensive imports when not needed.
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import rich_utils
         for line in rich_utils.decode_rich_status(response):
             if line is not None:
                 line_count += 1
@@ -131,6 +128,9 @@ def check(infra_list: Optional[Tuple[str, ...]],
         clouds = None
     else:
         specified_clouds = []
+        # We import infra_utils here to avoid expensive imports when not needed.
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import infra_utils
         for infra_str in infra_list:
             infra = infra_utils.InfraInfo.from_str(infra_str)
             if infra.cloud is None:
@@ -583,6 +583,9 @@ def _launch(
         # Prompt if (1) --cluster is None, or (2) cluster doesn't exist, or (3)
         # it exists but is STOPPED.
         prompt = None
+        # We import status_lib here to avoid expensive imports when not needed.
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import status_lib
         if cluster_status is None:
             prompt = (
                 f'Launching a new cluster {cluster_name!r}. '
@@ -1494,6 +1497,9 @@ def _update_remote_ssh_node_pools(file: str,
             raise ValueError(
                 f'SSH Node Pool config file {file} does not exist. '
                 'Please check if the file exists and the path is correct.')
+    # We import ssh_utils here to avoid expensive imports when not needed.
+    # pylint: disable=import-outside-toplevel
+    from sky.utils.kubernetes import ssh_utils
     config = ssh_utils.load_ssh_targets(file)
     config = ssh_utils.get_cluster_config(config, infra)
     pools_config = {}
@@ -1729,6 +1735,9 @@ def get(request_id: str) -> Any:
     error = request_task.get_error()
     if error is not None:
         error_obj = error['object']
+        # We import env_options here to avoid expensive imports when not needed.
+        # pylint: disable=import-outside-toplevel
+        from sky.utils import env_options
         if env_options.Options.SHOW_DEBUG_INFO.get():
             stacktrace = getattr(error_obj, 'stacktrace', str(error_obj))
             logger.error('=== Traceback on SkyPilot API Server ===\n'
@@ -1995,6 +2004,10 @@ def api_stop() -> None:
     for process in psutil.process_iter(attrs=['pid', 'cmdline']):
         cmdline = process.info['cmdline']
         if cmdline and server_common.API_SERVER_CMD in ' '.join(cmdline):
+            # We import subprocess_utils here to avoid expensive imports when
+            # not needed.
+            # pylint: disable=import-outside-toplevel
+            from sky.utils import subprocess_utils
             subprocess_utils.kill_children_processes(parent_pids=[process.pid],
                                                      force=True)
             found = True


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
If a package is only used for type checking, only import the package during type checking

If a package is only used for one specific SDK call, import the package at that SDK call. This is important when SDK is used by CLI, because each invocation of CLI calls one of the SDK calls only - so there is no need to import packages for unrelated SDK calls if that can be avoided.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
