### PR TITLE
don't show pools on old remote API server

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -62,6 +62,7 @@ from sky.provision.kubernetes import constants as kubernetes_constants
 from sky.provision.kubernetes import utils as kubernetes_utils
 from sky.server import common as server_common
 from sky.server import constants as server_constants
+from sky.server import versions
 from sky.server.requests import requests
 from sky.skylet import constants
 from sky.skylet import job_lib
@@ -1827,6 +1828,10 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
     show_endpoints = endpoints or endpoint is not None
     show_single_endpoint = endpoint is not None
     show_services = show_services and not any([clusters, ip, endpoints])
+    remote_api_version = versions.get_remote_api_version()
+    if remote_api_version is None or remote_api_version < 12:
+        show_pools = False
+
 
     query_clusters: Optional[List[str]] = None if not clusters else clusters
     refresh_mode = common.StatusRefreshMode.NONE

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1832,7 +1832,6 @@ def status(verbose: bool, refresh: bool, ip: bool, endpoints: bool,
     if remote_api_version is None or remote_api_version < 12:
         show_pools = False
 
-
     query_clusters: Optional[List[str]] = None if not clusters else clusters
     refresh_mode = common.StatusRefreshMode.NONE
     if refresh:


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Without this fix, `sky status` will error out from the pools request, instead of just skipping the pools.
```
cooperc@crispy ~> sky status
sky.exceptions.APINotSupportedError: Function pool_status is introduced after the remote server version '1.0.0-dev0 (commit: {{SKYPILOT_COMMIT_SHA}})' is released. Please upgrade the remote server.
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
