### PR TITLE
[config] Allow `config.kubernetes.custom_metadata` overrides in task

### DIFF
--- a/sky/backends/backend_utils.py
+++ b/sky/backends/backend_utils.py
@@ -922,7 +922,10 @@ def write_cluster_config(
             cluster_config_overrides=cluster_config_overrides,
             cloud=cloud,
             context=region.name)
-        kubernetes_utils.combine_metadata_fields(tmp_yaml_path, region.name)
+        kubernetes_utils.combine_metadata_fields(
+            tmp_yaml_path,
+            cluster_config_overrides=cluster_config_overrides,
+            context=region.name)
         yaml_obj = common_utils.read_yaml(tmp_yaml_path)
         pod_config: Dict[str, Any] = yaml_obj['available_node_types'][
             'ray_head_default']['node_config']

--- a/sky/skylet/constants.py
+++ b/sky/skylet/constants.py
@@ -369,6 +369,7 @@ OVERRIDEABLE_CONFIG_KEYS_IN_TASK: List[Tuple[str, ...]] = [
     ('docker', 'run_options'),
     ('nvidia_gpus', 'disable_ecc'),
     ('ssh', 'pod_config'),
+    ('kubernetes', 'custom_metadata'),
     ('kubernetes', 'pod_config'),
     ('kubernetes', 'provision_timeout'),
     ('kubernetes', 'dws'),


### PR DESCRIPTION
Allow `config.kubernetes.custom_metadata` overrides to let users set annotations. Required on certain clouds to set args for loadbalancers when opening ports, scraping pods for metrics etc. 

More generally - we should look into fixing #5585 so we don't require allow listing like this.