### PR TITLE
[Dashboard] Pressing tab in yaml textboxes will make 2 spaces

### DIFF
--- a/sky/dashboard/src/components/config.js
+++ b/sky/dashboard/src/components/config.js
@@ -286,6 +286,28 @@ export function Config() {
             <textarea
               value={editableConfig}
               onChange={(e) => setEditableConfig(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Tab') {
+                  e.preventDefault();
+                  const target = e.target;
+                  const start = target.selectionStart;
+                  const end = target.selectionEnd;
+                  const spaces = '  '; // 2 spaces for YAML indentation
+
+                  // Insert spaces at cursor position
+                  const newValue =
+                    editableConfig.substring(0, start) +
+                    spaces +
+                    editableConfig.substring(end);
+                  setEditableConfig(newValue);
+
+                  // Move cursor to after the inserted spaces
+                  setTimeout(() => {
+                    target.selectionStart = target.selectionEnd =
+                      start + spaces.length;
+                  }, 0);
+                }
+              }}
               className="w-full h-96 p-3 border border-gray-300 rounded font-mono text-sm resize-vertical focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder={
                 loading

--- a/sky/dashboard/src/components/workspace-editor.jsx
+++ b/sky/dashboard/src/components/workspace-editor.jsx
@@ -785,10 +785,32 @@ export function WorkspaceEditor({ workspaceName, isNewWorkspace = false }) {
                           </div>
                         </div>
 
-                        <Textarea
+                        <textarea
                           value={yamlValue}
                           onChange={(e) => handleYamlChange(e.target.value)}
-                          className="font-mono text-sm flex-1 resize-none"
+                          onKeyDown={(e) => {
+                            if (e.key === 'Tab') {
+                              e.preventDefault();
+                              const target = e.target;
+                              const start = target.selectionStart;
+                              const end = target.selectionEnd;
+                              const spaces = '  '; // 2 spaces for YAML indentation
+
+                              // Insert spaces at cursor position
+                              const newValue =
+                                yamlValue.substring(0, start) +
+                                spaces +
+                                yamlValue.substring(end);
+                              handleYamlChange(newValue);
+
+                              // Move cursor to after the inserted spaces
+                              setTimeout(() => {
+                                target.selectionStart = target.selectionEnd =
+                                  start + spaces.length;
+                              }, 0);
+                            }
+                          }}
+                          className="w-full font-mono text-sm flex-1 resize-none border border-gray-300 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
                           style={{ minHeight: '350px' }}
                           spellCheck={false}
                           placeholder={`# Enter workspace configuration in YAML format`}


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Pressing tab in yaml textboxes will make 2 spaces.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
