### PR TITLE
Fixed helm template for oauth

### DIFF
--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -57,52 +57,52 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: {{ index .Values.ingress "oauth2-proxy" "image" | default "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0" }}
+        image: {{ index $oauth2 "image" | default "quay.io/oauth2-proxy/oauth2-proxy:v7.9.0" }}
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
-        - --oidc-issuer-url={{ index .Values.ingress "oauth2-proxy" "oidc-issuer-url" }}
-        - --email-domain={{ index .Values.ingress "oauth2-proxy" "email-domain" | default "*" }}
+        - --oidc-issuer-url={{ index $oauth2 "oidc-issuer-url" }}
+        - --email-domain={{ index $oauth2 "email-domain" | default "*" }}
         - --upstream=file:///dev/null
         - --http-address=0.0.0.0:4180
         - --skip-provider-button=true
         - --reverse-proxy=true
         - --set-xauthrequest
-        - --session-store-type={{ index .Values.ingress "oauth2-proxy" "session-store-type" | default "redis" }}
-        {{- if not (index .Values.ingress "oauth2-proxy" "use-https" | default false) }}
+        - --session-store-type={{ index $oauth2 "session-store-type" | default "redis" }}
+        {{- if not (index $oauth2 "use-https" | default false) }}
         - --cookie-secure=false
         {{- end }}
-        {{- if (index .Values.ingress "oauth2-proxy" "cookie-refresh") }}
-        - --cookie-refresh={{ index .Values.ingress "oauth2-proxy" "cookie-refresh" }}
+        {{- if (index $oauth2 "cookie-refresh") }}
+        - --cookie-refresh={{ index $oauth2 "cookie-refresh" }}
         {{- end }}
-        {{- if (index .Values.ingress "oauth2-proxy" "cookie-expire") }}
-        - --cookie-expire={{ index .Values.ingress "oauth2-proxy" "cookie-expire" }}
+        {{- if (index $oauth2 "cookie-expire") }}
+        - --cookie-expire={{ index $oauth2 "cookie-expire" }}
         {{- end }}
-        {{- if eq (index .Values.ingress "oauth2-proxy" "session-store-type" | default "redis") "redis" }}
-        {{- if (index .Values.ingress "oauth2-proxy" "redis-url") }}
-        - --redis-connection-url={{ index .Values.ingress "oauth2-proxy" "redis-url" }}
+        {{- if eq (index $oauth2 "session-store-type" | default "redis") "redis" }}
+        {{- if (index $oauth2 "redis-url") }}
+        - --redis-connection-url={{ index $oauth2 "redis-url" }}
         {{- else }}
         - --redis-connection-url=redis://$(SERVICE_NAME)-oauth2-proxy-redis:6379/0
         {{- end }}
         {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
-          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
+          {{- if (index $oauth2 "client-details-from-secret") }}
           valueFrom:
             secretKeyRef:
-              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
+              name: {{ index $oauth2 "client-details-from-secret" }}
               key: {{ $clientIdKey }}
           {{- else }}
-          value: {{ index .Values.ingress "oauth2-proxy" "client-id" | quote }}
+          value: {{ index $oauth2 "client-id" | quote }}
           {{- end }}
         - name: OAUTH2_PROXY_CLIENT_SECRET
-          {{- if (index .Values.ingress "oauth2-proxy" "client-details-from-secret") }}
+          {{- if (index $oauth2 "client-details-from-secret") }}
           valueFrom:
             secretKeyRef:
-              name: {{ index .Values.ingress "oauth2-proxy" "client-details-from-secret" }}
+              name: {{ index $oauth2 "client-details-from-secret" }}
               key: {{ $clientSecretKey }}
           {{- else }}
-          value: {{ index .Values.ingress "oauth2-proxy" "client-secret" | quote }}
+          value: {{ index $oauth2 "client-secret" | quote }}
           {{- end }}
         - name: SERVICE_NAME
           value: {{ .Release.Name }}

--- a/charts/skypilot/tests/oauth2_test.yaml
+++ b/charts/skypilot/tests/oauth2_test.yaml
@@ -30,10 +30,6 @@ tests:
   - it: should create oauth2-proxy resources when legacy config is enabled
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -56,10 +52,6 @@ tests:
   - it: should configure oauth2-proxy deployment with legacy values
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -99,9 +91,6 @@ tests:
   - it: should configure oauth2-proxy with client credentials from secret (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-details-from-secret: "oauth-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -124,10 +113,6 @@ tests:
   - it: should configure oauth2-proxy with external redis (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -143,12 +128,6 @@ tests:
   - it: should not create redis when external redis is configured (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
-      # Due to template bug, Redis URL must be set in auth.oauth even for legacy config
-      auth.oauth.redis-url: "redis://external-redis:6379/1"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -163,10 +142,6 @@ tests:
   - it: should configure cookie session store when specified (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -182,10 +157,6 @@ tests:
   - it: should configure ingress with oauth2-proxy annotations (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -210,10 +181,6 @@ tests:
   - it: should configure ingress with HTTPS oauth2-proxy annotations (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -232,10 +199,6 @@ tests:
   - it: should create oauth2-proxy ingress (legacy)
     set:
       auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
@@ -265,11 +228,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
     asserts:
       - hasDocuments:
           count: 1
@@ -287,11 +245,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
     template: templates/api-deployment.yaml
     asserts:
       - contains:
@@ -311,11 +264,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
     template: templates/oauth2-proxy-ingress.yaml
     asserts:
       - hasDocuments:
@@ -328,11 +276,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
     template: templates/ingress.yaml
     asserts:
       - notExists:
@@ -340,45 +283,14 @@ tests:
       - notExists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/auth-url"]
 
-  # ============================================================================
-  # Tests for cookie timing configuration
-  # ============================================================================
-  - it: should configure cookie timing settings (legacy)
-    set:
-      auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
-      ingress.enabled: true
-      ingress.oauth2-proxy.enabled: true
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.cookie-refresh: 3600
-      ingress.oauth2-proxy.cookie-expire: 7200
-    template: templates/oauth2-proxy-deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--cookie-refresh=3600"
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--cookie-expire=7200"
-
   - it: should configure cookie timing settings (new auth)
     set:
       auth.oauth.enabled: true
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.cookie-refresh: 3600
-      ingress.oauth2-proxy.cookie-expire: 7200
+      auth.oauth.cookie-refresh: 3600
+      auth.oauth.cookie-expire: 7200
     template: templates/oauth2-proxy-deployment.yaml
     asserts:
       - contains:
@@ -391,7 +303,6 @@ tests:
   - it: should fail when oidc-issuer-url is missing (legacy)
     set:
       auth.oauth.enabled: false
-      # For error testing, we don't set auth.oauth values to trigger validation failure
       ingress.enabled: true
       ingress.oauth2-proxy.enabled: true
       ingress.oauth2-proxy.client-id: "test-client-id"
@@ -422,11 +333,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
     template: templates/oauth2-proxy-service.yaml
     asserts:
       - isKind:
@@ -450,12 +356,6 @@ tests:
       auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
       auth.oauth.client-id: "test-client-id"
       auth.oauth.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.enabled: false
-      # Since the template still uses ingress.oauth2-proxy values, we need to set them too
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
-      ingress.oauth2-proxy.session-store-type: "redis"
     template: templates/oauth2-proxy-redis.yaml
     asserts:
       - hasDocuments:
@@ -474,27 +374,3 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "redis:7-alpine"
         documentIndex: 0
-
-  - it: should use default values when not specified (legacy)
-    set:
-      auth.oauth.enabled: false
-      # Template bug: validation checks auth.oauth values even when disabled
-      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      auth.oauth.client-id: "test-client-id"
-      auth.oauth.client-secret: "test-client-secret"
-      ingress.enabled: true
-      ingress.oauth2-proxy.enabled: true
-      ingress.oauth2-proxy.oidc-issuer-url: "https://example.okta.com/oauth2/default"
-      ingress.oauth2-proxy.client-id: "test-client-id"
-      ingress.oauth2-proxy.client-secret: "test-client-secret"
-    template: templates/oauth2-proxy-deployment.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--email-domain=*"
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--session-store-type=redis"
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--cookie-secure=false"


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Fixed helm templating for OAuth when new config is not set under `auth.oauthn`

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
