### PR TITLE
[DB] fix initial alembic revision for global user state clusters table

### DIFF
--- a/sky/schemas/db/global_user_state/003_fix_initial_revision.py
+++ b/sky/schemas/db/global_user_state/003_fix_initial_revision.py
@@ -28,19 +28,19 @@ def upgrade() -> None:
                                              'storage_mounts_metadata',
                                              sa.LargeBinary(),
                                              server_default=None)
-        # Set the value to replace existing entries to 1 so that all the existing clusters 
-        # before #2977 are considered as ever up, i.e:
+        # Set the value to replace existing entries to 1 so that all the
+        # existing clusters before #2977 are considered as ever up, i.e:
         #   existing cluster's default (null) -> 1;
         #   new cluster's default -> 0;
         # This is conservative for the existing clusters: even if some INIT
         # clusters were never really UP, setting it to 1 means they won't be
         # auto-deleted during any failover.
-        db_utils.add_column_to_table_alembic('clusters',
-                                             'cluster_ever_up',
-                                             sa.Integer(),
-                                             server_default='0',
-                                             value_to_replace_existing_entries='1'
-                                             )
+        db_utils.add_column_to_table_alembic(
+            'clusters',
+            'cluster_ever_up',
+            sa.Integer(),
+            server_default='0',
+            value_to_replace_existing_entries=1)
         db_utils.add_column_to_table_alembic('clusters',
                                              'status_updated_at',
                                              sa.Integer(),

--- a/sky/schemas/db/global_user_state/003_fix_initial_revision.py
+++ b/sky/schemas/db/global_user_state/003_fix_initial_revision.py
@@ -1,4 +1,4 @@
-"""fix initial schema
+"""fix initial revision
 
 Revision ID: 003
 Revises: 002

--- a/sky/schemas/db/global_user_state/003_fix_initial_revision.py
+++ b/sky/schemas/db/global_user_state/003_fix_initial_revision.py
@@ -28,10 +28,19 @@ def upgrade() -> None:
                                              'storage_mounts_metadata',
                                              sa.LargeBinary(),
                                              server_default=None)
+        # Set the value to replace existing entries to 1 so that all the existing clusters 
+        # before #2977 are considered as ever up, i.e:
+        #   existing cluster's default (null) -> 1;
+        #   new cluster's default -> 0;
+        # This is conservative for the existing clusters: even if some INIT
+        # clusters were never really UP, setting it to 1 means they won't be
+        # auto-deleted during any failover.
         db_utils.add_column_to_table_alembic('clusters',
                                              'cluster_ever_up',
                                              sa.Integer(),
-                                             server_default='0')
+                                             server_default='0',
+                                             value_to_replace_existing_entries='1'
+                                             )
         db_utils.add_column_to_table_alembic('clusters',
                                              'status_updated_at',
                                              sa.Integer(),

--- a/sky/schemas/db/global_user_state/003_fix_initial_schema.py
+++ b/sky/schemas/db/global_user_state/003_fix_initial_schema.py
@@ -1,0 +1,45 @@
+"""fix initial schema
+
+Revision ID: 003
+Revises: 002
+Create Date: 2025-08-07
+
+"""
+# pylint: disable=invalid-name
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from sky.utils.db import db_utils
+
+# revision identifiers, used by Alembic.
+revision: str = '003'
+down_revision: Union[str, Sequence[str], None] = '002'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.get_context().autocommit_block():
+        # add missing columns to clusters table
+        db_utils.add_column_to_table_alembic('clusters',
+                                             'storage_mounts_metadata',
+                                             sa.LargeBinary(),
+                                             server_default=None)
+        db_utils.add_column_to_table_alembic('clusters',
+                                             'cluster_ever_up',
+                                             sa.Integer(),
+                                             server_default='0')
+        db_utils.add_column_to_table_alembic('clusters',
+                                             'status_updated_at',
+                                             sa.Integer(),
+                                             server_default=None)
+
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/sky/schemas/db/global_user_state/003_fix_initial_schema.py
+++ b/sky/schemas/db/global_user_state/003_fix_initial_schema.py
@@ -37,7 +37,14 @@ def upgrade() -> None:
                                              sa.Integer(),
                                              server_default=None)
 
-    pass
+        # remove mistakenly added columns
+        db_utils.drop_column_from_table_alembic('clusters', 'launched_nodes')
+        db_utils.drop_column_from_table_alembic('clusters', 'disk_tier')
+        db_utils.drop_column_from_table_alembic('clusters',
+                                                'config_hash_locked')
+        db_utils.drop_column_from_table_alembic('clusters', 'handle_locked')
+        db_utils.drop_column_from_table_alembic('clusters', 'num_failures')
+        db_utils.drop_column_from_table_alembic('clusters', 'configs')
 
 
 def downgrade() -> None:

--- a/sky/utils/db/migration_utils.py
+++ b/sky/utils/db/migration_utils.py
@@ -19,7 +19,7 @@ logger = sky_logging.init_logger(__name__)
 DB_INIT_LOCK_TIMEOUT_SECONDS = 10
 
 GLOBAL_USER_STATE_DB_NAME = 'state_db'
-GLOBAL_USER_STATE_VERSION = '002'
+GLOBAL_USER_STATE_VERSION = '003'
 GLOBAL_USER_STATE_LOCK_PATH = '~/.sky/locks/.state_db.lock'
 
 SPOT_JOBS_DB_NAME = 'spot_jobs_db'


### PR DESCRIPTION
<!-- Describe the changes in this PR -->
There are a few issues with the initial alembic revision for global user state:

There are a few columns missing (in the schema, not in the revision):
- storage_mounts_metadata
- cluster_ever_up
- status_updated_at

There are a few extra columns (not in the schema, in the revision):
- launched_nodes
- disk_tier
- config_hash_locked
- handle_locked
- num_failures
- configs

The missing columns are critical to add because while they are missing, there is a potential for someone who initialized their db prior to those columns being added, trying to upgrade to a new version of the db and will not see those columns show up. The exact user impact should be minimal because the most recent of the missing columns is 9 months ago, so only users who are currently running a db older than 9 months and looking to upgrade to specifically 10.0 or some version between this PR and the original alembic PR will encounter this issue.

The extra columns are not as critical to remove. It should be safe to remove them since they are not in the schema and should be completely unused. 

<!-- Describe the tests ran -->
I manually verified that the schema no longer has these unused columns that are not referenced in the schema to begin with. 
<!-- Unit tests (tests/test_*.py) are part of GitHub CI; below are tests that launch on the cloud. -->

Tested (run the relevant ones):

- [x] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [x] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
