### PR TITLE
Fix tls paths for skypilot serve

### DIFF
--- a/sky/serve/service_spec.py
+++ b/sky/serve/service_spec.py
@@ -195,9 +195,30 @@ class SkyServiceSpec:
 
         tls_section = config.get('tls', None)
         if tls_section is not None:
+            keyfile = tls_section.get('keyfile', None)
+            certfile = tls_section.get('certfile', None)
+            
+            # Expand TLS file paths similar to how workdir is handled
+            if keyfile is not None:
+                user_keyfile = keyfile
+                keyfile = os.path.abspath(os.path.expanduser(keyfile))
+                if not os.path.isfile(keyfile):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            'TLS keyfile must be a valid file. '
+                            f'{user_keyfile} not found.')
+            if certfile is not None:
+                user_certfile = certfile
+                certfile = os.path.abspath(os.path.expanduser(certfile))
+                if not os.path.isfile(certfile):
+                    with ux_utils.print_exception_no_traceback():
+                        raise ValueError(
+                            'TLS certfile must be a valid file. '
+                            f'{user_certfile} not found.')
+                
             service_config['tls_credential'] = serve_utils.TLSCredential(
-                keyfile=tls_section.get('keyfile', None),
-                certfile=tls_section.get('certfile', None),
+                keyfile=keyfile,
+                certfile=certfile,
             )
 
         return SkyServiceSpec(**service_config)


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR enables `sky serve` to use relative paths (including `~` expansion) for `tls.keyfile` and `tls.certfile` in service manifests. This makes manifests more portable and easier to commit, aligning their behavior with `workdir`. File existence validation is also added.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
  - Manual test: Verified `sky serve up` with a manifest using relative TLS paths and `~` expansion, confirming successful deployment and correct file validation.
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->

---
<a href="https://cursor.com/background-agent?bcId=bc-941484f8-5998-4f6a-87d5-831b9556dc70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-941484f8-5998-4f6a-87d5-831b9556dc70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>