### PR TITLE
Support redis-secret for configuring redis-url

### DIFF
--- a/charts/skypilot/templates/oauth2-proxy-deployment.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-deployment.yaml
@@ -12,6 +12,9 @@
 {{- if and (not (index $oauth2 "client-details-from-secret")) (eq (index $oauth2 "client-secret") "") -}}
 {{- fail "ingress.oauth2-proxy.client-secret is required when OAuth2 proxy is enabled and client-details-from-secret is not set" -}}
 {{- end -}}
+{{- if and (index $oauth2 "redis-url") (index $oauth2 "redis-secret") -}}
+{{- fail "redis-url and redis-secret are mutually exclusive when OAuth2 proxy is enabled" -}}
+{{- end -}}
 
 {{- /* Determine the secret key format when using client-details-from-secret */ -}}
 {{- $clientIdKey := "client-id" -}}
@@ -81,6 +84,8 @@ spec:
         {{- if eq (index $oauth2 "session-store-type" | default "redis") "redis" }}
         {{- if (index $oauth2 "redis-url") }}
         - --redis-connection-url={{ index $oauth2 "redis-url" }}
+        {{- else if (index $oauth2 "redis-secret") }}
+        - --redis-connection-url=$(REDIS_URL)
         {{- else }}
         - --redis-connection-url=redis://$(SERVICE_NAME)-oauth2-proxy-redis:6379/0
         {{- end }}
@@ -106,6 +111,13 @@ spec:
           {{- end }}
         - name: SERVICE_NAME
           value: {{ .Release.Name }}
+        {{- if (index $oauth2 "redis-secret") }}
+        - name: REDIS_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ index $oauth2 "redis-secret" }}
+              key: redis_url
+        {{- end }}
         - name: OAUTH2_PROXY_COOKIE_SECRET
           {{- /* Look up existing deployment to get the current cookie secret if available */}}
           {{- $deploymentName := printf "%s-oauth2-proxy" .Release.Name }}

--- a/charts/skypilot/templates/oauth2-proxy-redis.yaml
+++ b/charts/skypilot/templates/oauth2-proxy-redis.yaml
@@ -3,7 +3,7 @@
 {{- if not .Values.auth.oauth.enabled -}}
 {{- $oauth2 = index .Values.ingress "oauth2-proxy" -}}
 {{- end -}}
-{{- if and (eq (index $oauth2 "session-store-type" | default "redis") "redis") (not (index $oauth2 "redis-url")) -}}
+{{- if and (eq (index $oauth2 "session-store-type" | default "redis") "redis") (not (index $oauth2 "redis-url")) (not (index $oauth2 "redis-secret")) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/skypilot/tests/oauth2_test.yaml
+++ b/charts/skypilot/tests/oauth2_test.yaml
@@ -374,3 +374,51 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "redis:7-alpine"
         documentIndex: 0
+
+  - it: should configure oauth2-proxy with redis-secret
+    set:
+      auth.oauth.enabled: true
+      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
+      auth.oauth.client-id: "test-client-id"
+      auth.oauth.client-secret: "test-client-secret"
+      auth.oauth.redis-secret: "redis-credentials"
+    template: templates/oauth2-proxy-deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--redis-connection-url=$(REDIS_URL)"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: "redis-credentials"
+                key: "redis-url"
+
+
+  - it: should not create redis when redis-secret is configured
+    set:
+      auth.oauth.enabled: true
+      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
+      auth.oauth.client-id: "test-client-id"
+      auth.oauth.client-secret: "test-client-secret"
+      auth.oauth.redis-secret: "redis-credentials"
+    template: templates/oauth2-proxy-redis.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+
+  - it: should fail when both redis-url and redis-secret are set
+    set:
+      auth.oauth.enabled: true
+      auth.oauth.oidc-issuer-url: "https://example.okta.com/oauth2/default"
+      auth.oauth.client-id: "test-client-id"
+      auth.oauth.client-secret: "test-client-secret"
+      auth.oauth.redis-url: "redis://external-redis:6379/1"
+      auth.oauth.redis-secret: "redis-credentials"
+    template: templates/oauth2-proxy-deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "redis-url and redis-secret are mutually exclusive when OAuth2 proxy is enabled"

--- a/charts/skypilot/values.yaml
+++ b/charts/skypilot/values.yaml
@@ -177,6 +177,11 @@ auth:
     # If set, this external Redis instance will be used
     # @schema type: [string, null]
     redis-url: null
+    # Secret containing Redis connection URL (redis_url: 'redis://host[:port][/db-number]').
+    # This is used to set redis url from an existing secret and is mutually exclusive with the redis-url field.
+    # Refer to redis-url for more details.
+    # @schema type: [string, null]
+    redis-secret: null
     # Cookie timing settings (in seconds)
     # @schema type: [string, number, null]
     cookie-refresh: null  # refresh tokens after this duration (Access token lifespan minus 1 min)

--- a/docs/source/reference/api-server/helm-values-spec.rst
+++ b/docs/source/reference/api-server/helm-values-spec.rst
@@ -84,6 +84,7 @@ Below is the available helm value keys and the default value of each key:
       :ref:`email-domain <helm-values-auth-oauth-email-domain>`: "*"
       :ref:`session-store-type <helm-values-auth-oauth-session-store-type>`: "redis"
       :ref:`redis-url <helm-values-auth-oauth-redis-url>`: null
+      :ref:`redis-secret <helm-values-auth-oauth-redis-secret>`: null
       :ref:`cookie-refresh <helm-values-auth-oauth-cookie-refresh>`: null
       :ref:`cookie-expire <helm-values-auth-oauth-cookie-expire>`: null
     :ref:`serviceAccount <helm-values-auth-serviceAccount>`:
@@ -842,6 +843,24 @@ Default: ``null``
   auth:
     oauth:
       redis-url: "redis://redis-host:6379/0"
+
+
+.. _helm-values-auth-oauth-redis-secret:
+
+``auth.oauth.redis-secret``
+''''''''''''''''''''''''''''
+
+Alternative way to specify Redis connection URL using a Kubernetes secret. The secret must contain a key named ``redis_url`` with the Redis connection URL in the format ``redis://host[:port][/db-number]``.
+
+This field is mutually exclusive with :ref:`redis-url <helm-values-auth-oauth-redis-url>`.
+
+Default: ``null``
+
+.. code-block:: yaml
+
+  auth:
+    oauth:
+      redis-secret: "my-redis-credentials"
 
 .. _helm-values-auth-oauth-cookie-refresh:
 


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

close https://github.com/skypilot-org/skypilot/issues/6558

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
