### PR TITLE
Enable AWS eu-south-2 region

### DIFF
--- a/sky/catalog/aws_catalog.py
+++ b/sky/catalog/aws_catalog.py
@@ -38,14 +38,26 @@ _DEFAULT_INSTANCE_FAMILY = [
     # CPU: Intel Ice Lake 8375C.
     # Memory: 4 GiB RAM per 1 vCPU;
     'm6i',
+    # This is the latest general-purpose instance family as of Jul 2025.
+    # CPU: Intel Sapphire Rapids.
+    # Memory: 4 GiB RAM per 1 vCPU;
+    'm7i',
     # This is the latest memory-optimized instance family as of Mar 2023.
     # CPU: Intel Ice Lake 8375C
     # Memory: 8 GiB RAM per 1 vCPU;
     'r6i',
+    # This is the latest memory-optimized instance family as of Jul 2025.
+    # CPU: Intel Sapphire Rapids.
+    # Memory: 8 GiB RAM per 1 vCPU;
+    'r7i',
     # This is the latest compute-optimized instance family as of Mar 2023.
     # CPU: Intel Ice Lake 8375C
     # Memory: 2 GiB RAM per 1 vCPU;
     'c6i',
+    # This is the latest compute-optimized instance family as of Jul 2025.
+    # CPU: Intel Sapphire Rapids.
+    # Memory: 2 GiB RAM per 1 vCPU;
+    'c7i',
 ]
 _DEFAULT_NUM_VCPUS = 8
 _DEFAULT_MEMORY_CPU_RATIO = 4

--- a/sky/catalog/data_fetchers/fetch_aws.py
+++ b/sky/catalog/data_fetchers/fetch_aws.py
@@ -46,7 +46,7 @@ ALL_REGIONS = [
     'eu-west-1',
     'eu-west-2',
     'eu-south-1',
-    # 'eu-south-2', # no supported AMI
+    'eu-south-2',
     'eu-west-3',
     'eu-north-1',
     'me-south-1',


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR restores `eu-south-2` availability. It was previously disabled due to the lack of DL AMIs, which are now available.

As discussed on [Slack](https://skypilot-org.slack.com/archives/C03J2KQQZSS/p1753903697396199?thread_ts=1753843339.363879&cid=C03J2KQQZSS), I also added the latest generations to the list of default instance families because `eu-south-2` does not carry the older ones (though it has some variants like `m6in`).

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

* I generated new `az_mappings.csv` and `vms.csv` with:
```
python sky/catalog/data_fetchers/fetch_aws.py
```
* I replaced the files in my `.sky/catalogs/v7/aws` with the newly generated files
* I launched a cluster with a basic YAML config (just running nvidia-smi on L4)
* I verified that the nvidia-smi output was as expected
```
(setup pid=2207) +---------------------------------------------------------------------------------------+
(setup pid=2207) | NVIDIA-SMI 535.216.01             Driver Version: 535.216.01   CUDA Version: 12.2     |
(setup pid=2207) |-----------------------------------------+----------------------+----------------------+
(setup pid=2207) | GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
(setup pid=2207) | Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
(setup pid=2207) |                                         |                      |               MIG M. |
(setup pid=2207) |=========================================+======================+======================|
(setup pid=2207) |   0  NVIDIA L4                      On  | 00000000:31:00.0 Off |                    0 |
(setup pid=2207) | N/A   35C    P8              12W /  72W |      0MiB / 23034MiB |      0%      Default |
(setup pid=2207) |                                         |                      |                  N/A |
(setup pid=2207) +-----------------------------------------+----------------------+----------------------+
(setup pid=2207)
(setup pid=2207) +---------------------------------------------------------------------------------------+
(setup pid=2207) | Processes:                                                                            |
(setup pid=2207) |  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
(setup pid=2207) |        ID   ID                                                             Usage      |
(setup pid=2207) |=======================================================================================|
(setup pid=2207) |  No running processes found                                                           |
(setup pid=2207) +---------------------------------------------------------------------------------------+
```

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
