### PR TITLE
Fix `test_kubernetes_context_failover` failure

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -3694,6 +3694,9 @@ def show_gpus(
         print_section_titles = False
         if (is_ssh and query_ssh_realtime_gpu or query_k8s_realtime_gpu):
             context = region
+            # Convert '*' back to None for GPU query to query all contexts
+            if context == '*':
+                context = None
 
             try:
                 # If --cloud kubernetes is not specified, we want to catch
@@ -3745,9 +3748,13 @@ def show_gpus(
             print_section_titles = True
             # TODO(romilb): Show filtered per node GPU availability here as well
             try:
+                context = region
+                # Convert '*' back to None for GPU query to query all contexts
+                if context == '*':
+                    context = None
                 (k8s_realtime_infos, total_table,
                  all_nodes_info) = _get_kubernetes_realtime_gpu_tables(
-                     context=region,
+                     context=context,
                      name_filter=name,
                      quantity_filter=quantity,
                      is_ssh=is_ssh)

--- a/sky/utils/config_utils.py
+++ b/sky/utils/config_utils.py
@@ -254,7 +254,7 @@ def get_cloud_config_value_from_dict(
         region_key = 'region_configs'
 
     per_context_config = None
-    if region is not None and region_key is not None:
+    if region is not None and region != '*' and region_key is not None:
         per_context_config = input_config.get_nested(
             keys=(cloud, region_key, region) + keys,
             default_value=None,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Resolve #6508

# What PR #6392 Did

PR #6392: "Fix infra override flag precedence" introduced a change to improve how SkyPilot handles infrastructure override parameters. The key change was in the `_handle_infra_cloud_region_zone_options` function:

**Before PR #6392:**  

```python
if infra is not None:
    infra_info = infra_utils.InfraInfo.from_str(infra)
    cloud = infra_info.cloud
    region = infra_info.region  # Could be None
    zone = infra_info.zone      # Could be None
```

**After PR #6392:**  

```python
if infra is not None:
    infra_info = infra_utils.InfraInfo.from_str(infra)
    # Convert None to '*' to ensure proper override behavior
    cloud = infra_info.cloud if infra_info.cloud is not None else '*'
    region = infra_info.region if infra_info.region is not None else '*'
    zone = infra_info.zone if infra_info.zone is not None else '*'
```

### Problem
PR #6392 introduced a regression that broke the `test_kubernetes_context_failover` test. The issue was that the PR changed `--infra kubernetes` to return `region='*'` instead of `region=None`, which caused two problems:

1. **GPU Query Issue**: The GPU query logic expects `context=None` to query all contexts, but was receiving `context='*'`
2. **Config Lookup Issue**: The config lookup logic treats `region='*'` as a specific context lookup instead of global config lookup

### Root Cause Analysis
**Before PR #6392:**
- `--infra kubernetes` → `region=None`
  - GPU query with `context=None` → queries all contexts ✅
  - Config lookup with `region=None` → uses global config ✅

**After PR #6392:**
- `--infra kubernetes` → `region='*'`
  - GPU query with `context='*'` → fails to query all contexts ❌
  - Config lookup with `region='*'` → tries context-specific lookup at `kubernetes/context_configs/*/...` ❌

### Solution
1. **CLI Fix** (`sky/client/cli/command.py`)
   - Convert `'*'` back to `None` for GPU query context in two places

```python
# In show_gpus function
if (is_ssh and query_ssh_realtime_gpu or query_k8s_realtime_gpu):
    context = region
    # Convert '*' back to None for GPU query to query all contexts
    if context == '*':
        context = None

# In _possibly_show_k8s_like_realtime_for_acc function  
context = region
# Convert '*' back to None for GPU query to query all contexts
if context == '*':
    context = None
```

2. **Config Fix** (`sky/utils/config_utils.py`)
   - Treat `'*'` the same as `None` in config lookup

```python
# Before
if region is not None and region_key is not None:

# After  
if region is not None and region != '*' and region_key is not None:
```

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Relevant individual tests: `/smoke-test -k test_kubernetes_context_failover --kubernetes` (CI) or `pytest tests/test_smoke.py::test_name` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
