### PR TITLE
Enable smoke-test mount cached mode on kubernetes

### DIFF
--- a/tests/smoke_tests/test_mount_and_storage.py
+++ b/tests/smoke_tests/test_mount_and_storage.py
@@ -178,13 +178,15 @@ def _storage_mounts_commands_generator(f: TextIO, cluster_name: str,
         # the mounted directory
         f'sky exec {cluster_name} -- "set -ex; ls /mount_private_mount/hello.txt"',
     ]
-    if include_mount_cached and cloud != 'kubernetes':
+    if include_mount_cached:
         if cloud == 'aws':
             rclone_stores = data_utils.Rclone.RcloneStores.S3
         elif cloud == 'gcp':
             rclone_stores = data_utils.Rclone.RcloneStores.GCS
         elif cloud == 'azure':
             rclone_stores = data_utils.Rclone.RcloneStores.AZURE
+        elif cloud == 'kubernetes':
+            rclone_stores = data_utils.Rclone.RcloneStores.S3
         else:
             raise ValueError(f'Invalid cloud provider: {cloud}')
         rclone_profile_name = rclone_stores.get_profile_name(storage_name)
@@ -310,7 +312,7 @@ def test_kubernetes_storage_mounts():
     ls_hello_command = f'{cloud_cmd_cluster_setup_cmd} && {ls_hello_command}'
     with tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as f:
         test_commands, clean_command = _storage_mounts_commands_generator(
-            f, name, storage_name, ls_hello_command, 'kubernetes', False, False)
+            f, name, storage_name, ls_hello_command, 'kubernetes', False, True)
         test = smoke_tests_utils.Test(
             'kubernetes_storage_mounts',
             test_commands,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
