### PR TITLE
take use_spot into account when comparing Resources

### DIFF
--- a/sky/resources.py
+++ b/sky/resources.py
@@ -1730,6 +1730,8 @@ class Resources:
         if (blocked.accelerators is not None and
                 self.accelerators != blocked.accelerators):
             is_matched = False
+        if blocked.use_spot is not None and self.use_spot != blocked.use_spot:
+            is_matched = False
         return is_matched
 
     def is_empty(self) -> bool:

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -1131,7 +1131,8 @@ def test_priority_to_yaml_and_load(resources_kwargs, expected_yaml_config):
             'use_spot': True
         }, False),
     ])
-def test_should_be_blocked_by_table(r_kwargs, blocked_kwargs, expected):
+def test_should_be_blocked_by(r_kwargs, blocked_kwargs, expected):
+    """Test should_be_blocked_by method."""
     r = Resources(**r_kwargs)
     blocked = Resources(**blocked_kwargs)
     assert r.should_be_blocked_by(blocked) == expected

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -1047,3 +1047,91 @@ def test_priority_to_yaml_and_load(resources_kwargs, expected_yaml_config):
     assert loaded_r.cpus == r.cpus
     if 'accelerators' in expected_yaml_config:
         assert loaded_r.accelerators == r.accelerators
+
+
+@pytest.mark.parametrize(
+    'r_kwargs, blocked_kwargs, expected',
+    [
+        # All fields match
+        ({
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': True
+        }, {
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': True
+        }, True),
+        # use_spot mismatch
+        ({
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': True
+        }, {
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': False
+        }, False),
+        # cloud mismatch
+        ({
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+        }, {
+            'cloud': clouds.GCP(),
+            'instance_type': 'g2-standard-4',
+            'region': 'us-east4',
+            'zone': 'us-east4-c',
+            'accelerators': {
+                'L4': 1
+            },
+        }, False),
+        # instance_type mismatch
+        ({
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.2xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': True
+        }, {
+            'cloud': clouds.AWS(),
+            'instance_type': 'p3.8xlarge',
+            'region': 'us-west-2',
+            'zone': 'us-west-2a',
+            'accelerators': {
+                'V100': 1
+            },
+            'use_spot': True
+        }, False),
+    ])
+def test_should_be_blocked_by_table(r_kwargs, blocked_kwargs, expected):
+    r = Resources(**r_kwargs)
+    blocked = Resources(**blocked_kwargs)
+    assert r.should_be_blocked_by(blocked) == expected


### PR DESCRIPTION
In `RetryingVmProvisioner`, we store a set of `_blocked_resources`, which gets added to each time a resource fails to be provisioned.

This set is used to filter resources that are indicated to be unavailable from previous attempts:
https://github.com/skypilot-org/skypilot/blob/784b2e329d9d58c00caaa94f53d437f6158f8c7d/sky/backends/cloud_vm_ray_backend.py#L1396-L1415

The issue lies in the `should_be_blocked_by()` call. It doesn't take into account the `use_spot` property of the resources.

This means, if let's say you have this resources config:
```yaml
resources:
  # this forces the optimizer to choose g6.4xlarge for both spot and on-demand
  cpus: 16+
  any_of:
    - infra: aws/us-west-2/us-west-2c
      use_spot: true
      accelerators: "L4:1"
    - infra: aws/us-west-2/us-west-2c
      accelerators: "L4:1"
```

and you failed to provision a `g6.4xlarge` spot instance in `aws/us-west-2/us-west-2c` due to AWS running out of capacity, then your on demand `g6.4xlarge` which you expected to fall back to, would be blocked, and we wouldn't try to provision it, although it could've been provisioned successfully.

This PR fixes it by taking into account `use_spot` when comparing the two resources in `should_be_blocked_by`.

I added unit tests in `test_resources.py`.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
