### PR TITLE
Helm: upgrade ingress-nginx to 4.11.8

### DIFF
--- a/charts/skypilot/Chart.yaml
+++ b/charts/skypilot/Chart.yaml
@@ -7,7 +7,7 @@ version: 0.0.0
 appVersion: "0.0"
 dependencies:
   - name: ingress-nginx
-    version: 4.11.3
+    version: 4.11.8
     repository: https://kubernetes.github.io/ingress-nginx
     condition: ingress-nginx.enabled
   - name: prometheus


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

Upgrade the default ingress-nginx version in favor of https://github.com/kubernetes/kubernetes/issues/131009

4.11.8 release note: https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.11.8

<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
