### PR TITLE
[Coreweave] Fix `show-gpus` to filter HPC verification pods

### DIFF
--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -255,6 +255,12 @@ def _list_accelerators(
                     # Get all the pods running on the node
                     if (pod.spec.node_name == node.metadata.name and
                             pod.status.phase in ['Running', 'Pending']):
+                        # Skip low priority test pods that should not count against real GPU availability
+                        if kubernetes_utils.should_exclude_pod_from_gpu_allocation(pod):
+                            logger.debug(f'Excluding pod '
+                                       f'{pod.metadata.name} from GPU count '
+                                       f'calculations on node {node.metadata.name}')
+                            continue
                         # Iterate over all the containers in the pod and sum
                         # the GPU requests
                         for container in pod.spec.containers:

--- a/sky/catalog/kubernetes_catalog.py
+++ b/sky/catalog/kubernetes_catalog.py
@@ -255,11 +255,13 @@ def _list_accelerators(
                     # Get all the pods running on the node
                     if (pod.spec.node_name == node.metadata.name and
                             pod.status.phase in ['Running', 'Pending']):
-                        # Skip low priority test pods that should not count against real GPU availability
-                        if kubernetes_utils.should_exclude_pod_from_gpu_allocation(pod):
-                            logger.debug(f'Excluding pod '
-                                       f'{pod.metadata.name} from GPU count '
-                                       f'calculations on node {node.metadata.name}')
+                        # Skip pods that should not count against GPU count
+                        if (kubernetes_utils.
+                                should_exclude_pod_from_gpu_allocation(pod)):
+                            logger.debug(
+                                f'Excluding pod '
+                                f'{pod.metadata.name} from GPU count '
+                                f'calculations on node {node.metadata.name}')
                             continue
                         # Iterate over all the containers in the pod and sum
                         # the GPU requests

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -2970,9 +2970,10 @@ def get_kubernetes_node_info(
                         pod.status.phase in ['Running', 'Pending']):
                     # Skip low priority test pods that should not count against real GPU availability
                     if should_exclude_pod_from_gpu_allocation(pod):
-                        logger.debug(f'Excluding low priority pod '
-                                   f'{pod.metadata.name} from GPU allocation '
-                                   f'calculations on node {node.metadata.name}')
+                        logger.debug(
+                            f'Excluding low priority pod '
+                            f'{pod.metadata.name} from GPU allocation '
+                            f'calculations on node {node.metadata.name}')
                         continue
                     # Iterate over all the containers in the pod and sum the
                     # GPU requests
@@ -3573,22 +3574,23 @@ def delete_k8s_resource_with_retry(delete_func: Callable, resource_type: str,
             else:
                 raise
 
+
 def should_exclude_pod_from_gpu_allocation(pod) -> bool:
     """Check if a pod should be excluded from GPU count calculations.
-    
-    Some cloud providers run low priority test/verification pods that request 
-    GPUs but should not count against real GPU availability since they are 
+
+    Some cloud providers run low priority test/verification pods that request
+    GPUs but should not count against real GPU availability since they are
     designed to be evicted when higher priority workloads need resources.
-    
+
     Args:
         pod: Kubernetes pod object
-        
+
     Returns:
         bool: True if the pod should be excluded from GPU count calculations.
     """
     # CoreWeave HPC verification pods - identified by namespace
-    if (hasattr(pod.metadata, 'namespace') and 
-        pod.metadata.namespace == 'cw-hpc-verification'):
+    if (hasattr(pod.metadata, 'namespace') and
+            pod.metadata.namespace == 'cw-hpc-verification'):
         return True
-    
+
     return False

--- a/sky/templates/kubernetes-loadbalancer.yml.j2
+++ b/sky/templates/kubernetes-loadbalancer.yml.j2
@@ -12,6 +12,8 @@ service_spec:
       {%- for key, value in annotations.items() %}
       {{ key }}: {{ value|tojson }}
       {%- endfor %}
+      {# Note: It's ok to add cloud-specific annotations here since they will be ignored by other clouds #}
+      service.beta.kubernetes.io/coreweave-load-balancer-type: public
   spec:
     type: LoadBalancer
     selector:

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -360,3 +360,79 @@ def test_heterogenous_gpu_detection_key_counts():
         assert (set(counts.keys()) == set(capacity.keys()) == set(available.keys())), \
             (f'Keys of counts ({list(counts.keys())}), capacity ({list(capacity.keys())}), '
              f'and available ({list(available.keys())}) must be the same.')
+
+
+def test_low_priority_pod_filtering():
+    """Tests that low priority pods (e.g., CoreWeave HPC verification) are excluded from GPU allocation calculations."""
+    # Mock node with 8 GPUs
+    mock_node = mock.MagicMock()
+    mock_node.metadata.name = 'gpu-node'
+    mock_node.metadata.labels = {
+        'skypilot.co/accelerator': 'h100-80gb',
+        'cloud.google.com/gke-accelerator-count': '8'
+    }
+    mock_node.status.allocatable = {'nvidia.com/gpu': '8'}
+    mock_node.status.addresses = [
+        mock.MagicMock(type='InternalIP', address='10.0.0.1')
+    ]
+
+    # Mock regular pod requesting 2 GPUs
+    mock_regular_pod = mock.MagicMock()
+    mock_regular_pod.spec.node_name = 'gpu-node'
+    mock_regular_pod.status.phase = 'Running'
+    mock_regular_pod.metadata.name = 'regular-workload-pod'
+    mock_regular_pod.metadata.namespace = 'default'
+    mock_regular_pod.spec.containers = [
+        mock.MagicMock(resources=mock.MagicMock(
+            requests={'nvidia.com/gpu': '2'}))
+    ]
+
+    # Mock low priority pod requesting 4 GPUs (should be excluded)
+    mock_low_priority_pod = mock.MagicMock()
+    mock_low_priority_pod.spec.node_name = 'gpu-node'
+    mock_low_priority_pod.status.phase = 'Running'
+    mock_low_priority_pod.metadata.name = 'hpc-verification-h100-80gb-test'
+    mock_low_priority_pod.metadata.namespace = 'cw-hpc-verification'
+    mock_low_priority_pod.spec.containers = [
+        mock.MagicMock(resources=mock.MagicMock(
+            requests={'nvidia.com/gpu': '4'}))
+    ]
+
+    # Test with low priority pod filtering
+    with mock.patch('sky.provision.kubernetes.utils.get_kubernetes_nodes',
+                   return_value=[mock_node]), \
+         mock.patch('sky.provision.kubernetes.utils.'
+                   'get_all_pods_in_kubernetes_cluster',
+                   return_value=[mock_regular_pod, mock_low_priority_pod]), \
+         mock.patch('sky.provision.kubernetes.utils.get_gpu_resource_key',
+                    return_value='nvidia.com/gpu'):
+        
+        node_info = utils.get_kubernetes_node_info()
+        assert isinstance(node_info, models.KubernetesNodesInfo)
+        assert len(node_info.node_info_dict) == 1
+        # Should have 8 total GPUs, 2 allocated (regular pod only), 6 available
+        # Low priority pod should be excluded from allocation calculations
+        assert node_info.node_info_dict['gpu-node'].total['accelerator_count'] == 8
+        assert node_info.node_info_dict['gpu-node'].free['accelerators_available'] == 6
+
+
+def test_should_exclude_pod_from_gpu_allocation():
+    """Tests the helper function that identifies pods to exclude from GPU allocation calculations."""
+    # Test CoreWeave HPC verification pod (should be excluded)
+    mock_hpc_pod = mock.MagicMock()
+    mock_hpc_pod.metadata.namespace = 'cw-hpc-verification'
+
+    # Test regular pod (should not be excluded)
+    mock_regular_pod = mock.MagicMock()
+    mock_regular_pod.metadata.namespace = 'default'
+
+    # Test pod with different namespace (should not be excluded)
+    mock_other_pod = mock.MagicMock()
+    mock_other_pod.metadata.namespace = 'some-other-namespace'
+
+    # CoreWeave HPC verification pod should be excluded
+    assert utils.should_exclude_pod_from_gpu_allocation(mock_hpc_pod) == True
+    
+    # Regular pods should not be excluded
+    assert utils.should_exclude_pod_from_gpu_allocation(mock_regular_pod) == False
+    assert utils.should_exclude_pod_from_gpu_allocation(mock_other_pod) == False

--- a/tests/unit_tests/kubernetes/test_kubernetes_utils.py
+++ b/tests/unit_tests/kubernetes/test_kubernetes_utils.py
@@ -406,14 +406,16 @@ def test_low_priority_pod_filtering():
                    return_value=[mock_regular_pod, mock_low_priority_pod]), \
          mock.patch('sky.provision.kubernetes.utils.get_gpu_resource_key',
                     return_value='nvidia.com/gpu'):
-        
+
         node_info = utils.get_kubernetes_node_info()
         assert isinstance(node_info, models.KubernetesNodesInfo)
         assert len(node_info.node_info_dict) == 1
         # Should have 8 total GPUs, 2 allocated (regular pod only), 6 available
         # Low priority pod should be excluded from allocation calculations
-        assert node_info.node_info_dict['gpu-node'].total['accelerator_count'] == 8
-        assert node_info.node_info_dict['gpu-node'].free['accelerators_available'] == 6
+        assert node_info.node_info_dict['gpu-node'].total[
+            'accelerator_count'] == 8
+        assert node_info.node_info_dict['gpu-node'].free[
+            'accelerators_available'] == 6
 
 
 def test_should_exclude_pod_from_gpu_allocation():
@@ -432,7 +434,8 @@ def test_should_exclude_pod_from_gpu_allocation():
 
     # CoreWeave HPC verification pod should be excluded
     assert utils.should_exclude_pod_from_gpu_allocation(mock_hpc_pod) == True
-    
+
     # Regular pods should not be excluded
-    assert utils.should_exclude_pod_from_gpu_allocation(mock_regular_pod) == False
+    assert utils.should_exclude_pod_from_gpu_allocation(
+        mock_regular_pod) == False
     assert utils.should_exclude_pod_from_gpu_allocation(mock_other_pod) == False


### PR DESCRIPTION
CoreWeave runs low priority HPC Verification pods on idle clusters to test for GPU perf and correctness. These pods request `nvidia.com/gpu` resources but should not count against real GPU availability since they are designed to be evicted when higher priority workloads need resources.

Currently, SkyPilot's sky show-gpus command incorrectly reports these pods as consuming available GPUs, thus showing no GPUs available.

This PR fixes show-gpus logic to exclude these pods.