### PR TITLE
Remove minor version bump for release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -72,8 +72,6 @@ jobs:
             echo "previous_minor_release_branch=" >> $GITHUB_OUTPUT
           fi
 
-
-
       # Determine release version based on trigger type
       - name: Determine release version
         id: determine_version
@@ -83,14 +81,15 @@ jobs:
             RELEASE_VERSION="${{ github.event.inputs.release_version }}"
             echo "Using manually specified version: ${RELEASE_VERSION}"
           else
-            # Scheduled trigger or manual trigger without version - extract version from latest release and increment minor
+            # Scheduled trigger or manual trigger without version - extract version from latest release and increment patch
             LATEST_VERSION="${{ steps.find_previous_release_branch.outputs.latest_pypi_version }}"
             # Split version into parts
             MAJOR=$(echo $LATEST_VERSION | cut -d. -f1)
             MINOR=$(echo $LATEST_VERSION | cut -d. -f2)
-            # Always increment minor version
-            NEW_MINOR=$((MINOR + 1))
-            RELEASE_VERSION="${MAJOR}.${NEW_MINOR}.0"
+            PATCH=$(echo $LATEST_VERSION | cut -d. -f3)
+            # Always increment patch version
+            NEW_PATCH=$((PATCH + 1))
+            RELEASE_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
             echo "Incrementing from ${LATEST_VERSION} to ${RELEASE_VERSION}"
           fi
           echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
@@ -109,17 +108,18 @@ jobs:
           # Parse latest PyPI version
           PYPI_MAJOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f1)
           PYPI_MINOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f2)
+          PYPI_PATCH=$(echo $LATEST_PYPI_VERSION | cut -d. -f3)
 
-          # Calculate expected next minor version
-          NEXT_MINOR_VERSION="${PYPI_MAJOR}.$((PYPI_MINOR + 1)).0"
+          # Calculate expected next patch version
+          NEXT_PATCH_VERSION="${PYPI_MAJOR}.${PYPI_MINOR}.$((PYPI_PATCH + 1))"
 
-          echo "Expected next minor version: ${NEXT_MINOR_VERSION}"
+          echo "Expected next patch version: ${NEXT_PATCH_VERSION}"
 
-          # Check if the determined release version is the expected next minor version
-          if [ "${RELEASE_VERSION}" = "${NEXT_MINOR_VERSION}" ]; then
-            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is the expected next minor version."
+          # Check if the determined release version is the expected next patch version
+          if [ "${RELEASE_VERSION}" = "${NEXT_PATCH_VERSION}" ]; then
+            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is the expected next patch version."
           else
-            echo "Error: Determined release version ${RELEASE_VERSION} must be the next minor version (${NEXT_MINOR_VERSION}) compared to the latest PyPI version ${LATEST_PYPI_VERSION}."
+            echo "Error: Determined release version ${RELEASE_VERSION} must be the next patch version (${NEXT_PATCH_VERSION}) compared to the latest PyPI version ${LATEST_PYPI_VERSION}."
             exit 1
           fi
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -123,8 +123,6 @@ jobs:
             exit 1
           fi
 
-
-
       - name: Create release branch
         id: create_release_branch
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -72,82 +72,25 @@ jobs:
             echo "previous_minor_release_branch=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Get current sky api version
-        id: get_current_sky_api_version
-        run: |
-          echo "Reading current API version from the current checkout..."
-          # Extract current API version from the current checked-out state
-          CURRENT_SKY_API_VERSION=$(grep "^API_VERSION = " sky/server/constants.py | awk '{print $3}')
-          echo "Current API version (from checkout): ${CURRENT_SKY_API_VERSION}"
-          echo "current_sky_api_version=${CURRENT_SKY_API_VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Get latest release sky api version from PyPI
-        id: get_latest_release_sky_api_version
-        run: |
-          LATEST_PYPI_VERSION="${{ steps.find_previous_release_branch.outputs.latest_pypi_version }}"
-          # Create and activate uv virtual environment
-          echo "Creating uv virtual environment..."
-          uv venv --seed ~/pypi-check-env
-          echo "Activating virtual environment..."
-          source ~/pypi-check-env/bin/activate
-
-          echo "Installing skypilot==${LATEST_PYPI_VERSION} from PyPI using uv..."
-          uv pip install --prerelease=allow "azure-cli>=2.65.0"
-          uv pip install 'omegaconf>=2.4.0dev3' skypilot==${LATEST_PYPI_VERSION}
-
-          echo "Extracting API version from installed PyPI package..."
-          # Store current directory and change to a temporary one to avoid importing local sky package
-          ORIGINAL_DIR=$(pwd)
-          TEMP_DIR=$(mktemp -d)
-          cd "${TEMP_DIR}"
-          echo "Changed directory to ${TEMP_DIR} to ensure correct package import."
-
-          # Python command now runs within the activated venv and outside the project directory
-          LATEST_PYPI_SKY_API_VERSION=$(python -c "import sky.server.constants; print(sky.server.constants.API_VERSION)")
-
-          # Change back to original directory and clean up temp dir
-          cd "${ORIGINAL_DIR}"
-          rm -rf "${TEMP_DIR}"
-          echo "Restored original directory: ${ORIGINAL_DIR}"
-
-          # Deactivate environment
-          deactivate
-
-          if [[ -z "${LATEST_PYPI_SKY_API_VERSION}" ]]; then
-            echo "Error: Could not fetch API_VERSION from the installed PyPI package. Python command likely failed."
-            exit 1
-          fi
-
-          echo "Latest release PyPI API version: ${LATEST_PYPI_SKY_API_VERSION}"
-          echo "latest_pypi_sky_api_version=${LATEST_PYPI_SKY_API_VERSION}" >> $GITHUB_OUTPUT
 
       # Determine release version based on trigger type
       - name: Determine release version
         id: determine_version
         run: |
-          CURRENT_SKY_API_VERSION="${{ steps.get_current_sky_api_version.outputs.current_sky_api_version }}"
-          LATEST_PYPI_SKY_API_VERSION="${{ steps.get_latest_release_sky_api_version.outputs.latest_pypi_sky_api_version }}"
-
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.release_version }}" ]; then
             # Manual trigger with input version provided
             RELEASE_VERSION="${{ github.event.inputs.release_version }}"
             echo "Using manually specified version: ${RELEASE_VERSION}"
           else
-            # Scheduled trigger or manual trigger without version - extract version from latest release and increment patch
+            # Scheduled trigger or manual trigger without version - extract version from latest release and increment minor
             LATEST_VERSION="${{ steps.find_previous_release_branch.outputs.latest_pypi_version }}"
             # Split version into parts
             MAJOR=$(echo $LATEST_VERSION | cut -d. -f1)
             MINOR=$(echo $LATEST_VERSION | cut -d. -f2)
-            PATCH=$(echo $LATEST_VERSION | cut -d. -f3)
-            if [ "${CURRENT_SKY_API_VERSION}" -le "${LATEST_PYPI_SKY_API_VERSION}" ]; then
-              # Increment patch version
-              NEW_PATCH=$((PATCH + 1))
-              RELEASE_VERSION="${MAJOR}.${MINOR}.${NEW_PATCH}"
-            else
-              # Increment minor version
-              NEW_MINOR=$((MINOR + 1))
-              RELEASE_VERSION="${MAJOR}.${NEW_MINOR}.0"
-            fi
+            # Always increment minor version
+            NEW_MINOR=$((MINOR + 1))
+            RELEASE_VERSION="${MAJOR}.${NEW_MINOR}.0"
             echo "Incrementing from ${LATEST_VERSION} to ${RELEASE_VERSION}"
           fi
           echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
@@ -166,66 +109,21 @@ jobs:
           # Parse latest PyPI version
           PYPI_MAJOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f1)
           PYPI_MINOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f2)
-          PYPI_PATCH=$(echo $LATEST_PYPI_VERSION | cut -d. -f3)
 
-          # Calculate expected next versions
-          NEXT_PATCH_VERSION="${PYPI_MAJOR}.${PYPI_MINOR}.$((PYPI_PATCH + 1))"
+          # Calculate expected next minor version
           NEXT_MINOR_VERSION="${PYPI_MAJOR}.$((PYPI_MINOR + 1)).0"
 
-          echo "Expected next patch version: ${NEXT_PATCH_VERSION}"
           echo "Expected next minor version: ${NEXT_MINOR_VERSION}"
 
-          # Check if the determined release version is one of the expected next versions
-          if [ "${RELEASE_VERSION}" = "${NEXT_PATCH_VERSION}" ] || [ "${RELEASE_VERSION}" = "${NEXT_MINOR_VERSION}" ]; then
-            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is a valid next version."
+          # Check if the determined release version is the expected next minor version
+          if [ "${RELEASE_VERSION}" = "${NEXT_MINOR_VERSION}" ]; then
+            echo "Success: Version check passed. Determined version ${RELEASE_VERSION} is the expected next minor version."
           else
-            echo "Error: Determined release version ${RELEASE_VERSION} must be either the next patch version (${NEXT_PATCH_VERSION}) or the next minor version (${NEXT_MINOR_VERSION}) compared to the latest PyPI version ${LATEST_PYPI_VERSION}."
+            echo "Error: Determined release version ${RELEASE_VERSION} must be the next minor version (${NEXT_MINOR_VERSION}) compared to the latest PyPI version ${LATEST_PYPI_VERSION}."
             exit 1
           fi
 
-      - name: Verify API Version Compatibility
-        id: verify_api_version
-        if: ${{ !github.event.inputs.skip_version_checks }}
-        run: |
-          RELEASE_VERSION="${{ steps.determine_version.outputs.release_version }}"
-          LATEST_PYPI_VERSION="${{ steps.find_previous_release_branch.outputs.latest_pypi_version }}"
-          CURRENT_SKY_API_VERSION="${{ steps.get_current_sky_api_version.outputs.current_sky_api_version }}"
-          LATEST_PYPI_SKY_API_VERSION="${{ steps.get_latest_release_sky_api_version.outputs.latest_pypi_sky_api_version }}"
 
-          # Assert current API version >= PyPI API version
-          if [[ "${CURRENT_SKY_API_VERSION}" -lt "${LATEST_PYPI_SKY_API_VERSION}" ]]; then
-            echo "Error: Current API version (${CURRENT_SKY_API_VERSION}) is less than the latest PyPI API version (${LATEST_PYPI_SKY_API_VERSION})."
-            exit 1
-          fi
-          echo "Assertion passed: Current API version (${CURRENT_SKY_API_VERSION}) >= PyPI API version (${LATEST_PYPI_SKY_API_VERSION})."
-
-          # If API version changed, ensure it's not just a patch release
-          if [[ "${CURRENT_SKY_API_VERSION}" -gt "${LATEST_PYPI_SKY_API_VERSION}" ]]; then
-            echo "API version has increased from ${LATEST_PYPI_SKY_API_VERSION} to ${CURRENT_SKY_API_VERSION}."
-
-            # Parse versions
-            RELEASE_MAJOR=$(echo $RELEASE_VERSION | cut -d. -f1)
-            RELEASE_MINOR=$(echo $RELEASE_VERSION | cut -d. -f2)
-
-            PYPI_MAJOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f1)
-            PYPI_MINOR=$(echo $LATEST_PYPI_VERSION | cut -d. -f2)
-
-            IS_MINOR_OR_MAJOR_UPGRADE=false
-            if [[ "${RELEASE_MAJOR}" -gt "${PYPI_MAJOR}" ]]; then
-              IS_MINOR_OR_MAJOR_UPGRADE=true
-            elif [[ "${RELEASE_MAJOR}" -eq "${PYPI_MAJOR}" && "${RELEASE_MINOR}" -gt "${PYPI_MINOR}" ]]; then
-              IS_MINOR_OR_MAJOR_UPGRADE=true
-            fi
-
-            if [[ "${IS_MINOR_OR_MAJOR_UPGRADE}" == "false" ]]; then
-              echo "Error: API version changed (${LATEST_PYPI_SKY_API_VERSION} -> ${CURRENT_SKY_API_VERSION}), but the release (${RELEASE_VERSION}) is only a patch upgrade from the latest PyPI version (${LATEST_PYPI_VERSION}). API version changes require a minor or major version bump."
-              exit 1
-            else
-              echo "API version change is accompanied by a minor or major version bump (${LATEST_PYPI_VERSION} -> ${RELEASE_VERSION}). Proceeding."
-            fi
-          else
-            echo "API version has not changed (${LATEST_PYPI_SKY_API_VERSION}). Proceeding."
-          fi
 
       - name: Create release branch
         id: create_release_branch


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Remove sky API version check, always bump up patch version. No bump up for minor version.

Test in my [personal repo](https://github.com/zpoint/skypilot/actions/runs/16670578155/job/47185728499)

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
