### PR TITLE
[sdk] clarify the sdk call behavior on none request_id

### DIFF
--- a/sky/client/sdk.py
+++ b/sky/client/sdk.py
@@ -97,6 +97,8 @@ def stream_response(request_id: Optional[server_common.RequestId],
     Args:
         request_id: The request ID of the request to stream. May be a full
             request ID or a prefix.
+            If None, the latest request submitted to the API server is streamed.
+            Using None request_id is not recommended in multi-user environments.
         response: The HTTP response.
         output_stream: The output stream to write to. If None, print to the
             console.
@@ -1834,6 +1836,8 @@ def stream_and_get(
     Args:
         request_id: The request ID of the request to stream. May be a full
             request ID or a prefix.
+            If None, the latest request submitted to the API server is streamed.
+            Using None request_id is not recommended in multi-user environments.
         log_path: The path to the log file to stream.
         tail: The number of lines to show from the end of the logs.
             If None, show all logs.


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
`stream_response` and `stream_and_get` accepts `request_id` that is optional. The current docstring does not clarify what happens when `request_id` is None. Add some clarification to docstring.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
