### PR TITLE
[Hyperbolic] fix: mark `CUSTOM_MULTI_NETWORK ` un-supported

### DIFF
--- a/sky/clouds/hyperbolic.py
+++ b/sky/clouds/hyperbolic.py
@@ -55,6 +55,8 @@ class Hyperbolic(clouds.Cloud):
             ('Auto-stop not supported.'),
         clouds.CloudImplementationFeatures.AUTODOWN:
             ('Auto-down not supported.'),
+        clouds.CloudImplementationFeatures.CUSTOM_MULTI_NETWORK:
+            ('Customized multiple network interfaces not supported.'),
     }
 
     PROVISIONER_VERSION = clouds.ProvisionerVersion.SKYPILOT

--- a/sky/provision/hyperbolic/__init__.py
+++ b/sky/provision/hyperbolic/__init__.py
@@ -1,6 +1,7 @@
 """Hyperbolic provisioner for SkyPilot."""
 
 from sky.provision.hyperbolic.config import bootstrap_instances
+from sky.provision.hyperbolic.instance import cleanup_custom_multi_network
 from sky.provision.hyperbolic.instance import cleanup_ports
 from sky.provision.hyperbolic.instance import get_cluster_info
 from sky.provision.hyperbolic.instance import open_ports

--- a/sky/provision/hyperbolic/instance.py
+++ b/sky/provision/hyperbolic/instance.py
@@ -414,6 +414,15 @@ def cleanup_ports(
     raise NotImplementedError('cleanup_ports is not supported for Hyperbolic')
 
 
+def cleanup_custom_multi_network(
+    cluster_name_on_cloud: str,
+    provider_config: Dict[str, Any],
+    failover: bool = False,
+) -> None:
+    """Cleanup custom multi-network. Not supported for Hyperbolic."""
+    raise NotImplementedError('cleanup_custom_multi_network is not supported for Hyperbolic')
+
+
 def open_ports(
     cluster_name_on_cloud: str,
     ports: list,

--- a/sky/provision/hyperbolic/instance.py
+++ b/sky/provision/hyperbolic/instance.py
@@ -420,7 +420,8 @@ def cleanup_custom_multi_network(
     failover: bool = False,
 ) -> None:
     """Cleanup custom multi-network. Not supported for Hyperbolic."""
-    raise NotImplementedError('cleanup_custom_multi_network is not supported for Hyperbolic')
+    raise NotImplementedError(
+        'cleanup_custom_multi_network is not supported for Hyperbolic')
 
 
 def open_ports(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fix prevent cleanup_custom_multi_network error during Hyperbolic cluster teardown

**Problem**
`sky down` on Hyperbolic clusters was calling `cleanup_custom_multi_network()` and failing with `NotImplementedError` because Hyperbolic didn't declare this feature as unsupported.

**Solution**
- Added `CUSTOM_MULTI_NETWORK` to Hyperbolic's unsupported features list
- Implemented cleanup_custom_multi_network() function for proper routing
- Added necessary import in __init__.py

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [x] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
