### PR TITLE
[db] single init global user state, refactor migrations

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -236,13 +236,9 @@ def create_table(engine: sqlalchemy.engine.Engine):
             # If the database is locked, it is OK to continue, as the WAL mode
             # is not critical and is likely to be enabled by other processes.
 
-    # Get alembic config for state db and run migrations
-    alembic_config = migration_utils.get_alembic_config(
-        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME)
-    # pylint: disable=line-too-long
-    alembic_config.config_ini_section = migration_utils.GLOBAL_USER_STATE_DB_NAME
     migration_utils.safe_alembic_upgrade(
-        engine, alembic_config, migration_utils.GLOBAL_USER_STATE_VERSION)
+        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
+        migration_utils.GLOBAL_USER_STATE_VERSION)
 
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
@@ -255,9 +251,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     engine = migration_utils.get_engine('state')
 
     # run migrations if needed
-    migration_utils.safe_alembic_upgrade(
-        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
-        migration_utils.GLOBAL_USER_STATE_VERSION)
+    create_table(engine)
 
     # return engine
     _SQLALCHEMY_ENGINE = engine

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -126,11 +126,8 @@ def create_table(engine: sqlalchemy.engine.Engine):
             # If the database is locked, it is OK to continue, as the WAL mode
             # is not critical and is likely to be enabled by other processes.
 
-    # Get alembic config for spot jobs db and run migrations
-    alembic_config = migration_utils.get_alembic_config(
-        engine, migration_utils.SPOT_JOBS_DB_NAME)
-    alembic_config.config_ini_section = migration_utils.SPOT_JOBS_DB_NAME
-    migration_utils.safe_alembic_upgrade(engine, alembic_config,
+    migration_utils.safe_alembic_upgrade(engine,
+                                         migration_utils.SPOT_JOBS_DB_NAME,
                                          migration_utils.SPOT_JOBS_VERSION)
 
 
@@ -144,9 +141,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     engine = migration_utils.get_engine('spot_jobs')
 
     # run migrations if needed
-    migration_utils.safe_alembic_upgrade(engine,
-                                         migration_utils.SPOT_JOBS_DB_NAME,
-                                         migration_utils.SPOT_JOBS_VERSION)
+    create_table(engine)
 
     # return engine
     _SQLALCHEMY_ENGINE = engine

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -4,8 +4,6 @@
 import enum
 import functools
 import json
-import os
-import pathlib
 import time
 import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -20,7 +18,6 @@ from sqlalchemy.ext import declarative
 
 from sky import exceptions
 from sky import sky_logging
-from sky import skypilot_config
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils.db import db_utils
@@ -139,24 +136,20 @@ def create_table(engine: sqlalchemy.engine.Engine):
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
+
     if _SQLALCHEMY_ENGINE is not None:
         return _SQLALCHEMY_ENGINE
-    with migration_utils.db_lock(migration_utils.SPOT_JOBS_DB_NAME):
-        if _SQLALCHEMY_ENGINE is None:
-            conn_string = None
-            if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-                conn_string = skypilot_config.get_nested(('db',), None)
-            if conn_string:
-                logger.debug(f'using db URI from {conn_string}')
-                engine = sqlalchemy.create_engine(conn_string,
-                                                  poolclass=sqlalchemy.NullPool)
-            else:
-                db_path = os.path.expanduser('~/.sky/spot_jobs.db')
-                pathlib.Path(db_path).parents[0].mkdir(parents=True,
-                                                       exist_ok=True)
-                engine = sqlalchemy.create_engine('sqlite:///' + db_path)
-            create_table(engine)
-            _SQLALCHEMY_ENGINE = engine
+
+    # get an engine to the db
+    engine = migration_utils.get_engine('spot_jobs')
+
+    # run migrations if needed
+    migration_utils.safe_alembic_upgrade(engine,
+                                         migration_utils.SPOT_JOBS_DB_NAME,
+                                         migration_utils.SPOT_JOBS_VERSION)
+
+    # return engine
+    _SQLALCHEMY_ENGINE = engine
     return _SQLALCHEMY_ENGINE
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1764,6 +1764,9 @@ if __name__ == '__main__':
 
     from sky.server import uvicorn as skyuvicorn
 
+    # Initialize global user state db
+    global_user_state.initialize_and_get_db()
+    # Initialize request db
     requests_lib.reset_db_and_logs()
 
     parser = argparse.ArgumentParser()

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -3,12 +3,19 @@
 import contextlib
 import logging
 import os
+import pathlib
 
 from alembic import command as alembic_command
 from alembic.config import Config
 from alembic.runtime import migration
 import filelock
 import sqlalchemy
+
+from sky import sky_logging
+from sky import skypilot_config
+from sky.skylet import constants
+
+logger = sky_logging.init_logger(__name__)
 
 DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 
@@ -19,6 +26,21 @@ GLOBAL_USER_STATE_LOCK_PATH = '~/.sky/locks/.state_db.lock'
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
 SPOT_JOBS_VERSION = '001'
 SPOT_JOBS_LOCK_PATH = '~/.sky/locks/.spot_jobs_db.lock'
+
+
+def get_engine(db_name: str):
+    conn_string = None
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        conn_string = skypilot_config.get_nested(('db',), None)
+    if conn_string:
+        logger.debug(f'using db URI from {conn_string}')
+        engine = sqlalchemy.create_engine(conn_string,
+                                          poolclass=sqlalchemy.NullPool)
+    else:
+        db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
+        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
+        engine = sqlalchemy.create_engine('sqlite:///' + db_path)
+    return engine
 
 
 @contextlib.contextmanager
@@ -37,7 +59,6 @@ def db_lock(db_name: str):
 
 def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
     """Get Alembic configuration for the given section"""
-    # Use the alembic.ini file from setup_files (included in wheel)
     # From sky/utils/db/migration_utils.py -> sky/setup_files/alembic.ini
     alembic_ini_path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
@@ -57,26 +78,19 @@ def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
     return alembic_cfg
 
 
-def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine,
-                         alembic_config: Config, target_revision: str):
-    """Only upgrade if current version is older than target.
-
-    This handles the case where a database was created with a newer version of
-    the code and we're now running older code. Since our migrations are purely
-    additive, it's safe to run a newer database with older code.
+def needs_upgrade(engine: sqlalchemy.engine.Engine, section: str,
+                  target_revision: str):
+    """Check if the database needs to be upgraded.
 
     Args:
         engine: SQLAlchemy engine for the database
-        alembic_config: Alembic configuration object
+        section: Alembic section to upgrade (e.g., 'state_db' or 'spot_jobs_db')
         target_revision: Target revision to upgrade to (e.g., '001')
     """
-    # set alembic logger to warning level
-    alembic_logger = logging.getLogger('alembic')
-    alembic_logger.setLevel(logging.WARNING)
-
     current_rev = None
 
-    # Get the current revision from the database
+    # get alembic config for the given section
+    alembic_config = get_alembic_config(engine, section)
     version_table = alembic_config.get_section_option(
         alembic_config.config_ini_section, 'version_table', 'alembic_version')
 
@@ -86,13 +100,35 @@ def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine,
         current_rev = context.get_current_revision()
 
     if current_rev is None:
-        alembic_command.upgrade(alembic_config, target_revision)
-        return
+        return True
 
     # Compare revisions - assuming they are numeric strings like '001', '002'
     current_rev_num = int(current_rev)
     target_rev_num = int(target_revision)
 
-    # only upgrade if current revision is older than target revision
-    if current_rev_num < target_rev_num:
-        alembic_command.upgrade(alembic_config, target_revision)
+    return current_rev_num < target_rev_num
+
+
+def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine, section: str,
+                         target_revision: str):
+    """Upgrade the database if needed. Uses a file lock to ensure
+    that only one process tries to upgrade the database at a time.
+
+    Args:
+        engine: SQLAlchemy engine for the database
+        section: Alembic section to upgrade (e.g., 'state_db' or 'spot_jobs_db')
+        target_revision: Target revision to upgrade to (e.g., '001')
+    """
+    # set alembic logger to warning level
+    alembic_logger = logging.getLogger('alembic')
+    alembic_logger.setLevel(logging.WARNING)
+
+    alembic_config = get_alembic_config(engine, section)
+
+    # only acquire lock if db needs upgrade
+    if needs_upgrade(engine, section, target_revision):
+        with db_lock(section):
+            # check again if db needs upgrade in case another
+            # process upgraded it while we were waiting for the lock
+            if needs_upgrade(engine, section, target_revision):
+                alembic_command.upgrade(alembic_config, target_revision)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR deterministically initializes the global user state db when starting the api server. This is an improvement from the current method of db initialization where many processes may race to initialize the global user state db, creating lock contention. 

This PR also refactors the way that global user state db and the jobs state db get initialized, further reducing lock contention by checking if a db upgrade is necessary before trying to acquire the lock as well as after in case another process upgraded the db while the current process was waiting for the lock. 

The refactor also significantly improves readability of the db initialization code for the global user state and job state databases, making it easier to reason about. 

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
