### PR TITLE
[UX] Always optimizes in order to fail client side

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -4268,7 +4268,11 @@ def jobs_launch(
             f'Managed job {dag.name!r} will be launched on (estimated):',
             fg='yellow')
 
-    request_id = managed_jobs.launch(dag, name, _need_confirmation=not yes)
+    request_id = managed_jobs.launch(
+        dag,
+        name,
+        _need_confirmation=not yes,
+        _should_optimize=not (async_call or detach_run))
     job_id_handle = _async_call_or_wait(request_id, async_call,
                                         'sky.jobs.launch')
     if not async_call and not detach_run:

--- a/sky/jobs/client/sdk.py
+++ b/sky/jobs/client/sdk.py
@@ -36,6 +36,7 @@ def launch(
     # Internal only:
     # pylint: disable=invalid-name
     _need_confirmation: bool = False,
+    _should_optimize: bool = True,
 ) -> server_common.RequestId:
     """Launches a managed job.
 
@@ -66,8 +67,9 @@ def launch(
     with admin_policy_utils.apply_and_use_config_in_current_request(
             dag, at_client_side=True) as dag:
         sdk.validate(dag)
-        request_id = sdk.optimize(dag)
-        sdk.stream_and_get(request_id)
+        if _should_optimize:
+            request_id = sdk.optimize(dag)
+            sdk.stream_and_get(request_id)
         if _need_confirmation:
             prompt = f'Launching a managed job {dag.name!r}. Proceed?'
             if prompt is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Now will always optimize even if the `-y` option is set.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
