### PR TITLE
[sdk] change request id argument type to be more clear

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -88,7 +88,7 @@ def reload_config() -> None:
     skypilot_config.safe_reload_config()
 
 
-def stream_response(request_id: Optional[str],
+def stream_response(request_id: Optional[server_common.RequestId],
                     response: 'requests.Response',
                     output_stream: Optional['io.TextIOBase'] = None,
                     resumable: bool = False) -> Any:
@@ -1756,7 +1756,7 @@ def status_kubernetes() -> server_common.RequestId:
 # === API request APIs ===
 @usage_lib.entrypoint
 @annotations.client_api
-def get(request_id: str) -> Any:
+def get(request_id: server_common.RequestId) -> Any:
     """Waits for and gets the result of a request.
 
     This function will not check the server health since /api/get is typically
@@ -1818,7 +1818,7 @@ def get(request_id: str) -> Any:
 @server_common.check_server_healthy_or_start
 @annotations.client_api
 def stream_and_get(
-    request_id: Optional[str] = None,
+    request_id: Optional[server_common.RequestId] = None,
     log_path: Optional[str] = None,
     tail: Optional[int] = None,
     follow: bool = True,
@@ -1873,7 +1873,8 @@ def stream_and_get(
 
 @usage_lib.entrypoint
 @annotations.client_api
-def api_cancel(request_ids: Optional[Union[str, List[str]]] = None,
+def api_cancel(request_ids: Optional[Union[
+    server_common.RequestId, List[server_common.RequestId]]] = None,
                all_users: bool = False,
                silent: bool = False) -> server_common.RequestId:
     """Aborts a request or all requests.
@@ -1938,7 +1939,7 @@ def _local_api_server_running(kill: bool = False) -> bool:
 @usage_lib.entrypoint
 @annotations.client_api
 def api_status(
-    request_ids: Optional[List[str]] = None,
+    request_ids: Optional[List[server_common.RequestId]] = None,
     # pylint: disable=redefined-builtin
     all_status: bool = False
 ) -> List[payloads.RequestPayload]:

--- a/sky/client/sdk.pyi
+++ b/sky/client/sdk.pyi
@@ -38,7 +38,7 @@ def reload_config() -> None:
     ...
 
 
-def stream_response(request_id: Optional[str],
+def stream_response(request_id: Optional[server_common.RequestId],
                     response: requests.Response,
                     output_stream: Optional['io.TextIOBase'] = ...,
                     resumable: bool = ...) -> Any:
@@ -249,11 +249,11 @@ def status_kubernetes() -> server_common.RequestId:
     ...
 
 
-def get(request_id: str) -> Any:
+def get(request_id: server_common.RequestId) -> Any:
     ...
 
 
-def stream_and_get(request_id: Optional[str] = ...,
+def stream_and_get(request_id: Optional[server_common.RequestId] = ...,
                    log_path: Optional[str] = ...,
                    tail: Optional[int] = ...,
                    follow: bool = ...,
@@ -261,13 +261,14 @@ def stream_and_get(request_id: Optional[str] = ...,
     ...
 
 
-def api_cancel(request_ids: Optional[Union[str, List[str]]] = ...,
+def api_cancel(request_ids: Optional[Union[
+    server_common.RequestId, List[server_common.RequestId]]] = ...,
                all_users: bool = ...,
                silent: bool = ...) -> server_common.RequestId:
     ...
 
 
-def api_status(request_ids: Optional[List[str]] = ...,
+def api_status(request_ids: Optional[List[server_common.RequestId]] = ...,
                all_status: bool = ...) -> List[payloads.RequestPayload]:
     ...
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
When making an SDK call, the SDK call returns a `RequestID`.
<img width="504" height="146" alt="Screenshot 2025-08-01 at 12 13 33 PM" src="https://github.com/user-attachments/assets/734134f9-2c32-4366-a169-1871a9c323d6" />
The intended use is to then pass the RequestId (which is actually just a `str`) to `get` call or `stream_and_get` call, but those calls take `str` as an argument which is confusing.
<img width="441" height="68" alt="Screenshot 2025-08-01 at 12 13 40 PM" src="https://github.com/user-attachments/assets/3cf88431-f4fd-4c1c-af1b-e7636603d764" />
Suggested fix: Change the argument type for `request_id` in calls that accept request ID to `server_common.RequestID`


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
