### PR TITLE
[Perf] Remote API server checking network connection times out slowly

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1648,7 +1648,8 @@ def check_network_connection():
                 return
             except (requests.Timeout, requests.exceptions.ConnectionError):
                 continue
-    # If we get here, all IPs failed in this retry round
+    # If we get here, all IPs failed
+    # Assume network connection is down
     raise exceptions.NetworkError('Could not refresh the cluster. '
                                     'Network seems down.')
 

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -104,7 +104,7 @@ WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 # Fixed IP addresses are used to avoid DNS lookup blocking the check, for
 # machine with no internet connection.
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
-_TEST_IP_LIST = ['https://8.8.8.8', 'https://1.1.1.1']
+_TEST_IP_LIST = ['https://1.1.1.1', 'https://8.8.8.8']
 
 # Allow each CPU thread take 2 tasks.
 # Note: This value cannot be too small, otherwise OOM issue may occur.
@@ -1635,18 +1635,23 @@ def get_node_ips(cluster_yaml: str,
 
 def check_network_connection():
     # Tolerate 3 retries as it is observed that connections can fail.
-    adapter = adapters.HTTPAdapter(max_retries=retry_lib.Retry(total=3))
     http = requests.Session()
-    http.mount('https://', adapter)
-    http.mount('http://', adapter)
-    for i, ip in enumerate(_TEST_IP_LIST):
-        try:
-            http.head(ip, timeout=1)
-            return
-        except (requests.Timeout, requests.exceptions.ConnectionError) as e:
-            if i == len(_TEST_IP_LIST) - 1:
-                raise exceptions.NetworkError('Could not refresh the cluster. '
-                                              'Network seems down.') from e
+    http.mount('https://', adapters.HTTPAdapter())
+    http.mount('http://', adapters.HTTPAdapter())
+    
+    # Alternate between IPs on each retry
+    max_retries = 3
+    for retry in range(max_retries):
+        for ip in _TEST_IP_LIST:
+            try:
+                http.head(ip, timeout=1)
+                return
+            except (requests.Timeout, requests.exceptions.ConnectionError):
+                continue  # Try next IP
+        # If we get here, all IPs failed in this retry round
+        if retry == max_retries:
+            raise exceptions.NetworkError('Could not refresh the cluster. '
+                                          'Network seems down.')
 
 
 @timeline.event
@@ -2610,7 +2615,7 @@ def is_controller_accessible(
           need_connection_check):
         # Check ssh connection if (1) controller is in INIT state, or (2) we failed to fetch the
         # status, both of which can happen when controller's status lock is held by another `sky jobs launch` or
-        # `sky serve up`. If we have controller's head_ip available and it is ssh-reachable,
+        # `sky serve up`. If we have controller's head_ip available and it is ssh-reachable,
         # we can allow access to the controller.
         ssh_credentials = ssh_credential_from_yaml(handle.cluster_yaml,
                                                    handle.docker_user,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1641,17 +1641,16 @@ def check_network_connection():
     
     # Alternate between IPs on each retry
     max_retries = 3
-    for retry in range(max_retries):
+    for _ in range(max_retries):
         for ip in _TEST_IP_LIST:
             try:
                 http.head(ip, timeout=1)
                 return
             except (requests.Timeout, requests.exceptions.ConnectionError):
-                continue  # Try next IP
-        # If we get here, all IPs failed in this retry round
-        if retry == max_retries:
-            raise exceptions.NetworkError('Could not refresh the cluster. '
-                                          'Network seems down.')
+                continue
+    # If we get here, all IPs failed in this retry round
+    raise exceptions.NetworkError('Could not refresh the cluster. '
+                                    'Network seems down.')
 
 
 @timeline.event

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -104,7 +104,7 @@ WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 # Fixed IP addresses are used to avoid DNS lookup blocking the check, for
 # machine with no internet connection.
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
-_TEST_IP_LIST = ['https://1.1.1.1', 'https://8.8.8.8']
+_TEST_IP_LIST = ['https://8.8.8.8', 'https://1.1.1.1']
 
 # Allow each CPU thread take 2 tasks.
 # Note: This value cannot be too small, otherwise OOM issue may occur.
@@ -1641,7 +1641,7 @@ def check_network_connection():
     http.mount('http://', adapter)
     for i, ip in enumerate(_TEST_IP_LIST):
         try:
-            http.head(ip, timeout=3)
+            http.head(ip, timeout=1)
             return
         except (requests.Timeout, requests.exceptions.ConnectionError) as e:
             if i == len(_TEST_IP_LIST) - 1:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -1641,17 +1641,22 @@ def check_network_connection():
     
     # Alternate between IPs on each retry
     max_retries = 3
+    timeout = 0.5
+    
     for _ in range(max_retries):
         for ip in _TEST_IP_LIST:
             try:
-                http.head(ip, timeout=1)
+                http.head(ip, timeout=timeout)
                 return
             except (requests.Timeout, requests.exceptions.ConnectionError):
                 continue
+        
+        timeout *= 2  # Double the timeout for next retry
+    
     # If we get here, all IPs failed
     # Assume network connection is down
     raise exceptions.NetworkError('Could not refresh the cluster. '
-                                    'Network seems down.')
+                                  'Network seems down.')
 
 
 @timeline.event

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -104,7 +104,7 @@ WAIT_HEAD_NODE_IP_MAX_ATTEMPTS = 3
 # Fixed IP addresses are used to avoid DNS lookup blocking the check, for
 # machine with no internet connection.
 # Refer to: https://stackoverflow.com/questions/3764291/how-can-i-see-if-theres-an-available-and-active-network-connection-in-python # pylint: disable=line-too-long
-_TEST_IP_LIST = ['https://1.1.1.1', 'https://8.8.8.8']
+_TEST_IP_LIST = ['https://8.8.8.8', 'https://1.1.1.1']
 
 # Allow each CPU thread take 2 tasks.
 # Note: This value cannot be too small, otherwise OOM issue may occur.
@@ -1638,11 +1638,11 @@ def check_network_connection():
     http = requests.Session()
     http.mount('https://', adapters.HTTPAdapter())
     http.mount('http://', adapters.HTTPAdapter())
-    
+
     # Alternate between IPs on each retry
     max_retries = 3
     timeout = 0.5
-    
+
     for _ in range(max_retries):
         for ip in _TEST_IP_LIST:
             try:
@@ -1650,9 +1650,9 @@ def check_network_connection():
                 return
             except (requests.Timeout, requests.exceptions.ConnectionError):
                 continue
-        
+
         timeout *= 2  # Double the timeout for next retry
-    
+
     # If we get here, all IPs failed
     # Assume network connection is down
     raise exceptions.NetworkError('Could not refresh the cluster. '


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

<img width="1119" height="322" alt="image" src="https://github.com/user-attachments/assets/48b87f0d-3f48-46ca-a45a-0d8b1272871f" />

Sometimes for `sky status` for a remote api server, it checks the network connection by pinging endpoints. It tests two endpoints with 3 retries each for a three second timeout. This means that `https://1.1.1.1` is tested for 9 seconds before testing google's endpoint `https://8.8.8.8`. This PR swaps the order (google's endpoint first) and then the timeout is reduced to 1s instead of 3s. This was tested without any jobs running.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
