### PR TITLE
Fix hyperbolic unit test

### DIFF
--- a/tests/unit_tests/test_hyperbolic.py
+++ b/tests/unit_tests/test_hyperbolic.py
@@ -54,7 +54,7 @@ def test_hyperbolic_resource_feasibility():
     cloud = hyperbolic.Hyperbolic()
     resources = Resources(cloud=cloud,
                           instance_type='1x-H100-28-271',
-                          accelerators={'T4': 1})
+                          accelerators={'H100': 1})
     feasible = cloud._get_feasible_launchable_resources(resources)
     assert hasattr(feasible, 'resources_list')
     assert hasattr(feasible, 'fuzzy_candidate_list')

--- a/tests/unit_tests/test_hyperbolic.py
+++ b/tests/unit_tests/test_hyperbolic.py
@@ -53,7 +53,7 @@ def test_hyperbolic_resource_feasibility():
     """Test resource feasibility for Hyperbolic."""
     cloud = hyperbolic.Hyperbolic()
     resources = Resources(cloud=cloud,
-                          instance_type='1x-T4-4-17',
+                          instance_type='1x-H100-28-271',
                           accelerators={'T4': 1})
     feasible = cloud._get_feasible_launchable_resources(resources)
     assert hasattr(feasible, 'resources_list')


### PR DESCRIPTION
The `1x-T4-4-17` instance type were missing in the latest catalog ([commit](https://github.com/skypilot-org/skypilot-catalog/commit/06cb4087855609446f3ce9739d863ffd92cdbcd6)), causing this unit test to fail, as it's explicitly looking for that type.

This PR fixes it by switching to a valid instance type which exist on the latest catalog.

We probably should still investigate though why `1x-T4-4-17` went missing.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
