### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -214,6 +214,8 @@ jobs:
 
       - name: Create release branch
         id: create_release_branch
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_RELEASE }}
         run: |
           RELEASE_VERSION="${{ steps.determine_version.outputs.release_version }}"
           BRANCH_NAME="releases/${RELEASE_VERSION}"
@@ -222,10 +224,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
-          # Check if branch already exists
+          # Check if branch already exists and delete it
           if git ls-remote --exit-code --heads origin ${BRANCH_NAME} > /dev/null 2>&1; then
-            echo "Error: Release branch ${BRANCH_NAME} already exists. Please manually delete the branch first and then rerun the workflow."
-            exit 1
+            echo "Release branch ${BRANCH_NAME} already exists. Deleting it..."
+            git push origin --delete ${BRANCH_NAME}
+            echo "Deleted existing release branch: ${BRANCH_NAME}"
           fi
 
           # Create release branch

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -315,6 +315,7 @@ jobs:
 
   create-pr:
     needs: [release-build, smoke-tests, quicktest-core, release-tests]
+    if: always() && needs.release-build.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -114,6 +114,8 @@ jobs:
           fetch-depth: 0
 
       - name: Create and push tag
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_RELEASE }}
         run: |
           VERSION="${{ needs.extract-version.outputs.version }}"
           git config --global user.name "GitHub Action"
@@ -128,6 +130,7 @@ jobs:
           tag_name: "v${{ needs.extract-version.outputs.version }}"
           generate_release_notes: true
           draft: true
+          token: ${{ secrets.GH_PAT_FOR_RELEASE }}
 
   cleanup-branches:
     needs: extract-version
@@ -138,9 +141,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT_FOR_RELEASE }}
 
       - name: Delete branches
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_FOR_RELEASE }}
         run: |
           VERSION="${{ needs.extract-version.outputs.version }}"
           git config --global user.name "GitHub Action"
@@ -153,4 +158,13 @@ jobs:
             git push origin --delete ${TEST_BRANCH}
           else
             echo "Test branch ${TEST_BRANCH} does not exist, skipping"
+          fi
+
+          # Check if release branch exists and delete it
+          RELEASE_BRANCH="releases/${VERSION}"
+          if git ls-remote --heads origin ${RELEASE_BRANCH} | grep ${RELEASE_BRANCH}; then
+            echo "Deleting release branch: ${RELEASE_BRANCH}"
+            git push origin --delete ${RELEASE_BRANCH}
+          else
+            echo "Release branch ${RELEASE_BRANCH} does not exist, skipping"
           fi


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

* Use PAT to delete branch if release fail
* Use PAT to create tag and release

[Tested in my personal repo](https://github.com/zpoint/skypilot/actions/runs/16257431767/job/45896279833)


Need to update `content` with Read and Write access other @Michaelvll 

<img width="1680" height="1737" alt="image" src="https://github.com/user-attachments/assets/70166df6-9a71-4af9-b805-b8fac93fd1b4" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
