### PR TITLE
Fixed fake error msg after api_login

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -2343,6 +2343,7 @@ def api_login(endpoint: Optional[str] = None,
     _save_config_updates(endpoint=endpoint)
     dashboard_url = server_common.get_dashboard_url(endpoint)
 
+    server_common.get_api_server_status.cache_clear()
     # After successful authentication, check server health again to get user
     # identity
     server_status, final_api_server_info = server_common.check_server_healthy(


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Remove this error log:

```bash
sky api login -e https://zhwu-api.skypilot.co
A web browser has been opened at https://zhwu-api.skypilot.co/token?local_port=8000. Please continue the login in the web browser.
To manually copy the token, press ctrl+c.
ValueError: Cannot log in API server at https://zhwu-api.skypilot.co (status: needs_auth)
```


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
