### PR TITLE
Make sure catalogs get updated periodically on the executor processes

### DIFF
--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -13,6 +13,7 @@ from sky import sky_logging
 from sky.adaptors import common as adaptors_common
 from sky.clouds import cloud as cloud_lib
 from sky.skylet import constants
+from sky.utils import annotations
 from sky.utils import common_utils
 from sky.utils import registry
 from sky.utils import rich_utils
@@ -125,17 +126,21 @@ class LazyDataFrame:
 
     We don't need to load the catalog for every SkyPilot call, and this class
     allows us to load the catalog only when needed.
+
+    Use update_func to pass in a function that decides whether to update the
+    catalog on disk, updates it if needed, and returns a bool indicating
+    whether the update was done.
     """
 
-    def __init__(self, filename: str, update_func: Callable[[], None]):
+    def __init__(self, filename: str, update_func: Callable[[], bool]):
         self._filename = filename
         self._df: Optional['pd.DataFrame'] = None
         self._update_func = update_func
 
+    @annotations.lru_cache(scope='request')
     def _load_df(self) -> 'pd.DataFrame':
-        if self._df is None:
+        if self._update_func() or self._df is None:
             try:
-                self._update_func()
                 self._df = pd.read_csv(self._filename)
             except Exception as e:  # pylint: disable=broad-except
                 # As users can manually modify the catalog, read_csv can fail.
@@ -193,53 +198,58 @@ def read_catalog(filename: str,
         return last_update + pull_frequency_hours * 3600 < time.time()
 
     def _update_catalog():
+        # Fast path: Exit early to avoid lock contention.
+        if not _need_update():
+            return False
+
         # Atomic check, to avoid conflicts with other processes.
         with filelock.FileLock(meta_path + '.lock'):
-            if _need_update():
-                url = f'{constants.HOSTED_CATALOG_DIR_URL}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
-                url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
-                headers = {'User-Agent': 'SkyPilot/0.7'}
-                update_frequency_str = ''
-                if pull_frequency_hours is not None:
-                    update_frequency_str = (
-                        f' (every {pull_frequency_hours} hours)')
-                with rich_utils.safe_status(
-                        ux_utils.spinner_message(
-                            f'Updating {cloud} catalog: {filename}') +
-                        f'{update_frequency_str}'):
-                    try:
-                        r = requests.get(url=url, headers=headers)
-                        if r.status_code == 429:
-                            # fallback to s3 mirror, github introduced rate
-                            # limit after 2025-05, see
-                            # https://github.com/skypilot-org/skypilot/issues/5438
-                            # for more details
-                            r = requests.get(url=url_fallback, headers=headers)
-                        r.raise_for_status()
-                    except requests.exceptions.RequestException as e:
-                        error_str = (f'Failed to fetch {cloud} catalog '
-                                     f'{filename}. ')
-                        if os.path.exists(catalog_path):
-                            logger.warning(
-                                f'{error_str}Using cached catalog files.')
-                            # Update catalog file modification time.
-                            os.utime(catalog_path, None)  # Sets to current time
-                        else:
-                            logger.error(
-                                f'{error_str}Please check your internet '
-                                'connection.')
-                            with ux_utils.print_exception_no_traceback():
-                                raise e
+            # Double check after acquiring the lock.
+            if not _need_update():
+                return False
+
+            url = f'{constants.HOSTED_CATALOG_DIR_URL}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
+            url_fallback = f'{constants.HOSTED_CATALOG_DIR_URL_S3_MIRROR}/{constants.CATALOG_SCHEMA_VERSION}/{filename}'  # pylint: disable=line-too-long
+            headers = {'User-Agent': 'SkyPilot/0.7'}
+            update_frequency_str = ''
+            if pull_frequency_hours is not None:
+                update_frequency_str = (
+                    f' (every {pull_frequency_hours} hours)')
+            with rich_utils.safe_status(
+                    ux_utils.spinner_message(
+                        f'Updating {cloud} catalog: {filename}') +
+                    f'{update_frequency_str}'):
+                try:
+                    r = requests.get(url=url, headers=headers)
+                    if r.status_code == 429:
+                        # fallback to s3 mirror, github introduced rate
+                        # limit after 2025-05, see
+                        # https://github.com/skypilot-org/skypilot/issues/5438
+                        # for more details
+                        r = requests.get(url=url_fallback, headers=headers)
+                    r.raise_for_status()
+                except requests.exceptions.RequestException as e:
+                    error_str = (f'Failed to fetch {cloud} catalog '
+                                 f'{filename}. ')
+                    if os.path.exists(catalog_path):
+                        logger.warning(
+                            f'{error_str}Using cached catalog files.')
+                        # Update catalog file modification time.
+                        os.utime(catalog_path, None)  # Sets to current time
                     else:
-                        # Download successful, save the catalog to a local file.
-                        os.makedirs(os.path.dirname(catalog_path),
-                                    exist_ok=True)
-                        with open(catalog_path, 'w', encoding='utf-8') as f:
-                            f.write(r.text)
-                        with open(meta_path + '.md5', 'w',
-                                  encoding='utf-8') as f:
-                            f.write(hashlib.md5(r.text.encode()).hexdigest())
-                logger.debug(f'Updated {cloud} catalog {filename}.')
+                        logger.error(f'{error_str}Please check your internet '
+                                     'connection.')
+                        with ux_utils.print_exception_no_traceback():
+                            raise e
+                else:
+                    # Download successful, save the catalog to a local file.
+                    os.makedirs(os.path.dirname(catalog_path), exist_ok=True)
+                    with open(catalog_path, 'w', encoding='utf-8') as f:
+                        f.write(r.text)
+                    with open(meta_path + '.md5', 'w', encoding='utf-8') as f:
+                        f.write(hashlib.md5(r.text.encode()).hexdigest())
+            logger.debug(f'Updated {cloud} catalog {filename}.')
+        return True
 
     return LazyDataFrame(catalog_path, update_func=_update_catalog)
 

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -135,11 +135,11 @@ class LazyDataFrame:
     def __init__(self, filename: str, update_if_stale_func: Callable[[], bool]):
         self._filename = filename
         self._df: Optional['pd.DataFrame'] = None
-        self.update_if_stale_func = update_if_stale_func
+        self._update_if_stale_func = update_if_stale_func
 
     @annotations.lru_cache(scope='request')
     def _load_df(self) -> 'pd.DataFrame':
-        if self.update_if_stale_func() or self._df is None:
+        if self._update_if_stale_func() or self._df is None:
             try:
                 self._df = pd.read_csv(self._filename)
             except Exception as e:  # pylint: disable=broad-except

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -55,7 +55,7 @@ def test_read_catalog_triggers_update_on_stale_file(mock_get):
         mock_get.return_value = DummyResponse(NEW_DUMMY_CSV)
 
         # We haven't cleared annotations.FUNCTIONS_NEED_RELOAD_CACHE,
-        # so _load_df should still be cached and update_func
+        # so _load_df should still be cached and update_if_stale_func
         # should not be called, i.e. the file on disk and
         # DataFrame should not be updated.
         df.head()
@@ -65,7 +65,7 @@ def test_read_catalog_triggers_update_on_stale_file(mock_get):
         for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
             func.cache_clear()
 
-        # Now update_func should be called and should trigger a new fetch.
+        # Now update_if_stale_func should be called and should trigger a new fetch.
         df.head()
         # The file and DataFrame should match NEW_DUMMY_CSV.
         with open(abs_catalog_path) as f:

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -12,6 +12,9 @@ from sky.utils import annotations
 
 @mock.patch('sky.catalog.common.requests.get')
 def test_read_catalog_triggers_update_on_stale_file(mock_get):
+    """Test that read_catalog (and the LazyDataFrame it returns)
+    does an update when the catalog file is stale, and that
+    it's cached for the duration of the request."""
     DUMMY_CSV = 'col1,col2\n1,2\n3,4\n'
     NEW_DUMMY_CSV = 'col1,col2\n5,6\n7,8\n'
 

--- a/tests/unit_tests/test_catalog.py
+++ b/tests/unit_tests/test_catalog.py
@@ -1,0 +1,82 @@
+import os
+import tempfile
+import time
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from sky.catalog import common as catalog_common
+from sky.utils import annotations
+
+
+@mock.patch('sky.catalog.common.requests.get')
+def test_read_catalog_triggers_update_on_stale_file(mock_get):
+    DUMMY_CSV = 'col1,col2\n1,2\n3,4\n'
+    NEW_DUMMY_CSV = 'col1,col2\n5,6\n7,8\n'
+
+    class DummyResponse:
+
+        def __init__(self, text, status_code=200):
+            self.text = text
+            self.status_code = status_code
+
+        def raise_for_status(self):
+            if self.status_code != 200:
+                raise Exception('HTTP error')
+
+    mock_get.return_value = DummyResponse(DUMMY_CSV)
+
+    # Create a random file name.
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        filename = os.path.join(f'gcp/{os.path.basename(tmp.name)}.csv')
+
+    try:
+        df = catalog_common.read_catalog(filename, pull_frequency_hours=1)
+        # Force the CSV to be written to disk.
+        df.head()
+
+        # The file on disk and the DataFrame should match DUMMY_CSV.
+        abs_catalog_path = catalog_common.get_catalog_path(filename)
+        assert os.path.exists(abs_catalog_path)
+        with open(abs_catalog_path) as f:
+            content_on_disk = f.read()
+        assert content_on_disk == DUMMY_CSV
+        pd.testing.assert_frame_equal(df._df, pd.read_csv(abs_catalog_path))
+
+        # Modify the file's mtime to be 2 hours ago.
+        new_time = time.time() - 60 * 60 * 2
+        os.utime(abs_catalog_path, (new_time, new_time))
+
+        # Patch requests.get again to return NEW_DUMMY_CSV.
+        mock_get.return_value = DummyResponse(NEW_DUMMY_CSV)
+
+        # We haven't cleared annotations.FUNCTIONS_NEED_RELOAD_CACHE,
+        # so _load_df should still be cached and update_func
+        # should not be called, i.e. the file on disk and
+        # DataFrame should not be updated.
+        df.head()
+        pd.testing.assert_frame_equal(df._df, pd.read_csv(abs_catalog_path))
+
+        # Clear the cache.
+        for func in annotations.FUNCTIONS_NEED_RELOAD_CACHE:
+            func.cache_clear()
+
+        # Now update_func should be called and should trigger a new fetch.
+        df.head()
+        # The file and DataFrame should match NEW_DUMMY_CSV.
+        with open(abs_catalog_path) as f:
+            content_on_disk = f.read()
+        assert content_on_disk == NEW_DUMMY_CSV
+        pd.testing.assert_frame_equal(df._df, pd.read_csv(abs_catalog_path))
+    finally:
+        if os.path.exists(abs_catalog_path):
+            os.remove(abs_catalog_path)
+        meta_path = os.path.join(catalog_common._ABSOLUTE_VERSIONED_CATALOG_DIR,
+                                 '.meta', filename + '.md5')
+        if os.path.exists(meta_path):
+            os.remove(meta_path)
+        lock_path = os.path.join(catalog_common._ABSOLUTE_VERSIONED_CATALOG_DIR,
+                                 '.meta', filename + '.lock')
+        if os.path.exists(lock_path):
+            os.remove(lock_path)


### PR DESCRIPTION
When a new catalog file is fetched, there might be a difference for the catalogs among different executor processes, despite there being a single source of truth, on disk at `~/.sky/catalogs/*`.

TL;DR this is because `read_catalog` returns a `LazyDataFrame`, which gets assigned to a global variable, for each unique (cloud, catalog) pair. And `LazyDataFrame`  caches the DataFrame in memory for the duration of the process' lifetime, because it only calls `update_func` if `self._df` is None, which is only when it's first called.

This PR changes the behaviour of `LazyDataFrame`, such that now, `update_if_stale_func` returns a bool, that indicates if an update was done or not, and this is called on every read (`_load_df`), to ensure that a long running executor process is aware if it is time to refresh the catalog, and save the new one to disk.

To account for the performance penalty of calling the update if stale function for every read, we add two optimizations:
1. In `_update_catalog` of `read_catalog`, we add a fast path by calling `_need_update` before trying to acquire the file lock, to prevent lock contentions. We still need to do it after acquiring the lock, to ensure only one process gets to write to disk, so that part is left as is
2. Add `@annotations.lru_cache(scope='request')` to `_load_df` in `LazyDataFrame`. A single request could read a catalog multiple times, so this helps alleviate unnecessary calls to `update_if_stale_func`

I added a unit test in `test_catalog.py`

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
