### PR TITLE
[serve] substitute secret values

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -598,6 +598,8 @@ class Task:
         if config.get('service') is not None:
             config['service'] = _fill_in_env_vars(config['service'],
                                                   config.get('envs', {}))
+            config['service'] = _fill_in_env_vars(config['service'],
+                                                  config.get('secrets', {}))
 
         # Fill in any Task.envs into workdir
         if config.get('workdir') is not None:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses an issue where variables configured in the `secrets:` section of the task.yaml are not actually substituted in the `service:` section of the task.yaml. 

For example:

For the the given task yaml
```
service:
  readiness_probe:
    path: /health
    initial_delay_seconds: 600
    headers:
      Authorization: Bearer $AUTH_TOKEN
  replicas: 2

resources:
  ports: 8080
  cpus: 2+

secrets:
  AUTH_TOKEN: null # Pass with `--secret AUTH_TOKEN` in CLI

workdir: examples/serve/http_server

run: python3 server.py --api-key $AUTH_TOKEN
```

launched with `sky serve up task.yaml --secret AUTH_TOKEN=<SECRET_AUTH_TOKEN>`, the serve controller would send the literal string "Bearer $AUTH_TOKEN" rather than substituting the value as such: "Bearer <SECRET_AUTH_TOKEN>".

This PR ensures that variables passed in via the `--secret` flag get properly substituted in `task.py`. 

<!-- Describe the tests ran -->
This PR was tested by serving a basic HTTP server that accepts an api-key. I tested prior to the fix and saw that the literal "$AUTH_TOKEN" was being passed. With the fix, I saw that the actual token was being substituted.
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
