### PR TITLE
fix AWS catalog fetcher with fractional L4s (g6f/gr6f)

### DIFF
--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -78,6 +78,10 @@ PRICING_TABLE_URL_FMT = 'https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws
 # the permission to query the offerings of the instance.
 # Ref: https://aws.amazon.com/ec2/instance-types/p4/
 P4DE_REGIONS = ['us-east-1', 'us-west-2']
+# g6f instances have fractional GPUs, but the API returns Count: 1 under
+# GpuInfo. However, the GPU memory is properly scaled. Taking the instance GPU
+# divided by the total memory of an L4 will give us the fraction of the GPU.
+L4_GPU_MEMORY = 22888
 
 regions_enabled: Optional[Set[str]] = None
 
@@ -313,6 +317,14 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
                 # AWS API is 'NVIDIA', which is incorrect. See #4652.
                 acc_name = 'H200'
                 acc_count = 8
+            if (row['InstanceType'].startswith('g6f') or
+                row['InstanceType'].startswith('gr6f')):
+                # These instance actually have only fractional GPUs, but the API
+                # returns Count: 1 under GpuInfo. We need to check the GPU
+                # memory to get the actual fraction of the GPU.
+                # See also Standard_NV{vcpu}ads_A10_v5 support on Azure.
+                fraction = row['GpuInfo']['TotalGpuMemoryInMiB'] / L4_GPU_MEMORY
+                acc_count = round(fraction, 3)
             return pd.Series({
                 'AcceleratorName': acc_name,
                 'AcceleratorCount': acc_count,

--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -318,7 +318,7 @@ def _get_instance_types_df(region: str) -> Union[str, 'pd.DataFrame']:
                 acc_name = 'H200'
                 acc_count = 8
             if (row['InstanceType'].startswith('g6f') or
-                row['InstanceType'].startswith('gr6f')):
+                    row['InstanceType'].startswith('gr6f')):
                 # These instance actually have only fractional GPUs, but the API
                 # returns Count: 1 under GpuInfo. We need to check the GPU
                 # memory to get the actual fraction of the GPU.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] manually copied into current catalog and validated launch using `sky launch --gpus L4:0.5` and `sky launch --gpus L4:1`
<!-- CI commands (/-prefixed) can only be triggered by repo members -->
