### PR TITLE
Add GCP N4 Instance Support

### DIFF
--- a/sky/catalog/data_fetchers/fetch_gcp.py
+++ b/sky/catalog/data_fetchers/fetch_gcp.py
@@ -198,6 +198,7 @@ SERIES_TO_DESCRIPTION = {
     'n1': 'N1 Predefined Instance',
     'n2': 'N2 Instance',
     'n2d': 'N2D AMD Instance',
+    'n4': 'N4 Instance',
     't2a': 'T2A Arm Instance',
     't2d': 'T2D AMD Instance',
 }

--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -51,6 +51,20 @@ _DEFAULT_INSTANCE_FAMILY = [
     # CPU: Intel Ice Lake 8373C or Cascade Lake 6268CL.
     # Memory: 1 GiB RAM per 1 vCPU;
     'n2-highcpu',
+    # This is the latest general-purpose instance family as of July 2025.
+    # CPU: Intel 5th Gen Xeon Scalable processor (Emerald Rapids).
+    # Memory: 4 GiB RAM per 1 vCPU;
+    'n4-standard',
+    # This is the latest general-purpose instance family
+    # with a higher vCPU to memory ratio as of July 2025.
+    # CPU: Intel 5th Gen Xeon Scalable processor (Emerald Rapids).
+    # Memory: 2 GiB RAM per 1 vCPU;
+    'n4-highcpu',
+    # This is the latest general-purpose instance family
+    # with a lower vCPU to memory ratio as of July 2025.
+    # CPU: Intel 5th Gen Xeon Scalable processor (Emerald Rapids).
+    # Memory: 8 GiB RAM per 1 vCPU;
+    'n4-highmem',
 ]
 # n2 is not allowed for launching GPUs for now.
 _DEFAULT_HOST_VM_FAMILY = (

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -1173,7 +1173,7 @@ class GCP(clouds.Cloud):
             # These series don't support pd-standard, use pd-balanced for LOW.
             _propagate_disk_type(
                 lowest=tier2name[resources_utils.DiskTier.MEDIUM])
-        if instance_type.startswith('a3-ultragpu'):
+        if instance_type.startswith('a3-ultragpu') or series == 'n4':
             # a3-ultragpu instances only support hyperdisk-balanced.
             _propagate_disk_type(all='hyperdisk-balanced')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR introduces support for new GCP N4 instance family, https://github.com/skypilot-org/skypilot/issues/5949.

**Testing**

I've successfully tested the launch of an `n4-standard-2` instance: 
```bash
sky launch --cloud gcp --instance-type n4-standard-2
```

**Output** 
```bash 
The --cloud, --region, and --zone options are deprecated. Use --infra instead.
GCP
---
Considered resources (1 node):
------------------------------------------------------------------------------------
 INFRA                 INSTANCE        vCPUs   Mem(GB)   GPUS   COST ($)   CHOSEN   
------------------------------------------------------------------------------------
 GCP (us-central1-a)   n4-standard-2   2       8         -      0.10          ✔     
------------------------------------------------------------------------------------
Launching a new cluster
```
 
<img width="1174" height="162" alt="image" src="https://github.com/user-attachments/assets/00e4531e-be22-4e87-88d9-bbfb208964af" />

**Important Note**: This change may require an update to the vms.csv catalog file located at `https://skypilot-catalog.s3.us-east-1.amazonaws.com/catalogs/v7/gcp/vms.csv`

cc: @kyuds, @Michaelvll




<!-- CI commands (/-prefixed) can only be triggered by repo members -->
