### PR TITLE
[Core] Check for active SSH sessions when checking cluster idleness

### DIFF
--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -129,7 +129,8 @@ class AutostopEvent(SkyletEvent):
             return
 
         if (job_lib.is_cluster_idle() and
-                not managed_job_state.get_num_alive_jobs()):
+                not managed_job_state.get_num_alive_jobs() and
+                not autostop_lib.has_active_ssh_sessions()):
             idle_minutes = (time.time() -
                             autostop_lib.get_last_active_time()) // 60
             logger.debug(


### PR DESCRIPTION
Today, idleness for autodown/stop is measured from the completion of all tasks in the cluster's queue. However, a user may be SSH'd in, for example to debug some stuff. So we should count SSH activity as non-idle.

This PR implements this using [who](https://man7.org/linux/man-pages/man1/who.1.html), which is part of [GNU coreutils](https://man7.org/linux/man-pages/man1/who.1.html), which means it should be available in most if not all Linux systems.

The command is simple, it just prints a list of users who are currently logged in:
```bash
$ who
gcpuser  pts/0        2025-07-23 20:32 (12.144.77.92)
gcpuser  pts/1        2025-07-23 20:33 (12.144.77.92)
```

Other approaches considered include:
```bash
$ ps ax | grep -v grep | grep "sshd:.*@pts/"
   1690 ?        S      0:00 sshd: gcpuser@pts/0
   3602 ?        S      0:00 sshd: gcpuser@pts/1

# /dev/pts is the virtual filesystem where these pseudo-terminal devices reside
$ ls /dev/pts/
0  1  ptmx
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
        - New smoke test: `test_autostop_with_ssh_sessions`
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)
