### PR TITLE
[Core] Remove `show-gpus` backwards compat for 0.10.0

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -3387,13 +3387,6 @@ def show_gpus(
         num_filtered_contexts = 0
 
         if realtime_gpu_availability_lists:
-            if len(realtime_gpu_availability_lists[0]) != 2:
-                # TODO(kyuds): for backwards compatibility, as we add new
-                # context to the API server response in #5362. Remove this after
-                # 0.10.0.
-                realtime_gpu_availability_lists = [
-                    (context, realtime_gpu_availability_lists)
-                ]
             for (ctx, availability_list) in realtime_gpu_availability_lists:
                 if not _filter_ctx(ctx):
                     continue


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Related to #6318 

Don't merge until 0.10.0 is fully out.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
