### PR TITLE
Fixed autostop policy and refined lint

### DIFF
--- a/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
+++ b/examples/admin_policy/example_policy/example_policy/skypilot_policy.py
@@ -1,7 +1,9 @@
 """Example prebuilt admin policies."""
 import subprocess
+from typing import Any, Dict, List
 
 import sky
+from sky.utils import common
 
 
 class DoNothingPolicy(sky.AdminPolicy):
@@ -102,11 +104,16 @@ class EnforceAutostopPolicy(sky.AdminPolicy):
 
         # Get the cluster record to operate on.
         cluster_name = request_options.cluster_name
-        cluster_records = []
+        cluster_records: List[Dict[str, Any]] = []
         if cluster_name is not None:
-            cluster_records = sky.status(cluster_name,
-                                         refresh=True,
-                                         all_users=True)
+            try:
+                cluster_records = sky.get(
+                    sky.status([cluster_name],
+                               refresh=common.StatusRefreshMode.AUTO,
+                               all_users=True))
+            except Exception as e:
+                raise RuntimeError('Failed to get cluster status for '
+                                   f'{cluster_name}: {e}') from None
 
         # Check if the user request should specify autostop settings.
         need_autostop = False
@@ -148,9 +155,11 @@ class SetMaxAutostopIdleMinutesPolicy(sky.AdminPolicy):
         for r in task.resources:
             disabled = (r.autostop_config is None or
                         not r.autostop_config.enabled)
-            too_long = (not disabled and
-                        r.autostop_config.idle_minutes is not None and
-                        r.autostop_config.idle_minutes > max_idle_minutes)
+            too_long = False
+            if not disabled:
+                assert r.autostop_config is not None
+                too_long = (r.autostop_config.idle_minutes is not None and
+                            r.autostop_config.idle_minutes > max_idle_minutes)
             if disabled or too_long:
                 r.override_autostop_config(idle_minutes=max_idle_minutes)
 
@@ -161,8 +170,8 @@ class SetMaxAutostopIdleMinutesPolicy(sky.AdminPolicy):
 def update_current_kubernetes_clusters_from_registry():
     """Mock implementation of updating kubernetes clusters from registry."""
     # All cluster names can be fetched from an organization's internal API.
-    NEW_CLUSTER_NAMES = ['my-cluster']
-    for cluster_name in NEW_CLUSTER_NAMES:
+    new_cluster_names = ['my-cluster']
+    for cluster_name in new_cluster_names:
         # Update the local kubeconfig with the new cluster credentials.
         subprocess.run(
             f'gcloud container clusters get-credentials {cluster_name} '
@@ -173,6 +182,7 @@ def update_current_kubernetes_clusters_from_registry():
 
 def get_allowed_contexts():
     """Mock implementation of getting allowed kubernetes contexts."""
+    # pylint: disable=import-outside-toplevel
     from sky.provision.kubernetes import utils
     contexts = utils.get_all_kube_context_names()
     return contexts[:2]

--- a/format.sh
+++ b/format.sh
@@ -125,14 +125,14 @@ mypy $(cat tests/mypy_files.txt)
 # Run Pylint
 echo 'Sky Pylint:'
 if [[ "$1" == '--files' ]]; then
-    # If --files is passed, filter to files within sky/ and pass to pylint.
+    # If --files is passed, filter to files within sky/ and examples/ and pass to pylint.
     pylint "${PYLINT_FLAGS[@]}" "${@:2}"
 elif [[ "$1" == '--all' ]]; then
-    # Pylint entire sky directory.
-    pylint "${PYLINT_FLAGS[@]}" sky
+    # Pylint entire sky and examples directories.
+    pylint "${PYLINT_FLAGS[@]}" sky examples
 else
-    # Pylint only files in sky/ that have changed in last commit.
-    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi')
+    # Pylint only files in sky/ and examples/ that have changed in last commit.
+    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi' 'examples/*.py' 'examples/*.pyi')
     if [[ -n "$changed_files" ]]; then
         echo "$changed_files" | tr '\n' '\0' | xargs -0 pylint "${PYLINT_FLAGS[@]}"
     else

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -2143,7 +2143,9 @@ def logs(
     if sync_down:
         with rich_utils.client_status(
                 ux_utils.spinner_message('Downloading logs')):
-            log_local_path_dict = sdk.download_logs(cluster, job_ids)
+            log_local_path_dict = sdk.download_logs(
+                cluster,
+                list(job_ids) if job_ids else None)
         style = colorama.Style
         fore = colorama.Fore
         for job, log_local_path in log_local_path_dict.items():
@@ -2195,8 +2197,7 @@ def logs(
                 f'{colorama.Style.RESET_ALL}')
 
     # Stream logs from the server.
-    returncode = sdk.tail_logs(cluster, job_id, follow, tail=tail)
-    sys.exit(returncode)
+    sys.exit(sdk.tail_logs(cluster, job_id, follow, tail=tail))
 
 
 @cli.command()
@@ -3244,7 +3245,7 @@ def show_gpus(
         infra: Optional[str],
         cloud: Optional[str],
         region: Optional[str],
-        all_regions: Optional[bool]):
+        all_regions: bool):
     """Show supported GPU/TPU/accelerators and their prices.
 
     The names and counts shown can be set in the ``accelerators`` field in task
@@ -5398,7 +5399,7 @@ def api():
               required=False,
               help='Enable basic authentication in the SkyPilot API server.')
 @usage_lib.entrypoint
-def api_start(deploy: bool, host: Optional[str], foreground: bool,
+def api_start(deploy: bool, host: str, foreground: bool,
               enable_basic_auth: bool):
     """Starts the SkyPilot API server locally."""
     sdk.api_start(deploy=deploy,

--- a/sky/client/sdk.pyi
+++ b/sky/client/sdk.pyi
@@ -1,0 +1,295 @@
+import io
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from _typeshed import Incomplete
+import requests
+
+import sky
+from sky import admin_policy as admin_policy
+from sky import backends as backends
+from sky import exceptions as exceptions
+from sky import sky_logging as sky_logging
+from sky import skypilot_config as skypilot_config
+from sky.server import common as server_common
+from sky.server import rest as rest
+from sky.server.requests import payloads as payloads
+from sky.skylet import constants as constants
+from sky.usage import usage_lib as usage_lib
+from sky.utils import admin_policy_utils as admin_policy_utils
+from sky.utils import annotations as annotations
+from sky.utils import cluster_utils as cluster_utils
+from sky.utils import common as common
+from sky.utils import common_utils as common_utils
+from sky.utils import dag_utils as dag_utils
+from sky.utils import env_options as env_options
+from sky.utils import infra_utils as infra_utils
+from sky.utils import rich_utils as rich_utils
+from sky.utils import status_lib as status_lib
+from sky.utils import subprocess_utils as subprocess_utils
+from sky.utils import ux_utils as ux_utils
+from sky.utils.kubernetes import ssh_utils as ssh_utils
+
+logger: Incomplete
+
+
+def reload_config() -> None:
+    ...
+
+
+def stream_response(request_id: Optional[str],
+                    response: requests.Response,
+                    output_stream: Optional['io.TextIOBase'] = ...,
+                    resumable: bool = ...) -> Any:
+    ...
+
+
+def check(infra_list: Optional[Tuple[str, ...]],
+          verbose: bool,
+          workspace: Optional[str] = ...) -> server_common.RequestId:
+    ...
+
+
+def enabled_clouds(workspace: Optional[str] = ...,
+                   expand: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def list_accelerators(gpus_only: bool = ...,
+                      name_filter: Optional[str] = ...,
+                      region_filter: Optional[str] = ...,
+                      quantity_filter: Optional[int] = ...,
+                      clouds: Optional[Union[List[str], str]] = ...,
+                      all_regions: bool = ...,
+                      require_price: bool = ...,
+                      case_sensitive: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def list_accelerator_counts(
+        gpus_only: bool = ...,
+        name_filter: Optional[str] = ...,
+        region_filter: Optional[str] = ...,
+        quantity_filter: Optional[int] = ...,
+        clouds: Optional[Union[List[str],
+                               str]] = ...) -> server_common.RequestId:
+    ...
+
+
+def optimize(
+    dag: sky.Dag,
+    minimize: common.OptimizeTarget = ...,
+    admin_policy_request_options: Optional[admin_policy.RequestOptions] = ...
+) -> server_common.RequestId:
+    ...
+
+
+def workspaces() -> server_common.RequestId:
+    ...
+
+
+def validate(
+    dag: sky.Dag,
+    workdir_only: bool = ...,
+    admin_policy_request_options: Optional[admin_policy.RequestOptions] = ...
+) -> None:
+    ...
+
+
+def dashboard(starting_page: Optional[str] = ...) -> None:
+    ...
+
+
+def launch(task: Union['sky.Task', 'sky.Dag'],
+           cluster_name: Optional[str] = ...,
+           retry_until_up: bool = ...,
+           idle_minutes_to_autostop: Optional[int] = ...,
+           dryrun: bool = ...,
+           down: bool = ...,
+           backend: Optional['backends.Backend'] = ...,
+           optimize_target: common.OptimizeTarget = ...,
+           no_setup: bool = ...,
+           clone_disk_from: Optional[str] = ...,
+           fast: bool = ...,
+           _need_confirmation: bool = ...,
+           _is_launched_by_jobs_controller: bool = ...,
+           _is_launched_by_sky_serve_controller: bool = ...,
+           _disable_controller_check: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def exec(
+        task: Union['sky.Task', 'sky.Dag'],
+        cluster_name: Optional[str] = ...,
+        dryrun: bool = ...,
+        down: bool = ...,
+        backend: Optional['backends.Backend'] = ...) -> server_common.RequestId:
+    ...
+
+
+def tail_logs(cluster_name: str,
+              job_id: Optional[int],
+              follow: bool,
+              tail: int = ...,
+              output_stream: Optional['io.TextIOBase'] = ...) -> int:
+    ...
+
+
+def download_logs(cluster_name: str,
+                  job_ids: Optional[List[str]]) -> Dict[str, str]:
+    ...
+
+
+def start(cluster_name: str,
+          idle_minutes_to_autostop: Optional[int] = ...,
+          retry_until_up: bool = ...,
+          down: bool = ...,
+          force: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def down(cluster_name: str, purge: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def stop(cluster_name: str, purge: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def autostop(cluster_name: str,
+             idle_minutes: int,
+             down: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def queue(cluster_name: str,
+          skip_finished: bool = ...,
+          all_users: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def job_status(cluster_name: str,
+               job_ids: Optional[List[int]] = ...) -> server_common.RequestId:
+    ...
+
+
+def cancel(
+        cluster_name: str,
+        all: bool = ...,
+        all_users: bool = ...,
+        job_ids: Optional[List[int]] = ...,
+        _try_cancel_if_cluster_is_init: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def status(cluster_names: Optional[List[str]] = ...,
+           refresh: common.StatusRefreshMode = ...,
+           all_users: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def endpoints(cluster: str,
+              port: Optional[Union[int, str]] = ...) -> server_common.RequestId:
+    ...
+
+
+def cost_report(days: Optional[int] = ...) -> server_common.RequestId:
+    ...
+
+
+def storage_ls() -> server_common.RequestId:
+    ...
+
+
+def storage_delete(name: str) -> server_common.RequestId:
+    ...
+
+
+def local_up(gpus: bool,
+             ips: Optional[List[str]],
+             ssh_user: Optional[str],
+             ssh_key: Optional[str],
+             cleanup: bool,
+             context_name: Optional[str] = ...,
+             password: Optional[str] = ...) -> server_common.RequestId:
+    ...
+
+
+def local_down() -> server_common.RequestId:
+    ...
+
+
+def ssh_up(infra: Optional[str] = ...,
+           file: Optional[str] = ...) -> server_common.RequestId:
+    ...
+
+
+def ssh_down(infra: Optional[str] = ...) -> server_common.RequestId:
+    ...
+
+
+def realtime_kubernetes_gpu_availability(
+        context: Optional[str] = ...,
+        name_filter: Optional[str] = ...,
+        quantity_filter: Optional[int] = ...,
+        is_ssh: Optional[bool] = ...) -> server_common.RequestId:
+    ...
+
+
+def kubernetes_node_info(
+        context: Optional[str] = ...) -> server_common.RequestId:
+    ...
+
+
+def status_kubernetes() -> server_common.RequestId:
+    ...
+
+
+def get(request_id: str) -> Any:
+    ...
+
+
+def stream_and_get(request_id: Optional[str] = ...,
+                   log_path: Optional[str] = ...,
+                   tail: Optional[int] = ...,
+                   follow: bool = ...,
+                   output_stream: Optional['io.TextIOBase'] = ...) -> Any:
+    ...
+
+
+def api_cancel(request_ids: Optional[Union[str, List[str]]] = ...,
+               all_users: bool = ...,
+               silent: bool = ...) -> server_common.RequestId:
+    ...
+
+
+def api_status(request_ids: Optional[List[str]] = ...,
+               all_status: bool = ...) -> List[payloads.RequestPayload]:
+    ...
+
+
+def api_info() -> Dict[str, Any]:
+    ...
+
+
+def api_start(*,
+              deploy: bool = ...,
+              host: str = ...,
+              foreground: bool = ...,
+              metrics: bool = ...,
+              metrics_port: Optional[int] = ...,
+              enable_basic_auth: bool = ...) -> None:
+    ...
+
+
+def api_stop() -> None:
+    ...
+
+
+def api_server_logs(follow: bool = ..., tail: Optional[int] = ...) -> None:
+    ...
+
+
+def api_login(endpoint: Optional[str] = ...,
+              relogin: bool = ...,
+              service_account_token: Optional[str] = ...) -> None:
+    ...

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -203,17 +203,33 @@ class DagRequestBody(RequestBody):
         return kwargs
 
 
-class ValidateBody(DagRequestBody):
-    """The request body for the validate endpoint."""
-    dag: str
+class DagRequestBodyWithRequestOptions(DagRequestBody):
+    """Request body base class for endpoints with a dag and request options."""
     request_options: Optional[admin_policy.RequestOptions]
 
+    def get_request_options(self) -> admin_policy.RequestOptions:
+        """Get the request options."""
+        if self.request_options is None:
+            return admin_policy.RequestOptions()
+        if isinstance(self.request_options, dict):
+            return admin_policy.RequestOptions(**self.request_options)
+        return self.request_options
 
-class OptimizeBody(DagRequestBody):
+    def to_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().to_kwargs()
+        kwargs['request_options'] = self.get_request_options()
+        return kwargs
+
+
+class ValidateBody(DagRequestBodyWithRequestOptions):
+    """The request body for the validate endpoint."""
+    dag: str
+
+
+class OptimizeBody(DagRequestBodyWithRequestOptions):
     """The request body for the optimize endpoint."""
     dag: str
     minimize: common_lib.OptimizeTarget = common_lib.OptimizeTarget.COST
-    request_options: Optional[admin_policy.RequestOptions]
 
 
 class LaunchBody(RequestBody):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -827,7 +827,8 @@ async def validate(validate_body: payloads.ValidateBody) -> None:
         # added RTTs. For now, we stick to doing the validation inline in the
         # server thread.
         with admin_policy_utils.apply_and_use_config_in_current_request(
-                dag, request_options=validate_body.request_options) as dag:
+                dag,
+                request_options=validate_body.get_request_options()) as dag:
             # Skip validating workdir and file_mounts, as those need to be
             # validated after the files are uploaded to the SkyPilot API server
             # with `upload_mounts_to_api_server`.

--- a/tests/mypy_files.txt
+++ b/tests/mypy_files.txt
@@ -1,3 +1,5 @@
 sky
+examples/admin_policy/example_policy
 
 --exclude sky/backends/monkey_patches
+--exclude examples/admin_policy/example_policy/build


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/6328

This a long standing issue since there is no test and lint for this policy (`sky.status` is mocked in the relevant UT), this PR fixes the issue and add basic lint for example dir.

A stub of `sdk.py` is added to enable type checking while we does not follow import in mypy.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
