### PR TITLE
[Serve] Fix TLS key files upload path

### DIFF
--- a/sky/client/common.py
+++ b/sky/client/common.py
@@ -304,14 +304,12 @@ def upload_mounts_to_api_server(dag: 'sky.Dag',
                         task_.file_mounts_mapping[src] = _full_path(src)
         if (task_.service is not None and
                 task_.service.tls_credential is not None):
-            upload_list.append(task_.service.tls_credential.keyfile)
-            upload_list.append(task_.service.tls_credential.certfile)
-            task_.file_mounts_mapping[
-                task_.service.tls_credential.
-                keyfile] = task_.service.tls_credential.keyfile
-            task_.file_mounts_mapping[
-                task_.service.tls_credential.
-                certfile] = task_.service.tls_credential.certfile
+            keyfile = task_.service.tls_credential.keyfile
+            certfile = task_.service.tls_credential.certfile
+            upload_list.append(_full_path(keyfile))
+            upload_list.append(_full_path(certfile))
+            task_.file_mounts_mapping[keyfile] = _full_path(keyfile)
+            task_.file_mounts_mapping[certfile] = _full_path(certfile)
 
     if upload_list:
         os.makedirs(os.path.expanduser(FILE_UPLOAD_LOGS_DIR), exist_ok=True)

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -1021,7 +1021,6 @@ def test_skyserve_failures(generic_cloud: str):
 
 
 @pytest.mark.serve
-@pytest.mark.resource_heavy
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 def test_skyserve_https(generic_cloud: str):
     """Test skyserve with https"""

--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -1027,8 +1027,8 @@ def test_skyserve_https(generic_cloud: str):
     """Test skyserve with https"""
     name = _get_service_name()
 
+    keyfile = f'~/test-skyserve-key-{name}.pem'
     with tempfile.TemporaryDirectory() as tempdir:
-        keyfile = os.path.join(tempdir, 'key.pem')
         certfile = os.path.join(tempdir, 'cert.pem')
         subprocess_utils.run_no_outputs(
             f'openssl req -x509 -newkey rsa:2048 -days 36500 -nodes '
@@ -1053,7 +1053,7 @@ def test_skyserve_https(generic_cloud: str):
                 'output=$(curl $http_endpoint 2>&1); echo $output; '
                 'echo $output | grep "Empty reply from server"',
             ],
-            _TEARDOWN_SERVICE.format(name=name),
+            _TEARDOWN_SERVICE.format(name=name) + f'; rm -f {keyfile}',
             timeout=20 * 60,
             env=smoke_tests_utils.LOW_CONTROLLER_RESOURCE_ENV,
         )


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```
secrets:
  HF_TOKEN:
  VLLM_API_KEY:  # Provide value at launch time that will be used as API key for the service

service:
  readiness_probe:
    path: /v1/models
    headers:
      Authorization: Bearer $VLLM_API_KEY
  replicas: 1
  tls:
    keyfile: ~/skypilot-dev/test-key.pem
    certfile: ~/skypilot-dev/test-cert.pem

# Fields below describe each replica.
resources:
  ports: 8080

workdir: ~/skypilot-dev/examples

setup: |
  uv venv
  uv pip install vllm

run: |
  uv run python -m vllm.entrypoints.openai.api_server \
    --tensor-parallel-size $SKYPILOT_NUM_GPUS_PER_NODE \
    --host 0.0.0.0 --port 8080 \
    --model mistralai/Mixtral-8x7B-Instruct-v0.1 \
    --api-key "$VLLM_API_KEY"

```


Master: `ValueError: File mount source '/root/.sky/api_server/clients/xxx/file_mounts/~/skypilot-dev/test-key.pem' does not exist locally. To fix: check if it exists, and correct the path.`


This PR: passed and the service starts

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
