### PR TITLE
[k8s] Update generate_kubeconfig.sh

### DIFF
--- a/sky/utils/kubernetes/generate_kubeconfig.sh
+++ b/sky/utils/kubernetes/generate_kubeconfig.sh
@@ -156,6 +156,9 @@ rules:
   - apiGroups: [""]                 # Required for sky show-gpus command
     resources: ["pods"]
     verbs: ["get", "list"]
+  - apiGroups: ["rbac.authorization.k8s.io"]   # Required for SkyPilot to inspect its own permissions
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch"]
 ---
 # ClusterRoleBinding for the service account
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Previously generated kubeconfigs  would fail with:

```
D 07-11 12:23:13 provisioner.py:169] HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"clusterroles.rbac.authorization.k8s.io \"skypilot-service-account-cluster-role\" is forbidden: User \"system:serviceaccount:default:sky-sa\" cannot list resource \"clusterroles\" in API group \"rbac.authorization.k8s.io\" at the cluster scope","reason":"Forbidden","details":{"name":"skypilot-service-account-cluster-role","group":"rbac.authorization.k8s.io","kind":"clusterroles"},"code":403}
```

This PR adds the necessary permissions required by skypilot.