### PR TITLE
[UX] better logs for `sky api status` when local api server is not running

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5503,6 +5503,8 @@ def api_status(request_ids: Optional[List[str]], all_status: bool,
     if not request_ids:
         request_ids = None
     request_list = sdk.api_status(request_ids, all_status)
+    if not request_list:
+        return
     columns = ['ID', 'User', 'Name']
     if verbose:
         columns.append('Cluster')

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5503,26 +5503,32 @@ def api_status(request_ids: Optional[List[str]], all_status: bool,
     if not request_ids:
         request_ids = None
     request_list = sdk.api_status(request_ids, all_status)
-    if not request_list:
-        return
     columns = ['ID', 'User', 'Name']
     if verbose:
         columns.append('Cluster')
     columns.extend(['Created', 'Status'])
     table = log_utils.create_table(columns)
-    for request in request_list:
-        r_id = request.request_id
-        if not verbose:
-            r_id = common_utils.truncate_long_string(r_id, 36)
-        req_status = requests.RequestStatus(request.status)
-        row = [r_id, request.user_name, request.name]
+    if len(request_list) > 0:
+        for request in request_list:
+            r_id = request.request_id
+            if not verbose:
+                r_id = common_utils.truncate_long_string(r_id, 36)
+            req_status = requests.RequestStatus(request.status)
+            row = [r_id, request.user_name, request.name]
+            if verbose:
+                row.append(request.cluster_name)
+            row.extend([
+                log_utils.readable_time_duration(request.created_at),
+                req_status.colored_str()
+            ])
+            table.add_row(row)
+    else:
+        # add dummy data for when api server is down.
+        dummy_row = ['-'] * 5
         if verbose:
-            row.append(request.cluster_name)
-        row.extend([
-            log_utils.readable_time_duration(request.created_at),
-            req_status.colored_str()
-        ])
-        table.add_row(row)
+            dummy_row.append('-')
+        table.add_row(dummy_row)
+        click.echo()
     click.echo(table)
 
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1854,7 +1854,7 @@ def api_cancel(request_ids: Optional[Union[str, List[str]]] = None,
     return server_common.get_request_id(response)
 
 
-def _local_api_server_running(kill: bool=False) -> bool:
+def _local_api_server_running(kill: bool = False) -> bool:
     """Checks if the local api server is running."""
     for process in psutil.process_iter(attrs=['pid', 'cmdline']):
         cmdline = process.info['cmdline']

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1854,13 +1854,14 @@ def api_cancel(request_ids: Optional[Union[str, List[str]]] = None,
     return server_common.get_request_id(response)
 
 
-def _local_api_server_running() -> bool:
+def _local_api_server_running(kill: bool=False) -> bool:
     """Checks if the local api server is running."""
     for process in psutil.process_iter(attrs=['pid', 'cmdline']):
         cmdline = process.info['cmdline']
         if cmdline and server_common.API_SERVER_CMD in ' '.join(cmdline):
-            subprocess_utils.kill_children_processes(parent_pids=[process.pid],
-                                                     force=True)
+            if kill:
+                subprocess_utils.kill_children_processes(
+                    parent_pids=[process.pid], force=True)
             return True
     return False
 
@@ -2007,7 +2008,7 @@ def api_stop() -> None:
                 f'Cannot kill the API server at {server_url} because it is not '
                 f'the default SkyPilot API server started locally.')
 
-    found = _local_api_server_running()
+    found = _local_api_server_running(kill=True)
 
     # Remove the database for requests.
     server_common.clear_local_api_server_database()


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #6308 

When local api server is not up and we call `sky api status`, we show the same log as when we call `sky api stop` in the same situation.

** note this pr is only relevant for **local** api server. hence, the check for whether the server is configured to be local. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
