### PR TITLE
[Refactor] Fix backwards compatibility issues introduced by `wait_for` Autostop config

### DIFF
--- a/sky/backends/cloud_vm_ray_backend.py
+++ b/sky/backends/cloud_vm_ray_backend.py
@@ -4650,7 +4650,7 @@ class CloudVmRayBackend(backends.Backend['CloudVmRayResourceHandle']):
     def set_autostop(self,
                      handle: CloudVmRayResourceHandle,
                      idle_minutes_to_autostop: Optional[int],
-                     wait_for: autostop_lib.AutostopWaitFor,
+                     wait_for: Optional[autostop_lib.AutostopWaitFor],
                      down: bool = False,
                      stream_logs: bool = True) -> None:
         # The core.autostop() function should have already checked that the

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1199,7 +1199,7 @@ def launch(
         backend=backend,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
         wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for)
-        if wait_for else None,
+        if wait_for is not None else None,
         down=down,
         retry_until_up=retry_until_up,
         no_setup=no_setup,
@@ -2646,7 +2646,7 @@ def autostop(
         no_confirm=yes,
         idle_minutes_to_autostop=idle_minutes,
         wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for)
-        if wait_for else None,
+        if wait_for is not None else None,
         async_call=async_call)
 
 
@@ -2870,7 +2870,7 @@ def start(
         lambda name: sdk.start(name,
                                idle_minutes_to_autostop,
                                autostop_lib.AutostopWaitFor.from_str(wait_for)
-                               if wait_for else None,
+                               if wait_for is not None else None,
                                retry_until_up,
                                down=down,
                                force=force), to_start)

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -3260,7 +3260,7 @@ def _down_or_stop_clusters(
 
     def _down_or_stop(name: str):
         success_progress = False
-        if idle_minutes_to_autostop is not None and wait_for is not None:
+        if idle_minutes_to_autostop is not None:
             try:
                 request_id = sdk.autostop(name, idle_minutes_to_autostop,
                                           wait_for, down)

--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -1103,7 +1103,7 @@ def launch(
     network_tier: Optional[str],
     ports: Tuple[str, ...],
     idle_minutes_to_autostop: Optional[int],
-    wait_for: str,
+    wait_for: Optional[str],
     down: bool,  # pylint: disable=redefined-outer-name
     retry_until_up: bool,
     yes: bool,
@@ -1198,7 +1198,8 @@ def launch(
         cluster_name=cluster,
         backend=backend,
         idle_minutes_to_autostop=idle_minutes_to_autostop,
-        wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for),
+        wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for)
+        if wait_for else None,
         down=down,
         retry_until_up=retry_until_up,
         no_setup=no_setup,
@@ -2575,7 +2576,7 @@ def autostop(
     all: bool,  # pylint: disable=redefined-builtin
     all_users: bool,
     idle_minutes: Optional[int],
-    wait_for: str,
+    wait_for: Optional[str],
     cancel: bool,  # pylint: disable=redefined-outer-name
     down: bool,  # pylint: disable=redefined-outer-name
     yes: bool,
@@ -2644,7 +2645,8 @@ def autostop(
         down=down,
         no_confirm=yes,
         idle_minutes_to_autostop=idle_minutes,
-        wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for),
+        wait_for=autostop_lib.AutostopWaitFor.from_str(wait_for)
+        if wait_for else None,
         async_call=async_call)
 
 
@@ -2707,7 +2709,7 @@ def start(
     all: bool,
     yes: bool,
     idle_minutes_to_autostop: Optional[int],
-    wait_for: str,
+    wait_for: Optional[str],
     down: bool,  # pylint: disable=redefined-outer-name
     retry_until_up: bool,
     force: bool,
@@ -2867,7 +2869,8 @@ def start(
     request_ids = subprocess_utils.run_in_parallel(
         lambda name: sdk.start(name,
                                idle_minutes_to_autostop,
-                               autostop_lib.AutostopWaitFor.from_str(wait_for),
+                               autostop_lib.AutostopWaitFor.from_str(wait_for)
+                               if wait_for else None,
                                retry_until_up,
                                down=down,
                                force=force), to_start)

--- a/sky/client/cli/flags.py
+++ b/sky/client/cli/flags.py
@@ -350,7 +350,7 @@ def wait_for_option(pair: str):
         return click.option(
             '--wait-for',
             type=click.Choice(autostop_lib.AutostopWaitFor.supported_modes()),
-            default=autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR.value,
+            default=None,
             required=False,
             help=autostop_lib.AutostopWaitFor.cli_help_message(pair=pair))(func)
 

--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -1101,7 +1101,6 @@ def autostop(
                                  remote_api_version < 13):
         logger.warning('wait_for is not supported in your API server. '
                        'Please upgrade to a newer API server to use it.')
-        wait_for = None
 
     body = payloads.AutostopBody(
         cluster_name=cluster_name,

--- a/sky/client/sdk.pyi
+++ b/sky/client/sdk.pyi
@@ -105,7 +105,7 @@ def launch(task: Union['sky.Task', 'sky.Dag'],
            cluster_name: Optional[str] = ...,
            retry_until_up: bool = ...,
            idle_minutes_to_autostop: Optional[int] = ...,
-           wait_for: autostop_lib.AutostopWaitFor = ...,
+           wait_for: Optional[autostop_lib.AutostopWaitFor] = ...,
            dryrun: bool = ...,
            down: bool = ...,
            backend: Optional['backends.Backend'] = ...,
@@ -144,7 +144,7 @@ def download_logs(cluster_name: str,
 
 def start(cluster_name: str,
           idle_minutes_to_autostop: Optional[int] = ...,
-          wait_for: autostop_lib.AutostopWaitFor = ...,
+          wait_for: Optional[autostop_lib.AutostopWaitFor] = ...,
           retry_until_up: bool = ...,
           down: bool = ...,
           force: bool = ...) -> server_common.RequestId:
@@ -161,7 +161,7 @@ def stop(cluster_name: str, purge: bool = ...) -> server_common.RequestId:
 
 def autostop(cluster_name: str,
              idle_minutes: int,
-             wait_for: autostop_lib.AutostopWaitFor = ...,
+             wait_for: Optional[autostop_lib.AutostopWaitFor] = ...,
              down: bool = ...) -> server_common.RequestId:
     ...
 

--- a/sky/core.py
+++ b/sky/core.py
@@ -404,8 +404,8 @@ def cost_report(days: Optional[int] = None) -> List[Dict[str, Any]]:
 def _start(
     cluster_name: str,
     idle_minutes_to_autostop: Optional[int] = None,
-    wait_for: autostop_lib.AutostopWaitFor = autostop_lib.
-    DEFAULT_AUTOSTOP_WAIT_FOR,
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
+        autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR),
     retry_until_up: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
     force: bool = False,
@@ -484,8 +484,8 @@ def _start(
 def start(
     cluster_name: str,
     idle_minutes_to_autostop: Optional[int] = None,
-    wait_for: autostop_lib.AutostopWaitFor = autostop_lib.
-    DEFAULT_AUTOSTOP_WAIT_FOR,
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
+        autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR),
     retry_until_up: bool = False,
     down: bool = False,  # pylint: disable=redefined-outer-name
     force: bool = False,
@@ -657,7 +657,7 @@ def stop(cluster_name: str, purge: bool = False) -> None:
 def autostop(
         cluster_name: str,
         idle_minutes: int,
-        wait_for: autostop_lib.AutostopWaitFor = autostop_lib.
+        wait_for: Optional[autostop_lib.AutostopWaitFor] = autostop_lib.
     DEFAULT_AUTOSTOP_WAIT_FOR,
         down: bool = False,  # pylint: disable=redefined-outer-name
 ) -> None:

--- a/sky/execution.py
+++ b/sky/execution.py
@@ -310,7 +310,7 @@ def _execute_dag(
 
         idle_minutes_to_autostop: Optional[int] = None
         down = False
-        wait_for = autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR
+        wait_for: Optional[autostop_lib.AutostopWaitFor] = None
         if resource_autostop_config is not None:
             if resource_autostop_config.enabled:
                 idle_minutes_to_autostop = (

--- a/sky/resources.py
+++ b/sky/resources.py
@@ -70,17 +70,18 @@ class AutostopConfig:
     # flags.
     idle_minutes: int = 0
     down: bool = False
-    wait_for: autostop_lib.AutostopWaitFor = (
-        autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR)
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = None
 
     def to_yaml_config(self) -> Union[Literal[False], Dict[str, Any]]:
         if not self.enabled:
             return False
-        return {
+        config: Dict[str, Any] = {
             'idle_minutes': self.idle_minutes,
             'down': self.down,
-            'wait_for': self.wait_for.value,
         }
+        if self.wait_for is not None:
+            config['wait_for'] = self.wait_for.value
+        return config
 
     @classmethod
     def from_yaml_config(

--- a/sky/server/constants.py
+++ b/sky/server/constants.py
@@ -10,7 +10,7 @@ from sky.skylet import constants
 # based on version info is needed.
 # For more details and code guidelines, refer to:
 # https://docs.skypilot.co/en/latest/developers/CONTRIBUTING.html#backward-compatibility-guidelines
-API_VERSION = 12
+API_VERSION = 13
 
 # The minimum peer API version that the code should still work with.
 # Notes (dev):

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -313,8 +313,7 @@ class StartBody(RequestBody):
     """The request body for the start endpoint."""
     cluster_name: str
     idle_minutes_to_autostop: Optional[int] = None
-    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
-        autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR)
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = None
     retry_until_up: bool = False
     down: bool = False
     force: bool = False
@@ -324,8 +323,7 @@ class AutostopBody(RequestBody):
     """The request body for the autostop endpoint."""
     cluster_name: str
     idle_minutes: int
-    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
-        autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR)
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = None
     down: bool = False
 
 

--- a/sky/server/requests/payloads.py
+++ b/sky/server/requests/payloads.py
@@ -313,7 +313,7 @@ class StartBody(RequestBody):
     """The request body for the start endpoint."""
     cluster_name: str
     idle_minutes_to_autostop: Optional[int] = None
-    wait_for: autostop_lib.AutostopWaitFor = (
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
         autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR)
     retry_until_up: bool = False
     down: bool = False
@@ -324,7 +324,7 @@ class AutostopBody(RequestBody):
     """The request body for the autostop endpoint."""
     cluster_name: str
     idle_minutes: int
-    wait_for: autostop_lib.AutostopWaitFor = (
+    wait_for: Optional[autostop_lib.AutostopWaitFor] = (
         autostop_lib.DEFAULT_AUTOSTOP_WAIT_FOR)
     down: bool = False
 

--- a/sky/skylet/autostop_lib.py
+++ b/sky/skylet/autostop_lib.py
@@ -199,8 +199,10 @@ class AutostopCodeGen:
     def set_autostop(cls,
                      idle_minutes: int,
                      backend: str,
-                     wait_for: AutostopWaitFor,
+                     wait_for: Optional[AutostopWaitFor],
                      down: bool = False) -> str:
+        if wait_for is None:
+            wait_for = DEFAULT_AUTOSTOP_WAIT_FOR
         code = [
             f'\nif getattr(constants, "SKYLET_LIB_VERSION", 1) < 4: '
             f'\n autostop_lib.set_autostop({idle_minutes}, {backend!r}, {down})'

--- a/sky/skylet/events.py
+++ b/sky/skylet/events.py
@@ -159,7 +159,7 @@ class AutostopEvent(SkyletEvent):
         else:
             autostop_lib.set_last_active_time_to_now()
             minutes_since_last_active = -1
-            logger.debug('Not idle. Reset idle minutes.'
+            logger.debug('Not idle. Reset idle minutes. '
                          f'AutoStop idle minutes: '
                          f'{autostop_config.autostop_idle_minutes}, '
                          f'Wait for: {autostop_config.wait_for.value}')

--- a/tests/unit_tests/test_controller_utils.py
+++ b/tests/unit_tests/test_controller_utils.py
@@ -16,7 +16,6 @@ from sky.utils import registry
 _DEFAULT_AUTOSTOP = {
     'down': False,
     'idle_minutes': 10,
-    'wait_for': autostop_lib.AutostopWaitFor.JOBS_AND_SSH.value,
 }
 
 

--- a/tests/unit_tests/test_resources.py
+++ b/tests/unit_tests/test_resources.py
@@ -687,7 +687,7 @@ def test_autostop_config():
     assert r.autostop_config.enabled is True
     assert r.autostop_config.down is True
     assert r.autostop_config.idle_minutes == 0  # default value
-    assert r.autostop_config.wait_for == autostop_lib.AutostopWaitFor.JOBS_AND_SSH  # default value
+    assert r.autostop_config.wait_for == None  # default value
 
     # Override with idle_minutes when no existing autostop config
     r = Resources()
@@ -698,7 +698,7 @@ def test_autostop_config():
     assert r.autostop_config.enabled is True
     assert r.autostop_config.down is False  # default value
     assert r.autostop_config.idle_minutes == 10
-    assert r.autostop_config.wait_for == autostop_lib.AutostopWaitFor.JOBS_AND_SSH  # default value
+    assert r.autostop_config.wait_for == None  # default value
 
     # Override with both down and idle_minutes when no existing config
     r = Resources()


### PR DESCRIPTION
This PR fixes backwards compatibility issues introduced in #6361, by following https://github.com/skypilot-org/skypilot/blob/master/CONTRIBUTING.md#backward-compatibility-guidelines.

### The issues we saw were:

1. New client <-> old server errors with
```
% sky launch --infra aws -i 10
sky.exceptions.InvalidSkyPilotConfigError: Invalid resources YAML: {'idle_minutes': 10, 'down': False, 'wait_for': 'jobs_and_ssh'} is not valid under any of the given schemas. Check problematic field(s): $.autostop
```

This is because in `resources.AutostopConfig`, `wait_for` got serialized on the client, but the server does not recognize because it's still using the old schema

2. Old client <-> new server errors with
```
% sky autostop -i 20 mycluster
...
    request_task = requests_lib.Request.decode(
        payloads.RequestPayload(**response.json()))
  File "/Users/kevin/miniconda3/lib/python3.13/site-packages/sky/server/requests/requests.py", line 267, in decode
    request_body=decoders.decode_and_unpickle(payload.request_body),
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kevin/miniconda3/lib/python3.13/site-packages/sky/server/requests/serializers/decoders.py", line 25, in decode_and_unpickle
    return pickle.loads(base64.b64decode(obj.encode('utf-8')))
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: Can't get attribute 'AutostopWaitFor' on <module 'sky.skylet.autostop_lib' from '/Users/kevin/miniconda3/lib/python3.13/site-packages/sky/skylet/autostop_lib.py'>
```

### This PR does the following:
- Bumped `API_VERSION` to 13 in `sky/server/constants.py`
- Made `wait_for` optional everywhere in the frontend (CLI, SDK, payload)
- On the client, if `wait_for` is set but server api version is < 13, log a warning to warn users that the argument has no effect until they upgrade their API server
- Now, the default for `wait_for` is only set in one place, when doing the codegen with `AutostopCodeGen.set_autostop`. Above this layer, we assume `wait_for` is Optional

### Manual Testing:
1. New client <-> old server (1.0.0.dev20250728)
    - `sky launch -i 5`
    - `sky autostop -i 20 --wait-for none` -> autostop increased to 20m, but get a warning log because --wait-for has no effect
2.  Old client <-> new server
    - `sky launch -i 5`
    - `sky autostop -i 20 --wait-for none` -> error, `--wait-for` is not on the client yet
    - `sky autostop -i 20` -> autostop increased to 20m, `wait_for` is set to `JOBS_AND_SSH` by default


Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [x] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [x] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
