### PR TITLE
Fix release pipeline API version extract error

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           echo "Reading current API version from the current checkout..."
           # Extract current API version from the current checked-out state
-          CURRENT_SKY_API_VERSION=$(grep "^API_VERSION = " sky/server/constants.py | sed "s/API_VERSION = '\\(.*\\)'/\\1/")
+          CURRENT_SKY_API_VERSION=$(grep "^API_VERSION = " sky/server/constants.py | awk '{print $3}')
           echo "Current API version (from checkout): ${CURRENT_SKY_API_VERSION}"
           echo "current_sky_api_version=${CURRENT_SKY_API_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

We have an error in [release pipeline](https://github.com/skypilot-org/skypilot/actions/runs/16662669238/job/47163010425):

```bash
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.18/x64/lib
    UV_PYTHON: 3.10
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
/home/runner/work/_temp/c5b9fa87-6e19-4258-bbfb-2c40ef3b00b0.sh: line 15: [: API_VERSION = 12: integer expression expected
Incrementing from 0.10.0 to 0.11.0
```

Before:

```bash
zpoint:~/codes/skypilot (master)$ grep "^API_VERSION = " sky/server/constants.py | sed "s/API_VERSION = '\\(.*\\)'/\\1/"
API_VERSION = 12
```

After:

```bash
zpoint:~/codes/skypilot (master)$ grep "^API_VERSION = " sky/server/constants.py | awk '{print $3}'
12
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
