### PR TITLE
[UX] rich progress bar support on k8s

### DIFF
--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -115,13 +115,11 @@ def _handle_io_stream(io_stream, out_stream, args: _ProcessingArgs):
                     end_streaming_flag = True
                 if (args.stream_logs and start_streaming_flag and
                         not end_streaming_flag):
-                    # writes to run.log
                     print(streaming_prefix + line,
                           end='',
                           file=out_stream,
                           flush=True)
                 if args.log_path != '/dev/null':
-                    # writes to tasks/run.log
                     fout.write(line)
                     fout.flush()
                 line_processor.process_line(line)

--- a/sky/skylet/log_lib.py
+++ b/sky/skylet/log_lib.py
@@ -115,11 +115,13 @@ def _handle_io_stream(io_stream, out_stream, args: _ProcessingArgs):
                     end_streaming_flag = True
                 if (args.stream_logs and start_streaming_flag and
                         not end_streaming_flag):
+                    # writes to run.log
                     print(streaming_prefix + line,
                           end='',
                           file=out_stream,
                           flush=True)
                 if args.log_path != '/dev/null':
+                    # writes to tasks/run.log
                     fout.write(line)
                     fout.flush()
                 line_processor.process_line(line)

--- a/sky/templates/kubernetes-ray.yml.j2
+++ b/sky/templates/kubernetes-ray.yml.j2
@@ -777,6 +777,10 @@ available_node_types:
                 {{ ray_installation_commands }}
 
                 VIRTUAL_ENV=~/skypilot-runtime ~/.local/bin/uv pip install skypilot[kubernetes,remote]
+                # Apply Ray patches for progress bar fix
+                ~/.local/bin/uv pip list | grep "ray " | grep 2.9.3 2>&1 > /dev/null && { 
+                  VIRTUAL_ENV=~/skypilot-runtime python -c "from sky.skylet.ray_patches import patch; patch()" || exit 1; 
+                }
                 touch /tmp/ray_skypilot_installation_complete
                 echo "=== Ray and skypilot installation completed ==="
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR makes rich progress bars (like tqdm) render properly in the skypilot client-side for skypilot jobs launched on kubernetes. 

We had some ray patches to override their handling of `\r`, but they were only being applied to cloud vms, not kubernetes. This PR applies these patches to ray when launching skypilot clusters on kubernetes.


<!-- Describe the tests ran -->
This PR was tested by running a test script that runs a basic for loop wrapped by tqdm. I verified that the tqdm progress bar shows up in a single line rather than the previous "pyramid" behavior. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
