### PR TITLE
Move away from legacy Vast api key file path

### DIFF
--- a/docs/source/getting-started/installation.rst
+++ b/docs/source/getting-started/installation.rst
@@ -357,7 +357,8 @@ Vast
 .. code-block:: shell
 
   pip install "vastai-sdk>=0.1.12"
-  echo "<your_api_key_here>" > ~/.vast_api_key
+  mkdir -p ~/.config/vastai
+  echo "<your_api_key_here>" > ~/.config/vastai/vast_api_key
 
 RunPod
 ~~~~~~~~~~

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -260,7 +260,8 @@ class Vast(clouds.Cloud):
                     'error \n'  # First line is indented by 4 spaces
                     '    Credentials can be set up by running: \n'
                     '        $ pip install vastai\n'
-                    '        $ echo [key] > ~/.vast_api_key\n'
+                    '        $ mkdir -p ~/.config/vastai\n'
+                    '        $ echo [key] > ~/.config/vastai/vast_api_key\n'
                     '    For more information, see https://skypilot.readthedocs.io/en/latest/getting-started/installation.html#vast'  # pylint: disable=line-too-long
                 )
 


### PR DESCRIPTION
We tell our users to write to `~/.vast_api_key`. But it looks like that path is marked as legacy by [vast-sdk](https://github.com/vast-ai/vast-sdk), and instead it gets copied to `~/.config/vastai/vast_api_key`. 

https://github.com/vast-ai/vast-sdk/blob/6daa1fb63483e70cfd7bc6fc93204166622f2812/vastai_sdk/vast.py#L228-L233

The problem is the copying only happens once, which is when `~/.config/vastai/vast_api_key` does not exist.

So it won't sync again next time when you write to `~/.vast_api_key`, unless you delete `~/.config/vastai/vast_api_key`. This could be confusing as it may seem like the new API key is not being read by the API server.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
