### PR TITLE
Fix `test_skyserve_llm` failure

### DIFF
--- a/tests/skyserve/llm/service.yaml
+++ b/tests/skyserve/llm/service.yaml
@@ -22,7 +22,7 @@ resources:
 setup: |
   uv venv --python 3.10 --seed
   source .venv/bin/activate
-  uv pip install vllm==0.10.0 --torch-backend=auto
+  uv pip install vllm==0.10.0
   # Have to use triton==3.2.0 to avoid https://github.com/triton-lang/triton/issues/6698
   uv pip install triton==3.2.0
   uv pip install openai


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Error log:

```bash
I 08-05 03:09:03 replica_managers.py:111] Replica cluster t-ss-llm-5b3f911a-74-1 launched.
Start streaming logs for task job of replica 1...
Job ID not provided. Streaming the logs of the latest job.
├── Waiting for task resources on 1 node.
└── Job started. Streaming logs... (Ctrl-C to exit log streaming; job will not be killed)
(setup pid=1293) Using CPython 3.10.13 interpreter at: /home/sky/miniconda3/bin/python3.10
(setup pid=1293) Creating virtual environment with seed packages at: .venv
(setup pid=1293)  + pip==25.2
(setup pid=1293)  + setuptools==80.9.0
(setup pid=1293)  + wheel==0.45.1
(setup pid=1293) error: unexpected argument '--torch-backend' found
(setup pid=1293) 
(setup pid=1293)   tip: a similar argument exists: '--no-cache'
(setup pid=1293) 
(setup pid=1293) Usage: uv pip install --no-cache <PACKAGE|--requirements <REQUIREMENTS>|--editable <EDITABLE>>
(setup pid=1293) 
(setup pid=1293) For more information, try '--help'.
(setup pid=1293) Resolved 1 package in 49ms
(setup pid=1293) Downloading triton (241.4MiB)
(setup pid=1293)  Downloaded triton
(setup pid=1293) Prepared 1 package in 2.76s
(setup pid=1293) Installed 1 package in 9ms
(setup pid=1293)  + triton==3.2.0
(setup pid=1293) Resolved 17 packages in 118ms
(setup pid=1293) Downloading pydantic-core (1.9MiB)
(setup pid=1293)  Downloaded pydantic-core
(setup pid=1293) Prepared 13 packages in 145ms
(setup pid=1293) Installed 17 packages in 70ms
(setup pid=1293)  + annotated-types==0.7.0
(setup pid=1293)  + anyio==4.10.0
(setup pid=1293)  + certifi==2025.8.3
(setup pid=1293)  + distro==1.9.0
(setup pid=1293)  + exceptiongroup==1.3.0
(setup pid=1293)  + h11==0.16.0
(setup pid=1293)  + httpcore==1.0.9
(setup pid=1293)  + httpx==0.28.1
(setup pid=1293)  + idna==3.10
(setup pid=1293)  + jiter==0.10.0
(setup pid=1293)  + openai==1.98.0
(setup pid=1293)  + pydantic==2.11.7
(setup pid=1293)  + pydantic-core==2.33.2
(setup pid=1293)  + sniffio==1.3.1
(setup pid=1293)  + tqdm==4.67.1
(setup pid=1293)  + typing-extensions==4.14.1
(setup pid=1293)  + typing-inspection==0.4.1
(t-ss-llm-5b3f911a-74, pid=1293) bash: vllm: command not found
✓ Job finished (status: SUCCEEDED).

(base) buildkite@52:~/.buildkite-agent/builds/eks/52-91-93-48-buildkite-eks1-1/skypilot-1/smoke-tests$ 
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):
- [x] Relevant individual tests: `/smoke-test -k test_skyserve_llm` (CI)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
