### PR TITLE
[Admin Policy] run mypy/lint on example policies, fix mypy/lint issues, fix bugs related to EnforceAutostopPolicy

### DIFF
--- a/examples/admin_policy/example_server/policy_server.py
+++ b/examples/admin_policy/example_server/policy_server.py
@@ -12,7 +12,7 @@ import uvicorn
 
 import sky
 
-app = FastAPI(title="Example Admin Policy Server", version="1.0.0")
+app = FastAPI(title='Example Admin Policy Server', version='1.0.0')
 
 
 class DoNothingPolicy(sky.AdminPolicy):
@@ -33,7 +33,7 @@ async def apply_policy(request: Request) -> JSONResponse:
     json_data = await request.json()
     user_request = sky.UserRequest.decode(json_data)
     # Example: change the following list to apply different policies.
-    policies: List[sky.AdminPolicy] = [
+    policies: List = [
         # Example: policy that implemented in the server package.
         DoNothingPolicy,
         # Example: policy from third party packages.
@@ -64,4 +64,4 @@ if __name__ == '__main__':
                 workers=1,
                 host=args.host,
                 port=args.port,
-                log_level="info")
+                log_level='info')

--- a/format.sh
+++ b/format.sh
@@ -132,7 +132,7 @@ elif [[ "$1" == '--all' ]]; then
     pylint "${PYLINT_FLAGS[@]}" sky
 else
     # Pylint only files in sky/ that have changed in last commit.
-    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi')
+    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- 'sky/*.py' 'sky/*.pyi' 'examples/admin_policy/**/*.py')
     if [[ -n "$changed_files" ]]; then
         echo "$changed_files" | tr '\n' '\0' | xargs -0 pylint "${PYLINT_FLAGS[@]}"
     else

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -211,7 +211,8 @@ class ValidateBody(DagRequestBody):
     def to_kwargs(self) -> Dict[str, Any]:
         kwargs = super().to_kwargs()
 
-        # Convert request_options back to admin_policy.RequestOptions if it's a dict
+        # Convert request_options back to 
+        # admin_policy.RequestOptions if it's a dict
         if (kwargs.get('request_options') is not None and not isinstance(
                 kwargs['request_options'], admin_policy.RequestOptions)):
             kwargs['request_options'] = admin_policy.RequestOptions(
@@ -229,7 +230,8 @@ class OptimizeBody(DagRequestBody):
     def to_kwargs(self) -> Dict[str, Any]:
         kwargs = super().to_kwargs()
 
-        # Convert request_options back to admin_policy.RequestOptions if it's a dict
+        # Convert request_options back to 
+        # admin_policy.RequestOptions if it's a dict
         if (kwargs.get('request_options') is not None and not isinstance(
                 kwargs['request_options'], admin_policy.RequestOptions)):
             kwargs['request_options'] = admin_policy.RequestOptions(

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -211,7 +211,7 @@ class ValidateBody(DagRequestBody):
     def to_kwargs(self) -> Dict[str, Any]:
         kwargs = super().to_kwargs()
 
-        # Convert request_options back to 
+        # Convert request_options back to
         # admin_policy.RequestOptions if it's a dict
         if (kwargs.get('request_options') is not None and not isinstance(
                 kwargs['request_options'], admin_policy.RequestOptions)):
@@ -230,7 +230,7 @@ class OptimizeBody(DagRequestBody):
     def to_kwargs(self) -> Dict[str, Any]:
         kwargs = super().to_kwargs()
 
-        # Convert request_options back to 
+        # Convert request_options back to
         # admin_policy.RequestOptions if it's a dict
         if (kwargs.get('request_options') is not None and not isinstance(
                 kwargs['request_options'], admin_policy.RequestOptions)):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -208,12 +208,34 @@ class ValidateBody(DagRequestBody):
     dag: str
     request_options: Optional[admin_policy.RequestOptions]
 
+    def to_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().to_kwargs()
+
+        # Convert request_options back to admin_policy.RequestOptions if it's a dict
+        if (kwargs.get('request_options') is not None and not isinstance(
+                kwargs['request_options'], admin_policy.RequestOptions)):
+            kwargs['request_options'] = admin_policy.RequestOptions(
+                **kwargs['request_options'])
+
+        return kwargs
+
 
 class OptimizeBody(DagRequestBody):
     """The request body for the optimize endpoint."""
     dag: str
     minimize: common_lib.OptimizeTarget = common_lib.OptimizeTarget.COST
     request_options: Optional[admin_policy.RequestOptions]
+
+    def to_kwargs(self) -> Dict[str, Any]:
+        kwargs = super().to_kwargs()
+
+        # Convert request_options back to admin_policy.RequestOptions if it's a dict
+        if (kwargs.get('request_options') is not None and not isinstance(
+                kwargs['request_options'], admin_policy.RequestOptions)):
+            kwargs['request_options'] = admin_policy.RequestOptions(
+                **kwargs['request_options'])
+
+        return kwargs
 
 
 class LaunchBody(RequestBody):

--- a/tests/mypy_files.txt
+++ b/tests/mypy_files.txt
@@ -1,3 +1,5 @@
 sky
+examples/admin_policy
 
 --exclude sky/backends/monkey_patches
+--exclude examples/admin_policy/example_policy/build

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 
 import sky
+from sky.server import common as server_common
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
@@ -122,76 +123,75 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
         }
 
     # Cluster does not exist
-    with mock.patch('sky.status', return_value=[]):
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=10)
-
-        with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                           match='Autostop/down must be set'):
+    with mock.patch('sky.status', return_value=server_common.RequestId('test_request_id')):
+        with mock.patch('sky.get', return_value=[]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                     'enforce_autostop.yaml'),
-                                        idle_minutes_to_autostop=None)
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=10)
 
-    # Cluster is stopped
-    with mock.patch(
-            'sky.status',
-            return_value=[_gen_cluster_record(sky.ClusterStatus.STOPPED, 10)]):
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=10)
-        with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                           match='Autostop/down must be set'):
+            with pytest.raises(exceptions.UserRequestRejectedByPolicy,
+                            match='Autostop/down must be set'):
+                _load_task_and_apply_policy(task,
+                                            os.path.join(POLICY_PATH,
+                                                        'enforce_autostop.yaml'),
+                                            idle_minutes_to_autostop=None)
+
+        # Cluster is stopped
+        with mock.patch('sky.get', return_value=[_gen_cluster_record(sky.ClusterStatus.STOPPED, 10)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                     'enforce_autostop.yaml'),
-                                        idle_minutes_to_autostop=None)
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=10)
+            with pytest.raises(exceptions.UserRequestRejectedByPolicy,
+                            match='Autostop/down must be set'):
+                _load_task_and_apply_policy(task,
+                                            os.path.join(POLICY_PATH,
+                                                        'enforce_autostop.yaml'),
+                                            idle_minutes_to_autostop=None)
 
-    # Cluster is running but autostop is not set
-    with mock.patch(
-            'sky.status',
-            return_value=[_gen_cluster_record(sky.ClusterStatus.UP, -1)]):
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=10)
-        with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                           match='Autostop/down must be set'):
+        # Cluster is running but autostop is not set
+        with mock.patch(
+                'sky.get',
+                return_value=[_gen_cluster_record(sky.ClusterStatus.UP, -1)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                     'enforce_autostop.yaml'),
-                                        idle_minutes_to_autostop=None)
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=10)
+            with pytest.raises(exceptions.UserRequestRejectedByPolicy,
+                            match='Autostop/down must be set'):
+                _load_task_and_apply_policy(task,
+                                            os.path.join(POLICY_PATH,
+                                                        'enforce_autostop.yaml'),
+                                            idle_minutes_to_autostop=None)
 
-    # Cluster is init but autostop is not set
-    with mock.patch(
-            'sky.status',
-            return_value=[_gen_cluster_record(sky.ClusterStatus.INIT, -1)]):
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=10)
-        with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                           match='Autostop/down must be set'):
+        # Cluster is init but autostop is not set
+        with mock.patch(
+                'sky.get',
+                return_value=[_gen_cluster_record(sky.ClusterStatus.INIT, -1)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                     'enforce_autostop.yaml'),
-                                        idle_minutes_to_autostop=None)
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=10)
+            with pytest.raises(exceptions.UserRequestRejectedByPolicy,
+                            match='Autostop/down must be set'):
+                _load_task_and_apply_policy(task,
+                                            os.path.join(POLICY_PATH,
+                                                        'enforce_autostop.yaml'),
+                                            idle_minutes_to_autostop=None)
 
-    # Cluster is running and autostop is set
-    with mock.patch(
-            'sky.status',
-            return_value=[_gen_cluster_record(sky.ClusterStatus.UP, 10)]):
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=10)
-        _load_task_and_apply_policy(task,
-                                    os.path.join(POLICY_PATH,
-                                                 'enforce_autostop.yaml'),
-                                    idle_minutes_to_autostop=None)
+        # Cluster is running and autostop is set
+        with mock.patch(
+                'sky.get',
+                return_value=[_gen_cluster_record(sky.ClusterStatus.UP, 10)]):
+            _load_task_and_apply_policy(task,
+                                        os.path.join(POLICY_PATH,
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=10)
+            _load_task_and_apply_policy(task,
+                                        os.path.join(POLICY_PATH,
+                                                    'enforce_autostop.yaml'),
+                                        idle_minutes_to_autostop=None)
 
 
 def test_dynamic_kubernetes_contexts_policy(add_example_policy_paths, task):

--- a/tests/unit_tests/test_admin_policy.py
+++ b/tests/unit_tests/test_admin_policy.py
@@ -13,10 +13,10 @@ import pytest
 import requests
 
 import sky
-from sky.server import common as server_common
 from sky import exceptions
 from sky import sky_logging
 from sky import skypilot_config
+from sky.server import common as server_common
 from sky.utils import admin_policy_utils
 from sky.utils import common_utils
 from sky.utils import config_utils
@@ -123,31 +123,37 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
         }
 
     # Cluster does not exist
-    with mock.patch('sky.status', return_value=server_common.RequestId('test_request_id')):
+    with mock.patch('sky.status',
+                    return_value=server_common.RequestId('test_request_id')):
         with mock.patch('sky.get', return_value=[]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=10)
 
             with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                            match='Autostop/down must be set'):
+                               match='Autostop/down must be set'):
                 _load_task_and_apply_policy(task,
-                                            os.path.join(POLICY_PATH,
-                                                        'enforce_autostop.yaml'),
+                                            os.path.join(
+                                                POLICY_PATH,
+                                                'enforce_autostop.yaml'),
                                             idle_minutes_to_autostop=None)
 
         # Cluster is stopped
-        with mock.patch('sky.get', return_value=[_gen_cluster_record(sky.ClusterStatus.STOPPED, 10)]):
+        with mock.patch('sky.get',
+                        return_value=[
+                            _gen_cluster_record(sky.ClusterStatus.STOPPED, 10)
+                        ]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=10)
             with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                            match='Autostop/down must be set'):
+                               match='Autostop/down must be set'):
                 _load_task_and_apply_policy(task,
-                                            os.path.join(POLICY_PATH,
-                                                        'enforce_autostop.yaml'),
+                                            os.path.join(
+                                                POLICY_PATH,
+                                                'enforce_autostop.yaml'),
                                             idle_minutes_to_autostop=None)
 
         # Cluster is running but autostop is not set
@@ -156,13 +162,14 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
                 return_value=[_gen_cluster_record(sky.ClusterStatus.UP, -1)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=10)
             with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                            match='Autostop/down must be set'):
+                               match='Autostop/down must be set'):
                 _load_task_and_apply_policy(task,
-                                            os.path.join(POLICY_PATH,
-                                                        'enforce_autostop.yaml'),
+                                            os.path.join(
+                                                POLICY_PATH,
+                                                'enforce_autostop.yaml'),
                                             idle_minutes_to_autostop=None)
 
         # Cluster is init but autostop is not set
@@ -171,13 +178,14 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
                 return_value=[_gen_cluster_record(sky.ClusterStatus.INIT, -1)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=10)
             with pytest.raises(exceptions.UserRequestRejectedByPolicy,
-                            match='Autostop/down must be set'):
+                               match='Autostop/down must be set'):
                 _load_task_and_apply_policy(task,
-                                            os.path.join(POLICY_PATH,
-                                                        'enforce_autostop.yaml'),
+                                            os.path.join(
+                                                POLICY_PATH,
+                                                'enforce_autostop.yaml'),
                                             idle_minutes_to_autostop=None)
 
         # Cluster is running and autostop is set
@@ -186,11 +194,11 @@ def test_enforce_autostop_policy(add_example_policy_paths, task):
                 return_value=[_gen_cluster_record(sky.ClusterStatus.UP, 10)]):
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=10)
             _load_task_and_apply_policy(task,
                                         os.path.join(POLICY_PATH,
-                                                    'enforce_autostop.yaml'),
+                                                     'enforce_autostop.yaml'),
                                         idle_minutes_to_autostop=None)
 
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
`EnforceAutostopPolicy` is not working out of the box - part of the reason is we've let the policies fall into disrepair by not running pylint/mypy on them. This PR fixes the issue with `EnforceAutostopPolicy` and additionally includes the example policy directory to pylint/mypy runs.

Issues encountered were:

`EnforceAutostopPolicy` was expecting `sky.status` to return cluster results directly, when in reality `sky.status` just returns the request ID that needs to be passed to `sky.get`. Unfortunately, our unit tests were making the same incorrect assumption.

Arguments to `sky.status` were on invalid type - this has been fixed.

`OptimizeBody` were missing the `to_kwargs` function to properly serialize the request. This has been added.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
