### PR TITLE
Fixed sky api login when local one is running

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2126,11 +2126,6 @@ def api_login(endpoint: Optional[str] = None,
     Returns:
         None
     """
-    if _local_api_server_running():
-        with ux_utils.print_exception_no_traceback():
-            raise RuntimeError('Local API server is running. '
-                               'Stop it with `sky api stop` first.')
-
     # Validate and normalize endpoint
     endpoint = _validate_endpoint(endpoint)
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
