### PR TITLE
[db] make engine definition thread safe

### DIFF
--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -242,10 +242,11 @@ def create_table(engine: sqlalchemy.engine.Engine):
         engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
         migration_utils.GLOBAL_USER_STATE_VERSION)
 
+
 # We wrap the sqlalchemy engine initialization in a thread
 # lock to ensure that multiple threads do not initialize the
 # engine which could result in a rare race condition where
-# a session has already been created with _SQLALCHEMY_ENGINE = e1, 
+# a session has already been created with _SQLALCHEMY_ENGINE = e1,
 # and then another thread overwrites _SQLALCHEMY_ENGINE = e2
 # which could result in e1 being garbage collected unexpectedly.
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:

--- a/sky/global_user_state.py
+++ b/sky/global_user_state.py
@@ -242,7 +242,12 @@ def create_table(engine: sqlalchemy.engine.Engine):
         engine, migration_utils.GLOBAL_USER_STATE_DB_NAME,
         migration_utils.GLOBAL_USER_STATE_VERSION)
 
-
+# We wrap the sqlalchemy engine initialization in a thread
+# lock to ensure that multiple threads do not initialize the
+# engine which could result in a rare race condition where
+# a session has already been created with _SQLALCHEMY_ENGINE = e1, 
+# and then another thread overwrites _SQLALCHEMY_ENGINE = e2
+# which could result in e1 being garbage collected unexpectedly.
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -133,6 +133,12 @@ def create_table(engine: sqlalchemy.engine.Engine):
                                          migration_utils.SPOT_JOBS_VERSION)
 
 
+# We wrap the sqlalchemy engine initialization in a thread
+# lock to ensure that multiple threads do not initialize the
+# engine which could result in a rare race condition where
+# a session has already been created with _SQLALCHEMY_ENGINE = e1, 
+# and then another thread overwrites _SQLALCHEMY_ENGINE = e2
+# which could result in e1 being garbage collected unexpectedly.
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:
     global _SQLALCHEMY_ENGINE
 

--- a/sky/jobs/state.py
+++ b/sky/jobs/state.py
@@ -136,7 +136,7 @@ def create_table(engine: sqlalchemy.engine.Engine):
 # We wrap the sqlalchemy engine initialization in a thread
 # lock to ensure that multiple threads do not initialize the
 # engine which could result in a rare race condition where
-# a session has already been created with _SQLALCHEMY_ENGINE = e1, 
+# a session has already been created with _SQLALCHEMY_ENGINE = e1,
 # and then another thread overwrites _SQLALCHEMY_ENGINE = e2
 # which could result in e1 being garbage collected unexpectedly.
 def initialize_and_get_db() -> sqlalchemy.engine.Engine:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
There is a rare race condition in the db initialization code where two threads may call `_init_db()` at the same time, thread one sets the global `_SQLALCHEMY_ENGINE` to "e1", and then creates a session `with orm.Session(_SQLALCHEMY_ENGINE) as session:` and begins performing some operations on the db. Then, thread two modifies the global `_SQLALCHEMY_ENGINE` to "e2", resulting in "e1" being garbage collected due to a lack of strong references. 

This PR addresses this issue by adding a thread lock around the global `_SQLALCHEMY_ENGINE` initialization, ensuring that only a single thread within a process ever sets the value.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

This PR was manually tested by deleting the `~/.sky` folder, restarting the api server, and testing the cluster lifecycle. 

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
