### PR TITLE
[test] fix test_skyserve_dynamic_ondemand_fallback failure

### DIFF
--- a/tests/smoke_tests/test_sky_serve.py
+++ b/tests/smoke_tests/test_sky_serve.py
@@ -422,7 +422,7 @@ def test_skyserve_dynamic_ondemand_fallback():
         'test-skyserve-dynamic-ondemand-fallback',
         [
             smoke_tests_utils.launch_cluster_for_cloud_cmd('gcp', name),
-            f'sky serve up -n {name} --infra gcp {smoke_tests_utils.LOW_RESOURCE_ARG} -y tests/skyserve/spot/dynamic_ondemand_fallback.yaml',
+            f'sky serve up -n {name} {smoke_tests_utils.LOW_RESOURCE_ARG} -y tests/skyserve/spot/dynamic_ondemand_fallback.yaml',
             f'sleep 40',
             # 2 on-demand (provisioning) + 2 Spot (provisioning).
             f'{_SERVE_STATUS_WAIT.format(name=name)}; echo "$s";'


### PR DESCRIPTION
Fixes #6539.

Before, `--infra` flag would not override all of cloud/region/zone. After #6392, it will override all three, even if only one is specified. (So `--infra gcp` means "GCP, any region", even if there is a region specified in the YAML.)

Since the region info is specified in the YAML, the CLI `--infra gcp` flag is not needed. So we just remove it.

<!-- Describe the changes in this PR -->



<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] test_skyserve_dynamic_ondemand_fallback

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
