### PR TITLE
[UX] fix vs code remote ssh command

### DIFF
--- a/examples/k8s_cloud_deploy/README.md
+++ b/examples/k8s_cloud_deploy/README.md
@@ -60,7 +60,7 @@ To launch a [GPU enabled development cluster](https://docs.skypilot.co/en/latest
 
 SkyPilot will setup SSH config for you.
 * [SSH access](https://docs.skypilot.co/en/latest/examples/interactive-development.html#ssh): `ssh mycluster`
-* [VSCode remote development](https://docs.skypilot.co/en/latest/examples/interactive-development.html#vscode): `code --folder-uri "vscode-remote://ssh-remote+mycluster/home"`
+* [VSCode remote development](https://docs.skypilot.co/en/latest/examples/interactive-development.html#vscode): `code --remote ssh-remote+mycluster "/home"`
 
 
 ### Jobs

--- a/sky/dashboard/src/components/elements/modals.jsx
+++ b/sky/dashboard/src/components/elements/modals.jsx
@@ -121,8 +121,7 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                   <div className="flex items-center justify-between">
                     <pre className="text-sm">
                       <code>
-                        code --folder-uri &quot;vscode-remote://ssh-remote+
-                        {cluster}/home&quot;
+                        code --remote ssh-remote+{cluster} &quot;/home&quot;
                       </code>
                     </pre>
                     <Tooltip content="Copy command">
@@ -131,7 +130,7 @@ export function VSCodeInstructionsModal({ isOpen, onClose, cluster }) {
                         size="icon"
                         onClick={() =>
                           navigator.clipboard.writeText(
-                            `code --folder-uri "vscode-remote://ssh-remote+${cluster}/home"`
+                            `code --remote ssh-remote+${cluster} "/home"`
                           )
                         }
                         className="h-8 w-8 rounded-full"

--- a/sky/utils/kubernetes/deploy_remote_cluster.py
+++ b/sky/utils/kubernetes/deploy_remote_cluster.py
@@ -1276,9 +1276,9 @@ def deploy_cluster(head_node,
     print(
         '  • Launch a GPU development pod: sky launch -c devbox --cloud kubernetes'
     )
-    print('  • Connect to pod with VSCode: code --folder-uri '
-          '"vscode-remote://ssh-remote+devbox/home"')
-
+    print(
+        '  • Connect to pod with VSCode: code --remote ssh-remote+devbox "/home"'
+    )
     # Print completion marker for current cluster
     print(f'{GREEN}SKYPILOT_CLUSTER_COMPLETED: {NC}')
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
This PR addresses issue [6529](https://github.com/skypilot-org/skypilot/issues/6529) by updating the suggested command for opening up vs code via an ssh connection to a sky cluster:

The command was previously listed in some places as `code --remote ssh-remote+my-cluster "/"` which "works" but puts the user in the top level directory and in others (including the dashboard) as `code --remote ssh-remote+my-cluster` which does not work.

The recommended command was modified to `code --remote ssh-remote+my-cluster "/home"` which works on all infra types and puts the user in the home directory. We just specify the `/home` path rather than a specific user like `/home/ubuntu` or `/home/sky` because the user varies from cloud to cloud. For example, on k8s it's `/home/sky`, on aws it's `/home/ubuntu`, and on azure its `/home/azureuser`. 

<!-- Describe the tests ran -->
This PR was tested by sky launching a cluster on k8s, aws, and azure and verifying that the command specified in the dashboard indeed launched vs code and successfully established an ssh connection to the clusters' home directories.

<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
