### PR TITLE
Fix `test_skyserve_https` failure

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -1024,6 +1024,7 @@ def test_skyserve_failures(generic_cloud: str):
 
 
 @pytest.mark.serve
+@pytest.mark.resource_heavy
 @pytest.mark.no_hyperbolic  # Hyperbolic doesn't support opening ports for skypilot yet
 def test_skyserve_https(generic_cloud: str):
     """Test skyserve with https"""


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

The HTTPS support on the kind cluster seems problematic, causing release 0.10.1 to [fail](https://buildkite.com/organizations/skypilot-1/pipelines/full-smoke-tests-run/builds/50/jobs/01987482-413a-4905-993f-b66df5d5d4b0/log).  
The `resource_heavy` mark was accidentally removed in #6423 - we should add it back so the test runs on the EKS cluster instead of the kind cluster.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
