### PR TITLE
[db] Remove redundant global user state db initialization calls

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -236,13 +236,9 @@ def create_table(engine: sqlalchemy.engine.Engine):
             # If the database is locked, it is OK to continue, as the WAL mode
             # is not critical and is likely to be enabled by other processes.
 
-    # Get alembic config for state db and run migrations
-    alembic_config = migration_utils.get_alembic_config(
-        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME)
-    # pylint: disable=line-too-long
-    alembic_config.config_ini_section = migration_utils.GLOBAL_USER_STATE_DB_NAME
     migration_utils.safe_alembic_upgrade(
-        engine, alembic_config, migration_utils.GLOBAL_USER_STATE_VERSION)
+        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
+        migration_utils.GLOBAL_USER_STATE_VERSION)
 
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
@@ -255,9 +251,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     engine = migration_utils.get_engine('state')
 
     # run migrations if needed
-    migration_utils.safe_alembic_upgrade(
-        engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
-        migration_utils.GLOBAL_USER_STATE_VERSION)
+    create_table(engine)
 
     # return engine
     _SQLALCHEMY_ENGINE = engine

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -258,18 +258,20 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     return _SQLALCHEMY_ENGINE
 
 
-def _init_db(func):
-    """Initialize the database."""
+def _init_engine(func):
+    """Initialize a database engine."""
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        initialize_and_get_db()
+        global _SQLALCHEMY_ENGINE
+        if _SQLALCHEMY_ENGINE is None:
+            _SQLALCHEMY_ENGINE = migration_utils.get_engine('state')
         return func(*args, **kwargs)
 
     return wrapper
 
 
-@_init_db
+@_init_engine
 def add_or_update_user(user: models.User,
                        allow_duplicate_name: bool = True) -> bool:
     """Store the mapping from user hash to user name for display purposes.
@@ -363,7 +365,7 @@ def add_or_update_user(user: models.User,
             raise ValueError('Unsupported database dialect')
 
 
-@_init_db
+@_init_engine
 def get_user(user_id: str) -> Optional[models.User]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -376,7 +378,7 @@ def get_user(user_id: str) -> Optional[models.User]:
                        created_at=row.created_at)
 
 
-@_init_db
+@_init_engine
 def get_user_by_name(username: str) -> List[models.User]:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         rows = session.query(user_table).filter_by(name=username).all()
@@ -390,14 +392,14 @@ def get_user_by_name(username: str) -> List[models.User]:
     ]
 
 
-@_init_db
+@_init_engine
 def delete_user(user_id: str) -> None:
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
         session.query(user_table).filter_by(id=user_id).delete()
         session.commit()
 
 
-@_init_db
+@_init_engine
 def get_all_users() -> List[models.User]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -410,7 +412,7 @@ def get_all_users() -> List[models.User]:
     ]
 
 
-@_init_db
+@_init_engine
 def add_or_update_cluster(cluster_name: str,
                           cluster_handle: 'backends.ResourceHandle',
                           requested_resources: Optional[Set[Any]],
@@ -600,7 +602,7 @@ def _get_user_hash_or_current_user(user_hash: Optional[str]) -> str:
     return common_utils.get_user_hash()
 
 
-@_init_db
+@_init_engine
 def update_cluster_handle(cluster_name: str,
                           cluster_handle: 'backends.ResourceHandle'):
     assert _SQLALCHEMY_ENGINE is not None
@@ -611,7 +613,7 @@ def update_cluster_handle(cluster_name: str,
         session.commit()
 
 
-@_init_db
+@_init_engine
 def update_last_use(cluster_name: str):
     """Updates the last used command for the cluster."""
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -620,7 +622,7 @@ def update_last_use(cluster_name: str):
         session.commit()
 
 
-@_init_db
+@_init_engine
 def remove_cluster(cluster_name: str, terminate: bool) -> None:
     """Removes cluster_name mapping."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -657,7 +659,7 @@ def remove_cluster(cluster_name: str, terminate: bool) -> None:
         session.commit()
 
 
-@_init_db
+@_init_engine
 def get_handle_from_cluster_name(
         cluster_name: str) -> Optional['backends.ResourceHandle']:
     assert _SQLALCHEMY_ENGINE is not None
@@ -669,7 +671,7 @@ def get_handle_from_cluster_name(
     return pickle.loads(row.handle)
 
 
-@_init_db
+@_init_engine
 def get_glob_cluster_names(cluster_name: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     assert cluster_name is not None, 'cluster_name cannot be None'
@@ -688,7 +690,7 @@ def get_glob_cluster_names(cluster_name: str) -> List[str]:
     return [row.name for row in rows]
 
 
-@_init_db
+@_init_engine
 def set_cluster_status(cluster_name: str,
                        status: status_lib.ClusterStatus) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -705,7 +707,7 @@ def set_cluster_status(cluster_name: str,
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-@_init_db
+@_init_engine
 def set_cluster_autostop_value(cluster_name: str, idle_minutes: int,
                                to_down: bool) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -721,7 +723,7 @@ def set_cluster_autostop_value(cluster_name: str, idle_minutes: int,
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-@_init_db
+@_init_engine
 def get_cluster_launch_time(cluster_name: str) -> Optional[int]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -731,7 +733,7 @@ def get_cluster_launch_time(cluster_name: str) -> Optional[int]:
     return int(row.launched_at)
 
 
-@_init_db
+@_init_engine
 def get_cluster_info(cluster_name: str) -> Optional[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -741,7 +743,7 @@ def get_cluster_info(cluster_name: str) -> Optional[Dict[str, Any]]:
     return json.loads(row.metadata)
 
 
-@_init_db
+@_init_engine
 def set_cluster_info(cluster_name: str, metadata: Dict[str, Any]) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -754,7 +756,7 @@ def set_cluster_info(cluster_name: str, metadata: Dict[str, Any]) -> None:
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-@_init_db
+@_init_engine
 def get_cluster_storage_mounts_metadata(
         cluster_name: str) -> Optional[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
@@ -765,7 +767,7 @@ def get_cluster_storage_mounts_metadata(
     return pickle.loads(row.storage_mounts_metadata)
 
 
-@_init_db
+@_init_engine
 def set_cluster_storage_mounts_metadata(
         cluster_name: str, storage_mounts_metadata: Dict[str, Any]) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -781,7 +783,7 @@ def set_cluster_storage_mounts_metadata(
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-@_init_db
+@_init_engine
 def _get_cluster_usage_intervals(
         cluster_hash: Optional[str]
 ) -> Optional[List[Tuple[int, Optional[int]]]]:
@@ -822,7 +824,7 @@ def _get_cluster_duration(cluster_hash: str) -> int:
     return total_duration
 
 
-@_init_db
+@_init_engine
 def _set_cluster_usage_intervals(
         cluster_hash: str, usage_intervals: List[Tuple[int,
                                                        Optional[int]]]) -> None:
@@ -839,7 +841,7 @@ def _set_cluster_usage_intervals(
         raise ValueError(f'Cluster hash {cluster_hash} not found.')
 
 
-@_init_db
+@_init_engine
 def set_owner_identity_for_cluster(cluster_name: str,
                                    owner_identity: Optional[List[str]]) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -856,7 +858,7 @@ def set_owner_identity_for_cluster(cluster_name: str,
         raise ValueError(f'Cluster {cluster_name} not found.')
 
 
-@_init_db
+@_init_engine
 def _get_hash_for_existing_cluster(cluster_name: str) -> Optional[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -866,7 +868,7 @@ def _get_hash_for_existing_cluster(cluster_name: str) -> Optional[str]:
     return row.cluster_hash
 
 
-@_init_db
+@_init_engine
 def get_launched_resources_from_cluster_hash(
         cluster_hash: str) -> Optional[Tuple[int, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
@@ -912,7 +914,7 @@ def _load_storage_mounts_metadata(
     return pickle.loads(record_storage_mounts_metadata)
 
 
-@_init_db
+@_init_engine
 @context_utils.cancellation_guard
 def get_cluster_from_name(
         cluster_name: Optional[str]) -> Optional[Dict[str, Any]]:
@@ -951,7 +953,7 @@ def get_cluster_from_name(
     return record
 
 
-@_init_db
+@_init_engine
 def get_clusters() -> List[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -990,7 +992,7 @@ def get_clusters() -> List[Dict[str, Any]]:
     return records
 
 
-@_init_db
+@_init_engine
 def get_clusters_from_history(
         days: Optional[int] = None) -> List[Dict[str, Any]]:
     """Get cluster reports from history.
@@ -1110,7 +1112,7 @@ def get_clusters_from_history(
     return records
 
 
-@_init_db
+@_init_engine
 def get_cluster_names_start_with(starts_with: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1119,7 +1121,7 @@ def get_cluster_names_start_with(starts_with: str) -> List[str]:
     return [row.name for row in rows]
 
 
-@_init_db
+@_init_engine
 def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
                               workspace: str) -> List['clouds.Cloud']:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1144,7 +1146,7 @@ def get_cached_enabled_clouds(cloud_capability: 'cloud.CloudCapability',
     return enabled_clouds
 
 
-@_init_db
+@_init_engine
 def set_enabled_clouds(enabled_clouds: List[str],
                        cloud_capability: 'cloud.CloudCapability',
                        workspace: str) -> None:
@@ -1173,7 +1175,7 @@ def _get_enabled_clouds_key(cloud_capability: 'cloud.CloudCapability',
     return _ENABLED_CLOUDS_KEY_PREFIX + workspace + '_' + cloud_capability.value
 
 
-@_init_db
+@_init_engine
 def get_allowed_clouds(workspace: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1184,7 +1186,7 @@ def get_allowed_clouds(workspace: str) -> List[str]:
     return []
 
 
-@_init_db
+@_init_engine
 def set_allowed_clouds(allowed_clouds: List[str], workspace: str) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1210,7 +1212,7 @@ def _get_allowed_clouds_key(workspace: str) -> str:
     return _ALLOWED_CLOUDS_KEY_PREFIX + workspace
 
 
-@_init_db
+@_init_engine
 def add_or_update_storage(storage_name: str,
                           storage_handle: 'Storage.StorageMetadata',
                           storage_status: status_lib.StorageStatus):
@@ -1252,7 +1254,7 @@ def add_or_update_storage(storage_name: str,
         session.commit()
 
 
-@_init_db
+@_init_engine
 def remove_storage(storage_name: str):
     """Removes Storage from Database"""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1261,7 +1263,7 @@ def remove_storage(storage_name: str):
         session.commit()
 
 
-@_init_db
+@_init_engine
 def set_storage_status(storage_name: str,
                        status: status_lib.StorageStatus) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1274,7 +1276,7 @@ def set_storage_status(storage_name: str,
         raise ValueError(f'Storage {storage_name} not found.')
 
 
-@_init_db
+@_init_engine
 def get_storage_status(storage_name: str) -> Optional[status_lib.StorageStatus]:
     assert _SQLALCHEMY_ENGINE is not None
     assert storage_name is not None, 'storage_name cannot be None'
@@ -1285,7 +1287,7 @@ def get_storage_status(storage_name: str) -> Optional[status_lib.StorageStatus]:
     return None
 
 
-@_init_db
+@_init_engine
 def set_storage_handle(storage_name: str,
                        handle: 'Storage.StorageMetadata') -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1299,7 +1301,7 @@ def set_storage_handle(storage_name: str,
         raise ValueError(f'Storage{storage_name} not found.')
 
 
-@_init_db
+@_init_engine
 def get_handle_from_storage_name(
         storage_name: Optional[str]) -> Optional['Storage.StorageMetadata']:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1312,7 +1314,7 @@ def get_handle_from_storage_name(
     return None
 
 
-@_init_db
+@_init_engine
 def get_glob_storage_name(storage_name: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     assert storage_name is not None, 'storage_name cannot be None'
@@ -1331,7 +1333,7 @@ def get_glob_storage_name(storage_name: str) -> List[str]:
     return [row.name for row in rows]
 
 
-@_init_db
+@_init_engine
 def get_storage_names_start_with(starts_with: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1340,7 +1342,7 @@ def get_storage_names_start_with(starts_with: str) -> List[str]:
     return [row.name for row in rows]
 
 
-@_init_db
+@_init_engine
 def get_storage() -> List[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1358,7 +1360,7 @@ def get_storage() -> List[Dict[str, Any]]:
     return records
 
 
-@_init_db
+@_init_engine
 def get_volume_names_start_with(starts_with: str) -> List[str]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1367,7 +1369,7 @@ def get_volume_names_start_with(starts_with: str) -> List[str]:
     return [row.name for row in rows]
 
 
-@_init_db
+@_init_engine
 def get_volumes() -> List[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1387,7 +1389,7 @@ def get_volumes() -> List[Dict[str, Any]]:
     return records
 
 
-@_init_db
+@_init_engine
 def get_volume_by_name(name: str) -> Optional[Dict[str, Any]]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1406,7 +1408,7 @@ def get_volume_by_name(name: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-@_init_db
+@_init_engine
 def add_volume(name: str, config: models.VolumeConfig,
                status: status_lib.VolumeStatus) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1440,7 +1442,7 @@ def add_volume(name: str, config: models.VolumeConfig,
         session.commit()
 
 
-@_init_db
+@_init_engine
 def update_volume(name: str, last_attached_at: int,
                   status: status_lib.VolumeStatus) -> None:
     assert _SQLALCHEMY_ENGINE is not None
@@ -1452,7 +1454,7 @@ def update_volume(name: str, last_attached_at: int,
         session.commit()
 
 
-@_init_db
+@_init_engine
 def update_volume_status(name: str, status: status_lib.VolumeStatus) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1462,7 +1464,7 @@ def update_volume_status(name: str, status: status_lib.VolumeStatus) -> None:
         session.commit()
 
 
-@_init_db
+@_init_engine
 def delete_volume(name: str) -> None:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1470,7 +1472,7 @@ def delete_volume(name: str) -> None:
         session.commit()
 
 
-@_init_db
+@_init_engine
 def get_ssh_keys(user_hash: str) -> Tuple[str, str, bool]:
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1481,7 +1483,7 @@ def get_ssh_keys(user_hash: str) -> Tuple[str, str, bool]:
     return '', '', False
 
 
-@_init_db
+@_init_engine
 def set_ssh_keys(user_hash: str, ssh_public_key: str, ssh_private_key: str):
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1507,7 +1509,7 @@ def set_ssh_keys(user_hash: str, ssh_public_key: str, ssh_private_key: str):
         session.commit()
 
 
-@_init_db
+@_init_engine
 def add_service_account_token(token_id: str,
                               token_name: str,
                               token_hash: str,
@@ -1540,7 +1542,7 @@ def add_service_account_token(token_id: str,
         session.commit()
 
 
-@_init_db
+@_init_engine
 def get_service_account_token(token_id: str) -> Optional[Dict[str, Any]]:
     """Get a service account token by token_id."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1561,7 +1563,7 @@ def get_service_account_token(token_id: str) -> Optional[Dict[str, Any]]:
     }
 
 
-@_init_db
+@_init_engine
 def get_user_service_account_tokens(user_hash: str) -> List[Dict[str, Any]]:
     """Get all service account tokens for a user (as creator)."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1580,7 +1582,7 @@ def get_user_service_account_tokens(user_hash: str) -> List[Dict[str, Any]]:
     } for row in rows]
 
 
-@_init_db
+@_init_engine
 def update_service_account_token_last_used(token_id: str) -> None:
     """Update the last_used_at timestamp for a service account token."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1593,7 +1595,7 @@ def update_service_account_token_last_used(token_id: str) -> None:
         session.commit()
 
 
-@_init_db
+@_init_engine
 def delete_service_account_token(token_id: str) -> bool:
     """Delete a service account token.
 
@@ -1608,7 +1610,7 @@ def delete_service_account_token(token_id: str) -> bool:
     return result > 0
 
 
-@_init_db
+@_init_engine
 def rotate_service_account_token(token_id: str,
                                  new_token_hash: str,
                                  new_expires_at: Optional[int] = None) -> None:
@@ -1638,7 +1640,7 @@ def rotate_service_account_token(token_id: str,
         raise ValueError(f'Service account token {token_id} not found.')
 
 
-@_init_db
+@_init_engine
 def get_cluster_yaml_str(cluster_yaml_path: Optional[str]) -> Optional[str]:
     """Get the cluster yaml from the database or the local file system.
     If the cluster yaml is not in the database, check if it exists on the
@@ -1679,7 +1681,7 @@ def get_cluster_yaml_dict(cluster_yaml_path: Optional[str]) -> Dict[str, Any]:
     return yaml.safe_load(yaml_str)
 
 
-@_init_db
+@_init_engine
 def set_cluster_yaml(cluster_name: str, yaml_str: str) -> None:
     """Set the cluster yaml in the database."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1701,7 +1703,7 @@ def set_cluster_yaml(cluster_name: str, yaml_str: str) -> None:
         session.commit()
 
 
-@_init_db
+@_init_engine
 def remove_cluster_yaml(cluster_name: str):
     assert _SQLALCHEMY_ENGINE is not None
     with orm.Session(_SQLALCHEMY_ENGINE) as session:
@@ -1710,7 +1712,7 @@ def remove_cluster_yaml(cluster_name: str):
         session.commit()
 
 
-@_init_db
+@_init_engine
 def get_all_service_account_tokens() -> List[Dict[str, Any]]:
     """Get all service account tokens across all users (for admin access)."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1728,7 +1730,7 @@ def get_all_service_account_tokens() -> List[Dict[str, Any]]:
     } for row in rows]
 
 
-@_init_db
+@_init_engine
 def get_system_config(config_key: str) -> Optional[str]:
     """Get a system configuration value by key."""
     assert _SQLALCHEMY_ENGINE is not None
@@ -1740,7 +1742,7 @@ def get_system_config(config_key: str) -> Optional[str]:
     return row.config_value
 
 
-@_init_db
+@_init_engine
 def set_system_config(config_key: str, config_value: str) -> None:
     """Set a system configuration value."""
     assert _SQLALCHEMY_ENGINE is not None

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -126,11 +126,8 @@ def create_table(engine: sqlalchemy.engine.Engine):
             # If the database is locked, it is OK to continue, as the WAL mode
             # is not critical and is likely to be enabled by other processes.
 
-    # Get alembic config for spot jobs db and run migrations
-    alembic_config = migration_utils.get_alembic_config(
-        engine, migration_utils.SPOT_JOBS_DB_NAME)
-    alembic_config.config_ini_section = migration_utils.SPOT_JOBS_DB_NAME
-    migration_utils.safe_alembic_upgrade(engine, alembic_config,
+    migration_utils.safe_alembic_upgrade(engine,
+                                         migration_utils.SPOT_JOBS_DB_NAME,
                                          migration_utils.SPOT_JOBS_VERSION)
 
 
@@ -144,9 +141,7 @@ def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     engine = migration_utils.get_engine('spot_jobs')
 
     # run migrations if needed
-    migration_utils.safe_alembic_upgrade(engine,
-                                         migration_utils.SPOT_JOBS_DB_NAME,
-                                         migration_utils.SPOT_JOBS_VERSION)
+    create_table(engine)
 
     # return engine
     _SQLALCHEMY_ENGINE = engine

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -4,8 +4,6 @@
 import enum
 import functools
 import json
-import os
-import pathlib
 import time
 import typing
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -20,7 +18,6 @@ from sqlalchemy.ext import declarative
 
 from sky import exceptions
 from sky import sky_logging
-from sky import skypilot_config
 from sky.skylet import constants
 from sky.utils import common_utils
 from sky.utils.db import db_utils
@@ -139,24 +136,20 @@ def create_table(engine: sqlalchemy.engine.Engine):
 
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
+
     if _SQLALCHEMY_ENGINE is not None:
         return _SQLALCHEMY_ENGINE
-    with migration_utils.db_lock(migration_utils.SPOT_JOBS_DB_NAME):
-        if _SQLALCHEMY_ENGINE is None:
-            conn_string = None
-            if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-                conn_string = skypilot_config.get_nested(('db',), None)
-            if conn_string:
-                logger.debug(f'using db URI from {conn_string}')
-                engine = sqlalchemy.create_engine(conn_string,
-                                                  poolclass=sqlalchemy.NullPool)
-            else:
-                db_path = os.path.expanduser('~/.sky/spot_jobs.db')
-                pathlib.Path(db_path).parents[0].mkdir(parents=True,
-                                                       exist_ok=True)
-                engine = sqlalchemy.create_engine('sqlite:///' + db_path)
-            create_table(engine)
-            _SQLALCHEMY_ENGINE = engine
+
+    # get an engine to the db
+    engine = migration_utils.get_engine('spot_jobs')
+
+    # run migrations if needed
+    migration_utils.safe_alembic_upgrade(engine,
+                                         migration_utils.SPOT_JOBS_DB_NAME,
+                                         migration_utils.SPOT_JOBS_VERSION)
+
+    # return engine
+    _SQLALCHEMY_ENGINE = engine
     return _SQLALCHEMY_ENGINE
 
 

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1764,6 +1764,9 @@ if __name__ == '__main__':
 
     from sky.server import uvicorn as skyuvicorn
 
+    # Initialize global user state db
+    global_user_state.initialize_and_get_db()
+    # Initialize request db
     requests_lib.reset_db_and_logs()
 
     parser = argparse.ArgumentParser()

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -3,12 +3,19 @@
 import contextlib
 import logging
 import os
+import pathlib
 
 from alembic import command as alembic_command
 from alembic.config import Config
 from alembic.runtime import migration
 import filelock
 import sqlalchemy
+
+from sky import sky_logging
+from sky import skypilot_config
+from sky.skylet import constants
+
+logger = sky_logging.init_logger(__name__)
 
 DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 
@@ -19,6 +26,21 @@ GLOBAL_USER_STATE_LOCK_PATH = '~/.sky/locks/.state_db.lock'
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'
 SPOT_JOBS_VERSION = '001'
 SPOT_JOBS_LOCK_PATH = '~/.sky/locks/.spot_jobs_db.lock'
+
+
+def get_engine(db_name: str):
+    conn_string = None
+    if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
+        conn_string = skypilot_config.get_nested(('db',), None)
+    if conn_string:
+        logger.debug(f'using db URI from {conn_string}')
+        engine = sqlalchemy.create_engine(conn_string,
+                                          poolclass=sqlalchemy.NullPool)
+    else:
+        db_path = os.path.expanduser(f'~/.sky/{db_name}.db')
+        pathlib.Path(db_path).parents[0].mkdir(parents=True, exist_ok=True)
+        engine = sqlalchemy.create_engine('sqlite:///' + db_path)
+    return engine
 
 
 @contextlib.contextmanager
@@ -37,7 +59,6 @@ def db_lock(db_name: str):
 
 def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
     """Get Alembic configuration for the given section"""
-    # Use the alembic.ini file from setup_files (included in wheel)
     # From sky/utils/db/migration_utils.py -> sky/setup_files/alembic.ini
     alembic_ini_path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
@@ -57,26 +78,19 @@ def get_alembic_config(engine: sqlalchemy.engine.Engine, section: str):
     return alembic_cfg
 
 
-def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine,
-                         alembic_config: Config, target_revision: str):
-    """Only upgrade if current version is older than target.
-
-    This handles the case where a database was created with a newer version of
-    the code and we're now running older code. Since our migrations are purely
-    additive, it's safe to run a newer database with older code.
+def needs_upgrade(engine: sqlalchemy.engine.Engine, section: str,
+                  target_revision: str):
+    """Check if the database needs to be upgraded.
 
     Args:
         engine: SQLAlchemy engine for the database
-        alembic_config: Alembic configuration object
+        section: Alembic section to upgrade (e.g., 'state_db' or 'spot_jobs_db')
         target_revision: Target revision to upgrade to (e.g., '001')
     """
-    # set alembic logger to warning level
-    alembic_logger = logging.getLogger('alembic')
-    alembic_logger.setLevel(logging.WARNING)
-
     current_rev = None
 
-    # Get the current revision from the database
+    # get alembic config for the given section
+    alembic_config = get_alembic_config(engine, section)
     version_table = alembic_config.get_section_option(
         alembic_config.config_ini_section, 'version_table', 'alembic_version')
 
@@ -86,13 +100,35 @@ def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine,
         current_rev = context.get_current_revision()
 
     if current_rev is None:
-        alembic_command.upgrade(alembic_config, target_revision)
-        return
+        return True
 
     # Compare revisions - assuming they are numeric strings like '001', '002'
     current_rev_num = int(current_rev)
     target_rev_num = int(target_revision)
 
-    # only upgrade if current revision is older than target revision
-    if current_rev_num < target_rev_num:
-        alembic_command.upgrade(alembic_config, target_revision)
+    return current_rev_num < target_rev_num
+
+
+def safe_alembic_upgrade(engine: sqlalchemy.engine.Engine, section: str,
+                         target_revision: str):
+    """Upgrade the database if needed. Uses a file lock to ensure
+    that only one process tries to upgrade the database at a time.
+
+    Args:
+        engine: SQLAlchemy engine for the database
+        section: Alembic section to upgrade (e.g., 'state_db' or 'spot_jobs_db')
+        target_revision: Target revision to upgrade to (e.g., '001')
+    """
+    # set alembic logger to warning level
+    alembic_logger = logging.getLogger('alembic')
+    alembic_logger.setLevel(logging.WARNING)
+
+    alembic_config = get_alembic_config(engine, section)
+
+    # only acquire lock if db needs upgrade
+    if needs_upgrade(engine, section, target_revision):
+        with db_lock(section):
+            # check again if db needs upgrade in case another
+            # process upgraded it while we were waiting for the lock
+            if needs_upgrade(engine, section, target_revision):
+                alembic_command.upgrade(alembic_config, target_revision)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
