### PR TITLE
fix service account user_id length

### DIFF
--- a/sky/users/server.py
+++ b/sky/users/server.py
@@ -414,7 +414,7 @@ async def get_service_account_tokens(
 
 def _generate_service_account_user_id() -> str:
     """Generate a unique user ID for a service account."""
-    random_suffix = secrets.token_hex(16)  # 16 character hex string
+    random_suffix = secrets.token_hex(8)  # 16 character hex string
     service_account_id = (f'sa-{random_suffix}')
     return service_account_id
 


### PR DESCRIPTION
This was intended to be 16 random chars, but due to how secrets.token_hex works, it was actually 32, for a total user_id length of 35 chars (too long!).

This was causing SSH to give the error `unix_listener: path "/tmp/skypilot_ssh_blahblahblah" too long for Unix domain socket`. Since we construct the ControlPath including the user_id, the length was contributing to the problem.

Confirmed that we don't see the unix_listener error after shortening the SA user_id.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
