### PR TITLE
Remove fallback for cloudwatch logs

### DIFF
--- a/sky/logs/agent.py
+++ b/sky/logs/agent.py
@@ -67,20 +67,6 @@ class FluentbitAgent(LoggingAgent):
         }
         return common_utils.dump_yaml_str(cfg_dict)
 
-    def add_fallback_outputs(self, cfg_dict: Dict[str, Any]) -> Dict[str, Any]:
-        """Add fallback outputs to the Fluent Bit configuration.
-
-        This method can be overridden by subclasses to add fallback outputs
-        in case the primary output fails.
-
-        Args:
-            cfg_dict: The Fluent Bit configuration dictionary.
-
-        Returns:
-            The updated configuration dictionary.
-        """
-        return cfg_dict
-
     @abc.abstractmethod
     def fluentbit_output_config(
             self, cluster_name: resources_utils.ClusterName) -> Dict[str, Any]:

--- a/sky/logs/aws.py
+++ b/sky/logs/aws.py
@@ -211,35 +211,7 @@ class CloudwatchLoggingAgent(FluentbitAgent):
             }
         }
 
-        # Add fallback outputs for graceful failure handling
-        cfg_dict = self.add_fallback_outputs(cfg_dict)
-
         return common_utils.dump_yaml_str(cfg_dict)
-
-    def add_fallback_outputs(self, cfg_dict: Dict[str, Any]) -> Dict[str, Any]:
-        """Add fallback outputs to the Fluent Bit configuration.
-
-        This adds a local file output as a fallback in case
-        CloudWatch logging fails.
-
-        Args:
-            cfg_dict: The Fluent Bit configuration dictionary.
-
-        Returns:
-            The updated configuration dictionary.
-        """
-        # Add a local file output as a fallback
-        fallback_output = {
-            'name': 'file',
-            'match': '*',
-            'path': '/tmp/skypilot_logs_fallback.log',
-            'format': 'out_file',
-        }
-
-        # Add the fallback output to the configuration
-        cfg_dict['pipeline']['outputs'].append(fallback_output)
-
-        return cfg_dict
 
     def fluentbit_output_config(
             self, cluster_name: resources_utils.ClusterName) -> Dict[str, Any]:

--- a/tests/unit_tests/test_sky/logs/test_aws.py
+++ b/tests/unit_tests/test_sky/logs/test_aws.py
@@ -86,18 +86,6 @@ class TestCloudwatchLoggingAgent(unittest.TestCase):
                          f'my-prefix-{self.cluster_name.name_on_cloud}-')
         self.assertEqual(output_config['auto_create_group'], 'false')
 
-    def test_add_fallback_outputs(self):
-        """Test add_fallback_outputs method."""
-        agent = CloudwatchLoggingAgent({})
-        cfg_dict = {'pipeline': {'outputs': [{'name': 'cloudwatch_logs'}],}}
-        updated_cfg = agent.add_fallback_outputs(cfg_dict)
-        self.assertEqual(len(updated_cfg['pipeline']['outputs']), 2)
-        self.assertEqual(updated_cfg['pipeline']['outputs'][0]['name'],
-                         'cloudwatch_logs')
-        self.assertEqual(updated_cfg['pipeline']['outputs'][1]['name'], 'file')
-        self.assertEqual(updated_cfg['pipeline']['outputs'][1]['path'],
-                         '/tmp/skypilot_logs_fallback.log')
-
     @mock.patch('sky.logs.agent.FluentbitAgent.get_setup_command')
     def test_get_setup_command(self, mock_super_get_setup_command):
         """Test get_setup_command method."""
@@ -132,7 +120,6 @@ class TestCloudwatchLoggingAgent(unittest.TestCase):
         self.assertIn('inputs:', config_str)
         self.assertIn('outputs:', config_str)
         self.assertIn('name: cloudwatch', config_str)
-        self.assertIn('name: file', config_str)
 
         # parse yaml and check if the config is valid
         config_dict = yaml.safe_load(config_str)


### PR DESCRIPTION
Removing fallback for cloudwatch logs, wasn't super useful as the logs are already just written to disk. Caused issues for some setups.


Fixed `tests/unit_tests/test_sky/logs/test_aws.py` to match new behaviour.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)


