### PR TITLE
[db] Alembic fix new revisions backwards compatibility

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -17,7 +17,6 @@ import typing
 from typing import Any, Dict, List, Optional, Set, Tuple
 import uuid
 
-from alembic import command as alembic_command
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy import orm
@@ -243,8 +242,8 @@ def create_table(engine: sqlalchemy.engine.Engine):
         engine, migration_utils.GLOBAL_USER_STATE_DB_NAME)
     # pylint: disable=line-too-long
     alembic_config.config_ini_section = migration_utils.GLOBAL_USER_STATE_DB_NAME
-    alembic_command.upgrade(alembic_config,
-                            migration_utils.GLOBAL_USER_STATE_VERSION)
+    migration_utils.safe_alembic_upgrade(
+        engine, alembic_config, migration_utils.GLOBAL_USER_STATE_VERSION)
 
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -10,7 +10,6 @@ import time
 import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from alembic import command as alembic_command
 import colorama
 import sqlalchemy
 from sqlalchemy import exc as sqlalchemy_exc
@@ -134,7 +133,8 @@ def create_table(engine: sqlalchemy.engine.Engine):
     alembic_config = migration_utils.get_alembic_config(
         engine, migration_utils.SPOT_JOBS_DB_NAME)
     alembic_config.config_ini_section = migration_utils.SPOT_JOBS_DB_NAME
-    alembic_command.upgrade(alembic_config, migration_utils.SPOT_JOBS_VERSION)
+    migration_utils.safe_alembic_upgrade(engine, alembic_config,
+                                         migration_utils.SPOT_JOBS_VERSION)
 
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -3,7 +3,9 @@
 import contextlib
 import os
 
+from alembic import command as alembic_command
 from alembic.config import Config
+from alembic.runtime import migration
 import filelock
 import sqlalchemy
 
@@ -47,3 +49,40 @@ def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
     alembic_cfg.set_section_option(section, 'sqlalchemy.url', url)
 
     return alembic_cfg
+
+
+def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine,
+                         alembic_config: Config, target_revision: str):
+    """Only upgrade if current version is older than target.
+
+    This handles the case where a database was created with a newer version of
+    the code and we're now running older code. Since our migrations are purely
+    additive, it's safe to run a newer database with older code.
+
+    Args:
+        engine: SQLAlchemy engine for the database
+        alembic_config: Alembic configuration object
+        target_revision: Target revision to upgrade to (e.g., '001')
+    """
+    current_rev = None
+
+    # Get the current revision from the database
+    version_table = alembic_config.get_section_option(
+        alembic_config.config_ini_section, 'version_table', 'alembic_version')
+
+    with engine.connect() as connection:
+        context = migration.MigrationContext.configure(
+            connection, opts={'version_table': version_table})
+        current_rev = context.get_current_revision()
+
+    if current_rev is None:
+        alembic_command.upgrade(alembic_config, target_revision)
+        return
+
+    # Compare revisions - assuming they are numeric strings like '001', '002'
+    current_rev_num = int(current_rev)
+    target_rev_num = int(target_revision)
+
+    # only upgrade if current revision is older than target revision
+    if current_rev_num < target_rev_num:
+        alembic_command.upgrade(alembic_config, target_revision)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes and issue where adding new alembic revisions breaks backwards compatibility. 

The issue was that when a new PR adds a new revision #{x+1}, the db gets initialized at that revision #. Then when master gets checked out (assuming master is set to use revision #{x}, an error would get thrown, causing the api server to fail to start because when alembic tries to "upgrade" to revision #{x} it checks the current version of the db which is at #{x+1} which it does not recognize. 

This PR adds a check before upgrading the database such that the db only gets upgraded if the current version of the database either does not exist (pre-alembic) or is older than the desired version. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
