### PR TITLE
S3 Arm64 mount fix

### DIFF
--- a/docs/source/reference/storage.rst
+++ b/docs/source/reference/storage.rst
@@ -161,6 +161,12 @@ its performance requirements and size of the data.
     the symbolic links are directly copied, not their target data.
     The targets must be separately mounted or else the symlinks may break.
 
+.. note::
+    **Architecture compatibility**: S3 storage mounting (including S3-compatible services like 
+    Cloudflare R2 and Nebius) works on all architectures including ARM64 (e.g., Apple Silicon, 
+    AWS Graviton). SkyPilot automatically uses the optimal mounting tool for each architecture: 
+    goofys for x86_64 and rclone for ARM64.
+
 .. _mount_cached_mode_in_detail:
 
 MOUNT_CACHED mode in detail

--- a/sky/data/mounting_utils.py
+++ b/sky/data/mounting_utils.py
@@ -39,19 +39,32 @@ _GOOFYS_WRAPPER = ('$(if [ -S /dev/log ] ; then '
 
 
 def get_s3_mount_install_cmd() -> str:
-    """Returns a command to install S3 mount utility goofys."""
+    """Returns command for basic S3 mounting (goofys by default, rclone for
+    ARM64)."""
     # TODO(aylei): maintain our goofys fork under skypilot-org
-    install_cmd = ('ARCH=$(uname -m) && '
-                   'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
-                   '  echo "goofys is not supported on $ARCH" && '
-                   f'  exit {exceptions.ARCH_NOT_SUPPORTED_EXIT_CODE}; '
-                   'else '
-                   '  ARCH_SUFFIX="amd64"; '
-                   'fi && '
-                   'sudo wget -nc https://github.com/aylei/goofys/'
-                   'releases/download/0.24.0-aylei-upstream/goofys '
-                   '-O /usr/local/bin/goofys && '
-                   'sudo chmod 755 /usr/local/bin/goofys')
+    install_cmd = (
+        'ARCH=$(uname -m) && '
+        'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+        # Use rclone for ARM64 since goofys doesn't support it
+        # Extract core rclone installation logic without redundant ARCH check
+        '  ARCH_SUFFIX="arm" && '
+        f'  (which dpkg > /dev/null 2>&1 && (which rclone > /dev/null || '
+        f'(cd ~ > /dev/null && curl -O https://downloads.rclone.org/'
+        f'{RCLONE_VERSION}/rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb '
+        f'&& sudo dpkg -i rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb '
+        f'&& rm -f rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb))) || '
+        f'(which rclone > /dev/null || (cd ~ > /dev/null && curl -O '
+        f'https://downloads.rclone.org/{RCLONE_VERSION}/'
+        f'rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm && '
+        f'sudo yum --nogpgcheck install '
+        f'rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm -y && '
+        f'rm -f rclone-{RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm)); '
+        'else '
+        '  sudo wget -nc https://github.com/aylei/goofys/'
+        'releases/download/0.24.0-aylei-upstream/goofys '
+        '-O /usr/local/bin/goofys && '
+        'sudo chmod 755 /usr/local/bin/goofys; '
+        'fi')
     return install_cmd
 
 
@@ -59,15 +72,30 @@ def get_s3_mount_install_cmd() -> str:
 def get_s3_mount_cmd(bucket_name: str,
                      mount_path: str,
                      _bucket_sub_path: Optional[str] = None) -> str:
-    """Returns a command to mount an S3 bucket using goofys."""
+    """Returns a command to mount an S3 bucket (goofys by default, rclone for
+    ARM64)"""
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
     else:
         _bucket_sub_path = f':{_bucket_sub_path}'
-    mount_cmd = (f'{_GOOFYS_WRAPPER} -o allow_other '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    # Use rclone for ARM64 architectures since goofys doesn't support them
+    arch_check = 'ARCH=$(uname -m) && '
+    rclone_mount = (
+        f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
+        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        '--daemon --allow-other')
+    goofys_mount = (f'{_GOOFYS_WRAPPER} -o allow_other '
+                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    mount_cmd = (f'{arch_check}'
+                 f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                 f'  {rclone_mount}; '
+                 f'else '
+                 f'  {goofys_mount}; '
+                 f'fi')
     return mount_cmd
 
 
@@ -76,17 +104,33 @@ def get_nebius_mount_cmd(nebius_profile_name: str,
                          endpoint_url: str,
                          mount_path: str,
                          _bucket_sub_path: Optional[str] = None) -> str:
-    """Returns a command to install Nebius mount utility goofys."""
+    """Returns a command to mount Nebius bucket (goofys by default, rclone for
+    ARM64)."""
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
     else:
         _bucket_sub_path = f':{_bucket_sub_path}'
-    mount_cmd = (f'AWS_PROFILE={nebius_profile_name} {_GOOFYS_WRAPPER} '
-                 '-o allow_other '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'--endpoint {endpoint_url} '
-                 f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    # Use rclone for ARM64 architectures since goofys doesn't support them
+    arch_check = 'ARCH=$(uname -m) && '
+    rclone_mount = (
+        f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
+        f'AWS_PROFILE={nebius_profile_name} '
+        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'--s3-endpoint {endpoint_url} --daemon --allow-other')
+    goofys_mount = (f'AWS_PROFILE={nebius_profile_name} {_GOOFYS_WRAPPER} '
+                    '-o allow_other '
+                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                    f'--endpoint {endpoint_url} '
+                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    mount_cmd = (f'{arch_check}'
+                 f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                 f'  {rclone_mount}; '
+                 f'else '
+                 f'  {goofys_mount}; '
+                 f'fi')
     return mount_cmd
 
 
@@ -236,18 +280,35 @@ def get_r2_mount_cmd(r2_credentials_path: str,
                      bucket_name: str,
                      mount_path: str,
                      _bucket_sub_path: Optional[str] = None) -> str:
-    """Returns a command to install R2 mount utility goofys."""
+    """Returns a command to mount R2 bucket (goofys by default, rclone for
+    ARM64)."""
     if _bucket_sub_path is None:
         _bucket_sub_path = ''
     else:
         _bucket_sub_path = f':{_bucket_sub_path}'
-    mount_cmd = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
-                 f'AWS_PROFILE={r2_profile_name} {_GOOFYS_WRAPPER} '
-                 '-o allow_other '
-                 f'--stat-cache-ttl {_STAT_CACHE_TTL} '
-                 f'--type-cache-ttl {_TYPE_CACHE_TTL} '
-                 f'--endpoint {endpoint_url} '
-                 f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    # Use rclone for ARM64 architectures since goofys doesn't support them
+    arch_check = 'ARCH=$(uname -m) && '
+    rclone_mount = (
+        f'{FUSERMOUNT3_SOFT_LINK_CMD} && '
+        f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
+        f'AWS_PROFILE={r2_profile_name} '
+        f'rclone mount :s3:{bucket_name}{_bucket_sub_path} {mount_path} '
+        f'--s3-endpoint {endpoint_url} --daemon --allow-other')
+    goofys_mount = (f'AWS_SHARED_CREDENTIALS_FILE={r2_credentials_path} '
+                    f'AWS_PROFILE={r2_profile_name} {_GOOFYS_WRAPPER} '
+                    '-o allow_other '
+                    f'--stat-cache-ttl {_STAT_CACHE_TTL} '
+                    f'--type-cache-ttl {_TYPE_CACHE_TTL} '
+                    f'--endpoint {endpoint_url} '
+                    f'{bucket_name}{_bucket_sub_path} {mount_path}')
+
+    mount_cmd = (f'{arch_check}'
+                 f'if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then '
+                 f'  {rclone_mount}; '
+                 f'else '
+                 f'  {goofys_mount}; '
+                 f'fi')
     return mount_cmd
 
 

--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -57,8 +57,8 @@ def test_file_mounts(generic_cloud: str):
     extra_flags = ''
     if generic_cloud in 'kubernetes':
         # Kubernetes does not support multi-node
-        # NOTE: This test will fail if you have a Kubernetes cluster running on
-        #  arm64 (e.g., Apple Silicon) since goofys does not work on arm64.
+        # NOTE: S3 mounting now works on all architectures including ARM64
+        #  (uses rclone fallback for ARM64, goofys for x86_64).
         extra_flags = '--num-nodes 1'
     test_commands = [
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
@@ -282,8 +282,8 @@ def test_azure_storage_mounts_with_stop():
 @pytest.mark.kubernetes
 def test_kubernetes_storage_mounts():
     # Tests bucket mounting on k8s, assuming S3 is configured.
-    # This test will fail if run on non x86_64 architecture, since goofys is
-    # built for x86_64 only.
+    # S3 mounting now works on all architectures including ARM64
+    # (uses rclone fallback for ARM64, goofys for x86_64).
     name = smoke_tests_utils.get_cluster_name()
     storage_name = f'sky-test-{int(time.time())}'
 

--- a/tests/unit_tests/test_mounting_utils_arm64.py
+++ b/tests/unit_tests/test_mounting_utils_arm64.py
@@ -1,0 +1,250 @@
+"""Unit tests for ARM64 mounting utilities in sky.data.mounting_utils."""
+
+import unittest
+from unittest import mock
+
+from sky.data import mounting_utils
+
+
+class TestMountingUtilsArm64(unittest.TestCase):
+    """Test ARM64-specific functionality in mounting utilities."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.bucket_name = 'test-bucket'
+        self.mount_path = '/mnt/test'
+        self.bucket_sub_path = 'sub/path'
+
+    @mock.patch('platform.machine')
+    def test_s3_mount_install_cmd_arm64(self, mock_machine):
+        """Test S3 mount install command for ARM64 architecture."""
+        mock_machine.return_value = 'aarch64'
+
+        cmd = mounting_utils.get_s3_mount_install_cmd()
+
+        # Should contain architecture detection
+        self.assertIn('ARCH=$(uname -m)', cmd)
+        # Should contain ARM64 conditional logic
+        self.assertIn('if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]',
+                      cmd)
+        # Should install rclone for ARM64
+        self.assertIn('rclone', cmd)
+        self.assertIn('ARCH_SUFFIX="arm"', cmd)
+        # Should contain fallback for x86_64 (goofys)
+        self.assertIn('goofys', cmd)
+
+    @mock.patch('platform.machine')
+    def test_s3_mount_install_cmd_x86_64(self, mock_machine):
+        """Test S3 mount install command for x86_64 architecture."""
+        mock_machine.return_value = 'x86_64'
+
+        cmd = mounting_utils.get_s3_mount_install_cmd()
+
+        # Should contain architecture detection
+        self.assertIn('ARCH=$(uname -m)', cmd)
+        # Should still contain ARM64 conditional for runtime detection
+        self.assertIn('if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]',
+                      cmd)
+        # Should contain goofys installation in else branch
+        self.assertIn('goofys', cmd)
+
+    def test_s3_mount_cmd_structure(self):
+        """Test S3 mount command structure for ARM64 support."""
+        cmd = mounting_utils.get_s3_mount_cmd(self.bucket_name, self.mount_path)
+
+        # Should contain architecture detection
+        self.assertIn('ARCH=$(uname -m)', cmd)
+        # Should contain ARM64 conditional
+        self.assertIn('if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]',
+                      cmd)
+        # Should contain rclone mount command for ARM64
+        self.assertIn('rclone mount :s3:', cmd)
+        self.assertIn('--daemon --allow-other', cmd)
+        # Should contain goofys command for x86_64
+        self.assertIn('goofys', cmd)
+        self.assertIn('--stat-cache-ttl', cmd)
+        self.assertIn('--type-cache-ttl', cmd)
+
+    def test_s3_mount_cmd_with_sub_path(self):
+        """Test S3 mount command with bucket sub path."""
+        cmd = mounting_utils.get_s3_mount_cmd(self.bucket_name, self.mount_path,
+                                              self.bucket_sub_path)
+
+        # Should include sub path in both rclone and goofys commands
+        expected_sub_path = f':{self.bucket_sub_path}'
+        self.assertIn(f':s3:{self.bucket_name}{expected_sub_path}', cmd)
+        self.assertIn(f'{self.bucket_name}{expected_sub_path}', cmd)
+
+    def test_s3_mount_cmd_without_sub_path(self):
+        """Test S3 mount command without bucket sub path."""
+        cmd = mounting_utils.get_s3_mount_cmd(self.bucket_name, self.mount_path)
+
+        # Should not include colon prefix when no sub path
+        self.assertIn(f':s3:{self.bucket_name}', cmd)
+        self.assertIn(f'{self.bucket_name} {self.mount_path}', cmd)
+
+    def test_nebius_mount_cmd_structure(self):
+        """Test Nebius mount command structure for ARM64 support."""
+        profile_name = 'test-profile'
+        endpoint_url = 'https://storage.test.com'
+
+        cmd = mounting_utils.get_nebius_mount_cmd(profile_name,
+                                                  self.bucket_name,
+                                                  endpoint_url, self.mount_path)
+
+        # Should contain architecture detection
+        self.assertIn('ARCH=$(uname -m)', cmd)
+        # Should contain ARM64 conditional
+        self.assertIn('if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]',
+                      cmd)
+        # Should contain rclone mount with AWS profile and endpoint
+        self.assertIn(f'AWS_PROFILE={profile_name}', cmd)
+        self.assertIn(f'--s3-endpoint {endpoint_url}', cmd)
+        self.assertIn('rclone mount :s3:', cmd)
+        # Should contain goofys command with AWS profile and endpoint
+        self.assertIn('goofys', cmd)
+        self.assertIn(f'--endpoint {endpoint_url}', cmd)
+
+    def test_nebius_mount_cmd_with_sub_path(self):
+        """Test Nebius mount command with bucket sub path."""
+        profile_name = 'test-profile'
+        endpoint_url = 'https://storage.test.com'
+
+        cmd = mounting_utils.get_nebius_mount_cmd(profile_name,
+                                                  self.bucket_name,
+                                                  endpoint_url, self.mount_path,
+                                                  self.bucket_sub_path)
+
+        # Should include sub path in both rclone and goofys commands
+        expected_sub_path = f':{self.bucket_sub_path}'
+        self.assertIn(f':s3:{self.bucket_name}{expected_sub_path}', cmd)
+        self.assertIn(f'{self.bucket_name}{expected_sub_path}', cmd)
+
+    def test_r2_mount_cmd_structure(self):
+        """Test R2 mount command structure for ARM64 support."""
+        credentials_path = '/path/to/credentials'
+        profile_name = 'test-profile'
+        endpoint_url = 'https://r2.test.com'
+
+        cmd = mounting_utils.get_r2_mount_cmd(credentials_path, profile_name,
+                                              endpoint_url, self.bucket_name,
+                                              self.mount_path)
+
+        # Should contain architecture detection
+        self.assertIn('ARCH=$(uname -m)', cmd)
+        # Should contain ARM64 conditional
+        self.assertIn('if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]',
+                      cmd)
+        # Should contain rclone mount with credentials and endpoint
+        self.assertIn(f'AWS_SHARED_CREDENTIALS_FILE={credentials_path}', cmd)
+        self.assertIn(f'AWS_PROFILE={profile_name}', cmd)
+        self.assertIn(f'--s3-endpoint {endpoint_url}', cmd)
+        self.assertIn('rclone mount :s3:', cmd)
+        # Should contain goofys command with credentials and endpoint
+        self.assertIn('goofys', cmd)
+        self.assertIn(f'--endpoint {endpoint_url}', cmd)
+
+    def test_r2_mount_cmd_with_sub_path(self):
+        """Test R2 mount command with bucket sub path."""
+        credentials_path = '/path/to/credentials'
+        profile_name = 'test-profile'
+        endpoint_url = 'https://r2.test.com'
+
+        cmd = mounting_utils.get_r2_mount_cmd(credentials_path, profile_name,
+                                              endpoint_url, self.bucket_name,
+                                              self.mount_path,
+                                              self.bucket_sub_path)
+
+        # Should include sub path in both rclone and goofys commands
+        expected_sub_path = f':{self.bucket_sub_path}'
+        self.assertIn(f':s3:{self.bucket_name}{expected_sub_path}', cmd)
+        self.assertIn(f'{self.bucket_name}{expected_sub_path}', cmd)
+
+    def test_mount_binary_detection_rclone(self):
+        """Test mount binary detection for rclone commands."""
+        # Test with rclone command
+        rclone_cmd = 'rclone mount :s3:bucket /mnt/test --daemon'
+        binary = mounting_utils._get_mount_binary(rclone_cmd)
+        self.assertEqual(binary, 'rclone')
+
+    def test_mount_binary_detection_goofys(self):
+        """Test mount binary detection for goofys commands."""
+        # Test with goofys command
+        goofys_cmd = 'goofys -o allow_other bucket /mnt/test'
+        binary = mounting_utils._get_mount_binary(goofys_cmd)
+        self.assertEqual(binary, 'goofys')
+
+    def test_fusermount3_soft_link_in_rclone_commands(self):
+        """Test that rclone commands include fusermount3 soft link setup."""
+        # Test S3 mount command
+        s3_cmd = mounting_utils.get_s3_mount_cmd(self.bucket_name,
+                                                 self.mount_path)
+        self.assertIn(mounting_utils.FUSERMOUNT3_SOFT_LINK_CMD, s3_cmd)
+
+        # Test Nebius mount command
+        nebius_cmd = mounting_utils.get_nebius_mount_cmd(
+            'profile', self.bucket_name, 'https://endpoint.com',
+            self.mount_path)
+        self.assertIn(mounting_utils.FUSERMOUNT3_SOFT_LINK_CMD, nebius_cmd)
+
+        # Test R2 mount command
+        r2_cmd = mounting_utils.get_r2_mount_cmd('/creds', 'profile',
+                                                 'https://endpoint.com',
+                                                 self.bucket_name,
+                                                 self.mount_path)
+        self.assertIn(mounting_utils.FUSERMOUNT3_SOFT_LINK_CMD, r2_cmd)
+
+    def test_rclone_version_consistency(self):
+        """Test that all mount functions use consistent rclone version."""
+        # Test S3 install command uses RCLONE_VERSION
+        s3_install = mounting_utils.get_s3_mount_install_cmd()
+        self.assertIn(mounting_utils.RCLONE_VERSION, s3_install)
+
+        # Test general rclone install command
+        rclone_install = mounting_utils.get_rclone_install_cmd()
+        self.assertIn(mounting_utils.RCLONE_VERSION, rclone_install)
+
+    def test_mount_script_generation_with_rclone(self):
+        """Test mount script generation includes proper rclone binary detection."""
+        mount_cmd = 'rclone mount :s3:bucket /mnt/test --daemon'
+        install_cmd = 'echo "install rclone"'
+
+        script = mounting_utils.get_mounting_script(self.mount_path, mount_cmd,
+                                                    install_cmd)
+
+        # Should set MOUNT_BINARY to rclone
+        self.assertIn('MOUNT_BINARY=rclone', script)
+        # Should check for rclone installation
+        self.assertIn('[ -x "$(command -v rclone)" ]', script)
+
+    def test_mount_script_generation_with_goofys(self):
+        """Test mount script generation includes proper goofys binary detection."""
+        mount_cmd = 'goofys -o allow_other bucket /mnt/test'
+        install_cmd = 'echo "install goofys"'
+
+        script = mounting_utils.get_mounting_script(self.mount_path, mount_cmd,
+                                                    install_cmd)
+
+        # Should set MOUNT_BINARY to goofys
+        self.assertIn('MOUNT_BINARY=goofys', script)
+        # Should check for goofys installation
+        self.assertIn('[ -x "$(command -v goofys)" ]', script)
+
+    def test_architecture_specific_package_selection(self):
+        """Test that ARM and x86_64 use different package suffixes."""
+        install_cmd = mounting_utils.get_s3_mount_install_cmd()
+
+        # ARM64 should use "arm" suffix for rclone
+        self.assertIn('ARCH_SUFFIX="arm"', install_cmd)
+        # Should have dpkg installation for ARM with arm suffix
+        self.assertIn(
+            f'rclone-{mounting_utils.RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.deb',
+            install_cmd)
+        # Should have yum installation for ARM with arm suffix
+        self.assertIn(
+            f'rclone-{mounting_utils.RCLONE_VERSION}-linux-${{ARCH_SUFFIX}}.rpm',
+            install_cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
  Fix ARM64 mounting issues and improve storage system compatibility

  This addresses mounting problems specific to ARM64 architecture and includes updates to storage
  documentation for better cross-platform support.

For AWS or S3 compatible platform, use `rclone` if architecture is ARM64. Otherwise, default to goofys.




<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
Added unit test for arm 64 mounting.

closes #5484 
