### PR TITLE
allow float AcceleratorCount in catalog/optimizer

### DIFF
--- a/sky/catalog/__init__.py
+++ b/sky/catalog/__init__.py
@@ -91,7 +91,7 @@ def list_accelerator_counts(
     region_filter: Optional[str] = None,
     quantity_filter: Optional[int] = None,
     clouds: CloudFilter = None,
-) -> Dict[str, List[int]]:
+) -> Dict[str, List[float]]:
     """Lists all accelerators offered by Sky and available counts.
 
     Returns: A dictionary of canonical accelerator names mapped to a list
@@ -107,12 +107,12 @@ def list_accelerator_counts(
                                   require_price=False)
     if not isinstance(results, list):
         results = [results]
-    accelerator_counts: Dict[str, Set[int]] = collections.defaultdict(set)
+    accelerator_counts: Dict[str, Set[float]] = collections.defaultdict(set)
     for result in results:
         for gpu, items in result.items():
             for item in items:
                 accelerator_counts[gpu].add(item.accelerator_count)
-    ret: Dict[str, List[int]] = {}
+    ret: Dict[str, List[float]] = {}
     for gpu, counts in accelerator_counts.items():
         ret[gpu] = sorted(counts)
     return ret

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -631,7 +631,6 @@ def list_accelerators_impl(
         df = df[df['Region'].str.contains(region_filter,
                                           case=case_sensitive,
                                           regex=True)]
-    df['AcceleratorCount'] = df['AcceleratorCount']
     if quantity_filter is not None:
         df = df[df['AcceleratorCount'] == quantity_filter]
     grouped = df.groupby('AcceleratorName')

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -51,7 +51,7 @@ class InstanceTypeInfo(NamedTuple):
     cloud: str
     instance_type: Optional[str]
     accelerator_name: str
-    accelerator_count: int
+    accelerator_count: float
     cpu_count: Optional[float]
     device_memory: Optional[float]
     memory: Optional[float]
@@ -631,6 +631,7 @@ def list_accelerators_impl(
         df = df[df['Region'].str.contains(region_filter,
                                           case=case_sensitive,
                                           regex=True)]
+    df['AcceleratorCount'] = df['AcceleratorCount'].astype(float)
     if quantity_filter is not None:
         df = df[df['AcceleratorCount'] == quantity_filter]
     grouped = df.groupby('AcceleratorName')

--- a/sky/catalog/common.py
+++ b/sky/catalog/common.py
@@ -631,7 +631,7 @@ def list_accelerators_impl(
         df = df[df['Region'].str.contains(region_filter,
                                           case=case_sensitive,
                                           regex=True)]
-    df['AcceleratorCount'] = df['AcceleratorCount'].astype(int)
+    df['AcceleratorCount'] = df['AcceleratorCount']
     if quantity_filter is not None:
         df = df[df['AcceleratorCount'] == quantity_filter]
     grouped = df.groupby('AcceleratorName')


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Resolves the following error with `tests/test_optimizer_random_dag.py::test_optimizer`:
```
tests/test_optimizer_random_dag.py:183: in test_optimizer
    compare_optimization_results(dag, minimize_cost=True)
tests/test_optimizer_random_dag.py:154: in compare_optimization_results
    optimizer_plan = sky.Optimizer._optimize_dag(dag,
sky/optimizer.py:1107: in _optimize_dag
    Optimizer._estimate_nodes_cost_or_time(local_topo_order,
sky/optimizer.py:298: in _estimate_nodes_cost_or_time
    resource_hints) = (_fill_in_launchable_resources(
sky/optimizer.py:1356: in _fill_in_launchable_resources
    feasible_list = subprocess_utils.run_in_parallel(
sky/utils/subprocess_utils.py:131: in run_in_parallel
    return [func(args[0])]
sky/optimizer.py:1358: in <lambda>
    (cloud, cloud.get_feasible_launchable_resources(r, n)),
sky/utils/common_utils.py:653: in _record
    return f(*args, **kwargs)
sky/clouds/cloud.py:423: in get_feasible_launchable_resources
    self._check_instance_type_accelerators_combination(resources)
sky/clouds/cloud.py:802: in _check_instance_type_accelerators_combination
    raise exceptions.ResourcesMismatchError(
E   sky.exceptions.ResourcesMismatchError: Infeasible resource demands found:
E     Instance type requested: g6f.xlarge
E     Accelerators for g6f.xlarge: {'L4': 0.125}
E     Accelerators requested: {'L4': 0}
E   To fix: either only specify instance_type, or change the accelerators field to be consistent.
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
