### PR TITLE
[AWS] Add post_provision_runcmd config for running commands during final boot stage

### DIFF
--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -717,7 +717,7 @@ Supported values:
 
 Run commands during the instance initialization phase (optional).
 
-This is useful for doing any setup that must happen right after the instance starts, such as:
+This is executed through cloud-init's ``runcmd``, which is useful for doing any setup that must happen right after the instance starts, such as:
 
 - Configuring system settings
 - Installing certificates

--- a/docs/source/reference/config.rst
+++ b/docs/source/reference/config.rst
@@ -110,6 +110,8 @@ Below is the configuration syntax and some example values. See detailed explanat
     :ref:`specific_reservations <config-yaml-aws-specific-reservations>`:
       - cr-a1234567
     :ref:`remote_identity <config-yaml-aws-remote-identity>`: LOCAL_CREDENTIALS
+    :ref:`post_provision_runcmd <config-yaml-aws-post-provision-runcmd>`:
+      - echo "hello world!"
 
   :ref:`gcp <config-yaml-gcp>`:
     :ref:`labels <config-yaml-gcp-labels>`:
@@ -707,6 +709,30 @@ Supported values:
       - my-cluster-name: my-service-account-1
       - sky-serve-controller-*: my-service-account-2
       - "*": my-default-service-account
+
+.. _config-yaml-aws-post-provision-runcmd:
+
+``aws.post_provision_runcmd``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Run commands during the instance initialization phase (optional).
+
+This is useful for doing any setup that must happen right after the instance starts, such as:
+
+- Configuring system settings
+- Installing certificates
+- Installing packages
+
+Each item can be either a string or a list.
+
+Example:
+
+.. code-block:: yaml
+
+  aws:
+    post_provision_runcmd:
+      - echo "hello world!"
+      - [ls, -l, /]
 
 
 .. _config-yaml-gcp:

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -803,6 +803,12 @@ def write_cluster_config(
                 'volume_name_on_cloud': vol.volume_config.name_on_cloud,
             })
 
+    runcmd = skypilot_config.get_effective_region_config(
+        cloud=str(to_provision.cloud).lower(),
+        region=to_provision.region,
+        keys=('post_provision_runcmd',),
+        default_value=None)
+
     # Use a tmp file path to avoid incomplete YAML file being re-used in the
     # future.
     tmp_yaml_path = yaml_path + '.tmp'
@@ -838,7 +844,7 @@ def write_cluster_config(
                 # User-supplied remote_identity
                 'remote_identity': remote_identity,
                 # The reservation pools that specified by the user. This is
-                # currently only used by GCP.
+                # currently only used by AWS and GCP.
                 'specific_reservations': specific_reservations,
 
                 # Conda setup
@@ -901,6 +907,10 @@ def write_cluster_config(
 
                 # Volume mounts
                 'volume_mounts': volume_mount_vars,
+
+                # runcmd to append to the cloud-init cloud config passed to the
+                # machine's UserData. This is currently only used by AWS.
+                'runcmd': runcmd,
             }),
         output_path=tmp_yaml_path)
     config_dict['cluster_name'] = cluster_name

--- a/sky/templates/aws-ray.yml.j2
+++ b/sky/templates/aws-ray.yml.j2
@@ -131,6 +131,12 @@ available_node_types:
           - systemctl disable apt-daily.timer apt-daily-upgrade.timer unattended-upgrades.service
           - systemctl mask apt-daily.service apt-daily-upgrade.service unattended-upgrades.service
           - systemctl daemon-reload
+        {%- if runcmd %}
+        runcmd:
+        {%- for cmd in runcmd %}
+          - {{cmd}}
+        {%- endfor %}
+        {%- endif %}
       TagSpecifications:
         - ResourceType: instance
           Tags:

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1198,6 +1198,19 @@ def get_config_schema():
                         'type': 'null',
                     }],
                 },
+                'post_provision_runcmd': {
+                    'type': 'array',
+                    'items': {
+                        'oneOf': [{
+                            'type': 'string'
+                        }, {
+                            'type': 'array',
+                            'items': {
+                                'type': 'string'
+                            }
+                        }]
+                    },
+                },
                 **_LABELS_SCHEMA,
                 **_NETWORK_CONFIG_SCHEMA,
             },

--- a/tests/test_yamls/test_aws_config_runcmd.yaml
+++ b/tests/test_yamls/test_aws_config_runcmd.yaml
@@ -1,0 +1,4 @@
+aws:
+  post_provision_runcmd:
+    - echo "hello world!"
+    - [ls, -l, /]

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -120,3 +120,48 @@ def test_write_cluster_config_w_remote_identity(mock_fill_template,
             "config template incorrect")
     assert (mock_fill_template.call_args[0][1].items() >=
             expected_subset.items(), "config fill values incorrect")
+
+
+@mock.patch.object(skypilot_config, '_global_config_context',
+                   skypilot_config.ConfigContext())
+@mock.patch('sky.catalog.instance_type_exists', return_value=True)
+@mock.patch('sky.catalog.get_accelerators_from_instance_type',
+            return_value={'fake-acc': 2})
+@mock.patch('sky.catalog.get_image_id_from_tag', return_value='fake-image')
+@mock.patch('sky.backends.backend_utils._get_yaml_path_from_cluster_name',
+            return_value='/tmp/fake/path')
+@mock.patch('sky.utils.common_utils.fill_template')
+def test_write_cluster_config_w_post_provision_runcmd(mock_fill_template,
+                                                      *mocks):
+    os.environ[
+        skypilot_config.
+        ENV_VAR_SKYPILOT_CONFIG] = './tests/test_yamls/test_aws_config_runcmd.yaml'
+    skypilot_config.reload_config()
+
+    cloud = clouds.AWS()
+    region = clouds.Region(name='fake-region')
+    zones = [clouds.Zone(name='fake-zone')]
+    resource = Resources(cloud=cloud, instance_type='fake-type: 3')
+    cluster_config_template = 'aws-ray.yml.j2'
+
+    backend_utils.write_cluster_config(
+        to_provision=resource,
+        num_nodes=2,
+        cluster_config_template=cluster_config_template,
+        cluster_name="display",
+        local_wheel_path=pathlib.Path('/tmp/fake'),
+        wheel_hash='b1bd84059bc0342f7843fcbe04ab563e',
+        region=region,
+        zones=zones,
+        dryrun=True,
+        keep_launch_fields_in_existing_config=True)
+
+    expected_runcmd = [
+        'echo "hello world!"',
+        ['ls', '-l', '/'],
+    ]
+    mock_fill_template.assert_called_once()
+    assert mock_fill_template.call_args[0][
+        0] == cluster_config_template, "config template incorrect"
+    assert mock_fill_template.call_args[0][1][
+        'runcmd'] == expected_runcmd, "runcmd not passed correctly"


### PR DESCRIPTION
This PR adds a new config for AWS, called `post_provision_runcmd`, for running custom commands during the final boot stage, right after the instance starts.

Under the hood, for AWS we're already passing a cloud-init cloud config YAML (see [aws-ray.yml.j2](https://github.com/skypilot-org/skypilot/blob/master/sky/templates/aws-ray.yml.j2)) to the UserData of the EC2 instance we're provisioning. So to pass in the commands from the user's config, we just need to append it as is under the [runcmd](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#runcmd) field to the existing cloud-config.

Why this is needed: One of our users met an issue where MitM cert needs to be installed on the EC2 instance with the UserData / runcmd during the provisioning. The user tried installing the cert in the `setup` section of their Task, but the provisioning did not get that far before failing due to the missing cert.

References:
- https://cloudinit.readthedocs.io/en/latest/reference/yaml_examples/boot_cmds.html
- https://cloudinit.readthedocs.io/en/latest/explanation/boot.html#final

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
        1. `test_write_cluster_config_w_post_provision_runcmd`
        2. manual test:
```
# ~/.sky/config.yaml
# aws:
#  post_provision_runcmd:
#  - [ls, -l, /]
#  - [sh, -xc, 'echo $(date) '': hello world!''']

% sky launch -c mycluster --infra aws -y
% ssh mycluster
$ cat /var/log/cloud-init-output.log # should show the output from the runcmd
```
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
