### PR TITLE
[db] interpolation fix for alembic migration

### DIFF
--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -46,7 +46,7 @@ def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
 
     # Override the database URL to match SkyPilot's current connection
     # Use render_as_string to get the full URL with password
-    url = engine.url.render_as_string(hide_password=False)
+    url = engine.url.render_as_string(hide_password=False).replace('%', '%%')
     alembic_cfg.set_section_option(section, 'sqlalchemy.url', url)
 
     return alembic_cfg

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -46,7 +46,12 @@ def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
 
     # Override the database URL to match SkyPilot's current connection
     # Use render_as_string to get the full URL with password
-    url = engine.url.render_as_string(hide_password=False).replace('%', '%%')
+    url = engine.url.render_as_string(hide_password=False)
+    # Replace % with %% to escape the % character in the URL
+    # set_section_option uses variable interpolation, which treats % as a
+    # special character.
+    # any '%' symbol not used for interpolation needs to be escaped.
+    url = url.replace('%', '%%')
     alembic_cfg.set_section_option(section, 'sqlalchemy.url', url)
 
     return alembic_cfg


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The helptext for `set_section_option` says:
```
:param value: the value. Note that this value is passed to
 ConfigParser.set, which supports variable interpolation using pyformat (e.g. %(some_value)s). A raw percent sign not part of an interpolation symbol must therefore be escaped, e.g. %%. The given value may refer to another value already in the file using the interpolation format.
```
We add escape for '%' value (which may be used on URL escapes) to make sure this value is being handled correctly.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
