### PR TITLE
Fix skypilot github issue 6413

### DIFF
--- a/sky/clouds/gcp.py
+++ b/sky/clouds/gcp.py
@@ -595,6 +595,11 @@ class GCP(clouds.Cloud):
         if gcp_utils.is_tpu(resources) and not gcp_utils.is_tpu_vm(resources):
             if tpu_node_name is None:
                 tpu_node_name = cluster_name.name_on_cloud
+        elif gcp_utils.is_tpu_vm(resources):
+            # For TPU VMs, we should not set tpu_node_name as the TPU VM itself
+            # is the node. Setting this to None prevents the template from 
+            # creating a separate tpu_node section in provider_config.
+            tpu_node_name = None
 
         resources_vars['tpu_node_name'] = tpu_node_name
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Fixes `TypeError` when using `tpu_vm=True` (e.g., with TPU v6e) by preventing the generation of a redundant `tpu_node` section in `provider_config`. For TPU VMs, `tpu_node_name` is now explicitly set to `None`, ensuring only the correct TPU VM configuration in `node_config` is applied.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Verified `tpu_node_name` logic for both TPU VMs and traditional TPU nodes.
  - Ran a local test to confirm the fix.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

---
<a href="https://cursor.com/background-agent?bcId=bc-ffccb945-efc7-4d87-8d27-42a853b50821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffccb945-efc7-4d87-8d27-42a853b50821">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>