### PR TITLE
[k8s] Fix GPU name matching w/ underscores

### DIFF
--- a/sky/clouds/kubernetes.py
+++ b/sky/clouds/kubernetes.py
@@ -818,6 +818,10 @@ class Kubernetes(clouds.Cloud):
             assert len(accelerators) == 1, resources
             # GPUs requested - build instance type.
             acc_type, acc_count = list(accelerators.items())[0]
+            # If acc_type contains spaces, return empty list since Kubernetes
+            # does not support spaces in label values
+            if ' ' in acc_type:
+                return resources_utils.FeasibleResources([], [], None)
 
             # Parse into KubernetesInstanceType
             k8s_instance_type = (kubernetes_utils.KubernetesInstanceType.

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1984,11 +1984,8 @@ class KubernetesInstanceType:
         name = (f'{common_utils.format_float(self.cpus)}CPU--'
                 f'{common_utils.format_float(self.memory)}GB')
         if self.accelerator_count:
-            # Replace spaces with underscores in accelerator type to make it a
-            # valid logical instance type name.
             assert self.accelerator_type is not None, self.accelerator_count
-            acc_name = self.accelerator_type.replace(' ', '_')
-            name += f'--{acc_name}:{self.accelerator_count}'
+            name += f'--{self.accelerator_type}:{self.accelerator_count}'
         return name
 
     @staticmethod
@@ -2032,9 +2029,7 @@ class KubernetesInstanceType:
             accelerator_type = match.group('accelerator_type')
             if accelerator_count:
                 accelerator_count = int(accelerator_count)
-                # This is to revert the accelerator types with spaces back to
-                # the original format.
-                accelerator_type = str(accelerator_type).replace('_', ' ')
+                accelerator_type = str(accelerator_type)
             else:
                 accelerator_count = None
                 accelerator_type = None
@@ -2047,7 +2042,7 @@ class KubernetesInstanceType:
             accelerator_type = prev_match.group('accelerator_type')
             if accelerator_count:
                 accelerator_count = int(accelerator_count)
-                accelerator_type = str(accelerator_type).replace('_', ' ')
+                accelerator_type = str(accelerator_type)
             else:
                 accelerator_count = None
                 accelerator_type = None

--- a/sky/provision/kubernetes/utils.py
+++ b/sky/provision/kubernetes/utils.py
@@ -1984,8 +1984,11 @@ class KubernetesInstanceType:
         name = (f'{common_utils.format_float(self.cpus)}CPU--'
                 f'{common_utils.format_float(self.memory)}GB')
         if self.accelerator_count:
+            # Replace spaces with underscores in accelerator type to make it a
+            # valid logical instance type name.
             assert self.accelerator_type is not None, self.accelerator_count
-            name += f'--{self.accelerator_type}:{self.accelerator_count}'
+            acc_name = self.accelerator_type.replace(' ', '_')
+            name += f'--{acc_name}:{self.accelerator_count}'
         return name
 
     @staticmethod

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -89,24 +89,25 @@ def test_gpu_name_underscore_preservation():
         ("H100-80GB", "H100-80GB"),
         ("A100-40GB", "A100-40GB"),
     ]
-    
+
     for original_name, expected_name in test_cases:
         # Create instance type with accelerator name
         instance = KubernetesInstanceType.from_resources(
-            cpus=4, memory=16, accelerator_count=1, accelerator_type=original_name
-        )
-        
+            cpus=4,
+            memory=16,
+            accelerator_count=1,
+            accelerator_type=original_name)
+
         # Parse it back from the instance type string
-        parsed_instance = KubernetesInstanceType.from_instance_type(instance.name)
-        
+        parsed_instance = KubernetesInstanceType.from_instance_type(
+            instance.name)
+
         # Verify the accelerator name is preserved exactly
         assert parsed_instance.accelerator_type == expected_name, (
             f"Expected accelerator name '{expected_name}' but got "
-            f"'{parsed_instance.accelerator_type}' after round-trip parsing"
-        )
-        
+            f"'{parsed_instance.accelerator_type}' after round-trip parsing")
+
         # Verify the full instance type string contains the original name
         assert original_name in instance.name, (
             f"Instance type string '{instance.name}' should contain "
-            f"original accelerator name '{original_name}'"
-        )
+            f"original accelerator name '{original_name}'")

--- a/tests/unit_tests/kubernetes/test_instance_type.py
+++ b/tests/unit_tests/kubernetes/test_instance_type.py
@@ -17,6 +17,9 @@ def test_kubernetes_instance_type():
         (4, 16, 4, "4090", "4CPU--16GB--4090:4"),
         (4, 16, 1, "H100-80GB", "4CPU--16GB--H100-80GB:1"),
         (1, 6, 1, "K80", "1CPU--6GB--K80:1"),
+        # Test underscore-based GPU names (CoreWeave format)
+        (2, 8, 1, "H100_NVLINK_80GB", "2CPU--8GB--H100_NVLINK_80GB:1"),
+        (8, 32, 4, "A100_SXM4_80GB", "8CPU--32GB--A100_SXM4_80GB:4"),
     ]
 
     for cpus, memory, accelerator_count, accelerator_type, expected in test_cases:
@@ -69,3 +72,41 @@ def test_kubernetes_instance_type():
     assert memory == 16, f'Failed parse check for {prev_instance_type_name}'
     assert accelerator_count == 1, f'Failed parse check for {prev_instance_type_name}'
     assert accelerator_type == 'V100', f'Failed parse check for {prev_instance_type_name}'
+
+
+def test_gpu_name_underscore_preservation():
+    """Test that GPU names with underscores are preserved exactly as-is.
+    
+    This specifically tests the fix for CoreWeave H100_NVLINK_80GB support
+    where underscores were incorrectly converted to spaces during parsing.
+    """
+    test_cases = [
+        # (accelerator_name, expected_preserved_name)
+        ("H100_NVLINK_80GB", "H100_NVLINK_80GB"),
+        ("A100_SXM4_80GB", "A100_SXM4_80GB"),
+        ("RTX4090", "RTX4090"),
+        # Also test hyphen-based names continue to work
+        ("H100-80GB", "H100-80GB"),
+        ("A100-40GB", "A100-40GB"),
+    ]
+    
+    for original_name, expected_name in test_cases:
+        # Create instance type with accelerator name
+        instance = KubernetesInstanceType.from_resources(
+            cpus=4, memory=16, accelerator_count=1, accelerator_type=original_name
+        )
+        
+        # Parse it back from the instance type string
+        parsed_instance = KubernetesInstanceType.from_instance_type(instance.name)
+        
+        # Verify the accelerator name is preserved exactly
+        assert parsed_instance.accelerator_type == expected_name, (
+            f"Expected accelerator name '{expected_name}' but got "
+            f"'{parsed_instance.accelerator_type}' after round-trip parsing"
+        )
+        
+        # Verify the full instance type string contains the original name
+        assert original_name in instance.name, (
+            f"Instance type string '{instance.name}' should contain "
+            f"original accelerator name '{original_name}'"
+        )


### PR DESCRIPTION
`sky launch --gpus H100_NVLINK_80GB:1` would not work on CoreWeave clusters because SkyPilot converted underscores to spaces during parsing, breaking name matching (`H100_NVLINK_80GB` would become `H100 NVLINK 80GB` -> match fail). This was breaking H100 support on CW:

```
(py310) ➜  sky-experiments git:(cw_fix_h100) ✗ sky show-gpus --infra k8s
GPU label cloud.google.com/gke-accelerator matched for label formatter type, but has invalid value H100_NVLINK_80GB. Reason: Invalid accelerator name in GKE cluster: H100_NVLINK_80GB. Skipping...
GPU label cloud.google.com/gke-accelerator matched for label formatter type, but has invalid value H100_NVLINK_80GB. Reason: Invalid accelerator name in GKE cluster: H100_NVLINK_80GB. Skipping...
Kubernetes GPUs
Context: sky-dev
GPU               REQUESTABLE_QTY_PER_NODE  UTILIZATION   
H100_NVLINK_80GB  1.0, 2.0, 4.0, 8.0        0 of 16 free  
Kubernetes per-node GPU availability
CONTEXT  NODE     GPU               UTILIZATION  
sky-dev  g1421cc  H100_NVLINK_80GB  0 of 8 free  
sky-dev  g1e5316  H100_NVLINK_80GB  0 of 8 free  


(py310) ➜  sky-experiments git:(cw_fix_h100) ✗ sky launch --gpus H100_NVLINK_80GB:1    
GPU label cloud.google.com/gke-accelerator matched for label formatter type, but has invalid value H100_NVLINK_80GB. Reason: Invalid accelerator name in GKE cluster: H100_NVLINK_80GB. Skipping...
No resource satisfying <Cloud>({'H100_NVLINK_80GB': 1}) on [AWS, Vast, Lambda, Kubernetes, Azure, IBM, RunPod, GCP, Paperspace, Fluidstack].
sky.exceptions.ResourcesUnavailableError: Catalog and kubernetes cluster does not contain any instances satisfying the request: 1x <Cloud>({'H100_NVLINK_80GB': 1}).
To fix: relax or change the resource requirements.

Hint: sky show-gpus to list available accelerators.
      sky check to check the enabled clouds.
Hint: Check Per Resource Hint
```

This PR reverts the changes from https://github.com/skypilot-org/skypilot/pull/4382/ to not convert spaces to `_`. k8s labels do not allow spaces, so GPU names would never contain spaces anyway.