### PR TITLE
[Core] Don't reset autostop/down for abnormal clusters if head node is still alive

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -33,6 +33,7 @@ from sky import sky_logging
 from sky import skypilot_config
 from sky.adaptors import common as adaptors_common
 from sky.jobs import utils as managed_job_utils
+from sky.provision import common as provision_common
 from sky.provision import instance_setup
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.server.requests import requests as requests_lib
@@ -1812,6 +1813,45 @@ def _query_cluster_status_via_cloud_api(
     return node_statuses
 
 
+def _query_cluster_info_via_cloud_api(
+    handle: 'cloud_vm_ray_backend.CloudVmRayResourceHandle'
+) -> provision_common.ClusterInfo:
+    """Returns the cluster info.
+
+    Raises:
+        exceptions.NotSupportedError: the cloud does not support the new provisioner.
+        exceptions.FetchClusterInfoError: the cluster info cannot be
+          fetched from the cloud provider.
+    """
+    cloud = handle.launched_resources.cloud
+    assert cloud is not None, handle
+    if cloud.STATUS_VERSION >= clouds.StatusVersion.SKYPILOT:
+        try:
+            cloud_name = repr(cloud)
+            ray_config = global_user_state.get_cluster_yaml_dict(
+                handle.cluster_yaml)
+            provider_config = ray_config['provider']
+            region = provider_config.get('region') or provider_config.get(
+                'location')
+            cluster_info = provision_lib.get_cluster_info(
+                cloud_name, region, handle.cluster_name_on_cloud,
+                provider_config)
+            logger.debug(
+                f'Querying {cloud_name} cluster '
+                f'{handle.cluster_name_on_cloud} '
+                f'head instance:\n{cluster_info.get_head_instance()}\n'
+                f'worker instances:\n{cluster_info.get_worker_instances()}')
+            return cluster_info
+        except Exception as e:  # pylint: disable=broad-except
+            with ux_utils.print_exception_no_traceback():
+                raise exceptions.FetchClusterInfoError(
+                    reason=exceptions.FetchClusterInfoError.Reason.UNKNOWN
+                ) from e
+    else:
+        raise exceptions.NotSupportedError(
+            f'The cloud {cloud} does not support the SkyPilot provisioner.')
+
+
 def check_can_clone_disk_and_override_task(
     cluster_name: str, target_cluster_name: Optional[str], task: 'task_lib.Task'
 ) -> Tuple['task_lib.Task', 'cloud_vm_ray_backend.CloudVmRayResourceHandle']:
@@ -2152,68 +2192,89 @@ def _update_cluster_status(cluster_name: str) -> Optional[Dict[str, Any]]:
     #   * The cluster is partially or completely in the INIT state, which means
     #     that provisioning was interrupted. This is considered abnormal.
     #
-    # An abnormal cluster will transition to INIT and have any autostop setting
-    # reset (unless it's autostopping/autodowning).
+    # An abnormal cluster will transition to INIT, and one of the following will happen:
+    #  (1) If the SkyPilot provisioner is used AND the head node is alive, we
+    #      will not reset the autostop setting. Because autostop is handled by
+    #      the skylet through the cloud APIs, and will continue to function
+    #      regardless of the ray cluster's health.
+    #  (2) Otherwise, we will reset the autostop setting, unless the cluster is
+    #      autostopping/autodowning.
     is_abnormal = ((0 < len(node_statuses) < handle.launched_nodes) or any(
         status != status_lib.ClusterStatus.STOPPED for status in node_statuses))
     if is_abnormal:
         logger.debug('The cluster is abnormal. Setting to INIT status. '
                      f'node_statuses: {node_statuses}')
-        backend = get_backend_from_handle(handle)
-        if isinstance(backend,
-                      backends.CloudVmRayBackend) and record['autostop'] >= 0:
-            if not backend.is_definitely_autostopping(handle,
-                                                      stream_logs=False):
-                # Friendly hint.
-                autostop = record['autostop']
-                maybe_down_str = ' --down' if record['to_down'] else ''
-                noun = 'autodown' if record['to_down'] else 'autostop'
-
-                # Reset the autostopping as the cluster is abnormal, and may
-                # not correctly autostop. Resetting the autostop will let
-                # the user know that the autostop may not happen to avoid
-                # leakages from the assumption that the cluster will autostop.
-                success = True
-                reset_local_autostop = True
+        if record['autostop'] >= 0:
+            is_head_node_alive = False
+            if launched_resources.cloud.PROVISIONER_VERSION >= clouds.ProvisionerVersion.SKYPILOT:
+                # Check if the head node is alive
                 try:
-                    backend.set_autostop(handle, -1, stream_logs=False)
-                except exceptions.CommandError as e:
-                    success = False
-                    if e.returncode == 255:
-                        word = 'autostopped' if noun == 'autostop' else 'autodowned'
-                        logger.debug(f'The cluster is likely {word}.')
-                        reset_local_autostop = False
-                except (Exception, SystemExit) as e:  # pylint: disable=broad-except
-                    success = False
-                    logger.debug(f'Failed to reset autostop. Due to '
-                                 f'{common_utils.format_exception(e)}')
-                if reset_local_autostop:
-                    global_user_state.set_cluster_autostop_value(
-                        handle.cluster_name, -1, to_down=False)
+                    cluster_info = _query_cluster_info_via_cloud_api(handle)
+                    is_head_node_alive = cluster_info.get_head_instance(
+                    ) is not None
+                except Exception as e:  # pylint: disable=broad-except
+                    logger.debug(
+                        f'Failed to get cluster info for {cluster_name!r}: '
+                        f'{common_utils.format_exception(e)}')
 
-                if success:
-                    operation_str = (f'Canceled {noun} on the cluster '
-                                     f'{cluster_name!r}')
+            backend = get_backend_from_handle(handle)
+            if isinstance(backend, backends.CloudVmRayBackend):
+                if is_head_node_alive:
+                    logger.debug(
+                        f'Skipping autostop reset for cluster {cluster_name!r} '
+                        'because the head node is alive.')
+                elif not backend.is_definitely_autostopping(handle,
+                                                            stream_logs=False):
+                    # Friendly hint.
+                    autostop = record['autostop']
+                    maybe_down_str = ' --down' if record['to_down'] else ''
+                    noun = 'autodown' if record['to_down'] else 'autostop'
+
+                    # Reset the autostopping as the cluster is abnormal, and may
+                    # not correctly autostop. Resetting the autostop will let
+                    # the user know that the autostop may not happen to avoid
+                    # leakages from the assumption that the cluster will autostop.
+                    success = True
+                    reset_local_autostop = True
+                    try:
+                        backend.set_autostop(handle, -1, stream_logs=False)
+                    except exceptions.CommandError as e:
+                        success = False
+                        if e.returncode == 255:
+                            word = 'autostopped' if noun == 'autostop' else 'autodowned'
+                            logger.debug(f'The cluster is likely {word}.')
+                            reset_local_autostop = False
+                    except (Exception, SystemExit) as e:  # pylint: disable=broad-except
+                        success = False
+                        logger.debug(f'Failed to reset autostop. Due to '
+                                     f'{common_utils.format_exception(e)}')
+                    if reset_local_autostop:
+                        global_user_state.set_cluster_autostop_value(
+                            handle.cluster_name, -1, to_down=False)
+
+                    if success:
+                        operation_str = (f'Canceled {noun} on the cluster '
+                                         f'{cluster_name!r}')
+                    else:
+                        operation_str = (
+                            f'Attempted to cancel {noun} on the '
+                            f'cluster {cluster_name!r} with best effort')
+                    yellow = colorama.Fore.YELLOW
+                    bright = colorama.Style.BRIGHT
+                    reset = colorama.Style.RESET_ALL
+                    ux_utils.console_newline()
+                    logger.warning(
+                        f'{yellow}{operation_str}, since it is found to be in an '
+                        f'abnormal state. To fix, try running: {reset}{bright}sky '
+                        f'start -f -i {autostop}{maybe_down_str} {cluster_name}'
+                        f'{reset}')
                 else:
-                    operation_str = (
-                        f'Attempted to cancel {noun} on the '
-                        f'cluster {cluster_name!r} with best effort')
-                yellow = colorama.Fore.YELLOW
-                bright = colorama.Style.BRIGHT
-                reset = colorama.Style.RESET_ALL
-                ux_utils.console_newline()
-                logger.warning(
-                    f'{yellow}{operation_str}, since it is found to be in an '
-                    f'abnormal state. To fix, try running: {reset}{bright}sky '
-                    f'start -f -i {autostop}{maybe_down_str} {cluster_name}'
-                    f'{reset}')
-            else:
-                ux_utils.console_newline()
-                operation_str = 'autodowning' if record[
-                    'to_down'] else 'autostopping'
-                logger.info(
-                    f'Cluster {cluster_name!r} is {operation_str}. Setting to '
-                    'INIT status; try refresh again in a while.')
+                    ux_utils.console_newline()
+                    operation_str = 'autodowning' if record[
+                        'to_down'] else 'autostopping'
+                    logger.info(
+                        f'Cluster {cluster_name!r} is {operation_str}. Setting to '
+                        'INIT status; try refresh again in a while.')
 
         # If the user starts part of a STOPPED cluster, we still need a status
         # to represent the abnormal status. For spot cluster, it can also

--- a/sky/exceptions.py
+++ b/sky/exceptions.py
@@ -387,6 +387,7 @@ class FetchClusterInfoError(Exception):
     class Reason(enum.Enum):
         HEAD = 'HEAD'
         WORKER = 'WORKER'
+        UNKNOWN = 'UNKNOWN'
 
     def __init__(self, reason: Reason) -> None:
         super().__init__()

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1281,6 +1281,40 @@ def test_autostop(generic_cloud: str):
     smoke_tests_utils.run_one_test(test)
 
 
+@pytest.mark.no_fluidstack  # FluidStack does not support stopping in SkyPilot implementation
+@pytest.mark.no_scp  # SCP does not support num_nodes > 1 yet. Run test_scp_autodown instead.
+@pytest.mark.no_vast  # Vast does not support num_nodes > 1 yet
+@pytest.mark.no_nebius  # Nebius does not support autodown
+@pytest.mark.no_hyperbolic  # Hyperbolic does not support num_nodes > 1 yet
+def test_autostop_with_unhealthy_ray_cluster(generic_cloud: str):
+    name = smoke_tests_utils.get_cluster_name()
+    # See test_autostop() for explanation of autostop_timeout.
+    autostop_timeout = 600 if generic_cloud == 'azure' else 250
+    test = smoke_tests_utils.Test(
+        'autostop_with_unhealthy_ray_cluster',
+        [
+            f'sky launch -y -d -c {name} --down -i 5 --num-nodes 2 --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} tests/test_yamls/minimal.yaml',
+            # Ensure autostop is set.
+            f'sky status | grep {name} | grep "5m"',
+            # Stop the ray cluster, but leave the node running.
+            # TODO(kevin): Find a better way to replicate the issue
+            f'ssh {name} "skypilot-runtime/bin/ray stop"',
+            # Ensure the cluster is not terminated early, and is in INIT,
+            # because the ray cluster is stopped.
+            'sleep 240',
+            f's=$(sky status {name} --refresh); echo "$s"; echo; echo; echo "$s"  | grep {name} | grep INIT',
+            # Ensure the cluster is STOPPED.
+            smoke_tests_utils.get_cmd_wait_until_cluster_status_contains(
+                cluster_name=name,
+                cluster_status=[sky.ClusterStatus.STOPPED],
+                timeout=autostop_timeout),
+        ],
+        f'sky down -y {name}',
+        timeout=20 * 60,
+    )
+    smoke_tests_utils.run_one_test(test)
+
+
 # ---------- Testing Autodowning ----------
 @pytest.mark.no_fluidstack  # FluidStack does not support stopping in SkyPilot implementation
 @pytest.mark.no_scp  # SCP does not support num_nodes > 1 yet. Run test_scp_autodown instead.

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1297,6 +1297,8 @@ def test_autostop_with_unhealthy_ray_cluster(generic_cloud: str):
             f'sky autostop -y {name} -i 5',
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "5m"',
+            # Ensure the job succeeded.
+            f'sky logs {name} 1 --status',
             # Stop the ray cluster, but leave the node running.
             # TODO(kevin): Find a better way to replicate the issue
             f'ssh {name} "skypilot-runtime/bin/ray stop"',

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1293,7 +1293,8 @@ def test_autostop_with_unhealthy_ray_cluster(generic_cloud: str):
     test = smoke_tests_utils.Test(
         'autostop_with_unhealthy_ray_cluster',
         [
-            f'sky launch -y -d -c {name} --down -i 5 --num-nodes 2 --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} tests/test_yamls/minimal.yaml',
+            f'sky launch -y -d -c {name} --num-nodes 2 --infra {generic_cloud} {smoke_tests_utils.LOW_RESOURCE_ARG} tests/test_yamls/minimal.yaml',
+            f'sky autostop -y {name} -i 5',
             # Ensure autostop is set.
             f'sky status | grep {name} | grep "5m"',
             # Stop the ray cluster, but leave the node running.


### PR DESCRIPTION
Fixes #5946 

Context: 
When we refresh a cluster's status, either every 60s (through `skypilot-status-refresh-daemon`) or `sky status --refresh`, we check the status of the nodes using the cloud APIs, and also the status of the Ray cluster. And if it's "abnormal", as defined here: https://github.com/skypilot-org/skypilot/blob/de717752a6e06b3f1c154da25f6c00dd07780d9b/sky/backends/backend_utils.py#L2138-L2153

We cancel the autostop, because we cannot guarantee that autostop will happen correctly, as the Ray cluster is probably down in this case.

But this code path was written back when deprovisioning/stopping of clusters were done through Ray, and not the cloud APIs. Now that we're using cloud APIs invoked through skylet, which runs on the head node, we can improve this. Now, the property we have is as long as the head node (with the skylet) is alive, the cluster will be able to autostop correctly, even if the Ray cluster is down, or even if some worker nodes are down, in the case of a multi-node cluster.

Testing:
We still don't 100% know what exactly happened in the initial report. What we do know is this code path is only hit when either a node dies or the Ray cluster reports unhealthy.

So the way I attempted to replicate this is by saturating the CPUs or other resources in the node, and hoping that starves the ray process to the point that it can't response to status requests in time, so that it goes to the `INIT` state. And eventually, it will go back to `UP` once the system load is gone and it can respond again to status checks.
```yaml
# test.yaml
setup: |
  sudo apt-get update && sudo apt-get install -y stress
run: |
  stress --cpu 30000 -t 300s
```

Out of every 100 runs, usually only 1 gets to this bad state.
```bash
for i in {1..100}; do; sh -c 'sky launch --infra aws --cpus 2 --down -y --async test.yaml'; done;
```

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
       - New smoke test: `test_autostop_with_unhealthy_ray_cluster` - not perfectly representative of a real world scenario (forcefully doing `ray stop`), but is able to invoke the code path we're testing for
       - Manual test
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
