### PR TITLE
do not include db info in config after parsing

### DIFF
--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -570,7 +570,7 @@ def _reload_config_as_server() -> None:
     if db_url:
         if len(server_config.keys()) > 1:
             raise ValueError(
-                'if db config is specified, no other config is allowed')
+                'If db config is specified, no other config is allowed')
         logger.debug('retrieving config from database')
         with _DB_USE_LOCK:
             sqlalchemy_engine = sqlalchemy.create_engine(db_url,

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -567,7 +567,7 @@ def _reload_config_as_server() -> None:
         if len(server_config.keys()) > 1:
             raise ValueError(
                 'if db config is specified, no other config is allowed')
-        logger.debug(f'retrieving config from database')
+        logger.debug('retrieving config from database')
         with _DB_USE_LOCK:
             sqlalchemy_engine = sqlalchemy.create_engine(db_url,
                                                          poolclass=NullPool)
@@ -676,7 +676,11 @@ def override_skypilot_config(
         override_config_path = json.loads(override_config_path_serialized)
 
     disallowed_diff_keys = []
-    for key in constants.SKIPPED_CLIENT_OVERRIDE_KEYS - [('db',)]:
+    for key in constants.SKIPPED_CLIENT_OVERRIDE_KEYS:
+        if key == ('db',):
+            # since db key is popped out of server config, the key is expected
+            # to be different between client and server.
+            continue
         value = override_configs.pop_nested(key, default_value=None)
         if (value is not None and
                 value != original_config.get_nested(key, default_value=None)):

--- a/sky/skypilot_config.py
+++ b/sky/skypilot_config.py
@@ -495,6 +495,9 @@ def parse_and_validate_config_file(config_path: str) -> config_utils.Config:
     try:
         config_dict = common_utils.read_yaml(config_path)
         config = config_utils.Config.from_dict(config_dict)
+        # pop the db url from the config, and set it to the env var.
+        # this is to avoid db url (considered a sensitive value)
+        # being printed with the rest of the config.
         db_url = config.pop_nested(('db',), None)
         if db_url:
             os.environ[constants.ENV_VAR_DB_CONNECTION_URI] = db_url
@@ -560,7 +563,8 @@ def _reload_config_as_server() -> None:
 
     server_config_path = _resolve_server_config_path()
     server_config = _get_config_from_path(server_config_path)
-    # Get the db url, either from the env var or the config file.
+    # Get the db url from the env var. _get_config_from_path should have moved
+    # the db url specified in config file to the env var.
     db_url = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
 
     if db_url:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -12,7 +12,6 @@ import filelock
 import sqlalchemy
 
 from sky import sky_logging
-from sky import skypilot_config
 from sky.skylet import constants
 
 logger = sky_logging.init_logger(__name__)

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -32,7 +32,6 @@ def get_engine(db_name: str):
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
         conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
-        logger.debug(f'using db URI from {conn_string}')
         engine = sqlalchemy.create_engine(conn_string,
                                           poolclass=sqlalchemy.NullPool)
     else:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -31,7 +31,7 @@ SPOT_JOBS_LOCK_PATH = '~/.sky/locks/.spot_jobs_db.lock'
 def get_engine(db_name: str):
     conn_string = None
     if os.environ.get(constants.ENV_VAR_IS_SKYPILOT_SERVER) is not None:
-        conn_string = skypilot_config.get_nested(('db',), None)
+        conn_string = os.environ.get(constants.ENV_VAR_DB_CONNECTION_URI)
     if conn_string:
         logger.debug(f'using db URI from {conn_string}')
         engine = sqlalchemy.create_engine(conn_string,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Our config gets printed in many places for debugging purposes.

The db connection string, which could be set on the API server config file or as an environment variable, is a sensitive value that should not be logged. The current design puts the db connection string into the config, which gets printed for debugging purposes, leaking the connection string to the logs. We would like to avoid that.

Trying to track down every place the config is used and patching the code to not print db is impractical. Trying to change the print function to somehow not print the db value is also impractical, as that would involve somehow patching `logger.info/debug` or `print` functions which SkyPilot does not own.

The simplest way to make sure the db string is not printed when config is printed to make sure the db string is not in the config. This PR modifies the config parsing logic to guarantee the db connection string is in the environment variable and not in the config struct.

This PR only works because we currently support postgres database for API server only, not on (job|serve) controllers - see https://docs.skypilot.co/en/latest/reference/config.html#db. If we want to support postgres on (job|serve) controllers, we'd need to make sure we pass the environment variables over to (job|serve) controllers.

Testing:
- Launched a job with postgres backend and experimental consolidation mode enabled, observed no logging of postgres url
- Launched a job with postgres backend and experimental consolidation mode disabled, observed no logging of postgres url


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
