### PR TITLE
[API Server] Fix busy loop when consolidation mode is disabled

### DIFF
--- a/sky/server/server.py
+++ b/sky/server/server.py
@@ -451,6 +451,8 @@ async def lifespan(app: fastapi.FastAPI):  # pylint: disable=redefined-outer-nam
     del app  # unused
     # Startup: Run background tasks
     for event in daemons.INTERNAL_REQUEST_DAEMONS:
+        if event.should_skip():
+            continue
         try:
             executor.schedule_request(
                 request_id=event.id,


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Tested with only jobs consolidation mode and the serve refresh event is skipped. the cpu usage also becomes normal now.

<img width="648" height="140" alt="image" src="https://github.com/user-attachments/assets/66f8efac-0aa4-4e56-9ffd-1a8c1821252d" />
<img width="885" height="111" alt="image" src="https://github.com/user-attachments/assets/23546038-d172-4e18-8a0b-78eca4590d86" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
