### PR TITLE
[core] do not refresh cluster[s] that has an active request associated with it

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -35,6 +35,7 @@ from sky.adaptors import common as adaptors_common
 from sky.jobs import utils as managed_job_utils
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
+from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
 from sky.usage import usage_lib
 from sky.utils import cluster_utils
@@ -2841,6 +2842,12 @@ def get_clusters(
         force_refresh_statuses = None
 
     def _refresh_cluster(cluster_name):
+        request = requests_lib.get_request_tasks(
+            status=[requests_lib.RequestStatus.RUNNING],
+            cluster_names=[cluster_name])
+        logger.info(f'request {request}')
+        if len(request) > 0:
+            return global_user_state.get_cluster_from_name(cluster_name)
         try:
             record = refresh_cluster_record(
                 cluster_name,

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2842,15 +2842,20 @@ def get_clusters(
         force_refresh_statuses = None
 
     def _refresh_cluster(cluster_name):
+        # TODO(syang): we should try not to leak
+        # request info in backend_utils.py.
+        # Refactor this to use some other info to
+        # determine if a launch is in progress.
         request = requests_lib.get_request_tasks(
             status=[requests_lib.RequestStatus.RUNNING],
-            cluster_names=[cluster_name])
+            cluster_names=[cluster_name],
+            include_request_names=['sky.launch'])
         if len(request) > 0:
-            # There is an active request on the cluster,
+            # There is an active launch request on the cluster,
             # so we don't want to update the cluster status until
             # the request is completed.
             logger.debug(f'skipping refresh for cluster {cluster_name} '
-                         'as there is an active request')
+                         'as there is an active launch request')
             return global_user_state.get_cluster_from_name(cluster_name)
         try:
             record = refresh_cluster_record(

--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -2845,8 +2845,12 @@ def get_clusters(
         request = requests_lib.get_request_tasks(
             status=[requests_lib.RequestStatus.RUNNING],
             cluster_names=[cluster_name])
-        logger.info(f'request {request}')
         if len(request) > 0:
+            # There is an active request on the cluster,
+            # so we don't want to update the cluster status until
+            # the request is completed.
+            logger.debug(f'skipping refresh for cluster {cluster_name} '
+                         'as there is an active request')
             return global_user_state.get_cluster_from_name(cluster_name)
         try:
             record = refresh_cluster_record(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR fixes an issue where launch command using `--retry-until-up` sometimes fails after a retry due to the error
```
AssertionError: Trying to launch cluster '<cluster-name>' recently terminated on the cloud, but the handle is not a CloudVmRayResourceHandle (None).
```

This error is caused by https://github.com/skypilot-org/skypilot/pull/5556. In this PR, the worker process yields on retry instead of busy-waiting on an executor. Notably, before this PR, the while loop that busy-waits the request has the `to_provision_config` declared and constant, whereas after the PR the `to_provision_config` is calculated on every retry attempt.

From my understanding, `to_provision_config` is only calculated when the optimizer runs, and the optimizer does not run if the cluster record already exists in the DB. In a retry, the cluster record should already be in the DB with INIT status, so the optimizer should not run and `to_provision_config` _should_ be None. Then, `_check_existing_cluster` pulls the DB record of the cluster to construct the provision config.

However, either the background cluster refresh daemon or an explicit `sky status --refresh`, when called while the request is on a retry backoff, can delete the cluster record. This is somewhat fine, as the DB record being deleted would cause the optimizer to run, and populate `to_provision_config`. The `_check_existing_cluster` function works if either `to_provision_config` or the DB record is present, and `to_provision_config` is present if DB record is not present.

Of course, there is a probabilistic exception to this case, when the cluster refresh (= DB record deletion) happens after `to_provision_config` is computed and before `_check_existing_cluster` is called. In such case, `_check_existing_cluster` would be None as the DB record existed then, and `_check_existing_cluster` will see a None `to_provision_config` and no DB record, in which case the assertion is raised.

---

There are a few ways to fix this problem, with varying tradeoffs. The approaches considered are described here.

1. When a launch request with `--retry-until-up` fails, make sure the DB record of the cluster is deleted before the retry backoff is started. This approaches guarantees that optimizer will run on the next try, and guarantee the existence of `to_provision_config`. However, this approach has a flaw that `sky status` will see the cluster being in INIT at some points (when the launch request is being tried) and the cluster disappearing at other points (when the launch is in a retry backoff), resulting in a bad UX. This approach was abandoned due to UX concerns.
2. Make the launch request hold the cluster lock throughout the entirety of the request, including the backoff. Besides the technical caution needed to avoid double-locking given current implementation, this means a super long-running request (where the launch fails and is retried potentially indefinitely) can meaningfully slow the background cluster refresh process or `sky status --refresh`.
3. (chosen approach) Have the cluster refresh ignore clusters that has an active request associated with it. The idea is that the cluster status is actively being updated/monitored by the request, so there is no need for the refresh to do anything on the cluster. This has a positive side effect of speeding up `sky status --refresh` in cases where a launch operation is happening.



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
