### PR TITLE
[config] test config mutation in per context config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -989,15 +989,18 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
 
     # mutate per-context config and check if it's updated
     context_a_custom_labels = skypilot_config.get_nested(
-        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), {})
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
+         'labels'), {})
     context_a_custom_labels['contextA_label'] = 'contextA_value_updated'
     mutated_config = skypilot_config.set_nested(
-        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), 
-        context_a_custom_labels)
-    
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
+         'labels'), context_a_custom_labels)
+
     context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
         dict_config=mutated_config,
-        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+        cloud='kubernetes',
+        region='contextA',
+        keys=('custom_metadata',))
     assert context_a_custom_metadata == {
         'labels': {
             'global_label': 'global_value',
@@ -1013,7 +1016,9 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
         ('kubernetes', 'custom_metadata', 'labels'), global_custom_labels)
     context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
         dict_config=mutated_config,
-        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+        cloud='kubernetes',
+        region='contextA',
+        keys=('custom_metadata',))
     assert context_a_custom_metadata == {
         'labels': {
             'global_label': 'global_value_updated',
@@ -1023,19 +1028,24 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
 
     # mutate label defined by global config in per-context config
     context_a_custom_labels = skypilot_config.get_nested(
-        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), {})
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
+         'labels'), {})
     context_a_custom_labels['global_label'] = 'global_value_updated'
     mutated_config = skypilot_config.set_nested(
-        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), context_a_custom_labels)
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
+         'labels'), context_a_custom_labels)
     context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
         dict_config=mutated_config,
-        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+        cloud='kubernetes',
+        region='contextA',
+        keys=('custom_metadata',))
     assert context_a_custom_metadata == {
         'labels': {
             'global_label': 'global_value_updated',
             'contextA_label': 'contextA_value'
         }
     }
+
 
 def test_standardized_region_configs(monkeypatch, tmp_path) -> None:
     """Test that nested per-region standardized config works

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1030,7 +1030,7 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
     context_a_custom_labels = skypilot_config.get_nested(
         ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
          'labels'), {})
-    context_a_custom_labels['global_label'] = 'global_value_updated'
+    context_a_custom_labels['global_label'] = 'global_value_contextA_specific'
     mutated_config = skypilot_config.set_nested(
         ('kubernetes', 'context_configs', 'contextA', 'custom_metadata',
          'labels'), context_a_custom_labels)
@@ -1041,7 +1041,7 @@ def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
         keys=('custom_metadata',))
     assert context_a_custom_metadata == {
         'labels': {
-            'global_label': 'global_value_updated',
+            'global_label': 'global_value_contextA_specific',
             'contextA_label': 'contextA_value'
         }
     }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -958,6 +958,85 @@ def test_kubernetes_context_configs(monkeypatch, tmp_path) -> None:
     assert contexts[1] == 'contextB'
 
 
+def test_kubernetes_context_configs_mutation(monkeypatch, tmp_path) -> None:
+    """Test that the nested config works when part of the config is mutated."""
+    from sky.provision.kubernetes import utils as kubernetes_utils
+    with open(tmp_path / 'context_configs.yaml', 'w', encoding='utf-8') as f:
+        f.write(f"""\
+        kubernetes:
+            custom_metadata:
+                labels:
+                    global_label: global_value
+            context_configs:
+                contextA:
+                    custom_metadata:
+                        labels:
+                            contextA_label: contextA_value
+        """)
+    monkeypatch.setattr(skypilot_config, '_GLOBAL_CONFIG_PATH',
+                        tmp_path / 'context_configs.yaml')
+    skypilot_config.reload_config()
+
+    # test custom_metadata property
+    context_a_custom_metadata = skypilot_config.get_effective_region_config(
+        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+    assert context_a_custom_metadata == {
+        'labels': {
+            'global_label': 'global_value',
+            'contextA_label': 'contextA_value'
+        }
+    }
+
+    # mutate per-context config and check if it's updated
+    context_a_custom_labels = skypilot_config.get_nested(
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), {})
+    context_a_custom_labels['contextA_label'] = 'contextA_value_updated'
+    mutated_config = skypilot_config.set_nested(
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), 
+        context_a_custom_labels)
+    
+    context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
+        dict_config=mutated_config,
+        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+    assert context_a_custom_metadata == {
+        'labels': {
+            'global_label': 'global_value',
+            'contextA_label': 'contextA_value_updated'
+        }
+    }
+
+    # mutate global config and check if it's updated
+    global_custom_labels = skypilot_config.get_nested(
+        ('kubernetes', 'custom_metadata', 'labels'), {})
+    global_custom_labels['global_label'] = 'global_value_updated'
+    mutated_config = skypilot_config.set_nested(
+        ('kubernetes', 'custom_metadata', 'labels'), global_custom_labels)
+    context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
+        dict_config=mutated_config,
+        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+    assert context_a_custom_metadata == {
+        'labels': {
+            'global_label': 'global_value_updated',
+            'contextA_label': 'contextA_value'
+        }
+    }
+
+    # mutate label defined by global config in per-context config
+    context_a_custom_labels = skypilot_config.get_nested(
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), {})
+    context_a_custom_labels['global_label'] = 'global_value_updated'
+    mutated_config = skypilot_config.set_nested(
+        ('kubernetes', 'context_configs', 'contextA', 'custom_metadata', 'labels'), context_a_custom_labels)
+    context_a_custom_metadata = config_utils.get_cloud_config_value_from_dict(
+        dict_config=mutated_config,
+        cloud='kubernetes', region='contextA', keys=('custom_metadata',))
+    assert context_a_custom_metadata == {
+        'labels': {
+            'global_label': 'global_value_updated',
+            'contextA_label': 'contextA_value'
+        }
+    }
+
 def test_standardized_region_configs(monkeypatch, tmp_path) -> None:
     """Test that nested per-region standardized config works
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Add a unit test to better clarify the behavior when a per-context config is mutated (e.g. within admin policy)


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
