### PR TITLE
Restore frontend tour functionality

### DIFF
--- a/sky/dashboard/src/hooks/useTour.js
+++ b/sky/dashboard/src/hooks/useTour.js
@@ -1726,7 +1726,7 @@ export function TourProvider({ children }) {
         tourRef.current.complete();
       }
     };
-  }, [isFirstVisit, markTourCompleted, router, tourAutoStarted]);
+  }, [isFirstVisit]);
 
   // Block navigation during tour
   useEffect(() => {


### PR DESCRIPTION
<!-- Describe the changes in this PR -->

### Problem
The frontend tour was not displaying for first-time visitors after #6473. This was caused by an overly aggressive ESLint dependency fix in `useTour.js`.

### Root Cause
In `sky/dashboard/src/hooks/useTour.js` line 1729, the `useEffect` dependency array was changed from `[isFirstVisit]` to `[isFirstVisit, markTourCompleted, router, tourAutoStarted]`. This created a problematic dependency cycle:
- When `isFirstVisit` is true, the effect runs and calls `startTour()`
- `startTour()` sets `setTourAutoStarted(true)`
- This causes the `useEffect` to re-run because `tourAutoStarted` changed
- But now `tourAutoStarted` is already true, so the condition `if (isFirstVisit && !tourAutoStarted)` fails
- The tour never starts

### Solution
Reverted the dependency array back to `[isFirstVisit]` only. This restores the original logic where:
- The effect runs once when `isFirstVisit` becomes true
- Tour starts and `tourAutoStarted` is set to true
- Effect doesn't re-run unnecessarily since `isFirstVisit` doesn't change again

### Testing
✅ Tour now displays correctly for first-time visitors  
✅ Manual tour start via TourButton still works  
✅ Tour completion and navigation blocking remain functional  
✅ All other improvements from the original commit (YAML syntax highlighter) are preserved  


<img width="3660" height="1766" alt="image" src="https://github.com/user-attachments/assets/98719ede-714c-4270-882f-b452d08b3a0a" />


### Files Changed
`sky/dashboard/src/hooks/useTour.js` - Reverted dependency array to fix tour auto-start logic  

This fix resolves the tour display issue while maintaining all other functionality and improvements from the original commit.


<!-- Describe the tests ran -->
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
