### PR TITLE
[dashboard] sky check on infra page hard refresh

### DIFF
--- a/sky/dashboard/src/data/connectors/infra.jsx
+++ b/sky/dashboard/src/data/connectors/infra.jsx
@@ -3,11 +3,36 @@ import { CLOUDS_LIST, COMMON_GPUS } from '@/data/connectors/constants';
 // Importing from the same directory
 import { apiClient } from '@/data/connectors/client';
 
-export async function getCloudInfrastructure(clusters, jobs) {
+export async function getCloudInfrastructure(
+  clusters,
+  jobs,
+  forceRefresh = false
+) {
   try {
     // Get enabled clouds
     let enabledCloudsList = [];
     try {
+      // If forceRefresh is true, first run sky check to refresh cloud status
+      if (forceRefresh) {
+        console.log('Force refreshing clouds by running sky check...');
+        try {
+          const checkResponse = await apiClient.post('/check', {});
+          const checkId =
+            checkResponse.headers.get('X-Skypilot-Request-ID') ||
+            checkResponse.headers.get('X-Request-ID');
+
+          // Wait for the check to complete
+          const checkResult = await apiClient.get(
+            `/api/get?request_id=${checkId}`
+          );
+          const checkData = await checkResult.json();
+          console.log('Sky check completed:', checkData);
+        } catch (checkError) {
+          console.error('Error running sky check:', checkError);
+          // Continue anyway - we'll still try to get the cached enabled clouds
+        }
+      }
+
       const enabledCloudsResponse = await apiClient.get(`/enabled_clouds`);
 
       const id =
@@ -95,7 +120,7 @@ export async function getCloudInfrastructure(clusters, jobs) {
  * Main function to get all infrastructure data.
  * Uses cached data from clusters and jobs to avoid redundant API calls.
  */
-export async function getInfraData() {
+export async function getInfraData(forceRefresh = false) {
   // Import here to avoid circular dependencies
   const { getClusters } = await import('@/data/connectors/clusters');
   const { getManagedJobs } = await import('@/data/connectors/jobs');
@@ -113,7 +138,7 @@ export async function getInfraData() {
   // Fetch both GPU and cloud data together
   const [gpuData, cloudData] = await Promise.all([
     getGPUs(clusters, jobs),
-    getCloudInfrastructure(clusters, jobs),
+    getCloudInfrastructure(clusters, jobs, forceRefresh),
   ]);
 
   return {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses issue [6470](https://github.com/skypilot-org/skypilot/issues/6470) where newly added credentials were not being "discovered" by the dashboard until the user ran `sky check`. If a user is clicking the refresh button or hard refreshing the page with cmd/ctrl+r, we should respect their intent and run `sky check` to pick up on newly added/removed credentials.


<!-- Describe the tests ran -->
This PR was tested by manually adding and removing clouds from the `allowed_cloud:` section of the global sky config yaml and verifying that the updates show up in the dashboard on refresh. This is in comparison to the previous behavior where the dashboard would not pick up on the change until the user runs `sky check`. 

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
