### PR TITLE
[UX] implement `sky api logout`

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -5577,6 +5577,12 @@ def api_login(endpoint: Optional[str], relogin: bool,
     sdk.api_login(endpoint, relogin, service_account_token)
 
 
+@api.command('logout', cls=_DocumentedCodeCommand)
+def api_logout():
+    """Logs out of the api server"""
+    sdk.api_logout()
+
+
 @api.command('info', cls=_DocumentedCodeCommand)
 @flags.config_option(expose_value=False)
 @usage_lib.entrypoint

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2089,7 +2089,7 @@ def _clear_api_server_config() -> None:
         config = dict(config)
         del config['api_server']
 
-        common_utils.dump_yaml(str(config_path), config)
+        common_utils.dump_yaml(str(config_path), config, blank=True)
         skypilot_config.reload_config()
 
 
@@ -2126,6 +2126,11 @@ def api_login(endpoint: Optional[str] = None,
     Returns:
         None
     """
+    if _local_api_server_running():
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError('Local API server is running. '
+                               'Stop it with `sky api stop` first.')
+
     # Validate and normalize endpoint
     endpoint = _validate_endpoint(endpoint)
 
@@ -2357,7 +2362,7 @@ def api_logout() -> None:
     """Logout of the API server.
 
     Clears all cookies and settings stored in ~/.sky/config.yaml"""
-    if not server_common.is_api_server_local():
+    if server_common.is_api_server_local():
         with ux_utils.print_exception_no_traceback():
             raise RuntimeError('Local api server cannot be logged out. '
                                'Use `sky api stop` instead.')
@@ -2366,3 +2371,5 @@ def api_logout() -> None:
     server_common.set_api_cookie_jar(cookiejar.MozillaCookieJar(),
                                      create_if_not_exists=False)
     _clear_api_server_config()
+    logger.info(f'{colorama.Fore.GREEN}Logged out of SkyPilot API server.'
+                f'{colorama.Style.RESET_ALL}')

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2077,6 +2077,22 @@ def _save_config_updates(endpoint: Optional[str] = None,
         skypilot_config.reload_config()
 
 
+def _clear_api_server_config() -> None:
+    """Clear endpoint and service account token from config file."""
+    config_path = pathlib.Path(
+        skypilot_config.get_user_config_path()).expanduser()
+    with filelock.FileLock(config_path.with_suffix('.lock')):
+        if not config_path.exists():
+            return
+
+        config = skypilot_config.get_user_config()
+        config = dict(config)
+        del config['api_server']
+
+        common_utils.dump_yaml(str(config_path), config)
+        skypilot_config.reload_config()
+
+
 def _validate_endpoint(endpoint: Optional[str]) -> str:
     """Validate and normalize the endpoint URL."""
     if endpoint is None:
@@ -2333,3 +2349,20 @@ def api_login(endpoint: Optional[str] = None,
         endpoint)
     _show_logged_in_message(endpoint, dashboard_url, final_api_server_info.user,
                             server_status)
+
+
+@usage_lib.entrypoint
+@annotations.client_api
+def api_logout() -> None:
+    """Logout of the API server.
+
+    Clears all cookies and settings stored in ~/.sky/config.yaml"""
+    if not server_common.is_api_server_local():
+        with ux_utils.print_exception_no_traceback():
+            raise RuntimeError('Local api server cannot be logged out. '
+                               'Use `sky api stop` instead.')
+
+    # no need to clear cookies if it doesn't exist.
+    server_common.set_api_cookie_jar(cookiejar.MozillaCookieJar(),
+                                     create_if_not_exists=False)
+    _clear_api_server_config()

--- a/sky/utils/common_utils.py
+++ b/sky/utils/common_utils.py
@@ -562,8 +562,9 @@ def read_yaml_all(path: str) -> List[Dict[str, Any]]:
         return read_yaml_all_str(f.read())
 
 
-def dump_yaml(path: str, config: Union[List[Dict[str, Any]],
-                                       Dict[str, Any]]) -> None:
+def dump_yaml(path: str,
+              config: Union[List[Dict[str, Any]], Dict[str, Any]],
+              blank: bool = False) -> None:
     """Dumps a YAML file.
 
     Args:
@@ -571,7 +572,11 @@ def dump_yaml(path: str, config: Union[List[Dict[str, Any]],
         config: the configuration to dump.
     """
     with open(path, 'w', encoding='utf-8') as f:
-        f.write(dump_yaml_str(config))
+        contents = dump_yaml_str(config)
+        if blank and isinstance(config, dict) and len(config) == 0:
+            # when dumping to yaml, an empty dict will go in as {}.
+            contents = ''
+        f.write(contents)
 
 
 def dump_yaml_str(config: Union[List[Dict[str, Any]], Dict[str, Any]]) -> str:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixes #6326 

As a follow up, it is important to REMOVE ALL SESSIONS AND REVOKE ANY OAUTH2 TOKENS. The motivation of this PR is to logout so to enable users to easily switch between local/remote api servers, to change server urls without modifying `config.yaml`. However, from a security standpoint, this would cause a session leak. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [X] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [X] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
