### PR TITLE
[Network] Add specific image for infiniband on nebius

### DIFF
--- a/llm/llama-4-finetuning/llama-4-maverick-lora.yaml
+++ b/llm/llama-4-finetuning/llama-4-maverick-lora.yaml
@@ -32,6 +32,9 @@ file_mounts:
   /configs: ./configs
 
 setup: |
+  conda create -n training python=3.10 -y
+  conda activate training
+
   # Download the repository configuration package
   wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
 
@@ -51,6 +54,8 @@ setup: |
 
 
 run: |
+  conda activate training
+
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed finetuning, head node: $MASTER_ADDR"
 

--- a/llm/llama-4-finetuning/llama-4-maverick-sft.yaml
+++ b/llm/llama-4-finetuning/llama-4-maverick-sft.yaml
@@ -27,6 +27,9 @@ num_nodes: 4
 #    mode: MOUNT_CACHED  # MOUNT_CACHED mode will intelligently cache the checkpoint for faster writes
 
 setup: |
+  conda create -n training python=3.10 -y
+  conda activate training
+
   # Install torch and torchtune nightly builds
   pip install --pre --upgrade torch==2.8.0.dev20250610+cu126 torchvision==0.23.0.dev20250610+cu126 torchao==0.12.0.dev20250611+cu126 --index-url https://download.pytorch.org/whl/nightly/cu126 # full options are cpu/cu118/cu124/cu126/xpu/rocm6.2/rocm6.3/rocm6.4
   pip install --pre --upgrade torchtune==0.7.0.dev20250610+cpu --extra-index-url https://download.pytorch.org/whl/nightly/cpu
@@ -36,6 +39,8 @@ setup: |
     --hf-token $HF_TOKEN
 
 run: |
+  conda activate training
+
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed finetuning, head node: $MASTER_ADDR"
 

--- a/llm/llama-4-finetuning/llama-4-maverick.yaml
+++ b/llm/llama-4-finetuning/llama-4-maverick.yaml
@@ -27,6 +27,9 @@ num_nodes: 2
 #    mode: MOUNT_CACHED  # MOUNT_CACHED mode will intelligently cache the checkpoint for faster writes
 
 setup: |
+  conda create -n training python=3.10 -y
+  conda activate training
+
   # Install torch and torchtune nightly builds
   pip install --pre --upgrade torch==2.8.0.dev20250610+cu126 torchvision==0.23.0.dev20250610+cu126 torchao==0.12.0.dev20250611+cu126 --index-url https://download.pytorch.org/whl/nightly/cu126 # full options are cpu/cu118/cu124/cu126/xpu/rocm6.2/rocm6.3/rocm6.4
   pip install --pre --upgrade torchtune==0.7.0.dev20250610+cpu --extra-index-url https://download.pytorch.org/whl/nightly/cpu
@@ -36,6 +39,8 @@ setup: |
     --hf-token $HF_TOKEN
 
 run: |
+  conda activate training
+
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed finetuning, head node: $MASTER_ADDR"
 

--- a/llm/llama-4-finetuning/llama-4-scout-sft.yaml
+++ b/llm/llama-4-finetuning/llama-4-scout-sft.yaml
@@ -27,6 +27,9 @@ num_nodes: 2
 #    mode: MOUNT_CACHED  # MOUNT_CACHED mode will intelligently cache the checkpoint for faster writes
 
 setup: |
+  conda create -n training python=3.10 -y
+  conda activate training
+
   # Install torch and torchtune nightly builds
   pip install --pre --upgrade torch==2.8.0.dev20250610+cu126 torchvision==0.23.0.dev20250610+cu126 torchao==0.12.0.dev20250611+cu126 --index-url https://download.pytorch.org/whl/nightly/cu126 # full options are cpu/cu118/cu124/cu126/xpu/rocm6.2/rocm6.3/rocm6.4
   pip install --pre --upgrade torchtune==0.7.0.dev20250610+cpu --extra-index-url https://download.pytorch.org/whl/nightly/cpu
@@ -36,6 +39,8 @@ setup: |
     --hf-token $HF_TOKEN
 
 run: |
+  conda activate training
+
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed finetuning, head node: $MASTER_ADDR"
 

--- a/sky/provision/nebius/constants.py
+++ b/sky/provision/nebius/constants.py
@@ -15,6 +15,9 @@ INFINIBAND_ENV_VARS = {
                         'mlx5_4:1,mlx5_5:1,mlx5_6:1,mlx5_7:1')
 }
 
+# pylint: disable=line-too-long
+INFINIBAND_IMAGE_ID = 'docker:cr.eu-north1.nebius.cloud/nebius-benchmarks/nccl-tests:2.23.4-ubu22.04-cu12.4'
+
 # Docker run options for InfiniBand support
 INFINIBAND_DOCKER_OPTIONS = ['--device=/dev/infiniband', '--cap-add=IPC_LOCK']
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR adds a default image when `network_tier: best` is selected on nebius for infiniband. Otherwise, infiniband will not be used

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
