### PR TITLE
Filter by region and zone too when getting default instance type

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -221,6 +221,8 @@ def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
                               disk_tier: Optional[
                                   resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None,
                               clouds: CloudFilter = None) -> Optional[str]:
     """Returns the cloud's default instance type for given #vCPUs and memory.
 
@@ -234,7 +236,7 @@ def get_default_instance_type(cpus: Optional[str] = None,
     the given CPU and memory requirement.
     """
     return _map_clouds_catalog(clouds, 'get_default_instance_type', cpus,
-                               memory, disk_tier)
+                               memory, disk_tier, region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -230,10 +230,12 @@ def get_vcpus_mem_from_instance_type(
                                                         instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
@@ -247,7 +249,8 @@ def get_default_instance_type(
     df = _get_df()
     df = df[df['InstanceType'].str.startswith(instance_type_prefix)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/azure_catalog.py
+++ b/sky/catalog/azure_catalog.py
@@ -114,10 +114,12 @@ def _get_instance_family(instance_type: str) -> str:
     return instance_family
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:
@@ -133,7 +135,8 @@ def get_default_instance_type(
 
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -476,8 +476,11 @@ def _filter_region_zone(df: 'pd.DataFrame', region: Optional[str],
 
 
 def get_instance_type_for_cpus_mem_impl(
-        df: 'pd.DataFrame', cpus: Optional[str],
-        memory_gb_or_ratio: Optional[str]) -> Optional[str]:
+        df: 'pd.DataFrame',
+        cpus: Optional[str],
+        memory_gb_or_ratio: Optional[str],
+        region: Optional[str] = None,
+        zone: Optional[str] = None) -> Optional[str]:
     """Returns the cheapest instance type that satisfies the requirements.
 
     Args:
@@ -490,7 +493,10 @@ def get_instance_type_for_cpus_mem_impl(
             returned instance type should have at least the given memory size.
             If the string ends with "x", then the returned instance type should
             have at least the given number of vCPUs times the given ratio.
+        region: The region to filter by.
+        zone: The zone to filter by.
     """
+    df = _filter_region_zone(df, region, zone)
     df = _filter_with_cpus(df, cpus)
     df = _filter_with_mem(df, memory_gb_or_ratio)
     if df.empty:

--- a/sky/catalog/cudo_catalog.py
+++ b/sky/catalog/cudo_catalog.py
@@ -51,7 +51,9 @@ def get_vcpus_mem_from_instance_type(
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
-                              disk_tier: Optional[str] = None) -> Optional[str]:
+                              disk_tier: Optional[str] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier
     # NOTE: After expanding catalog to multiple entries, you may
     # want to specify a default instance type or family.
@@ -62,7 +64,8 @@ def get_default_instance_type(cpus: Optional[str] = None,
     if memory is None:
         memory_gb_or_ratio = f'{_DEFAULT_MEMORY_CPU_RATIO}x'
     return common.get_instance_type_for_cpus_mem_impl(_df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/do_catalog.py
+++ b/sky/catalog/do_catalog.py
@@ -52,11 +52,14 @@ def get_default_instance_type(
     cpus: Optional[str] = None,
     memory: Optional[str] = None,
     disk_tier: Optional[str] = None,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
 ) -> Optional[str]:
     # NOTE: After expanding catalog to multiple entries, you may
     # want to specify a default instance type or family.
     del disk_tier  # unused
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/fluidstack_catalog.py
+++ b/sky/catalog/fluidstack_catalog.py
@@ -52,7 +52,9 @@ def get_vcpus_mem_from_instance_type(
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
-                              disk_tier: Optional[str] = None) -> Optional[str]:
+                              disk_tier: Optional[str] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
@@ -61,7 +63,8 @@ def get_default_instance_type(cpus: Optional[str] = None,
     else:
         memory_gb_or_ratio = memory
     return common.get_instance_type_for_cpus_mem_impl(_df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/gcp_catalog.py
+++ b/sky/catalog/gcp_catalog.py
@@ -279,10 +279,12 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
     if memory is None:
@@ -300,7 +302,8 @@ def get_default_instance_type(
 
     df = df.loc[df['InstanceType'].apply(_filter_disk_type)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/hyperbolic_catalog.py
+++ b/sky/catalog/hyperbolic_catalog.py
@@ -67,9 +67,12 @@ def get_zone_shell_cmd() -> Optional[str]:
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
-                              disk_tier: Optional[str] = None) -> Optional[str]:
+                              disk_tier: Optional[str] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # Unused
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_instance_type_for_accelerator(

--- a/sky/catalog/ibm_catalog.py
+++ b/sky/catalog/ibm_catalog.py
@@ -92,10 +92,12 @@ def list_accelerators(
                                          case_sensitive, all_regions)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
@@ -107,7 +109,8 @@ def get_default_instance_type(
     instance_type_prefix = f'{_DEFAULT_INSTANCE_FAMILY}-'
     df = _df[_df['InstanceType'].str.startswith(instance_type_prefix)]
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def is_image_tag_valid(tag: str, region: Optional[str]) -> bool:

--- a/sky/catalog/lambda_catalog.py
+++ b/sky/catalog/lambda_catalog.py
@@ -56,10 +56,12 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = f'{_DEFAULT_NUM_VCPUS}+'
@@ -68,7 +70,8 @@ def get_default_instance_type(
     else:
         memory_gb_or_ratio = memory
     return common.get_instance_type_for_cpus_mem_impl(_df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/nebius_catalog.py
+++ b/sky/catalog/nebius_catalog.py
@@ -51,12 +51,15 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/oci_catalog.py
+++ b/sky/catalog/oci_catalog.py
@@ -101,10 +101,12 @@ def get_hourly_cost(instance_type: str,
                                        region, zone)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     if cpus is None:
         cpus = f'{oci_utils.oci_config.DEFAULT_NUM_VCPUS}+'
 
@@ -127,7 +129,8 @@ def get_default_instance_type(
 
     logger.debug(f'# get_default_instance_type: {df}')
     return common.get_instance_type_for_cpus_mem_impl(df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/paperspace_catalog.py
+++ b/sky/catalog/paperspace_catalog.py
@@ -52,11 +52,14 @@ def get_default_instance_type(
     cpus: Optional[str] = None,
     memory: Optional[str] = None,
     disk_tier: Optional[str] = None,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
 ) -> Optional[str]:
     # NOTE: After expanding catalog to multiple entries, you may
     # want to specify a default instance type or family.
     del disk_tier  # unused
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/runpod_catalog.py
+++ b/sky/catalog/runpod_catalog.py
@@ -41,11 +41,14 @@ def get_vcpus_mem_from_instance_type(
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
-                              disk_tier: Optional[str] = None) -> Optional[str]:
+                              disk_tier: Optional[str] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # RunPod does not support disk tiers.
     # NOTE: After expanding catalog to multiple entries, you may
     # want to specify a default instance type or family.
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/scp_catalog.py
+++ b/sky/catalog/scp_catalog.py
@@ -51,10 +51,12 @@ def get_vcpus_mem_from_instance_type(
     return common.get_vcpus_mem_from_instance_type_impl(_df, instance_type)
 
 
-def get_default_instance_type(
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None) -> Optional[str]:
+def get_default_instance_type(cpus: Optional[str] = None,
+                              memory: Optional[str] = None,
+                              disk_tier: Optional[
+                                  resources_utils.DiskTier] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
         cpus = str(_DEFAULT_NUM_VCPUS)
@@ -63,7 +65,8 @@ def get_default_instance_type(
     else:
         memory_gb_or_ratio = memory
     return common.get_instance_type_for_cpus_mem_impl(_df, cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/vast_catalog.py
+++ b/sky/catalog/vast_catalog.py
@@ -48,11 +48,14 @@ def get_vcpus_mem_from_instance_type(
 
 def get_default_instance_type(cpus: Optional[str] = None,
                               memory: Optional[str] = None,
-                              disk_tier: Optional[str] = None) -> Optional[str]:
+                              disk_tier: Optional[str] = None,
+                              region: Optional[str] = None,
+                              zone: Optional[str] = None) -> Optional[str]:
     del disk_tier
     # NOTE: After expanding catalog to multiple entries, you may
     # want to specify a default instance type or family.
-    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory)
+    return common.get_instance_type_for_cpus_mem_impl(_df, cpus, memory, region,
+                                                      zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/catalog/vsphere_catalog.py
+++ b/sky/catalog/vsphere_catalog.py
@@ -72,6 +72,8 @@ def get_default_instance_type(
     cpus: Optional[str] = None,
     memory: Optional[str] = None,
     disk_tier: Optional[str] = None,
+    region: Optional[str] = None,
+    zone: Optional[str] = None,
 ) -> Optional[str]:
     del disk_tier  # unused
     if cpus is None and memory is None:
@@ -81,7 +83,8 @@ def get_default_instance_type(
     else:
         memory_gb_or_ratio = memory
     return common.get_instance_type_for_cpus_mem_impl(_get_df(), cpus,
-                                                      memory_gb_or_ratio)
+                                                      memory_gb_or_ratio,
+                                                      region, zone)
 
 
 def get_accelerators_from_instance_type(

--- a/sky/clouds/aws.py
+++ b/sky/clouds/aws.py
@@ -404,15 +404,18 @@ class AWS(clouds.Cloud):
         return cost
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='aws')
 
     # TODO: factor the following three methods, as they are the same logic
@@ -554,7 +557,9 @@ class AWS(clouds.Cloud):
             default_instance_type = AWS.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/azure.py
+++ b/sky/clouds/azure.py
@@ -154,15 +154,18 @@ class Azure(clouds.Cloud):
         return cost
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='azure')
 
     @classmethod
@@ -499,7 +502,9 @@ class Azure(clouds.Cloud):
             default_instance_type = Azure.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/cloud.py
+++ b/sky/clouds/cloud.py
@@ -341,14 +341,15 @@ class Cloud:
         raise NotImplementedError
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
-        """Returns the default instance type with the given #vCPUs, memory and
-        disk tier.
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
+        """Returns the default instance type with the given #vCPUs, memory,
+        disk tier, region, and zone.
 
         For example, if cpus='4', this method returns the default instance type
         with 4 vCPUs.  If cpus='4+', this method returns the default instance

--- a/sky/clouds/cudo.py
+++ b/sky/clouds/cudo.py
@@ -175,14 +175,18 @@ class Cudo(clouds.Cloud):
         return 0.0
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
+                                                 disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='cudo')
 
     @classmethod
@@ -251,7 +255,9 @@ class Cudo(clouds.Cloud):
             default_instance_type = Cudo.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/do.py
+++ b/sky/clouds/do.py
@@ -156,16 +156,19 @@ class DO(clouds.Cloud):
         return self._REPR
 
     @classmethod
-    def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None,
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type for DO."""
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='DO')
 
     @classmethod
@@ -246,7 +249,9 @@ class DO(clouds.Cloud):
             default_instance_type = DO.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/fluidstack.py
+++ b/sky/clouds/fluidstack.py
@@ -154,14 +154,17 @@ class Fluidstack(clouds.Cloud):
         return 'Fluidstack'
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[DiskTier] = None) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='fluidstack')
 
     @classmethod
@@ -243,7 +246,9 @@ class Fluidstack(clouds.Cloud):
             default_instance_type = Fluidstack.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -436,15 +436,18 @@ class GCP(clouds.Cloud):
         return cls._get_image_size(image_id)
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='gcp')
 
     @classmethod
@@ -681,7 +684,10 @@ class GCP(clouds.Cloud):
             host_vm_type = GCP.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
+            logger.info(f'host_vm_type: {host_vm_type}')
             if host_vm_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.

--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -687,7 +687,6 @@ class GCP(clouds.Cloud):
                 disk_tier=resources.disk_tier,
                 region=resources.region,
                 zone=resources.zone)
-            logger.info(f'host_vm_type: {host_vm_type}')
             if host_vm_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.

--- a/sky/clouds/hyperbolic.py
+++ b/sky/clouds/hyperbolic.py
@@ -109,14 +109,17 @@ class Hyperbolic(clouds.Cloud):
                                        clouds='hyperbolic')
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[DiskTier] = None) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='hyperbolic')
 
     @classmethod
@@ -199,7 +202,9 @@ class Hyperbolic(clouds.Cloud):
         default_instance_type = self.get_default_instance_type(
             cpus=resources.cpus,
             memory=resources.memory,
-            disk_tier=resources.disk_tier)
+            disk_tier=resources.disk_tier,
+            region=resources.region,
+            zone=resources.zone)
         if default_instance_type is None:
             return resources_utils.FeasibleResources([], [], None)
         else:

--- a/sky/clouds/ibm.py
+++ b/sky/clouds/ibm.py
@@ -262,14 +262,17 @@ class IBM(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional['resources_utils.DiskTier'] = None
-    ) -> Optional[str]:
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None,
+            disk_tier: Optional['resources_utils.DiskTier'] = None,
+            region: Optional[str] = None,
+            zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='ibm')
 
     def _get_feasible_launchable_resources(
@@ -305,7 +308,9 @@ class IBM(clouds.Cloud):
             default_instance_type = IBM.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -349,10 +349,12 @@ class Kubernetes(clouds.Cloud):
             cls,
             cpus: Optional[str] = None,
             memory: Optional[str] = None,
-            disk_tier: Optional['resources_utils.DiskTier'] = None) -> str:
+            disk_tier: Optional['resources_utils.DiskTier'] = None,
+            region: Optional[str] = None,
+            zone: Optional[str] = None) -> str:
         # TODO(romilb): In the future, we may want to move the instance type
         #  selection + availability checking to a kubernetes_catalog module.
-        del disk_tier  # Unused.
+        del disk_tier, region, zone  # Unused.
         # We strip '+' from resource requests since Kubernetes can provision
         # exactly the requested resources.
         instance_cpus = float(
@@ -806,7 +808,9 @@ class Kubernetes(clouds.Cloud):
         default_instance_type = Kubernetes.get_default_instance_type(
             cpus=resources.cpus,
             memory=resources.memory,
-            disk_tier=resources.disk_tier)
+            disk_tier=resources.disk_tier,
+            region=resources.region,
+            zone=resources.zone)
 
         if accelerators is None:
             # For CPU only clusters, need no special handling

--- a/sky/clouds/lambda_cloud.py
+++ b/sky/clouds/lambda_cloud.py
@@ -132,14 +132,17 @@ class Lambda(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional['resources_utils.DiskTier'] = None
-    ) -> Optional[str]:
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None,
+            disk_tier: Optional['resources_utils.DiskTier'] = None,
+            region: Optional[str] = None,
+            zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='lambda')
 
     @classmethod
@@ -227,7 +230,9 @@ class Lambda(clouds.Cloud):
             default_instance_type = Lambda.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/nebius.py
+++ b/sky/clouds/nebius.py
@@ -175,16 +175,19 @@ class Nebius(clouds.Cloud):
         return isinstance(other, Nebius)
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type for Nebius."""
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='nebius')
 
     @classmethod
@@ -320,7 +323,9 @@ class Nebius(clouds.Cloud):
             default_instance_type = Nebius.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.

--- a/sky/clouds/oci.py
+++ b/sky/clouds/oci.py
@@ -187,15 +187,18 @@ class OCI(clouds.Cloud):
         return (num_gigabytes - 10 * 1024) * 0.0085
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='oci')
 
     @classmethod
@@ -378,7 +381,9 @@ class OCI(clouds.Cloud):
             default_instance_type = OCI.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
 
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)

--- a/sky/clouds/paperspace.py
+++ b/sky/clouds/paperspace.py
@@ -160,16 +160,19 @@ class Paperspace(clouds.Cloud):
         return self._REPR
 
     @classmethod
-    def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None,
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type for Paperspace."""
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='paperspace')
 
     @classmethod
@@ -237,7 +240,9 @@ class Paperspace(clouds.Cloud):
             default_instance_type = Paperspace.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/runpod.py
+++ b/sky/clouds/runpod.py
@@ -141,16 +141,19 @@ class RunPod(clouds.Cloud):
         return 0.0
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type for RunPod."""
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='runpod')
 
     @classmethod
@@ -240,7 +243,9 @@ class RunPod(clouds.Cloud):
             default_instance_type = RunPod.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.

--- a/sky/clouds/scp.py
+++ b/sky/clouds/scp.py
@@ -156,14 +156,17 @@ class SCP(clouds.Cloud):
 
     @classmethod
     def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional['resources_utils.DiskTier'] = None
-    ) -> Optional[str]:
+            cls,
+            cpus: Optional[str] = None,
+            memory: Optional[str] = None,
+            disk_tier: Optional['resources_utils.DiskTier'] = None,
+            region: Optional[str] = None,
+            zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='scp')
 
     @classmethod
@@ -301,7 +304,9 @@ class SCP(clouds.Cloud):
             default_instance_type = SCP.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)
             else:

--- a/sky/clouds/vast.py
+++ b/sky/clouds/vast.py
@@ -136,16 +136,19 @@ class Vast(clouds.Cloud):
         return 0.0
 
     @classmethod
-    def get_default_instance_type(
-            cls,
-            cpus: Optional[str] = None,
-            memory: Optional[str] = None,
-            disk_tier: Optional[resources_utils.DiskTier] = None
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         """Returns the default instance type for Vast."""
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds='vast')
 
     @classmethod
@@ -218,7 +221,9 @@ class Vast(clouds.Cloud):
             default_instance_type = Vast.get_default_instance_type(
                 cpus=resources.cpus,
                 memory=resources.memory,
-                disk_tier=resources.disk_tier)
+                disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone)
             if default_instance_type is None:
                 # TODO: Add hints to all return values in this method to help
                 #  users understand why the resources are not launchable.

--- a/sky/clouds/vsphere.py
+++ b/sky/clouds/vsphere.py
@@ -149,15 +149,18 @@ class Vsphere(clouds.Cloud):
         return 'vSphere'
 
     @classmethod
-    def get_default_instance_type(
-        cls,
-        cpus: Optional[str] = None,
-        memory: Optional[str] = None,
-        disk_tier: Optional[resources_utils.DiskTier] = None,
-    ) -> Optional[str]:
+    def get_default_instance_type(cls,
+                                  cpus: Optional[str] = None,
+                                  memory: Optional[str] = None,
+                                  disk_tier: Optional[
+                                      resources_utils.DiskTier] = None,
+                                  region: Optional[str] = None,
+                                  zone: Optional[str] = None) -> Optional[str]:
         return catalog.get_default_instance_type(cpus=cpus,
                                                  memory=memory,
                                                  disk_tier=disk_tier,
+                                                 region=region,
+                                                 zone=zone,
                                                  clouds=_CLOUD_VSPHERE)
 
     @classmethod
@@ -240,6 +243,8 @@ class Vsphere(clouds.Cloud):
                 cpus=resources.cpus,
                 memory=resources.memory,
                 disk_tier=resources.disk_tier,
+                region=resources.region,
+                zone=resources.zone,
             )
             if default_instance_type is None:
                 return resources_utils.FeasibleResources([], [], None)

--- a/tests/test_optimizer_dryruns.py
+++ b/tests/test_optimizer_dryruns.py
@@ -588,9 +588,7 @@ def test_invalid_accelerators_regions(enable_all_clouds):
 def test_infer_cloud_from_region_or_zone(enable_all_clouds):
     # Maps to GCP.
     _test_resources_launch(region='us-east1')
-    # TODO(aylei): us-west2-a does not have n4-standard-8, should fix the
-    # optimizer issue that n2-standard-8 is not chosen.
-    _test_resources_launch(zone='us-west2-c')
+    _test_resources_launch(zone='us-west2-a')
 
     # Maps to AWS.
     # Not use us-east-2 or us-west-1 as it is also supported by Lambda.


### PR DESCRIPTION
Fixes #6290.

We recently added support for n4 instances for GCP ([PR](https://github.com/skypilot-org/skypilot/pull/6253)) and added it to `_DEFAULT_INSTANCE_FAMILY`, so now the default instance types for GCP are n2 and n4. And n4 is cheaper than n2 for most if not all zones.

The problem is, in `common.get_instance_type_for_cpus_mem_impl`, we only filter by CPU and memory, before sorting by price and getting the cheapest one.

We don't filter the zone, meaning we don't take into account the possibility that an instance may be cheapest overall, but doesn't exist in a particular zone, like what's happening here with n4-standard.

This PR fixes it by adding `region` and `zone` as optional input params to:
1. `cloud.Cloud.get_default_instance_type`
2. `catalog.get_default_instance_type`
3. `common.get_instance_type_for_cpus_mem_impl`, where we finally do `df = _filter_region_zone(df, region, zone)`

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
