### PR TITLE
[Controller] Hide clusters from consolidation mode

### DIFF
--- a/sky/dashboard/src/components/clusters.jsx
+++ b/sky/dashboard/src/components/clusters.jsx
@@ -627,11 +627,25 @@ export function ClusterTable({
   const sortedData = React.useMemo(() => {
     // Main filter function
     const filterData = (data, filters) => {
-      if (filters.length === 0) {
-        return data;
+      // First, filter out consolidation-system clusters by default
+      // unless there's an explicit user filter that includes consolidation-system
+      let filteredData = data;
+      
+      const userFilters = filters.filter(filter => filter.property === 'User');
+      const hasConsolidationSystemFilter = userFilters.some(filter => 
+        filter.value && filter.value.toLowerCase() === 'consolidation-system'
+      );
+      
+      // Only exclude consolidation-system if there's no explicit user filter for it
+      if (userFilters.length === 0 || !hasConsolidationSystemFilter) {
+        filteredData = data.filter((item) => item.user !== 'consolidation-system');
       }
 
-      return data.filter((item) => {
+      if (filters.length === 0) {
+        return filteredData;
+      }
+
+      return filteredData.filter((item) => {
         let result = null;
 
         for (let i = 0; i < filters.length; i++) {

--- a/sky/jobs/server/core.py
+++ b/sky/jobs/server/core.py
@@ -348,6 +348,7 @@ def launch(
                     # afterwards without recreate the controller. Need to
                     # revisit this.
                     local_user_config=mutated_user_config,
+                    is_consolidation_mode=consolidation_mode_job_id is not None,
                 ),
             }
 

--- a/sky/serve/server/impl.py
+++ b/sky/serve/server/impl.py
@@ -213,6 +213,7 @@ def up(
                 controller=controller_utils.Controllers.SKY_SERVE_CONTROLLER,
                 remote_user_config_path=remote_config_yaml_path,
                 local_user_config=mutated_user_config,
+                is_consolidation_mode=controller_job_id is not None,
             ),
         }
         common_utils.fill_template(serve_constants.CONTROLLER_TEMPLATE,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

This PR moves cluster created by consolidation mode controller to a special user `consolidation-system`. It will not show up in both CLI and dashboard by default but still available on `-u` option or user filter.

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
