### PR TITLE
fix '*' handling in show_gpus

### DIFF
--- a/sky/client/cli/command.py
+++ b/sky/client/cli/command.py
@@ -3463,6 +3463,17 @@ def show_gpus(
                                                                region,
                                                                zone=None)
 
+    # cloud and region could be '*' from _handle_infra_cloud_region_zone_options
+    # which normally indicates to
+    # _make_task_or_dag_from_entrypoint_with_overrides -> _parse_override_params
+    # to disregard the cloud and region from the YAML.
+    # In show_gpus, there is no YAML, so we need to handle the '*' value
+    # directly here. We should use None instead to indicate "any".
+    if cloud == '*':
+        cloud = None
+    if region == '*':
+        region = None
+
     # validation for the --region flag
     if region is not None and cloud is None:
         raise click.UsageError(


### PR DESCRIPTION
Fixes #6508.

See #6508 and #6509 for details.

This PR is an alternative approach that aims to keep all the `show_gpus` behavior the same as before. The special `'*'` value was intended to interact only with the task overrides, and the effect on `show_gpus` was unintentional. So this will revert to the previous behavior for `show_gpus`.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] The specific failed k8s test (#6508)
