### PR TITLE
Builtin oauth2 proxy integration

### DIFF
--- a/charts/skypilot/templates/NOTES.txt
+++ b/charts/skypilot/templates/NOTES.txt
@@ -2,3 +2,4 @@
 {{- include "skypilot.checkResources" . }}
 {{- end }}
 {{- include "skypilot.checkUpgradeConfig" . }}
+{{- include "skypilot.validateOAuth2Config" . }}

--- a/charts/skypilot/templates/api-deployment.yaml
+++ b/charts/skypilot/templates/api-deployment.yaml
@@ -75,7 +75,7 @@ spec:
               name: {{ include "skypilot.initialBasicAuthSecretName" . }}
               key: auth
         {{- end }}
-        {{- if .Values.apiService.enableServiceAccounts }}
+        {{- if include "skypilot.serviceAccountAuthEnabled" . | trim | eq "true" }}
         - name: ENABLE_SERVICE_ACCOUNTS
           value: "true"
         {{- end }}
@@ -119,6 +119,12 @@ spec:
         {{- if .Values.apiService.metrics.enabled }}
         - name: SKY_API_SERVER_METRICS_ENABLED
           value: "true"
+        {{- end }}
+        {{- if .Values.auth.oauth2Proxy.enabled }}
+        - name: SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED
+          value: "true"
+        - name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
+          value: {{ include "skypilot.oauth2ProxyURL" . }}
         {{- end }}
         # Use tini as the init process
         command: ["tini", "--"]

--- a/charts/skypilot/templates/ingress.yaml
+++ b/charts/skypilot/templates/ingress.yaml
@@ -22,7 +22,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-next-upstream: "http_502 non_idempotent"
     nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
     {{- end }}
-    {{- if index .Values.ingress "oauth2-proxy" "enabled" }}
+    {{/* If oauth2-proxy based authentication is enabled on the API server, disable the oauth2-proxy at ingress to avoid conflicts */}}
+    {{- if and (index .Values.ingress "oauth2-proxy" "enabled") (not .Values.auth.oauth2Proxy.enabled) }}
     # OAuth2 Proxy authentication for browser-based access
     # Bearer token requests bypass OAuth2 proxy and go directly to the application
     nginx.ingress.kubernetes.io/auth-signin: {{ if index .Values.ingress "oauth2-proxy" "use-https" | default false }}https{{ else }}http{{ end }}://$host/oauth2/start?rd=$escaped_request_uri

--- a/charts/skypilot/tests/deployment_test.yaml
+++ b/charts/skypilot/tests/deployment_test.yaml
@@ -156,6 +156,45 @@ tests:
           content:
             name: SKYPILOT_DB_CONNECTION_URI
 
+  - it: should enable service accounts when auth.serviceAccount.enabled is explicitly true
+    set:
+      auth.serviceAccount.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+            value: "true"
+
+  - it: should disable service accounts when auth.serviceAccount.enabled is explicitly false
+    set:
+      auth.serviceAccount.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+
+  - it: should respect auth.serviceAccount.enabled over apiService.enableServiceAccounts
+    set:
+      auth.serviceAccount.enabled: false
+      apiService.enableServiceAccounts: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+
+  - it: should fallback to apiService.enableServiceAccounts when auth.serviceAccount.enabled is null
+    set:
+      auth.serviceAccount.enabled: null
+      apiService.enableServiceAccounts: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+
   - it: should mount r2 credentials correctly when r2Credentials is enabled
     set:
       r2Credentials.enabled: true

--- a/charts/skypilot/tests/ingress_test.yaml
+++ b/charts/skypilot/tests/ingress_test.yaml
@@ -55,6 +55,56 @@ tests:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
           value: "https://$host/oauth2/auth"
 
+  # Test OAuth2 proxy integration with API server authentication
+  - it: should disable ingress OAuth2 proxy when API server OAuth2 auth is enabled
+    set:
+      ingress.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      auth.oauth2Proxy.enabled: true
+      auth.oauth2Proxy.baseUrl: "https://external-oauth2-proxy.example.com"
+    asserts:
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-snippet"]
+
+  - it: should enable ingress OAuth2 proxy when API server OAuth2 auth is disabled
+    set:
+      ingress.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      ingress.oauth2-proxy.use-https: false
+      auth.oauth2Proxy.enabled: false
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+          value: "http://$host/oauth2/start?rd=$escaped_request_uri"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+          value: "http://$host/oauth2/auth"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+          value: "X-Auth-Request-Email, X-Skypilot-Auth"
+
+  - it: should enable ingress OAuth2 proxy when auth.oauth2Proxy is not configured
+    set:
+      ingress.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      ingress.oauth2-proxy.use-https: false
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+          value: "http://$host/oauth2/start?rd=$escaped_request_uri"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+          value: "http://$host/oauth2/auth"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+          value: "X-Auth-Request-Email, X-Skypilot-Auth"
+
   # Test basic auth annotations
   - it: should add basic auth annotations when authSecret is provided and user management disabled
     set:

--- a/charts/skypilot/tests/oauth2_proxy_test.yaml
+++ b/charts/skypilot/tests/oauth2_proxy_test.yaml
@@ -1,0 +1,227 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: oauth2_proxy_test
+templates:
+  - templates/api-deployment.yaml
+  - templates/ingress.yaml
+  - templates/NOTES.txt
+tests:
+  - it: should pass validation when oauth2Proxy auth is enabled with external baseUrl
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: true
+      auth.oauth2Proxy.baseUrl: "https://external-oauth2-proxy.example.com"
+      ingress.oauth2-proxy.enabled: false
+      ingress.enabled: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should pass validation when oauth2Proxy auth is enabled with ingress oauth2-proxy
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: true
+      auth.oauth2Proxy.baseUrl: null
+      ingress.oauth2-proxy.enabled: true
+      ingress.enabled: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should pass validation when oauth2Proxy auth is disabled
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: false
+      ingress.oauth2-proxy.enabled: true
+      ingress.enabled: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  # API Deployment OAuth2 Environment Variables Tests
+  - it: should set OAuth2 proxy environment variables when enabled with external baseUrl
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: true
+      auth.oauth2Proxy.baseUrl: "https://external-oauth2-proxy.example.com"
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
+            value: "https://external-oauth2-proxy.example.com"
+
+  - it: should set OAuth2 proxy environment variables when enabled with ingress oauth2-proxy
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
+            value: "http://RELEASE-NAME-oauth2-proxy:4180"
+
+  - it: should not set OAuth2 proxy environment variables when disabled
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.oauth2Proxy.enabled: false
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL
+
+  # Service Account Authentication Tests
+  - it: should enable service accounts when auth.serviceAccount.enabled is true
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.serviceAccount.enabled: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+            value: "true"
+
+  - it: should disable service accounts when auth.serviceAccount.enabled is false
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.serviceAccount.enabled: false
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+
+  - it: should fallback to apiService.enableServiceAccounts when auth.serviceAccount.enabled is null
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.serviceAccount.enabled: null
+      apiService.enableServiceAccounts: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+            value: "true"
+
+  - it: should override apiService.enableServiceAccounts when auth.serviceAccount.enabled is set
+    templates:
+      - templates/api-deployment.yaml
+    set:
+      auth.serviceAccount.enabled: false
+      apiService.enableServiceAccounts: true
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_SERVICE_ACCOUNTS
+
+  # Ingress OAuth2 Integration Tests
+  - it: should disable ingress oauth2-proxy when API server oauth2 auth is enabled
+    templates:
+      - templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      auth.oauth2Proxy.enabled: true
+      auth.oauth2Proxy.baseUrl: "https://external-oauth2-proxy.example.com"
+      ingress.oauth2-proxy.enabled: false
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-snippet"]
+
+  - it: should enable ingress oauth2-proxy when API server oauth2 auth is disabled
+    templates:
+      - templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      auth.oauth2Proxy.enabled: false
+      ingress.oauth2-proxy.enabled: true
+      ingress.oauth2-proxy.use-https: false
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+          value: "http://$host/oauth2/start?rd=$escaped_request_uri"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+          value: "http://$host/oauth2/auth"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-response-headers"]
+          value: "X-Auth-Request-Email, X-Skypilot-Auth"
+
+  - it: should enable ingress oauth2-proxy when auth.oauth2Proxy is not configured
+    templates:
+      - templates/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.oauth2-proxy.enabled: true
+      ingress.oauth2-proxy.use-https: false
+      apiService.metrics.enabled: false
+      apiService.skipResourceCheck: true
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-signin"]
+          value: "http://$host/oauth2/start?rd=$escaped_request_uri"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
+          value: "http://$host/oauth2/auth"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -25,10 +25,8 @@ apiService:
   # If enabled, the basic auth configuration `ingress.authCredentials`
   # and `ingress.authSecret` in the ingress will be ignored.
   enableUserManagement: false
-  # Enable service account tokens for automated API access
-  # If enabled, users can create bearer tokens to bypass SSO authentication
-  # for automated systems. This works independently of enableUserManagement.
-  # JWT secrets are automatically stored in the database for persistence across restarts.
+  # Deprecated: use `apiService.auth.serviceAccount.enabled` instead.
+  # @schema type: [boolean]
   enableServiceAccounts: true
   # Initial basic auth credentials for the API server
   # The user in the credentials will be used to create a new admin user in the API server,
@@ -144,6 +142,32 @@ apiService:
 
   # [Internal] Enable developer mode for SkyPilot
   skypilotDev: false
+
+# Authentication configuration for the API server
+# @schema type: [object, null]
+auth:
+  # OAuth2 Proxy based authentication for the API server
+  # @schema type: [object, null]
+  oauth2Proxy:
+    # Enable/disable OAuth2 Proxy based authentication
+    # @schema type: [boolean]
+    enabled: false
+    # Base URL of the OAuth2 Proxy:
+    # - If you are using a self-hosted OAuth2 Proxy, set this to the base URL of the OAuth2 Proxy.
+    # - If you want this chart to provision an OAuth2 Proxy, leave this unset and enable the OAuth2 Proxy deployment via `ingress.oauth2-proxy` config.
+    # Therefore, a non-empty base-url is mutually exclusive with `ingress.oauth2-proxy.enabled`.
+    # @schema type: [string, null]
+    baseUrl: null
+  # Service account token based authentication for the API server
+  # @schema type: [object, null]
+  serviceAccount:
+    # Enable service account tokens for automated API access
+    # If enabled, users can create bearer tokens to bypass SSO authentication
+    # for automated systems. This works independently of enableUserManagement.
+    # JWT secrets are automatically stored in the database for persistence across restarts.
+    # Default to `.apiService.enableServiceAccounts` (true) for backward compatibility, setting this will override the default value.
+    # @schema type: [boolean, null]
+    enabled: null
 
 storage:
   # Enable/disable persistent storage

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -37,6 +37,7 @@ from sky.client import common as client_common
 from sky.client import oauth as oauth_lib
 from sky.server import common as server_common
 from sky.server import rest
+from sky.server import versions
 from sky.server.requests import payloads
 from sky.server.requests import requests as requests_lib
 from sky.skylet import constants
@@ -1927,7 +1928,15 @@ def api_info() -> Dict[str, Any]:
         Note that user may be None if we are not using an auth proxy.
 
     """
-    response = server_common.make_authenticated_request('GET', '/api/health')
+    if versions.get_remote_api_version() < 13:
+        # TODO(aylei): remove this after min_compatible_api_version >= 13.
+        # /api/health does not require authentication, thus running
+        # `sky api info` upon an legacy server would not trigger the login
+        # process.
+        response = server_common.make_authenticated_request(
+            'GET', '/api/health')
+    else:
+        response = server_common.make_authenticated_request('GET', '/api/info')
     response.raise_for_status()
     return response.json()
 

--- a/sky/server/auth/authn.py
+++ b/sky/server/auth/authn.py
@@ -1,6 +1,5 @@
 """Authentication module."""
 
-
 # TODO(hailong): Remove this function and use request.state.auth_user instead.
 import json
 from typing import Optional
@@ -15,7 +14,7 @@ logger = sky_logging.init_logger(__name__)
 
 
 async def override_user_info_in_request_body(request: fastapi.Request,
-                                              auth_user: Optional[models.User]):
+                                             auth_user: Optional[models.User]):
     if auth_user is None:
         return
 

--- a/sky/server/auth/authn.py
+++ b/sky/server/auth/authn.py
@@ -1,0 +1,48 @@
+"""Authentication module."""
+
+
+# TODO(hailong): Remove this function and use request.state.auth_user instead.
+import json
+from typing import Optional
+
+import fastapi
+
+from sky import models
+from sky import sky_logging
+from sky.skylet import constants
+
+logger = sky_logging.init_logger(__name__)
+
+
+async def override_user_info_in_request_body(request: fastapi.Request,
+                                              auth_user: Optional[models.User]):
+    if auth_user is None:
+        return
+
+    body = await request.body()
+    if body:
+        try:
+            original_json = await request.json()
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            logger.error(f'Error parsing request JSON: {e}')
+        else:
+            logger.debug(f'Overriding user for {request.state.request_id}: '
+                         f'{auth_user.name}, {auth_user.id}')
+            if 'env_vars' in original_json:
+                if isinstance(original_json.get('env_vars'), dict):
+                    original_json['env_vars'][
+                        constants.USER_ID_ENV_VAR] = auth_user.id
+                    original_json['env_vars'][
+                        constants.USER_ENV_VAR] = auth_user.name
+                else:
+                    logger.warning(
+                        f'"env_vars" in request body is not a dictionary '
+                        f'for request {request.state.request_id}. '
+                        'Skipping user info injection into body.')
+            else:
+                original_json['env_vars'] = {}
+                original_json['env_vars'][
+                    constants.USER_ID_ENV_VAR] = auth_user.id
+                original_json['env_vars'][
+                    constants.USER_ENV_VAR] = auth_user.name
+            request._body = json.dumps(original_json).encode('utf-8')  # pylint: disable=protected-access

--- a/sky/server/auth/oauth2_proxy.py
+++ b/sky/server/auth/oauth2_proxy.py
@@ -1,0 +1,158 @@
+"""Authentication based on oauth2-proxy."""
+
+import asyncio
+import hashlib
+import http
+import os
+from typing import Optional
+
+import aiohttp
+import fastapi
+import starlette.middleware.base
+
+from sky import models
+from sky import sky_logging
+from sky.server.auth import authn
+from sky.utils import common_utils
+
+logger = sky_logging.init_logger(__name__)
+
+# We do not support setting these in config.yaml because:
+# 1. config.yaml can be updated dynamically, but auth middleware does not
+#    support hot reload yet.
+# 2. If we introduce hot reload for auth middleware, bad config might
+#    invalidate all authenticated sessions and thus cannot be rolled back
+#    by API users.
+# TODO(aylei): we should introduce server.yaml for static server admin config,
+# which is more structured than multiple environment variables and can be less
+# confusing to users.
+OAUTH2_PROXY_BASE_URL_ENV_VAR = 'SKYPILOT_AUTH_OAUTH2_PROXY_BASE_URL'
+OAUTH2_PROXY_ENABLED_ENV_VAR = 'SKYPILOT_AUTH_OAUTH2_PROXY_ENABLED'
+
+
+class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
+    """Middleware to handle authentication by delegating to OAuth2 Proxy."""
+
+    def __init__(self, application: fastapi.FastAPI):
+        super().__init__(application)
+        self.enabled: bool = (os.getenv(OAUTH2_PROXY_ENABLED_ENV_VAR, 'false')
+                              == 'true')
+        self.proxy_base: str = ''
+        if self.enabled:
+            proxy_base = os.getenv(OAUTH2_PROXY_BASE_URL_ENV_VAR)
+            if not proxy_base:
+                raise ValueError('OAuth2 Proxy is enabled but base_url is not '
+                                 'set')
+            self.proxy_base = proxy_base.rstrip('/')
+
+    async def dispatch(self, request: fastapi.Request, call_next):
+        if not self.enabled:
+            return await call_next(request)
+
+        # Forward /oauth2/* to oauth2-proxy, including /oauth2/start and
+        # /oauth2/callback.
+        if request.url.path.startswith('/oauth2'):
+            return await self.forward_to_oauth2_proxy(request)
+
+        return await self.authenticate(request, call_next)
+
+    async def forward_to_oauth2_proxy(self, request: fastapi.Request):
+        """Forward requests to oauth2-proxy service."""
+        logger.debug(f'forwarding to oauth2-proxy: {request.url.path}')
+        target_url = f'{self.proxy_base}/{request.url.path}'
+        body = await request.body()
+        async with aiohttp.ClientSession() as session:
+            try:
+                forwarded_headers = dict(request.headers)
+                async with session.request(
+                        method=request.method,
+                        url=target_url,
+                        headers=forwarded_headers,
+                        data=body,
+                        cookies=request.cookies,
+                        params=request.query_params,
+                        allow_redirects=False,
+                ) as response:
+                    response_body = await response.read()
+                    return fastapi.responses.Response(
+                        content=response_body,
+                        status_code=response.status,
+                        headers=dict(response.headers),
+                    )
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                logger.error(f'Error forwarding to OAuth2 proxy: {e}')
+                return fastapi.responses.JSONResponse(
+                    status_code=http.HTTPStatus.BAD_GATEWAY,
+                    content={'detail': 'oauth2-proxy service unavailable'})
+
+    async def authenticate(self, request: fastapi.Request, call_next):
+        if request.state.auth_user is not None:
+            # Already authenticated
+            return await call_next(request)
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                return await self._authenticate(request, call_next, session)
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                logger.error(f'Error communicating with OAuth2 proxy: {e}')
+                # Fail open or closed based on your security requirements
+                return fastapi.responses.JSONResponse(
+                    status_code=http.HTTPStatus.BAD_GATEWAY,
+                    content={'detail': 'oauth2-proxy service unavailable'})
+
+    async def _authenticate(self, request: fastapi.Request, call_next,
+                            session: aiohttp.ClientSession):
+        forwarded_headers = dict(request.headers)
+        auth_url = f'{self.proxy_base}/oauth2/auth'
+        forwarded_headers['X-Forwarded-Uri'] = str(request.url)
+        logger.debug(f'authenticate request: {request.url.path}')
+
+        async with session.request(
+                method=request.method,
+                url=auth_url,
+                headers=forwarded_headers,
+                cookies=request.cookies,
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+        ) as auth_response:
+
+            if auth_response.status == http.HTTPStatus.ACCEPTED:
+                # User is authenticated, extract user info from headers
+                auth_user = self.get_auth_user(auth_response)
+                if not auth_user:
+                    return fastapi.responses.JSONResponse(
+                        status_code=http.HTTPStatus.INTERNAL_SERVER_ERROR,
+                        content={
+                            'detail':
+                                'oauth2-proxy is enabled but did not'
+                                'return user info, check your oauth2-proxy'
+                                'setup.'
+                        })
+                request.state.auth_user = auth_user
+                await authn.override_user_info_in_request_body(
+                    request, auth_user)
+                return await call_next(request)
+            elif auth_response.status == http.HTTPStatus.UNAUTHORIZED:
+                # TODO(aylei): in unified authentication, the redirection
+                # or rejection should be done after all the authentication
+                # methods are performed.
+                # Not authenticated, redirect to sign-in
+                signin_url = (f'{request.base_url}oauth2/start?'
+                              f'rd={str(request.url)}')
+                return fastapi.responses.RedirectResponse(url=signin_url)
+            else:
+                logger.error('oauth2-proxy returned unexpected status '
+                             f'{auth_response.status}: {auth_response.text}')
+                return fastapi.responses.JSONResponse(
+                    status_code=auth_response.status,
+                    content={'detail': 'oauth2-proxy error'})
+
+    def get_auth_user(
+            self, response: aiohttp.ClientResponse) -> Optional[models.User]:
+        """Extract user info from OAuth2 proxy response headers."""
+        email_header = response.headers.get('X-Auth-Request-Email')
+        if email_header:
+            user_hash = hashlib.md5(email_header.encode()).hexdigest(
+            )[:common_utils.USER_HASH_LENGTH]
+            return models.User(id=user_hash, name=email_header)
+        return None

--- a/sky/server/common.py
+++ b/sky/server/common.py
@@ -322,13 +322,15 @@ def get_api_server_status(endpoint: Optional[str] = None) -> ApiServerInfo:
         # The response is 200, so we can parse the response.
         try:
             result = response.json()
+            # TODO(aylei): backward compatbility
+            server_status = result.get('status')
             api_version = result.get('api_version')
             version = result.get('version')
             version_on_disk = result.get('version_on_disk')
             commit = result.get('commit')
             user = result.get('user')
             basic_auth_enabled = result.get('basic_auth_enabled')
-            server_info = ApiServerInfo(status=ApiServerStatus.HEALTHY,
+            server_info = ApiServerInfo(status=ApiServerStatus(server_status),
                                         api_version=api_version,
                                         version=version,
                                         version_on_disk=version_on_disk,

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 12
+API_VERSION = 13
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -492,7 +492,8 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                             session: aiohttp.ClientSession):
         forwarded_headers = dict(request.headers)
         auth_url = f'{self.proxy_base}/oauth2/auth'
-        forwarded_headers['X-Forwarded-Uri'] = request.url
+        forwarded_headers['X-Forwarded-Uri'] = str(request.url)
+        logger.info(f'forwarded headers: {forwarded_headers}')
 
         async with session.request(
                 method=request.method,

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1544,7 +1544,7 @@ async def health(request: fastapi.Request) -> Dict[str, Any]:
     """
     user = request.state.auth_user
     user_dict = None
-    status = common.ApiServerStatus.HEALTHY
+    server_status = common.ApiServerStatus.HEALTHY
     if user is not None:
         user_dict = user.to_dict()
     elif getattr(request.state, 'anonymous_user', False):
@@ -1559,11 +1559,11 @@ async def health(request: fastapi.Request) -> Dict[str, Any]:
             'name': 'anonymous',
             'id': 'anonymous',
         }
-        status = common.ApiServerStatus.NEEDS_AUTH
+        server_status = common.ApiServerStatus.NEEDS_AUTH
 
     logger.debug(f'Health endpoint: request.state.auth_user = {user}')
     return {
-        'status': status,
+        'status': server_status,
         # Kept for backward compatibility, clients before 0.11.0 will read this
         # field to check compatibility and hint the user to upgrade the CLI.
         # TODO(aylei): remove this field after 0.13.0

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -447,6 +447,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
     async def forward_to_oauth2_proxy(self, request: fastapi.Request):
         """Forward requests to oauth2-proxy service."""
+        logger.info(f'forwarding to oauth2-proxy: {request.url.path}')
         target_url = f'{self.proxy_base}/{request.url.path}'
         body = await request.body()
         async with aiohttp.ClientSession() as session:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -505,7 +505,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
                 allow_redirects=False,
         ) as auth_response:
 
-            if auth_response.status == 200:
+            if auth_response.status == 202:
                 # User is authenticated, extract user info from headers
                 auth_user = self.get_auth_user(auth_response)
                 if not auth_user:

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -1544,10 +1544,11 @@ async def health(request: fastapi.Request) -> Dict[str, Any]:
     """
     user = request.state.auth_user
     user_dict = None
+    status = common.ApiServerStatus.HEALTHY
     if user is not None:
         user_dict = user.to_dict()
     elif getattr(request.state, 'anonymous_user', False):
-        # /api/health had two different usage previously:
+        # /api/health had several different usage previously:
         # 1. For health check from CLI and external ochestration tools (k8s).
         # 2. For `sky api info` call to get the user info.
         # The first does not require authentication while the second does,
@@ -1558,10 +1559,11 @@ async def health(request: fastapi.Request) -> Dict[str, Any]:
             'name': 'anonymous',
             'id': 'anonymous',
         }
+        status = common.ApiServerStatus.NEEDS_AUTH
 
     logger.debug(f'Health endpoint: request.state.auth_user = {user}')
     return {
-        'status': common.ApiServerStatus.HEALTHY.value,
+        'status': status,
         # Kept for backward compatibility, clients before 0.11.0 will read this
         # field to check compatibility and hint the user to upgrade the CLI.
         # TODO(aylei): remove this field after 0.13.0

--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -481,7 +481,7 @@ class OAuth2ProxyMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
 
         async with aiohttp.ClientSession() as session:
             try:
-                await self._authenticate(request, call_next, session)
+                return await self._authenticate(request, call_next, session)
             except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                 logger.error(f'Error communicating with OAuth2 proxy: {e}')
                 # Fail open or closed based on your security requirements

--- a/sky/setup_files/dependencies.py
+++ b/sky/setup_files/dependencies.py
@@ -69,6 +69,7 @@ install_requires = [
     'gitpython',
     'types-paramiko',
     'alembic',
+    'aiohttp',
 ]
 
 server_dependencies = [
@@ -76,6 +77,7 @@ server_dependencies = [
     'sqlalchemy_adapter',
     'passlib',
     'pyjwt',
+    'aiohttp',
 ]
 
 local_ray = [

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1713,6 +1713,28 @@ def get_config_schema():
         },
     }
 
+    auth_schema = {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+            'oauth2-proxy': {
+                'type': 'object',
+                'required': [],
+                'additionalProperties': False,
+                'properties': {
+                    'enabled': {
+                        'type': 'boolean',
+                    },
+                    'base_url': {
+                        'type': 'string',
+                        'pattern': r'^https?://.*$',
+                    },
+                }
+            }
+        }
+    }
+
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update(
@@ -1747,6 +1769,7 @@ def get_config_schema():
             'rbac': rbac_schema,
             'logs': logs_schema,
             'daemons': daemon_schema,
+            'auth': auth_schema,
             **cloud_configs,
         },
     }

--- a/sky/utils/schemas.py
+++ b/sky/utils/schemas.py
@@ -1713,28 +1713,6 @@ def get_config_schema():
         },
     }
 
-    auth_schema = {
-        'type': 'object',
-        'required': [],
-        'additionalProperties': False,
-        'properties': {
-            'oauth2-proxy': {
-                'type': 'object',
-                'required': [],
-                'additionalProperties': False,
-                'properties': {
-                    'enabled': {
-                        'type': 'boolean',
-                    },
-                    'base_url': {
-                        'type': 'string',
-                        'pattern': r'^https?://.*$',
-                    },
-                }
-            }
-        }
-    }
-
     for cloud, config in cloud_configs.items():
         if cloud == 'aws':
             config['properties'].update(
@@ -1769,7 +1747,6 @@ def get_config_schema():
             'rbac': rbac_schema,
             'logs': logs_schema,
             'daemons': daemon_schema,
-            'auth': auth_schema,
             **cloud_configs,
         },
     }

--- a/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
+++ b/tests/unit_tests/test_sky/server/test_bearer_token_middleware.py
@@ -136,7 +136,7 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used, \
-                mock.patch('sky.server.server._override_user_info_in_request_body') as mock_override_user_info:
+                mock.patch('sky.server.auth.authn.override_user_info_in_request_body') as mock_override_user_info:
 
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info
@@ -250,7 +250,7 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used') as mock_update_last_used, \
-                mock.patch('sky.server.server._override_user_info_in_request_body') as mock_override_user_info:
+                mock.patch('sky.server.authn.override_user_info_in_request_body') as mock_override_user_info:
 
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info
@@ -308,7 +308,7 @@ class TestBearerTokenMiddleware:
                 mock.patch('sky.users.token_service.token_service') as mock_token_service, \
                 mock.patch('sky.global_user_state.get_user') as mock_get_user, \
                 mock.patch('sky.global_user_state.update_service_account_token_last_used'), \
-                mock.patch('sky.server.server._override_user_info_in_request_body'):
+                mock.patch('sky.server.auth.authn.override_user_info_in_request_body'):
 
             mock_token_service.verify_token.return_value = mock_payload
             mock_get_user.return_value = mock_user_info


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Allows service accounts and OAuth2 to be used at the same time without ingress support.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
