### PR TITLE
Fixed doc of cloud watch external logging

### DIFF
--- a/docs/source/cloud-setup/external-logging.rst
+++ b/docs/source/cloud-setup/external-logging.rst
@@ -124,7 +124,10 @@ Example queries:
 .. code-block:: bash
 
     # Get logs of a specific cluster by name using AWS CLI
-    aws logs filter-log-events --log-group-name my-skypilot-logs --filter-pattern "skypilot_cluster_name=my-cluster-name"
+    aws logs filter-log-events --log-group-name my-skypilot-logs --filter-pattern 'skypilot.cluster_name = "my-cluster-name"' | | jq -r ".events[].message | fromjson | .log"
+
+    # Get logs of a specific job by name using AWS CLI
+    aws logs filter-log-events --log-group-name my-skypilot-logs --filter-pattern '%my-job-name%' | | jq -r ".events[].message | fromjson | .log"
 
     # Using CloudWatch Logs Insights
     fields @timestamp, @message


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Make it consistent with the smoke test in https://github.com/skypilot-org/skypilot/pull/6331

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
