### PR TITLE
[sdk] underscore internal arguments to task initialization

### DIFF
--- a/sky/task.py
+++ b/sky/task.py
@@ -656,11 +656,7 @@ class Task:
             secrets=config.pop('secrets', None),
             volumes=config.pop('volumes', None),
             event_callback=config.pop('event_callback', None),
-            _file_mounts_mapping=config.pop(
-                '_file_mounts_mapping',
-                # BW compatibility: This field used to be named file_mounts_mapping.
-                # TODO(syang): Remove this in 0.11.0.
-                config.pop('file_mounts_mapping', None)),
+            _file_mounts_mapping=config.pop('file_mounts_mapping', None),
             _metadata=config.pop('_metadata', None),
             _user_specified_yaml=user_specified_yaml,
         )
@@ -797,11 +793,7 @@ class Task:
             pool = service_spec.SkyServiceSpec.from_yaml_config(pool)
             task.set_service(pool)
 
-        volume_mounts = config.pop(
-            '_volume_mounts',
-            # BW compatibility: This field used to be named volume_mounts.
-            # TODO(syang): Remove this in 0.11.0.
-            config.pop('volume_mounts', None))
+        volume_mounts = config.pop('volume_mounts', None)
         if volume_mounts is not None:
             task.volume_mounts = []
             for vol in volume_mounts:
@@ -1676,10 +1668,10 @@ class Task:
                 for mount_path, storage in self.storage_mounts.items()
             })
 
-        add_if_not_none('_file_mounts_mapping', self.file_mounts_mapping)
+        add_if_not_none('file_mounts_mapping', self.file_mounts_mapping)
         add_if_not_none('volumes', self.volumes)
         if self.volume_mounts is not None:
-            config['_volume_mounts'] = [
+            config['volume_mounts'] = [
                 volume_mount.to_yaml_config()
                 for volume_mount in self.volume_mounts
             ]


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
Unfortunately, the `# Internal use only.` comment on L255 is not visible on the docstring so there is no way for the user to know what fields are meant for them and what fields are meant for SkyPilot use. Prefix an underscore in front of the internal variables to make clear that these arguments are for internal use only.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
