### PR TITLE
Fix frntend workspace display

### DIFF
--- a/sky/dashboard/src/components/workspace-editor.jsx
+++ b/sky/dashboard/src/components/workspace-editor.jsx
@@ -94,7 +94,23 @@ const WorkspaceConfigDescription = ({
 
     const cloudName =
       CLOUD_CANONICALIZATIONS[cloud.toLowerCase()] || cloud.toUpperCase();
-    const isActuallyEnabled = enabledCloudsSet.has(cloudName?.toLowerCase());
+
+    // Check if cloud is enabled - handle both exact matches and expanded cloud names
+    // (e.g., 'kubernetes' should match both 'kubernetes' and 'kubernetes/context-name')
+    const cloudLower = cloudName?.toLowerCase();
+    const isActuallyEnabled = enabledCloudsSet.has(cloudLower) ||
+      Array.from(enabledCloudsSet).some(enabledCloud =>
+        enabledCloud.startsWith(cloudLower + '/'));
+
+    // For Kubernetes, get the specific contexts that are enabled
+    const getEnabledKubernetesContexts = () => {
+      if (cloud.toLowerCase() === 'kubernetes') {
+        return Array.from(enabledCloudsSet).filter(enabledCloud =>
+          enabledCloud.startsWith(cloudLower + '/')
+        ).map(k8sCloud => k8sCloud.split('/')[1]); // Extract context name
+      }
+      return [];
+    };
 
     if (cloudConfig?.disabled === true) {
       disabledClouds.push(cloudName);
@@ -104,6 +120,11 @@ const WorkspaceConfigDescription = ({
         detail = ` (Project ID: ${cloudConfig.project_id})`;
       } else if (cloud.toLowerCase() === 'aws' && cloudConfig.region) {
         detail = ` (Region: ${cloudConfig.region})`;
+      } else if (cloud.toLowerCase() === 'kubernetes') {
+        const enabledContexts = getEnabledKubernetesContexts();
+        if (enabledContexts.length > 0) {
+          detail = ` (Contexts: ${enabledContexts.join(', ')})`;
+        }
       }
 
       if (isActuallyEnabled) {
@@ -126,9 +147,18 @@ const WorkspaceConfigDescription = ({
       }
     } else {
       if (isActuallyEnabled) {
+        // For Kubernetes with no specific config, still show available contexts
+        let defaultDetail = '';
+        if (cloud.toLowerCase() === 'kubernetes') {
+          const enabledContexts = getEnabledKubernetesContexts();
+          if (enabledContexts.length > 0) {
+            defaultDetail = ` (Contexts: ${enabledContexts.join(', ')})`;
+          }
+        }
+
         enabledDescriptions.push(
           <span key={`${cloud}-default-enabled`} className="block">
-            {cloudName} is enabled (using default settings).
+            {cloudName}{defaultDetail} is enabled (using default settings).
           </span>
         );
       } else {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

```bash
(sky) zpoint:~/codes/skypilot (dev/zeping/fix_workspace_displaying)$ cat ~/.sky/config.yaml 
workspaces:
  research-private:
    private: true
    allowed_users:
      - alice@skypilot.co
      - mike@skypilot.co
    gcp:
      project_id: sky-dev-465
    aws:
      disabled: true
    kubernetes:
      allowed_contexts:
        - kind-skypilot
        - gke_skypilot-demo-465806_us-central1-a_skypilot-demo-new-staging
```

# Before:

<img width="2550" height="1197" alt="image" src="https://github.com/user-attachments/assets/b81ef699-7466-4852-b0bc-036cd0406974" />

# After:

<img width="2934" height="1617" alt="image" src="https://github.com/user-attachments/assets/75d7ac9e-21c3-4331-bd72-e8e3d48b3331" />


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
