### PR TITLE
Fix `test_gcp_disk_tier` failure

### DIFF
--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1660,14 +1660,15 @@ def test_gcp_disk_tier(instance_types: List[str]):
         if disk_tier == resources_utils.DiskTier.BEST:
             # Ultra disk tier requires n2 instance types to have more than 64 CPUs.
             # If using default instance type, it will only enable the high disk tier.
+            # Test both scenarios: n2-standard-2 maps to HIGH, n2-standard-64 maps to ULTRA
             disk_types = [
-                GCP._get_disk_type(instance_type,
+                GCP._get_disk_type(instance_type_low,
                                    resources_utils.DiskTier.HIGH),
                 GCP._get_disk_type(instance_type,
                                    resources_utils.DiskTier.ULTRA),
             ]
             instance_type_options = [
-                f'--instance-type {instance_type}',
+                f'--instance-type {instance_type_low}',
                 f'--instance-type {instance_type}'
             ]
         for disk_type, instance_type_option in zip(disk_types,

--- a/tests/smoke_tests/test_cluster_job.py
+++ b/tests/smoke_tests/test_cluster_job.py
@@ -1656,7 +1656,7 @@ def test_gcp_disk_tier(instance_types: List[str]):
         name_on_cloud = common_utils.make_cluster_name_on_cloud(
             name, sky.GCP.max_cluster_name_length())
         region = 'us-central1'
-        instance_type_options = ['']
+        instance_type_options = [f'--instance-type {instance_type}']
         if disk_tier == resources_utils.DiskTier.BEST:
             # Ultra disk tier requires n2 instance types to have more than 64 CPUs.
             # If using default instance type, it will only enable the high disk tier.
@@ -1666,7 +1666,10 @@ def test_gcp_disk_tier(instance_types: List[str]):
                 GCP._get_disk_type(instance_type,
                                    resources_utils.DiskTier.ULTRA),
             ]
-            instance_type_options = ['', f'--instance-type {instance_type}']
+            instance_type_options = [
+                f'--instance-type {instance_type}',
+                f'--instance-type {instance_type}'
+            ]
         for disk_type, instance_type_option in zip(disk_types,
                                                    instance_type_options):
             test = smoke_tests_utils.Test(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6465

The optimized setting seems to have changed the default instance type. Previously, we didn't specify the launch instance type and assumed the optimizer would choose `n2-standard-2`, then we used the gcloud command to filter based on this instance type.  

Now we'll specify the instance type in the launch command.  

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_gcp_disk_tier --gcp` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
