### PR TITLE
[Example] Training 400b maverick model with CPU offloading

### DIFF
--- a/llm/llama-4-finetuning/configs/llama4_maverick_full_sft_cpu.yaml
+++ b/llm/llama-4-finetuning/configs/llama4_maverick_full_sft_cpu.yaml
@@ -1,0 +1,50 @@
+# pip install git+https://github.com/hiyouga/transformers.git@llama4_train
+
+### model
+model_name_or_path: meta-llama/Llama-4-Maverick-17B-128E-Instruct
+trust_remote_code: true
+
+### method
+stage: sft
+do_train: true
+finetuning_type: full
+# deepspeed: examples/deepspeed/ds_z2_offload_config.json  # choices: [ds_z0_config.json, ds_z2_config.json, ds_z3_config.json]
+deepspeed: /configs/offload_cpu.yaml
+flash_attn: fa2
+enable_liger_kernel: True
+
+### dataset
+dataset: alpaca_en_demo
+template: llama4
+cutoff_len: 128
+max_samples: 100
+overwrite_cache: true
+preprocessing_num_workers: 4
+dataloader_num_workers: 1
+
+### output
+output_dir: saves/llama4-8b/lora/sft
+logging_steps: 10
+save_steps: 500
+plot_loss: true
+overwrite_output_dir: true
+save_only_model: false
+report_to: none  # choices: [none, wandb, tensorboard, swanlab, mlflow]
+
+### train
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 1
+learning_rate: 1.0e-4
+num_train_epochs: 1.0
+lr_scheduler_type: cosine
+warmup_ratio: 0.0
+bf16: true
+ddp_timeout: 180000000
+resume_from_checkpoint: null
+
+### eval
+# eval_dataset: alpaca_en_demo
+# val_size: 0.1
+# per_device_eval_batch_size: 1
+# eval_strategy: steps
+# eval_steps: 500

--- a/llm/llama-4-finetuning/configs/offload_cpu.yaml
+++ b/llm/llama-4-finetuning/configs/offload_cpu.yaml
@@ -1,0 +1,38 @@
+{
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": 1,
+  "gradient_accumulation_steps": 1,
+  "gradient_clipping": "auto",
+  "zero_allow_untested_optimizer": true,
+  "fp16": {
+    "enabled": "auto",
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "initial_scale_power": 16,
+    "hysteresis": 2,
+    "min_loss_scale": 1
+  },
+  "bf16": {
+    "enabled": "auto"
+  },
+  "zero_optimization": {
+    "stage": 3,
+    "offload_optimizer": {
+      "device": "cpu",
+      "pin_memory": true
+    },
+    "offload_param": {
+      "device": "cpu",
+      "pin_memory": true
+    },
+    "overlap_comm": true,
+    "contiguous_gradients": true,
+    "sub_group_size": 1000000000,
+    "reduce_bucket_size": 1000000000,
+    "stage3_prefetch_bucket_size": 200000000,
+    "stage3_param_persistence_threshold": 1000000,
+    "stage3_max_live_parameters": 2000000000,
+    "stage3_max_reuse_distance": 2000000000,
+    "stage3_gather_16bit_weights_on_model_save": true
+  }
+} 

--- a/llm/llama-4-finetuning/llama-4-maverick_gke_llama_factory_sft_cpu.yaml
+++ b/llm/llama-4-finetuning/llama-4-maverick_gke_llama_factory_sft_cpu.yaml
@@ -1,0 +1,71 @@
+# Full finetuning of Llama-4 Maverick 17B MoE model with 128 experts.
+#
+# Usage:
+#
+#  HF_TOKEN=xxx sky launch llama-4-maverick.yaml -c maverick --env HF_TOKEN
+#
+# This config uses H200 GPUs with 141GB memory each (much better for LLaMA-4!)
+
+envs:
+  HF_TOKEN: 
+
+resources:
+  infra: k8s
+  cpus: 100+
+  memory: 1000+
+  accelerators: H200:8
+  disk_tier: best
+  network_tier: best
+
+num_nodes: 2
+
+# Optional: configure buckets for dataset and checkpoints. You can then use the /outputs directory to write checkpoints.
+# file_mounts:
+#  /dataset:
+#    source: s3://my-dataset-bucket
+#    mode: COPY  # COPY mode will prefetch the dataset to the node for faster access
+#  /checkpoints:
+#    source: s3://my-checkpoint-bucket
+#    mode: MOUNT_CACHED  # MOUNT_CACHED mode will intelligently cache the checkpoint for faster writes
+
+file_mounts:
+  /configs: ./configs
+
+setup: |
+  # Optional: Mount additional NVMe if available
+  # sudo mkdir -p /mnt/nvme/deepspeed_offload
+  # sudo chmod 777 /mnt/nvme/deepspeed_offload
+
+  # Download the repository configuration package
+  wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+
+  # Install the keyring package
+  sudo dpkg -i cuda-keyring_1.1-1_all.deb
+
+  # Update package list
+  sudo apt-get update
+
+  # Install CUDA and build tools
+  sudo apt-get install cuda-toolkit-12-6 -y
+  sudo apt-get install -y nvidia-cuda-dev libaio-dev libssl-dev build-essential cmake ninja-build
+
+  sudo apt-get install -y net-tools htop
+  pip install nvitop
+
+  git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
+  cd LLaMA-Factory
+  pip install -e ".[torch,metrics,deepspeed,liger-kernel]" --no-build-isolation
+  pip install "transformers>=4.51.1"
+  pip install deepspeed==0.16.9 --upgrade --force-reinstall --no-cache-dir
+
+run: |
+  MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
+  echo "Starting distributed finetuning, head node: $MASTER_ADDR"
+
+  cd LLaMA-Factory
+
+  HF_TOKEN=$HF_TOKEN FORCE_TORCHRUN=1 NNODES=2 NODE_RANK=$SKYPILOT_NODE_RANK MASTER_ADDR=$MASTER_ADDR MASTER_PORT=29500 llamafactory-cli train /configs/llama4_maverick_full_sft_cpu.yaml
+
+
+
+

--- a/llm/llama-4-finetuning/llama-4-maverick_gke_llama_factory_sft_cpu.yaml
+++ b/llm/llama-4-finetuning/llama-4-maverick_gke_llama_factory_sft_cpu.yaml
@@ -2,7 +2,7 @@
 #
 # Usage:
 #
-#  HF_TOKEN=xxx sky launch llama-4-maverick.yaml -c maverick --env HF_TOKEN
+#  HF_TOKEN=xxx sky launch llama-4-maverick_gke_llama_factory_sft_cpu.yaml -c llama4_cpu --env HF_TOKEN
 #
 # This config uses H200 GPUs with 141GB memory each (much better for LLaMA-4!)
 
@@ -32,10 +32,6 @@ file_mounts:
   /configs: ./configs
 
 setup: |
-  # Optional: Mount additional NVMe if available
-  # sudo mkdir -p /mnt/nvme/deepspeed_offload
-  # sudo chmod 777 /mnt/nvme/deepspeed_offload
-
   # Download the repository configuration package
   wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds an example with training maverick on a nebius cluster (cpu offloading)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
