### PR TITLE
Fix failure of `test_remote_server_api_login`

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -2004,6 +2004,8 @@ def test_remote_server_api_login():
         [
             # Backup existing config file if it exists
             f'if [ -f {config_path} ]; then cp {config_path} {backup_path}; fi',
+            # Stop local api server
+            f'sky api stop',
             # Run sky api login
             f'sky api login -e {endpoint}',
             # Echo the config file content to see what was written


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fail in [nightly](https://buildkite.com/skypilot-1/smoke-tests/builds/1924#_)

<img width="2331" height="1692" alt="image" src="https://github.com/user-attachments/assets/05da7879-4f61-4b7c-9300-753b544bfd45" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
