### PR TITLE
[sdk] specify request ID can be prefix

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -95,7 +95,8 @@ def stream_response(request_id: Optional[str],
     """Streams the response to the console.
 
     Args:
-        request_id: The request ID.
+        request_id: The request ID of the request to stream. May be a full
+            request ID or a prefix.
         response: The HTTP response.
         output_stream: The output stream to write to. If None, print to the
             console.
@@ -1764,7 +1765,8 @@ def get(request_id: str) -> Any:
     may cause GET /api/get being sent to a restarted API server.
 
     Args:
-        request_id: The request ID of the request to get.
+        request_id: The request ID of the request to get. May be a full request
+            ID or a prefix.
 
     Returns:
         The ``Request Returns`` of the specified request. See the documentation
@@ -1830,7 +1832,8 @@ def stream_and_get(
     prefix of the full request id.
 
     Args:
-        request_id: The prefix of the request ID of the request to stream.
+        request_id: The request ID of the request to stream. May be a full
+            request ID or a prefix.
         log_path: The path to the log file to stream.
         tail: The number of lines to show from the end of the logs.
             If None, show all logs.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
The function signature/docstring of get makes it seem like the request_id must be the full request ID. 
<img width="584" height="171" alt="Screenshot 2025-08-01 at 12 23 23 PM" src="https://github.com/user-attachments/assets/2a6fa26a-c10d-494a-8a94-eebb82a100b5" />
In reality, all functions that takes in a request ID as an argument work even if the request ID is a prefix of a full request ID.

Modify the docstring to make this fact clear.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
