### PR TITLE
[Core] Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,25 @@
-# Use the latest version with Python 3.10
-FROM continuumio/miniconda3:23.3.1-0
+# Stage 1: Install Google Cloud SDK using APT
+FROM python:3.10-slim AS gcloud-apt-install
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg lsb-release && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        google-cloud-cli \
+        google-cloud-cli-gke-gcloud-auth-plugin && \
+    apt-get clean && rm -rf /usr/lib/google-cloud-sdk/platform/bundledpythonunix \
+    /var/lib/apt/lists/*
+
+# Stage 2: Main image
+FROM python:3.10-slim
+
+# Copy Google Cloud SDK from Stage 1
+COPY --from=gcloud-apt-install /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
+
+# Set environment variable
+ENV PATH="/opt/google-cloud-sdk/bin:$PATH"
 
 # Detect architecture
 ARG TARGETARCH
@@ -10,19 +30,12 @@ ARG NEXT_BASE_PATH=/dashboard
 # Control installation method - default to install from source
 ARG INSTALL_FROM_SOURCE=true
 
-# Install Google Cloud SDK (least likely to change)
-RUN conda install -c conda-forge google-cloud-sdk
-
-# Install GKE auth plugin
-RUN gcloud components install gke-gcloud-auth-plugin --quiet && \
-    find /opt/conda -name 'gke-gcloud-auth-plugin' -type f -exec ln -s {} /usr/local/bin/gke-gcloud-auth-plugin \;
-
 # Install system packages
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
         git gcc rsync sudo patch openssh-server \
-        pciutils nano fuse socat netcat-openbsd curl rsync vim tini autossh jq && \
-    rm -rf /var/lib/apt/lists/*
+        pciutils nano fuse socat netcat-openbsd curl tini autossh jq && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install kubectl based on architecture
 RUN ARCH=${TARGETARCH:-$(case "$(uname -m)" in \
@@ -44,12 +57,14 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
         curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
         apt-get install -y nodejs && \
         npm install -g npm@latest; \
-    fi
-
+    fi && \
+    ~/.local/bin/uv cache clean && \
+    rm -rf ~/.cache/pip ~/.cache/uv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add source code
 COPY . /skypilot
-
 
 # Install SkyPilot and set up dashboard based on installation method
 RUN cd /skypilot && \
@@ -69,10 +84,8 @@ RUN cd /skypilot && \
         fi && \
         ~/.local/bin/uv pip install "${WHEEL_FILE}[all]" --system && \
         echo "Skipping dashboard build for wheel installation"; \
-    fi
-
-# Cleanup all caches to reduce the image size
-RUN conda clean -afy && \
+    fi && \
+    # Cleanup all caches to reduce the image size
     ~/.local/bin/uv cache clean && \
     rm -rf ~/.cache/pip ~/.cache/uv && \
     apt-get clean && \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,14 +490,14 @@ def setup_docker_container(request):
 
         if worker_count == 0:
             logger.info('Last worker finished, cleaning up container...')
-            subprocess.run([
-                'docker', 'stop', '-t', '600',
-                docker_utils.get_container_name()
-            ],
-                           check=False)
-            subprocess.run(['docker', 'rm',
-                            docker_utils.get_container_name()],
-                           check=False)
+            # subprocess.run([
+            #     'docker', 'stop', '-t', '600',
+            #     docker_utils.get_container_name()
+            # ],
+            #                check=False)
+            # subprocess.run(['docker', 'rm',
+            #                 docker_utils.get_container_name()],
+            #                check=False)
             try:
                 os.remove(counter_file)
             except OSError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,14 +490,14 @@ def setup_docker_container(request):
 
         if worker_count == 0:
             logger.info('Last worker finished, cleaning up container...')
-            # subprocess.run([
-            #     'docker', 'stop', '-t', '600',
-            #     docker_utils.get_container_name()
-            # ],
-            #                check=False)
-            # subprocess.run(['docker', 'rm',
-            #                 docker_utils.get_container_name()],
-            #                check=False)
+            subprocess.run([
+                'docker', 'stop', '-t', '600',
+                docker_utils.get_container_name()
+            ],
+                           check=False)
+            subprocess.run(['docker', 'rm',
+                            docker_utils.get_container_name()],
+                           check=False)
             try:
                 os.remove(counter_file)
             except OSError:

--- a/tests/smoke_tests/docker/Dockerfile_test
+++ b/tests/smoke_tests/docker/Dockerfile_test
@@ -1,4 +1,25 @@
-FROM ubuntu:latest
+# Stage 1: Install Google Cloud SDK using APT
+FROM python:3.10-slim AS gcloud-apt-install
+
+RUN apt-get update && \
+    apt-get install -y curl gnupg lsb-release && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y \
+        google-cloud-cli \
+        google-cloud-cli-gke-gcloud-auth-plugin && \
+    apt-get clean && rm -rf /usr/lib/google-cloud-sdk/platform/bundledpythonunix \
+    /var/lib/apt/lists/*
+
+# Stage 2: Main image
+FROM python:3.10-slim
+
+# Copy Google Cloud SDK from Stage 1
+COPY --from=gcloud-apt-install /usr/lib/google-cloud-sdk /opt/google-cloud-sdk
+
+# Set environment variable
+ENV PATH="/opt/google-cloud-sdk/bin:$PATH"
 
 # Usage:
 # Command on Mac:
@@ -113,21 +134,6 @@ RUN source ~/miniconda3/etc/profile.d/conda.sh && \
     uv pip install -e ".[all]" && \
     # Install httpx with SOCKS support for proxy environments - necessary when system has proxy enabled
     uv pip install httpx[socks]
-
-RUN source ~/miniconda3/etc/profile.d/conda.sh && \
-    conda activate base && \
-    export PATH="$PATH:$HOME/.local/bin" && \
-    conda install -c conda-forge google-cloud-sdk -y && \
-    gcloud components install gke-gcloud-auth-plugin --quiet
-
-# Fix the gsutil problem
-# Install specific pyOpenSSL version to avoid SSL compatibility issues with gsutil
-# Higher versions can cause SSL errors when gsutil doesn't specify compatible SSL version
-RUN source ~/miniconda3/etc/profile.d/conda.sh && \
-    conda activate base && \
-    export PATH="$PATH:$HOME/.local/bin" && \
-    uv pip install pyOpenSSL==23.1.1
-
 
 # Install Helm
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash

--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -671,7 +671,8 @@ def launch_cluster_for_cloud_cmd(cloud: str, test_cluster_name: str) -> str:
 
 def run_cloud_cmd_on_cluster(test_cluster_name: str,
                              cmd: str,
-                             envs: Set[str] = None) -> str:
+                             envs: Set[str] = None,
+                             timeout: int = 180) -> str:
     """Run the cloud command on the remote cluster for cloud commands."""
     cluster_name = test_cluster_name + _CLOUD_CMD_CLUSTER_NAME_SUFFIX
     if sky.server.common.is_api_server_local() and not is_remote_server_test():
@@ -681,7 +682,7 @@ def run_cloud_cmd_on_cluster(test_cluster_name: str,
         wait_for_cluster_up = get_cmd_wait_until_cluster_status_contains(
             cluster_name=cluster_name,
             cluster_status=[sky.ClusterStatus.UP],
-            timeout=180,
+            timeout=timeout,
         )
         envs_str = ''
         if envs is not None:

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1734,7 +1734,7 @@ def test_gcp_disk_tier(instance_types: List[str]):
         name = smoke_tests_utils.get_cluster_name() + '-' + disk_tier.value
         name_on_cloud = common_utils.make_cluster_name_on_cloud(
             name, sky.GCP.max_cluster_name_length())
-        region = 'us-west2'
+        region = 'us-central1'
         instance_type_options = ['']
         if disk_tier == resources_utils.DiskTier.BEST:
             # Ultra disk tier requires n2 instance types to have more than 64 CPUs.

--- a/tests/smoke_tests/test_managed_job.py
+++ b/tests/smoke_tests/test_managed_job.py
@@ -543,7 +543,7 @@ def test_managed_jobs_recovery_multi_node_gcp():
     name = smoke_tests_utils.get_cluster_name()
     name_on_cloud = common_utils.make_cluster_name_on_cloud(
         name, jobs.JOBS_CLUSTER_NAME_PREFIX_LENGTH, add_user_hash=False)
-    zone = 'us-west2-a'
+    zone = 'us-central1-a'
     # Use ':' to match as the cluster name will contain the suffix with job id
     query_cmd = (
         f'gcloud compute instances list --filter='
@@ -856,7 +856,7 @@ def test_managed_jobs_storage(generic_cloud: str):
             name,
             f'{non_persistent_bucket_removed_check_cmd} && exit 1 || true')
     elif generic_cloud == 'gcp':
-        region = 'us-west2'
+        region = 'us-central1'
         region_flag = f'/{region}'
         region_cmd = test_mount_and_storage.TestStorageWithCredentials.cli_region_cmd(
             storage_lib.StoreType.GCS, bucket_name=output_storage_name)

--- a/tests/smoke_tests/test_volume_mount.py
+++ b/tests/smoke_tests/test_volume_mount.py
@@ -215,7 +215,8 @@ def _volume_mounts_commands_generator(f: TextIO, name: str,
 
     test_commands = [
         smoke_tests_utils.run_cloud_cmd_on_cluster(name,
-                                                   cmd=pre_launch_disk_cmd),
+                                                   cmd=pre_launch_disk_cmd,
+                                                   timeout=10 * 60),
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
         launch_cmd,
         f'sky logs {name} 1 --status',  # Ensure the job succeeded.
@@ -225,6 +226,6 @@ def _volume_mounts_commands_generator(f: TextIO, name: str,
     if not tpu and not use_mig:
         test_commands.append(
             smoke_tests_utils.run_cloud_cmd_on_cluster(
-                name, cmd=post_launch_disk_cmd))
+                name, cmd=post_launch_disk_cmd, timeout=10 * 60))
 
     return test_commands, clean_cmd

--- a/tests/smoke_tests/test_volume_mount.py
+++ b/tests/smoke_tests/test_volume_mount.py
@@ -214,9 +214,7 @@ def _volume_mounts_commands_generator(f: TextIO, name: str,
             launch_cmd = f'sky launch -y -c {name} --infra gcp/{region} --instance-type {instance_type} {file_path}'
 
     test_commands = [
-        smoke_tests_utils.run_cloud_cmd_on_cluster(name,
-                                                   cmd=pre_launch_disk_cmd,
-                                                   timeout=10 * 60),
+        pre_launch_disk_cmd,
         *smoke_tests_utils.STORAGE_SETUP_COMMANDS,
         launch_cmd,
         f'sky logs {name} 1 --status',  # Ensure the job succeeded.
@@ -224,9 +222,6 @@ def _volume_mounts_commands_generator(f: TextIO, name: str,
     # Have not support creating new volumes for TPU node now
     # and MIGs do not support specifying volume name
     if not tpu and not use_mig:
-        test_commands.append(
-            smoke_tests_utils.run_cloud_cmd_on_cluster(name,
-                                                       cmd=post_launch_disk_cmd,
-                                                       timeout=10 * 60))
+        test_commands.append(post_launch_disk_cmd)
 
     return test_commands, clean_cmd

--- a/tests/smoke_tests/test_volume_mount.py
+++ b/tests/smoke_tests/test_volume_mount.py
@@ -225,7 +225,8 @@ def _volume_mounts_commands_generator(f: TextIO, name: str,
     # and MIGs do not support specifying volume name
     if not tpu and not use_mig:
         test_commands.append(
-            smoke_tests_utils.run_cloud_cmd_on_cluster(
-                name, cmd=post_launch_disk_cmd, timeout=10 * 60))
+            smoke_tests_utils.run_cloud_cmd_on_cluster(name,
+                                                       cmd=post_launch_disk_cmd,
+                                                       timeout=10 * 60))
 
     return test_commands, clean_cmd


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Reduce docker image size by:
- Install google-cloud-sdk via multi-stage build
- Replace the base image with `python:3.10-slim`

The image size for installing from wheel package is reduced from 4.13GB to 2.64GB, about 36% decrease.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Local smoke test for gcp (partial cases)
  - gcloud command line operations in API server container
  - Launch a cluster on GKE with remote API server
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
