### PR TITLE
[nebius] suppress superflous nebius config logs

### DIFF
--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -263,12 +263,13 @@ def get_cloud_config_value_from_dict(
                 keys=(cloud, region) + keys,
                 default_value=None,
                 override_configs=override_configs)
-            logger.info(
-                'Nebius configuration is using the legacy format. \n'
-                'This format will be deprecated after 0.11.0, refer to '
-                '`https://docs.skypilot.co/en/latest/reference/config.html#nebius` '  # pylint: disable=line-too-long
-                'for the new format. Please use `region_configs` to specify region specific configuration.'
-            )
+            if per_context_config is not None:
+                logger.info(
+                    'Nebius configuration is using the legacy format. \n'
+                    'This format will be deprecated after 0.11.0, refer to '
+                    '`https://docs.skypilot.co/en/latest/reference/config.html#nebius` '  # pylint: disable=line-too-long
+                    'for the new format. Please use `region_configs` to specify region specific configuration.'
+                )
     # if no override found for specified region
     general_config = input_config.get_nested(keys=(cloud,) + keys,
                                              default_value=default_value,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Currently, we're printing the incompatibility logs if the nebius config being searched for does not exist in the new region config location. However, it is possible the config being searched for does not exist anywhere, because the user didn't set them. This is not a case of user still using the old configuration format, so we should not be printing the deprecation notice in that case.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
