### PR TITLE
[API server] migrate basic auth from ingress to server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ AUTH_STRING=$(htpasswd -nb $WEB_USERNAME $WEB_PASSWORD)
 helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
   --namespace $NAMESPACE \
   --create-namespace \
-  --set ingress.authCredentials=$AUTH_STRING
+  --set ingress.initialBasicAuthCredentials=$AUTH_STRING
 ```
 
 Then build the local changes and deploy the new changes to the API Server:

--- a/charts/skypilot/templates/_helpers.tpl
+++ b/charts/skypilot/templates/_helpers.tpl
@@ -73,10 +73,25 @@ metadata:
 
 {{/* Whether to enable basic auth */}}
 {{- define "skypilot.enableBasicAuthInAPIServer" -}}
-{{- if and (not (index .Values.ingress "oauth2-proxy" "enabled")) .Values.apiService.enableUserManagement -}}
+{{- if eq .Values.apiService.enableBasicAuth nil -}}
+  {{- if .Release.IsInstall -}}
+    {{- if not (index .Values.ingress "oauth2-proxy" "enabled") -}}
 true
-{{- else -}}
+    {{- else -}}
 false
+    {{- end -}}
+  {{- else -}}
+    {{- /* TODO: remove backward compatbility in 0.12.0 */ -}}
+    {{- /* Keep existing behavior for deployment when the option is unset */ -}}
+    {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-initial-basic-auth" .Release.Name) -}}
+    {{- if $existingSecret -}}
+true
+    {{- else -}}
+false
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+{{ .Values.apiService.enableBasicAuth }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -75,6 +75,10 @@ spec:
               name: {{ include "skypilot.initialBasicAuthSecretName" . }}
               key: auth
         {{- end }}
+        {{- if .Values.apiService.enableUserManagement }}
+        - name: SKYPILOT_API_BASIC_AUTH_RBAC
+          value: "true"
+        {{- end }}
         {{- if .Values.apiService.enableServiceAccounts }}
         - name: ENABLE_SERVICE_ACCOUNTS
           value: "true"

--- a/charts/skypilot/templates/auth.yaml
+++ b/charts/skypilot/templates/auth.yaml
@@ -1,4 +1,6 @@
-{{- if and (not .Values.ingress.authSecret) .Values.ingress.authCredentials (not .Values.apiService.enableUserManagement) (not (index .Values.ingress "oauth2-proxy" "enabled")) }}
+{{- /* TODO(aylei): remove backward compatibility in 0.12.0 */ -}}
+{{- $enableBasicAuthInAPIServer := include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true" -}}
+{{- if and (not .Values.ingress.authSecret) .Values.ingress.authCredentials (not $enableBasicAuthInAPIServer) (not (index .Values.ingress "oauth2-proxy" "enabled")) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -35,7 +35,8 @@ metadata:
         set $x_skypilot_auth_mode "token";
         return 200;
       }
-    {{- else if and (not $enableBasicAuthInAPIServer) (or .Values.ingress.authSecret .Values.ingress.authCredentials) }}
+    {{/* TODO(aylei): backward compatibility for existing deployments when enableBasicAuth is not explicitly set, remove after 0.12.0 */}}
+    {{- else if and (and (not $enableBasicAuthInAPIServer) (or .Values.ingress.authSecret .Values.ingress.authCredentials)) (eq .Values.apiService.enableBasicAuth nil ) }}
     # Basic authentication
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-realm: "SkyPilot API Server"

--- a/charts/skypilot/templates/initial-auth.yaml
+++ b/charts/skypilot/templates/initial-auth.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (index .Values.ingress "oauth2-proxy" "enabled")) .Values.apiService.enableUserManagement (not .Values.apiService.initialBasicAuthSecret) .Values.apiService.initialBasicAuthCredentials }}
+{{- if and (include "skypilot.enableBasicAuthInAPIServer" . | trim | eq "true") (not .Values.apiService.initialBasicAuthSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/skypilot/tests/auth_test.yaml
+++ b/charts/skypilot/tests/auth_test.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: auth_test
+templates:
+  - templates/auth.yaml
+tests:
+  # Test cases for backward compatibility auth secret creation
+  # Note: The lookup function used in the helper for upgrades cannot be tested in unit tests
+  # These tests focus on the other conditions that can be tested
+  - it: should create auth secret when enableBasicAuth is false and conditions are met
+    set:
+      apiService.enableBasicAuth: false  # Explicitly false makes enableBasicAuthInAPIServer false
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-basic-auth
+      - equal:
+          path: stringData.auth
+          value: "olduser:oldpass"
+
+  - it: should not create auth secret when enableBasicAuth is explicitly true
+    set:
+      apiService.enableBasicAuth: true
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create auth secret when enableBasicAuth is explicitly true
+    set:
+      apiService.enableBasicAuth: true
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create auth secret when oauth2-proxy is enabled
+    set:
+      apiService.enableBasicAuth: null
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create auth secret when authSecret is provided
+    set:
+      apiService.enableBasicAuth: null
+      ingress.authSecret: my-existing-auth-secret
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create auth secret when authCredentials is not provided
+    set:
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test cases for new install behavior
+  - it: should not create auth secret for new install even with authCredentials when enableBasicAuth is null
+    set:
+      apiService.enableBasicAuth: null
+      ingress.authCredentials: "olduser:oldpass"
+      ingress.oauth2-proxy.enabled: false
+    release:
+      upgrade: false
+    asserts:
+      - hasDocuments:
+          count: 0 

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -156,6 +156,33 @@ tests:
           content:
             name: SKYPILOT_DB_CONNECTION_URI
 
+  # Test cases for SKYPILOT_API_BASIC_AUTH_RBAC environment variable
+  - it: should set SKYPILOT_API_BASIC_AUTH_RBAC when enableUserManagement is true
+    set:
+      apiService.enableUserManagement: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_API_BASIC_AUTH_RBAC
+            value: "true"
+
+  - it: should not set SKYPILOT_API_BASIC_AUTH_RBAC when enableUserManagement is false
+    set:
+      apiService.enableUserManagement: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_API_BASIC_AUTH_RBAC
+
+  - it: should not set SKYPILOT_API_BASIC_AUTH_RBAC when enableUserManagement is not set
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_API_BASIC_AUTH_RBAC
+
   - it: should mount r2 credentials correctly when r2Credentials is enabled
     set:
       r2Credentials.enabled: true

--- a/charts/skypilot/tests/helpers_test.yaml
+++ b/charts/skypilot/tests/helpers_test.yaml
@@ -1,0 +1,101 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: helpers_test
+templates:
+  - templates/api-deployment.yaml
+tests:
+  # Test cases for enableBasicAuth explicitly set to true
+  - it: should enable basic auth when enableBasicAuth is explicitly true
+    set:
+      apiService.enableBasicAuth: true
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-initial-basic-auth
+                key: auth
+
+  - it: should enable basic auth when enableBasicAuth is true even with oauth2-proxy enabled
+    set:
+      apiService.enableBasicAuth: true
+      ingress.oauth2-proxy.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-initial-basic-auth
+                key: auth
+
+  # Test cases for enableBasicAuth explicitly set to false
+  - it: should not enable basic auth when enableBasicAuth is explicitly false
+    set:
+      apiService.enableBasicAuth: false
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+
+  # Test cases for enableBasicAuth = null on fresh install
+  - it: should enable basic auth for new install when enableBasicAuth is null and oauth2-proxy disabled
+    set:
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
+    release:
+      upgrade: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-initial-basic-auth
+                key: auth
+
+  - it: should not enable basic auth for new install when enableBasicAuth is null and oauth2-proxy enabled
+    set:
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: true
+    release:
+      upgrade: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+
+  # Test cases for enableBasicAuth = null on upgrade (backward compatibility)
+  # Note: The lookup function used in the helper cannot be fully tested in unit tests
+  # This test just verifies the template renders without error for upgrade scenarios
+  - it: should render correctly for upgrade when enableBasicAuth is null
+    set:
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
+    release:
+      upgrade: true
+    asserts:
+      - isKind:
+          of: Deployment
+
+  # Test using external secret
+  - it: should use external secret when initialBasicAuthSecret is provided
+    set:
+      apiService.enableBasicAuth: true
+      apiService.initialBasicAuthSecret: my-external-auth-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_INITIAL_BASIC_AUTH
+            valueFrom:
+              secretKeyRef:
+                name: my-external-auth-secret
+                key: auth 

--- a/charts/skypilot/tests/ingress_test.yaml
+++ b/charts/skypilot/tests/ingress_test.yaml
@@ -56,43 +56,80 @@ tests:
           value: "https://$host/oauth2/auth"
 
   # Test basic auth annotations
-  - it: should add basic auth annotations when authSecret is provided and user management disabled
+  - it: should not add basic auth in ingress when basic auth is explicitly enabled in API server
     set:
       ingress.enabled: true
       ingress.authSecret: my-auth-secret
-      apiService.enableUserManagement: false
+      apiService.enableBasicAuth: true
     asserts:
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-type"]
-          value: "basic"
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-realm"]
-          value: "SkyPilot API Server"
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-secret"]
-          value: "my-auth-secret"
 
-  - it: should add basic auth annotations when authCredentials is provided and user management disabled
+  - it: should not add basic auth in ingress when basic auth is explicitly disabled
     set:
       ingress.enabled: true
       ingress.authCredentials: "user:pass"
-      apiService.enableUserManagement: false
+      apiService.enableBasicAuth: false
     asserts:
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-type"]
-          value: "basic"
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-realm"]
-          value: "SkyPilot API Server"
-      - equal:
+      - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-secret"]
-          value: "RELEASE-NAME-basic-auth"
 
-  - it: should not add basic auth annotations when user management is enabled
+  # Test backward compatibility logic when enableBasicAuth is null
+  # Note: The complex helper logic with lookup cannot be fully tested in unit tests
+  # These tests verify the template renders correctly without the complex conditional logic
+  - it: should render ingress correctly when enableBasicAuth is null for backward compatibility
     set:
       ingress.enabled: true
       ingress.authCredentials: "user:pass"
-      apiService.enableUserManagement: true
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress
+
+  - it: should render ingress correctly with authSecret when enableBasicAuth is null
+    set:
+      ingress.enabled: true
+      ingress.authSecret: my-auth-secret
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ingress
+
+  - it: should not add basic auth in ingress when enableBasicAuth is null and oauth2-proxy is enabled
+    set:
+      ingress.enabled: true
+      ingress.authCredentials: "user:pass"
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-type"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-realm"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-secret"]
+
+  - it: should not add basic auth in ingress when enableBasicAuth is null and no auth credentials provided
+    set:
+      ingress.enabled: true
+      apiService.enableBasicAuth: null
+      ingress.oauth2-proxy.enabled: false
     asserts:
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-type"]

--- a/charts/skypilot/tests/initial_auth_test.yaml
+++ b/charts/skypilot/tests/initial_auth_test.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: initial_auth_test
+templates:
+  - templates/initial-auth.yaml
+tests:
+  # Test cases for enableBasicAuth = true
+  - it: should create initial auth secret when enableBasicAuth is true
+    set:
+      apiService.enableBasicAuth: true
+      apiService.initialBasicAuthCredentials: "testuser:testpass"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-initial-basic-auth
+      - equal:
+          path: stringData.auth
+          value: "testuser:testpass"
+
+  - it: should not create initial auth secret when enableBasicAuth is false
+    set:
+      apiService.enableBasicAuth: false
+      apiService.initialBasicAuthCredentials: "testuser:testpass"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test cases for enableBasicAuth = null (default behavior)
+  - it: should create initial auth secret for new install when enableBasicAuth is null and oauth2-proxy disabled
+    set:
+      apiService.enableBasicAuth: null
+      apiService.initialBasicAuthCredentials: "testuser:testpass"
+      ingress.oauth2-proxy.enabled: false
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    release:
+      upgrade: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-initial-basic-auth
+
+  - it: should not create initial auth secret for new install when enableBasicAuth is null and oauth2-proxy enabled
+    set:
+      apiService.enableBasicAuth: null
+      apiService.initialBasicAuthCredentials: "testuser:testpass"
+      ingress.oauth2-proxy.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 20
+    release:
+      upgrade: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test cases when initialBasicAuthSecret is provided
+  - it: should not create initial auth secret when initialBasicAuthSecret is provided
+    set:
+      apiService.enableBasicAuth: true
+      apiService.initialBasicAuthSecret: my-existing-secret
+      apiService.initialBasicAuthCredentials: "testuser:testpass"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Test cases for using default credentials
+  - it: should use default credentials when enableBasicAuth is true and no credentials provided
+    set:
+      apiService.enableBasicAuth: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: stringData.auth
+          value: "skypilot:$apr1$c1h4rNxt$2NnL7dIDUV0tWsnuNMGSr/" 

--- a/charts/skypilot/values.schema.json
+++ b/charts/skypilot/values.schema.json
@@ -35,6 +35,12 @@
                         "null"
                     ]
                 },
+                "enableBasicAuth": {
+                    "type": [
+                        "boolean",
+                        "null"
+                    ]
+                },
                 "enableServiceAccounts": {
                     "type": "boolean"
                 },

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -19,24 +19,29 @@ apiService:
   # - RollingUpdate: [EXPERIMENTAL] create a new pod first, wait for it to be ready, then delete the old one (zero downtime).
   # Default to Recreate. When set to RollingUpdate, an external database must be configured via .apiService.dbConnectionSecretName or .apiService.dbConnectionString.
   upgradeStrategy: Recreate
-  # Enable basic auth and user management in the API server
-  # If enabled, the user can be created, updated, and deleted in the Dashboard,
-  # and the basic auth will be done in the API server instead of the ingress.
-  # If enabled, the basic auth configuration `ingress.authCredentials`
-  # and `ingress.authSecret` in the ingress will be ignored.
+  # If enabled, the basic auth user will be used as the principal for RBAC instead of
+  # client-side whoami
   enableUserManagement: false
   # Enable service account tokens for automated API access
   # If enabled, users can create bearer tokens to bypass SSO authentication
   # for automated systems. This works independently of enableUserManagement.
   # JWT secrets are automatically stored in the database for persistence across restarts.
   enableServiceAccounts: true
+  # Enable basic auth in the API server
+  # Default to null, which has the following behavior:
+  # - For existing deployments, keep the previous setting to avoid breaking existing users;
+  # - For new deployments, enabled if `ingress.oauth2-proxy.enabled` is false to ensure the server is protected by default.
+  # Setting this to true/false explicitly overrides the default behavior.
+  # @schema type: [boolean, null]
+  enableBasicAuth: null
   # Initial basic auth credentials for the API server
-  # The user in the credentials will be used to create a new admin user in the API server,
-  # and the password can be updated by the user in the Dashboard.
-  # If both `initialBasicAuthCredentials` and `initialBasicAuthSecret` are set,
-  # `initialBasicAuthSecret` will be used.
-  # They are only used when `enableUserManagement` is true.
+  # The user in the credentials will be used to create a new admin user in the API server.
+  # After the initial deployment, the password can only be updated in the Dashboard.
+  # This will only be used when `enableBasicAuth` is true.
   initialBasicAuthCredentials: "skypilot:$apr1$c1h4rNxt$2NnL7dIDUV0tWsnuNMGSr/"
+  # Set the initial basic auth secret for the API server
+  # After the initial deployment, the password can only be updated in the Dashboard.
+  # This will only be used when `enableBasicAuth` is true.
   # @schema type: [string, null]
   initialBasicAuthSecret: null
   # Custom header name for user authentication (overrides default 'X-Auth-Request-Email')
@@ -166,11 +171,14 @@ storage:
 
 ingress:
   enabled: true
+  # TODO(aylei): remove basic auth in ingress after 0.12.0
+  # Deprecated: use apiService.initialBasicAuthSecret instead
   # Name of the secret containing basic auth credentials for ingress. If not specified, a new secret will be created using authCredentials
   # @schema type: [string, null]
   authSecret: null
+  # Deprecated: use apiService.initialBasicAuthCredentials instead
   # Basic auth credentials in format "username:encrypted_password" (only used if ingress.authSecret is not set)
-  authCredentials: "username:$apr1$encrypted_password"
+  authCredentials: ""
   # Host to exclusively accept traffic from (optional) - will respond to all host requests if not set
   # @schema type: [string, null]
   host: null

--- a/docs/source/reference/api-server/api-server-admin-deploy.rst
+++ b/docs/source/reference/api-server/api-server-admin-deploy.rst
@@ -52,7 +52,7 @@ Install the SkyPilot Helm chart with the following command:
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
       --namespace $NAMESPACE \
       --create-namespace \
-      --set ingress.authCredentials=$AUTH_STRING
+      --set apiService.initialBasicAuthCredentials=$AUTH_STRING
 
 .. dropdown:: Flags explanation
 
@@ -62,7 +62,7 @@ Install the SkyPilot Helm chart with the following command:
     * ``--devel``: Use the latest development version of the SkyPilot helm chart. To use a specific version, pass the ``--version`` flag to the ``helm upgrade`` command (e.g., ``--version 0.1.0``).
     * ``--namespace $NAMESPACE``: Specify the namespace to deploy the API server in.
     * ``--create-namespace``: Create the namespace if it doesn't exist.
-    * :ref:`--set ingress.authCredentials=$AUTH_STRING <helm-values-ingress-authCredentials>`: Set the basic auth credentials for the API server.
+    * :ref:`--set apiService.intialBasicAuthCredentials=$AUTH_STRING <helm-values-apiService-initialBasicAuthCredentials>`: Set the basic auth credentials for the API server.
 
     For more details on the available configuration options, refer to :ref:`SkyPilot API Server Helm Chart Values <helm-values-spec>`.
 
@@ -951,7 +951,7 @@ To reuse an existing ingress controller, you can set :ref:`ingress-nginx.enabled
         --namespace $ANOTHER_NAMESPACE \
         --set ingress-nginx.enabled=false \
         --set ingress.path=/second-server \
-        --set ingress.authCredentials=$ANOTHER_AUTH_STRING
+        --set apiService.initialBasicAuthCredentials=$ANOTHER_AUTH_STRING
 
 With the above commands, these two API servers will share the same ingress controller and serves under different paths of the same host. To get the endpoints, follow :ref:`Step 2: Get the API server URL <sky-get-api-server-url>` to get the host from the helm release that has the ingress-nginx controller deployed, and then append the basic auth and path to the host:
 
@@ -994,11 +994,6 @@ By default, the SkyPilot helm chart will deploy a new ingress-nginx controller w
         --set ingress-nginx.enabled=false \
         --set ingress.ingressClassName=custom-ingress-class \
         --set ingress.annotations.custom-ingress-annotation=custom-ingress-annotation-value
-
-.. note::
-
-    :ref:`Basic auth on ingress <helm-values-ingress-authcredentials>` and :ref:`OAuth2 <helm-values-ingress-oauth2-proxy>` are only supported when using ingress-nginx controller. For other ingress controllers, you can refer to :ref:`deploy-api-server-basic-auth` to setup authentication on the API server.
-
 
 .. _sky-api-server-cloud-deploy:
 

--- a/docs/source/reference/api-server/examples/api-server-basic-auth.rst
+++ b/docs/source/reference/api-server/examples/api-server-basic-auth.rst
@@ -27,12 +27,12 @@ Use ``helm upgrade`` to redeploy the API server.
 
     $ # --reuse-values is critical to keep the old values that aren't being updated here.
     $ helm upgrade -n $NAMESPACE $RELEASE_NAME skypilot/skypilot-nightly --devel --reuse-values \
-            --set apiService.enableUserManagement=true \
+            --set apiService.enableBasicAuth=true \
             --set apiService.initialBasicAuthCredentials=$AUTH_STRING
 
 Flags explanation:
 
-* :ref:`--set apiService.enableUserManagement=true <helm-values-apiService-enableUserManagement>`: Enable basic auth and user management in the API server.
+* :ref:`--set apiService.enableBasicAuth=true <helm-values-apiService-enableBasicAuth>`: Enable basic auth in the API server.
 * :ref:`--set apiService.initialBasicAuthCredentials=$AUTH_STRING <helm-values-apiService-initialBasicAuthCredentials>`: Set the initial basic auth credentials in the API server, if this is not set, a default user ``skypilot`` with password ``skypilot`` will be created.
 
 Now, you can use ``sky api login -e <ENDPOINT>``, for example, ``sky api login -e http://skypilot:yourpassword@myendpoint.com:30050`` to go though the login flow for the CLI. All the operations will be done with the user ``skypilot``.

--- a/docs/source/reference/api-server/examples/api-server-persistence.rst
+++ b/docs/source/reference/api-server/examples/api-server-persistence.rst
@@ -128,7 +128,7 @@ Next, deploy the API server using Helm with the following command.
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
     --namespace $NAMESPACE \
     --create-namespace \
-    --set ingress.authCredentials=$AUTH_STRING \
+    --set apiService.initialBasicAuthCredentials=$AUTH_STRING \
     --set storage.storageClassName=$PV_CLASS_NAME \
     --set storage.size=$DISK_SIZE
 

--- a/docs/source/reference/api-server/examples/example-deploy-gcp-cloud-sql.rst
+++ b/docs/source/reference/api-server/examples/example-deploy-gcp-cloud-sql.rst
@@ -361,4 +361,4 @@ Then run the following command to deploy the API server using helm:
     helm upgrade --install $RELEASE_NAME skypilot/skypilot-nightly --devel \
     --namespace $NAMESPACE \
     -f values.yaml \
-    --set ingress.authCredentials=$AUTH_STRING
+    --set ingress.initialBasicAuthCredentials=$AUTH_STRING

--- a/docs/source/reference/auth.rst
+++ b/docs/source/reference/auth.rst
@@ -3,24 +3,23 @@
 Authentication and RBAC
 =========================
 
-SkyPilot API server supports three authentication methods:
+SkyPilot API server supports two authentication methods:
 
 - **Basic auth**: Use an admin-configured username and password to authenticate.
-- **Basic auth with RBAC**: Use an admin-configured username and password to as an ``Admin`` user, and manage other users and their roles.
 - **SSO (recommended)**: Use an auth proxy (e.g.,
   `OAuth2 Proxy <https://oauth2-proxy.github.io/oauth2-proxy/>`__) to
   authenticate. For example, Okta, Google Workspace, or other SSO providers are supported.
 
-Comparison of the three methods:
+Comparison of the two methods:
 
 .. csv-table::
-    :header: "", "Basic Auth", "Basic Auth with RBAC", "SSO (recommended)"
-    :widths: 20, 40, 40, 40
+    :header: "", "Basic Auth", "SSO (recommended)"
+    :widths: 20, 40, 40
     :align: left
 
-    "User identity", "Client's ``whoami`` + hash of MAC address", "Users created by the ``Admin`` user", "User email (e.g., ``who@skypilot.co``), read from ``X-Auth-Request-Email``"
-    "SkyPilot RBAC", "Not supported", "Supported", "Supported"
-    "Setup", "Automatically enabled", "Can be enabled during deployment with Helm", "Bring your Okta, Google Workspace, or other SSO provider"
+    "User identity", "Client's ``whoami`` + hash of MAC address", "User email (e.g., ``who@skypilot.co``), read from ``X-Auth-Request-Email``"
+    "SkyPilot RBAC", "Not supported", "Supported"
+    "Setup", "Automatically enabled", "Bring your Okta, Google Workspace, or other SSO provider"
 
 
 .. _api-server-basic-auth:
@@ -30,21 +29,6 @@ Basic auth
 
 Basic auth is automatically enabled if you use the :ref:`helm chart
 <sky-api-server-deploy>` to deploy the API server. See the ``AUTH_STRING``
-environment variable in the deployment instructions.
-
-Example login command:
-
-.. code-block:: console
-
-    $ sky api login -e http://username:password@<SKYPILOT_API_SERVER_ENDPOINT>
-
-.. _api-server-basic-auth-rbac:
-
-Basic auth with RBAC
---------------------
-
-Basic auth with RBAC can be enabled if you use the :ref:`helm chart
-<deploy-api-server-basic-auth>` to deploy the API server. See the ``AUTH_STRING``
 environment variable in the deployment instructions.
 
 Example login command:
@@ -400,7 +384,7 @@ SkyPilot provides basic RBAC (role-based access control) support. Two roles are 
 - **User**: Use SkyPilot as usual to launch and manage resources (clusters, jobs, etc.).
 - **Admin**: Manage SkyPilot API server settings, users, and workspaces.
 
-RBAC support is enabled when :ref:`SSO authentication <api-server-auth-proxy>` or :ref:`basic auth with RBAC <api-server-basic-auth-rbac>` is used (not when using :ref:`basic auth <api-server-basic-auth>`).
+RBAC support is enabled only when :ref:`SSO authentication <api-server-auth-proxy>` is used (not when using :ref:`basic auth <api-server-basic-auth>`).
 
 Config :ref:`config-yaml-rbac-default-role` determines whether a new
 SkyPilot user is created with the ``user`` or ``admin`` role. By default, it is
@@ -409,9 +393,7 @@ set to ``admin`` to ease first-time setup.
 User management
 ~~~~~~~~~~~~~~~
 
-When SSO authentication is used, SkyPilot automatically creates a user for each authenticated user. The user's email is used as the username.
-
-When basic auth with RBAC is used, the initial admin user is created with the ``admin`` role and it can create new users and manage their roles in the dashboard.
+SkyPilot automatically creates a user for each authenticated user. The user's email is used as the username.
 
 Admins can click on the **Users** tab in the SkyPilot dashboard to manage users and their roles.
 
@@ -421,5 +403,5 @@ Admins can click on the **Users** tab in the SkyPilot dashboard to manage users 
 
 Supported operations:
 
-* ``Admin`` role can create users (only when basic auth with RBAC is used), update the role for all users, and delete users.
+* ``Admin`` role can create users, update the role for all users, and delete users.
 * ``User`` role can view all users and their roles.

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -53,6 +53,9 @@ API_COOKIE_FILE_ENV_VAR = f'{constants.SKYPILOT_ENV_VAR_PREFIX}API_COOKIE_FILE'
 # Default file if unset.
 # Keep in sync with websocket_proxy.py
 API_COOKIE_FILE_DEFAULT_LOCATION = '~/.sky/cookies.txt'
+# Environment variable for enabling basic auth user principal for RBAC.
+API_BASIC_AUTH_RBAC_ENV_VAR = (
+    f'{constants.SKYPILOT_ENV_VAR_PREFIX}API_BASIC_AUTH_RBAC')
 
 # The path to the dashboard build output
 DASHBOARD_DIR = os.path.join(os.path.dirname(__file__), '..', 'dashboard',

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -279,8 +279,9 @@ class BasicAuthMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             if (username_encoded == db_username_encoded and
                     apr_md5_crypt.verify(password, user.password)):
                 valid_user = True
-                request.state.auth_user = user
-                await _override_user_info_in_request_body(request, user)
+                if os.getenv(server_constants.API_BASIC_AUTH_RBAC_ENV_VAR):
+                    request.state.auth_user = user
+                    await _override_user_info_in_request_body(request, user)
                 break
         if not valid_user:
             return _basic_auth_401_response('Invalid credentials')

--- a/tests/kubernetes/scripts/helm_gcp.sh
+++ b/tests/kubernetes/scripts/helm_gcp.sh
@@ -73,7 +73,7 @@ fi
 helm upgrade --install $RELEASE_NAME skypilot/$PACKAGE_NAME $extra_flag \
     --namespace $NAMESPACE \
     --create-namespace \
-    --set ingress.authCredentials=$AUTH_STRING
+    --set apiService.initialBasicAuthCredentials=$AUTH_STRING
 
 # Wait for pods to be ready
 echo "Waiting for pods to be ready..."


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR migrate basic auth to API server so that users can enable basic auth without the ingress support.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
