### PR TITLE
[helm] Add service account annotations field to helm chart

### DIFF
--- a/charts/skypilot/templates/rbac.yaml
+++ b/charts/skypilot/templates/rbac.yaml
@@ -9,6 +9,10 @@ kind: ServiceAccount
 metadata:
   name: {{ include "skypilot.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.rbac.serviceAccountAnnotations }}
+  annotations:
+    {{- toYaml .Values.rbac.serviceAccountAnnotations | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -301,6 +301,9 @@ rbac:
   # object store mounting or you manage system components manually, i.e. outside of SkyPilot.
   manageSystemComponents: true
 
+  # Custom annotations for the API server service account.
+  serviceAccountAnnotations: null
+
 # kubernetesCredentials add additional kubernetes cluster permissions to the API server.
 kubernetesCredentials:
   # Enable/disable using the API server's cluster for workloads

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -146,6 +146,7 @@ Below is the available helm value keys and the default value of each key:
         verbs: ["list", "get"]
     :ref:`manageRbacPolicies <helm-values-rbac-manageRbacPolicies>`: true
     :ref:`manageSystemComponents <helm-values-rbac-manageSystemComponents>`: true
+    :ref:`serviceAccountAnnotations <helm-values-rbac-serviceAccountAnnotations>`: null
 
   :ref:`kubernetesCredentials <helm-values-kubernetesCredentials>`:
     :ref:`useApiServerCluster <helm-values-kubernetesCredentials-useApiServerCluster>`: true
@@ -1012,6 +1013,22 @@ Default: ``true``
 
   rbac:
     manageSystemComponents: true
+
+.. _helm-values-rbac-serviceAccountAnnotations:
+
+``rbac.serviceAccountAnnotations``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Custom annotations for the API server service account. This is useful for cloud provider integrations that require specific annotations on service accounts, such as AWS IAM roles for service accounts (IRSA) or GCP Workload Identity.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  rbac:
+    serviceAccountAnnotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/MyServiceAccountRole"
+      iam.gke.io/gcp-service-account: "my-gcp-service-account@my-project.iam.gserviceaccount.com"
 
 .. _helm-values-kubernetesCredentials:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add a field to specify custom annotations for skypilot service account. This is useful for cloud provider integrations that require specific annotations on service accounts, such as AWS IAM roles for service accounts (IRSA) or GCP Workload Identity.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
