### PR TITLE
Fix wrong spec for Nebius spot pricing

### DIFF
--- a/sky/catalog/data_fetchers/fetch_nebius.py
+++ b/sky/catalog/data_fetchers/fetch_nebius.py
@@ -126,8 +126,9 @@ def _estimate_platforms(platforms: List[Any], parent_id: str,
                         resources=compute().ResourcesSpec(
                             platform=platform_name,
                             preset=preset.name,
-                        )),
-                    preemptible=compute().PreemptibleSpec(priority=1),
+                        ),
+                        preemptible=compute().PreemptibleSpec(priority=1),
+                    ),
                 ))
             spot_price_request = billing().EstimateBatchRequest(
                 resource_specs=[spot_estimate_spec])


### PR DESCRIPTION
Fix bad spec generating for Nebius spot pricing.

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
