### PR TITLE
Update default image of the helm chart

### DIFF
--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -1,5 +1,7 @@
 apiService:
-  image: berkeleyskypilot/skypilot:0.9.2
+  # The container image of the API server, the default value is set by the release pipeline.
+  # - For nightly release, 
+  image: berkeleyskypilot/skypilot-nightly:latest
   # Number of replicas to deploy - replicas > 1 is not well tested.
   replicas: 1
   preDeployHook: |-

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -1,6 +1,6 @@
 apiService:
-  # The container image of the API server, the default value is set by the release pipeline.
-  # - For nightly release, 
+  # Docker image to use for the API server. The default value will be updated by the release pipeline to be consistent with the SkyPilot release or nightly build.
+  # Refer to https://docs.skypilot.co/en/latest/reference/api-server/helm-values-spec.html#helm-values-apiservice-image for more details.
   image: berkeleyskypilot/skypilot-nightly:latest
   # Number of replicas to deploy - replicas > 1 is not well tested.
   replicas: 1

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -34,7 +34,7 @@ Below is the available helm value keys and the default value of each key:
 .. parsed-literal::
 
   :ref:`apiService <helm-values-apiService>`:
-    :ref:`image <helm-values-apiService-image>`: berkeleyskypilot/skypilot:0.9.2
+    :ref:`image <helm-values-apiService-image>`: berkeleyskypilot/skypilot-nightly:latest
     :ref:`upgradeStrategy <helm-values-apiService-upgradeStrategy>`: Recreate
     :ref:`replicas <helm-values-apiService-replicas>`: 1
     :ref:`enableUserManagement <helm-values-apiService-enableUserManagement>`: false
@@ -242,14 +242,18 @@ Configuration for the SkyPilot API server deployment.
 ``apiService.image``
 ^^^^^^^^^^^^^^^^^^^^
 
-Docker image to use for the API server.
+Docker image to use for the API server. The default value is depending on the chart you are using:
 
-Default: ``"berkeleyskypilot/skypilot:0.9.2"``
+- Stable release of the chart(``skypilot/skypilot``): the same stable release of SkyPilot will be used by default, i.e. ``berkeleyskypilot/skypilot:$CHART_VERSION``.
+- Nightly release of the chart(``skypilot/skypilot-nightly``): the same nightly build of SkyPilot will be used by default, i.e. ``berkeleyskypilot/skypilot-nightly:$CHART_VERSION``.
+- Installing from `source <https://github.com/skypilot-org/skypilot/tree/master/charts/skypilot>`_: the latest nightly build of SkyPilot will be used by default, i.e. ``berkeleyskypilot/skypilot-nightly:latest``.
+
+To use a specific release version, set the ``image`` value to the desired version:
 
 .. code-block:: yaml
 
   apiService:
-    image: berkeleyskypilot/skypilot:0.9.2
+    image: berkeleyskypilot/skypilot:0.10.0
 
 To use a nightly build, find the desired nightly version on `pypi <https://pypi.org/project/skypilot-nightly/#history>`_ and update the ``image`` value:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Clarify the default image strategy, so that the helm chart and our python code are consistent by default.

Note that there is no exact consistency when user install the chart from source since we do not release image for every commit, in this case, the closest version is used by default (`skypilot-nightly:latest`)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
