### PR TITLE
auto-reload config for sdk functions

### DIFF
--- a/sky/volumes/client/sdk.py
+++ b/sky/volumes/client/sdk.py
@@ -4,6 +4,7 @@ import typing
 from typing import List
 
 from sky import sky_logging
+from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.server import common as server_common
 from sky.server.requests import payloads
@@ -24,9 +25,12 @@ logger = sky_logging.init_logger(__name__)
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def apply(volume: volume_lib.Volume) -> server_common.RequestId:
+def apply(volume: volume_lib.Volume,
+          reload_config: bool = True) -> server_common.RequestId:
     """Creates or registers a volume.
     """
+    if reload_config:
+        skypilot_config.safe_reload_config()
     body = payloads.VolumeApplyBody(name=volume.name,
                                     volume_type=volume.type,
                                     cloud=volume.cloud,
@@ -44,8 +48,10 @@ def apply(volume: volume_lib.Volume) -> server_common.RequestId:
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def ls() -> server_common.RequestId:
+def ls(reload_config: bool = True) -> server_common.RequestId:
     """Lists all volumes."""
+    if reload_config:
+        skypilot_config.safe_reload_config()
     response = requests.get(f'{server_common.get_server_url()}/volumes',
                             cookies=server_common.get_api_cookie_jar())
     return server_common.get_request_id(response)
@@ -55,8 +61,11 @@ def ls() -> server_common.RequestId:
 @usage_lib.entrypoint
 @server_common.check_server_healthy_or_start
 @annotations.client_api
-def delete(names: List[str]) -> server_common.RequestId:
+def delete(names: List[str],
+           reload_config: bool = True) -> server_common.RequestId:
     """Deletes a volume."""
+    if reload_config:
+        skypilot_config.safe_reload_config()
     body = payloads.VolumeDeleteBody(names=names)
     response = requests.post(f'{server_common.get_server_url()}/volumes/delete',
                              json=json.loads(body.model_dump_json()),


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Give an option for SDK calls to reload config at the start of the call, enabling this option by default. This is useful for long running application using SkyPilot SDK where the config may be updated.

Then disable this for two notable scenarios:
1. in CLI (command.py). This is because each CLI call spawns a new process that lives through the duration of a single CLI call. The config loaded at the start of the CLI call can be used throughout the handling of that CLI, without having to reload the config for each SDK call.
- It is also worth pointing out that `config_option` flag decorator used by `command.py` overrides the skypilot config initially loaded with whatever CLI flags user specified, and reloading the config in sdk call will erase the CLI flag overrides.
3. if the SDK call is used within another SDK call that accepts a `reload_config` parameter. In this case, the config is already reloaded by the parent function if `reload_config` is specified, and there is no need to reload the config again.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
