### PR TITLE
helm chart option to enable debug logs

### DIFF
--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         resources:
           {{- toYaml .Values.apiService.resources | nindent 10 }}
         env:
+        {{- if .Values.apiService.debug_logs }}
+        - name: SKYPILOT_DEBUG
+          value: "1"
+        {{- end }}
         - name: SKYPILOT_DEV
           value: {{ .Values.apiService.skypilotDev | quote }}
         - name: SKYPILOT_RELEASE_NAME

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -101,6 +101,9 @@ apiService:
       cpu: "4"
       memory: "8Gi"
 
+  # Enable debug logs for the API server
+  debug_logs: false
+
   # [Internal] Enable developer mode for SkyPilot
   skypilotDev: false
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Allows an easy way for a user to enable debug logs on API server deployment (e.g. for use in dev or test deployments)

The default can be argued.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
