### PR TITLE
fix logging in optimizer's `_print_candidates`

### DIFF
--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -1007,7 +1007,6 @@ class Optimizer:
                 for cloud, candidate_list in candidate_set.items():
                     # Filter only the candidates matching the best
                     # resources chosen by the optimizer.
-                    best_resources_candidates = []
                     best_resources_candidates = [
                         res for res in candidate_list if
                         res.get_accelerators_str() == f'{acc_name}:{acc_count}'

--- a/sky/optimizer.py
+++ b/sky/optimizer.py
@@ -997,23 +997,30 @@ class Optimizer:
     @staticmethod
     def _print_candidates(node_to_candidate_map: _TaskToPerCloudCandidates):
         for node, candidate_set in node_to_candidate_map.items():
-            if node.best_resources:
-                accelerator = node.best_resources.accelerators
-            else:
-                accelerator = list(node.resources)[0].accelerators
+            best_resources = node.best_resources
+            if best_resources is None:
+                best_resources = list(node.resources)[0]
             is_multi_instances = False
-            if accelerator:
-                acc_name, acc_count = list(accelerator.items())[0]
+            if best_resources.accelerators:
+                acc_name, acc_count = list(
+                    best_resources.accelerators.items())[0]
                 for cloud, candidate_list in candidate_set.items():
-                    if len(candidate_list) > 1:
+                    # Filter only the candidates matching the best
+                    # resources chosen by the optimizer.
+                    best_resources_candidates = []
+                    best_resources_candidates = [
+                        res for res in candidate_list if
+                        res.get_accelerators_str() == f'{acc_name}:{acc_count}'
+                    ]
+                    if len(best_resources_candidates) > 1:
                         is_multi_instances = True
-                        instance_list = [
+                        instance_list = set([
                             res.instance_type
-                            for res in candidate_list
+                            for res in best_resources_candidates
                             if res.instance_type is not None
-                        ]
+                        ])
                         candidate_str = resources_utils.format_resource(
-                            candidate_list[0], simplify=True)
+                            best_resources, simplify=True)
 
                         logger.info(
                             f'{colorama.Style.DIM}🔍 Multiple {cloud} instances '
@@ -1327,8 +1334,7 @@ def _fill_in_launchable_resources(
     launchable: Dict[resources_lib.Resources, List[resources_lib.Resources]] = (
         collections.defaultdict(list))
     all_fuzzy_candidates = set()
-    cloud_candidates: _PerCloudCandidates = collections.defaultdict(
-        List[resources_lib.Resources])
+    cloud_candidates: _PerCloudCandidates = collections.defaultdict(list)
     resource_hints: Dict[resources_lib.Resources,
                          List[str]] = collections.defaultdict(list)
     if blocked_resources is None:
@@ -1365,7 +1371,10 @@ def _fill_in_launchable_resources(
                 launchable[resources].extend(
                     resources_utils.make_launchables_for_valid_region_zones(
                         cheapest))
-                cloud_candidates[cloud] = feasible_resources.resources_list
+                # Each cloud can occur multiple times in feasible_list,
+                # for different region/zone.
+                cloud_candidates[cloud].extend(
+                    feasible_resources.resources_list)
             else:
                 all_fuzzy_candidates.update(
                     feasible_resources.fuzzy_candidate_list)

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -845,10 +845,9 @@ def test_accelerator_cloud_filtering(capfd, enable_all_clouds):
     stdout, _ = capfd.readouterr()
 
 
-def test_optimizer_candidate_logging(enable_all_clouds, capfd):
+def test_candidate_logging(enable_all_clouds, capfd):
     """
-    Verifies that the optimizer candidate log only lists matching resources for each accelerator
-    and that the chosen resource is correct.
+    Verifies that the optimizer candidate log outputs the correct chosen/cheapest resource.
     """
     with sky.Dag() as dag:
         task = sky.Task('test_candidate_logging')
@@ -856,6 +855,7 @@ def test_optimizer_candidate_logging(enable_all_clouds, capfd):
             sky.Resources(accelerators={'L4': 1},
                           use_spot=True,
                           cloud=sky.AWS()),
+            # Other more expensive GPUs
             sky.Resources(accelerators={'A100': 1}, use_spot=True),
             sky.Resources(accelerators={'H100': 1}, use_spot=True),
             sky.Resources(accelerators={'H200': 1}, use_spot=True),
@@ -865,5 +865,5 @@ def test_optimizer_candidate_logging(enable_all_clouds, capfd):
     stdout, _ = capfd.readouterr()
     l4_section = any(
         'L4:1' in line and '✔' in line for line in stdout.splitlines())
-    assert l4_section, 'Expected L4:1 to be marked as chosen.'
-    assert 'Multiple AWS instances satisfy L4:1. The cheapest [spot](gpus=L4:1' in stdout, 'Expected L4:1 to be marked as cheapest.'
+    assert l4_section, 'Expected L4:1 to be chosen.'
+    assert f'Multiple {sky.AWS()} instances satisfy L4:1. The cheapest [spot](gpus=L4:1' in stdout, 'Expected L4:1 to be marked as cheapest.'


### PR DESCRIPTION
We were not returning the full list of resources candidates in `_fill_in_launchable_resources`, as we were overwriting it each time we process the same `cloud` (with `resources.any_of`, you could have the same cloud with different regions/zones). As a result, in `_print_candidates`, what would happen is the list of candidates might not match the optimizer’s chosen resource, thus making it inconsistent with the printed plan on the table right above it.

For example here, the chosen instance is `g6.4xlarge[Spot]`, but below it says `The cheapest [spot](gpus=A10G:1, g5.xlarge, ...) is considered ...`

```
YAML to run: hello_sky.yaml
Considered resources (1 node):
--------------------------------------------------------------------------------------
 INFRA              INSTANCE           vCPUs   Mem(GB)   GPUS     COST ($)   CHOSEN
--------------------------------------------------------------------------------------
 AWS (us-west-2a)   g6.4xlarge[Spot]   16      64        L4:1     0.17          ✔
 AWS (us-west-2c)   g5.xlarge[Spot]    4       16        A10G:1   0.38
 AWS (us-east-1)    g6.xlarge          4       16        L4:1     0.80
 AWS (us-east-1)    g5.xlarge          4       16        A10G:1   1.01
--------------------------------------------------------------------------------------

🔍 Multiple AWS instances satisfy L4:1. The cheapest [spot](gpus=A10G:1, g5.xlarge, ...) is considered among:
g5.xlarge, g5.4xlarge, g5.2xlarge, g5.8xlarge, g5.16xlarge.
```

I added a new test `test_optimizer_candidate_logging` in `test_optimizer_dryruns.py`.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)


