### PR TITLE
[API server] Rebuild broken pool

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -491,6 +491,9 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
                 func=event.run_event,
                 schedule_type=requests_lib.ScheduleType.SHORT,
                 is_skypilot_system=True,
+                # Request deamon should be retried if the process pool is
+                # broken.
+                retryable=True,
             )
         except exceptions.RequestAlreadyExistsError:
             # Lifespan will be executed in each uvicorn worker process, we

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -171,7 +171,7 @@ def test_burstable_executor_pool_recovery():
         # behavior across all instances
         original_submit = PoolExecutor.submit
 
-        def mock_submit(self, *args, **kwargs):
+        def mock_submit(self, fn, *args, **kwargs):
             nonlocal submit_call_count
             submit_call_count += 1
             if submit_call_count == 1:
@@ -181,11 +181,11 @@ def test_burstable_executor_pool_recovery():
             else:
                 # Subsequent calls should work normally
                 # Call the original submit method
-                return original_submit(self, *args, **kwargs)
+                return original_submit(self, fn, *args, **kwargs)
 
         with unittest.mock.patch.object(PoolExecutor,
                                         'submit',
-                                        side_effect=mock_submit):
+                                        new=mock_submit):
             # This should trigger the pool recovery logic in
             # _submit_to_guaranteed_pool
             future = executor.submit_until_success(dummy_task)

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -1,6 +1,8 @@
 """Unit tests for sky/server/requests/process.py."""
 from concurrent.futures import Future
+import concurrent.futures.process
 import time
+import unittest.mock
 
 import pytest
 
@@ -151,5 +153,53 @@ def test_burstable_executor_no_burst():
         executor.submit_until_success(dummy_task)
         # Should queue to guaranteed pool even when busy
         executor.submit_until_success(dummy_task)
+    finally:
+        executor.shutdown()
+
+
+def test_burstable_executor_pool_recovery():
+    """Test BurstableExecutor recovery from BrokenProcessPool exception."""
+
+    executor = BurstableExecutor(garanteed_workers=1, burst_workers=0)
+
+    try:
+        # Store reference to original executor
+        original_executor = executor._executor
+        submit_call_count = 0
+
+        # Mock the PoolExecutor.submit method at class level to control
+        # behavior across all instances
+        original_submit = PoolExecutor.submit
+
+        def mock_submit(self, *args, **kwargs):
+            nonlocal submit_call_count
+            submit_call_count += 1
+            if submit_call_count == 1:
+                # First call raises BrokenProcessPool to simulate pool failure
+                raise concurrent.futures.process.BrokenProcessPool(
+                    "Simulated process pool failure")
+            else:
+                # Subsequent calls should work normally
+                # Call the original submit method
+                return original_submit(self, *args, **kwargs)
+
+        with unittest.mock.patch.object(PoolExecutor,
+                                        'submit',
+                                        side_effect=mock_submit):
+            # This should trigger the pool recovery logic in
+            # _submit_to_guaranteed_pool
+            future = executor.submit_until_success(dummy_task)
+            result = future.result(timeout=5.0)
+
+            # Verify the task completed successfully despite initial failure
+            assert result is True
+
+            # Verify that submit was called at least twice
+            # (initial failure + successful retry)
+            assert submit_call_count >= 2
+
+            # Verify that a new executor was created after the failure
+            assert executor._executor is not original_executor
+
     finally:
         executor.shutdown()

--- a/tests/unit_tests/test_sky/server/requests/test_process.py
+++ b/tests/unit_tests/test_sky/server/requests/test_process.py
@@ -183,8 +183,7 @@ def test_burstable_executor_pool_recovery():
                 # Call the original submit method
                 return original_submit(self, fn, *args, **kwargs)
 
-        with unittest.mock.patch.object(PoolExecutor,
-                                        'submit',
+        with unittest.mock.patch.object(PoolExecutor, 'submit',
                                         new=mock_submit):
             # This should trigger the pool recovery logic in
             # _submit_to_guaranteed_pool


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR fixes an issue that a disrupted executor process will break the entire process pool:

- **Previously**: when a executor process exited (e.g. OOM killed), the entire process will be broken and neither user requests nor background daemons can proceed;
- **PR**: when the pool is broken, rebuild a new pool to replace the broken pool. Background daemon and retryable request will be retried.

User will see the following logs when this issue happens:

```
Error processing request: [...] [concurrent.futures.process.BrokenProcessPool[] A child process terminated abruptly, the process pool is not usable anymore
```

Test:

```bash
# Simulate an OOM kill
$ kill -9 14749
# Verify the daemons are retried and pool is rebuilt
$ cat  ~/.sky/api_server/server.log
...
Process SpawnProcess-442:
Process SpawnProcess-448:
Process SpawnProcess-444:
KeyboardInterrupt
KeyboardInterrupt
Traceback (most recent call last):
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/concurrent/futures/process.py", line 240, in _process_worker
    call_item = call_queue.get(block=True)
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/multiprocessing/queues.py", line 102, in get
    with self._rlock:
  File "/opt/homebrew/anaconda3/envs/sky/lib/python3.10/multiprocessing/synchronize.py", line 95, in __enter__
    return self._semlock.__enter__()
  File "/Users/aylei/repo/skypilot-org/skypilot/sky/server/requests/executor.py", line 342, in _sigterm_handler
    raise KeyboardInterrupt
KeyboardInterrupt
E 07-14 21:26:25 executor.py:216] Request skypilot-status-refresh-daemon failed to get processed [concurrent.futures.process.BrokenProcessPool] A process in the process pool was terminated abruptly while the future was running or pending.
E 07-14 21:26:25 executor.py:216] Request skypilot-volume-status-refresh-daemon failed to get processed [concurrent.futures.process.BrokenProcessPool] A process in the process pool was terminated abruptly while the future was running or pending.
I 07-14 21:26:25 executor.py:184] [Worker(schedule_type=short)] Submitting request: skypilot-status-refresh-daemon
W 07-14 21:26:25 process.py:279] The guaranteed pool is broken, replacing the pool and retrying. Error: A child process terminated abruptly, the process pool is not usable anymore
I 07-14 21:26:25 executor.py:198] [Worker(schedule_type=short)] Submitted request: skypilot-status-refresh-daemon
I 07-14 21:26:25 executor.py:184] [Worker(schedule_type=short)] Submitting request: skypilot-volume-status-refresh-daemon
I 07-14 21:26:25 executor.py:198] [Worker(schedule_type=short)] Submitted request: skypilot-volume-status-refresh-daemon
I 07-14 21:26:26 executor.py:361] Running request skypilot-status-refresh-daemon with pid 19948
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
